### PR TITLE
fix(rdf-store): flock-based compact/recover coordination, nightly 5am MST, Pending Attention alerting

### DIFF
--- a/services/orion-rdf-store/.env_example
+++ b/services/orion-rdf-store/.env_example
@@ -49,8 +49,11 @@ RDF_STORE_UPDATE_URL=
 RDF_STORE_GRAPH_STORE_URL=
 
 # === Athena CPU/JVM scaling ===
+# 2026-07-15: was 8g/36g -- raised to match this file's own "Recreate Athena
+# Fuseki ops" checklist below, which already documented 96g as the expected
+# FUSEKI_JVM_XMX; this template had drifted from its own stated target.
 FUSEKI_JVM_XMS=8g
-FUSEKI_JVM_XMX=36g
+FUSEKI_JVM_XMX=96g
 FUSEKI_JVM_GC_OPTS=-XX:+UseG1GC -XX:MaxGCPauseMillis=200
 FUSEKI_EXTRA_JAVA_OPTS=
 FUSEKI_JVM_ARGS=-Xms${FUSEKI_JVM_XMS} -Xmx${FUSEKI_JVM_XMX} ${FUSEKI_JVM_GC_OPTS} ${FUSEKI_EXTRA_JAVA_OPTS}
@@ -59,9 +62,19 @@ FUSEKI_JVM_ARGS=-Xms${FUSEKI_JVM_XMS} -Xmx${FUSEKI_JVM_XMX} ${FUSEKI_JVM_GC_OPTS
 FUSEKI_HTTP_RETRY_ATTEMPTS=4
 FUSEKI_HTTP_RETRY_BASE_DELAY_SEC=0.5
 
+# orion-notify base URL/token used by scripts/fuseki_tdb_compact.sh to post an
+# operator attention request (Hub Pending Attention, severity=error) if a
+# scheduled compact fails -- same pattern as orion-mesh-guardian. Host-reachable
+# (orion-notify publishes its port directly), not the in-network container
+# hostname, since this cron job runs on the host, not inside a container.
+NOTIFY_BASE_URL=http://localhost:7140
+NOTIFY_API_TOKEN=
+
 # Optional compose resource hints.
 # deploy.resources limits are enforced by Docker Compose v2 (docker compose plugin).
 FUSEKI_CPU_LIMIT=
 FUSEKI_CPU_RESERVATION=
-FUSEKI_MEM_LIMIT=40g
+# 2026-07-15: raised alongside FUSEKI_JVM_XMX above -- must stay comfortably
+# above the JVM heap ceiling plus non-heap/container overhead.
+FUSEKI_MEM_LIMIT=110g
 FUSEKI_MEM_RESERVATION=8g

--- a/services/orion-rdf-store/README.md
+++ b/services/orion-rdf-store/README.md
@@ -115,11 +115,12 @@ Jena 5 compacts **in-place** (creates a new `Data-NNNN` tree, then `--deleteOld`
 
 The script:
 
-1. Creates **`FUSEKI_DATA_DIR/.compact-in-progress`** so `make recover` skips restarts during compact
-2. Stops **`orion-athena-fuseki`** and **`orion-athena-rdf-writer`**
-3. Runs **`tdb2.tdbcompact`** via host Java, or **`eclipse-temurin:21-jre-jammy`** Docker if no host JDK
-4. **`chown -R 100:101`** on the dataset (compact in Docker runs as root; without this step Fuseki returns **503** / `AccessDeniedException` on `tdb.lock`)
-5. Restarts Fuseki + rdf-writer, runs **`make health-probe`**
+1. Acquires an exclusive `flock` on **`FUSEKI_DATA_DIR/.compact-in-progress`** (2026-07-15: was a plain `touch`/existence check, which raced against `make recover`'s cron — see [Scheduled maintenance](#scheduled-maintenance-athena-cron)) so `make recover` skips restarts during compact
+2. Validates the dataset shape and free space (still runs under `DRY_RUN=1`, matching the "checks disk space, prints plan" behavior below)
+3. Stops **`orion-athena-fuseki`** and **`orion-athena-rdf-writer`**
+4. Runs **`tdb2.tdbcompact`** via host Java, or **`eclipse-temurin:21-jre-jammy`** Docker if no host JDK
+5. **`chown -R 100:101`** on the dataset (compact in Docker runs as root; without this step Fuseki returns **503** / `AccessDeniedException` on `tdb.lock`)
+6. Restarts Fuseki + rdf-writer, runs **`make health-probe`**
 
 Requires free space on the dataset filesystem **≥ current dataset size** (peak usage during compact).
 
@@ -152,7 +153,7 @@ Under heavy write load, Fuseki/TDB2 can return **`Maximum lock count exceeded`**
 4. Cron every 20 min: `make recover` (see [Scheduled maintenance](#scheduled-maintenance-athena-cron))
 5. Lower writer concurrency: `RDF_WRITE_WORKERS=2`, `RDF_WRITE_MAX_IN_FLIGHT=8`
 6. Client retries via `FUSEKI_HTTP_RETRY_*` on Hub/writer paths
-7. Weekly **`make compact`** — primary defense against index bloat causing lock/GC pressure
+7. Nightly **`make compact`** — primary defense against index bloat causing lock/GC pressure
 
 ---
 
@@ -161,21 +162,27 @@ Under heavy write load, Fuseki/TDB2 can return **`Maximum lock count exceeded`**
 Install on the host that runs Fuseki (`crontab -e` as `athena`):
 
 ```cron
-# Fuseki lock recovery — restarts when health-probe fails; skips if compact lock present
-*/20 * * * * cd /mnt/scripts/Orion-Sapienform/services/orion-rdf-store && make recover >> /mnt/scripts/Orion-Sapienform/logs/orion-fuseki-recover.log 2>&1
+# Fuseki lock recovery — restarts when health-probe fails; skips if compact holds the lock (flock-checked, see below)
+5,25,45 * * * * cd /mnt/scripts/Orion-Sapienform/services/orion-rdf-store && make recover >> /mnt/scripts/Orion-Sapienform/logs/orion-fuseki-recover.log 2>&1
 
-# Weekly TDB compact — reclaims index bloat; ~downtime scales with dataset size
-0 3 * * 0 cd /mnt/scripts/Orion-Sapienform/services/orion-rdf-store && SOURCE=/mnt/graphdb/rdf-store/fuseki/databases/orion make compact >> /mnt/graphdb/rdf_logs/fuseki-compact-run.log 2>&1
+# Nightly TDB compact, 5am MST (12:00 UTC year-round — MST has no DST) — reclaims index bloat
+0 12 * * * cd /mnt/scripts/Orion-Sapienform/services/orion-rdf-store && SOURCE=/mnt/graphdb/rdf-store/fuseki/databases/orion make compact >> /mnt/graphdb/rdf_logs/fuseki-compact-run.log 2>&1
 ```
+
+**2026-07-15**: was `*/20 * * * *` (recover) + `0 3 * * 0` (weekly compact). Both changes fix a real, live bug, not just a schedule preference:
+
+- **Recover's minutes were shifted off `:00`** so it can never fire in the exact same minute as compact's `0 12 * * *` (or any future compact time landing on the hour). This is defense in depth, not the actual fix — see next point.
+- **`fuseki_tdb_compact.sh` and `fuseki_recover.sh` now coordinate via `flock`** on the same lock file, not a plain `[ -f lockfile ]` existence check. The old check-then-act was a genuine TOCTOU race: compact didn't create its marker file until *after* a `du -sb` that takes 30s+ on a large dataset, leaving a real window where recover's cron (same-minute collision under the old weekly-Sunday schedule) could see "no lock yet" and restart Fuseki mid-compact — corrupting the shutdown sequence and leaving compact fighting a live `tdb.lock` it didn't expect. This exact race caused **4 consecutive weekly compact failures** (Jun 21, 28, Jul 5, Jul 12) after the one successful run on Jun 17-18, with the dataset growing unchecked the whole time. `flock -n` is kernel-atomic — there's no gap between check and act regardless of cron timing, so this is fixed at the root, not just avoided by scheduling.
+- **Compact now posts to Hub's Pending Attention on any failure** (same pattern as `orion-mesh-guardian` — `POST {NOTIFY_BASE_URL}/attention/request`, `source_service=orion-rdf-store-compact`, `severity=error`, escalates via email after 60 min unacked). A silent weekly failure that nobody notices for a month is exactly what happened here; this closes that gap going forward.
 
 | Job | Prevents bloat? | What it does |
 |-----|-----------------|--------------|
-| **`make recover`** (every 20 min) | No | Ping + query + write probe; restart on failure |
-| **`make compact`** (weekly) | **Yes** | Offline in-place TDB rebuild; keeps all triples |
+| **`make recover`** (every 20 min, `:05/:25/:45`) | No | Ping + query + write probe; restart on failure; skips if compact holds the flock |
+| **`make compact`** (nightly, 5am MST) | **Yes** | Offline in-place TDB rebuild; keeps all triples; posts to Hub Pending Attention on failure |
 | Writer `RDF_WRITE_*` limits | Slows bloat | Continuous; configured in orion-rdf-writer |
 | **`make disk-guard`** | No (ENOSPC guard) | Only runs on manual `make up` |
 
-After weekly compact, confirm success:
+After compact, confirm success:
 
 ```bash
 tail -30 /mnt/graphdb/rdf_logs/fuseki-compact-run.log   # look for "Compact complete"
@@ -183,7 +190,7 @@ cd services/orion-rdf-store && make health-probe
 du -sh /mnt/graphdb/rdf-store/fuseki/databases/orion
 ```
 
-Schedule compact more often if `make storage-status` shows dataset size creeping up while triple count is stable.
+If nightly compact stops working again, you'll see it in Hub's Pending Attention (severity `error`, `source_service=orion-rdf-store-compact`) — don't rely on manually tailing the log.
 
 ---
 
@@ -204,19 +211,20 @@ Usually **`tdb.lock` owned by root** after Docker compact. Fix and restart:
 docker stop orion-athena-fuseki
 docker run --rm -v /mnt/graphdb/rdf-store/fuseki/databases/orion:/db alpine \
   sh -c 'chown -R 100:101 /db && chmod -R u+rwX,g+rwX /db'
-rm -f /mnt/graphdb/rdf-store/fuseki/.compact-in-progress
 cd services/orion-rdf-store && docker compose restart orion-athena-fuseki && make health-probe
 ```
+
+2026-07-15: do **not** `rm -f .compact-in-progress` as part of this recipe. It provides no benefit under the current `flock`-based coordination (a genuinely stale, unheld lock file is already instantly acquirable by the next `flock -n`) and is actively unsafe if compact is still alive and holding the lock on that file's inode — deleting the path and letting another process create a fresh file there gives that new file no lock at all, defeating the coordination. See [Recover cron restarted Fuseki during compact](#recover-cron-restarted-fuseki-during-compact) below.
 
 The compact script performs this chown automatically; manual fix only needed if compact was interrupted or run outside the script.
 
 ### Recover cron restarted Fuseki during compact
 
-`make recover` checks **`$FUSEKI_DATA_DIR/.compact-in-progress`** and exits without restarting. If compact was killed mid-run, remove a stale lock:
+**Fixed 2026-07-15** — `make recover` and `make compact` now coordinate via `flock` on `$FUSEKI_DATA_DIR/.compact-in-progress` instead of a plain existence check, closing the TOCTOU race that let this actually happen (see [Scheduled maintenance](#scheduled-maintenance-athena-cron) for the incident this fixed: 4 consecutive weekly compact failures). This should no longer occur.
 
-```bash
-rm -f /mnt/graphdb/rdf-store/fuseki/.compact-in-progress
-```
+If compact was killed by something other than recover (e.g. host reboot, OOM-killer) and left a stale marker file, `flock` self-heals on the next run automatically — a leftover file with no process holding its lock is immediately acquirable, no manual cleanup needed.
+
+**Do not `rm -f .compact-in-progress` as a manual fix, ever, under the new scheme** — this is a real behavior change from the old advice, not a harmless no-op. If compact's process is genuinely still alive but hung (not dead — e.g. `docker stop` or `tdb2.tdbcompact` itself wedged, not OOM-killed), it still holds a real flock on that file's current inode. Deleting the file and letting the next process create a fresh one at that path gives the new file no lock on it at all, silently defeating the coordination and reopening the exact race this fix closes. If you suspect a genuinely stuck (not dead) holder, identify and deal with the actual process instead: `fuser /mnt/graphdb/rdf-store/fuseki/.compact-in-progress` or `lsof /mnt/graphdb/rdf-store/fuseki/.compact-in-progress` to find it, confirm what it's doing before killing it.
 
 ### `Maximum lock count exceeded`
 

--- a/services/orion-rdf-store/docker-compose.yml
+++ b/services/orion-rdf-store/docker-compose.yml
@@ -36,6 +36,6 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${FUSEKI_MEM_LIMIT:-40g}
+          memory: ${FUSEKI_MEM_LIMIT:-110g}
         reservations:
           memory: ${FUSEKI_MEM_RESERVATION:-8g}

--- a/services/orion-rdf-store/scripts/fuseki_recover.sh
+++ b/services/orion-rdf-store/scripts/fuseki_recover.sh
@@ -9,7 +9,25 @@ SERVICE="${FUSEKI_SERVICE_NAME:-orion-athena-fuseki}"
 WAIT_SEC="${FUSEKI_RECOVER_WAIT_SEC:-20}"
 COMPACT_LOCK="${FUSEKI_COMPACT_LOCK:-${FUSEKI_DATA_DIR:-/mnt/graphdb/rdf-store/fuseki}/.compact-in-progress}"
 
-if [ -f "${COMPACT_LOCK}" ]; then
+# 2026-07-15 fix: acquire the SAME lock fuseki_tdb_compact.sh holds via flock,
+# not a plain `[ -f lockfile ]` existence check. The old check-then-act was a
+# real TOCTOU race: this cron fires every 20 min, including the exact minute
+# compact's own schedule fires on, and compact didn't create its marker file
+# until after a du -sb that can take 30s+ on a large dataset -- leaving a
+# window where this script could see "no lock yet" and restart Fuseki mid-
+# compact. flock -n is a kernel-atomic test: if compact holds the lock, this
+# fails immediately and consistently, no gap.
+#
+# Deliberately held (not released) for the rest of this script, through the
+# restart + reprobe below -- an earlier draft released it right after this
+# check, which only proved the lock was free at that instant, not for the
+# duration of the restart action that follows. A compact starting in that
+# gap would race a live `docker compose restart` the same way the original
+# incident did, just through a narrower window. Held-until-exit (same as
+# fuseki_tdb_compact.sh) closes that too: the kernel releases the lock
+# automatically when this script's process exits, on every exit path.
+exec 9>"${COMPACT_LOCK}"
+if ! flock -n 9; then
   echo "fuseki_recover: compact in progress (${COMPACT_LOCK}); skipping"
   exit 0
 fi

--- a/services/orion-rdf-store/scripts/fuseki_tdb_compact.sh
+++ b/services/orion-rdf-store/scripts/fuseki_tdb_compact.sh
@@ -7,9 +7,17 @@
 # Example:
 #   SOURCE=/mnt/graphdb/rdf-store/fuseki/databases/orion \
 #   ./scripts/fuseki_tdb_compact.sh
-set -euo pipefail
+# -E (errtrace) is load-bearing, not decorative: without it, the ERR trap
+# below does NOT fire when a function's failure comes from its own last
+# command failing naturally (no explicit `return N`) -- which is exactly the
+# shape of _run_tdbcompact and _ensure_jena below. Verified empirically
+# (2026-07-15 review): identical function structure without -E silently never
+# triggers the trap for the tdb2.tdbcompact failure this whole notify
+# mechanism exists to catch -- the literal failure mode from the incident.
+set -Eeuo pipefail
 
 ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "${ROOT}/../.." && pwd)"
 cd "${ROOT}"
 
 SOURCE="${SOURCE:-/mnt/graphdb/rdf-store/fuseki/databases/orion}"
@@ -20,7 +28,26 @@ SERVICE="${FUSEKI_SERVICE_NAME:-orion-athena-fuseki}"
 WRITER_SERVICE="${RDF_WRITER_SERVICE_NAME:-orion-athena-rdf-writer}"
 DRY_RUN="${DRY_RUN:-0}"
 DELETE_OLD="${DELETE_OLD:-1}"
-COMPACT_LOCK="${FUSEKI_COMPACT_LOCK:-$(dirname "$(dirname "${SOURCE}")")/.compact-in-progress}"
+# Same derivation as fuseki_recover.sh (FUSEKI_DATA_DIR-based, not
+# SOURCE-derived) -- 2026-07-15 review finding: the two scripts previously
+# computed this path via different formulas that only happened to agree
+# under the current default layout. A deployment that overrides SOURCE to a
+# sibling dataset without also setting FUSEKI_DATA_DIR to match could
+# silently defeat the flock coordination (each script locking a different,
+# uncontended file). Single formula now, both scripts, always identical.
+COMPACT_LOCK="${FUSEKI_COMPACT_LOCK:-${FUSEKI_DATA_DIR:-/mnt/graphdb/rdf-store/fuseki}/.compact-in-progress}"
+NOTIFY_BASE_URL="${NOTIFY_BASE_URL:-http://localhost:7140}"
+NOTIFY_API_TOKEN="${NOTIFY_API_TOKEN:-}"
+
+# Same interpreter-resolution fallback as fuseki_prune_retention.sh in this
+# same directory (repo venv over bare python3, since the athena cron host's
+# bare python3 isn't guaranteed to have a usable stdlib/PATH entry).
+PYTHON="${PYTHON:-python3}"
+if [ -x "${REPO_ROOT}/orion_dev/bin/python" ]; then
+  PYTHON="${REPO_ROOT}/orion_dev/bin/python"
+elif [ -x "${REPO_ROOT}/venv/bin/python" ]; then
+  PYTHON="${REPO_ROOT}/venv/bin/python"
+fi
 
 _bytes() {
   local dir="$1"
@@ -30,6 +57,69 @@ _bytes() {
 _free_bytes() {
   local dir="$1"
   df -Pk "${dir}" | awk 'NR==2 {print $4 * 1024}'
+}
+
+# 2026-07-15 fix: on any failure past this point, post an operator attention
+# request to orion-notify so it surfaces in Hub's Pending Attention panel
+# (same pattern orion-mesh-guardian uses -- see
+# services/orion-mesh-guardian/app/attention.py -- NOT the cognitive-loop-only
+# PendingAttentionCardV1 schema, which is unrelated and schema-locked against
+# non-cognitive sources). Best-effort: curl/python failures here must never
+# mask the real compact failure, so errors are swallowed (`|| return 0` /
+# trailing `|| true`).
+_notify_failure() {
+  local exit_code="$1"
+  local failed_command="$2"
+  local line_no="$3"
+  local message="Fuseki TDB compact failed (exit ${exit_code}) at line ${line_no}: ${failed_command}. See /mnt/graphdb/rdf_logs/fuseki-compact-run.log on the host for full output."
+  local payload
+  payload=$("${PYTHON}" -c '
+import json, sys
+print(json.dumps({
+    "source_service": "orion-rdf-store-compact",
+    "reason": "fuseki_tdb_compact_failed",
+    "severity": "error",
+    "message": sys.argv[1],
+    "require_ack": True,
+    "context": {
+        "source_service": "orion-rdf-store-compact",
+        "event_kind": "orion.rdf_store.compact.failed.v1",
+        "reason": "fuseki_tdb_compact_failed",
+        "exit_code": sys.argv[2],
+        "failed_command": sys.argv[3],
+        "line_no": sys.argv[4],
+        "source_dataset": sys.argv[5],
+    },
+}))
+' "${message}" "${exit_code}" "${failed_command}" "${line_no}" "${SOURCE}" 2>/dev/null) || {
+    echo "compact: WARNING -- could not build notify payload (is ${PYTHON} usable?); Pending Attention will NOT see this failure" >&2
+    return 0
+  }
+  if ! curl -fsS -X POST "${NOTIFY_BASE_URL%/}/attention/request" \
+    -H "Content-Type: application/json" \
+    ${NOTIFY_API_TOKEN:+-H "X-Orion-Notify-Token: ${NOTIFY_API_TOKEN}"} \
+    -d "${payload}" \
+    --max-time 10 >/dev/null 2>&1; then
+    echo "compact: WARNING -- notify POST to ${NOTIFY_BASE_URL} failed; Pending Attention will NOT see this failure (this message is the only record)" >&2
+  fi
+}
+# Catches any UNANTICIPATED command failure under set -e (docker/curl/tar/mv
+# calls in _ensure_jena, the tdb2.tdbcompact call itself -- the actual failure
+# mode from the incident this fix addresses). Does NOT fire for explicit
+# `exit N` statements -- bash's ERR trap is documented to skip those (verified
+# empirically: `exit 1` inside an `if ! cmd; then exit 1; fi` block never
+# triggers a registered ERR trap, only real non-zero command exits do). The
+# three explicit-exit paths below (bad dataset shape, insufficient free space,
+# health-probe failure) each call _fail(), which notifies explicitly for
+# exactly this reason -- 2026-07-15 review finding, confirmed live before
+# fixing.
+trap '_notify_failure "$?" "${BASH_COMMAND}" "${LINENO}"' ERR
+
+_fail() {
+  local msg="$1"
+  echo "compact: ${msg}" >&2
+  _notify_failure "1" "${msg}" "${LINENO}"
+  exit 1
 }
 
 _ensure_jena() {
@@ -68,9 +158,34 @@ _run_tdbcompact() {
     /jena/bin/tdb2.tdbcompact --loc=/db "${delete_old_flag[@]}"
 }
 
+# 2026-07-15 fix: acquire the compact lock FIRST, atomically, before any other
+# work -- including before the du -sb / free-space checks below. The previous
+# version touched a plain marker file only after those checks (du -sb alone
+# can take 30s+ on a 300GB+ dataset) and fuseki_recover.sh's cron (every 20
+# min, including the exact minute this schedule fires on) only did a plain
+# `[ -f lockfile ]` existence check -- neither half was atomic, so recover
+# could restart Fuseki mid-compact in the window before the marker existed,
+# leaving compact fighting a live tdb.lock it didn't expect ("held by process
+# N"). flock on the same lock file, tested via a non-blocking acquire, closes
+# that race for both scripts: whichever side's flock() syscall wins the
+# exclusive lock first is guaranteed consistent, kernel-atomic mutual
+# exclusion -- no check-then-act gap. This exact race caused 4 consecutive
+# weekly compact failures (Jun 21/28, Jul 5/12 2026) after the one successful
+# run on Jun 17-18.
+#
+# DRY_RUN still runs the dataset-shape and free-space checks below (matching
+# pre-2026-07-15 behavior, and this file's own "Dry-run (checks disk space,
+# prints plan)" description in the README) -- it just does so under the lock,
+# which is harmless since DRY_RUN never stops Fuseki or writes anything; the
+# lock releases automatically when the script exits either way.
+exec 200>"${COMPACT_LOCK}"
+if ! flock -n 200; then
+  echo "compact: another compact (or a probing recover) holds the lock; exiting" >&2
+  exit 0
+fi
+
 if ! compgen -G "${SOURCE}/Data-*" >/dev/null && [ ! -f "${SOURCE}/tdb.lock" ]; then
-  echo "compact: source does not look like a TDB2 dataset: ${SOURCE}" >&2
-  exit 1
+  _fail "source does not look like a TDB2 dataset: ${SOURCE}"
 fi
 
 src_bytes="$(_bytes "${SOURCE}")"
@@ -79,21 +194,13 @@ echo "==> Source ${SOURCE}: ${src_bytes} bytes"
 echo "==> Filesystem free: ${fs_free} bytes"
 
 if [ "${fs_free}" -lt "${src_bytes}" ]; then
-  echo "compact: need >= source bytes free on dataset filesystem (have ${fs_free}, need ${src_bytes})" >&2
-  exit 1
+  _fail "need >= source bytes free on dataset filesystem (have ${fs_free}, need ${src_bytes})"
 fi
 
 if [ "${DRY_RUN}" = "1" ]; then
   echo "DRY_RUN=1: would stop ${SERVICE} (+ ${WRITER_SERVICE}), compact in-place ${SOURCE}, restart ${SERVICE}"
   exit 0
 fi
-
-_cleanup() {
-  rm -f "${COMPACT_LOCK}"
-}
-trap _cleanup EXIT INT TERM
-
-touch "${COMPACT_LOCK}"
 
 echo "==> Stopping ${SERVICE} and ${WRITER_SERVICE}"
 docker stop "${SERVICE}" "${WRITER_SERVICE}" 2>/dev/null || true
@@ -125,8 +232,7 @@ PROBE_INTERVAL="${FUSEKI_COMPACT_HEALTH_PROBE_INTERVAL_SEC:-5}"
 if ! FUSEKI_HEALTH_PROBE_MAX_ATTEMPTS="${PROBE_ATTEMPTS}" \
      FUSEKI_HEALTH_PROBE_INTERVAL_SEC="${PROBE_INTERVAL}" \
      make health-probe; then
-  echo "compact: health-probe failed after restart (${PROBE_ATTEMPTS} attempts × ${PROBE_INTERVAL}s)" >&2
-  exit 1
+  _fail "health-probe failed after restart (${PROBE_ATTEMPTS} attempts x ${PROBE_INTERVAL}s)"
 fi
 
 echo "==> Compact complete"

--- a/services/orion-rdf-store/scripts/test_compact_lock_coordination.sh
+++ b/services/orion-rdf-store/scripts/test_compact_lock_coordination.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Regression test for the 2026-07-15 fix: fuseki_tdb_compact.sh and
+# fuseki_recover.sh coordinate via flock on a shared lock file. This was
+# previously a plain `[ -f lockfile ]` existence check, which was a real
+# TOCTOU race that caused 4 consecutive weekly production compact failures
+# (see README.md "Scheduled maintenance" section for the incident).
+#
+# This test doesn't touch Docker/Fuseki -- it validates the locking primitive
+# itself in isolation: does a concurrent flock probe correctly detect
+# contention while a holder is active, and correctly succeed once released?
+set -euo pipefail
+
+LOCK_FILE="$(mktemp -u /tmp/test-compact-lock-coordination.XXXXXX)"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# --- Test 1: a concurrent holder blocks a probing flock -n ---
+(
+  exec 200>"${LOCK_FILE}"
+  flock -n 200 || exit 1
+  sleep 2
+) &
+holder_pid=$!
+sleep 0.5
+
+(
+  exec 9>"${LOCK_FILE}"
+  if flock -n 9; then
+    echo "prober acquired lock while holder was still active" >&2
+    exit 1
+  fi
+  exit 0
+) || fail "Test 1: concurrent prober should have been blocked by the holder, but was not (this is the exact race that caused the production incident)"
+
+wait "${holder_pid}"
+echo "PASS: Test 1 (concurrent holder correctly blocks a probing flock -n)"
+
+# --- Test 2: after the holder releases, a probe can acquire cleanly ---
+(
+  exec 9>"${LOCK_FILE}"
+  flock -n 9 || exit 1
+  flock -u 9
+) || fail "Test 2: prober should acquire cleanly once the holder has released, but did not"
+echo "PASS: Test 2 (lock is acquirable again after release)"
+
+echo "All compact/recover lock coordination tests passed."


### PR DESCRIPTION
## Summary

Root-causes and fixes a real production incident: `fuseki_tdb_compact.sh` (nightly TDB2 offline compact) and `fuseki_recover.sh` (health-check/restart, every ~20min) coordinated via a plain `[ -f lockfile ]` existence check — a genuine TOCTOU race, since compact didn't create its marker file until after a `du -sb` that takes 30s+ on a 300GB+ dataset. This caused **4 consecutive weekly compact failures** (Jun 21/28, Jul 5/12) after the one successful run on Jun 17-18, with the dataset growing unchecked the whole time (611GB+ by the time this was found and diagnosed).

## Changes

- **Real fix**: both scripts now coordinate via `flock` (kernel-atomic), not existence checks. Compact acquires the lock before ANY work, including before the slow `du -sb`. Recover now *holds* the lock for its entire restart sequence — an earlier draft of this fix released it right after the initial probe, which only proved the lock was free at that instant, reopening a narrower version of the same race (caught in review).
- **`set -E` (errtrace)** added to `compact.sh` — without it, the `ERR` trap added below does not fire for a function's own last-command failure (verified empirically with a standalone repro). This specifically would have missed the `tdb2.tdbcompact` failure that caused the original incident — i.e. the notify mechanism would have silently not covered the exact failure it was built for.
- **Hub Pending Attention alerting**: compact now posts to `POST /attention/request` (same pattern as `orion-mesh-guardian`) on any real failure — via a `_fail()` helper for the three explicit `exit 1` paths (bash's `ERR` trap does not fire for explicit `exit N`, also verified empirically) plus the `ERR` trap itself for unanticipated command failures.
- **Schedule**: weekly Sunday 3am → nightly 5am MST (`0 12 * * *`, MST has no DST so this is always 12:00 UTC). Recover's cron minutes shifted off `:00` as defense in depth on top of the flock fix.
- Unified the two scripts' lock-path derivation (previously two different formulas that only coincidentally agreed under current defaults).
- `FUSEKI_JVM_XMX`/`FUSEKI_MEM_LIMIT` bumped in `.env_example` + compose fallback to match the live values already deployed this session (96g/110g) and this file's own pre-existing "Recreate Athena Fuseki ops" checklist, which had already documented 96g as the target — `.env_example` had drifted from its own stated expectation.
- README: fixed a factually wrong "harmless to `rm -f .compact-in-progress`" claim (unsafe if the holder is alive-but-hung, not dead — deleting the file while it's locked just creates a fresh, lock-free file at that path), fixed a stale step-1 description of the old touch-based mechanism, removed a now-dangerous `rm -f` from the "Fuseki 503 after compact" recipe.
- Added `services/orion-rdf-store/scripts/test_compact_lock_coordination.sh` — this service had zero test precedent before now; validates the actual locking primitive (concurrent holder blocks a probe; probe succeeds after release) without touching Docker/Fuseki.

## Review

Ran `/code-review --level high` (8 finder angles, verified findings). Confirmed and fixed:
- `set -E` requirement (would have silently broken the fix's core purpose)
- `exit N` not triggering `ERR` trap for 3 explicit-failure paths
- recover.sh's release-before-act reopening a narrower race
- README's incorrect "harmless" claim
- Divergent lock-path derivation formulas
- Missing regression test (none existed for this fix)
- Stale doc description of the old mechanism
- `docker-compose.yml`'s stale inline memory-limit fallback

## Test plan

- [x] Both scripts pass `bash -n`/`sh -n` syntax check
- [x] flock coordination tested empirically (concurrent holder blocks prober; prober succeeds after release) — both manually and via the new committed regression test
- [x] `set -E` fix verified against a structural mirror of the actual `_run_tdbcompact` failure shape
- [x] Notify integration tested end-to-end against the real live `orion-notify` endpoint (test attention cards created and dismissed via `/attention/{id}/ack`)
- [x] Full `_fail()` path tested via a forced bad-`SOURCE` run of the real script — correct error message, correct exit code
- [x] Live `.env` for `orion-rdf-store` confirmed already synced (`NOTIFY_BASE_URL`, `NOTIFY_API_TOKEN`, `FUSEKI_JVM_XMX=96g`, `FUSEKI_MEM_LIMIT=110g`)
- [ ] Not yet observed: a full real nightly compact run end-to-end (next natural run is tonight at 5am MST once merged and the crontab is updated)

## Restart required

None for this PR alone (script/doc changes only). The crontab itself needs a manual update on the host (`crontab -e` as `athena`) to switch from the old schedule to the new one documented in the README — not part of this PR's diff since crontab isn't a tracked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)