### PR TITLE
fix(substrate): attention salience decay-bypass + dwell not loop-scoped

### DIFF
--- a/docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md
+++ b/docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md
@@ -161,6 +161,47 @@ independently real and low-risk:
 - No change to `recurrence` or `resonance` weighting — both are already
   correctly loop-scoped (keyed by `theme_key`), just small in magnitude.
 
+## Review findings (code-review skill, high effort, 8 finder angles)
+
+Fixed (see commit `f707d67f`):
+
+- A third pre-existing test file (`test_attention_broadcast_recency.py`)
+  reset `attention_broadcast`'s module globals but was missed when adding
+  `_current_dwelling_loop_id` — found independently by 2 of 8 angles.
+- Two pre-existing tests (`test_rumination_replay.py`,
+  `test_salience_combiner.py`) construct `SalienceHistory(dwell_ticks=N,
+  ...)` directly without the new `dwelling_loop_id` field — found
+  independently by 3 of 8 angles, live-verified: both still passed, but the
+  dwell term silently contributed nothing, shrinking
+  `test_rumination_replay`'s own documented margin from ~0.02 to ~0.015 by
+  accident. Restored by setting `dwelling_loop_id` on both.
+- Dead redundant `is None` guard in `_loop_dwell()`.
+- `_current_dwelling_loop_id` was set from `selected.open_loop_id`
+  unconditionally, even when that id didn't resolve to a real loop in
+  `frame.open_loops` — now guarded the same way `attended_node_ids` already
+  is.
+
+Not fixed, accepted as documented tradeoffs (would expand this patch beyond
+its two files):
+
+- A freshly-written `prediction_error` node reports 0 salience (filtered
+  below `min_salience`) until the next dynamics tick (default 30s) populates
+  `dynamic_pressure`. Direct, minor, bounded consequence of no longer
+  trusting the undecaying raw value.
+- `kind`/`target_type_hint` stays `"prediction_error"`/`"anomaly"` forever
+  once any nonzero raw `prediction_error` was ever written, even after
+  `dynamic_pressure` is driven by an unrelated source. Affects
+  display/typing only, not salience ranking. A real fix needs
+  `dynamics.py`'s `_compute_pressures()` to persist its own `reason` onto
+  node metadata instead of discarding it after `tick()` — a separate change.
+- **New sibling-bug finding**: `orion/substrate/endogenous_curiosity.py`'s
+  `_prediction_error_candidates()` reads the same raw, never-decaying
+  `metadata["prediction_error"]` field directly as a "sustained prediction
+  error" signal, with no staleness check — the identical bug pattern found
+  and fixed here, in a sibling consumer. Currently dormant behind
+  `ORION_ENDOGENOUS_CURIOSITY_ENABLED=false`; worth revisiting before that
+  flag is ever flipped on.
+
 ## Acceptance checks
 
 - A node whose `dynamic_pressure` has decayed well below its raw

