### PR TITLE
fix(orion-bus): grammar atoms never got real wall-clock observed_at

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-15-bus-transport-grammar-atom-wall-clock-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-15-bus-transport-grammar-atom-wall-clock-pr.md
@@ -1,0 +1,252 @@
+# PR report — bus-transport grammar atoms never got real wall-clock observed_at
+
+PR: (create at https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/bus-transport-grammar-atom-wall-clock)
+Branch: `fix/bus-transport-grammar-atom-wall-clock`
+Status: **DONE**
+
+## Summary
+
+- Fixed the third and final sibling of the shared-`observed_at` bug
+  (memory `project_grammar_collector_shared_timestamp_bug_siblings`):
+  `BusTransportGrammarCollector` (`services/orion-bus/app/grammar_emit.py`)
+  had the identical bug already fixed in `CortexExecGrammarCollector`
+  (PR #1042) and `HarnessGrammarCollector` (PR, commit `4620c21b`) — every
+  `GrammarAtomV1`/edge/`trace_ended` event in a trace shared one
+  collector-construction-time `observed_at` instead of each atom's own real
+  capture time.
+- Same fix shape: new `_atom_observed_at: dict[str, datetime]`, populated
+  by `_put_atom()` alongside `GrammarAtomV1.time_range` (previously always
+  `None`); a new `observed_at_for()` helper used by
+  `build_bus_transport_grammar_events()` for both atoms and edges;
+  `trace_ended` now uses `max(_atom_observed_at.values(), default=observed_at)`
+  instead of reusing trace-start.
+- Investigated (not assumed) whether this collector needed the
+  idempotency-per-`atom_id` guard the other two siblings needed —
+  **it does not**. Every real call site constructs a brand-new collector
+  per observer tick and calls each `record_*()` method at most once per
+  instance. See "Re-invocation investigation" below.
+- Audited all 7 `record_*()` methods for the harness sibling's second bug
+  class (methods bypassing `_put_atom()` with a direct
+  `self._atoms[key] = atom` assignment) — **none bypass it**, so there was
+  no second bug to fix here.
+- Live-verified before touching code: this collector's real-world timing
+  spread is genuinely negligible, not just theoretically nonzero. See
+  "Live-data findings" below — this is the honest, calibrated version of
+  the "Outcome moved" claim for this specific sibling.
+
+## Outcome moved
+
+Bus-transport observer-tick traces now carry per-atom `time_range` and, in
+principle, per-atom `observed_at` distinct from trace-start. In practice
+(see live-data findings below), every atom in a real observer tick is
+recorded within the same event-loop tick with no `await` between
+`record_*()` calls, so the real-world timestamp spread this fix produces is
+sub-millisecond — the fix removes the structural bug (a shared constant
+masquerading as per-atom timing, which `orion/grammar/ledger.py`'s
+`time_range`-reading Grammar Atlas API consumers should never see as
+identical-by-construction), but it does **not** meaningfully change
+`grammar_traces.started_at`/`ended_at` duration for this producer the way
+the harness fix did (harness traces spanned up to 2m15s; bus-transport
+traces span microseconds). Calibrated claim, not oversold.
+
+## Current architecture
+
+`BusTransportGrammarCollector` (`services/orion-bus/app/grammar_emit.py`)
+is the last of three independently-duplicated grammar-collector classes
+(siblings: `CortexExecGrammarCollector` in
+`services/orion-cortex-exec/app/grammar_emit.py`, `HarnessGrammarCollector`
+in `orion/harness/grammar_emit.py`) — no shared base class exists; each
+accumulates `GrammarAtomV1`s/edges via `record_*()` methods, then a
+`build_*_grammar_events()` function assembles the final `GrammarEventV1`
+list for publish. `services/orion-bus/app/bus_observer.py`'s
+`run_bus_observer_loop()` calls `run_observer_tick()` once per poll
+interval; `run_observer_tick()` builds a fresh `ObserverRollup` from a
+Redis snapshot, calls `rollup.to_collector()` to get a brand-new
+`BusTransportGrammarCollector`, then `build_bus_transport_grammar_events()`
+and publishes via `publish_bus_transport_grammar_trace()`. The
+except-path constructs a second, independent `fail_collector` for the
+same tick.
+
+## Re-invocation investigation (step 3)
+
+Traced the real call graph in `services/orion-bus/`:
+
+- `ObserverRollup.to_collector()` (`bus_observer.py:58-79`) constructs one
+  `BusTransportGrammarCollector` and calls `record_tick_started()`,
+  `record_health_observed()`, `record_stream_depth()` (once per stream in a
+  loop, but each stream key is a distinct `role`/`atom_id`, not a repeat
+  call for the same atom), `record_backpressure()` (same, per stream key),
+  `record_uncataloged_stream()` (same), and `record_tick_completed()` —
+  each of the fixed-role methods (`record_tick_started`,
+  `record_health_observed`, `record_tick_completed`) called exactly once.
+- `run_observer_tick()`'s except-path (`bus_observer.py:163-170`)
+  constructs a second, independent `fail_collector` and calls
+  `record_tick_started()` + `record_tick_failed()`, each once.
+- `run_observer_tick()` itself is called once per `while True` iteration in
+  `run_bus_observer_loop()` (`bus_observer.py:181-195`) — no retry/backoff
+  wrapper, no shared/cached collector across iterations, every iteration
+  builds a brand-new `ObserverRollup`/collector.
+
+No path exists where the same `record_*()` method is invoked twice on the
+same collector instance — unlike `HarnessGrammarCollector`'s
+`record_result_assembled`, which is genuinely re-invoked across the
+motor-publish and finalize-publish phases. **Conclusion: no idempotency
+guard needed here.** Independently re-verified by a code-review subagent
+that grepped every `BusTransportGrammarCollector(` construction site
+(production + tests) and confirmed the same finding.
+
+## Live-data findings
+
+Query (per the mandatory pre-work check, `source_service='orion-bus'`
+confirmed via `_provenance()`):
+
+```text
+SELECT trace_id, count(*) AS atoms, count(DISTINCT observed_at) AS distinct_observed_at,
+  max(observed_at) - min(observed_at) AS observed_at_spread,
+  max(created_at) - min(created_at) AS wall_clock_spread
+FROM grammar_events
+WHERE source_service = 'orion-bus' AND event_kind = 'atom_emitted'
+GROUP BY trace_id HAVING count(*) > 2
+ORDER BY max(created_at) DESC LIMIT 10;
+```
+
+Result: 10 real traces, all with 7 atoms, `distinct_observed_at = 1` for
+every trace (confirming the bug) — but **also** `wall_clock_spread =
+00:00:00` for every trace. A follow-up query with microsecond-precision
+`EXTRACT(EPOCH ...)` confirmed `wall_clock_spread_ms = 0.000000` exactly,
+i.e. `min(created_at)` and `max(created_at)` are bit-for-bit identical
+timestamps for all 7 rows in a trace (e.g.
+`2026-07-16 01:01:25.858311+00` for every row of that trace).
+
+This confirms the flagged possibility explicitly: this collector's atoms
+really do span one observer tick with genuinely negligible real elapsed
+time, because `ObserverRollup.to_collector()` and `run_observer_tick()`
+are pure synchronous Python with no `await`/I/O between `record_*()`
+calls — unlike the harness/cortex-exec producers, which interleave
+`record_*()` calls with real async work (LLM calls, tool execution,
+recall). The fix is still correct to ship (it removes a structural bug:
+`time_range` was always `None`, and `observed_at` was a shared constant by
+construction rather than a genuinely-measured value that happened to be
+close), but the "Outcome moved" claim for this specific sibling is
+calibrated accordingly — do not expect
+`grammar_traces.started_at`/`ended_at` duration to visibly change for
+`bus.transport:*` traces the way it did for harness traces.
+
+## Architecture touched
+
+`services/orion-bus/app/grammar_emit.py` and its test file only. No
+schema/env/Docker changes. No changes to `bus_observer.py` or any other
+consumer.
+
+## Files changed
+
+- `services/orion-bus/app/grammar_emit.py`: `_atom_observed_at` dict +
+  `time_range` stamping in `_put_atom()` (no idempotency guard — see
+  investigation above); new `observed_at_for()` helper;
+  `build_bus_transport_grammar_events()` uses real per-atom timestamps for
+  atoms and edges; `trace_ended` uses the real max recorded timestamp
+  instead of reusing trace-start.
+- `services/orion-bus/tests/test_orion_bus_grammar_emit.py`: 7 new
+  regression tests mirroring `HarnessGrammarCollector`'s test suite,
+  adapted to `BusTransportGrammarCollector`'s actual API (no idempotency
+  test — not applicable, see investigation above).
+
+## Schema / bus / API changes
+
+None. `BusTransportGrammarCollector._atom_observed_at` and
+`observed_at_for()` are purely additive/internal — no consumer-visible
+shape change. `GrammarAtomV1.time_range` was already part of the schema
+(used by the other two siblings); this collector now populates it like
+they do.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=services/orion-bus:. .venv/bin/python -m pytest services/orion-bus/tests/test_orion_bus_grammar_emit.py -q
+=> 11 passed (4 pre-existing + 7 new)
+
+PYTHONPATH=services/orion-bus:. .venv/bin/python -m pytest services/orion-bus/tests -q
+=> 15 passed (full service test dir, no regressions)
+```
+
+## Evals run
+
+None applicable — no `services/orion-bus/evals/` directory exists (same
+gap as the harness/cortex-exec siblings' reports). The live Postgres query
+above is the closest thing to an eval — informal, by hand, not automated.
+
+## Docker/build/smoke checks
+
+Not run — pure Python logic change inside `orion-bus`'s existing code
+path, no config/dependency changes to validate.
+
+## Review findings fixed
+
+Code-review skill (equivalent, dispatched as a repo-aware subagent with
+independent verification instructions), high effort, covering: correctness
+of the re-invocation claim (independently re-traced the call graph),
+`_put_atom()`-bypass audit, `observed_at_for()` extraction/duplication
+check, edge-timestamp-direction check, altitude/architecture, conventions,
+and a live before/after test-mutation check (reverted the timestamp
+substitutions, confirmed 4 of the 6 timing-sensitive tests fail as
+expected, then restored).
+
+**No material findings.** All checks passed on first pass:
+
+- Re-invocation claim independently confirmed safe (no repeat
+  `record_*()` calls on any real collector instance).
+- No `_put_atom()`-bypass bug found (unlike the harness sibling, all 7
+  `record_*()` methods already routed through `_put_atom()` before this
+  patch).
+- `observed_at_for()` correctly extracted and used at both call sites, no
+  duplicated inline fallback lookups.
+- Edge `to_atom_id` confirmed to always be the just-recorded atom at all 4
+  edge-append sites — timestamp direction is correct.
+- New tests independently verified to catch the regression (reverting the
+  fix locally made 4 of 6 new tests fail, as expected).
+
+Nice-to-have, not fixed (out of scope, noted for follow-up):
+
+- `CortexExecGrammarCollector`'s three inline `.get(id, observed_at)`
+  lookups (`services/orion-cortex-exec/app/grammar_emit.py:562,594,620`)
+  were never given the `observed_at_for()`-style extraction the harness
+  sibling got in its own review round — this patch is actually ahead of
+  that sibling on this specific cleanup, not behind it.
+- No shared base class/mixin exists across the three sibling collectors,
+  so this is now the third independent copy of the same
+  `_atom_observed_at`/`_put_atom`/fallback pattern. A future 4th producer
+  of this bug class would need another independent patch. Flagged by both
+  this review and the harness PR's review; still not undertaken, to keep
+  each patch thin and scoped.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-bus/.env \
+  -f services/orion-bus/docker-compose.yml up -d --build
+```
+Not run this session.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: as documented in "Live-data findings," the real-world impact of
+  this fix for this specific producer is negligible (sub-millisecond,
+  genuinely simultaneous atom recording) — do not expect this PR to move
+  any dashboard/duration metric for `bus.transport:*` traces the way the
+  harness fix moved harness trace durations. The fix is still correct
+  (removes a structural bug in `time_range`/`observed_at` semantics that a
+  raw bus consumer or the Grammar Atlas API could observe), just low
+  practical impact.
+- Severity: low
+- Concern: same as the harness/cortex-exec PRs' reports — no shared base
+  class exists across the three sibling collectors. Not addressed here,
+  consistent with keeping this patch thin.
+
+## PR link
+
+`gh` is authenticated in this environment.

