### PR TITLE
fix(harness): grammar atoms never got real wall-clock observed_at

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-15-harness-grammar-atom-wall-clock-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-15-harness-grammar-atom-wall-clock-pr.md
@@ -1,0 +1,218 @@
+# PR report — harness grammar atoms never got real wall-clock observed_at
+
+PR: (create at https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/harness-grammar-atom-wall-clock)
+Branch: `fix/harness-grammar-atom-wall-clock`
+Status: **DONE**
+
+## Summary
+
+- Confirmed and fixed a real, non-speculative sibling bug flagged in memory
+  (`project_grammar_collector_shared_timestamp_bug_siblings`): `HarnessGrammarCollector`
+  (`orion/harness/grammar_emit.py`) shared the exact bug already fixed in
+  `CortexExecGrammarCollector` (PR #1042) — every `GrammarAtomV1`/edge/
+  `trace_ended` event in a harness trace got one shared `observed_at`
+  captured once at collector construction, regardless of how much real
+  elapsed time separated request-received from step-started from
+  step-completed from result-assembled.
+- Live-verified before touching code: harness traces with 7–55 atoms,
+  spanning up to 2m15s of real wall-clock time (per the sibling
+  bare-correlation-id trace's `created_at` range), all showed exactly 1
+  distinct `observed_at` value across every atom.
+- Fixed with the same shape as the cortex-exec patch: a new
+  `_atom_observed_at` dict populated in `_put_atom()`, alongside
+  `GrammarAtomV1.time_range` (previously always `None` — a second location
+  the same "timing is fake" symptom survived).
+- Found and fixed a **second, distinct bug** while writing the regression
+  tests: `record_step_started`/`record_step_completed`/`record_step_failed`
+  — the three most timing-sensitive atom types — bypassed `_put_atom()`
+  entirely (`self._atoms[key] = atom` direct assignment, pre-dating this
+  patch), so even with the collector-level fix in place these three would
+  have kept falling back to the trace-start timestamp.
+- Code review (high effort, 8 angles) found and fixed a **third bug**,
+  independently flagged by 2 of 8 angles from tracing the real production
+  call graph: `record_result_assembled` is genuinely re-invoked on the same
+  collector instance across two production phases (motor publish, then
+  finalize publish), and since its `atom_id` is deterministic, the naive
+  fix would have published the same identity twice with contradictory
+  timestamps. Fixed by making `_put_atom()` idempotent per `atom_id`. The
+  identical fix was then backported to the sibling `CortexExecGrammarCollector`,
+  confirmed live-relevant there too (not hypothetical — traced the real
+  4-call-site production pattern in `router.py`).
+
+## Outcome moved
+
+Harness execution traces now carry real per-atom timestamps. `orion/grammar/ledger.py`'s
+existing `_upsert_trace()` (already fixed in PR #1042 to prefer `observed_at`
+over `emitted_at`) now gets real, non-collapsed data from the harness
+producer too — `grammar_traces.started_at`/`ended_at` for harness traces
+should stop showing zero-duration.
+
+## Current architecture
+
+`HarnessGrammarCollector` (`orion/harness/grammar_emit.py`) is one of three
+independently-duplicated grammar-collector classes (siblings:
+`CortexExecGrammarCollector` in `services/orion-cortex-exec/app/grammar_emit.py`,
+`BusTransportGrammarCollector` in `services/orion-bus/app/grammar_emit.py`) —
+no shared base class exists; each accumulates `GrammarAtomV1`s/edges via
+`record_*()` methods, then `build_*_grammar_events()` assembles the final
+`GrammarEventV1` list for publish. `HarnessRunner.run()` constructs one
+collector per turn; the same instance is threaded through the motor-publish
+path (`runner.py`) and, if `final_text` is present, a second finalize-publish
+path (`services/orion-harness-governor/app/bus_listener.py`).
+
+## Architecture touched
+
+`orion/harness/grammar_emit.py` (shared package code), `services/orion-cortex-exec/app/grammar_emit.py`
+(separate service, backported fix), plus 2 test files. No schema/env/Docker
+changes.
+
+## Files changed
+
+- `orion/harness/grammar_emit.py`: `_atom_observed_at` dict + `time_range`
+  stamping in `_put_atom()` (made idempotent per `atom_id` after review);
+  `record_step_started`/`record_step_completed`/`record_step_failed` routed
+  through `_put_atom()` instead of direct dict assignment;
+  `build_harness_grammar_events()`/`build_harness_grammar_finalize_events()`
+  use real per-atom timestamps via a new `observed_at_for()` helper;
+  `trace_ended` uses the real max recorded timestamp instead of reusing
+  trace-start.
+- `orion/harness/tests/test_harness_grammar_emit.py`: 8 new regression
+  tests, mirroring `CortexExecGrammarCollector`'s test suite, adapted to
+  `HarnessGrammarCollector`'s actual API.
+- `services/orion-cortex-exec/app/grammar_emit.py`: backported the
+  idempotency-per-`atom_id` guard to `_put_atom()` (the timestamp/`time_range`
+  fix itself already shipped in PR #1042; this patch only adds the
+  re-invocation guard, newly proven necessary).
+- `services/orion-cortex-exec/tests/test_exec_grammar_emit.py`: 1 new
+  regression test mirroring the harness one.
+
+## Schema / bus / API changes
+
+None. `HarnessGrammarCollector._atom_observed_at` and
+`CortexExecGrammarCollector`'s idempotency change are both purely additive/
+internal — no consumer-visible shape change.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest orion/harness/tests/test_harness_grammar_emit.py -q
+=> 15 passed
+
+.venv/bin/python -m pytest orion/harness/ -q
+=> 145 passed, 3 failed (pre-existing on main, unrelated: test_grounding_capsule_consumers.py x2,
+   test_harness_runner.py x1 -- confirmed identical failures on main before this branch)
+
+PYTHONPATH=services/orion-harness-governor:. .venv/bin/python -m pytest services/orion-harness-governor/tests -q
+=> 13 passed
+
+PYTHONPATH=services/orion-cortex-exec:. .venv/bin/python -m pytest services/orion-cortex-exec/tests/test_exec_grammar_emit.py -q
+=> 16 passed (15 pre-existing + 1 new)
+```
+
+## Evals run
+
+None applicable — no eval harness exists for `orion/harness/grammar_emit.py`
+or its cortex-exec sibling. The live Postgres query (`grammar_events`
+grouped by `trace_id`, filtered `source_service='orion-harness-governor'`,
+comparing `count(DISTINCT observed_at)` against `wall_clock_spread`) used to
+confirm this bug before touching code is the closest thing to an eval —
+informal, by hand, not automated. Same gap flagged in PR #1052/#1061's
+reports this session.
+
+## Docker/build/smoke checks
+
+Not run — pure Python logic change inside `orion-harness-governor`'s shared
+package code and `orion-cortex-exec`'s existing code path, no config/
+dependency changes to validate.
+
+## Review findings fixed
+
+Code-review skill, high effort (3 correctness + 3 cleanup + altitude +
+conventions = 8 finder angles, verified):
+
+- **Finding** (2 of 8 angles, independently, both tracing the real
+  production call graph): `record_result_assembled` is genuinely
+  re-invoked on the same collector across the motor-publish and
+  finalize-publish phases (`orion/harness/runner.py` → `services/orion-harness-governor/app/bus_listener.py:344-354`).
+  Since `atom_id` is deterministic, the second call would advance
+  `_atom_observed_at` and publish the same `atom_id`/`event_id` twice with
+  contradictory `observed_at`. `on_conflict_do_nothing` in
+  `orion/grammar/ledger.py` masks this at the DB layer, but a raw bus
+  consumer of `orion:grammar:event` would see it directly.
+  - **Fix**: `_put_atom()` made idempotent per `atom_id` — first-seen
+    timestamp wins; atom content still refreshes on every call.
+  - **Evidence**: new `test_result_assembled_reinvoked_keeps_first_observed_at`
+    reproduces the real double-call sequence and asserts pinned timestamp +
+    refreshed content.
+- **Finding** (altitude angle, backed by concrete `router.py` line
+  citations): `CortexExecGrammarCollector`'s `_put_atom()` has the identical
+  `_atom_observed_at` shape but never got an idempotency guard, and the
+  same re-invocation pattern is confirmed live there too
+  (`get_or_create_collector()` caches one collector per `ctx`;
+  `record_assembled_grammar()` is called from 4 separate sites in
+  `router.py`).
+  - **Fix**: backported the identical guard.
+  - **Evidence**: all 16 cortex-exec grammar_emit tests pass (15
+    pre-existing + 1 new, mirroring the harness regression test).
+- **Finding** (simplification angle): the `observed_at` fallback lookup
+  (`collector._atom_observed_at.get(id, observed_at)`) was copy-pasted 4
+  times across the two harness builder functions.
+  - **Fix**: extracted into one `observed_at_for()` method.
+  - **Evidence**: full suite still passes (behavior-neutral refactor).
+- **Finding** (conventions angle): a code comment cited "PR #1039" for the
+  cortex-exec grammar-atom-wall-clock work; the actual PR was #1042 (#1039
+  is unrelated — `fix/execution-dispatch-real-send-bugs`).
+  - **Fix**: corrected the comment.
+  - **Evidence**: `git log` cross-check.
+
+Not fixed, accepted and documented — would expand scope beyond the
+confirmed bug class:
+
+- `orion/grammar/ledger.py`'s `on_conflict_do_nothing` means a re-invoked
+  `record_result_assembled`'s refreshed *content* (not just timestamp)
+  never actually reaches Postgres — only the first-arriving row persists.
+  Whether atom rows should be upsertable-on-conflict instead of insert-only
+  is a real, separate persistence-semantics question.
+- `services/orion-bus/app/grammar_emit.py`'s `BusTransportGrammarCollector`
+  still has neither the timestamp fix nor the idempotency guard —
+  confirmed still true, matches prior memory, lower priority per that same
+  memory (sub-millisecond real timescale for that collector's atoms).
+- `observed_at_for()`'s fallback to trace-start when an atom bypassed
+  `_put_atom()` is currently dead code in production (all 9 `record_*`
+  methods route through it) — a candidate for louder failure (log/raise)
+  instead of a silent default, but guards a hypothetical future bug, not a
+  live one; left matching the already-accepted sibling pattern.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-harness-governor/.env \
+  -f services/orion-harness-governor/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build
+```
+Not run this session.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `services/orion-bus/app/grammar_emit.py`'s `BusTransportGrammarCollector`
+  is now the last of the three sibling collectors with neither fix. Per
+  existing memory this is intentionally lower priority (sub-millisecond
+  real timescale, genuinely less consequential) — not a new concern, just
+  confirmed still open.
+- Severity: low
+- Concern: no shared base class/mixin exists across the three collectors,
+  so a future 4th instance of this bug class (or the next timing-semantics
+  fix) requires another independent patch. Flagged by the review's reuse
+  angle as worth a future architecture decision, not undertaken here to
+  keep this patch thin and scoped to the confirmed bug.
+
+## PR link
+
+`gh` is authenticated in this environment.

--- a/orion/harness/grammar_emit.py
+++ b/orion/harness/grammar_emit.py
@@ -13,6 +13,7 @@ from orion.schemas.grammar import (
     GrammarEdgeV1,
     GrammarEventV1,
     GrammarProvenanceV1,
+    TimeRangeV1,
 )
 from orion.substrate.execution_loop.ids import cortex_exec_trace_id
 
@@ -69,6 +70,19 @@ class HarnessGrammarCollector:
     session_id: str | None = None
     turn_id: str | None = None
     _atoms: dict[str, GrammarAtomV1] = field(default_factory=dict)
+    # Real wall-clock moment each atom was actually recorded, keyed by
+    # atom_id. Populated by _put_atom() -- same fix shape as
+    # CortexExecGrammarCollector's _atom_observed_at
+    # (services/orion-cortex-exec/app/grammar_emit.py, PR #1039/spec
+    # 2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md). Before this,
+    # every GrammarEventV1's observed_at in a harness trace was the same
+    # value captured once at collector construction (self.observed_at,
+    # trace-START -- not "flush time", that's the separate emitted_at set
+    # in build_harness_grammar_events()). Confirmed live: harness traces
+    # with 7-55 atoms and up to 2m15s of real wall-clock span between their
+    # sibling (bare-correlation-id) trace's created_at rows all showed
+    # exactly 1 distinct observed_at value across every atom.
+    _atom_observed_at: dict[str, datetime] = field(default_factory=dict)
     _edge_specs: list[tuple[str, str, str]] = field(default_factory=list)
     _last_completed_atom_id: str | None = None
 
@@ -90,7 +104,14 @@ class HarnessGrammarCollector:
         return f"{self.trace_id}:{key}"
 
     def _put_atom(self, key: str, atom: GrammarAtomV1) -> None:
+        now = datetime.now(timezone.utc)
+        # Same source timestamp for both, set together so they can never
+        # drift -- see CortexExecGrammarCollector._put_atom's identical
+        # pattern for why time_range is stamped here too (ledger.py's
+        # atom-row persistence and the Grammar Atlas API read it).
+        atom.time_range = TimeRangeV1(start=now, end=now)
         self._atoms[key] = atom
+        self._atom_observed_at[atom.atom_id] = now
 
     def record_request_received(self) -> None:
         ref = f"harness.exec.request:{self.correlation_id}"
@@ -187,7 +208,7 @@ class HarnessGrammarCollector:
             source_event_id=f"{self.correlation_id}:{order}",
             payload_ref=ref,
         )
-        self._atoms[key] = atom
+        self._put_atom(key, atom)
         if self._last_completed_atom_id:
             self._edge_specs.append(
                 (self._last_completed_atom_id, atom.atom_id, "temporal_successor")
@@ -226,7 +247,7 @@ class HarnessGrammarCollector:
             source_event_id=f"{self.correlation_id}:{order}",
             payload_ref=ref,
         )
-        self._atoms[key] = atom
+        self._put_atom(key, atom)
         started = self._atoms.get(started_key)
         if started:
             self._edge_specs.append((started.atom_id, atom.atom_id, "derived_from"))
@@ -249,7 +270,7 @@ class HarnessGrammarCollector:
             source_event_id=f"{self.correlation_id}:{order}",
             payload_ref=ref,
         )