--- a/docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md
+++ b/docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md
@@ -1,0 +1,174 @@
+# Attention salience: decay-bypass + dwell-scoping investigation
+
+Context: `fix/attention-loop-recency-never-decays` (PR #1052, merged) fixed one
+dead-feature bug in rung-3's salience scoring (`_recency()`'s half-life decay
+was correctly implemented but never fed real `first_seen_at` data, so it
+returned `1.0` forever). That fix was found by hand-verifying a live reverie
+narration claim against real Postgres data — a loop verdicted `resolved`
+(2026-07-08) and `dismissed` (2026-07-10) via the Hub was still winning
+`attention_broadcast`'s coalition selection on 2026-07-14.
+
+PR #1055 (merged same day) separately fixed the *narration* symptom: reverie's
+chain-refractory suppression had a theme-key format mismatch (`"loop:<id>"`
+vs. the bare id everything else uses), and its prompt had no visibility into
+`attention_loop_outcome` verdicts at all. Both fixes are real and live, but
+they operate entirely inside `services/orion-thought/app/{chain,reverie,store}.py`
+— the narration/chain-trigger layer. Neither touches
+`orion/substrate/attention_broadcast.py` / `scoring.py` / `salience.py`, the
+rung-3 coalition-*selection* path that actually decides
+`AttentionBroadcastProjectionV1.selected_open_loop_id`.
+
+This doc covers the follow-up investigation into why the *selection* layer
+still let that same loop dominate indefinitely even with recency now fixed,
+and what else in the same salience pipeline shares the "computed correctly
+somewhere, never actually consumed" bug shape.
+
+## Evidence: live Postgres data, not speculation
+
+`attention_salience_trace` (written by reverie as a side effect of reading
+each broadcast, `scope='reverie'`) has 2,166 rows for
+`loop_id = open-loop-9d84d08cddf5` (`description = 'substrate:node:substrate.transport'`),
+spanning 2026-07-08 19:56 through 2026-07-14 22:41 — after both #1052 and
+#1055 had deployed:
+
+```sql
+SELECT min(created_at), max(created_at), count(*),
+  count(DISTINCT features->>'evidence_strength') AS distinct_ev,
+  count(DISTINCT features->>'recency') AS distinct_recency
+FROM attention_salience_trace WHERE loop_id LIKE '%9d84d08cddf5%';
+```
+
+```
+min=2026-07-08 19:56:31   max=2026-07-14 22:41:07   count=2166
+distinct_evidence_strength_values = 1     -- pinned at exactly 1.0, always
+distinct_recency_values           = 15    -- varies (recency fix confirmed working)
+```
+
+`attention_loop_outcome` confirms this loop was explicitly closed by Juniper
+twice (`resolved` 07-08 20:32, `dismissed` 07-10 21:49, `habituation=1.0` —
+fully saturated — at the second verdict) and kept winning anyway.
+
+Even after the recency fix deployed, the loop's `salience` only dropped from
+~0.59 to ~0.566 by 22:41 today — nowhere near enough to lose, because
+`evidence_strength` (combiner weight `+0.30`, the largest single weight)
+never moved.
+
+## Finding A (primary root cause, being fixed): `_node_salience()` races raw vs. decayed and always picks raw
+
+`orion/substrate/attention_broadcast.py:102-115`:
+
+```python
+def _node_salience(metadata: dict[str, Any]) -> tuple[float, str]:
+    pressure = _f("dynamic_pressure")
+    prediction_error = _f("prediction_error")
+    if prediction_error >= pressure:
+        return prediction_error, "prediction_error"
+    return pressure, "pressure"
+```
+
+`dynamic_pressure` is properly time-decayed: `SubstrateDynamicsEngine.tick()`
+(`orion/substrate/dynamics.py`, live, `SUBSTRATE_DYNAMICS_TICK_ENABLED=true`,
+runs every 30s in prod) recomputes it every tick via
+`prediction_error_pressure()` (`orion/substrate/pressure.py`), which applies
+`weight=0.6` and a linear decay to zero over `prediction_error_decay_horizon_seconds`
+(1800s / 30min) measured from the node's `observed_at`.
+
+But `dynamic_pressure = raw_prediction_error * 0.6 * decay(<=1)` can **never
+exceed** the raw `metadata["prediction_error"]` value, by construction. So
+`prediction_error >= pressure` is true on every tick, forever, for any node
+that has ever had a nonzero `prediction_error` written. The dynamics engine's
+decay is computed correctly and then unconditionally discarded by the one
+function that actually decides workspace salience. Same bug *shape* as the
+recency fix (a real decay mechanism exists; the consumer doesn't use its
+output) — third instance of this pattern found this session (recency, dwell
+below, now this).
+
+The raw value's origin: `_write_prediction_error_node()`
+(`services/orion-substrate-runtime/app/worker.py:664`) upserts a single
+fixed-identity node per source (re-writes collapse, no growth — that part is
+sound), called from `_transport_tick()` (`worker.py:1687`) whenever
+`transport_prediction_error(prev, curr)` (`orion/substrate/prediction_error.py`,
+mean delta across `bus_health`/`delivery_confidence`/`transport_pressure`
+over `_THRESHOLD=0.30`, clamped to `[0,1]`) returns `>0`. Whether this specific
+node's raw value is a single stale write from 07-08 that was never revisited,
+or an actively-recurring ~1.0 delta on every batch with events, wasn't
+distinguished — out of scope for this patch (see Non-goals).
+
+## Finding B (secondary, being fixed): `dwell` habituation is a global scalar, not loop-scoped
+
+`orion/substrate/attention/salience.py:116-120`:
+
+```python
+def _habituation(theme_key: str, history: SalienceHistory) -> float:
+    recurrence = min(1.0, history.recent_theme_counts.get(theme_key, 0) / RECURRENCE_NORM)
+    dwell = min(1.0, history.dwell_ticks / DWELL_NORM)
+    resonance = 1.0 if theme_key in history.resonance_theme_keys else 0.0
+    return bounded(0.5 * recurrence + 0.3 * dwell + 0.2 * resonance)
+```
+
+`history.dwell_ticks` is a single `int` (`attention_broadcast.py`'s
+module-level `_dwell_ticks`, tracking how long the *current active coalition*
+has persisted) — not keyed by `theme_key`. `scoring.build_open_loops()`
+constructs one `SalienceHistory` per tick and passes the *same* instance into
+`compute_salience()` for every competing loop, so `dwell` contributes the
+identical value to every candidate's habituation score in a given tick,
+including loops that are not part of the dwelling coalition at all. It cannot
+demote the specific stuck loop relative to its competitors — a uniform
+per-tick offset changes nothing about who wins.
+
+Net weight math confirms this is real but small: direct combiner weight
+`dwell=+0.10`, indirect via habituation `-0.35 * 0.3 = -0.105` → net `-0.005`
+regardless of which loop is scored. (For comparison: `recurrence` nets
+`-0.025`; `resonance`, the only feature with no offsetting positive weight,
+nets `-0.07`. All three together, even fully saturated, max out around
+`-0.10` to `-0.20` — nowhere near enough to counter a pinned
+`evidence_strength=+0.30` on its own, which is why Finding A is the one that
+actually explains the live incident.)
+
+## Decision
+
+Fix both in this patch — same file family, same investigative session, both
+independently real and low-risk:
+
+1. `_node_salience()` should seed pressure from `prediction_error`, not race
+   an undecayed copy of it against the properly-decayed output. Concretely:
+   stop reading `metadata["prediction_error"]` directly in
+   `attention_broadcast.py` at all — `dynamic_pressure` is already the
+   decayed, authoritative signal (`prediction_error_pressure()` is exactly
+   "prediction_error seeded into pressure, with decay"). Use `dynamic_pressure`
+   alone.
+2. Scope the `dwell` habituation term to loops that are members of the
+   current active coalition (`_current_active_coalition`) instead of applying
+   the module-level tick counter to every candidate uniformly.
+
+## Non-goals (explicitly deferred)
+
+- **Verdict-aware selection** (excluding `resolved`/`dismissed` loops from
+  `build_open_loops`/`compute_salience` entirely): raised and explicitly
+  *not* chosen for this patch — it's a real behavior change to the selection
+  path, not a bug-shaped fix, and deserves its own scoping decision. Reverie's
+  *narration* about a verdicted loop is already truthful (#1055); this patch
+  only stops that loop's `evidence_strength` from being artificially pinned
+  at max, which independently gives it a real (if not absolute) chance to
+  lose the competition once other candidates have comparable evidence.
+- **Root-causing why `substrate.transport`'s raw `prediction_error` reached /
+  stayed at 1.0** (passive single stale write vs. actively-recurring
+  near-1.0 transport-bus delta): not distinguished. Worth a follow-up if the
+  same node (or another transport-adjacent one) keeps re-pinning after this
+  fix — would show up as `dynamic_pressure` staying near its ceiling despite
+  decay, rather than the `evidence_strength` never moving at all as observed
+  here.
+- No change to `recurrence` or `resonance` weighting — both are already
+  correctly loop-scoped (keyed by `theme_key`), just small in magnitude.
+
+## Acceptance checks
+
+- A node whose `dynamic_pressure` has decayed well below its raw
+  `prediction_error` seed no longer reports maximal salience from that raw
+  value alone.
+- A loop outside the current active coalition receives zero dwell
+  contribution to its habituation score; a loop inside it still receives the
+  existing dwell signal.
+- Existing recency/habituation/dwell test suites (`test_attention_broadcast_recency.py`,
+  `test_broadcast_habituation.py`, `test_attention_broadcast_dwell.py`,
+  `test_scoring_salience_wiring.py`) still pass.

--- a/docs/superpowers/pr-reports/2026-07-14-attention-salience-decay-bypass-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-attention-salience-decay-bypass-pr.md
@@ -1,0 +1,234 @@
+# PR report — attention salience decay-bypass + dwell not loop-scoped
+
+PR: (create at https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/attention-salience-decay-bypass — `gh` unauthenticated in this environment)
+Branch: `fix/attention-salience-decay-bypass`
+Status: **DONE**
+
+## Summary
+
+- Follow-up to `fix/attention-loop-recency-never-decays` (PR #1052) and
+  `fix/reverie-verdict-aware-narration` (PR #1055): those fixed one dead
+  feature (recency) and the narration-layer symptom, but left the rung-3
+  *selection* competition itself still permanently favoring a verdicted-dead
+  loop. Investigated why, using live Postgres data, and found two more
+  independent dead-feature bugs in the same salience-scoring pipeline.
+- **Root cause (primary)**: `_node_salience()` raced a raw, never-decaying
+  `metadata["prediction_error"]` field against the dynamics engine's
+  properly time-decayed `metadata["dynamic_pressure"]` and always picked the
+  raw value — `dynamic_pressure = raw * weight(0.6) * decay(<=1)` can never
+  mathematically exceed the raw seed, so the decay was computed correctly by
+  `SubstrateDynamicsEngine` every 30s and then silently discarded by its own
+  consumer, forever, for any node that ever had a `prediction_error` written.
+  Confirmed live: a verdicted-`resolved`/`dismissed` loop's
+  `evidence_strength` sat at exactly `1.0` across 2,166 real trace rows over
+  6 days.
+- **Second bug**: `dwell` habituation used a single module-level tick
+  counter applied uniformly to every competing loop in a tick — a per-tick
+  offset shared by everyone changes nothing about who wins, so it could
+  never demote the specific dwelling loop relative to its competitors.
+- Both fixed. Code review (high effort, 8 finder angles) found and fixed 4
+  more issues surfaced by the change (3 test files silently losing dwell
+  coverage they used to have, one dead conditional, one unguarded edge
+  case), and surfaced 3 real findings deliberately left as documented,
+  accepted follow-ups.
+
+## Outcome moved
+
+The rung-3 workspace-competition scorer now uses the dynamics engine's own
+decayed pressure as the sole magnitude signal, and dwell habituation
+actually targets the loop that's dwelling instead of applying a flat,
+rank-irrelevant offset to every candidate. A loop with a permanently pinned
+raw `prediction_error` no longer gets to bypass decay by construction.
+
+## Current architecture
+
+`orion/substrate/attention_broadcast.py` runs the rung-3 continuous
+workspace competition (`build_substrate_attention_frame` → `build_open_loops`
+→ `select_actions`, then `broadcast_projection_from_frame` records the
+winner and updates hysteresis/dwell/habituation state).
+`orion/substrate/attention/salience.py`'s `compute_features()` computes 7
+features combined via `LinearSalienceCombiner` (seed weights:
+`evidence_strength=0.30`, `recency=0.13`, `habituation=-0.35`, `dwell=0.10`,
+others smaller). `SubstrateDynamicsEngine` (`orion/substrate/dynamics.py`)
+runs on its own 30s-default loop, recomputing `metadata["dynamic_pressure"]`
+per node with a real, working, time-decaying model; `metadata["prediction_error"]`
+is a separate, raw, write-once-then-upserted field that nothing ever clears
+or decays on its own.
+
+## Architecture touched
+
+`orion/substrate/attention_broadcast.py`, `orion/substrate/attention/salience.py`
+(both live production modules, `orion-substrate-runtime`), plus 6 test
+files. No schema/env/Docker changes — pure scoring-logic fix.
+
+## Files changed
+
+- `orion/substrate/attention_broadcast.py`: `_node_salience()` now returns
+  `dynamic_pressure` alone as magnitude (raw `prediction_error` only decides
+  the `kind` string for anomaly-vs-concept typing). New
+  `_current_dwelling_loop_id` module global, tracked in lockstep with the
+  existing `_current_active_coalition`/`_dwell_ticks` transition logic in
+  `broadcast_projection_from_frame`, guarded the same way
+  `attended_node_ids` already is (only set when the selected loop actually
+  resolves against `frame.open_loops`).
+- `orion/substrate/attention/salience.py`: `SalienceHistory` gained
+  `dwelling_loop_id: str | None = None`. New `_loop_dwell(theme_key,
+  history)` helper returns 0 unless `theme_key == history.dwelling_loop_id`;
+  used by both `_habituation()` and `compute_features()`'s standalone
+  `dwell` feature, replacing the old unconditional
+  `min(1.0, history.dwell_ticks / DWELL_NORM)`.
+- `orion/substrate/tests/test_attention_broadcast.py`: fixed
+  `test_prediction_error_beats_equal_plain_pressure`'s fixture (it modeled
+  an unrealistic state — raw `prediction_error` set with no `dynamic_pressure`
+  at all, exactly what let the old raw-value race win); new
+  `test_salience_uses_decayed_pressure_not_raw_prediction_error` regression
+  test.
+- `orion/substrate/tests/test_scoring_salience_wiring.py`: new
+  `test_dwell_scoped_to_dwelling_loop_only`.
+- `orion/substrate/tests/test_attention_broadcast_dwell.py`,
+  `test_broadcast_habituation.py`, `test_attention_broadcast_recency.py`:
+  fixtures updated to also reset `_current_dwelling_loop_id`.
+- `orion/substrate/tests/test_rumination_replay.py`,
+  `test_salience_combiner.py`: pre-existing `SalienceHistory(dwell_ticks=N,
+  ...)` constructions updated to also set `dwelling_loop_id`, restoring dwell
+  coverage the dwell-scoping fix would otherwise have silently zeroed.
+- `docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md`
+  (new): full investigation, live-data evidence, decision, non-goals,
+  review findings.
+
+## Schema / bus / API changes
+
+None. `SalienceHistory.dwelling_loop_id` is purely additive with a safe
+default (`None`) — every existing caller that doesn't set it gets the same
+behavior it would have gotten from an unset dwelling loop (dwell=0),
+matching the "no history / Phase 1 shadow behavior" convention this
+dataclass already documents for its other fields.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest orion/substrate/tests/ -q
+=> 203 passed
+
+.venv/bin/python -m pytest \
+  orion/substrate/tests/test_rumination_replay.py \
+  orion/substrate/tests/test_salience_combiner.py \
+  orion/substrate/tests/test_attention_broadcast_recency.py -v
+=> all 17 passed individually (confirms the review-fixed dwell/reset
+   regressions are actually exercised, not just passing by omission)
+```
+
+## Evals run
+
+None applicable — same as PR #1052, no eval harness exists for
+`orion/substrate/attention/`. The live Postgres query against
+`attention_salience_trace`/`attention_loop_outcome` (2,166 real rows, 6-day
+span) that found this bug is the closest thing to an eval here — informal,
+by hand, not automated. Same gap flagged in #1052's report: this class of
+bug (a dead/bypassed feature) would benefit from a periodic live check.
+
+## Docker/build/smoke checks
+
+Not run — pure Python scoring-logic change inside `orion-substrate-runtime`'s
+existing code path, no config/dependency/compose changes to validate.
+
+## Review findings fixed
+
+Code-review skill, high effort (3 correctness + 3 cleanup + altitude +
+conventions = 8 finder angles, verified):
+
+- **Finding**: `test_attention_broadcast_recency.py`'s reset fixture was the
+  third file touching `attention_broadcast`'s module globals but wasn't
+  updated to clear `_current_dwelling_loop_id` — found independently by 2 of
+  8 angles.
+  - **Fix**: added the reset to both setup and teardown.
+  - **Evidence**: all 4 tests in that file still pass individually.
+- **Finding**: `test_rumination_replay.py` and `test_salience_combiner.py`
+  (both pre-existing, untouched by the original patch) construct
+  `SalienceHistory(dwell_ticks=N, ...)` directly without the new
+  `dwelling_loop_id` field — found independently by 3 of 8 angles,
+  live-verified: both tests still passed, but the dwell term's 0.3 combiner
+  weight silently contributed nothing, shrinking
+  `test_rumination_replay`'s own documented margin (`stuckN=0.45` vs
+  `freshN=0.47`) to an accidental ~0.015 instead of the ~0.02 the file's
+  docstring claims.
+  - **Fix**: set `dwelling_loop_id` on both fixtures.
+  - **Evidence**: both tests still pass, now exercising the dwell term for
+    real again.
+- **Finding**: `_loop_dwell()`'s `history.dwelling_loop_id is None` guard
+  clause was dead code — `theme_key != None` already evaluates `True` on its
+  own for any real string `theme_key`.
+  - **Fix**: removed the redundant clause.
+  - **Evidence**: full suite still passes (behavior-neutral simplification).
+- **Finding**: `_current_dwelling_loop_id` was set from
+  `selected.open_loop_id` unconditionally, even when that id didn't resolve
+  to a real loop in `frame.open_loops` (`selected_loop=None`) — inconsistent
+  with `attended_node_ids`'s existing guard one line above.
+  - **Fix**: guard `_current_dwelling_loop_id` the same way.
+  - **Evidence**: full suite still passes; behavior was already fail-safe
+    (dwell silently stayed 0) but is now consistent with the existing
+    pattern.
+
+Not fixed, accepted and documented (in the working doc and above) — would
+expand this patch's scope beyond its two files:
+
+- A freshly-written `prediction_error` node reports 0 salience (filtered
+  below `min_salience`) until the next dynamics tick (default 30s interval)
+  populates `dynamic_pressure`. Direct, bounded, minor consequence of no
+  longer trusting the undecaying raw value — the tradeoff that fixes the
+  actual live incident.
+- `kind`/`target_type_hint` stays pinned to `"prediction_error"`/`"anomaly"`
+  forever once any nonzero raw `prediction_error` was ever written, even
+  after `dynamic_pressure` is driven by an unrelated source. Affects
+  display/typing only, not salience ranking. A real fix needs
+  `dynamics.py`'s `_compute_pressures()` to persist its own per-node
+  `reason` onto metadata instead of discarding it after `tick()`.
+- **New finding**: `orion/substrate/endogenous_curiosity.py`'s
+  `_prediction_error_candidates()` reads the same raw, never-decaying
+  `metadata["prediction_error"]` field directly as a "sustained prediction
+  error" signal, with no staleness check — the identical bug pattern found
+  and fixed here, in a sibling consumer. Currently dormant behind
+  `ORION_ENDOGENOUS_CURIOSITY_ENABLED=false`; worth revisiting before that
+  flag is ever flipped on.
+
+Also explicitly deferred (not a review finding, a scoping decision recorded
+in the working doc): wiring `attention_loop_outcome` verdicts into
+`build_open_loops`/`compute_salience` so resolved/dismissed loops stop
+competing entirely, rather than merely losing their artificial magnitude
+boost. Raised, discussed, and deliberately not chosen for this patch.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+```
+Not run this session.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: a freshly-seeded `prediction_error` node is invisible to the
+  workspace competition for up to one dynamics-tick interval (default 30s)
+  instead of immediately, since magnitude no longer comes from the raw
+  (undecaying) field. Intentional tradeoff, not treated as a regression —
+  see "not fixed, accepted" above.
+- Severity: low
+- Concern: this patch does not guarantee a verdicted-dead loop can never win
+  again — it removes the artificial `evidence_strength=1.0` pin, giving
+  other candidates a real chance, but if the underlying transport-bus
+  reducer (`transport_prediction_error()`) is genuinely, repeatedly
+  re-seeding a near-1.0 raw value on every tick with events (vs. a one-time
+  stale write — not distinguished this session, see working doc), the same
+  loop could still win on legitimately-recomputed (if not stale) pressure.
+  Worth a live re-check after this deploys, same as #1052's own open
+  question about the habituation/resonance safety valve.
+
+## PR link
+
+`gh` is unauthenticated in this environment — open manually at:
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/attention-salience-decay-bypass

--- a/orion/substrate/attention/salience.py
+++ b/orion/substrate/attention/salience.py
@@ -124,7 +124,7 @@ def _loop_dwell(theme_key: str, history: SalienceHistory) -> float:
     changes nothing about who wins. Only the loop that IS the dwelling one
     should carry a dwell signal; everyone else gets 0.
     """
-    if history.dwelling_loop_id is None or theme_key != history.dwelling_loop_id:
+    if theme_key != history.dwelling_loop_id:
         return 0.0
     return min(1.0, history.dwell_ticks / DWELL_NORM)
 

--- a/orion/substrate/attention/salience.py
+++ b/orion/substrate/attention/salience.py
@@ -64,6 +64,7 @@ class SalienceHistory:
     """
 
     dwell_ticks: int = 0
+    dwelling_loop_id: str | None = None
     recent_theme_counts: dict[str, int] = field(default_factory=dict)
     resonance_theme_keys: set[str] = field(default_factory=set)
     first_seen_at: dict[str, datetime] = field(default_factory=dict)
@@ -113,9 +114,24 @@ def _recency(theme_key: str, history: SalienceHistory, now: datetime) -> float:
     return bounded(0.5 ** (age_hours / 6.0))
 
 
+def _loop_dwell(theme_key: str, history: SalienceHistory) -> float:
+    """Dwell, scoped to the loop actually dwelling -- not every competitor.
+
+    `history.dwell_ticks` counts how long ONE coalition (`dwelling_loop_id`)
+    has held the workspace. Previously this scalar was applied to every
+    candidate loop scored in a tick, which cannot demote the specific
+    dwelling loop relative to its competitors: a uniform per-tick offset
+    changes nothing about who wins. Only the loop that IS the dwelling one
+    should carry a dwell signal; everyone else gets 0.
+    """
+    if history.dwelling_loop_id is None or theme_key != history.dwelling_loop_id:
+        return 0.0
+    return min(1.0, history.dwell_ticks / DWELL_NORM)
+
+
 def _habituation(theme_key: str, history: SalienceHistory) -> float:
     recurrence = min(1.0, history.recent_theme_counts.get(theme_key, 0) / RECURRENCE_NORM)
-    dwell = min(1.0, history.dwell_ticks / DWELL_NORM)
+    dwell = _loop_dwell(theme_key, history)
     resonance = 1.0 if theme_key in history.resonance_theme_keys else 0.0
     return bounded(0.5 * recurrence + 0.3 * dwell + 0.2 * resonance)
 
@@ -144,7 +160,7 @@ def compute_features(
     recurrence = bounded(history.recent_theme_counts.get(theme_key, 0) / RECURRENCE_NORM)
     recency = _recency(theme_key, history, now)
     novelty_vs_known = 0.15 if loop.already_known else evidence_strength
-    dwell = bounded(history.dwell_ticks / DWELL_NORM)
+    dwell = bounded(_loop_dwell(theme_key, history))
     habituation = _habituation(theme_key, history)
 
     return SalienceFeaturesV1(

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -345,7 +345,13 @@ def broadcast_projection_from_frame(frame: AttentionFrameV1) -> AttentionBroadca
                 }
             )
         _dwell_ticks += 1
-        _current_dwelling_loop_id = selected.open_loop_id if selected is not None else None
+        # Mirror attended_node_ids' own guard above: only attribute dwell to a
+        # loop id that actually resolved against frame.open_loops. A dangling
+        # selected.open_loop_id (no matching loop) must not be recorded as
+        # dwelling -- _loop_dwell would just never match it anyway, but
+        # leaving it unset here keeps dwelling_loop_id meaning "a real loop
+        # is dwelling" rather than "some id was selected, resolved or not."
+        _current_dwelling_loop_id = selected_loop.id if selected_loop is not None else None
     else:
         # Decay: active coalition has left the recent window entirely
         if _current_active_coalition is not None and all(

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -41,6 +41,15 @@ DEFAULT_MAX_SIGNALS = 24
 _coalition_history: deque[frozenset[str]] = deque(maxlen=3)
 _current_active_coalition: frozenset[str] | None = None
 _dwell_ticks: int = 0
+# The open-loop id whose selection produced the currently-active coalition
+# (mirrors _current_active_coalition's own lifecycle exactly -- set/cleared
+# at the same transition points in broadcast_projection_from_frame). Lets
+# salience._loop_dwell() apply the dwell habituation signal only to the loop
+# actually dwelling, instead of the tick-count scalar being applied
+# uniformly to every competing loop (found live 2026-07-14: dwell could
+# never demote the specific stuck loop relative to its competitors, since a
+# per-tick offset shared by everyone changes nothing about who wins).
+_current_dwelling_loop_id: str | None = None
 # Transition log: last 10 activation/decay events, mirrored into
 # AttentionBroadcastProjectionV1.coalition_history (schema caps at 10).
 _transition_history: deque[dict[str, Any]] = deque(maxlen=10)
@@ -89,6 +98,7 @@ def _current_history(resonance_theme_keys: set[str] | None = None) -> "SalienceH
         }
     return SalienceHistory(
         dwell_ticks=_dwell_ticks,
+        dwelling_loop_id=_current_dwelling_loop_id,
         recent_theme_counts=dict(_recent_selected_counts),
         resonance_theme_keys=set(resonance_theme_keys),
         first_seen_at=dict(_first_selected_at),
@@ -100,7 +110,22 @@ def attention_broadcast_enabled() -> bool:
 
 
 def _node_salience(metadata: dict[str, Any]) -> tuple[float, str]:
-    """Salience for the workspace competition, and which signal drove it."""
+    """Salience for the workspace competition, and which signal drove it.
+
+    Magnitude always comes from ``dynamic_pressure`` -- the dynamics engine's
+    single time-decayed pressure signal (seeded from ``prediction_error`` via
+    ``prediction_error_pressure()``, or from drive/contradiction pressure;
+    see ``orion/substrate/dynamics.py``/``pressure.py``). The raw
+    ``prediction_error`` metadata value must NOT be read as a magnitude here:
+    it never decays on its own, and since ``dynamic_pressure`` is derived
+    from it via ``raw * weight(<1) * decay(<=1)``, racing the two always
+    picks the raw value -- silently discarding the dynamics engine's decay
+    on every tick (found live 2026-07-14: a node's raw prediction_error sat
+    at 1.0, undecayed, for 6+ days while dynamic_pressure correctly decayed
+    around it and was never actually used). Still surface whether a
+    prediction-error seed exists at all, for the anomaly-vs-concept typing
+    downstream -- that's a stable category, not the buggy part.
+    """
 
     def _f(key: str) -> float:
         try:
@@ -109,10 +134,8 @@ def _node_salience(metadata: dict[str, Any]) -> tuple[float, str]:
             return 0.0
 
     pressure = _f("dynamic_pressure")
-    prediction_error = _f("prediction_error")
-    if prediction_error >= pressure:
-        return prediction_error, "prediction_error"
-    return pressure, "pressure"
+    kind = "prediction_error" if _f("prediction_error") > 0.0 else "pressure"
+    return pressure, kind
 
 
 def substrate_pressure_signals(
@@ -293,7 +316,7 @@ def _apply_voluntary_attention(
 
 
 def broadcast_projection_from_frame(frame: AttentionFrameV1) -> AttentionBroadcastProjectionV1:
-    global _current_active_coalition, _dwell_ticks, _coalition_history
+    global _current_active_coalition, _dwell_ticks, _coalition_history, _current_dwelling_loop_id
 
     selected = frame.selected_action
     selected_loop = None
@@ -322,6 +345,7 @@ def broadcast_projection_from_frame(frame: AttentionFrameV1) -> AttentionBroadca
                 }
             )
         _dwell_ticks += 1
+        _current_dwelling_loop_id = selected.open_loop_id if selected is not None else None
     else:
         # Decay: active coalition has left the recent window entirely
         if _current_active_coalition is not None and all(
@@ -336,6 +360,7 @@ def broadcast_projection_from_frame(frame: AttentionFrameV1) -> AttentionBroadca
             )
             _current_active_coalition = None
             _dwell_ticks = 0
+            _current_dwelling_loop_id = None
 
     # Compute stability score from recent salience consistency
     # (simplified: high if dwell_ticks > 3, medium if transitioning, low if flickering)

--- a/orion/substrate/tests/test_attention_broadcast.py
+++ b/orion/substrate/tests/test_attention_broadcast.py
@@ -46,9 +46,19 @@ def test_high_pressure_node_wins_over_calm() -> None:
 
 
 def test_prediction_error_beats_equal_plain_pressure() -> None:
+    # dynamic_pressure carries magnitude for both nodes (what the dynamics
+    # engine would have populated by the time either node is scored --
+    # magnitude must never come from the raw, non-decaying prediction_error
+    # field directly, see _node_salience()). prediction_error is still set
+    # on node:surprise purely for its anomaly-vs-concept typing effect.
     nodes = [
         _node("node:pressure", "steady pressure region", dynamic_pressure=0.8),
-        _node("node:surprise", "surprising transport batch", prediction_error=0.8),
+        _node(
+            "node:surprise",
+            "surprising transport batch",
+            dynamic_pressure=0.8,
+            prediction_error=0.8,
+        ),
     ]
     frame = build_substrate_attention_frame(nodes=nodes, now=_NOW)
     assert frame.selected_action is not None
@@ -57,6 +67,31 @@ def test_prediction_error_beats_equal_plain_pressure() -> None:
     )
     assert winner.description == "surprising transport batch"
     assert winner.target_type == "anomaly"
+
+
+def test_salience_uses_decayed_pressure_not_raw_prediction_error() -> None:
+    """A node whose prediction_error seed has decayed (dynamic_pressure near
+    zero, as SubstrateDynamicsEngine.tick() would compute after enough
+    elapsed time) must report low salience -- not near-maximal salience just
+    because the raw, non-decaying metadata['prediction_error'] field is
+    still 1.0. Regression for the live bug where _node_salience() raced the
+    two and always picked the raw value (dynamic_pressure = raw * weight(<1)
+    * decay(<=1) can mathematically never exceed it), silently discarding
+    the dynamics engine's decay on every tick, forever, for any node that
+    ever had a prediction_error written. `kind` should still resolve to
+    "prediction_error" (anomaly typing) even though magnitude is low."""
+    nodes = [
+        _node(
+            "node:stale-surprise",
+            "long-stale transport anomaly",
+            dynamic_pressure=0.02,  # decayed by the dynamics engine over time
+            prediction_error=1.0,  # raw seed -- never decays on its own
+        ),
+    ]
+    signals = substrate_pressure_signals(nodes, min_salience=0.0)
+    assert signals
+    assert signals[0].salience == 0.02
+    assert signals[0].target_type_hint == "anomaly"
 
 
 def test_broadcast_never_generates_questions() -> None:

--- a/orion/substrate/tests/test_attention_broadcast_dwell.py
+++ b/orion/substrate/tests/test_attention_broadcast_dwell.py
@@ -21,6 +21,7 @@ def _reset_broadcast_globals():
     attention_broadcast._coalition_history.clear()
     attention_broadcast._current_active_coalition = None
     attention_broadcast._dwell_ticks = 0
+    attention_broadcast._current_dwelling_loop_id = None
     attention_broadcast._transition_history.clear()
     attention_broadcast._recent_selected_counts.clear()
     attention_broadcast._first_selected_at.clear()
@@ -28,6 +29,7 @@ def _reset_broadcast_globals():
     attention_broadcast._coalition_history.clear()
     attention_broadcast._current_active_coalition = None
     attention_broadcast._dwell_ticks = 0
+    attention_broadcast._current_dwelling_loop_id = None
     attention_broadcast._transition_history.clear()
     attention_broadcast._recent_selected_counts.clear()
     attention_broadcast._first_selected_at.clear()

--- a/orion/substrate/tests/test_attention_broadcast_recency.py
+++ b/orion/substrate/tests/test_attention_broadcast_recency.py
@@ -37,6 +37,7 @@ def _reset_broadcast_globals(monkeypatch: pytest.MonkeyPatch):
     attention_broadcast._coalition_history.clear()
     attention_broadcast._current_active_coalition = None
     attention_broadcast._dwell_ticks = 0
+    attention_broadcast._current_dwelling_loop_id = None
     attention_broadcast._transition_history.clear()
     attention_broadcast._recent_selected_counts.clear()
     attention_broadcast._first_selected_at.clear()
@@ -44,6 +45,7 @@ def _reset_broadcast_globals(monkeypatch: pytest.MonkeyPatch):
     attention_broadcast._coalition_history.clear()
     attention_broadcast._current_active_coalition = None
     attention_broadcast._dwell_ticks = 0
+    attention_broadcast._current_dwelling_loop_id = None
     attention_broadcast._transition_history.clear()
     attention_broadcast._recent_selected_counts.clear()
     attention_broadcast._first_selected_at.clear()

--- a/orion/substrate/tests/test_broadcast_habituation.py
+++ b/orion/substrate/tests/test_broadcast_habituation.py
@@ -17,6 +17,7 @@ def _reset_broadcast_state():
     ab._recent_selected_counts.clear()
     ab._first_selected_at.clear()
     ab._dwell_ticks = 0
+    ab._current_dwelling_loop_id = None
     ab._coalition_history.clear()
     ab._current_active_coalition = None
     ab._transition_history.clear()
@@ -24,6 +25,7 @@ def _reset_broadcast_state():
     ab._recent_selected_counts.clear()
     ab._first_selected_at.clear()
     ab._dwell_ticks = 0
+    ab._current_dwelling_loop_id = None
     ab._coalition_history.clear()
     ab._current_active_coalition = None
     ab._transition_history.clear()

--- a/orion/substrate/tests/test_rumination_replay.py
+++ b/orion/substrate/tests/test_rumination_replay.py
@@ -36,7 +36,8 @@ def test_habituation_demotes_stuck_loop_below_competitor():
                                  history=SalienceHistory(), apply_habituation=True)
     assert stuck0 > fresh0
 
-    stuck_hist = SalienceHistory(dwell_ticks=8, recent_theme_counts={"open-loop-stuck": 8},
+    stuck_hist = SalienceHistory(dwell_ticks=8, dwelling_loop_id="open-loop-stuck",
+                                 recent_theme_counts={"open-loop-stuck": 8},
                                  resonance_theme_keys={"open-loop-stuck"})
     stuckN, feats = compute_salience(loop=stuck, signals=[_sig("open-loop-stuck", 0.9)],
                                      history=stuck_hist, apply_habituation=True)

--- a/orion/substrate/tests/test_salience_combiner.py
+++ b/orion/substrate/tests/test_salience_combiner.py
@@ -128,7 +128,8 @@ def test_recency_decays_with_age():
 
 def test_apply_habituation_toggle_changes_score():
     loop = _loop()
-    hist = SalienceHistory(dwell_ticks=6, recent_theme_counts={loop.id: 5},
+    hist = SalienceHistory(dwell_ticks=6, dwelling_loop_id=loop.id,
+                           recent_theme_counts={loop.id: 5},
                            resonance_theme_keys={loop.id})
     with_hab, _ = compute_salience(loop=loop, signals=[_signal(0.9, 0.9)],
                                    history=hist, apply_habituation=True)

--- a/orion/substrate/tests/test_scoring_salience_wiring.py
+++ b/orion/substrate/tests/test_scoring_salience_wiring.py
@@ -88,3 +88,44 @@ def test_build_open_loops_now_param_reaches_recency_calculation():
     assert fresh.salience_features["recency"] == 1.0
     # One half-life (see salience._recency's docstring: half-life ~6h).
     assert six_hours_later.salience_features["recency"] == pytest.approx(0.5, abs=0.01)
+
+
+def test_dwell_scoped_to_dwelling_loop_only():
+    """dwell must only penalize the loop actually recorded as dwelling.
+
+    Previously `history.dwell_ticks` (a single module-level tick counter,
+    see attention_broadcast.py's `_dwell_ticks`) was applied uniformly to
+    every competing loop scored in a tick -- a uniform per-tick offset
+    shared by every candidate cannot demote the specific stuck loop
+    relative to its competitors, since it changes nothing about who wins.
+    Found live 2026-07-14 alongside the recency bug."""
+    from orion.substrate.attention.common import compact, stable_id
+
+    signals = [
+        AttentionSignalV1(
+            signal_id="s1", source="current_turn", target_text="the reactor plan",
+            target_type_hint="plan", signal_kind="test", salience=0.9, confidence=0.9,
+            evidence_refs=["r1"],
+        ),
+        AttentionSignalV1(
+            signal_id="s2", source="current_turn", target_text="a fresh competitor thread",
+            target_type_hint="concept", signal_kind="test", salience=0.9, confidence=0.9,
+            evidence_refs=["r2"],
+        ),
+    ]
+    dwelling_id = stable_id("open-loop", compact("the reactor plan", 120).lower())
+    history = SalienceHistory(dwell_ticks=5, dwelling_loop_id=dwelling_id)
+
+    loops = build_open_loops(
+        signals=signals,
+        ctx={"user_message": "the reactor plan a fresh competitor thread"},
+        inputs={}, belief_lineage=[], direct_turn=False, generic_reversal=False,
+        stale_thread_active=False, max_open=5, history=history,
+    )
+    by_id = {loop.id: loop for loop in loops}
+    assert len(by_id) == 2
+    other_id = next(lid for lid in by_id if lid != dwelling_id)
+
+    assert by_id[dwelling_id].salience_features["dwell"] > 0.0
+    assert by_id[other_id].salience_features["dwell"] == 0.0
+    assert by_id[dwelling_id].salience_features["habituation"] > by_id[other_id].salience_features["habituation"]


### PR DESCRIPTION
## Summary

Follow-up to #1052 (recency fix) and #1055 (verdict-aware narration): those fixed one dead feature and the narration-layer symptom, but the rung-3 *selection* competition itself still permanently favored a verdicted-dead loop. Investigation (live Postgres data, 2166 real trace rows over 6 days) found two more independent dead-feature bugs in the same salience pipeline, both fixed here:

1. **`_node_salience()` raced raw vs. decayed and always picked raw.** `metadata["prediction_error"]` never decays; `metadata["dynamic_pressure"]` is properly time-decayed by `SubstrateDynamicsEngine` every 30s. But `dynamic_pressure = raw * weight(0.6) * decay(<=1)` can never exceed the raw value, so the raw branch always won — silently discarding the dynamics engine's decay, forever, for any node that ever had a `prediction_error` written. Confirmed live: a verdicted-`resolved`/`dismissed` loop's `evidence_strength` sat at exactly `1.0` for 6 straight days.
2. **`dwell` habituation was a global scalar, not loop-scoped.** A single module-level tick counter was applied uniformly to every competing loop in a tick — a per-tick offset shared by everyone can't demote the specific dwelling loop relative to its competitors.

Code review (high effort, 8 finder angles) found and fixed 4 more issues the change surfaced (3 test files silently losing dwell coverage, one dead conditional, one unguarded edge case), and flagged 3 real findings left as documented, accepted follow-ups (see PR report).

## Test plan

- [x] `pytest orion/substrate/tests/ -q` → 203 passed
- [x] `test_rumination_replay.py`, `test_salience_combiner.py`, `test_attention_broadcast_recency.py` individually → all 17 pass (confirms review-fixed dwell/reset regressions are actually exercised)
- [x] Code review skill (high, 8 angles, verified) run and material findings fixed
- [ ] Deploy + live re-verify (same open question as #1052: whether a verdicted-dead loop can still win on legitimately-recomputed, not just stale, pressure — see PR report "Risks")

Full report: `docs/superpowers/pr-reports/2026-07-14-attention-salience-decay-bypass-pr.md`
Investigation doc: `docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)