--- a/services/orion-bus/app/grammar_emit.py
+++ b/services/orion-bus/app/grammar_emit.py
@@ -10,6 +10,7 @@ from orion.schemas.grammar import (
     GrammarEdgeV1,
     GrammarEventV1,
     GrammarProvenanceV1,
+    TimeRangeV1,
 )
 
 
@@ -29,6 +30,20 @@ class BusTransportGrammarCollector:
     observed_at: datetime
     code_version: str | None = None
     _atoms: dict[str, GrammarAtomV1] = field(default_factory=dict)
+    # Real wall-clock moment each atom was actually recorded, keyed by
+    # atom_id. Populated by _put_atom() -- same fix shape as
+    # CortexExecGrammarCollector/HarnessGrammarCollector's _atom_observed_at
+    # (services/orion-cortex-exec/app/grammar_emit.py,
+    # orion/harness/grammar_emit.py). Before this, every GrammarEventV1's
+    # observed_at in a bus-transport trace was the same value captured once
+    # at collector construction (self.observed_at, trace-START). Unlike the
+    # other two siblings, no idempotency-per-atom_id guard is needed here:
+    # a fresh BusTransportGrammarCollector is constructed per observer tick
+    # (ObserverRollup.to_collector() in bus_observer.py, and the except-path
+    # fail_collector in run_observer_tick()) and every record_*() method is
+    # called at most once per instance -- confirmed by tracing the real call
+    # sites, not assumed.
+    _atom_observed_at: dict[str, datetime] = field(default_factory=dict)
     _edge_specs: list[tuple[str, str, str]] = field(default_factory=list)
 
     @property