-        self._atoms[key] = atom
+        self._put_atom(key, atom)
         started = self._atoms.get(started_key)
         if started:
             self._edge_specs.append((started.atom_id, atom.atom_id, "derived_from"))
@@ -436,12 +457,18 @@ def build_harness_grammar_events(
     events: list[GrammarEventV1] = [root]
 
     for atom in collector._atoms.values():
+        # Real wall-clock moment this atom was actually recorded (see
+        # _put_atom / _atom_observed_at docstring above), not the single
+        # trace-START value every atom in a trace previously shared. Falls
+        # back to trace-start observed_at only if an atom somehow bypassed
+        # _put_atom(). emitted_at stays the shared flush-time value.
+        atom_ts = collector._atom_observed_at.get(atom.atom_id, observed_at)
         events.append(
             _event(
                 event_kind="atom_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=atom_ts,
                 provenance=provenance,
                 atom=atom,
                 parent_event_id=root_id,
@@ -465,12 +492,15 @@ def build_harness_grammar_events(
             salience=0.7,
             evidence_event_ids=[collector.correlation_id],
         )
+        # observed_at = real moment the target atom happened; emitted_at
+        # stays the shared flush-time value, same reasoning as above.
+        edge_ts = collector._atom_observed_at.get(to_atom_id, observed_at)
         events.append(
             _event(
                 event_kind="edge_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=edge_ts,
                 provenance=provenance,
                 edge=edge,
                 parent_event_id=root_id,
@@ -483,12 +513,18 @@ def build_harness_grammar_events(
             )
         )
 
+    # Real trace-end moment = the last atom actually recorded, not
+    # collector.observed_at (trace-START, which trace_ended previously
+    # reused, collapsing trace_started/trace_ended's observed_at to the
+    # same instant). Falls back to trace-start observed_at only for a
+    # trace with zero recorded atoms.
+    trace_ended_at = max(collector._atom_observed_at.values(), default=observed_at)
     events.append(
         _event(
             event_kind="trace_ended",
             trace_id=trace_id,
             emitted_at=datetime.now(timezone.utc),
-            observed_at=observed_at,
+            observed_at=trace_ended_at,
             provenance=provenance,
             parent_event_id=root_id,
             root_event_id=root_id,
@@ -521,12 +557,13 @@ def build_harness_grammar_finalize_events(
     provenance = collector._provenance(f"harness.exec.finalize:{collector.correlation_id}")
     events: list[GrammarEventV1] = []
     for atom in atoms:
+        atom_ts = collector._atom_observed_at.get(atom.atom_id, observed_at)
         events.append(
             _event(
                 event_kind="atom_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=atom_ts,
                 provenance=provenance,
                 atom=atom,
                 layer=atom.layer,
@@ -550,12 +587,13 @@ def build_harness_grammar_finalize_events(
             salience=0.7,
             evidence_event_ids=[collector.correlation_id],
         )
+        edge_ts = collector._atom_observed_at.get(emitted.atom_id, observed_at)
         events.append(
             _event(
                 event_kind="edge_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=edge_ts,
                 provenance=provenance,
                 edge=edge,
                 layer="step",

--- a/orion/harness/grammar_emit.py
+++ b/orion/harness/grammar_emit.py
@@ -73,7 +73,7 @@ class HarnessGrammarCollector:
     # Real wall-clock moment each atom was actually recorded, keyed by
     # atom_id. Populated by _put_atom() -- same fix shape as
     # CortexExecGrammarCollector's _atom_observed_at
-    # (services/orion-cortex-exec/app/grammar_emit.py, PR #1039/spec
+    # (services/orion-cortex-exec/app/grammar_emit.py, PR #1042/spec
     # 2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md). Before this,
     # every GrammarEventV1's observed_at in a harness trace was the same
     # value captured once at collector construction (self.observed_at,
@@ -104,7 +104,20 @@ class HarnessGrammarCollector:
         return f"{self.trace_id}:{key}"
 
     def _put_atom(self, key: str, atom: GrammarAtomV1) -> None:
-        now = datetime.now(timezone.utc)
+        # Idempotent per atom_id, not per call: record_result_assembled() is
+        # genuinely re-invoked on the SAME collector in production (motor
+        # publish in runner.py, then a second call from the finalize chain
+        # in services/orion-harness-governor/app/bus_listener.py) with a
+        # deterministic atom_id both times. Advancing the timestamp on the
+        # second call would publish the same atom_id/event_id twice with
+        # contradictory observed_at -- orion/grammar/ledger.py's
+        # on_conflict_do_nothing masks this at the DB layer (first write
+        # wins there too), but a raw bus consumer would see it directly.
+        # Reusing the first-seen timestamp keeps every publish for a given
+        # atom_id self-consistent, matching the DB's own dedup semantics.
+        # The atom's content (self._atoms[key]) still updates on every call
+        # -- only its recorded occurrence time is pinned to first sight.
+        now = self._atom_observed_at.get(atom.atom_id) or datetime.now(timezone.utc)
         # Same source timestamp for both, set together so they can never
         # drift -- see CortexExecGrammarCollector._put_atom's identical
         # pattern for why time_range is stamped here too (ledger.py's
@@ -112,6 +125,15 @@ class HarnessGrammarCollector:
         atom.time_range = TimeRangeV1(start=now, end=now)
         self._atoms[key] = atom
         self._atom_observed_at[atom.atom_id] = now
+
+    def observed_at_for(self, atom_id: str) -> datetime:
+        """Real recorded timestamp for a given atom_id, falling back to
+        trace-start observed_at only if that atom somehow bypassed
+        _put_atom(). Single source for the lookup build_harness_grammar_events()
+        and build_harness_grammar_finalize_events() both need per atom and
+        per edge, so a future change to the fallback policy can't be applied
+        to some call sites and missed at others."""
+        return self._atom_observed_at.get(atom_id, self.observed_at)
 
     def record_request_received(self) -> None:
         ref = f"harness.exec.request:{self.correlation_id}"
@@ -462,7 +484,7 @@ def build_harness_grammar_events(
         # trace-START value every atom in a trace previously shared. Falls
         # back to trace-start observed_at only if an atom somehow bypassed
         # _put_atom(). emitted_at stays the shared flush-time value.
-        atom_ts = collector._atom_observed_at.get(atom.atom_id, observed_at)
+        atom_ts = collector.observed_at_for(atom.atom_id)
         events.append(
             _event(
                 event_kind="atom_emitted",
@@ -494,7 +516,7 @@ def build_harness_grammar_events(
         )
         # observed_at = real moment the target atom happened; emitted_at
         # stays the shared flush-time value, same reasoning as above.
-        edge_ts = collector._atom_observed_at.get(to_atom_id, observed_at)
+        edge_ts = collector.observed_at_for(to_atom_id)
         events.append(
             _event(
                 event_kind="edge_emitted",
@@ -557,7 +579,7 @@ def build_harness_grammar_finalize_events(
     provenance = collector._provenance(f"harness.exec.finalize:{collector.correlation_id}")
     events: list[GrammarEventV1] = []
     for atom in atoms:
-        atom_ts = collector._atom_observed_at.get(atom.atom_id, observed_at)
+        atom_ts = collector.observed_at_for(atom.atom_id)
         events.append(
             _event(
                 event_kind="atom_emitted",
@@ -587,7 +609,7 @@ def build_harness_grammar_finalize_events(
             salience=0.7,
             evidence_event_ids=[collector.correlation_id],
         )
-        edge_ts = collector._atom_observed_at.get(emitted.atom_id, observed_at)
+        edge_ts = collector.observed_at_for(emitted.atom_id)
         events.append(
             _event(
                 event_kind="edge_emitted",

--- a/orion/harness/tests/test_harness_grammar_emit.py
+++ b/orion/harness/tests/test_harness_grammar_emit.py
@@ -288,6 +288,54 @@ def test_finalize_atoms_use_real_observed_at(monkeypatch: pytest.MonkeyPatch) ->
     assert edge_events[0].observed_at == emitted_atom.observed_at
 
 
+def test_result_assembled_reinvoked_keeps_first_observed_at(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """record_result_assembled (and record_result_emitted) really is called
+    twice on the SAME collector in production: orion/harness/runner.py's
+    motor-lifecycle publish calls it once, then
+    services/orion-harness-governor/app/bus_listener.py's finalize-lifecycle
+    publish calls it again on motor.grammar_collector -- the identical
+    instance. Both calls produce the same deterministic atom_id/event_id.
+    Before this test's fix: the second call would advance
+    _atom_observed_at, so a motor-time publish and a later finalize-time
+    publish would carry the SAME atom_id/event_id but DIFFERENT
+    observed_at/time_range -- exactly the 'same identity, contradictory
+    timestamp' shape this whole patch exists to eliminate, just moved from
+    'always identical' (the original bug) to 'identical id, drifting
+    timestamp' (a new variant). orion/grammar/ledger.py's
+    on_conflict_do_nothing masks this at the DB layer, but a raw bus
+    consumer of orion:grammar:event would see the drift directly."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    _record_two_step_trace(c)
+    first_events = build_harness_grammar_events(c)
+    first_assembled = next(
+        e for e in first_events if e.atom and e.atom.semantic_role == "exec_result_assembled"
+    )
+    first_ts = first_assembled.observed_at
+
+    # Simulate the finalize chain re-invoking these on the same instance,
+    # as bus_listener.py's _emit_finalize_lifecycle_grammar really does --
+    # step_count=0 here (vs. the first call's 2) so the refreshed content
+    # is observably different from the first call's summary text.
+    c.record_result_assembled(
+        status="success", final_text_present=True, step_count=0,
+        grammar_receipt_count=1, reflection_ran=True, quick_lane_skipped_5b=False,
+    )
+    c.record_result_emitted(reply_present=True, status="success")
+
+    second_events = build_harness_grammar_finalize_events(c)
+    second_assembled = next(
+        e for e in second_events if e.atom and e.atom.semantic_role == "exec_result_assembled"
+    )
+    assert second_assembled.atom.atom_id == first_assembled.atom.atom_id
+    assert second_assembled.observed_at == first_ts
+    assert second_assembled.atom.time_range.start == first_ts
+    # Content still refreshes on the second call -- only timing is pinned.
+    assert "thinking_source=finalize_reflect" in second_assembled.atom.summary
+
+
 def test_finalize_events_emit_only_assembled_and_egress() -> None:
     c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
     c.record_request_received()

--- a/orion/harness/tests/test_harness_grammar_emit.py
+++ b/orion/harness/tests/test_harness_grammar_emit.py
@@ -1,4 +1,7 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
 
 from orion.harness.grammar_emit import (
     HarnessGrammarCollector,
@@ -12,6 +15,38 @@ from orion.substrate.execution_loop.ids import cortex_exec_trace_id
 NODE = "athena"
 CORR = "corr-harness-1"
 FIXED = datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc)
+
+
+def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch grammar_emit's datetime.now() to return strictly increasing,
+    deterministic timestamps -- one tick per call -- so tests can assert
+    real ordering/distinctness without depending on wall-clock speed. Same
+    pattern as CortexExecGrammarCollector's test suite
+    (services/orion-cortex-exec/tests/test_exec_grammar_emit.py)."""
+    import orion.harness.grammar_emit as ge
+
+    counter = {"n": 0}
+    base = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _fake_now(tz: object = None) -> datetime:
+        counter["n"] += 1
+        return base + timedelta(milliseconds=counter["n"])
+
+    monkeypatch.setattr(ge, "datetime", SimpleNamespace(now=_fake_now))
+
+
+def _record_two_step_trace(collector: HarnessGrammarCollector) -> None:
+    collector.record_request_received()
+    collector.record_plan_started(step_count=2)
+    collector.record_recall_gate_observed(run_recall=False, profile="p", reason="r")
+    for i in (1, 2):
+        collector.record_step_started(order=i, summary=f"step_{i}")
+        collector.record_step_completed(order=i)
+    collector.record_result_assembled(
+        status="success", final_text_present=True, step_count=2,
+        grammar_receipt_count=1, reflection_ran=False, quick_lane_skipped_5b=True,
+    )
+    collector.record_result_emitted(reply_present=True, status="success")
 
 
 def test_trace_id_matches_cortex_exec_shape() -> None:
@@ -93,6 +128,164 @@ def test_record_tool_provenance_mismatch_becomes_last_completed_atom() -> None:
         edge.from_atom_id == mismatch_atom.atom_id and edge.to_atom_id == assembled_atom.atom_id
         for edge in edges
     )
+
+
+def test_atoms_get_distinct_real_observed_at_not_shared_flush_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before this fix: every atom in a harness trace shared one trace-START
+    timestamp (confirmed live: harness traces with 7-55 atoms and up to
+    2m15s real wall-clock span all showed exactly 1 distinct observed_at
+    across every atom). Each record_*() call must now stamp its own real
+    observed_at, in recording order. Same fix shape as
+    CortexExecGrammarCollector (services/orion-cortex-exec/app/grammar_emit.py)."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    _record_two_step_trace(c)
+
+    events = build_harness_grammar_events(c)
+    atom_events = [e for e in events if e.atom is not None]
+    observed_ats = [e.observed_at for e in atom_events]
+
+    assert len(set(observed_ats)) == len(observed_ats), (
+        f"expected distinct observed_at per atom, got duplicates: {observed_ats}"
+    )
+    assert observed_ats == sorted(observed_ats), "expected observed_at in recording order"
+
+
+def test_emitted_at_stays_shared_flush_time_across_all_atoms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """emitted_at was never wrong -- every event in a trace genuinely is
+    published to the bus in the same flush batch. Only observed_at (real
+    occurrence time) should change."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    _record_two_step_trace(c)
+
+    events = build_harness_grammar_events(c)
+    atom_events = [e for e in events if e.atom is not None]
+    emitted_ats = {e.emitted_at for e in atom_events}
+    assert len(emitted_ats) == 1, f"expected one shared emitted_at, got {emitted_ats}"
+
+
+def test_edge_observed_at_matches_target_atom_real_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    _record_two_step_trace(c)
+
+    events = build_harness_grammar_events(c)
+    atom_observed_at = {e.atom.atom_id: e.observed_at for e in events if e.atom is not None}
+    edge_events = [e for e in events if e.edge is not None]
+    assert edge_events, "expected at least one edge in a two-step trace"
+    for edge_event in edge_events:
+        target_id = edge_event.edge.to_atom_id
+        assert target_id in atom_observed_at
+        assert edge_event.observed_at == atom_observed_at[target_id]
+        # Self-consistency alone (edge == its own target atom) passes
+        # trivially even if the whole per-atom fix were reverted back to one
+        # shared value -- also assert against the pre-fix shared constant
+        # (trace-start observed_at) directly, so a revert fails this too.
+        assert edge_event.observed_at != FIXED
+
+
+def test_atom_missing_from_observed_at_map_falls_back_to_trace_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive fallback: if an atom somehow bypassed _put_atom() and has no
+    captured observed_at, use the collector's trace-start observed_at rather
+    than crashing or emitting None."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    c.record_request_received()
+    missing_atom_id = next(iter(c._atoms.values())).atom_id
+    del c._atom_observed_at[missing_atom_id]
+
+    events = build_harness_grammar_events(c)
+    atom_event = next(e for e in events if e.atom is not None and e.atom.atom_id == missing_atom_id)
+    assert atom_event.observed_at == FIXED
+
+
+def test_atom_time_range_populated_with_real_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GrammarAtomV1.time_range previously stayed None for every harness
+    atom -- orion/grammar/ledger.py wires it through to persisted
+    grammar_atoms.time_start/time_end, read by the live Grammar Atlas API,
+    so this was a second place the same 'timing is fake' symptom survived
+    even after observed_at is fixed on the sibling GrammarEventV1 envelope.
+    _put_atom() must now stamp it too, from the same captured moment as
+    _atom_observed_at."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    _record_two_step_trace(c)
+
+    events = build_harness_grammar_events(c)
+    atom_events = [e for e in events if e.atom is not None]
+    assert atom_events
+    for event in atom_events:
+        assert event.atom.time_range is not None
+        assert event.atom.time_range.start == event.observed_at
+        assert event.atom.time_range.end == event.observed_at
+
+
+def test_trace_ended_observed_at_reflects_last_atom_not_trace_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before this fix: trace_ended.observed_at reused collector.observed_at
+    (trace-START time), identical to trace_started's -- the exact mechanism
+    behind orion/grammar/ledger.py's grammar_traces.started_at/ended_at
+    collapsing to zero duration. trace_ended must now reflect the real last
+    recorded atom's timestamp."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    _record_two_step_trace(c)
+
+    events = build_harness_grammar_events(c)
+    trace_started = next(e for e in events if e.event_kind == "trace_started")
+    trace_ended = next(e for e in events if e.event_kind == "trace_ended")
+    atom_events = [e for e in events if e.atom is not None]
+
+    assert trace_started.observed_at == FIXED
+    assert trace_ended.observed_at != trace_started.observed_at
+    assert trace_ended.observed_at == max(e.observed_at for e in atom_events)
+
+
+def test_trace_ended_falls_back_to_trace_start_with_zero_atoms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A trace that fails before any record_*() call has no atoms to derive
+    a real end time from -- trace_ended must fall back to trace-start
+    observed_at rather than raising (max() on an empty sequence)."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    events = build_harness_grammar_events(c)
+    trace_ended = next(e for e in events if e.event_kind == "trace_ended")
+    assert trace_ended.observed_at == FIXED
+
+
+def test_finalize_atoms_use_real_observed_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    """build_harness_grammar_finalize_events must apply the same per-atom
+    real-timestamp fix as build_harness_grammar_events -- it re-emits
+    exec_result_assembled/exec_result_emitted from the same collector state,
+    so it shares the exact bug shape if left on the old shared observed_at."""
+    _install_fake_clock(monkeypatch)
+    c = HarnessGrammarCollector(node_name=NODE, correlation_id=CORR, observed_at=FIXED)
+    _record_two_step_trace(c)
+
+    events = build_harness_grammar_finalize_events(c)
+    atom_events = [e for e in events if e.atom is not None]
+    assert len(atom_events) == 2
+    observed_ats = {e.observed_at for e in atom_events}
+    assert len(observed_ats) == 2, f"expected distinct observed_at per atom, got {observed_ats}"
+    assert FIXED not in observed_ats
+
+    edge_events = [e for e in events if e.edge is not None]
+    assert edge_events
+    emitted_atom = next(e for e in atom_events if e.atom.semantic_role == "exec_result_emitted")
+    assert edge_events[0].observed_at == emitted_atom.observed_at
 
 
 def test_finalize_events_emit_only_assembled_and_egress() -> None:

--- a/services/orion-cortex-exec/app/grammar_emit.py
+++ b/services/orion-cortex-exec/app/grammar_emit.py
@@ -89,7 +89,23 @@ class CortexExecGrammarCollector:
         return f"{self.trace_id}:{key}"
 
     def _put_atom(self, key: str, atom: GrammarAtomV1) -> None:
-        now = datetime.now(timezone.utc)
+        # Idempotent per atom_id, not per call: get_or_create_collector()
+        # caches one collector per ctx (below), and record_assembled_grammar()
+        # reads that same cached instance from 4 separate call sites in
+        # router.py (motor/finalize/voice-finalize lanes) -- the exact
+        # same-collector-reinvoked-across-phases shape found live in the
+        # sibling HarnessGrammarCollector (orion/harness/grammar_emit.py,
+        # 2026-07-15). record_result_assembled's atom_id is deterministic
+        # (trace_id + fixed key), so a second call would otherwise advance
+        # _atom_observed_at and publish the same atom_id/event_id twice with
+        # contradictory observed_at -- orion/grammar/ledger.py's
+        # on_conflict_do_nothing masks this at the DB layer (first write
+        # wins there too), but a raw bus consumer would see it directly.
+        # Reusing the first-seen timestamp keeps every publish for a given
+        # atom_id self-consistent, matching the DB's own dedup semantics.
+        # The atom's content (self._atoms[key]) still updates on every call
+        # -- only its recorded occurrence time is pinned to first sight.
+        now = self._atom_observed_at.get(atom.atom_id) or datetime.now(timezone.utc)
         # Also stamp the atom's own time_range (GrammarAtomV1.time_range,
         # orion/schemas/grammar.py) -- previously never populated by this
         # producer, so orion/grammar/ledger.py's atom-row persistence

--- a/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
+++ b/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
@@ -482,6 +482,50 @@ def test_trace_ended_observed_at_reflects_last_atom_not_trace_start(
     assert trace_ended.observed_at == max(e.observed_at for e in atom_events)
 
 
+def test_result_assembled_reinvoked_keeps_first_observed_at(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """record_result_assembled really can be called more than once on the
+    SAME collector in production: get_or_create_collector() caches one
+    collector per ctx, and record_assembled_grammar() reads that same
+    cached instance from 4 separate call sites in router.py (motor/
+    finalize/voice-finalize lanes) -- the exact same-collector-reinvoked-
+    across-phases shape found live in the sibling HarnessGrammarCollector
+    (orion/harness/grammar_emit.py, 2026-07-15). Before this fix: the
+    second call would advance _atom_observed_at, so an earlier-phase
+    publish and a later-phase publish would carry the SAME atom_id/
+    event_id (deterministic, trace_id + fixed key) but DIFFERENT
+    observed_at/time_range -- the 'same identity, contradictory timestamp'
+    shape this whole fix exists to eliminate. on_conflict_do_nothing masks
+    it at the DB layer, but a raw bus consumer of the event stream
+    wouldn't be."""
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    _record_two_step_trace(collector)
+    first_events = build_cortex_exec_grammar_events(collector)
+    first_assembled = next(
+        e for e in first_events if e.atom and e.atom.semantic_role == "exec_result_assembled"
+    )
+    first_ts = first_assembled.observed_at
+
+    collector.record_result_assembled(
+        status="success", final_text_present=True, reasoning_present=True,
+        thinking_source="finalize_reflect",
+    )
+
+    second_events = build_cortex_exec_grammar_events(collector)
+    second_assembled = next(
+        e for e in second_events if e.atom and e.atom.semantic_role == "exec_result_assembled"
+    )
+    assert second_assembled.atom.atom_id == first_assembled.atom.atom_id
+    assert second_assembled.observed_at == first_ts
+    assert second_assembled.atom.time_range.start == first_ts
+    # Content still refreshes on the second call -- only timing is pinned.
+    assert "thinking_source=finalize_reflect" in second_assembled.atom.summary
+
+
 def test_trace_ended_falls_back_to_trace_start_with_zero_atoms(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Confirmed and fixed the sibling bug flagged in memory: `HarnessGrammarCollector` (`orion/harness/grammar_emit.py`) shared the exact "every atom in a trace gets one shared observed_at" bug already fixed in `CortexExecGrammarCollector` (PR #1042). Live-verified before touching code: harness traces with 7–55 atoms and up to 2m15s of real wall-clock span all showed exactly 1 distinct `observed_at` across every atom.

Two more bugs found and fixed along the way:
1. `record_step_started`/`record_step_completed`/`record_step_failed` — the three most timing-sensitive atom types — bypassed the fix's `_put_atom()` mechanism entirely (pre-dated this patch), so even with the collector-level fix they'd have kept using the trace-start timestamp.
2. Code review (8 angles) independently found, via 2 angles tracing the real production call graph, that `record_result_assembled` is genuinely re-invoked on the same collector across two production phases (motor publish, then finalize publish) with a deterministic `atom_id` — the naive fix would have published the same identity twice with contradictory timestamps. Fixed by making `_put_atom()` idempotent per atom_id, then backported the identical fix to the sibling `CortexExecGrammarCollector` (confirmed live-relevant there too via `router.py`'s 4 call sites).

## Test plan

- [x] `pytest orion/harness/tests/test_harness_grammar_emit.py -q` → 15 passed
- [x] `pytest orion/harness/ -q` → 145 passed, 3 pre-existing unrelated failures (confirmed identical on main)
- [x] `pytest services/orion-harness-governor/tests -q` → 13 passed
- [x] `pytest services/orion-cortex-exec/tests/test_exec_grammar_emit.py -q` → 16 passed (15 pre-existing + 1 new)
- [x] Code review skill (high, 8 angles, verified) run and material findings fixed

Full report: `docs/superpowers/pr-reports/2026-07-15-harness-grammar-atom-wall-clock-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)