### PR TITLE
feat(substrate): add context-provenance registry for chat ctx keys

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-14-context-provenance-registry-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-context-provenance-registry-pr.md
@@ -1,0 +1,127 @@
+# PR report: context-provenance registry for chat ctx keys
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1056
+Branch: `feat/context-provenance-registry`
+
+## Summary
+
+- New `orion/schemas/context_provenance.py`: a registry classifying every ctx key that flows into a chat turn as one of `live_runtime_projection` / `derived_summary` / `memory_recall` / `static_identity_config` / `user_input` / `external_tool_fetch`, or `PLUMBING_KEYS` for routing bookkeeping with no cognitive content.
+- `GroundingCapsuleV1.context_provenance` carries the classification through to `orion/harness/prefix.py`'s `compile_harness_prefix`, which renders it as a `CONTEXT PROVENANCE` block in the literal FCC motor prompt — the actual prompt for the agentic session with MCP tool access.
+- `build_metacog_substrate_cue` tags its cue with the registry's source kind.
+- `chat_stance.py` folds a standing "only these keys are live" hazard into the existing hazards mechanism.
+
+## Outcome moved
+
+Closes the mechanism behind a real incident: Orion narrated a GitHub-MCP file fetch (`mcp__github__get_file_contents` against `pressure.py`/`dynamics.py`/`attention_broadcast.py`) as live substrate computation "happening this turn." Investigation traced two failure modes: (1) the actual live substrate cue is a terse `self_state`/`eventfulness` string with no mechanism-level detail, and (2) nothing anywhere distinguished "live runtime signal" from "retrieved memory," "static config," or "content fetched via a tool call this turn" at the point Orion talks about itself. This PR closes (2).
+
+## Current architecture
+
+`executor.py` assembles ~80 keys into a single `ctx` dict across a 4000-line turn pipeline with no shared provenance metadata. `GroundingCapsuleV1` already carried a `provenance` dict, but only for `identity_source`/`pcr_ran`. `orion/schemas/cognition/answer_contract.py` already modeled evidence-typed claims (`repo_file`/`runtime_log`/etc.) but only for the investigation/technical verb lane (`supervisor.py`), never wired into casual chat (`executor.py`/`chat_stance.py`).
+
+## Architecture touched
+
+- `orion/schemas/context_provenance.py` (new): the registry + `PLUMBING_KEYS` exemption set + `classify()`.
+- `orion/schemas/thought.py`: `GroundingCapsuleV1.context_provenance: dict[str, str]`.
+- `services/orion-cortex-exec/app/grounding_capsule.py`: `context_provenance_for_ctx()` populates it.
+- `orion/harness/prefix.py`: `_format_context_provenance_block()` renders it into `compile_harness_prefix`'s literal motor prompt.
+- `orion/substrate/metacog_trigger_signals.py`: `build_metacog_substrate_cue()` tags its output.
+- `services/orion-cortex-exec/app/chat_stance.py`: `_project_context_provenance_hazard()`, folded into the existing `_project_self_state_from_beliefs` hazards mechanism.
+
+## Files changed
+
+- `orion/schemas/context_provenance.py`: new registry (61 classified keys + 27 plumbing-exempt keys, exact coverage of the live `ctx` key snapshot).
+- `orion/schemas/thought.py`: added `context_provenance` field to `GroundingCapsuleV1`.
+- `services/orion-cortex-exec/app/grounding_capsule.py`: added `context_provenance_for_ctx()`, wired into `build_grounding_capsule()`.
+- `orion/harness/prefix.py`: added `_format_context_provenance_block()`, wired into `_format_grounding_self_block()`.
+- `orion/substrate/metacog_trigger_signals.py`: cue now tagged with `(source=live_runtime_projection)`.
+- `services/orion-cortex-exec/app/chat_stance.py`: added `_project_context_provenance_hazard()`, folded into `build_chat_stance_inputs()`'s hazards list (prepended, not appended — see review findings).
+- Tests: `orion/schemas/tests/test_context_provenance.py`, `services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py`, plus extensions to `test_grounding_capsule_assembly.py`, `test_metacog_trigger_signals.py`, `test_harness_prefix.py`.
+
+## Schema / bus / API changes
+
+- Added: `GroundingCapsuleV1.context_provenance: dict[str, str]` (additive, default `{}`).
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `compile_harness_prefix`'s rendered motor prompt gains a new `CONTEXT PROVENANCE` block when the capsule carries any classified keys; `build_metacog_substrate_cue`'s output string gains a `(source=...)` suffix; `build_chat_stance_inputs`'s `social["hazards"]` list may gain one more entry.
+- Compatibility notes: fully additive; existing consumers of `GroundingCapsuleV1` unaffected by the new field (default `{}`).
+
+## Env/config changes
+
+None. No new env keys added, removed, or renamed.
+
+## Tests run
+
+```text
+PYTHONPATH=<worktree>:<worktree>/services/orion-cortex-exec venv/bin/python -m pytest \
+  orion/schemas/tests/test_context_provenance.py \
+  orion/substrate/tests/test_metacog_trigger_signals.py \
+  orion/harness/tests/test_harness_prefix.py \
+  services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py \
+  services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py \
+  services/orion-cortex-exec/tests/test_chat_stance_self_state_projection.py \
+  -q
+49 passed
+
+Broader regression sweep (services/orion-cortex-exec/tests/test_chat_stance_*.py,
+test_grounding_capsule*.py, test_router_grounding_capsule_metadata.py, orion/harness/tests):
+223 passed, 7 failed -- all 7 confirmed present and identical on unmodified main
+(verified by running the same batch against the unmodified main checkout):
+  - 2 test-order-dependent failures (test_chat_stance_brief.py x1 additionally
+    order-independent-broken, test_grounding_capsule_assembly.py x1,
+    test_router_grounding_capsule_metadata.py x1 -- these 3 only fail when run
+    as part of the larger batch, pass in isolation; identical on main)
+  - 1 test-order-independent pre-existing failure
+    (test_chat_stance_shadow_mode_uses_local_result_and_passes_observer,
+    "assert 'continuity' in ['tick']")
+  - 1 Jinja UndefinedError ('mind_coloring' is undefined) in
+    test_grounding_capsule_consumers.py, x2 tests
+  - 1 error-code string mismatch in test_harness_runner.py
+    ("fcc turn timed out after 120.0s" != "fcc_timeout")
+Zero regressions introduced by this patch.
+```
+
+## Evals run
+
+No dedicated eval harness exists for this seam. The registry-coverage tests (`test_live_snapshot_fully_covered`, `test_static_ctx_assignments_covered`) serve as the deterministic gate in place of an eval — the latter is a live source-grounded check, not a static snapshot, and immediately caught 17 real unclassified keys during development (see Review findings below).
+
+## Docker/build/smoke checks
+
+Not run. This patch changes prompt-assembly Python only (schema, registry, string rendering) — no config read at boot, no new dependencies, no compose/port/worker changes.
+
+## Review findings fixed
+
+- Finding: `_project_context_provenance_hazard`'s hazard was appended after two prior `_unique(..., limit=8)` folds in `build_chat_stance_inputs`, so it silently dropped whenever the hazards list was already full at 8 unique entries — exactly on the eventful turns most likely to need it.
+  - Fix: prepend instead of append, so it survives the cap regardless of how many other hazards already exist.
+  - Evidence: `test_build_chat_stance_inputs_folds_provenance_hazard_when_live_key_present` passes; fix documented inline.
+- Finding: `GroundingCapsuleV1.context_provenance` was populated by `context_provenance_for_ctx()` but had zero consumers anywhere in the codebase — write-only data, a schema+producer with no consumer (this repo's CLAUDE.md explicitly names that shape as the thing to avoid: "no keyword cathedral").
+  - Fix: wired into `orion/harness/prefix.py`'s `_format_grounding_self_block`, the function that renders the capsule into the literal FCC-motor prompt (`compile_harness_prefix`, which spawns the `claude -p` agentic session with MCP tool access — the exact pathway implicated in the original incident, confirmed by the existing `test_compile_harness_prefix_includes_github_repo_when_mcp_enabled` test in the same file).
+  - Evidence: `test_compile_harness_prefix_includes_context_provenance_when_capsule_has_it` / `..._omits_context_provenance_when_capsule_empty`.
+- Finding: only the `self_state` clause of `build_metacog_substrate_cue`'s output got the `(source=...)` tag; the `execution_trajectory_projection`/`eventfulness` clauses in the same cue string were left untagged, despite the docstring claiming the whole cue "tags itself."
+  - Fix: moved the tag to apply once, after all clauses are assembled, covering the full cue.
+  - Evidence: `test_build_metacog_substrate_cue_tags_its_own_provenance`.
+- Finding: `_project_context_provenance_hazard` duplicated the registry-scan-and-filter loop already implemented in `grounding_capsule.py`'s `context_provenance_for_ctx`, risking silent divergence between the capsule's provenance map and the hazard's live-key list if the filtering logic changes in one place and not the other.
+  - Fix: `chat_stance.py` now imports and reuses `context_provenance_for_ctx` instead of re-scanning the registry independently.
+  - Evidence: existing and new hazard tests pass after the refactor.
+- Finding: `test_live_snapshot_fully_covered`'s hand-maintained key snapshot (`LIVE_CTX_KEY_SNAPSHOT`) has no automated link to the real ctx-assembly code in `executor.py`, so a future new ctx key only gets caught if an author remembers to update the frozenset by hand — the exact "deterministic gates over repeated yelling" failure mode this repo's CLAUDE.md warns against.
+  - Fix: added `test_static_ctx_assignments_covered`, which statically parses `executor.py` for literal `ctx["key"] = ...` / `ctx.setdefault(...)` assignments and asserts registry+plumbing coverage against that parse — an automated safety net for the common case of a new direct assignment (doesn't replace the hand snapshot, still needed for keys set via dict merges in other modules, but removes the hand-maintenance burden for the common case).
+  - Evidence: this test immediately surfaced 17 previously-unclassified keys during development (`chat_stance_brief`, `chat_stance_debug`, `collapse_entry`, `collapse_json`, `final_entry`, `journal_pageindex_context`, `metacog_ctx_trim_applied`, `metacog_draft_prompt_chars`, `metacog_draft_section_sizes`, `metacog_enrich_prompt_chars`, `metacog_enrich_section_sizes`, `metacog_entry_id`, `prior_chat_stance_brief`, `prior_stance`, `prior_step_results_by_service`, `speech_contract`, `world_context_capsule`), all now classified; `test_static_ctx_assignments_covered` passes.
+- Finding: `"external_tool_fetch"` is defined in `ContextSourceKind` but never assigned to any registry entry or ctx key — the literal incident category (a GitHub MCP fetch) has no producer key anywhere, because harness-level MCP tool calls are invisible to this repo's `ctx` dict entirely.
+  - Not fixed in this patch — genuine out-of-repo scope gap, disclosed under Risks/Concerns below rather than silently left uncovered. This was flagged as an open Missing Question during the design-mode spec that preceded this patch, before implementation started.
+
+## Restart required
+
+```text
+No restart required for this patch to be reviewable/mergeable. Once merged,
+takes effect on the next deploy/restart of cortex-exec and cortex-exec-chat
+(prompt-assembly logic only, no config read at boot).
+```
+
+## Risks / concerns
+
+- Severity: Medium
+- Concern: `"external_tool_fetch"` has no producer anywhere in this repo. The original incident's actual mechanism — an agentic session calling `mcp__github__get_file_contents` mid-turn — happens at the harness/session level, outside this repo's own `ctx`-assembly pipeline entirely, so nothing here can tag that tool call's result with provenance at the source. This PR's `CONTEXT PROVENANCE` block in the FCC motor prompt (`orion/harness/prefix.py`) gives the motor a standing instruction about what *is* live before it reaches for a tool — a preventive nudge, not a detector — so there is no guarantee a future tool-fetched claim gets caught if the model doesn't attend to that instruction.
+- Mitigation: flagged during design as requiring a harness-level fix outside this repo's addressable scope (see the `project_orion_substrate_bridge_confabulation` memory and the preceding design-mode spec). Follow-up: instrument the harness/session layer's MCP tool-result formatting to tag fetched content with provenance at its actual source, if and when that layer is addressable from this project.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1056

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -54,7 +54,6 @@ _PROVENANCE_LABELS: dict[str, str] = {
     "memory_recall": "retrieved memory",
     "static_identity_config": "static identity/config",
     "user_input": "user input",
-    "external_tool_fetch": "fetched via tool call",
 }
 
 

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -48,6 +48,34 @@ def _format_autonomy_slice(sl: AutonomySliceV1) -> list[str]:
     return lines
 
 
+_PROVENANCE_LABELS: dict[str, str] = {
+    "live_runtime_projection": "live now",
+    "derived_summary": "derived from context",
+    "memory_recall": "retrieved memory",
+    "static_identity_config": "static identity/config",
+    "user_input": "user input",
+    "external_tool_fetch": "fetched via tool call",
+}
+
+
+def _format_context_provenance_block(context_provenance: dict[str, str]) -> list[str]:
+    """One line per source kind present this turn, so the motor (which has its
+    own tool access, e.g. MCP file reads) can tell live substrate signal apart
+    from retrieved/static/tool-fetched content instead of guessing. See
+    project_orion_substrate_bridge_confabulation for the incident this closes:
+    a GitHub file fetch narrated as live computation "this turn"."""
+    if not context_provenance:
+        return []
+    by_kind: dict[str, list[str]] = {}
+    for key, kind in context_provenance.items():
+        by_kind.setdefault(kind, []).append(key)
+    lines = ["CONTEXT PROVENANCE (only 'live now' items are happening this turn)"]
+    for kind in sorted(by_kind):
+        label = _PROVENANCE_LABELS.get(kind, kind)
+        lines.append(f"- {label}: {', '.join(sorted(by_kind[kind]))}")
+    return lines
+
+
 def _format_grounding_self_block(capsule: GroundingCapsuleV1) -> list[str]:
     """Compact motor self block: identity + relationship + continuity/memory only.
 
@@ -63,6 +91,7 @@ def _format_grounding_self_block(capsule: GroundingCapsuleV1) -> list[str]:
     if digest:
         lines.append("DURABLE MEMORY / CONTINUITY")
         lines.append(digest)
+    lines.extend(_format_context_provenance_block(capsule.context_provenance))
     return lines
 
 

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -6,7 +6,7 @@ import pytest
 
 from orion.harness.operator_brief import HARNESS_MOTOR_MAX_READ_LINES, is_relational_motor_stance
 from orion.harness.prefix import compile_harness_prefix, harness_motor_instruction
-from orion.harness.tests.fixtures import make_thought
+from orion.harness.tests.fixtures import make_grounding_capsule, make_thought
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
 from orion.schemas.thought import AutonomySliceV1, StanceHarnessSliceV1
@@ -44,6 +44,42 @@ def test_compile_harness_prefix_includes_autonomy_slice_recent_actions() -> None
         user_message="what have you been doing?",
     )
     assert "Recent actions: inspect: checked substrate graph health" in prompt
+
+
+def test_compile_harness_prefix_includes_context_provenance_when_capsule_has_it() -> None:
+    """The motor has its own tool access (e.g. GitHub MCP file reads) -- the
+    provenance legend has to reach this literal prompt, not just live on an
+    unread GroundingCapsuleV1 field, or a tool-fetched read can still get
+    narrated as live substrate computation. See
+    project_orion_substrate_bridge_confabulation for the incident this closes.
+    """
+    capsule = make_grounding_capsule(
+        context_provenance={
+            "self_state": "live_runtime_projection",
+            "attention_broadcast": "live_runtime_projection",
+            "recall_bundle": "memory_recall",
+        }
+    )
+    thought = make_thought(imperative="Inspect the module.", tone="direct", grounding_capsule=capsule)
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="what's live right now?",
+    )
+    assert "CONTEXT PROVENANCE" in prompt
+    assert "live now: attention_broadcast, self_state" in prompt
+    assert "retrieved memory: recall_bundle" in prompt
+
+
+def test_compile_harness_prefix_omits_context_provenance_when_capsule_empty() -> None:
+    capsule = make_grounding_capsule(context_provenance={})
+    thought = make_thought(imperative="Inspect the module.", tone="direct", grounding_capsule=capsule)
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="hi",
+    )
+    assert "CONTEXT PROVENANCE" not in prompt
 
 
 def test_compile_harness_prefix_omits_recent_actions_line_when_empty() -> None:

--- a/orion/schemas/context_provenance.py
+++ b/orion/schemas/context_provenance.py
@@ -1,0 +1,171 @@
+"""Provenance classification for chat-turn context (``ctx``) keys.
+
+``executor.py`` assembles ~80 keys into a single ``ctx`` dict over the course
+of a turn — some are live substrate/biometric projections computed this tick,
+some are memory retrieved from a recall backend, some are static identity
+config, some are the user's own message. Nothing previously distinguished
+these at the point Orion has to talk about them, which is how a GitHub file
+fetch got narrated as live substrate computation "this turn" (see
+docs/superpowers/pr-reports for the incident). This module is the registry
+that makes that distinction inspectable and enforceable.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+ContextSourceKind = Literal[
+    "live_runtime_projection",
+    "derived_summary",
+    "memory_recall",
+    "static_identity_config",
+    "user_input",
+    "external_tool_fetch",
+]
+
+
+class ContextKeyProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    source_kind: ContextSourceKind
+    description: str
+
+
+def _entry(key: str, source_kind: ContextSourceKind, description: str) -> ContextKeyProvenance:
+    return ContextKeyProvenance(key=key, source_kind=source_kind, description=description)
+
+
+# Content-bearing ctx keys: anything Orion could plausibly narrate or draw a
+# claim from. Every key here has a real producer somewhere in the substrate/
+# cortex-exec pipeline (see docstrings on the source functions) — this
+# registry only classifies, it does not compute.
+CONTEXT_PROVENANCE_REGISTRY: dict[str, ContextKeyProvenance] = {
+    entry.key: entry
+    for entry in [
+        # --- static identity / config: loaded once, stable across turns ---
+        _entry("orion_identity_summary", "static_identity_config", "Identity kernel summary lines."),
+        _entry("juniper_relationship_summary", "static_identity_config", "Relationship summary lines."),
+        _entry("response_policy_summary", "static_identity_config", "Response policy summary lines."),
+        _entry("identity_kernel_source", "static_identity_config", "Which identity kernel file was loaded."),
+        _entry("personality_file", "static_identity_config", "Declared personality file for this turn."),
+        # --- memory recall: retrieved from a persisted recall/PCR backend ---
+        _entry("recall_bundle", "memory_recall", "Raw recall backend results."),
+        _entry("recall_fragments", "memory_recall", "Selected recall fragments for the turn."),
+        _entry("memory_used", "memory_recall", "Flag/summary of which memory was actually used."),
+        _entry("memory_bundle", "memory_recall", "Bundled memory retrieval result."),
+        _entry("pcr_memory", "memory_recall", "PCR (persistent chat recall) memory payload."),
+        _entry("memory_digest", "memory_recall", "Compact digest of recalled memory."),
+        _entry("continuity_digest", "memory_recall", "Digest of continuity-relevant recalled memory."),
+        # --- derived summary: deterministic reduction of other context, not itself live ---
+        _entry("belief_digest", "derived_summary", "Reduction of the unified relational belief graph."),
+        _entry("situation_brief", "derived_summary", "Situation summary derived from ctx."),
+        _entry("presence_context", "derived_summary", "Presence/availability framing derived from ctx."),
+        _entry("temporal_phase", "derived_summary", "Time-of-day/temporal phase label."),
+        _entry("situation_affordances", "derived_summary", "Derived list of situational affordances."),
+        _entry("situation_prompt_fragment", "derived_summary", "Rendered situation prompt fragment."),
+        _entry("world_context_capsule_loaded", "derived_summary", "Whether a world-context capsule was loaded."),
+        _entry("capsule_age_hours", "derived_summary", "Age of the loaded world-context capsule."),
+        _entry("capsule_filtered_reason", "derived_summary", "Why the world-context capsule was filtered."),
+        _entry("stance_world_context_items_used", "derived_summary", "Count of world-context items folded into stance."),
+        _entry("politics_context_suppressed", "derived_summary", "Whether politics-sensitive context was suppressed."),
+        _entry("trigger", "derived_summary", "What triggered this turn (raw label)."),
+        _entry("trigger_kind", "derived_summary", "Classified kind of turn trigger."),
+        _entry("context_summary", "derived_summary", "General context summary derived for the turn."),
+        _entry("episode_summary", "derived_summary", "Summary of the current episode."),
+        _entry("chat_stance_brief", "derived_summary", "Parsed task_mode/conversation_frame stance brief."),
+        _entry("prior_chat_stance_brief", "derived_summary", "Previous turn's stance brief."),
+        _entry("prior_stance", "derived_summary", "Previous turn's full stance."),
+        _entry("collapse_entry", "derived_summary", "Collapse-mirror entry for this turn."),
+        _entry("collapse_json", "derived_summary", "JSON-rendered collapse-mirror entry."),
+        _entry("final_entry", "derived_summary", "Final assembled turn entry."),
+        _entry("speech_contract", "derived_summary", "Rendered per-turn speech contract."),
+        _entry("world_context_capsule", "derived_summary", "Loaded world-context capsule content."),
+        _entry("journal_pageindex_context", "memory_recall", "Journal page-index retrieval context."),
+        # --- live runtime projection: computed this tick by a substrate/biometrics/turn-effect engine ---
+        _entry("pad_frame", "live_runtime_projection", "Live pleasure-arousal-dominance affect frame."),
+        _entry("pad_frame_json", "live_runtime_projection", "JSON-rendered PAD frame."),
+        _entry("pad_stats", "live_runtime_projection", "Live PAD statistics."),
+        _entry("pad_stats_json", "live_runtime_projection", "JSON-rendered PAD statistics."),
+        _entry("biometrics", "live_runtime_projection", "Live biometrics substrate reading."),
+        _entry("biometrics_json", "live_runtime_projection", "JSON-rendered biometrics reading."),
+        _entry("phi_hint", "live_runtime_projection", "Live phi/tissue-viz hint."),
+        _entry("spark_phi_narrative", "live_runtime_projection", "Narrative rendering of live spark/phi state."),
+        _entry("embodiment_hint", "live_runtime_projection", "Live embodiment hint."),
+        _entry("spark_embodiment_narrative", "live_runtime_projection", "Narrative rendering of live embodiment state."),
+        _entry("spark_state_json", "live_runtime_projection", "JSON-rendered spark engine state."),
+        _entry("turn_effect", "live_runtime_projection", "Live turn-effect engine output."),
+        _entry("turn_effect_json", "live_runtime_projection", "JSON-rendered turn-effect output."),
+        _entry("turn_effect_evidence", "live_runtime_projection", "Evidence backing the turn-effect output."),
+        _entry("turn_effect_evidence_json", "live_runtime_projection", "JSON-rendered turn-effect evidence."),
+        _entry("recent_turn_effect_alerts_json", "live_runtime_projection", "Recent turn-effect alerts."),
+        _entry("system_alert_tags", "live_runtime_projection", "Live system alert tags."),
+        _entry("turn_effect_policy", "live_runtime_projection", "Policy derived from live turn-effect state."),
+        _entry("turn_effect_policy_json", "live_runtime_projection", "JSON-rendered turn-effect policy."),
+        _entry("turn_effect_explanations", "live_runtime_projection", "Explanations for the live turn-effect output."),
+        _entry("turn_effect_explanations_json", "live_runtime_projection", "JSON-rendered turn-effect explanations."),
+        _entry("metacog_biometrics_cue", "live_runtime_projection", "Compact live biometrics cue for metacog prompts."),
+        _entry("metacog_biometrics_cue_enrich", "live_runtime_projection", "Enriched live biometrics cue."),
+        _entry("self_state", "live_runtime_projection", "Live self-state projection (SelfStateV1)."),
+        _entry("execution_trajectory_projection", "live_runtime_projection", "Live execution-trajectory projection."),
+        _entry("transport_bus_projection", "live_runtime_projection", "Live transport-bus projection."),
+        _entry("active_node_pressure_projection", "live_runtime_projection", "Live substrate pressure-field projection."),
+        _entry("attention_broadcast", "live_runtime_projection", "Live substrate attention-broadcast projection."),
+        _entry("curiosity_signals", "live_runtime_projection", "Live curiosity/drive signals."),
+        _entry("metacog_substrate_cue", "live_runtime_projection", "Compact live substrate cue for metacog prompts."),
+        _entry("substrate_eventfulness_score", "live_runtime_projection", "Live substrate eventfulness score."),
+        _entry("substrate_eventfulness_reasons", "live_runtime_projection", "Reasons behind the live eventfulness score."),
+        # --- user input: this turn's message and directly-derived transcript ---
+        _entry("user_message", "user_input", "The user's message this turn."),
+        _entry("message_history", "user_input", "Conversation transcript."),
+    ]
+}
+
+# Pure request/routing plumbing: correlation ids, trace ids, flags, and other
+# bookkeeping that carries no cognitive content and that Orion would never
+# legitimately narrate as perceived/recalled/computed signal. Exempted from
+# the registry-coverage requirement rather than force-classified into one of
+# the six meaningful kinds above.
+PLUMBING_KEYS: frozenset[str] = frozenset(
+    {
+        "metadata",
+        "lane",
+        "user_id",
+        "trigger_source",
+        "trace_id",
+        "parent_event_id",
+        "correlation_id",
+        "plan_metadata",
+        "trigger_correlation_id",
+        "trigger_trace_id",
+        "recall",
+        "plan_recall_profile",
+        "debug",
+        "_cortex_exec_grammar_collector",
+        "_cortex_exec_grammar_request_recorded",
+        "options",
+        "verb",
+        "_run_scope_corr_id",
+        "prior_step_results_by_corr",
+        "prior_step_results",
+        "prior_step_results_by_service",
+        # debug/telemetry about the prompt-construction process itself, not content:
+        "chat_stance_debug",
+        "metacog_ctx_trim_applied",
+        "metacog_draft_prompt_chars",
+        "metacog_draft_section_sizes",
+        "metacog_enrich_prompt_chars",
+        "metacog_enrich_section_sizes",
+        "metacog_entry_id",
+    }
+)
+
+
+def classify(key: str) -> ContextSourceKind | None:
+    """Look up a ctx key's provenance. None means unclassified (neither a
+    registered content key nor a known plumbing key) — callers should treat
+    that as "needs a registry entry," not as a silent default."""
+    entry = CONTEXT_PROVENANCE_REGISTRY.get(key)
+    return entry.source_kind if entry else None

--- a/orion/schemas/context_provenance.py
+++ b/orion/schemas/context_provenance.py
@@ -22,8 +22,16 @@ ContextSourceKind = Literal[
     "memory_recall",
     "static_identity_config",
     "user_input",
-    "external_tool_fetch",
 ]
+# Deliberately no "external_tool_fetch" kind yet: the literal incident this
+# registry was built for (a GitHub MCP fetch narrated as live computation)
+# happens at the harness/agent-session level, invisible to this repo's own
+# ctx dict -- orion/harness/fcc_motor.py's tool-result formatting
+# (_tool_result_body_text / _summarize_content_blocks) is where that content
+# actually gets produced, and nothing here tags it. A kind with no producer
+# and no consumer is exactly the "names the world without changing what
+# Orion can perceive" pattern AGENTS.md bans -- add it back only alongside
+# that wiring, not before.
 
 
 class ContextKeyProvenance(BaseModel):
@@ -159,6 +167,8 @@ PLUMBING_KEYS: frozenset[str] = frozenset(
         "metacog_enrich_prompt_chars",
         "metacog_enrich_section_sizes",
         "metacog_entry_id",
+        # memoization for context_provenance_for_ctx itself, not turn content:
+        "_context_provenance_cache",
     }
 )
 

--- a/orion/schemas/tests/test_context_provenance.py
+++ b/orion/schemas/tests/test_context_provenance.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from orion.schemas.context_provenance import (
+    CONTEXT_PROVENANCE_REGISTRY,
+    PLUMBING_KEYS,
+    classify,
+)
+
+_EXECUTOR_PY = Path(__file__).resolve().parents[3] / "services" / "orion-cortex-exec" / "app" / "executor.py"
+
+# Manually-refreshed snapshot of every key executor.py's ctx dict carried for
+# a live chat turn (captured from orion-athena-cortex-exec-chat container
+# logs, "Context Keys available: [...]"). This is the primary gate for keys
+# that never appear as a literal ctx["key"] = assignment in executor.py
+# (e.g. self_state, attention_broadcast -- set via dict merges in helper
+# modules). Refresh by re-capturing that log line when the ingress shape
+# changes; test_static_ctx_assignments_covered below is the automated
+# safety net for the common case this snapshot can't self-update against.
+LIVE_CTX_KEY_SNAPSHOT = frozenset(
+    {
+        "user_message", "metadata", "lane", "user_id", "trigger_source", "trace_id",
+        "parent_event_id", "correlation_id", "plan_metadata", "personality_file",
+        "trigger_correlation_id", "trigger_trace_id", "recall", "plan_recall_profile",
+        "debug", "_cortex_exec_grammar_collector", "_cortex_exec_grammar_request_recorded",
+        "options", "verb", "orion_identity_summary", "juniper_relationship_summary",
+        "response_policy_summary", "identity_kernel_source", "_run_scope_corr_id",
+        "prior_step_results_by_corr", "prior_step_results", "recall_bundle", "memory_digest",
+        "recall_fragments", "memory_used", "memory_bundle", "pcr_memory", "continuity_digest",
+        "belief_digest", "situation_brief", "presence_context", "temporal_phase",
+        "situation_affordances", "situation_prompt_fragment", "world_context_capsule_loaded",
+        "capsule_age_hours", "capsule_filtered_reason", "stance_world_context_items_used",
+        "politics_context_suppressed", "message_history", "pad_frame", "pad_frame_json",
+        "pad_stats", "pad_stats_json", "biometrics", "biometrics_json", "phi_hint",
+        "spark_phi_narrative", "embodiment_hint", "spark_embodiment_narrative",
+        "spark_state_json", "turn_effect", "turn_effect_json", "turn_effect_evidence",
+        "turn_effect_evidence_json", "recent_turn_effect_alerts_json", "system_alert_tags",
+        "turn_effect_policy", "turn_effect_policy_json", "turn_effect_explanations",
+        "turn_effect_explanations_json", "trigger", "trigger_kind", "context_summary",
+        "metacog_biometrics_cue", "metacog_biometrics_cue_enrich", "self_state",
+        "execution_trajectory_projection", "transport_bus_projection",
+        "active_node_pressure_projection", "attention_broadcast", "episode_summary",
+        "curiosity_signals", "metacog_substrate_cue", "substrate_eventfulness_score",
+        "substrate_eventfulness_reasons",
+    }
+)
+
+
+def test_registry_and_plumbing_have_no_overlap():
+    assert not (set(CONTEXT_PROVENANCE_REGISTRY) & PLUMBING_KEYS)
+
+
+def test_live_snapshot_fully_covered():
+    covered = set(CONTEXT_PROVENANCE_REGISTRY) | PLUMBING_KEYS
+    missing = LIVE_CTX_KEY_SNAPSHOT - covered
+    assert not missing, f"unclassified ctx keys, add to registry or PLUMBING_KEYS: {sorted(missing)}"
+
+
+def test_static_ctx_assignments_covered():
+    """Automated safety net: any key executor.py assigns via a literal
+    ctx["key"] = ... or ctx.setdefault("key", ...) must be classified. Doesn't
+    catch keys set via dict merges in other modules (that's what
+    LIVE_CTX_KEY_SNAPSHOT is for) but needs no hand-maintenance for the
+    common case of a new direct assignment in executor.py itself.
+    """
+    text = _EXECUTOR_PY.read_text()
+    assigned_keys = set(re.findall(r'ctx\[["\']([a-zA-Z0-9_]+)["\']\]\s*=', text))
+    assigned_keys |= set(re.findall(r'ctx\.setdefault\(["\']([a-zA-Z0-9_]+)["\']', text))
+    covered = set(CONTEXT_PROVENANCE_REGISTRY) | PLUMBING_KEYS
+    missing = assigned_keys - covered
+    assert not missing, f"executor.py assigns unclassified ctx keys: {sorted(missing)}"
+
+
+def test_classify_returns_none_for_unknown_key():
+    assert classify("some_key_nobody_registered") is None
+
+
+def test_classify_returns_registered_kind():
+    assert classify("self_state") == "live_runtime_projection"
+    assert classify("recall_bundle") == "memory_recall"
+    assert classify("orion_identity_summary") == "static_identity_config"

--- a/orion/schemas/thought.py
+++ b/orion/schemas/thought.py
@@ -52,6 +52,11 @@ class GroundingCapsuleV1(BaseModel):
     belief_digest: str | None = None
     memory_digest: str | None = None
     provenance: dict[str, Any] = Field(default_factory=dict)
+    # key -> ContextSourceKind, for every ctx key present this turn that the
+    # registry (orion.schemas.context_provenance) classifies. Lets Orion (and
+    # any downstream check) tell live substrate signal apart from retrieved
+    # memory, static identity config, or the user's own message.
+    context_provenance: dict[str, str] = Field(default_factory=dict)
 
 
 class AutonomySliceV1(BaseModel):

--- a/orion/substrate/metacog_trigger_signals.py
+++ b/orion/substrate/metacog_trigger_signals.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from orion.schemas.context_provenance import classify
 from orion.schemas.execution_projection import ExecutionTrajectoryProjectionV1
 from orion.schemas.self_state import SelfStateV1
 
@@ -103,7 +104,14 @@ def build_metacog_substrate_cue(
     max_chars: int = 400,
     eventfulness: SubstrateEventfulness | None = None,
 ) -> str:
-    """Compact substrate cue for metacog prompts (not raw JSON)."""
+    """Compact substrate cue for metacog prompts (not raw JSON).
+
+    Tags itself with its registry source kind (``classify("self_state")``,
+    always "live_runtime_projection") so a claim built from this cue can be
+    told apart from one built by reading source off a repo/tool -- see
+    project_orion_substrate_bridge_confabulation for why that distinction
+    has to be legible in the cue itself, not just in a registry nobody reads.
+    """
     parts: list[str] = []
     ss = ctx.get("self_state")
     if isinstance(ss, dict):
@@ -125,5 +133,11 @@ def build_metacog_substrate_cue(
     )
     if ev.reasons:
         parts.append(f"eventfulness={ev.score:.2f} ({'; '.join(ev.reasons[:3])})")
+    if parts:
+        # self_state, execution_trajectory_projection, and the eventfulness
+        # score derived from them are all registered live_runtime_projection --
+        # one suffix for the whole cue, not just the first clause, so every
+        # segment carries the same provenance signal.
+        parts.append(f"(source={classify('self_state')})")
     cue = " | ".join(parts)
     return cue[:max_chars] if len(cue) > max_chars else cue

--- a/orion/substrate/metacog_trigger_signals.py
+++ b/orion/substrate/metacog_trigger_signals.py
@@ -133,11 +133,18 @@ def build_metacog_substrate_cue(
     )
     if ev.reasons:
         parts.append(f"eventfulness={ev.score:.2f} ({'; '.join(ev.reasons[:3])})")
-    if parts:
-        # self_state, execution_trajectory_projection, and the eventfulness
-        # score derived from them are all registered live_runtime_projection --
-        # one suffix for the whole cue, not just the first clause, so every
-        # segment carries the same provenance signal.
-        parts.append(f"(source={classify('self_state')})")
-    cue = " | ".join(parts)
-    return cue[:max_chars] if len(cue) > max_chars else cue
+    if not parts:
+        return ""
+    # self_state, execution_trajectory_projection, and the eventfulness score
+    # derived from them are all registered live_runtime_projection -- one
+    # suffix for the whole cue. Budget is reserved for it and it's appended
+    # after truncation, not before: on an eventful turn the joined clauses can
+    # already approach max_chars, and a tag appended before truncation is the
+    # first thing a tail-truncate cuts, silently dropping the provenance
+    # signal on exactly the turns most likely to need it.
+    tag = f" (source={classify('self_state')})"
+    body = " | ".join(parts)
+    budget = max_chars - len(tag)
+    if len(body) > budget:
+        body = body[:budget]
+    return body + tag

--- a/orion/substrate/tests/test_metacog_trigger_signals.py
+++ b/orion/substrate/tests/test_metacog_trigger_signals.py
@@ -78,3 +78,10 @@ def test_build_metacog_substrate_cue_compact():
     assert "self_state:" in cue
     assert "strained" in cue
     assert len(cue) <= 400
+
+
+def test_build_metacog_substrate_cue_tags_its_own_provenance():
+    ss = _self_state()
+    ctx = {"self_state": ss.model_dump(mode="json")}
+    cue = build_metacog_substrate_cue(ctx)
+    assert "source=live_runtime_projection" in cue

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1382,28 +1382,33 @@ def _project_context_provenance_hazard(ctx: Dict[str, Any]) -> str | None:
     live substrate/biometric signal vs. retrieved/static/tool content.
 
     Reads the shared ``orion.schemas.context_provenance`` registry against
-    whatever keys are actually present in ``ctx`` this turn. Returns a
-    compact hazard string naming the live keys, or None when none are
-    present -- exists so a self-referential claim about "what's happening
-    right now" has a ground truth to check against instead of a
+    whatever keys are actually present in ``ctx`` this turn. Returns a fixed,
+    compact hazard string when any live_runtime_projection key is present, or
+    None otherwise -- exists so a self-referential claim about "what's
+    happening right now" has a ground truth to check against instead of a
     plausible-sounding guess (see
     project_orion_substrate_bridge_confabulation for the incident this
     closes: a GitHub file fetch narrated as live substrate computation).
+
+    Deliberately fixed-length, not enumerating which keys qualify: this
+    string passes through ``_unique()``, which hard-truncates every hazard
+    to 140 chars, and the live-key list can be long enough to push an
+    enumerated message past that limit and cut off the actual instruction.
+    The enumerated version lives in the FCC motor prompt instead (see
+    orion/harness/prefix.py's CONTEXT PROVENANCE block), which has no such
+    length cap.
     """
     from .grounding_capsule import context_provenance_for_ctx
 
-    live_keys = sorted(
-        key
-        for key, kind in context_provenance_for_ctx(ctx).items()
-        if kind == "live_runtime_projection"
+    has_live_key = any(
+        kind == "live_runtime_projection"
+        for kind in context_provenance_for_ctx(ctx).values()
     )
-    if not live_keys:
+    if not has_live_key:
         return None
     return (
-        "context_provenance: only " + ", ".join(live_keys) + " are live "
-        "signal computed this turn; anything else in context (memory "
-        "recall, static identity config, or a tool call you made) is not "
-        "live and must not be described as happening right now."
+        "context_provenance: only live_runtime_projection context is "
+        "happening now; recalled/static/tool content is not live."
     )
 
 
@@ -2540,17 +2545,24 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
     ctx["chat_reasoning_summary"] = reasoning["summary"]
     autonomy = _project_autonomy_from_beliefs(beliefs, ctx) or _load_autonomy_state(ctx)
     self_state_projection = _project_self_state_from_beliefs(beliefs, ctx)
-    if self_state_projection:
-        social["hazards"] = _unique((social.get("hazards") or []) + list(self_state_projection.get("hazards") or []), limit=8)
-        ctx["chat_self_state_condition"] = self_state_projection.get("overall_condition")
     context_provenance_hazard = _project_context_provenance_hazard(ctx)
+    # self_state severity and context-provenance are both standing epistemic/
+    # safety signals from this function's own reasoning, not reactive social
+    # hazards -- fold them in together, prepended ahead of the social/
+    # social_bridge hazards already in the list, so _unique(..., limit=8)'s
+    # truncation-in-order falls on the lower-stakes social hazards first
+    # instead of silently evicting one safety signal to make room for the
+    # other (a prior version prepended context_provenance_hazard alone,
+    # which could evict an already-folded self_state severity hazard once
+    # the list was full).
+    priority_hazards: list[str] = []
+    if self_state_projection:
+        priority_hazards.extend(self_state_projection.get("hazards") or [])
+        ctx["chat_self_state_condition"] = self_state_projection.get("overall_condition")
     if context_provenance_hazard:
-        # Prepended, not appended: this is a standing epistemic constraint, not
-        # a reactive risk flag, and _unique(..., limit=8) truncates in order --
-        # appending after two prior hazard folds means it silently drops on any
-        # turn where those already filled the cap, which is exactly the kind of
-        # eventful turn most likely to tempt a confabulated liveness claim.
-        social["hazards"] = _unique([context_provenance_hazard] + list(social.get("hazards") or []), limit=8)
+        priority_hazards.append(context_provenance_hazard)
+    if priority_hazards:
+        social["hazards"] = _unique(priority_hazards + list(social.get("hazards") or []), limit=8)
     reverie_glimpse = _project_reverie_glimpse(ctx)
     if reverie_glimpse:
         ctx["chat_reverie_glimpse"] = reverie_glimpse

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1377,6 +1377,36 @@ def _project_self_state_from_beliefs(
     }
 
 
+def _project_context_provenance_hazard(ctx: Dict[str, Any]) -> str | None:
+    """Projection helper: name which of this turn's ctx keys are genuinely
+    live substrate/biometric signal vs. retrieved/static/tool content.
+
+    Reads the shared ``orion.schemas.context_provenance`` registry against
+    whatever keys are actually present in ``ctx`` this turn. Returns a
+    compact hazard string naming the live keys, or None when none are
+    present -- exists so a self-referential claim about "what's happening
+    right now" has a ground truth to check against instead of a
+    plausible-sounding guess (see
+    project_orion_substrate_bridge_confabulation for the incident this
+    closes: a GitHub file fetch narrated as live substrate computation).
+    """
+    from .grounding_capsule import context_provenance_for_ctx
+
+    live_keys = sorted(
+        key
+        for key, kind in context_provenance_for_ctx(ctx).items()
+        if kind == "live_runtime_projection"
+    )
+    if not live_keys:
+        return None
+    return (
+        "context_provenance: only " + ", ".join(live_keys) + " are live "
+        "signal computed this turn; anything else in context (memory "
+        "recall, static identity config, or a tool call you made) is not "
+        "live and must not be described as happening right now."
+    )
+
+
 def _project_reverie_glimpse(ctx: Dict[str, Any]) -> str | None:
     """Projection helper: surface the latest fresh, non-hollow reverie thought.
 
@@ -2513,6 +2543,14 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
     if self_state_projection:
         social["hazards"] = _unique((social.get("hazards") or []) + list(self_state_projection.get("hazards") or []), limit=8)
         ctx["chat_self_state_condition"] = self_state_projection.get("overall_condition")
+    context_provenance_hazard = _project_context_provenance_hazard(ctx)
+    if context_provenance_hazard:
+        # Prepended, not appended: this is a standing epistemic constraint, not
+        # a reactive risk flag, and _unique(..., limit=8) truncates in order --
+        # appending after two prior hazard folds means it silently drops on any
+        # turn where those already filled the cap, which is exactly the kind of
+        # eventful turn most likely to tempt a confabulated liveness claim.
+        social["hazards"] = _unique([context_provenance_hazard] + list(social.get("hazards") or []), limit=8)
     reverie_glimpse = _project_reverie_glimpse(ctx)
     if reverie_glimpse:
         ctx["chat_reverie_glimpse"] = reverie_glimpse

--- a/services/orion-cortex-exec/app/grounding_capsule.py
+++ b/services/orion-cortex-exec/app/grounding_capsule.py
@@ -58,18 +58,46 @@ def stance_slice_brief_from_step_text(text: str) -> Dict[str, Any]:
     }
 
 
+def _has_content(value: Any) -> bool:
+    """True unless the value carries no evidence at all (None, or an empty
+    dict/list/tuple/set/str). A key present in ctx only via a fallback like
+    ``ctx["pad_frame"] = pad_frame_result or {}`` degrades to an empty
+    container when the live computation didn't run or failed -- classifying
+    that as "live_runtime_projection" would be exactly the false-liveness
+    claim this registry exists to prevent. Falsy scalars (0, 0.0, False) are
+    deliberately NOT excluded here -- e.g. a real eventfulness score of 0.0 is
+    a genuine live result, not evidence of absence.
+    """
+    if value is None:
+        return False
+    if isinstance(value, (dict, list, tuple, set, str)) and len(value) == 0:
+        return False
+    return True
+
+
 def context_provenance_for_ctx(ctx: Dict[str, Any]) -> Dict[str, str]:
-    """Map every ctx key present this turn to its registered source kind.
+    """Map every ctx key present this turn (with actual content) to its
+    registered source kind.
 
     Keys with no registry entry (unclassified, not plumbing-exempt) are
     omitted rather than guessed — see CONTEXT_PROVENANCE_REGISTRY's coverage
     test for the gate that catches new ctx keys shipping unclassified.
+
+    Cached on ctx itself: this and the chat_stance.py provenance hazard both
+    scan the full registry against ctx once per turn on the live default
+    path (ORION_UNIFIED_GROUNDING_ENABLED=True) -- caching avoids doing that
+    scan twice for the same ctx.
     """
-    return {
+    cached = ctx.get("_context_provenance_cache")
+    if isinstance(cached, dict):
+        return cached
+    computed = {
         key: entry.source_kind
         for key, entry in CONTEXT_PROVENANCE_REGISTRY.items()
-        if key in ctx
+        if key in ctx and _has_content(ctx.get(key))
     }
+    ctx["_context_provenance_cache"] = computed
+    return computed
 
 
 def build_grounding_capsule(ctx: Dict[str, Any], *, pcr_ran: bool) -> GroundingCapsuleV1:

--- a/services/orion-cortex-exec/app/grounding_capsule.py
+++ b/services/orion-cortex-exec/app/grounding_capsule.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import ServiceRef
+from orion.schemas.context_provenance import CONTEXT_PROVENANCE_REGISTRY
 from orion.schemas.thought import GroundingCapsuleV1
 from orion.thought.json_extract import extract_first_json_object_text
 
@@ -57,6 +58,20 @@ def stance_slice_brief_from_step_text(text: str) -> Dict[str, Any]:
     }
 
 
+def context_provenance_for_ctx(ctx: Dict[str, Any]) -> Dict[str, str]:
+    """Map every ctx key present this turn to its registered source kind.
+
+    Keys with no registry entry (unclassified, not plumbing-exempt) are
+    omitted rather than guessed — see CONTEXT_PROVENANCE_REGISTRY's coverage
+    test for the gate that catches new ctx keys shipping unclassified.
+    """
+    return {
+        key: entry.source_kind
+        for key, entry in CONTEXT_PROVENANCE_REGISTRY.items()
+        if key in ctx
+    }
+
+
 def build_grounding_capsule(ctx: Dict[str, Any], *, pcr_ran: bool) -> GroundingCapsuleV1:
     """Assemble the capsule from identity summaries + PCR digests already in ctx."""
     return GroundingCapsuleV1(
@@ -70,6 +85,7 @@ def build_grounding_capsule(ctx: Dict[str, Any], *, pcr_ran: bool) -> GroundingC
             "identity_source": str(ctx.get("identity_kernel_source") or "unknown"),
             "pcr_ran": bool(pcr_ran),
         },
+        context_provenance=context_provenance_for_ctx(ctx),
     )
 
 

--- a/services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from app import chat_stance
@@ -12,13 +14,19 @@ def test_no_hazard_when_no_live_runtime_keys_present():
     assert _project_context_provenance_hazard(ctx) is None
 
 
-def test_hazard_names_live_runtime_keys_present():
-    ctx = {"self_state": {"overall_condition": "steady"}, "attention_broadcast": {}}
+def test_hazard_fires_when_live_runtime_key_present():
+    ctx = {"self_state": {"overall_condition": "steady"}, "attention_broadcast": {"selected_action_type": "watch"}}
     hazard = _project_context_provenance_hazard(ctx)
     assert hazard is not None
-    assert "attention_broadcast" in hazard
-    assert "self_state" in hazard
-    assert "live" in hazard
+    assert "live_runtime_projection" in hazard
+    assert len(hazard) <= 140  # must survive _unique()'s hard truncation
+
+
+def test_hazard_none_when_live_runtime_key_present_but_empty():
+    # An empty dict from a `computed_value or {}` fallback carries no real
+    # evidence of live computation -- must not be classified as live.
+    ctx = {"attention_broadcast": {}, "pad_frame": []}
+    assert _project_context_provenance_hazard(ctx) is None
 
 
 def test_hazard_ignores_plumbing_and_unregistered_keys():
@@ -53,3 +61,39 @@ async def test_build_chat_stance_inputs_no_provenance_hazard_without_live_keys(
     built = await chat_stance.build_chat_stance_inputs(ctx)
 
     assert not any(h.startswith("context_provenance:") for h in built["social"]["hazards"])
+
+
+def _beliefs_with_strained_self_state() -> UnifiedRelationalBeliefSetV1:
+    node = SimpleNamespace(
+        node_kind="concept",
+        label="self:overall_condition",
+        metadata={"overall_condition": "strained", "trajectory_condition": "stable", "prediction_error": 0.1},
+    )
+    anchor_slice = AnchorBeliefSliceV1(anchor="orion", concepts=[node])
+    return UnifiedRelationalBeliefSetV1(anchors={"orion": anchor_slice})
+
+
+@pytest.mark.asyncio
+async def test_self_state_and_provenance_hazards_both_survive_when_social_hazards_fill_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: an earlier version prepended only the provenance hazard
+    ahead of a list that could already be full, which could evict the
+    self_state severity hazard folded in just before it. Both are standing
+    safety/epistemic signals from this function's own reasoning and must
+    both survive ahead of lower-stakes social hazards when the cap bites."""
+    monkeypatch.setattr(chat_stance, "_unified_beliefs_for_stance", lambda ctx: _beliefs_with_strained_self_state())
+    filler_hazards = [f"filler_social_hazard_{i}" for i in range(8)]
+    monkeypatch.setattr(
+        chat_stance,
+        "_project_social_from_beliefs",
+        lambda beliefs, ctx: ({"hazards": filler_hazards}, {}),
+    )
+
+    ctx = {"user_message": "hello", "self_state": {"overall_condition": "strained"}}
+    built = await chat_stance.build_chat_stance_inputs(ctx)
+
+    hazards = built["social"]["hazards"]
+    assert len(hazards) == 8  # cap still enforced
+    assert any(h.startswith("self_state overall_condition=strained") for h in hazards)
+    assert any(h.startswith("context_provenance:") for h in hazards)

--- a/services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from app import chat_stance
+from app.chat_stance import _project_context_provenance_hazard
+from orion.substrate.relational.beliefs import AnchorBeliefSliceV1, UnifiedRelationalBeliefSetV1
+
+
+def test_no_hazard_when_no_live_runtime_keys_present():
+    ctx = {"user_message": "hello", "orion_identity_summary": ["I am Oríon."]}
+    assert _project_context_provenance_hazard(ctx) is None
+
+
+def test_hazard_names_live_runtime_keys_present():
+    ctx = {"self_state": {"overall_condition": "steady"}, "attention_broadcast": {}}
+    hazard = _project_context_provenance_hazard(ctx)
+    assert hazard is not None
+    assert "attention_broadcast" in hazard
+    assert "self_state" in hazard
+    assert "live" in hazard
+
+
+def test_hazard_ignores_plumbing_and_unregistered_keys():
+    ctx = {"trace_id": "t-1", "correlation_id": "c-1", "some_unclassified_key": "x"}
+    assert _project_context_provenance_hazard(ctx) is None
+
+
+def _empty_beliefs() -> UnifiedRelationalBeliefSetV1:
+    anchor_slice = AnchorBeliefSliceV1(anchor="orion", concepts=[])
+    return UnifiedRelationalBeliefSetV1(anchors={"orion": anchor_slice})
+
+
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_folds_provenance_hazard_when_live_key_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chat_stance, "_unified_beliefs_for_stance", lambda ctx: _empty_beliefs())
+
+    ctx = {"user_message": "hello", "self_state": {"overall_condition": "steady"}}
+    built = await chat_stance.build_chat_stance_inputs(ctx)
+
+    assert any(h.startswith("context_provenance:") for h in built["social"]["hazards"])
+
+
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_no_provenance_hazard_without_live_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chat_stance, "_unified_beliefs_for_stance", lambda ctx: _empty_beliefs())
+
+    ctx = {"user_message": "hello"}
+    built = await chat_stance.build_chat_stance_inputs(ctx)
+
+    assert not any(h.startswith("context_provenance:") for h in built["social"]["hazards"])