@@ -49,7 +64,23 @@ class BusTransportGrammarCollector:
         return f"{self.trace_id}:{role}"
 
     def _put_atom(self, role: str, atom: GrammarAtomV1) -> None:
+        now = datetime.now(timezone.utc)
+        # Same source timestamp for both, set together so they can never
+        # drift -- see CortexExecGrammarCollector/HarnessGrammarCollector's
+        # identical pattern for why time_range is stamped here too
+        # (ledger.py's atom-row persistence and the Grammar Atlas API
+        # read it).
+        atom.time_range = TimeRangeV1(start=now, end=now)
         self._atoms[role] = atom
+        self._atom_observed_at[atom.atom_id] = now
+
+    def observed_at_for(self, atom_id: str) -> datetime:
+        """Real recorded timestamp for a given atom_id, falling back to
+        trace-start observed_at only if that atom somehow bypassed
+        _put_atom(). Single source for the lookup build_bus_transport_grammar_events()
+        needs per atom and per edge, so a future change to the fallback
+        policy can't be applied to some call sites and missed at others."""
+        return self._atom_observed_at.get(atom_id, self.observed_at)
 
     def record_tick_started(self) -> None:
         self._put_atom(
@@ -293,12 +324,18 @@ def build_bus_transport_grammar_events(
     events: list[GrammarEventV1] = [root]
 
     for atom in collector._atoms.values():
+        # Real wall-clock moment this atom was actually recorded (see
+        # _put_atom / _atom_observed_at docstring above), not the single
+        # trace-START value every atom in a trace previously shared. Falls
+        # back to trace-start observed_at only if an atom somehow bypassed
+        # _put_atom(). emitted_at stays the shared flush-time value.
+        atom_ts = collector.observed_at_for(atom.atom_id)
         events.append(
             _event(
                 event_kind="atom_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=atom_ts,
                 provenance=provenance,
                 atom=atom,
                 parent_event_id=root_id,
@@ -319,12 +356,15 @@ def build_bus_transport_grammar_events(
             salience=0.6,
             evidence_event_ids=[collector.sample_window_id],
         )
+        # observed_at = real moment the target atom happened; emitted_at
+        # stays the shared flush-time value, same reasoning as above.
+        edge_ts = collector.observed_at_for(to_atom_id)
         events.append(
             _event(
                 event_kind="edge_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=edge_ts,
                 provenance=provenance,
                 edge=edge,
                 parent_event_id=root_id,
@@ -334,12 +374,18 @@ def build_bus_transport_grammar_events(
             )
         )
 
+    # Real trace-end moment = the last atom actually recorded, not
+    # collector.observed_at (trace-START, which trace_ended previously
+    # reused, collapsing trace_started/trace_ended's observed_at to the
+    # same instant). Falls back to trace-start observed_at only for a
+    # trace with zero recorded atoms.
+    trace_ended_at = max(collector._atom_observed_at.values(), default=observed_at)
     events.append(
         _event(
             event_kind="trace_ended",
             trace_id=trace_id,
             emitted_at=datetime.now(timezone.utc),
-            observed_at=observed_at,
+            observed_at=trace_ended_at,
             provenance=provenance,
             parent_event_id=root_id,
             root_event_id=root_id,

--- a/services/orion-bus/tests/test_orion_bus_grammar_emit.py
+++ b/services/orion-bus/tests/test_orion_bus_grammar_emit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import get_args
 
 import pytest
@@ -15,6 +16,38 @@ from orion.schemas.grammar import AtomType, GrammarEventKind, RelationType
 FIXED_OBS = datetime(2026, 5, 25, 17, 0, 0, tzinfo=timezone.utc)
 WINDOW = "20260525T170000Z"
 NODE = "athena"
+
+
+def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch grammar_emit's datetime.now() to return strictly increasing,
+    deterministic timestamps -- one tick per call -- so tests can assert
+    real ordering/distinctness without depending on wall-clock speed. Same
+    pattern as HarnessGrammarCollector/CortexExecGrammarCollector's test
+    suites."""
+    import app.grammar_emit as ge
+
+    counter = {"n": 0}
+    base = datetime(2026, 5, 25, 17, 0, 0, tzinfo=timezone.utc)
+
+    def _fake_now(tz: object = None) -> datetime:
+        counter["n"] += 1
+        return base + timedelta(milliseconds=counter["n"])
+
+    monkeypatch.setattr(ge, "datetime", SimpleNamespace(now=_fake_now))
+
+
+def _record_full_tick(collector: BusTransportGrammarCollector) -> None:
+    collector.record_tick_started()
+    collector.record_health_observed(redis_ping_ok=True)
+    collector.record_stream_depth(stream_key="orion:evt:gateway", stream_length=123)
+    collector.record_backpressure(
+        stream_key="orion:evt:gateway",
+        stream_length=50000,
+        threshold=25000,
+        severity="warning",
+    )
+    collector.record_uncataloged_stream(stream_key="orion:evt:gateway")
+    collector.record_tick_completed(streams_observed=1)
 
 
 def test_trace_id_format() -> None:
@@ -123,3 +156,152 @@ def test_summaries_never_include_redis_values_or_envelope_material() -> None:
             assert frag not in summary, f"forbidden fragment {frag!r} in {summary!r}"
         if event.atom.semantic_role == "bus_stream_depth_observed":
             assert "stream_length=42" in summary
+
+
+def test_atoms_get_distinct_real_observed_at_not_shared_flush_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before this fix: every atom in a bus-transport trace shared one
+    trace-START timestamp (BusTransportGrammarCollector.observed_at,
+    captured once at construction). Each record_*() call must now stamp
+    its own real observed_at, in recording order. Same fix shape as
+    HarnessGrammarCollector/CortexExecGrammarCollector."""
+    _install_fake_clock(monkeypatch)
+    collector = BusTransportGrammarCollector(
+        node_id=NODE, sample_window_id=WINDOW, observed_at=FIXED_OBS,
+    )
+    _record_full_tick(collector)
+
+    events = build_bus_transport_grammar_events(collector)
+    atom_events = [e for e in events if e.atom is not None]
+    observed_ats = [e.observed_at for e in atom_events]
+
+    assert len(set(observed_ats)) == len(observed_ats), (
+        f"expected distinct observed_at per atom, got duplicates: {observed_ats}"
+    )
+    assert observed_ats == sorted(observed_ats), "expected observed_at in recording order"
+
+
+def test_emitted_at_stays_shared_flush_time_across_all_atoms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """emitted_at was never wrong -- every event in a trace genuinely is
+    published to the bus in the same flush batch. Only observed_at (real
+    occurrence time) should change."""
+    _install_fake_clock(monkeypatch)
+    collector = BusTransportGrammarCollector(
+        node_id=NODE, sample_window_id=WINDOW, observed_at=FIXED_OBS,
+    )
+    _record_full_tick(collector)
+
+    events = build_bus_transport_grammar_events(collector)
+    atom_events = [e for e in events if e.atom is not None]
+    emitted_ats = {e.emitted_at for e in atom_events}
+    assert len(emitted_ats) == 1, f"expected one shared emitted_at, got {emitted_ats}"
+
+
+def test_edge_observed_at_matches_target_atom_real_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_clock(monkeypatch)
+    collector = BusTransportGrammarCollector(
+        node_id=NODE, sample_window_id=WINDOW, observed_at=FIXED_OBS,
+    )
+    _record_full_tick(collector)
+
+    events = build_bus_transport_grammar_events(collector)
+    atom_observed_at = {e.atom.atom_id: e.observed_at for e in events if e.atom is not None}
+    edge_events = [e for e in events if e.edge is not None]
+    assert edge_events, "expected at least one edge in a full tick"
+    for edge_event in edge_events:
+        target_id = edge_event.edge.to_atom_id
+        assert target_id in atom_observed_at
+        assert edge_event.observed_at == atom_observed_at[target_id]
+        # Self-consistency alone (edge == its own target atom) passes
+        # trivially even if the whole per-atom fix were reverted back to one
+        # shared value -- also assert against the pre-fix shared constant
+        # (trace-start observed_at) directly, so a revert fails this too.
+        assert edge_event.observed_at != FIXED_OBS
+
+
+def test_atom_missing_from_observed_at_map_falls_back_to_trace_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive fallback: if an atom somehow bypassed _put_atom() and has no
+    captured observed_at, use the collector's trace-start observed_at rather
+    than crashing or emitting None."""
+    _install_fake_clock(monkeypatch)
+    collector = BusTransportGrammarCollector(
+        node_id=NODE, sample_window_id=WINDOW, observed_at=FIXED_OBS,
+    )
+    collector.record_tick_started()
+    missing_atom_id = next(iter(collector._atoms.values())).atom_id
+    del collector._atom_observed_at[missing_atom_id]
+
+    events = build_bus_transport_grammar_events(collector)
+    atom_event = next(e for e in events if e.atom is not None and e.atom.atom_id == missing_atom_id)
+    assert atom_event.observed_at == FIXED_OBS
+
+
+def test_atom_time_range_populated_with_real_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GrammarAtomV1.time_range previously stayed None for every bus-transport
+    atom -- orion/grammar/ledger.py wires it through to persisted
+    grammar_atoms.time_start/time_end, read by the live Grammar Atlas API,
+    so this was a second place the same 'timing is fake' symptom survived
+    even after observed_at is fixed on the sibling GrammarEventV1 envelope.
+    _put_atom() must now stamp it too, from the same captured moment as
+    _atom_observed_at."""
+    _install_fake_clock(monkeypatch)
+    collector = BusTransportGrammarCollector(
+        node_id=NODE, sample_window_id=WINDOW, observed_at=FIXED_OBS,
+    )
+    _record_full_tick(collector)
+
+    events = build_bus_transport_grammar_events(collector)
+    atom_events = [e for e in events if e.atom is not None]
+    assert atom_events
+    for event in atom_events:
+        assert event.atom.time_range is not None
+        assert event.atom.time_range.start == event.observed_at
+        assert event.atom.time_range.end == event.observed_at
+
+
+def test_trace_ended_observed_at_reflects_last_atom_not_trace_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before this fix: trace_ended.observed_at reused collector.observed_at
+    (trace-START time), identical to trace_started's -- the exact mechanism
+    behind orion/grammar/ledger.py's grammar_traces.started_at/ended_at
+    collapsing to zero duration. trace_ended must now reflect the real last
+    recorded atom's timestamp."""
+    _install_fake_clock(monkeypatch)
+    collector = BusTransportGrammarCollector(
+        node_id=NODE, sample_window_id=WINDOW, observed_at=FIXED_OBS,
+    )
+    _record_full_tick(collector)
+
+    events = build_bus_transport_grammar_events(collector)
+    trace_started = next(e for e in events if e.event_kind == "trace_started")
+    trace_ended = next(e for e in events if e.event_kind == "trace_ended")
+    atom_events = [e for e in events if e.atom is not None]
+
+    assert trace_started.observed_at == FIXED_OBS
+    assert trace_ended.observed_at != trace_started.observed_at
+    assert trace_ended.observed_at == max(e.observed_at for e in atom_events)
+
+
+def test_trace_ended_falls_back_to_trace_start_with_zero_atoms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A trace that fails before any record_*() call has no atoms to derive
+    a real end time from -- trace_ended must fall back to trace-start
+    observed_at rather than raising (max() on an empty sequence)."""
+    _install_fake_clock(monkeypatch)
+    collector = BusTransportGrammarCollector(
+        node_id=NODE, sample_window_id=WINDOW, observed_at=FIXED_OBS,
+    )
+    events = build_bus_transport_grammar_events(collector)
+    trace_ended = next(e for e in events if e.event_kind == "trace_ended")
+    assert trace_ended.observed_at == FIXED_OBS


### PR DESCRIPTION
## Summary

- Third and final sibling fix for the shared-`observed_at` bug (`CortexExecGrammarCollector` and `HarnessGrammarCollector` already fixed): `BusTransportGrammarCollector` shared one collector-construction-time `observed_at` across every atom/edge/`trace_ended` in a trace instead of each atom's own real capture time.
- New `_atom_observed_at` dict populated in `_put_atom()` alongside `GrammarAtomV1.time_range` (previously always `None`); new `observed_at_for()` helper; `trace_ended` now reflects `max(_atom_observed_at.values())` instead of trace-start.
- Investigated (not assumed) whether the idempotency-per-`atom_id` guard the other two siblings needed applies here — **it does not**: traced the real call graph (`ObserverRollup.to_collector()` / `run_observer_tick()`'s except-path in `bus_observer.py`) and confirmed a fresh collector is constructed per observer tick with every `record_*()` method called at most once. Independently re-verified by a code-review subagent.
- Audited all 7 `record_*()` methods for the harness sibling's second bug class (bypassing `_put_atom()` with a direct dict assignment) — none bypass it, so no second bug existed here.
- Live-verified: real traces show `observed_at` collapsed to 1 distinct value (confirms the bug), but `wall_clock_spread` is exactly `0.000000ms` across all atoms in a trace — this producer's `record_*()` calls run synchronously with no I/O between them, so real-world impact is genuinely sub-millisecond, unlike the harness fix (up to 2m15s spans). Calibrated honestly in the PR report rather than oversold.

Full investigation detail, live-data query/output, and re-invocation call-graph trace are in `docs/superpowers/pr-reports/2026-07-15-bus-transport-grammar-atom-wall-clock-pr.md`.

## Test plan

- [x] `PYTHONPATH=services/orion-bus:. .venv/bin/python -m pytest services/orion-bus/tests/test_orion_bus_grammar_emit.py -q` → 11 passed (4 pre-existing + 7 new)
- [x] `PYTHONPATH=services/orion-bus:. .venv/bin/python -m pytest services/orion-bus/tests -q` → 15 passed, no regressions
- [x] Code-review subagent (high effort) — no material findings; independently re-traced the re-invocation claim, the `_put_atom()`-bypass audit, edge-timestamp direction, and confirmed reverting the fix locally makes 4/6 new tests fail as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)