### PR TITLE
feat(harness): cross-turn tool-fetch continuity (same-service redesign)

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-15-cross-turn-tool-fetch-continuity-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-15-cross-turn-tool-fetch-continuity-pr.md
@@ -1,0 +1,120 @@
+# PR report: cross-turn tool-fetch continuity (same-service redesign)
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1065
+Branch: `feat/cross-turn-tool-fetch-continuity`
+
+## Summary
+
+- `orion/harness/last_tool_fetch_cache.py`: `publish_last_tool_fetch()` (write, end of a turn) and `read_last_tool_fetch()` (read, start of the next turn), both keyed by `thought.session_id`, both fail-open.
+- `HarnessRunner.run()` reads at the start (before prompt compilation) and writes at the end (success path only).
+- `compile_harness_prefix()` renders "Last turn you fetched content via tool: X, Y" directly into the FCC motor's own prompt when present.
+
+## Outcome moved
+
+Gives a harness-mode conversation memory of its own recent tool use across turns — closing the disclosed gap from PR #1060 (the tool-provenance audit), which could detect a same-turn mismatch but had no way to carry that fact forward.
+
+## This is a rebuild — the design changed mid-flight, twice
+
+**First attempt** wired the cache cross-service: write in `orion-harness-governor`, read in `orion-cortex-exec`, on the theory that a cortex-exec chat turn is "what comes next" after a harness turn in the same conversation.
+
+- **Review round 1** caught real bugs in that version (hazard-string truncation past its own warning clause, a hazard-eviction regression, a metacog-cue truncation bug, a false-liveness classification on empty-dict fallbacks, a confirmed per-turn double registry scan) — all fixed at the time.
+- **Review round 2** traced the actual dispatch path end-to-end and found the whole premise was wrong: `orion/hub/turn_orchestrator.py::run_unified_turn` (harness path) and `cortex-exec`'s `chat()` RPC are mutually exclusive per-message branches in `services/orion-hub/scripts/websocket_handler.py` — confirmed directly by Juniper and then verified in source (`client_mode == "orion"` hits `continue` right after the harness call, never reaching the cortex-exec branch). The two services are never sequential turns of one conversation, so the write-key (`session_id`, stable per-conversation) and read-key (a fresh per-turn UUID) could never have matched regardless of any bug fix.
+
+**This version** is rebuilt entirely within `orion/harness/` — same service for both sides, same `thought.session_id` key on both. The session_id-stability assumption was verified end-to-end via source trace this time, not just asserted: backend (`services/orion-hub/scripts/websocket_handler.py:718`, read fresh from client-sent data on every message, no server-side regeneration) *and* frontend (`services/orion-hub/static/js/app.js`'s `orionSessionId`, loaded once from `localStorage` at page load and resent unchanged on every WS message).
+
+**Review round 3** on this corrected design confirmed the session_id theory holds end-to-end, and caught two more real bugs, both fixed (see Review findings below).
+
+## Current architecture
+
+`orion/harness/fcc_motor.py::run_fcc_turn` spawns the FCC motor as a single-shot `claude` subprocess. `HarnessRunner.run()` (`orion/harness/runner.py`) drives one turn: compiles the prompt via `compile_harness_prefix`, streams the subprocess's events into `GrammarReceiptV1`s, captures `draft_text`. Prior work (PR #1060) added `detect_tool_provenance_mismatch()`, a same-turn post-hoc audit with no cross-turn memory.
+
+## Architecture touched
+
+- `orion/harness/last_tool_fetch_cache.py` (new)
+- `orion/harness/runner.py`
+- `orion/harness/prefix.py`
+- `orion/harness/tool_provenance_audit.py` (one function made public: `fetch_shaped_tool_names`)
+
+## Files changed
+
+- `orion/harness/last_tool_fetch_cache.py`: new, `publish_last_tool_fetch()` + `read_last_tool_fetch()`.
+- `orion/harness/runner.py`: reads at the start of `run()`, writes at the end (success path, explicitly excluding the error/partial-draft path via a new `error_path_taken` flag).
+- `orion/harness/prefix.py`: `compile_harness_prefix()` gains `prior_tool_fetch_names: list[str] | None = None`, rendered as one line when present.
+- `orion/harness/tool_provenance_audit.py`: `_fetch_shaped_tool_names` → public `fetch_shaped_tool_names` (no behavior change).
+- Tests: `orion/harness/tests/test_last_tool_fetch_cache.py` (new, 14 tests covering write/read/round-trip/malformed-payload/element-validation/never-raises), extensions to `test_harness_runner.py` (6 new tests including the read-wiring, the partial-draft-error exclusion, and the session_id-keying assertion) and `test_harness_prefix.py` (2 new rendering tests).
+
+## Schema / bus / API changes
+
+- None. No new schema, no new bus channel — plain Redis key via the existing `OrionBusAsync.redis` property both services already hold.
+- `build_harness_prompt()`/`compile_harness_prefix()` gain one new optional kwarg each (`prior_tool_fetch_names`), additive, defaults to `None`.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=<worktree> venv/bin/python -m pytest orion/harness/tests -q
+145 passed, 3 failed -- all 3 confirmed pre-existing and identical on
+unmodified main (2 unrelated Jinja UndefinedError failures in
+test_grounding_capsule_consumers.py, 1 unrelated error-code string
+mismatch in test_harness_runner_surfaces_fcc_error_code). Zero
+regressions from this patch.
+
+services/orion-cortex-exec side verified back to clean baseline after
+reverting the first (wrong) design: 15 passed, no lingering changes
+(`git status --short services/orion-cortex-exec/` empty before commit).
+```
+
+## Evals run
+
+No dedicated eval harness exists for `orion/harness/` covering prompt-content behavior (i.e. whether the FCC model actually uses the injected continuity line correctly without over-claiming immediacy from it). Flagged as a gap, not silently skipped — only unit tests cover this patch.
+
+## Docker/build/smoke checks
+
+Not run — Python-only change to prompt assembly and a Redis read/write already using the existing shared bus connection; no config read at boot, no new dependencies, no compose/port changes.
+
+## Review findings fixed
+
+**Round 1 (first, cross-service design — later reverted entirely; findings still worth recording since the same bug class could recur elsewhere):**
+- Hazard string truncated to 140 chars by an existing `_unique()` helper, cutting off its own warning clause.
+- Hazard-eviction regression from a naive fix to the above.
+- Metacog-cue provenance tag truncated on eventful turns.
+- `key in ctx` presence-check misclassified empty-dict fallbacks as live.
+- Confirmed per-turn double scan of the provenance registry.
+(All fixed in the reverted design; superseded by this patch's same-service rebuild, which doesn't touch that registry at all.)
+
+**Round 2 (architecture correction):**
+- Finding: the write-key (`session_id`) and read-key (`chat_correlation_id`, unpopulated, falling back to a fresh per-turn UUID) never match — the two services aren't sequential turns of one conversation at all.
+  - Fix: full redesign, this PR.
+
+**Round 3 (this design):**
+- Finding: the write guard (`if not draft_text: return`) only excludes the fully-empty-draft case; a turn that errors/times out with a salvaged partial draft falls through non-empty and still records a tool-fetch for a turn the user may not have fully seen — contradicting the code's own inline comment.
+  - Fix: explicit `error_path_taken` flag, set in the `error` event branch, gates the write regardless of whether a partial draft exists.
+  - Evidence: `test_harness_runner_does_not_publish_last_tool_fetch_on_partial_draft_error`.
+- Finding: `read_last_tool_fetch` validated `tool_names` was a list but not that its elements were strings — a malformed cache row would crash `prefix.py`'s `", ".join(...)` uncaught, breaking the whole next turn over one bad Redis row.
+  - Fix: element-level `isinstance(name, str)` validation.
+  - Evidence: `test_read_returns_none_when_tool_names_has_non_string_element`.
+- Finding (disclosed, not fixed): `session_id` is loaded once from browser `localStorage` and shared across every tab on the same origin — the same value `websocket_handler.py` already flags as cross-tab-shared for a different reason (its own turn-cancel registry deliberately avoids keying on it). Two tabs on the same session will cross-contaminate this cache.
+  - Not fixed: low severity (continuity confusion, not a content/security leak), and multi-tab-same-session may not be a supported usage pattern at all. Documented prominently in `last_tool_fetch_cache.py`'s module docstring for whoever picks up a proper per-tab/per-chain key if that assumption turns out wrong.
+
+## Restart required
+
+```text
+No restart required to review/merge. Once merged, takes effect on the next
+deploy/restart of orion-harness-governor.
+```
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: the cross-tab session_id sharing described above.
+- Mitigation: disclosed in code and here; not a supported-usage-pattern question this patch can resolve alone.
+- Severity: Low
+- Concern: no eval harness exercises whether the FCC model actually uses the injected continuity line correctly (vs. ignoring it or over-interpreting it).
+- Mitigation: flagged as a gap; unit tests cover the mechanism, not model behavior.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1065

--- a/orion/harness/last_tool_fetch_cache.py
+++ b/orion/harness/last_tool_fetch_cache.py
@@ -1,0 +1,150 @@
+"""Cross-turn continuity, within one service, for "what tool fetched content
+last turn of this session".
+
+The FCC motor (HarnessRunner.run(), orion-harness-governor) knows, per turn,
+which tools were used to fetch static content (see
+tool_provenance_audit.fetch_shaped_tool_names). That fact is useful on the
+*next* turn of the same conversation -- but each turn is an independent
+HarnessRunner.run() call with no shared process memory, only the Redis bus
+already available via OrionBusAsync.
+
+NOTE: this is deliberately NOT cross-service. An earlier version of this
+module tried to surface this into orion-cortex-exec's chat pipeline on the
+theory that a cortex-exec turn is "what comes after" a harness turn in the
+same conversation -- that's wrong. orion/hub/turn_orchestrator.py's
+run_unified_turn (harness path) and cortex-exec's chat() RPC are mutually
+exclusive per-message branches in services/orion-hub/scripts/websocket_handler.py
+(client_mode == "orion" hits `continue` right after the harness call and
+never reaches the cortex-exec branch) -- they're two different modes, not
+sequential turns of one thing. The only turn that legitimately comes "next"
+after a harness turn is another harness turn of the same session_id, so both
+sides of this cache live here, in orion/harness/.
+
+Write: publish_last_tool_fetch(), called at the end of HarnessRunner.run().
+Read: read_last_tool_fetch(), called at the start of the next run() for the
+same session_id.
+
+Key: ``orion:harness:last_tool_fetch:{session_id}``
+Payload: ``{"tool_names": [...], "correlation_id": "...", "at": "<ISO8601 UTC>"}``
+TTL: 600s (single SETEX call, not SET+EXPIRE).
+
+KNOWN LIMITATION, disclosed not silently shipped: session_id is loaded once
+from browser localStorage and reused across every tab on the same origin
+(see the comment at services/orion-hub/scripts/websocket_handler.py's
+session_id handling, which already flags this same value as cross-tab-shared
+for a different reason -- its own turn-cancel registry deliberately does NOT
+key on session_id for exactly this hazard). This cache does key on it, so
+two tabs open to the same origin/session will cross-contaminate: tab A's
+fetch can surface as "last turn you fetched X" on tab B's next turn, which
+never happened in tab B. Low severity (a continuity-confusion nit, not a
+content/security leak) and the multi-tab-same-session case may not be a
+supported usage pattern at all -- but worth fixing properly (a per-tab or
+per-turn-chain identifier) if that assumption turns out to be wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger("orion.harness.last_tool_fetch_cache")
+
+_KEY_PREFIX = "orion:harness:last_tool_fetch"
+
+
+async def publish_last_tool_fetch(
+    bus: Any,
+    *,
+    session_id: str | None,
+    correlation_id: str,
+    tool_names: list[str],
+    ttl_seconds: int = 600,
+) -> None:
+    """Best-effort write of this turn's fetch-shaped tool names to Redis.
+
+    No-op (no Redis call at all) when there's no session to key on or no
+    fetch-shaped tool was actually used this turn -- an empty/absent signal
+    isn't worth a cache write and a stale entry lingering past this turn's
+    relevance. Never raises: this runs on the hot chat-turn path inline with
+    HarnessRunner.run(), and a Redis hiccup here must not break a turn that
+    otherwise completed successfully.
+    """
+    if not session_id or not tool_names:
+        if tool_names and not session_id:
+            # Distinguishable from "no fetch tool used this turn" (the
+            # common, silent no-op) -- a session-less turn using a fetch
+            # tool is unusual enough to be worth a trace, since it means
+            # continuity can never kick in for that turn's conversation.
+            logger.info("last_tool_fetch_write_skipped reason=no_session_id tool_names=%s", tool_names)
+        return
+
+    key = f"{_KEY_PREFIX}:{session_id}"
+    payload = json.dumps(
+        {
+            "tool_names": tool_names,
+            "correlation_id": correlation_id,
+            "at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    try:
+        await bus.redis.setex(key, ttl_seconds, payload)
+        logger.info("last_tool_fetch_write key=%s tool_names=%s", key, tool_names)
+    except Exception:
+        logger.warning(
+            "last_tool_fetch_write_failed key=%s tool_names=%s",
+            key,
+            tool_names,
+            exc_info=True,
+        )
+
+
+_EXPECTED_KEYS = ("tool_names", "correlation_id", "at")
+
+
+async def read_last_tool_fetch(bus: Any, *, session_id: str | None) -> dict[str, Any] | None:
+    """Read the immediately-prior turn's tool-fetch record for this session.
+
+    Fail-open: returns None (never raises) when session_id is falsy, the key
+    is absent, Redis errors, or the payload is malformed/incomplete. Called
+    at the start of HarnessRunner.run() so the same turn that reads it can
+    render it into that turn's own compiled prompt.
+    """
+    if not session_id:
+        return None
+
+    key = f"{_KEY_PREFIX}:{session_id}"
+    try:
+        raw = await bus.redis.get(key)
+    except Exception:
+        logger.warning("last_tool_fetch_read key=%s found=False redis_error", key, exc_info=True)
+        return None
+
+    found = raw is not None
+    logger.info("last_tool_fetch_read key=%s found=%s", key, found)
+    if not found:
+        return None
+
+    try:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        parsed = json.loads(raw)
+    except Exception:
+        logger.warning("last_tool_fetch_read key=%s found=%s malformed_json", key, found, exc_info=True)
+        return None
+
+    if not isinstance(parsed, dict) or not all(k in parsed for k in _EXPECTED_KEYS):
+        logger.warning("last_tool_fetch_read key=%s found=%s missing_expected_keys", key, found)
+        return None
+
+    tool_names = parsed.get("tool_names")
+    if not isinstance(tool_names, list) or not all(isinstance(name, str) for name in tool_names):
+        # Guards prefix.py's `", ".join(prior_tool_fetch_names)` -- a
+        # non-string element would raise there uncaught, breaking the whole
+        # next turn over one malformed cache row. Validation belongs here,
+        # at the one place responsible for what this function hands back.
+        logger.warning("last_tool_fetch_read key=%s found=%s tool_names_invalid_shape", key, found)
+        return None
+
+    return parsed

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -110,6 +110,7 @@ def compile_harness_prefix(
     user_message: str = "",
     answer_contract: AnswerContract | None = None,
     workspace: str | None = None,
+    prior_tool_fetch_names: list[str] | None = None,
 ) -> str:
     """Orion capability: motor-context assembly for the unified turn.
 
@@ -143,6 +144,17 @@ def compile_harness_prefix(
 
     if thought.strain_refs:
         parts.append(f"Strain refs: {', '.join(thought.strain_refs)}")
+
+    if prior_tool_fetch_names:
+        # Cross-turn continuity within this same session (see
+        # orion/harness/last_tool_fetch_cache.py): what you fetched via a
+        # tool last turn, not what's computing live right now -- named
+        # explicitly so it isn't confused with the latter (see
+        # project_orion_substrate_bridge_confabulation for why that
+        # distinction matters).
+        parts.append(
+            "Last turn you fetched content via tool: " + ", ".join(prior_tool_fetch_names)
+        )
 
     if user_message.strip():
         parts.append(f"User message: {user_message.strip()}")

--- a/orion/harness/runner.py
+++ b/orion/harness/runner.py
@@ -23,10 +23,11 @@ from orion.harness.grammar_emit import (
     short_error_kind,
 )
 from orion.harness.grammar_publish import publish_harness_step_grammar
+from orion.harness.last_tool_fetch_cache import publish_last_tool_fetch, read_last_tool_fetch
 from orion.harness.prefix import compile_harness_prefix, harness_motor_instruction
 from orion.harness.repair import map_repair_pressure_contract
 from orion.harness.step_stream import publish_harness_run_step
-from orion.harness.tool_provenance_audit import detect_tool_provenance_mismatch
+from orion.harness.tool_provenance_audit import detect_tool_provenance_mismatch, fetch_shaped_tool_names
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import (
     GrammarReceiptV1,
@@ -98,6 +99,7 @@ def build_harness_prompt(
     repair_overlay: HarnessRepairOverlayV1,
     answer_contract: AnswerContract | None = None,
     workspace: str | None = None,
+    prior_tool_fetch_names: list[str] | None = None,
 ) -> str:
     prefix = compile_harness_prefix(
         thought,
@@ -105,6 +107,7 @@ def build_harness_prompt(
         user_message=user_message,
         answer_contract=answer_contract,
         workspace=workspace or os.environ.get("HARNESS_FCC_WORKSPACE"),
+        prior_tool_fetch_names=prior_tool_fetch_names,
     )
     instruction = harness_motor_instruction(
         thought=thought,
@@ -210,12 +213,17 @@ class HarnessRunner:
         thought = request.thought_event
         overlay = repair_overlay or map_repair_pressure_contract(request.repair_pressure_contract)
         coalition = coalition_snapshot or build_coalition_snapshot(thought)
+
+        prior_tool_fetch = await read_last_tool_fetch(self.bus, session_id=thought.session_id)
+        prior_tool_fetch_names = (prior_tool_fetch or {}).get("tool_names")
+
         prompt = build_harness_prompt(
             thought=thought,
             user_message=request.user_message,
             repair_overlay=overlay,
             answer_contract=request.answer_contract,
             workspace=os.environ.get("HARNESS_FCC_WORKSPACE"),
+            prior_tool_fetch_names=prior_tool_fetch_names,
         )
 
         collector = HarnessGrammarCollector(
@@ -234,6 +242,12 @@ class HarnessRunner:
         compliance_verdict = "completed"
         grounding_status = "grounded"
         motor_failed = False
+        # Distinct from `motor_failed`: that's only True on a *fully* failed
+        # turn (no partial text). This tracks the "error" event branch
+        # regardless of whether a partial draft was salvaged, so a
+        # timed-out/errored turn that still produced some visible text
+        # doesn't get treated as clean for cross-turn continuity purposes.
+        error_path_taken = False
 
         async for event in self.fcc_runner(
             prompt=prompt,
@@ -286,6 +300,7 @@ class HarnessRunner:
                     if isinstance(raw_exit, int):
                         exit_code = raw_exit
             elif etype == "error":
+                error_path_taken = True
                 partial = str(event.get("llm_response") or "").strip()
                 error_code = str(event.get("error_code") or "").strip()
                 error_msg = str(event.get("error") or "").strip()
@@ -376,6 +391,23 @@ class HarnessRunner:
             )
 
         await _publish_motor_lifecycle(status="success", final_text_present=False)
+
+        # Cross-turn continuity within this same session: only on a turn that
+        # completed cleanly via the "final" event, not one that crashed/timed
+        # out after using a fetch tool (error_path_taken) even if a partial
+        # draft was salvaged -- a fetch tied to a turn the user may not have
+        # fully seen isn't worth surfacing to the next one. (The `if not
+        # draft_text` branch above already excludes the fully-empty-draft
+        # case; error_path_taken additionally excludes the partial-draft
+        # error case, which reaches this point with non-empty draft_text.)
+        fetch_tool_names = fetch_shaped_tool_names(receipts) if not error_path_taken else []
+        if fetch_tool_names:
+            await publish_last_tool_fetch(
+                self.bus,
+                session_id=thought.session_id,
+                correlation_id=request.correlation_id,
+                tool_names=fetch_tool_names,
+            )
 
         molecule = build_draft_molecule(
             correlation_id=request.correlation_id,

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -24,6 +24,27 @@ def test_compile_harness_prefix_includes_stance_slice() -> None:
     assert "how does coalition work?" in prompt
 
 
+def test_compile_harness_prefix_includes_prior_tool_fetch_line() -> None:
+    thought = make_thought(imperative="Inspect the module.", tone="direct")
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="what did you fetch?",
+        prior_tool_fetch_names=["mcp__github__get_file_contents", "WebFetch"],
+    )
+    assert "Last turn you fetched content via tool: mcp__github__get_file_contents, WebFetch" in prompt
+
+
+def test_compile_harness_prefix_omits_prior_tool_fetch_line_when_none() -> None:
+    thought = make_thought(imperative="Inspect the module.", tone="direct")
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="hello",
+    )
+    assert "Last turn you fetched content via tool" not in prompt
+
+
 def test_compile_harness_prefix_includes_autonomy_slice_recent_actions() -> None:
     """Regression for the stance_react dispatch-evidence patch: the FCC
     motor's own prefix must render recent_actions directly, not just leave

--- a/orion/harness/tests/test_harness_runner.py
+++ b/orion/harness/tests/test_harness_runner.py
@@ -126,6 +126,100 @@ async def test_harness_runner_flags_tool_provenance_mismatch() -> None:
 
 
 @pytest.mark.asyncio
+async def test_harness_runner_publishes_last_tool_fetch_on_fetch_tool_use() -> None:
+    thought = make_thought(session_id="sess-cross-turn")
+    request = HarnessRunRequestV1(
+        correlation_id="c-cross-turn",
+        thought_event=thought,
+        user_message="what's live right now?",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    bus = AsyncMock()
+    runner = HarnessRunner(bus, fcc_runner=_mock_fcc_runner_fetch_then_confabulate)
+    publish_mock = AsyncMock()
+
+    with patch("orion.harness.runner.publish_last_tool_fetch", publish_mock):
+        await runner.run(request)
+
+    publish_mock.assert_awaited_once_with(
+        bus,
+        session_id="sess-cross-turn",
+        correlation_id="c-cross-turn",
+        tool_names=["mcp__github__get_file_contents"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_does_not_publish_last_tool_fetch_when_no_fetch_tool() -> None:
+    thought = make_thought()
+    request = HarnessRunRequestV1(
+        correlation_id="c-no-fetch",
+        thought_event=thought,
+        user_message="hello",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    bus = AsyncMock()
+    runner = HarnessRunner(bus, fcc_runner=_mock_fcc_runner)
+    publish_mock = AsyncMock()
+
+    with patch("orion.harness.runner.publish_last_tool_fetch", publish_mock):
+        await runner.run(request)
+
+    publish_mock.assert_not_awaited()
+
+
+async def _mock_fcc_runner_fetch_then_error_with_partial(**_: Any) -> AsyncIterator[dict[str, Any]]:
+    yield {
+        "type": "step",
+        "step": {
+            "type": "assistant",
+            "raw": {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "mcp__github__get_file_contents", "input": {}},
+                    ]
+                },
+            },
+        },
+    }
+    yield {
+        "type": "error",
+        "llm_response": "partial text salvaged before the timeout",
+        "error_code": "fcc_timeout",
+        "error": "fcc turn timed out after 120.0s",
+    }
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_does_not_publish_last_tool_fetch_on_partial_draft_error() -> None:
+    """Regression: a turn that used a fetch tool but then errored/timed out
+    with only a partial draft must NOT record a tool-fetch for continuity --
+    the `if not draft_text` early return doesn't catch this case (draft_text
+    is non-empty), so the exclusion has to be explicit."""
+    thought = make_thought(session_id="sess-partial-error")
+    request = HarnessRunRequestV1(
+        correlation_id="c-partial-error",
+        thought_event=thought,
+        user_message="what's in the file?",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    bus = AsyncMock()
+    runner = HarnessRunner(bus, fcc_runner=_mock_fcc_runner_fetch_then_error_with_partial)
+    publish_mock = AsyncMock()
+
+    with patch("orion.harness.runner.publish_last_tool_fetch", publish_mock):
+        result = await runner.run(request)
+
+    assert result.draft_text  # partial draft is non-empty, confirming this exercises the right branch
+    assert result.compliance_verdict == "partial"
+    publish_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_harness_runner_no_tool_provenance_mismatch_on_normal_turn() -> None:
     thought = make_thought()
     request = HarnessRunRequestV1(
@@ -204,3 +298,76 @@ async def test_harness_runner_uses_compile_harness_prefix() -> None:
     assert "Tone: direct" in prompt
     assert "what broke?" in prompt
     assert "Execute your imperative" in prompt
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_reads_prior_tool_fetch_keyed_by_session_id() -> None:
+    """Cross-turn continuity: run() must call read_last_tool_fetch with
+    thought.session_id -- the same value the write side (publish_last_tool_fetch)
+    keys by -- not any cross-service correlation id."""
+    thought = make_thought(session_id="sess-continuity")
+    request = HarnessRunRequestV1(
+        correlation_id="c-continuity",
+        thought_event=thought,
+        user_message="what did you find?",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    read_mock = AsyncMock(return_value=None)
+    runner = HarnessRunner(AsyncMock(), fcc_runner=_mock_fcc_runner)
+
+    with patch("orion.harness.runner.read_last_tool_fetch", read_mock):
+        await runner.run(request)
+
+    read_mock.assert_awaited_once_with(runner.bus, session_id="sess-continuity")
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_renders_prior_tool_fetch_in_compiled_prompt() -> None:
+    thought = make_thought(session_id="sess-continuity-2")
+    captured: dict[str, str] = {}
+
+    async def _capture_prompt(*, prompt: str, **__: Any) -> AsyncIterator[dict[str, Any]]:
+        captured["prompt"] = prompt
+        yield {"type": "final", "llm_response": "done", "metadata": {"exit_code": 0}}
+
+    request = HarnessRunRequestV1(
+        correlation_id="c-continuity-2",
+        thought_event=thought,
+        user_message="what did you find?",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    read_mock = AsyncMock(
+        return_value={"tool_names": ["mcp__github__get_file_contents"], "correlation_id": "c-prev", "at": "x"}
+    )
+    runner = HarnessRunner(AsyncMock(), fcc_runner=_capture_prompt)
+
+    with patch("orion.harness.runner.read_last_tool_fetch", read_mock):
+        await runner.run(request)
+
+    assert "Last turn you fetched content via tool: mcp__github__get_file_contents" in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_omits_prior_tool_fetch_line_when_none_found() -> None:
+    thought = make_thought(session_id="sess-fresh")
+    captured: dict[str, str] = {}
+
+    async def _capture_prompt(*, prompt: str, **__: Any) -> AsyncIterator[dict[str, Any]]:
+        captured["prompt"] = prompt
+        yield {"type": "final", "llm_response": "done", "metadata": {"exit_code": 0}}
+
+    request = HarnessRunRequestV1(
+        correlation_id="c-fresh",
+        thought_event=thought,
+        user_message="hello",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    runner = HarnessRunner(AsyncMock(), fcc_runner=_capture_prompt)
+
+    with patch("orion.harness.runner.read_last_tool_fetch", AsyncMock(return_value=None)):
+        await runner.run(request)
+
+    assert "Last turn you fetched content via tool" not in captured["prompt"]

--- a/orion/harness/tests/test_last_tool_fetch_cache.py
+++ b/orion/harness/tests/test_last_tool_fetch_cache.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orion.harness.last_tool_fetch_cache import publish_last_tool_fetch, read_last_tool_fetch
+
+
+def _bus_with_redis() -> MagicMock:
+    bus = MagicMock()
+    bus.redis = AsyncMock()
+    return bus
+
+
+@pytest.mark.asyncio
+async def test_noop_when_session_id_missing() -> None:
+    bus = _bus_with_redis()
+
+    await publish_last_tool_fetch(
+        bus,
+        session_id=None,
+        correlation_id="c-1",
+        tool_names=["mcp__github__get_file_contents"],
+    )
+
+    bus.redis.setex.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_tool_names_empty() -> None:
+    bus = _bus_with_redis()
+
+    await publish_last_tool_fetch(
+        bus,
+        session_id="sess-1",
+        correlation_id="c-1",
+        tool_names=[],
+    )
+
+    bus.redis.setex.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_writes_setex_with_exact_key_and_payload_shape() -> None:
+    bus = _bus_with_redis()
+
+    await publish_last_tool_fetch(
+        bus,
+        session_id="sess-42",
+        correlation_id="c-99",
+        tool_names=["mcp__github__get_file_contents", "WebFetch"],
+    )
+
+    bus.redis.setex.assert_awaited_once()
+    args, kwargs = bus.redis.setex.await_args
+    key, ttl, payload_raw = args
+    assert key == "orion:harness:last_tool_fetch:sess-42"
+    assert ttl == 600
+    payload = json.loads(payload_raw)
+    assert set(payload.keys()) == {"tool_names", "correlation_id", "at"}
+    assert payload["tool_names"] == ["mcp__github__get_file_contents", "WebFetch"]
+    assert payload["correlation_id"] == "c-99"
+    assert isinstance(payload["at"], str) and payload["at"]
+
+
+@pytest.mark.asyncio
+async def test_custom_ttl_is_passed_through() -> None:
+    bus = _bus_with_redis()
+
+    await publish_last_tool_fetch(
+        bus,
+        session_id="sess-7",
+        correlation_id="c-7",
+        tool_names=["WebFetch"],
+        ttl_seconds=30,
+    )
+
+    args, _ = bus.redis.setex.await_args
+    assert args[1] == 30
+
+
+@pytest.mark.asyncio
+async def test_never_raises_when_redis_setex_fails(caplog: pytest.LogCaptureFixture) -> None:
+    bus = _bus_with_redis()
+    bus.redis.setex.side_effect = RuntimeError("redis is down")
+
+    with caplog.at_level(logging.WARNING, logger="orion.harness.last_tool_fetch_cache"):
+        await publish_last_tool_fetch(
+            bus,
+            session_id="sess-1",
+            correlation_id="c-1",
+            tool_names=["WebFetch"],
+        )
+
+    assert any("last_tool_fetch_write_failed" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_read_returns_none_when_session_id_missing() -> None:
+    bus = _bus_with_redis()
+    assert await read_last_tool_fetch(bus, session_id=None) is None
+    bus.redis.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_returns_none_when_key_absent() -> None:
+    bus = _bus_with_redis()
+    bus.redis.get.return_value = None
+    assert await read_last_tool_fetch(bus, session_id="sess-1") is None
+
+
+@pytest.mark.asyncio
+async def test_read_round_trips_what_write_wrote() -> None:
+    """Same key format both directions: write with publish_last_tool_fetch,
+    read back with read_last_tool_fetch, using one shared fake Redis."""
+    store: dict[str, str] = {}
+
+    async def _setex(key, ttl, value):
+        store[key] = value
+
+    async def _get(key):
+        return store.get(key)
+
+    bus = MagicMock()
+    bus.redis = MagicMock()
+    bus.redis.setex = AsyncMock(side_effect=_setex)
+    bus.redis.get = AsyncMock(side_effect=_get)
+
+    await publish_last_tool_fetch(
+        bus,
+        session_id="sess-round-trip",
+        correlation_id="c-1",
+        tool_names=["mcp__github__get_file_contents"],
+    )
+    result = await read_last_tool_fetch(bus, session_id="sess-round-trip")
+
+    assert result is not None
+    assert result["tool_names"] == ["mcp__github__get_file_contents"]
+    assert result["correlation_id"] == "c-1"
+
+
+@pytest.mark.asyncio
+async def test_read_returns_none_on_malformed_json() -> None:
+    bus = _bus_with_redis()
+    bus.redis.get.return_value = "not json"
+    assert await read_last_tool_fetch(bus, session_id="sess-1") is None
+
+
+@pytest.mark.asyncio
+async def test_read_returns_none_when_missing_expected_keys() -> None:
+    bus = _bus_with_redis()
+    bus.redis.get.return_value = json.dumps({"tool_names": ["WebFetch"]})  # missing correlation_id/at
+    assert await read_last_tool_fetch(bus, session_id="sess-1") is None
+
+
+@pytest.mark.asyncio
+async def test_read_returns_none_when_tool_names_not_a_list() -> None:
+    bus = _bus_with_redis()
+    bus.redis.get.return_value = json.dumps({"tool_names": "WebFetch", "correlation_id": "c-1", "at": "now"})
+    assert await read_last_tool_fetch(bus, session_id="sess-1") is None
+
+
+@pytest.mark.asyncio
+async def test_read_returns_none_when_tool_names_has_non_string_element() -> None:
+    """Regression: a non-string element would reach prefix.py's
+    ", ".join(prior_tool_fetch_names) uncaught -- validation belongs here."""
+    bus = _bus_with_redis()
+    bus.redis.get.return_value = json.dumps(
+        {"tool_names": ["WebFetch", 42], "correlation_id": "c-1", "at": "now"}
+    )
+    assert await read_last_tool_fetch(bus, session_id="sess-1") is None
+
+
+@pytest.mark.asyncio
+async def test_read_never_raises_on_redis_error(caplog: pytest.LogCaptureFixture) -> None:
+    bus = _bus_with_redis()
+    bus.redis.get.side_effect = RuntimeError("redis is down")
+
+    with caplog.at_level(logging.WARNING, logger="orion.harness.last_tool_fetch_cache"):
+        result = await read_last_tool_fetch(bus, session_id="sess-1")
+
+    assert result is None
+    assert any("redis_error" in record.message for record in caplog.records)

--- a/orion/harness/tool_provenance_audit.py
+++ b/orion/harness/tool_provenance_audit.py
@@ -43,7 +43,7 @@ _IMMEDIACY_PATTERN = re.compile(
 )
 
 
-def _fetch_shaped_tool_names(receipts: Sequence[GrammarReceiptV1]) -> list[str]:
+def fetch_shaped_tool_names(receipts: Sequence[GrammarReceiptV1]) -> list[str]:
     return sorted(
         {
             receipt.tool_name
@@ -64,7 +64,7 @@ def detect_tool_provenance_mismatch(
     tool fetch involved."""
     if not draft_text or not receipts:
         return None