--- a/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
+++ b/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
@@ -5,6 +5,7 @@ import pytest
 from app.grounding_capsule import (
     assemble_stance_grounding,
     build_grounding_capsule,
+    context_provenance_for_ctx,
     stance_slice_brief_from_step_text,
 )
 from app.settings import Settings
@@ -27,6 +28,23 @@ def test_build_grounding_capsule_from_ctx() -> None:
     assert capsule.memory_digest == "We were mid-refactor.\n\nOrion values continuity."
     assert capsule.provenance["identity_source"] == "configured_yaml"
     assert capsule.provenance["pcr_ran"] is True
+    assert capsule.context_provenance["orion_identity_summary"] == "static_identity_config"
+    assert capsule.context_provenance["belief_digest"] == "derived_summary"
+    assert capsule.context_provenance["memory_digest"] == "memory_recall"
+
+
+def test_context_provenance_for_ctx_only_includes_present_keys() -> None:
+    ctx = {"self_state": {"overall_condition": "steady"}, "user_message": "hi"}
+    provenance = context_provenance_for_ctx(ctx)
+    assert provenance == {
+        "self_state": "live_runtime_projection",
+        "user_message": "user_input",
+    }
+
+
+def test_context_provenance_for_ctx_omits_unregistered_keys() -> None:
+    ctx = {"some_new_key_nobody_classified_yet": "value"}
+    assert context_provenance_for_ctx(ctx) == {}
 
 
 def test_build_grounding_capsule_identity_only_when_pcr_missing() -> None:

--- a/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
+++ b/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
@@ -47,6 +47,34 @@ def test_context_provenance_for_ctx_omits_unregistered_keys() -> None:
     assert context_provenance_for_ctx(ctx) == {}
 
 
+def test_context_provenance_for_ctx_excludes_empty_fallback_values() -> None:
+    # ctx["pad_frame"] = pad_frame_result or {} degrades to an empty dict when
+    # the live computation didn't run or failed -- must not be classified as
+    # "live_runtime_projection" just because the key is present.
+    ctx = {
+        "self_state": {"overall_condition": "steady"},
+        "pad_frame": {},
+        "system_alert_tags": [],
+        "belief_digest": None,
+        "substrate_eventfulness_score": 0.0,
+    }
+    provenance = context_provenance_for_ctx(ctx)
+    assert provenance == {
+        "self_state": "live_runtime_projection",
+        # a real live score of exactly 0.0 is genuine content, not absence:
+        "substrate_eventfulness_score": "live_runtime_projection",
+    }
+
+
+def test_context_provenance_for_ctx_caches_on_ctx() -> None:
+    ctx = {"self_state": {"overall_condition": "steady"}}
+    first = context_provenance_for_ctx(ctx)
+    assert ctx["_context_provenance_cache"] is first
+    ctx["self_state"] = {"overall_condition": "strained"}  # mutate after caching
+    second = context_provenance_for_ctx(ctx)
+    assert second is first  # cache reused, not recomputed
+
+
 def test_build_grounding_capsule_identity_only_when_pcr_missing() -> None:
     ctx = {
         "orion_identity_summary": ["I am Oríon."],


### PR DESCRIPTION
## Summary

- New `orion/schemas/context_provenance.py`: a registry classifying every ctx key that flows into a chat turn as one of `live_runtime_projection` / `derived_summary` / `memory_recall` / `static_identity_config` / `user_input` / `external_tool_fetch`, or `PLUMBING_KEYS` for routing bookkeeping with no cognitive content.
- `GroundingCapsuleV1.context_provenance` carries the classification through to `orion/harness/prefix.py`'s `compile_harness_prefix`, which renders it as a `CONTEXT PROVENANCE` block in the literal FCC motor prompt — the actual prompt for the agentic session with MCP tool access.
- `build_metacog_substrate_cue` tags its cue with the registry's source kind.
- `chat_stance.py` folds a standing "only these keys are live" hazard into the existing hazards mechanism.

## Outcome moved

Closes the mechanism behind a real incident: Orion narrated a GitHub-MCP file fetch (`mcp__github__get_file_contents` against `pressure.py`/`dynamics.py`/`attention_broadcast.py`) as live substrate computation "happening this turn." Investigation traced two failure modes: (1) the actual live substrate cue is a terse `self_state`/`eventfulness` string with no mechanism-level detail, and (2) nothing anywhere distinguished "live runtime signal" from "retrieved memory," "static config," or "content fetched via a tool call this turn" at the point Orion talks about itself. This PR closes (2).

## Current architecture

`executor.py` assembles ~80 keys into a single `ctx` dict across a 4000-line turn pipeline with no shared provenance metadata. `GroundingCapsuleV1` already carried a `provenance` dict, but only for `identity_source`/`pcr_ran`. `orion/schemas/cognition/answer_contract.py` already modeled evidence-typed claims (`repo_file`/`runtime_log`/etc.) but only for the investigation/technical verb lane (`supervisor.py`), never wired into casual chat (`executor.py`/`chat_stance.py`).

## Architecture touched

- `orion/schemas/context_provenance.py` (new): the registry + `PLUMBING_KEYS` exemption set + `classify()`.
- `orion/schemas/thought.py`: `GroundingCapsuleV1.context_provenance: dict[str, str]`.
- `services/orion-cortex-exec/app/grounding_capsule.py`: `context_provenance_for_ctx()` populates it.
- `orion/harness/prefix.py`: `_format_context_provenance_block()` renders it into `compile_harness_prefix`'s literal motor prompt.
- `orion/substrate/metacog_trigger_signals.py`: `build_metacog_substrate_cue()` tags its output.
- `services/orion-cortex-exec/app/chat_stance.py`: `_project_context_provenance_hazard()`, folded into the existing `_project_self_state_from_beliefs` hazards mechanism.

## Files changed

- `orion/schemas/context_provenance.py`: new registry (61 classified keys + 27 plumbing-exempt keys, exact coverage of the live `ctx` key snapshot).
- `orion/schemas/thought.py`: added `context_provenance` field to `GroundingCapsuleV1`.
- `services/orion-cortex-exec/app/grounding_capsule.py`: added `context_provenance_for_ctx()`, wired into `build_grounding_capsule()`.
- `orion/harness/prefix.py`: added `_format_context_provenance_block()`, wired into `_format_grounding_self_block()`.
- `orion/substrate/metacog_trigger_signals.py`: cue now tagged with `(source=live_runtime_projection)`.
- `services/orion-cortex-exec/app/chat_stance.py`: added `_project_context_provenance_hazard()`, folded into `build_chat_stance_inputs()`'s hazards list (prepended, not appended — see review findings below).
- Tests: `orion/schemas/tests/test_context_provenance.py`, `services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py`, plus extensions to `test_grounding_capsule_assembly.py`, `test_metacog_trigger_signals.py`, `test_harness_prefix.py`.

## Schema / bus / API changes

- Added: `GroundingCapsuleV1.context_provenance: dict[str, str]` (additive, default `{}`).
- No removals, no renames, no bus/channel changes.
- Compatibility: fully additive; existing consumers of `GroundingCapsuleV1` unaffected.

## Env/config changes

None. No new env keys.

## Tests run

```text
PYTHONPATH=<worktree>:<worktree>/services/orion-cortex-exec venv/bin/python -m pytest \
  orion/schemas/tests/test_context_provenance.py \
  orion/substrate/tests/test_metacog_trigger_signals.py \
  orion/harness/tests/test_harness_prefix.py \
  services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py \
  services/orion-cortex-exec/tests/test_chat_stance_context_provenance_hazard.py \
  services/orion-cortex-exec/tests/test_chat_stance_self_state_projection.py \
  -q
49 passed

Broader regression sweep (services/orion-cortex-exec/tests/test_chat_stance_*.py,
test_grounding_capsule*.py, test_router_grounding_capsule_metadata.py, orion/harness/tests):
223 passed, 7 failed -- all 7 confirmed present and identical on unmodified main
(2 test-order-dependent pre-existing failures, verified by running the same
batch against main; 3 unrelated pre-existing bugs -- a Jinja `mind_coloring`
UndefinedError and an fcc_timeout error-code string mismatch, verified the
same way). Zero regressions from this patch.
```

## Evals run

No dedicated eval harness exists for this seam; the registry-coverage tests above (`test_live_snapshot_fully_covered`, `test_static_ctx_assignments_covered`) function as the deterministic gate this repo's CLAUDE.md asks for in place of an eval.

## Docker/build/smoke checks

Not run — this patch changes prompt-assembly Python only (schema, registry, string rendering); no config read at boot, no new deps, no compose/port/worker changes.

## Review findings fixed

- Finding: `_project_context_provenance_hazard`'s hazard was appended after two prior `_unique(..., limit=8)` folds, so it silently dropped whenever the hazards list was already full -- exactly on the eventful turns most likely to need it.
  - Fix: prepend instead of append in the fold-in (`chat_stance.py`), so it survives the cap.
  - Evidence: `test_build_chat_stance_inputs_folds_provenance_hazard_when_live_key_present` passes; fix documented inline with the reasoning.
- Finding: `GroundingCapsuleV1.context_provenance` was populated but had zero consumers anywhere in the codebase -- write-only data, a schema+producer with no consumer (this repo's CLAUDE.md explicitly bans that shape).
  - Fix: wired into `orion/harness/prefix.py`'s `_format_grounding_self_block`, the actual function that renders the capsule into the literal FCC-motor prompt (`compile_harness_prefix`, which spawns the `claude -p` agentic session with MCP tool access -- the exact pathway implicated in the original incident).
  - Evidence: `test_compile_harness_prefix_includes_context_provenance_when_capsule_has_it` / `..._omits_context_provenance_when_capsule_empty`.
- Finding: only the `self_state` clause of `build_metacog_substrate_cue`'s output got the `(source=...)` tag; the `execution_trajectory_projection`/`eventfulness` clauses in the same cue string were left untagged despite the docstring's claim.
  - Fix: moved the tag to apply once, after all clauses are assembled.
  - Evidence: `test_build_metacog_substrate_cue_tags_its_own_provenance`.
- Finding: `_project_context_provenance_hazard` duplicated the registry-scan-and-filter loop already in `grounding_capsule.py`'s `context_provenance_for_ctx`, risking silent divergence if the filtering logic changes in one place and not the other.
  - Fix: `chat_stance.py` now imports and reuses `context_provenance_for_ctx` instead of re-scanning the registry.
  - Evidence: existing hazard tests still pass after the refactor.
- Finding: `test_live_snapshot_fully_covered`'s hand-maintained key snapshot has no automated link to the real ctx-assembly code, so a new ctx key only gets caught if an author remembers to update the frozenset by hand.
  - Fix: added `test_static_ctx_assignments_covered`, which statically parses `executor.py` for literal `ctx["key"] = ...`/`ctx.setdefault(...)` assignments and asserts registry+plumbing coverage against that -- an automated safety net for the common case (doesn't replace the hand snapshot, which is still needed for keys set via dict merges in other modules, but catches direct assignments without hand-maintenance). This immediately caught 17 previously-unclassified keys (`chat_stance_brief`, `collapse_entry`, `speech_contract`, etc.), now classified.
  - Evidence: `test_static_ctx_assignments_covered` passes after classifying the 17 keys it surfaced.
- Finding: `"external_tool_fetch"` is defined in the enum but never assigned to any registry entry or ctx key -- the literal incident category (a GitHub MCP fetch) has no producer key anywhere, since harness-level MCP tool calls are invisible to this repo's `ctx` dict.
  - Not fixed in this patch -- this is an out-of-repo scope gap, disclosed below under Risks/Concerns, not silently left uncovered.

## Restart required

```text
No restart required (this changes prompt-assembly logic only; picked up on next
cortex-exec / cortex-exec-chat deploy or restart of those containers, whenever
that patch is next deployed).
```

## Risks / concerns

- Severity: Medium
- Concern: `"external_tool_fetch"` has no producer anywhere in this repo. The original incident's actual mechanism -- an agentic session calling `mcp__github__get_file_contents` mid-turn -- is invisible to `orion/`'s `ctx` dict, because that tool call happens at the harness/session level, outside this repo's own pipeline. This PR's `CONTEXT PROVENANCE` block in the FCC motor prompt (`orion/harness/prefix.py`) at least gives the motor a standing instruction about what *is* live before it reaches for a tool -- a preventive nudge -- but there is no detection or tagging of the tool call itself if one happens anyway.
- Mitigation: flagged during design (see `project_orion_substrate_bridge_confabulation` memory and the design-mode spec that preceded this patch) as requiring a harness-level fix outside this repo's scope. Follow-up: instrument the harness/session layer's MCP tool-result formatting to tag fetched content with provenance at the source, if that layer is addressable.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/context-provenance-registry