### PR TITLE
feat(harness): post-hoc tool-provenance mismatch audit for the FCC motor

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-15-fcc-tool-provenance-audit-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-15-fcc-tool-provenance-audit-pr.md
@@ -1,0 +1,98 @@
+# PR report: post-hoc tool-provenance mismatch audit for the FCC motor
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1060
+Branch: `feat/fcc-tool-provenance-audit`
+
+## Summary
+
+- `orion/harness/tool_provenance_audit.py`: pure `detect_tool_provenance_mismatch(draft_text, receipts)` — flags when a turn's draft uses live-immediacy language ("this turn", "right now", "happening now", "in the background") while that same turn's tool trace shows a fetch-shaped tool call (`get_file_contents`, `read_file`, web fetch, etc.).
+- Wired into `HarnessRunner.run()`: computed once after the FCC subprocess stream completes, before either lifecycle-publish path, so it reaches both the empty-draft and success return paths.
+- `HarnessMotorResult`/`HarnessDraftMoleculeV1` both get a new `tool_provenance_audit: str | None` field, kept deliberately separate from the existing `grounding_status` field.
+- `HarnessGrammarCollector.record_tool_provenance_mismatch()` publishes a `GrammarAtomV1(atom_type="uncertainty_marker")` on the same grammar bus channel every other harness event already uses, plus a correlation-ID'd warning log.
+
+## Outcome moved
+
+Closes the audit half of a real incident: Orion narrated a GitHub-MCP file fetch as live substrate computation "happening this turn." A prior PR (#1056) fixed the prevention side (the FCC motor's own system prompt now carries a `CONTEXT PROVENANCE` block). This PR closes the detection side: since the FCC motor is a single-shot `claude -p` subprocess with no mid-run injection point (confirmed by reading `fcc_motor.py` — nothing can reach back into a live run to stop a confabulation before it's generated), the only remaining lever is a post-hoc check comparing what the draft claims against what the turn's own tool trace shows. That's what this PR builds.
+
+## Current architecture
+
+`orion/harness/fcc_motor.py::run_fcc_turn` spawns the FCC motor as a single-shot `claude` subprocess and streams back JSON events; `_summarize_content_blocks`/`_tool_result_body_text` already parse every `tool_use`/`tool_result` block. `HarnessRunner.run()` (`orion/harness/runner.py`) consumes that stream, publishing each step as a `GrammarReceiptV1` via the existing grammar bus/schema contract (`orion/grammar/publish.py`), and captures `draft_text` from the `final` event — both available together, in the same function, before the turn's result is returned. `HarnessMotorResult.grounding_status` already exists but is an overloaded error/overflow code with real downstream consumers (`orion/hub/turn_orchestrator.py`, `services/orion-harness-governor/app/bus_listener.py`) that surface it as `base["error"] = ...` — confirmed via grep that repurposing it for this signal would misreport a soft audit as a hard motor failure, so this uses a new, separate field instead.
+
+## Architecture touched
+
+- `orion/harness/tool_provenance_audit.py` (new)
+- `orion/harness/runner.py`
+- `orion/harness/grammar_emit.py`
+- `orion/schemas/harness_finalize.py`
+
+## Files changed
+
+- `orion/harness/tool_provenance_audit.py`: new, pure detection function + two regexes (fetch-shaped tool names, immediacy language).
+- `orion/harness/runner.py`: computes the audit once per turn in `HarnessRunner.run()`, threads it into both `HarnessMotorResult` return sites and `build_draft_molecule()`.
+- `orion/harness/grammar_emit.py`: new `HarnessGrammarCollector.record_tool_provenance_mismatch()` method.
+- `orion/schemas/harness_finalize.py`: `HarnessDraftMoleculeV1.tool_provenance_audit: str | None = None`.
+- Tests: `orion/harness/tests/test_tool_provenance_audit.py` (9 unit tests), extensions to `test_harness_runner.py` (2 integration tests) and `test_harness_grammar_emit.py` (2 tests, including an edge-topology regression test).
+
+## Schema / bus / API changes
+
+- Added: `HarnessMotorResult.tool_provenance_audit: str | None = None`, `HarnessDraftMoleculeV1.tool_provenance_audit: str | None = None` — both additive with safe defaults.
+- Added: a new grammar atom `semantic_role="exec_tool_provenance_mismatch"` (`atom_type="uncertainty_marker"`, an existing enum value — no new AtomType needed), published on the existing `orion:grammar:event` channel.
+- Removed: none. Renamed: none.
+- Behavior changed: none for any turn without a tool-provenance mismatch (field stays `None`, no new atom emitted). `grounding_status`/`compliance_verdict` are explicitly untouched by design.
+- Compatibility notes: fully additive; `HarnessDraftMoleculeV1` has no `extra="forbid"`, `HarnessMotorResult` is a plain dataclass with the field appended last with a default — verified no downstream construction site breaks.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=<worktree> venv/bin/python -m pytest \
+  orion/harness/tests/test_tool_provenance_audit.py \
+  orion/harness/tests/test_harness_runner.py \
+  orion/harness/tests/test_harness_grammar_emit.py \
+  -q
+20 passed, 1 failed (test_harness_runner_surfaces_fcc_error_code -- confirmed
+pre-existing on unmodified main, unrelated to this diff: an error-code string
+mismatch, "fcc turn timed out after 120.0s" != "fcc_timeout")
+
+Full orion/harness/tests suite: 123 passed, 3 failed -- same pre-existing
+failure above plus two unrelated Jinja UndefinedError failures in
+test_grounding_capsule_consumers.py, both independently confirmed present
+and identical on unmodified main. Zero regressions from this patch.
+```
+
+## Evals run
+
+No dedicated eval harness exists for this seam. The regression tests above (particularly the edge-topology test for the grammar-graph fix below) function as the deterministic gate.
+
+## Docker/build/smoke checks
+
+Not run — this changes harness/schema Python only, no config read at boot, no new dependencies, no compose/port/worker changes.
+
+## Review findings fixed
+
+- Finding: `_IMMEDIACY_PATTERN`'s bare `\bcomputing\b` alternative (in the phase-1 commit) had no temporal/proximity qualifier, so it false-positived on any generic use of the word ("cloud computing costs are rising").
+  - Fix: dropped that alternative. The incident's actual phrase ("computing in the background this turn") is still caught by "in the background"/"this turn" alone.
+  - Evidence: `test_no_flag_for_generic_use_of_the_word_computing` regression test.
+- Finding: `HarnessGrammarCollector.record_tool_provenance_mismatch` didn't update `self._last_completed_atom_id`, unlike its sibling terminal methods (`record_step_completed`, `record_step_failed`) — so the subsequent `record_result_assembled`'s own `derived_from` edge still pointed at the last *step* atom instead of the mismatch atom, leaving it a graph leaf with an incoming edge but no outgoing edge into the result-assembled/emitted chain, despite being semantically about the result.
+  - Fix: one-line addition setting `self._last_completed_atom_id` after emitting the atom.
+  - Evidence: `test_record_tool_provenance_mismatch_becomes_last_completed_atom`, which asserts the edge from the mismatch atom to the `exec_result_assembled` atom actually exists in the built event graph.
+
+## Restart required
+
+```text
+No restart required to review/merge. Once merged, takes effect on the next
+deploy/restart of whatever service runs HarnessRunner (orion-harness-governor).
+```
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: This is a post-hoc audit only — by design, it cannot prevent a confabulation in the same generation (the FCC motor subprocess has already run to completion by the time this check runs). It also doesn't yet feed back into a future turn's context (no cross-turn continuity) or reinstate `external_tool_fetch` in `orion/schemas/context_provenance.py` (from PR #1056), since that touches a different subsystem (`services/orion-cortex-exec`'s chat `ctx` pipeline) and was deliberately scoped out of this patch.
+- Mitigation: tracked as an explicit next step, not silently dropped — see `project_orion_substrate_bridge_confabulation` memory and the design-mode spec that preceded this patch.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1060

--- a/orion/harness/grammar_emit.py
+++ b/orion/harness/grammar_emit.py
@@ -255,6 +255,44 @@ class HarnessGrammarCollector:
             self._edge_specs.append((started.atom_id, atom.atom_id, "derived_from"))
         self._last_completed_atom_id = atom.atom_id
 
+    def record_tool_provenance_mismatch(self, *, mismatch: str) -> None:
+        """Draft used live-immediacy language while this turn's own tool
+        trace shows a fetch-shaped call -- the confabulation pattern from
+        project_orion_substrate_bridge_confabulation. uncertainty_marker is
+        the right atom_type here (same as record_step_failed): not a hard
+        motor failure, but a flag on the claim's own grounding."""
+        ref = f"harness.exec.tool_provenance:{self.correlation_id}"
+        self._put_atom(
+            "exec_tool_provenance_mismatch",
+            GrammarAtomV1(
+                atom_id=self._atom_id("exec_tool_provenance_mismatch"),
+                trace_id=self.trace_id,
+                atom_type="uncertainty_marker",
+                semantic_role="exec_tool_provenance_mismatch",
+                layer="result",
+                dimensions=["execution", "grounding", "tool_use"],
+                summary=mismatch,
+                confidence=0.7,
+                salience=0.8,
+                source_event_id=self.correlation_id,
+                payload_ref=ref,
+            ),
+        )
+        if self._last_completed_atom_id:
+            self._edge_specs.append(
+                (
+                    self._last_completed_atom_id,
+                    self._atoms["exec_tool_provenance_mismatch"].atom_id,
+                    "derived_from",
+                )
+            )
+        # Unlike record_step_failed, this atom was missing this update --
+        # without it, record_result_assembled's own derived_from edge still
+        # points at the last *step* atom instead of this one, leaving the
+        # mismatch atom a graph leaf with no outgoing edge into the
+        # result-assembled/emitted chain despite being about the result.
+        self._last_completed_atom_id = self._atoms["exec_tool_provenance_mismatch"].atom_id
+
     def record_result_assembled(
         self,
         *,

--- a/orion/harness/runner.py
+++ b/orion/harness/runner.py
@@ -26,6 +26,7 @@ from orion.harness.grammar_publish import publish_harness_step_grammar
 from orion.harness.prefix import compile_harness_prefix, harness_motor_instruction
 from orion.harness.repair import map_repair_pressure_contract
 from orion.harness.step_stream import publish_harness_run_step
+from orion.harness.tool_provenance_audit import detect_tool_provenance_mismatch
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import (
     GrammarReceiptV1,
@@ -50,6 +51,12 @@ class HarnessMotorResult:
     grounding_status: str = "grounded"
     draft_molecule: HarnessDraftMoleculeV1 | None = None
     grammar_collector: HarnessGrammarCollector | None = None
+    # Distinct from grounding_status: that field is an overloaded error/
+    # overflow code already surfaced as a user-visible error by downstream
+    # consumers (orion/hub/turn_orchestrator.py, orion-harness-governor).
+    # This is a soft audit signal, not a motor failure -- never repurpose
+    # grounding_status for it.
+    tool_provenance_audit: str | None = None
 
 
 def _default_harness_node_name() -> str:
@@ -116,6 +123,7 @@ def build_draft_molecule(
     grammar_receipts: list[GrammarReceiptV1],
     coalition_snapshot: CoalitionSnapshotV1,
     repair_overlay: HarnessRepairOverlayV1,
+    tool_provenance_audit: str | None = None,
 ) -> HarnessDraftMoleculeV1:
     return HarnessDraftMoleculeV1(
         correlation_id=correlation_id,
@@ -126,6 +134,7 @@ def build_draft_molecule(
         grammar_receipts=list(grammar_receipts),
         coalition_snapshot=coalition_snapshot,
         repair_overlay_mode=repair_overlay.mode if repair_overlay.mode != "default" else None,
+        tool_provenance_audit=tool_provenance_audit,
     )
 
 
@@ -301,6 +310,21 @@ class HarnessRunner:
                 )
                 break
 
+        # Post-hoc audit, not prevention: the fcc subprocess has already run
+        # to completion by this point, so this can only flag a mismatch
+        # between what the draft claims and this turn's own tool trace, not
+        # stop it before generation. Computed once here (before either
+        # _publish_motor_lifecycle call) so both the empty-draft and success
+        # paths' grammar events pick it up via build_harness_grammar_events.
+        tool_provenance_audit = detect_tool_provenance_mismatch(draft_text, receipts)
+        if tool_provenance_audit:
+            collector.record_tool_provenance_mismatch(mismatch=tool_provenance_audit)
+            logger.warning(
+                "harness_tool_provenance_mismatch corr=%s detail=%s",
+                request.correlation_id,
+                tool_provenance_audit,
+            )
+
         async def _publish_motor_lifecycle(*, status: str, final_text_present: bool) -> None:
             collector.record_result_assembled(
                 status=status,
@@ -348,6 +372,7 @@ class HarnessRunner:
                 compliance_verdict=compliance_verdict if compliance_verdict != "completed" else "failed",
                 grounding_status=grounding_status if grounding_status != "grounded" else "empty_draft",
                 grammar_collector=collector,
+                tool_provenance_audit=tool_provenance_audit,
             )
 
         await _publish_motor_lifecycle(status="success", final_text_present=False)
@@ -359,6 +384,7 @@ class HarnessRunner:
             grammar_receipts=receipts,
             coalition_snapshot=coalition,
             repair_overlay=overlay,
+            tool_provenance_audit=tool_provenance_audit,
         )
         logger.info(
             "harness_motor_complete corr=%s steps=%s grammar_receipts=%s verdict=%s grounding=%s draft_len=%s",
@@ -378,4 +404,5 @@ class HarnessRunner:
             grounding_status=grounding_status,
             draft_molecule=molecule,
             grammar_collector=collector,
+            tool_provenance_audit=tool_provenance_audit,
         )

--- a/orion/harness/tests/test_harness_grammar_emit.py
+++ b/orion/harness/tests/test_harness_grammar_emit.py
@@ -54,6 +54,47 @@ def test_build_events_include_lifecycle_roles() -> None:
     assert "thinking_source=harness_fcc" in assembled.atom.summary
 
 
+def test_record_tool_provenance_mismatch_emits_uncertainty_marker_atom() -> None:
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    c.record_request_received()
+    c.record_step_started(order=1, summary="fcc step")
+    c.record_step_completed(order=1)
+    c.record_tool_provenance_mismatch(mismatch="tool_provenance_mismatch: draft uses live-immediacy language...")
+    events = build_harness_grammar_events(c)
+    atom = next(e for e in events if e.atom and e.atom.semantic_role == "exec_tool_provenance_mismatch")
+    assert atom.atom.atom_type == "uncertainty_marker"
+    assert atom.atom.summary.startswith("tool_provenance_mismatch:")
+
+
+def test_record_tool_provenance_mismatch_becomes_last_completed_atom() -> None:
+    """Regression: record_tool_provenance_mismatch must update
+    _last_completed_atom_id like its sibling terminal methods do, or the
+    subsequent record_result_assembled's own derived_from edge points past
+    it at the last *step* atom, leaving the mismatch atom a graph leaf with
+    no outgoing edge into the result-assembled chain."""
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    c.record_request_received()
+    c.record_step_started(order=1, summary="fcc step")
+    c.record_step_completed(order=1)
+    c.record_tool_provenance_mismatch(mismatch="tool_provenance_mismatch: ...")
+    c.record_result_assembled(
+        status="success",
+        final_text_present=True,
+        step_count=1,
+        grammar_receipt_count=1,
+        reflection_ran=False,
+        quick_lane_skipped_5b=True,
+    )
+    events = build_harness_grammar_events(c)
+    mismatch_atom = next(e.atom for e in events if e.atom and e.atom.semantic_role == "exec_tool_provenance_mismatch")
+    assembled_atom = next(e.atom for e in events if e.atom and e.atom.semantic_role == "exec_result_assembled")
+    edges = [e.edge for e in events if e.edge]
+    assert any(
+        edge.from_atom_id == mismatch_atom.atom_id and edge.to_atom_id == assembled_atom.atom_id
+        for edge in edges
+    )
+
+
 def test_finalize_events_emit_only_assembled_and_egress() -> None:
     c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
     c.record_request_received()

--- a/orion/harness/tests/test_harness_runner.py
+++ b/orion/harness/tests/test_harness_runner.py
@@ -79,6 +79,71 @@ async def test_harness_runner_collects_grammar_receipts_and_draft() -> None:
     assert result.compliance_verdict == "completed"
 
 
+async def _mock_fcc_runner_fetch_then_confabulate(**_: Any) -> AsyncIterator[dict[str, Any]]:
+    yield {
+        "type": "step",
+        "step": {
+            "type": "assistant",
+            "raw": {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "mcp__github__get_file_contents", "input": {}},
+                    ]
+                },
+            },
+        },
+    }
+    yield {
+        "type": "final",
+        "llm_response": "This is computing in the background right now.",
+        "metadata": {"exit_code": 0},
+    }
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_flags_tool_provenance_mismatch() -> None:
+    thought = make_thought()
+    request = HarnessRunRequestV1(
+        correlation_id="c-mismatch",
+        thought_event=thought,
+        user_message="what's live right now?",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    bus = AsyncMock()
+    runner = HarnessRunner(bus, fcc_runner=_mock_fcc_runner_fetch_then_confabulate)
+
+    result = await runner.run(request)
+
+    assert result.tool_provenance_audit is not None
+    assert "mcp__github__get_file_contents" in result.tool_provenance_audit
+    assert result.draft_molecule is not None
+    assert result.draft_molecule.tool_provenance_audit == result.tool_provenance_audit
+    # Not a motor failure -- grounding_status/compliance_verdict untouched.
+    assert result.compliance_verdict == "completed"
+    assert result.grounding_status == "grounded"
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_no_tool_provenance_mismatch_on_normal_turn() -> None:
+    thought = make_thought()
+    request = HarnessRunRequestV1(
+        correlation_id="c-normal",
+        thought_event=thought,
+        user_message="hello",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    bus = AsyncMock()
+    runner = HarnessRunner(bus, fcc_runner=_mock_fcc_runner)
+
+    result = await runner.run(request)
+
+    assert result.tool_provenance_audit is None
+    assert result.draft_molecule.tool_provenance_audit is None
+
+
 @pytest.mark.asyncio
 async def test_harness_runner_publishes_lifecycle_grammar_on_motor_run() -> None:
     thought = make_thought()

--- a/orion/harness/tests/test_tool_provenance_audit.py
+++ b/orion/harness/tests/test_tool_provenance_audit.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from orion.harness.tool_provenance_audit import detect_tool_provenance_mismatch
+from orion.schemas.harness_finalize import GrammarReceiptV1
+
+
+def _receipt(tool_name: str | None, *, index: int = 0) -> GrammarReceiptV1:
+    return GrammarReceiptV1(step_index=index, tool_name=tool_name, summary=f"[{index}] step", grammar_event_id=f"g{index}")
+
+
+def test_flags_fetch_plus_immediacy_language():
+    receipts = [_receipt("mcp__github__get_file_contents")]
+    draft = "Yeah, that's pressure gradients actively computing in the background this turn."
+    result = detect_tool_provenance_mismatch(draft, receipts)
+    assert result is not None
+    assert "mcp__github__get_file_contents" in result
+    assert "tool_provenance_mismatch" in result
+
+
+def test_no_flag_for_fetch_without_immediacy_language():
+    receipts = [_receipt("mcp__github__get_file_contents")]
+    draft = "Here's what I found when I looked at pressure.py just now: it does bounded propagation."
+    assert detect_tool_provenance_mismatch(draft, receipts) is None
+
+
+def test_no_flag_for_immediacy_language_without_fetch():
+    receipts = [_receipt(None), _receipt("Bash", index=1)]
+    draft = "Lots of signal computing in the background this turn."
+    assert detect_tool_provenance_mismatch(draft, receipts) is None
+
+
+def test_no_flag_for_non_fetch_tool_use():
+    receipts = [_receipt("Bash"), _receipt("Grep", index=1)]
+    draft = "Something is happening right now in the substrate."
+    assert detect_tool_provenance_mismatch(draft, receipts) is None
+
+
+def test_no_flag_when_no_receipts():
+    assert detect_tool_provenance_mismatch("computing this turn", []) is None
+
+
+def test_no_flag_when_no_draft_text():
+    receipts = [_receipt("mcp__github__get_file_contents")]
+    assert detect_tool_provenance_mismatch("", receipts) is None
+
+
+def test_names_multiple_fetch_tools():
+    receipts = [
+        _receipt("mcp__github__get_file_contents"),
+        _receipt("WebFetch", index=1),
+    ]
+    draft = "This is computing right now."
+    result = detect_tool_provenance_mismatch(draft, receipts)
+    assert result is not None
+    assert "WebFetch" in result
+    assert "mcp__github__get_file_contents" in result
+
+
+def test_case_insensitive_matching():
+    receipts = [_receipt("MCP__GITHUB__GET_FILE_CONTENTS")]
+    draft = "RIGHT NOW this is live."
+    assert detect_tool_provenance_mismatch(draft, receipts) is not None
+
+
+def test_no_flag_for_generic_use_of_the_word_computing():
+    # Regression: a bare "computing" match (no temporal/proximity qualifier)
+    # false-positives on ordinary language unrelated to any liveness claim.
+    receipts = [_receipt("mcp__github__get_file_contents")]
+    draft = "Cloud computing costs are rising, so I pulled this config to check line counts."
+    assert detect_tool_provenance_mismatch(draft, receipts) is None

--- a/orion/harness/tool_provenance_audit.py
+++ b/orion/harness/tool_provenance_audit.py
@@ -1,0 +1,75 @@
+"""Post-hoc audit: did this turn's draft claim live computation for content
+that was actually a tool fetch?
+
+The FCC motor (fcc_motor.py) spawns a single-shot ``claude -p`` subprocess
+with no mid-run injection point, so nothing here can prevent a confabulated
+claim before it's generated -- that's what compile_harness_prefix's CONTEXT
+PROVENANCE block is for. What this module can do is compare, after the fact,
+in the same turn: did the tool trace (grammar_receipts, already collected by
+HarnessRunner.run()) include a fetch-shaped tool call, and does draft_text
+use immediacy language ("this turn", "right now", ...) that would only be
+true of live substrate signal? See
+project_orion_substrate_bridge_confabulation for the incident this audits
+against: a GitHub file fetch narrated as live computation "this turn".
+
+Pure and synchronous by design -- no bus/schema wiring yet (that's the
+second, separate patch once this detection heuristic is validated).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+from orion.schemas.harness_finalize import GrammarReceiptV1
+
+# Tool names shaped like "go read something and bring back its contents" --
+# matched against GrammarReceiptV1.tool_name. Deliberately narrow (false
+# negatives are safer than false positives for an audit signal): a generic
+# code-execution or search tool isn't itself evidence of a static-content
+# fetch the way a file-read/get-contents/fetch call is.
+_FETCH_SHAPED_TOOL_PATTERN = re.compile(
+    r"get_file_contents|read_file|web[_-]?fetch|fetch_url|read_content",
+    re.IGNORECASE,
+)
+
+_IMMEDIACY_PATTERN = re.compile(
+    # Deliberately no bare "computing" -- that fires on any generic use
+    # ("cloud computing costs") with no temporal/proximity claim attached.
+    # The incident's actual phrase ("computing in the background this
+    # turn") is still caught by "in the background" and "this turn" alone.
+    r"\bthis turn\b|\bright now\b|\bhappening now\b|\bin the background\b",
+    re.IGNORECASE,
+)
+
+
+def _fetch_shaped_tool_names(receipts: Sequence[GrammarReceiptV1]) -> list[str]:
+    return sorted(
+        {
+            receipt.tool_name
+            for receipt in receipts
+            if receipt.tool_name and _FETCH_SHAPED_TOOL_PATTERN.search(receipt.tool_name)
+        }
+    )
+
+
+def detect_tool_provenance_mismatch(
+    draft_text: str,
+    receipts: Sequence[GrammarReceiptV1],
+) -> str | None:
+    """None unless this turn both fetched content via a tool AND the draft
+    uses live-immediacy language -- the pairing the incident this audits was
+    an instance of. Either alone is legitimate: a fetch with no immediacy
+    claim, or immediacy language backed by a real live substrate cue with no
+    tool fetch involved."""
+    if not draft_text or not receipts:
+        return None
+    fetch_tools = _fetch_shaped_tool_names(receipts)
+    if not fetch_tools:
+        return None
+    if not _IMMEDIACY_PATTERN.search(draft_text):
+        return None
+    return (
+        "tool_provenance_mismatch: draft uses live-immediacy language but this "
+        "turn's tool trace shows content fetched via " + ", ".join(fetch_tools)
+    )

--- a/orion/schemas/harness_finalize.py
+++ b/orion/schemas/harness_finalize.py
@@ -26,6 +26,10 @@ class HarnessDraftMoleculeV1(BaseModel):
     grammar_receipts: list[GrammarReceiptV1] = Field(default_factory=list)
     coalition_snapshot: CoalitionSnapshotV1
     repair_overlay_mode: str | None = None
+    # Set by orion.harness.tool_provenance_audit.detect_tool_provenance_mismatch
+    # when draft_text uses live-immediacy language but grammar_receipts show a
+    # fetch-shaped tool call this same turn. None on every normal turn.
+    tool_provenance_audit: str | None = None
 
 
 class SubstrateFinalizeAppraisalV1(BaseModel):

--- a/services/orion-harness-governor/README.md
+++ b/services/orion-harness-governor/README.md
@@ -24,6 +24,12 @@ LISTEN orion:harness:run:request
   → emit_post_turn_closure (step 7)
 ```
 
+## Tool-provenance audit
+
+`orion/harness/tool_provenance_audit.py::detect_tool_provenance_mismatch()` runs once per turn in `HarnessRunner.run()`, after the fcc stream completes: flags when `draft_text` uses live-immediacy language ("this turn", "right now", "happening now", "in the background") while that same turn's `grammar_receipts` show a fetch-shaped tool call (`get_file_contents`, `read_file`, a web fetch). It's a post-hoc audit, not prevention — the fcc subprocess is single-shot with no mid-run injection point, so nothing here can stop a confabulated claim before it's generated (that's `orion/harness/prefix.py`'s `CONTEXT PROVENANCE` block's job, in the compiled motor prompt).
+
+On a mismatch: `HarnessMotorResult.tool_provenance_audit` / `HarnessDraftMoleculeV1.tool_provenance_audit` are set (both `None` otherwise), a `GrammarAtomV1(atom_type="uncertainty_marker", semantic_role="exec_tool_provenance_mismatch")` is published on `CHANNEL_HARNESS_RESULT_PREFIX`'s underlying grammar channel alongside the rest of the turn's grammar receipts, and a `harness_tool_provenance_mismatch` warning is logged with the correlation ID. Deliberately kept separate from `grounding_status` (an overloaded error/overflow code that downstream consumers surface as a user-visible error) — this is a soft grounding signal on the claim, not a motor failure.
+
 ## Local checks
 
 ```bash


### PR DESCRIPTION
## Summary

- `orion/harness/tool_provenance_audit.py`: pure `detect_tool_provenance_mismatch(draft_text, receipts)` — flags when a turn's draft uses live-immediacy language ("this turn", "right now", "happening now", "in the background") while that same turn's tool trace shows a fetch-shaped tool call (`get_file_contents`, `read_file`, web fetch, etc.).
- Wired into `HarnessRunner.run()`: computed once after the FCC subprocess stream completes, before either lifecycle-publish path, so it reaches both the empty-draft and success return paths.
- `HarnessMotorResult`/`HarnessDraftMoleculeV1` both get a new `tool_provenance_audit: str | None` field, kept deliberately separate from the existing `grounding_status` field.
- `HarnessGrammarCollector.record_tool_provenance_mismatch()` publishes a `GrammarAtomV1(atom_type="uncertainty_marker")` on the same grammar bus channel every other harness event already uses, plus a correlation-ID'd warning log.

## Outcome moved

Closes the audit half of a real incident: Orion narrated a GitHub-MCP file fetch as live substrate computation "happening this turn." A prior PR (#1056) fixed the prevention side (the FCC motor's own system prompt now carries a `CONTEXT PROVENANCE` block). This PR closes the detection side: since the FCC motor is a single-shot `claude -p` subprocess with no mid-run injection point (confirmed by reading `fcc_motor.py` — nothing can reach back into a live run to stop a confabulation before it's generated), the only remaining lever is a post-hoc check comparing what the draft claims against what the turn's own tool trace shows. That's what this PR builds.

## Current architecture

`orion/harness/fcc_motor.py::run_fcc_turn` spawns the FCC motor as a single-shot `claude` subprocess and streams back JSON events; `_summarize_content_blocks`/`_tool_result_body_text` already parse every `tool_use`/`tool_result` block. `HarnessRunner.run()` (`orion/harness/runner.py`) consumes that stream, publishing each step as a `GrammarReceiptV1` via the existing grammar bus/schema contract (`orion/grammar/publish.py`), and captures `draft_text` from the `final` event — both available together, in the same function, before the turn's result is returned. `HarnessMotorResult.grounding_status` already exists but is an overloaded error/overflow code with real downstream consumers (`orion/hub/turn_orchestrator.py`, `services/orion-harness-governor/app/bus_listener.py`) that surface it as `base["error"] = ...` — confirmed via grep that repurposing it for this signal would misreport a soft audit as a hard motor failure, so this uses a new, separate field instead.

## Architecture touched

- `orion/harness/tool_provenance_audit.py` (new)
- `orion/harness/runner.py`
- `orion/harness/grammar_emit.py`
- `orion/schemas/harness_finalize.py`

## Files changed

- `orion/harness/tool_provenance_audit.py`: new, pure detection function + two regexes (fetch-shaped tool names, immediacy language).
- `orion/harness/runner.py`: computes the audit once per turn in `HarnessRunner.run()`, threads it into both `HarnessMotorResult` return sites and `build_draft_molecule()`.
- `orion/harness/grammar_emit.py`: new `HarnessGrammarCollector.record_tool_provenance_mismatch()` method.
- `orion/schemas/harness_finalize.py`: `HarnessDraftMoleculeV1.tool_provenance_audit: str | None = None`.
- Tests: `orion/harness/tests/test_tool_provenance_audit.py` (9 unit tests), extensions to `test_harness_runner.py` (2 integration tests) and `test_harness_grammar_emit.py` (2 tests, including an edge-topology regression test).

## Schema / bus / API changes

- Added: `HarnessMotorResult.tool_provenance_audit: str | None = None`, `HarnessDraftMoleculeV1.tool_provenance_audit: str | None = None` — both additive with safe defaults.
- Added: a new grammar atom `semantic_role="exec_tool_provenance_mismatch"` (`atom_type="uncertainty_marker"`, an existing enum value — no new AtomType needed), published on the existing `orion:grammar:event` channel.
- Removed: none. Renamed: none.
- Behavior changed: none for any turn without a tool-provenance mismatch (field stays `None`, no new atom emitted). `grounding_status`/`compliance_verdict` are explicitly untouched by design.
- Compatibility notes: fully additive; `HarnessDraftMoleculeV1` has no `extra="forbid"`, `HarnessMotorResult` is a plain dataclass with the field appended last with a default — verified no downstream construction site breaks.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=<worktree> venv/bin/python -m pytest \
  orion/harness/tests/test_tool_provenance_audit.py \
  orion/harness/tests/test_harness_runner.py \
  orion/harness/tests/test_harness_grammar_emit.py \
  -q
20 passed, 1 failed (test_harness_runner_surfaces_fcc_error_code -- confirmed
pre-existing on unmodified main, unrelated to this diff: an error-code string
mismatch, "fcc turn timed out after 120.0s" != "fcc_timeout")

Full orion/harness/tests suite: 123 passed, 3 failed -- same pre-existing
failure above plus two unrelated Jinja UndefinedError failures in
test_grounding_capsule_consumers.py, both independently confirmed present
and identical on unmodified main. Zero regressions from this patch.
```

