### PR TITLE
chore(graphify): sync knowledge graph with today's 5 merged PRs

### DIFF
--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -4,11 +4,6 @@
     "ast_hash": "612bd60d0903ad81b4bd319a074d580e",
     "semantic_hash": "612bd60d0903ad81b4bd319a074d580e"
   },
-  ".claude/settings.local.json": {
-    "mtime": 1781757826.5226443,
-    "ast_hash": "711eaddfadf9c93a51750d7d33bbb155",
-    "semantic_hash": "711eaddfadf9c93a51750d7d33bbb155"
-  },
   ".verify-run/disk.json": {
     "mtime": 1775948546.048512,
     "ast_hash": "c0cfbb1db29836ae4a3767bc29a4c39e",
@@ -19478,10 +19473,5 @@
     "mtime": 1784008374.246501,
     "ast_hash": "0c2e463317dce3ea4bc31c3550841ff1",
     "semantic_hash": "0c2e463317dce3ea4bc31c3550841ff1"
-  },
-  "reviews/pending/2026-07-14-agent-worktree-discipline-and-graphify-sync-spec.md": {
-    "mtime": 1784008006.0574543,
-    "ast_hash": "fad87289461d90a247ce68fb178e4b1e",
-    "semantic_hash": "fad87289461d90a247ce68fb178e4b1e"
   }
 }


### PR DESCRIPTION
## Summary

Refreshes graphify-out/graph.json + manifest.json, stale since 08:30 this morning (the Postgres schema merge), missing 55 changed .py/.sh files across today's five merged PRs: #1041, #1044, #1046, #1050, #1051.

## Why this PR exists

Prompted by an unrelated but directly relevant data point: a fresh coding-agent session in this repo, asked whether it used the new graphify tooling, self-reported the exact same gap -- used graphify to orient at the start, did all real work with direct Read/grep, and never ran `graphify update .` afterward, leaving the graph stale relative to its own branch. Checked whether this session had the same gap. It did.

The root cause: the post-commit auto-rebuild hook (`graphify hook install`, set up earlier today) only fires on commits *in the primary checkout*. Every commit today happened in a worktree per this repo's own policy, and `git pull --ff-only` doesn't trigger a post-commit hook at all -- so the auto-rebuild mechanism never had a chance to fire for any of today's work.

## Tests run

Not applicable -- generated artifact, not code.

## What changed

Incremental update (`graphify update . --no-cluster`, deterministic AST re-extraction, no LLM): 1559 nodes, 2095 edges rebuilt from the 55 changed files.

Also reported by the tool itself (not an error): "kept 28186 node(s) from 3403 file(s) that left the scan corpus but still exist on disk" -- graphify's fail-closed default when files it previously indexed no longer match the current scan. Most likely explanation: the 202 worktrees pruned earlier today (`scripts/prune_merged_worktrees.py --yes`) removed a lot of files graphify had cached results for. Not purged here -- that would need a full re-extraction, a bigger and slower operation, and this PR is scoped to the fast incremental sync only.

## Risks / concerns

None -- generated data file, no behavior change.

## PR link

(filled in by gh pr create)