-    fetch_tools = _fetch_shaped_tool_names(receipts)
+    fetch_tools = fetch_shaped_tool_names(receipts)
     if not fetch_tools:
         return None
     if not _IMMEDIACY_PATTERN.search(draft_text):


### PR DESCRIPTION
## Summary

- `orion/harness/last_tool_fetch_cache.py`: `publish_last_tool_fetch()` (write, end of a turn) and `read_last_tool_fetch()` (read, start of the next turn), both keyed by `thought.session_id`, both fail-open.
- `HarnessRunner.run()` reads at the start (before prompt compilation) and writes at the end (success path only).
- `compile_harness_prefix()` renders "Last turn you fetched content via tool: X, Y" directly into the FCC motor's own prompt when present.

## Outcome moved

Gives a harness-mode conversation memory of its own recent tool use across turns — closing the disclosed gap from PR #1060 (the tool-provenance audit), which could detect a same-turn mismatch but had no way to carry that fact forward.

## This is a rebuild — the design changed mid-flight, twice

**First attempt** wired the cache cross-service: write in `orion-harness-governor`, read in `orion-cortex-exec`, on the theory that a cortex-exec chat turn is "what comes next" after a harness turn in the same conversation.

- **Review round 1** caught real bugs in that version (hazard-string truncation past its own warning clause, a hazard-eviction regression, a metacog-cue truncation bug, a false-liveness classification on empty-dict fallbacks, a confirmed per-turn double registry scan) — all fixed.
- **Review round 2** traced the actual dispatch path end-to-end and found the whole premise was wrong: `orion/hub/turn_orchestrator.py::run_unified_turn` (harness path) and `cortex-exec`'s `chat()` RPC are mutually exclusive per-message branches in `services/orion-hub/scripts/websocket_handler.py` — confirmed directly (`client_mode == "orion"` hits `continue` right after the harness call, never reaching the cortex-exec branch). The two services are never sequential turns of one conversation, so the write-key (`session_id`, stable per-conversation) and read-key (a fresh per-turn UUID) could never have matched regardless of any bug fix.

