### PR TITLE
fix(substrate): type attention broadcast nodes by current pressure driver, not stale raw prediction_error

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-16-dynamic-pressure-reason-typing-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-dynamic-pressure-reason-typing-pr.md
@@ -1,0 +1,230 @@
+# PR report — attention broadcast typing pinned to stale raw prediction_error
+
+PR: (create at https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/dynamic-pressure-reason-typing)
+Branch: `fix/dynamic-pressure-reason-typing`
+Status: **DONE**
+
+## Summary
+
+- Fixed a review finding from PR #1061: `orion/substrate/attention_broadcast.py::_node_salience()`'s
+  `kind` (used for `target_type_hint`: `"anomaly"` vs `"concept"`) stayed
+  pinned to `"prediction_error"`/anomaly forever once any nonzero raw
+  `metadata["prediction_error"]` was ever observed on a node — even after
+  the node's *current* `dynamic_pressure` was being driven entirely by an
+  unrelated source (drive seed, contradiction propagation). Salience
+  magnitude/ranking was already correct (fixed in #1061); this only
+  affected display/typing.
+- `orion/substrate/dynamics.py::SubstrateDynamicsEngine.tick()` already
+  computed a `reasons: dict[str, str]` per node inside `_compute_pressures()`
+  (values like `"prediction_error_seed"`, `"drive_seed"`,
+  `"contradiction_unresolved"`, `"prediction_error_propagation:{predicate}"`,
+  `"drive_propagation:{predicate}"`, `"contradiction_involved"`) but
+  discarded it after use. Now persisted onto the node as
+  `metadata["dynamic_pressure_reason"]` at the same `node.model_copy()`
+  call site that already writes `metadata["dynamic_pressure"]`.
+- `_node_salience()` now derives `kind` from that reason string
+  (`startswith("prediction_error")` → anomaly typing, else → concept
+  typing) instead of the raw presence check, with a fallback to the old
+  presence-check behavior for nodes that predate any dynamics tick (no
+  `dynamic_pressure_reason` key at all).
+- Code review (high effort) found a second, related bug while reviewing
+  this same seam: the drive_seed and contradiction passes in
+  `_compute_pressures()` wrote their reason string unconditionally
+  whenever their own seed/amp was positive — even when a different pass's
+  already-larger pressure value was the actual dominant driver for that
+  node. Only the prediction_error pass had the correct
+  `if seed > pressure[node_id]:` guard. Fixed both to match that pattern.
+  This bug predates this PR (it lived in `_compute_pressures()` before the
+  `reasons` dict was ever consumer-visible) but this PR is what made it
+  typing-relevant for the first time.
+
+## Outcome moved
+
+A node's anomaly-vs-concept typing in the substrate attention broadcast
+now reflects what is *currently* driving its pressure, not a raw seed
+field that never decays and never clears once set. Concretely: a node
+that once had a prediction-error surprise but is now purely
+drive-pressured (or contradiction-pressured) will correctly type as
+`"concept"`/`"pressure"` instead of permanently as `"anomaly"`.
+
+## Current architecture
+
+`SubstrateDynamicsEngine.tick()` (`orion/substrate/dynamics.py`) is
+instantiated and ticked in the live worker loop
+(`services/orion-substrate-runtime/app/worker.py:798`), not just in
+tests — a real runtime seam. It writes `metadata["dynamic_pressure"]`
+onto substrate nodes each tick. `attention_broadcast.py::_node_salience()`
+reads that metadata (via `substrate_pressure_signals()` →
+`build_substrate_attention_frame()`) to build workspace competition
+signals; `kind` feeds both `target_type_hint` and `signal_kind` on the
+resulting `AttentionSignalV1`.
+
+## Architecture touched
+
+`orion/substrate/dynamics.py` (writer), `orion/substrate/attention_broadcast.py`
+(reader/typing), plus their test suites. No schema/bus/env changes — this
+is a new key inside the existing flexible `metadata: dict` field already
+carried by substrate nodes.
+
+## Files changed
+
+- `orion/substrate/dynamics.py`: `tick()` now writes
+  `metadata["dynamic_pressure_reason"] = pressure_reasons.get(node_id, "none")`
+  alongside `metadata["dynamic_pressure"]`. `_compute_pressures()`'s
+  drive_seed and contradiction passes now guard their reason write with
+  `if seed/amp > pressure[node_id]:`, matching the prediction_error pass's
+  existing pattern, so the reason attributed to a node is always the
+  actually-dominant source, not whichever pass ran last.
+- `orion/substrate/attention_broadcast.py`: `_node_salience()` derives
+  `kind` from `metadata["dynamic_pressure_reason"]` when present
+  (`startswith("prediction_error")` → anomaly), falling back to the old
+  raw-presence check when the key is absent (pre-tick node). Docstring
+  updated to explain the staleness problem and the fallback.
+- `orion/substrate/tests/test_attention_broadcast.py`: updated
+  `test_prediction_error_beats_equal_plain_pressure` and
+  `test_salience_uses_decayed_pressure_not_raw_prediction_error` to set
+  `dynamic_pressure_reason` explicitly (realistic post-tick node state,
+  not relying on the fallback). Added 4 new regression tests: drive_seed
+  reason types as concept despite stale raw prediction_error;
+  prediction_error_propagation reason types as anomaly; no-reason-metadata
+  node falls back to old presence-check behavior.
+- `tests/test_cognitive_substrate_phase4_dynamics.py`: added
+  `test_dynamic_pressure_reason_is_persisted_on_node_metadata` (covers
+  drive_seed/prediction_error_seed/prediction_error_propagation/no-driver
+  cases via a real `tick()`) and
+  `test_dynamic_pressure_reason_attributes_to_the_dominant_source_not_the_last_pass`
+  (regression for the review-found second bug — a single node with a
+  dominant prediction_error seed and a smaller, unrelated open
+  contradiction must keep `dynamic_pressure_reason == "prediction_error_seed"`,
+  not have it clobbered by the later-running contradiction pass).
+
+## Schema / bus / API changes
+
+- Added: `metadata["dynamic_pressure_reason"]` (string) on substrate
+  nodes, written by `SubstrateDynamicsEngine.tick()`. No schema/model
+  change needed — `metadata` is an already-flexible dict field on
+  `BaseSubstrateNodeV1`.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `_node_salience()`'s `kind` (and therefore
+  `AttentionSignalV1.target_type_hint`/`signal_kind`) now reflects the
+  current dominant pressure driver instead of a raw, never-clearing
+  metadata field, for any node that has been through at least one
+  dynamics tick.
+- Compatibility notes: fully backward compatible. Nodes without the new
+  key (never ticked) fall back to the exact pre-patch behavior.
+
+## Env/config changes
+
+None. No `.env_example` changes; `python scripts/sync_local_env_from_example.py`
+not applicable.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest orion/substrate/tests/ tests/test_cognitive_substrate_phase4_dynamics.py tests/test_cognitive_substrate_phase5_graph_cognition.py -q
+=> 223 passed
+
+.venv/bin/python -m pytest services/orion-substrate-runtime/tests/test_worker_dynamics_tick.py -q
+=> included in the 227-pass run below
+
+.venv/bin/python -m pytest orion/substrate/tests/ tests/test_cognitive_substrate_phase4_dynamics.py tests/test_cognitive_substrate_phase5_graph_cognition.py services/orion-substrate-runtime/tests/test_worker_dynamics_tick.py -q
+=> 227 passed
+```
+
+Broader sweep (`services/orion-substrate-runtime/tests/`, excluding a
+Postgres-dependent integration test file) surfaced 14 failing tests
+unrelated to this diff (cursor/reducer-health/quarantine tests requiring
+a live Postgres on `localhost:5432`, refused). Confirmed pre-existing on
+unmodified `main` by running the same specific failing tests from the
+original `/mnt/scripts/Orion-Sapienform` checkout — same failures, same
+reasons, before this branch existed.
+
+Sanity-checked the new
+`test_dynamic_pressure_reason_attributes_to_the_dominant_source_not_the_last_pass`
+regression test actually catches the review-found bug: temporarily
+reverted just the contradiction-pass guard, reran the test, confirmed it
+failed with `AssertionError: assert 'contradiction_unresolved' == 'prediction_error_seed'`,
+then restored the fix and reran the full suite green.
+
+## Evals run
+
+None applicable — no eval harness exists for `orion/substrate/dynamics.py`
+or `attention_broadcast.py`; this is deterministic unit-testable logic,
+fully covered by the gate tests above.
+
+## Docker/build/smoke checks
+
+Not run — pure Python logic change inside `orion/substrate/` (shared
+package code consumed by `orion-substrate-runtime`'s worker loop). No
+config, dependency, port, or compose changes to validate.
+
+## Review findings fixed
+
+Code-review skill (subagent, high effort) against the diff:
+
+- **Finding** (MATERIAL): `_compute_pressures()`'s drive_seed pass
+  (`dynamics.py`, was line ~195) and contradiction pass (was line ~256)
+  wrote `reasons[node_id]` unconditionally whenever their own seed/amp
+  was positive, even when `pressure[node_id]` was already higher from a
+  different pass — only the prediction_error pass correctly gated with
+  `if seed > pressure[node.node_id]:`. Concrete impact: a node whose
+  pressure is genuinely dominated by `prediction_error_seed` but also has
+  a smaller, unrelated open contradiction would get its reason silently
+  overwritten to `"contradiction_unresolved"` by the third pass, flipping
+  its typing from anomaly to concept — directly undermining this patch's
+  stated purpose.
+  - **Fix**: mirrored the existing `if seed > pressure[node_id]:` pattern
+    in both the drive_seed and contradiction passes.
+  - **Evidence**: new test
+    `test_dynamic_pressure_reason_attributes_to_the_dominant_source_not_the_last_pass`
+    reproduces the exact scenario (single node with both a dominant
+    prediction-error seed and a smaller open contradiction), fails without
+    the fix (`AssertionError: assert 'contradiction_unresolved' ==
+    'prediction_error_seed'`, verified by temporary revert), passes with
+    it.
+- **Finding** (MINOR, accepted as-is, not fixed): a node whose pressure
+  coincidentally settles within `1e-6` of its previous value while the
+  underlying driver silently changes in the same tick keeps a stale
+  `dynamic_pressure_reason` (the pre-existing early-continue in `tick()`
+  skips the whole metadata rewrite, not just `dynamic_pressure`). Same
+  class of approximation the pre-existing `dynamic_pressure` skip already
+  makes; requires a near-exact magnitude coincidence across a driver
+  change in the same tick — far narrower than the material finding above.
+  Left as-is to keep the patch thin; documented in this report rather than
+  silently ignored.
+- Confirmed not issues (reviewer verified, no action needed): the
+  `"none"`/absent-key distinction in `_node_salience()`'s fallback logic
+  is correct (metadata key is only ever written as a string once ticked,
+  never `None`); `str(reason).startswith("prediction_error")` is
+  exhaustive against all six possible reason values with no
+  false-positives; the modified/new tests exercise real code paths, not
+  vacuous fixtures; the runtime wiring is real (`worker.py:798`), not an
+  empty-shell change.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+```
+Not run this session — pure logic change inside `orion/substrate/`
+(shared package), takes effect on next `orion-substrate-runtime` restart/
+redeploy. No other services import `dynamics.py`/`attention_broadcast.py`
+directly.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the `1e-6` early-continue staleness case described above
+  (minor review finding, not fixed) means `dynamic_pressure_reason` can
+  theoretically lag one tick behind a driver change in a narrow coincidence
+  case.
+- Mitigation: not fixed in this patch to keep it thin; same tolerance the
+  existing `dynamic_pressure` value itself already accepts. Worth a
+  one-line follow-up docstring note in `tick()` if it ever becomes a real
+  observed issue.
+
+## PR link
+
+`gh` is authenticated in this environment — see below.

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -125,6 +125,22 @@ def _node_salience(metadata: dict[str, Any]) -> tuple[float, str]:
     around it and was never actually used). Still surface whether a
     prediction-error seed exists at all, for the anomaly-vs-concept typing
     downstream -- that's a stable category, not the buggy part.
