### PR TITLE
fix(graphify): revert destructive graph update that shipped on main

### DIFF
--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -4,6 +4,11 @@
     "ast_hash": "612bd60d0903ad81b4bd319a074d580e",
     "semantic_hash": "612bd60d0903ad81b4bd319a074d580e"
   },
+  ".claude/settings.local.json": {
+    "mtime": 1781757826.5226443,
+    "ast_hash": "711eaddfadf9c93a51750d7d33bbb155",
+    "semantic_hash": "711eaddfadf9c93a51750d7d33bbb155"
+  },
   ".verify-run/disk.json": {
     "mtime": 1775948546.048512,
     "ast_hash": "c0cfbb1db29836ae4a3767bc29a4c39e",
@@ -19473,5 +19478,10 @@
     "mtime": 1784008374.246501,
     "ast_hash": "0c2e463317dce3ea4bc31c3550841ff1",
     "semantic_hash": "0c2e463317dce3ea4bc31c3550841ff1"
+  },
+  "reviews/pending/2026-07-14-agent-worktree-discipline-and-graphify-sync-spec.md": {
+    "mtime": 1784008006.0574543,
+    "ast_hash": "fad87289461d90a247ce68fb178e4b1e",
+    "semantic_hash": "fad87289461d90a247ce68fb178e4b1e"
   }
 }


### PR DESCRIPTION
## Summary

Reverts `graphify-out/graph.json`/`manifest.json` on main back to the last known-good state (commit `77ea7e2d`, 31566 nodes). PR #1057 merged with a version that had shrunk to 1559 nodes -- a ~95% loss -- currently live on main right now.

## What happened, plainly

I ran `graphify update .` (both from the main checkout and, separately, from a worktree -- same result both times), got a log message claiming to have "kept" the old nodes, did not verify the actual file content, committed it, and opened PR #1057 with a description incorrectly characterizing it as a safe incremental sync. It merged before I discovered -- via an independent, correct diagnosis from a different session that caught the same failure *before* committing -- that the update was destructive. I pushed a revert commit to that same branch, but the PR had already merged with only the bad commit included, so the revert never reached main. This PR fixes that directly.

## Root cause

The original 31566-node graph was built scanning worktree-nested directories (`.worktrees/*`, `.claude/worktrees/*`), which held duplicate copies of the same source files across ~80 worktrees at build time. An incremental `graphify update .` run against today's much smaller real file set can't reconcile against that duplicate-heavy baseline -- graphify's own "fail-closed: kept N nodes from M files" log message does not accurately describe what actually lands in the rebuilt `graph.json`.

## Tests run

Not applicable -- generated data file. Verified node count directly: `python3 -c "import json; print(len(json.load(open('graphify-out/graph.json'))['nodes']))"` → 31566, matching commit 77ea7e2d.

## Risks / concerns

- Severity: Low (this PR). Restores known-good state.
- Severity: Medium, unresolved: the graph is genuinely stale relative to today's 5 merged PRs, and I don't yet understand why incremental update disagrees with itself about what it "kept." Not re-attempting a fix in this PR -- needs actual investigation (likely a full re-extraction, not incremental) before another try.

## PR link

(filled in by gh pr create)