## Evals run

No dedicated eval harness exists for this seam. The regression tests above (particularly the edge-topology test for the grammar-graph fix below) function as the deterministic gate.

## Docker/build/smoke checks

Not run — this changes harness/schema Python only, no config read at boot, no new dependencies, no compose/port/worker changes.

## Review findings fixed

- Finding: `_IMMEDIACY_PATTERN`'s bare `\bcomputing\b` alternative (in the phase-1 commit) had no temporal/proximity qualifier, so it false-positived on any generic use of the word ("cloud computing costs are rising").
  - Fix: dropped that alternative. The incident's actual phrase ("computing in the background this turn") is still caught by "in the background"/"this turn" alone.
  - Evidence: `test_no_flag_for_generic_use_of_the_word_computing` regression test.
- Finding: `HarnessGrammarCollector.record_tool_provenance_mismatch` didn't update `self._last_completed_atom_id`, unlike its sibling terminal methods (`record_step_completed`, `record_step_failed`) — so the subsequent `record_result_assembled`'s own `derived_from` edge still pointed at the last *step* atom instead of the mismatch atom, leaving it a graph leaf with an incoming edge but no outgoing edge into the result-assembled/emitted chain, despite being semantically about the result.
  - Fix: one-line addition setting `self._last_completed_atom_id` after emitting the atom.
  - Evidence: `test_record_tool_provenance_mismatch_becomes_last_completed_atom`, which asserts the edge from the mismatch atom to the `exec_result_assembled` atom actually exists in the built event graph.

## Restart required

```text
No restart required to review/merge. Once merged, takes effect on the next
deploy/restart of whatever service runs HarnessRunner (orion-harness-governor).
```

## Risks / concerns

- Severity: Low
- Concern: This is a post-hoc audit only — by design, it cannot prevent a confabulation in the same generation (the FCC motor subprocess has already run to completion by the time this check runs). It also doesn't yet feed back into a future turn's context (no cross-turn continuity) or reinstate `external_tool_fetch` in `orion/schemas/context_provenance.py` (from PR #1056), since that touches a different subsystem (`services/orion-cortex-exec`'s chat `ctx` pipeline) and was deliberately scoped out of this patch.
- Mitigation: tracked as an explicit next step, not silently dropped — see `project_orion_substrate_bridge_confabulation` memory and the design-mode spec that preceded this patch.

## PR link

(filled in by gh pr create output)