+
+    Typing itself has the same staleness problem the magnitude fix above
+    solved: the raw ``prediction_error`` metadata field never clears once
+    set, so a node whose *current* ``dynamic_pressure`` is now driven
+    entirely by an unrelated source (a drive seed, contradiction
+    propagation) still gets typed "anomaly" forever off an old, no-longer
+    relevant prediction-error value. ``SubstrateDynamicsEngine.tick()``
+    persists ``metadata["dynamic_pressure_reason"]`` -- the actual driver of
+    *this tick's* pressure value (``"prediction_error_seed"``,
+    ``"prediction_error_propagation:{predicate}"``, ``"drive_seed"``,
+    ``"drive_propagation:{predicate}"``, ``"contradiction_unresolved"``,
+    ``"contradiction_involved"``, or ``"none"``) -- so typing is derived from
+    that instead. Nodes that predate a dynamics tick (no reason key present
+    at all, e.g. freshly materialized or in tests that model synthetic
+    pre-tick state) fall back to the old presence-check behavior so this
+    change does not regress typing for those.
     """
 
     def _f(key: str) -> float:
@@ -134,7 +150,11 @@ def _node_salience(metadata: dict[str, Any]) -> tuple[float, str]:
             return 0.0
 
     pressure = _f("dynamic_pressure")
-    kind = "prediction_error" if _f("prediction_error") > 0.0 else "pressure"
+    reason = metadata.get("dynamic_pressure_reason")
+    if reason is not None:
+        kind = "prediction_error" if str(reason).startswith("prediction_error") else "pressure"
+    else:
+        kind = "prediction_error" if _f("prediction_error") > 0.0 else "pressure"
     return pressure, kind
 
 

--- a/orion/substrate/dynamics.py
+++ b/orion/substrate/dynamics.py
@@ -89,6 +89,14 @@ class SubstrateDynamicsEngine:
                 continue
             metadata = dict(node.metadata)
             metadata["dynamic_pressure"] = round(new_pressure, 6)
+            # Persist which source actually drove this tick's pressure value
+            # (drive_seed, prediction_error_seed/propagation:*, contradiction_*,
+            # or "none" if this node has no active driver) so downstream
+            # consumers -- attention_broadcast._node_salience() in particular --
+            # can type a node by what is CURRENTLY moving its pressure, instead
+            # of a raw metadata field that never decays and never clears once
+            # set (see orion/substrate/attention_broadcast.py::_node_salience).
+            metadata["dynamic_pressure_reason"] = pressure_reasons.get(node_id, "none")
             updated = node.model_copy(update={"metadata": metadata})
             updated_nodes[node_id] = updated
             pressure_updates.append(
@@ -184,8 +192,9 @@ class SubstrateDynamicsEngine:
             seed = drive_seed_pressure(node, self._pressure_config)
             if seed <= 0:
                 continue
-            pressure[node.node_id] = max(pressure[node.node_id], seed)
-            reasons[node.node_id] = "drive_seed"
+            if seed > pressure[node.node_id]:
+                pressure[node.node_id] = seed
+                reasons[node.node_id] = "drive_seed"
             frontier: list[tuple[str, float, int]] = [(node.node_id, seed, 0)]
             visited: set[tuple[str, int]] = set()
             while frontier:
@@ -245,8 +254,9 @@ class SubstrateDynamicsEngine:
             amp, involved = contradiction_amplification(node, now=now)
             if amp <= 0:
                 continue
-            pressure[node.node_id] = max(pressure[node.node_id], amp)
-            reasons[node.node_id] = "contradiction_unresolved"
+            if amp > pressure[node.node_id]:
+                pressure[node.node_id] = amp
+                reasons[node.node_id] = "contradiction_unresolved"
             for involved_id in involved:
                 propagated = max(0.0, min(self._pressure_config.max_pressure, amp * self._pressure_config.contradiction_neighbor_attenuation))
                 if propagated > pressure[involved_id]:

--- a/orion/substrate/tests/test_attention_broadcast.py
+++ b/orion/substrate/tests/test_attention_broadcast.py
@@ -49,8 +49,10 @@ def test_prediction_error_beats_equal_plain_pressure() -> None:
     # dynamic_pressure carries magnitude for both nodes (what the dynamics
     # engine would have populated by the time either node is scored --
     # magnitude must never come from the raw, non-decaying prediction_error
-    # field directly, see _node_salience()). prediction_error is still set
-    # on node:surprise purely for its anomaly-vs-concept typing effect.
+    # field directly, see _node_salience()). dynamic_pressure_reason is what
+    # a real dynamics tick would have written for node:surprise -- typing
+    # comes from that, not the raw prediction_error field (also set here,
+    # purely to prove it is no longer what drives typing).
     nodes = [
         _node("node:pressure", "steady pressure region", dynamic_pressure=0.8),
         _node(
@@ -58,6 +60,7 @@ def test_prediction_error_beats_equal_plain_pressure() -> None:
             "surprising transport batch",
             dynamic_pressure=0.8,
             prediction_error=0.8,
+            dynamic_pressure_reason="prediction_error_seed",
         ),
     ]
     frame = build_substrate_attention_frame(nodes=nodes, now=_NOW)
@@ -79,19 +82,79 @@ def test_salience_uses_decayed_pressure_not_raw_prediction_error() -> None:
     * decay(<=1) can mathematically never exceed it), silently discarding
     the dynamics engine's decay on every tick, forever, for any node that
     ever had a prediction_error written. `kind` should still resolve to
-    "prediction_error" (anomaly typing) even though magnitude is low."""
+    "prediction_error" (anomaly typing) even though magnitude is low --
+    driven by dynamic_pressure_reason (what a real tick would persist here),
+    not the raw, never-decaying prediction_error field."""
     nodes = [
         _node(
             "node:stale-surprise",
             "long-stale transport anomaly",
             dynamic_pressure=0.02,  # decayed by the dynamics engine over time
             prediction_error=1.0,  # raw seed -- never decays on its own
+            dynamic_pressure_reason="prediction_error_seed",
         ),
     ]
     signals = substrate_pressure_signals(nodes, min_salience=0.0)
     assert signals
     assert signals[0].salience == 0.02
     assert signals[0].target_type_hint == "anomaly"
+
+
+def test_drive_seed_reason_types_as_pressure_despite_stale_raw_prediction_error() -> None:
+    """Regression for the PR #1061 review finding: a node's `kind` must stop
+    being pinned to "anomaly" once its *current* dynamic_pressure is driven
+    by an unrelated source, even if the node has an old, nonzero raw
+    metadata['prediction_error'] sitting untouched from some earlier tick.
+    dynamic_pressure_reason == "drive_seed" (what a real tick would persist
+    once a drive seed, not a prediction error, is the active driver) must
+    win typing over the stale raw field."""
+    nodes = [
+        _node(
+            "node:reclaimed",
+            "now driven by an unrelated drive",
+            dynamic_pressure=0.6,
+            prediction_error=0.9,  # stale raw seed from a much earlier tick
+            dynamic_pressure_reason="drive_seed",
+        ),
+    ]
+    signals = substrate_pressure_signals(nodes, min_salience=0.0)
+    assert signals
+    assert signals[0].target_type_hint == "concept"
+    assert signals[0].signal_kind == "substrate_pressure"
+
+
+def test_prediction_error_propagation_reason_types_as_anomaly() -> None:
+    """A neighbor node that never had a raw prediction_error field at all,
+    but whose pressure was propagated to it from a prediction-error seed,
+    must still type as anomaly -- dynamic_pressure_reason carries that
+    signal even when the raw seed field lives on a different node."""
+    nodes = [
+        _node(
+            "node:propagated",
+            "downstream of a surprising node",
+            dynamic_pressure=0.4,
+            dynamic_pressure_reason="prediction_error_propagation:supports",
+        ),
+    ]
+    signals = substrate_pressure_signals(nodes, min_salience=0.0)
+    assert signals
+    assert signals[0].target_type_hint == "anomaly"
+    assert signals[0].signal_kind == "substrate_prediction_error"
+
+
+def test_no_reason_metadata_falls_back_to_raw_prediction_error_presence() -> None:
+    """A node that has never been through a dynamics tick (no
+    dynamic_pressure_reason key at all -- e.g. freshly materialized) must
+    keep today's pre-fix behavior: type from the raw prediction_error
+    presence check. This is the fallback path, not the primary one."""
+    nodes = [
+        _node("node:pretick-anomaly", "pre-tick surprise", dynamic_pressure=0.5, prediction_error=0.7),
+        _node("node:pretick-plain", "pre-tick plain concept", dynamic_pressure=0.5),
+    ]
+    signals = substrate_pressure_signals(nodes, min_salience=0.0)
+    by_id = {s.evidence_refs[0]: s for s in signals}
+    assert by_id["node:pretick-anomaly"].target_type_hint == "anomaly"
+    assert by_id["node:pretick-plain"].target_type_hint == "concept"
 
 
 def test_broadcast_never_generates_questions() -> None:

--- a/tests/test_cognitive_substrate_phase4_dynamics.py
+++ b/tests/test_cognitive_substrate_phase4_dynamics.py
@@ -322,6 +322,116 @@ def test_prediction_error_seeds_pressure_propagates_and_leaves_calm_nodes_cold()
     assert calm_pressure == 0.0
 
 
+def test_dynamic_pressure_reason_is_persisted_on_node_metadata() -> None:
+    """SubstrateDynamicsEngine.tick() must write metadata["dynamic_pressure_reason"]
+    alongside dynamic_pressure so downstream typing (attention_broadcast's
+    _node_salience()) can key off what actually drove *this tick's* pressure
+    instead of a raw seed field that never clears. Cover all three source
+    kinds plus the "no active driver" default."""
+    drive = DriveNodeV1(
+        node_id="drive-reason",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        drive_kind="stability",
+        temporal=_temporal(0),
+        provenance=_prov(),
+        signals={"salience": 0.9},
+        metadata={"drive_status": "active", "pressure": 0.8},
+    )
+    surprising = ConceptNodeV1(
+        node_id="concept-surprising-reason",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Surprising",
+        temporal=_temporal(0),
+        provenance=_prov(),
+        metadata={"prediction_error": 0.8},
+    )
+    neighbor = ConceptNodeV1(
+        node_id="concept-neighbor-reason",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Neighbor",
+        temporal=_temporal(0),
+        provenance=_prov(),
+    )
+    calm = ConceptNodeV1(
+        node_id="concept-calm-reason",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Calm",
+        temporal=_temporal(0),
+        provenance=_prov(),
+    )
+    record = SubstrateGraphRecordV1(
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        nodes=[drive, surprising, neighbor, calm],
+        edges=[_edge("concept-surprising-reason", "concept", "concept-neighbor-reason", "concept", "supports")],
+    )
+    materializer = SubstrateGraphMaterializer(store=InMemorySubstrateGraphStore())
+    materializer.apply_record(record)
+    engine = SubstrateDynamicsEngine(store=materializer.store)
+    engine.tick(now=datetime.now(timezone.utc))
+    snap = materializer.store.snapshot()
+
+    assert snap.nodes["drive-reason"].metadata.get("dynamic_pressure_reason") == "drive_seed"
+    assert snap.nodes["concept-surprising-reason"].metadata.get("dynamic_pressure_reason") == "prediction_error_seed"
+    assert snap.nodes["concept-neighbor-reason"].metadata.get("dynamic_pressure_reason") == "prediction_error_propagation:supports"
+    # calm node's pressure never changes from its 0.0 default, so tick()
+    # skips the metadata rewrite entirely (same short-circuit dynamic_pressure
+    # itself already relies on) -- no reason key is written at all.
+    assert "dynamic_pressure_reason" not in snap.nodes["concept-calm-reason"].metadata
+
+
+def test_dynamic_pressure_reason_attributes_to_the_dominant_source_not_the_last_pass() -> None:
+    """_compute_pressures() runs three passes in a fixed order (drive_seed,
+    prediction_error, contradiction) that all write into the same shared
+    `pressure`/`reasons` dicts. A single node with both a dominant
+    prediction_error seed (0.8, scored by weight 0.6 -> ~0.48, from the
+    2nd/prediction_error pass) and a smaller, unrelated open contradiction on
+    itself (severity 0.3 -> amp ~0.15, from the 3rd/contradiction pass) must
+    keep dynamic_pressure_reason == "prediction_error_seed" -- the later
+    contradiction pass must not unconditionally clobber the reason string
+    just because it runs last, even though it doesn't actually raise the
+    node's pressure (0.15 < 0.48). Regression for a review finding on the
+    reason-typing patch: only the prediction_error pass originally guarded
+    its reason write with `if seed > pressure[node_id]`; the drive_seed and
+    contradiction passes wrote their reason unconditionally whenever their
+    own seed/amp was positive, silently overwriting a correctly-dominant
+    reason from an earlier pass. prediction_error_pressure() reads
+    metadata['prediction_error'] regardless of node_kind, so a single
+    ContradictionNodeV1 can carry both signals at once."""
+    node = ContradictionNodeV1(
+        node_id="contra-with-prediction-error",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        summary="minor unrelated conflict, but also a bigger surprise",
+        involved_node_ids=["concept-other-a", "concept-other-b"],
+        temporal=_temporal(0),
+        provenance=_prov(),
+        metadata={"resolved": False, "severity": 0.3, "prediction_error": 0.8},
+    )
+    record = SubstrateGraphRecordV1(
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        nodes=[node],
+        edges=[],
+    )
+    materializer = SubstrateGraphMaterializer(store=InMemorySubstrateGraphStore())
+    materializer.apply_record(record)
+    engine = SubstrateDynamicsEngine(store=materializer.store)
+    engine.tick(now=datetime.now(timezone.utc))
+    snap = materializer.store.snapshot()
+
+    updated = snap.nodes["contra-with-prediction-error"]
+    pressure = updated.metadata.get("dynamic_pressure", 0.0)
+    # sanity: the prediction-error seed really is the larger contributor
+    # (~0.48) over the contradiction amplification (~0.15)
+    assert pressure > 0.4
+    assert updated.metadata.get("dynamic_pressure_reason") == "prediction_error_seed"
+
+
 def test_prediction_error_pressure_decays_with_age() -> None:
     fresh = ConceptNodeV1(
         node_id="concept-fresh",


### PR DESCRIPTION
## Summary

- Fixed PR #1061's review finding: `attention_broadcast.py::_node_salience()`'s `kind` (anomaly vs concept typing) stayed pinned to `"prediction_error"` forever once any nonzero raw `metadata["prediction_error"]` was ever seen on a node, even after the node's current `dynamic_pressure` was driven entirely by an unrelated source (drive seed, contradiction). Display/typing only — salience magnitude/ranking was already fixed in #1061.
- `dynamics.py::SubstrateDynamicsEngine.tick()` already computed a `reasons` dict per node but discarded it. Now persisted as `metadata["dynamic_pressure_reason"]` alongside `metadata["dynamic_pressure"]`.
- `_node_salience()` now types from that reason string, falling back to the old raw-presence check for nodes that predate any dynamics tick.
- Code review (high effort) found and fixed a second, related bug: the drive_seed and contradiction passes in `_compute_pressures()` wrote their reason unconditionally whenever their own seed/amp was positive, even when a different pass's larger value was actually dominant — only the prediction_error pass guarded correctly. Fixed both to match.

## Test plan

- [x] `orion/substrate/tests/` + `tests/test_cognitive_substrate_phase4_dynamics.py` + `tests/test_cognitive_substrate_phase5_graph_cognition.py` + `services/orion-substrate-runtime/tests/test_worker_dynamics_tick.py` — 227 passed
- [x] New regression test for the review-found bug verified to fail without the fix (temporary revert), pass with it
- [x] Confirmed 14 unrelated Postgres-dependent test failures elsewhere in `services/orion-substrate-runtime/tests/` are pre-existing on unmodified `main`
- [x] Code review (subagent, high effort) run against the diff; material finding fixed

Full details in `docs/superpowers/pr-reports/2026-07-16-dynamic-pressure-reason-typing-pr.md`.