**This version** is rebuilt entirely within `orion/harness/` — same service for both sides, same `thought.session_id` key on both. The session_id-stability assumption was verified end-to-end via source trace this time (not just asserted): backend (`websocket_handler.py:718`, read fresh from client data every message, no server-side regeneration) *and* frontend (`services/orion-hub/static/js/app.js`'s `orionSessionId`, loaded once from `localStorage` at page load and resent unchanged on every WS message).

**Review round 3** on this corrected design confirmed the session_id theory holds, and caught two more real bugs, both fixed (see Review findings below).

## Current architecture

`orion/harness/fcc_motor.py::run_fcc_turn` spawns the FCC motor as a single-shot `claude` subprocess. `HarnessRunner.run()` (`orion/harness/runner.py`) drives one turn: compiles the prompt via `compile_harness_prefix`, streams the subprocess's events into `GrammarReceiptV1`s, captures `draft_text`. Prior work (PR #1060) added `detect_tool_provenance_mismatch()`, a same-turn post-hoc audit with no cross-turn memory.

## Architecture touched

- `orion/harness/last_tool_fetch_cache.py` (new)
- `orion/harness/runner.py`
- `orion/harness/prefix.py`
- `orion/harness/tool_provenance_audit.py` (one function made public: `fetch_shaped_tool_names`)

## Files changed

- `orion/harness/last_tool_fetch_cache.py`: new, `publish_last_tool_fetch()` + `read_last_tool_fetch()`.
- `orion/harness/runner.py`: reads at the start of `run()`, writes at the end (success path, explicitly excluding the error/partial-draft path).
- `orion/harness/prefix.py`: `compile_harness_prefix()` gains `prior_tool_fetch_names: list[str] | None = None`, rendered as one line when present.
- `orion/harness/tool_provenance_audit.py`: `_fetch_shaped_tool_names` → public `fetch_shaped_tool_names` (no behavior change).
- Tests: `orion/harness/tests/test_last_tool_fetch_cache.py` (new, 14 tests covering write/read/round-trip/malformed-payload/element-validation/never-raises), extensions to `test_harness_runner.py` (6 new tests including the read-wiring, the partial-draft-error exclusion, and the session_id-keying assertion) and `test_harness_prefix.py` (2 new rendering tests).

## Schema / bus / API changes

- None. No new schema, no new bus channel — plain Redis key via the existing `OrionBusAsync.redis` property both services already hold.
- `build_harness_prompt()`/`compile_harness_prefix()` gain one new optional kwarg each (`prior_tool_fetch_names`), additive, defaults to `None`.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=<worktree> venv/bin/python -m pytest orion/harness/tests -q
145 passed, 3 failed -- all 3 confirmed pre-existing and identical on
unmodified main (2 unrelated Jinja UndefinedError failures in
test_grounding_capsule_consumers.py, 1 unrelated error-code string
mismatch in test_harness_runner_surfaces_fcc_error_code). Zero
regressions from this patch.

services/orion-cortex-exec side verified back to clean baseline after
reverting the first (wrong) design: 15 passed, no lingering changes
(`git status --short services/orion-cortex-exec/` empty).
```

## Evals run

No dedicated eval harness exists for `orion/harness/` covering prompt-content behavior (i.e. whether the FCC model correctly uses the injected continuity line without over-claiming immediacy from it). Flagged as a gap, not silently skipped -- only unit tests cover this patch.

## Docker/build/smoke checks

Not run — Python-only change to prompt assembly and a Redis read/write already using the existing shared bus connection; no config read at boot, no new dependencies, no compose/port changes.

## Review findings fixed

**Round 1 (first, cross-service design — later reverted, findings still worth recording since the same class of bug could recur):**
- Hazard string truncated to 140 chars by an existing `_unique()` helper, cutting off its own warning clause.
- Hazard-eviction regression from a naive fix to the above.
- Metacog-cue provenance tag truncated on eventful turns.
- `key in ctx` presence-check misclassified empty-dict fallbacks as live.
- Confirmed per-turn double scan of the provenance registry.
(All fixed in the reverted design; superseded by this patch's same-service rebuild, which doesn't touch that registry at all.)

**Round 2 (architecture correction):**
- Finding: the write-key (`session_id`) and read-key (`chat_correlation_id`, unpopulated, falling back to a fresh per-turn UUID) never match — the two services aren't sequential turns of one conversation at all.
  - Fix: full redesign, this PR.

**Round 3 (this design):**
- Finding: the write guard (`if not draft_text: return`) only excludes the fully-empty-draft case; a turn that errors/times out with a salvaged partial draft falls through non-empty and still records a tool-fetch for a turn the user may not have fully seen — contradicting the code's own inline comment.
  - Fix: explicit `error_path_taken` flag, set in the `error` event branch, gates the write regardless of whether a partial draft exists.
  - Evidence: `test_harness_runner_does_not_publish_last_tool_fetch_on_partial_draft_error`.
- Finding: `read_last_tool_fetch` validated `tool_names` was a list but not that its elements were strings — a malformed cache row would crash `prefix.py`'s `", ".join(...)` uncaught, breaking the whole next turn over one bad Redis row.
  - Fix: element-level `isinstance(name, str)` validation.
  - Evidence: `test_read_returns_none_when_tool_names_has_non_string_element`.
- Finding (disclosed, not fixed): `session_id` is loaded once from browser `localStorage` and shared across every tab on the same origin — the same value `websocket_handler.py` already flags as cross-tab-shared for a different reason (its turn-cancel registry deliberately avoids keying on it). Two tabs on the same session will cross-contaminate this cache.
  - Not fixed: low severity (continuity confusion, not a content/security leak), and multi-tab-same-session may not be a supported usage pattern at all. Documented prominently in `last_tool_fetch_cache.py`'s module docstring for whoever picks up a proper per-tab/per-chain key if that assumption turns out wrong.

## Restart required

```text
No restart required to review/merge. Once merged, takes effect on the next
deploy/restart of orion-harness-governor.
```

## Risks / concerns

- Severity: Low
- Concern: the cross-tab session_id sharing described above.
- Mitigation: disclosed in code and here; not a supported-usage-pattern question this patch can resolve alone.
- Severity: Low
- Concern: no eval harness exercises whether the FCC model actually uses the injected continuity line correctly (vs. ignoring it or over-interpreting it).
- Mitigation: flagged as a gap; unit tests cover the mechanism, not model behavior.

## PR link

(filled in by gh pr create output)