### PR TITLE
fix(substrate): exclude resolved/dismissed loops from rung-3 attention selection

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-16-attention-verdict-aware-selection-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-attention-verdict-aware-selection-pr.md
@@ -1,0 +1,312 @@
+# PR report — verdict-aware selection for rung-3 attention broadcast
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1078
+Branch: `fix/attention-verdict-aware-selection`
+Status: **DONE**
+
+## Summary
+
+- Implemented the "verdict-aware selection" fix explicitly deferred as its
+  own scoping decision by PR #1061 (see
+  `docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md`'s
+  Non-goals section): a loop a human explicitly Resolved or Dismissed via
+  the Hub could still win rung-3's continuous workspace competition
+  (`orion/substrate/attention_broadcast.py::build_substrate_attention_frame`,
+  every 30s) forever, because `build_open_loops()` never consulted
+  `attention_loop_outcome` verdicts at all.
+- New module `orion/substrate/attention/verdicts.py`:
+  `load_terminal_verdict_loop_ids(loop_ids)` -- a bounded (never
+  whole-table), read-only, fail-open direct-SQLAlchemy lookup against
+  `attention_loop_outcome`, mirroring the exact connection/query pattern
+  already shipped twice for the same table
+  (`services/orion-hub/scripts/attention_loops_store.py`,
+  `services/orion-thought/app/store.py::load_recent_loop_outcomes`).
+- `orion/substrate/attention/scoring.py::build_open_loops()` gained an
+  optional `verdict_lookup: Callable[[list[str]], set[str]] | None = None`
+  parameter. Excluded loops are genuinely absent from `open_loops` -- not
+  down-weighted -- so they cannot become `selected_action`. Default `None`
+  preserves prior behavior byte-for-byte for the chat-scoped caller
+  (`attention_frame.py`), which does not pass it.
+- `orion/substrate/attention_broadcast.py::build_substrate_attention_frame`
+  wires in `verdict_lookup=load_terminal_verdict_loop_ids` -- scoped to only
+  this path, matching the original incident and this fix's stated scope.
+- 12 new regression tests
+  (`orion/substrate/tests/test_attention_verdict_exclusion.py`) plus one
+  end-to-end live-data confirmation against the real
+  `open-loop-9d84d08cddf5` verdict rows from the original investigation.
+
+## Outcome moved
+
+The rung-3 workspace-competition path that let a closed loop dominate
+indefinitely (the live incident PR #1061 investigated and partially fixed)
+now has a second, independent gate: even if a loop's salience recovers for
+any reason (recency reset, a fresh evidence write, a future scoring change),
+a human's explicit Resolve/Dismiss verdict permanently removes it from
+competing, not just down-weights it.
+
+## Current architecture
+
+`build_open_loops()` (`orion/substrate/attention/scoring.py`) is the single
+shared loop-construction function used by both the chat-scoped, per-turn
+`attention_frame.py` and the substrate-broadcast, continuous-tick
+`attention_broadcast.py::build_substrate_attention_frame`. Neither caller
+had any visibility into `attention_loop_outcome` (the table
+`services/orion-hub/scripts/attention_loops_store.py::persist_loop_outcome`
+writes when a human clicks Resolve/Dismiss in the Hub) -- that table was
+previously only read by `orion-hub` itself (surfacing pending cards) and by
+`orion-thought`'s reverie narration layer (PR #1055, prompt-level
+truthfulness only, no effect on selection).
+`services/orion-substrate-runtime/app/worker.py::_attention_broadcast_tick`
+runs `build_substrate_attention_frame` every
+`ORION_ATTENTION_BROADCAST_INTERVAL_SEC` (default 30.0s, confirmed live in
+this environment's `.env`), each tick building `open_loops` capped at
+`max_open=5` from a `max_open*3`-wide deduped signal pool passed in as
+headroom -- headroom that existed already but, before this patch, had no
+consumer that could actually use it for backfill.
+
+## Architecture touched
+
+`orion/substrate/attention/scoring.py` (shared, imported by both chat-scoped
+and substrate-broadcast callers), `orion/substrate/attention_broadcast.py`
+(substrate-broadcast caller only), one new pure module
+`orion/substrate/attention/verdicts.py`. No schema/bus/API contract changes,
+no new env keys, no Docker/dependency changes (`sqlalchemy` is already a
+dependency of `orion-substrate-runtime`).
+
+## Files changed
+
+- `orion/substrate/attention/verdicts.py` (new): read-only, bounded,
+  fail-open `attention_loop_outcome` lookup. `TERMINAL_VERDICTS =
+  {"resolved", "dismissed"}` -- deliberately excludes the table's third
+  valid verdict, `decayed_unattended`, which is implicit non-engagement
+  (an automatic timeout label), not an explicit human closure, and stays
+  eligible to compete.
+- `orion/substrate/attention/scoring.py`: `build_open_loops()` gained
+  `verdict_lookup`. Refactored the candidate pipeline so `loop_id` is
+  computed exactly once per deduped signal (previously two independent call
+  sites computed the identical `stable_id(...)` expression -- a latent
+  drift risk flagged by code review) and so verdict exclusion is applied to
+  the full deduped signal pool *before* the `max_open` truncation, not
+  after (also flagged by code review -- see below).
+- `orion/substrate/attention_broadcast.py`: `build_substrate_attention_frame`
+  passes `verdict_lookup=load_terminal_verdict_loop_ids` to `build_open_loops`,
+  with an inline comment documenting why `attention_frame.py`'s chat-scoped
+  call site is deliberately left unwired.
+- `orion/substrate/tests/test_attention_verdict_exclusion.py` (new): 12
+  tests -- see Tests run below.
+
+## Schema / bus / API changes
+
+None. `attention_loop_outcome` is an existing table (migration:
+`services/orion-sql-db/manual_migration_attention_loop_outcome.sql`,
+already applied and in live use by `orion-hub`); this patch only adds a
+third, bounded, read-only reader of it. No new bus channel, no new schema
+registration, no payload-shape change to any existing event.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: not applicable -- `verdicts.py` reuses the
+  existing `POSTGRES_URI` env key, already present in
+  `services/orion-substrate-runtime/.env_example` and `.env` (used by
+  `worker.py::_get_sql_engine` for turn-referent persistence).
+- local `.env` synced: not applicable, no template change.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest orion/substrate/tests/ -q
+=> 218 passed (12 new)
+
+.venv/bin/python -m pytest orion/substrate/tests/test_attention_verdict_exclusion.py -q
+=> 12 passed
+
+.venv/bin/python -m pytest services/orion-substrate-runtime/tests/test_worker_attention_broadcast_tick.py -q
+=> 6 passed
+```
+
+New test coverage:
+- a loop with no verdict competes normally
+- a `resolved` verdict excludes the loop even at max salience
+- a `dismissed` verdict excludes the loop
+- exclusion frees the slot for the next-best candidate instead of just
+  shrinking the field (regression test for the code-review finding below)
+- `verdict_lookup` is called exactly once per tick, bounded to that tick's
+  candidate loop_ids only
+- `verdict_lookup=None` (the default) preserves prior behavior exactly
+- a raising `verdict_lookup` callable doesn't crash `build_open_loops`
+- `load_terminal_verdict_loop_ids`: empty-input short circuit,
+  verdict-filtering logic (mocked engine), fail-open on a mocked
+  connection failure
+- end-to-end through `build_substrate_attention_frame`: exclusion works
+  with real node/signal inputs; a DB failure during the lookup doesn't
+  crash frame-building and the loop stays eligible (fail-open, verified at
+  the top-level entry point, not just the lookup function in isolation)
+
+## Evals run
+
+None applicable -- no eval harness exists for
+`orion/substrate/attention_broadcast.py` or `scoring.py` (same gap noted in
+PR #1061's own report). The live Postgres query below is the closest thing
+to an eval for this specific fix, run by hand.
+
+## Docker/build/smoke checks
+
+Not run as a container build -- pure Python logic change, no new
+dependency (`sqlalchemy==2.0.36` already in
+`services/orion-substrate-runtime/requirements.txt`), no compose/Dockerfile
+change. Instead ran a direct, read-only smoke against the live database
+from the worktree (no restart needed for this, since it calls the new
+function directly against real data rather than through the running
+container):
+
+```text
+POSTGRES_URI="postgresql://postgres:postgres@localhost:55432/conjourney" \
+  .venv/bin/python -c "
+from orion.substrate.attention.verdicts import load_terminal_verdict_loop_ids
+print(load_terminal_verdict_loop_ids(['open-loop-9d84d08cddf5', 'open-loop-does-not-exist']))
+"
+=> {'open-loop-9d84d08cddf5'}
+```
+
+This confirms the query correctly identifies the exact loop from the
+original PR #1061 investigation (verdicted `resolved` 2026-07-08 20:32,
+`dismissed` 2026-07-10 21:49, confirmed live via `psql`) as terminal-
+verdicted, against the real `attention_loop_outcome` table.
+
+**Full end-to-end live verification (through the running container) was
+NOT performed** -- see "Live-data findings" below for why, and what would
+be needed.
+
+## Review findings fixed
+
+Code-review skill (subagent, high effort) run against the full diff before
+this report. Two material findings, both fixed and re-verified:
+
+- **Finding**: exclusion was applied to the signal pool *after* it was
+  already truncated to `max_open` (`candidates = merge_signals(signals,
+  limit=max_open)` ran before `verdict_lookup`). `attention_broadcast.py`
+  deliberately passes a `max_open*3`-wide pool as headroom specifically so
+  an excluded loop's slot can be backfilled by the next-best candidate, but
+  that headroom was discarded by `build_open_loops`'s own internal
+  truncation before exclusion ever ran -- so excluding a loop just shrank
+  the competing field by one instead of freeing a slot.
+  - **Fix**: restructured to dedupe the full signal pool first
+    (`merge_signals(signals, limit=len(signals))` -- a no-op cap), apply
+    `verdict_lookup` to the full deduped pool, and *then* truncate to
+    `max_open`.
+  - **Evidence**: new
+    `test_excluded_loop_frees_its_slot_for_the_next_best_candidate` (3
+    signals, `max_open=2`, excludes the top-ranked signal, asserts the
+    3rd-ranked signal -- previously truncated away before it could even be
+    considered -- now appears).
+- **Finding**: `loop_id` was computed twice from the same expression
+  (`stable_id("open-loop", compact(s.target_text, 120).lower())`) at two
+  independent call sites -- correct today (both pure/deterministic), but a
+  latent drift risk: if either call site were edited alone in a future
+  patch, the exclusion check would silently stop matching with no
+  structural guarantee of a test catching it.
+  - **Fix**: `loop_id` is now computed exactly once per deduped signal
+    (`id_signal_pairs = [(stable_id(...), s) for s in deduped]`) and
+    threaded through the rest of the function as the single source of
+    truth.
+  - **Evidence**: full test suite re-run after the refactor, all 218 pass
+    (12 new + 206 pre-existing), confirming byte-identical behavior for the
+    `verdict_lookup=None` case.
+
+Not fixed, accepted as documented (per reviewer, non-blocking):
+
+- `attention_loop_outcome` has no index on `loop_id` itself (only
+  `created_at` and `(verdict, created_at)`), so `WHERE loop_id IN (...)` is
+  a sequential scan -- identical to the pre-existing pattern in
+  `services/orion-thought/app/store.py::load_recent_loop_outcomes`. The
+  table is sparse (human Resolve/Dismiss clicks only), so this is cheap
+  today; worth a follow-up index if the table grows materially.
+- A second, independent SQLAlchemy engine/pool in `verdicts.py` alongside
+  `worker.py::_get_sql_engine`'s own cached engine for the same Postgres
+  instance -- reviewer confirmed this matches (and is more disciplined
+  than) existing precedent in `orion/substrate/policy_profiles.py` and
+  `review_telemetry.py`, which `create_engine()` fresh on every call with
+  no caching at all. Given the 30s tick cadence, not a real exhaustion
+  risk.
+- The new test suite doesn't exercise the multi-tick dwell/coalition-decay
+  transition specifically (only single-tick scenarios) -- reviewer traced
+  the decay code path by hand and confirmed no special-case bug exists (an
+  excluded loop just triggers the same decay path any naturally-losing loop
+  already goes through), so this is a minor coverage gap, not a defect.
+
+## Live-data findings
+
+Confirmed live in this environment before writing code:
+
+```sql
+SELECT loop_id, verdict, created_at FROM attention_loop_outcome
+WHERE loop_id LIKE '%9d84d08cddf5%' ORDER BY created_at;
+
+        loop_id         |  verdict  |          created_at
+------------------------+-----------+-------------------------------
+ open-loop-9d84d08cddf5 | resolved  | 2026-07-08 20:32:35.513266+00
+ open-loop-9d84d08cddf5 | dismissed | 2026-07-10 21:49:16.812265+00
+```
+
+Checked whether `open-loop-9d84d08cddf5` still appears in the live
+substrate-broadcast projection (`substrate_attention_broadcast_projection`,
+a single-row-upserted table other organs query) as of this session
+(2026-07-16 02:37 UTC): it does not, and in fact **no loop is currently
+competing at all** --
+`docker logs orion-athena-substrate-runtime` shows
+`substrate_attention_broadcast_completed selected=none loop=None
+open_loops=0` on the most recent tick, and `ORION_ATTENTION_BROADCAST_ENABLED=true`
+with the container actively running confirms the tick loop is live, not
+just configured.
+
+This is consistent with PR #1061's fix (recency + dwell-scoping, already
+deployed since 2026-07-14) having already worked as intended: the
+`substrate.transport` node's `dynamic_pressure` has apparently decayed
+below `ORION_ATTENTION_BROADCAST_MIN_SALIENCE` (0.2) over the intervening
+~8 days, so it no longer generates a competing signal at all, independent
+of this patch's verdict exclusion. **This means a full restart-based,
+end-to-end live verification of this specific fix (watching a verdicted
+loop get excluded from a live tick) is not currently possible in this
+environment** -- there is no verdicted loop presently in play to exclude.
+I did not restart `orion-athena-substrate-runtime`, both because it would
+not currently demonstrate anything (no candidate loop exists to test
+against) and per this task's own instruction that a restart-based
+verification is a bonus, not a requirement, when unit tests already prove
+the exclusion logic. The direct query smoke test above (against real data,
+no restart) is the live verification actually performed.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+```
+
+Required for this fix to take effect on the live `orion-athena-substrate-runtime`
+container. **Not run this session** (see Live-data findings above for why).
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `attention_loop_outcome` has no index on `loop_id`, so the new
+  query is a sequential scan (bounded by table size, which is small and
+  human-verdict-only). Matches existing precedent elsewhere; noted as a
+  follow-up, not a blocker.
+- Severity: low
+- Concern: because no loop is currently competing live in this environment
+  (see above), this specific fix has only been verified at the code level
+  (12 new tests covering the exclusion logic, the DB lookup, and fail-open
+  behavior end-to-end through `build_substrate_attention_frame`) plus a
+  direct real-data query smoke test -- not through an actual running-tick,
+  post-restart observation. Low risk given the thin, well-isolated,
+  fail-open nature of the change, but worth a follow-up live check once the
+  restart above happens and/or once a new loop accumulates a verdict while
+  still salient enough to compete.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1078

--- a/orion/substrate/attention/scoring.py
+++ b/orion/substrate/attention/scoring.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import logging
 import re
 from datetime import datetime
-from typing import Any
+from typing import Any, Callable
 
 from orion.schemas.attention_frame import AttentionSignalV1, OpenLoopV1
 from orion.substrate.attention.common import bounded, compact, stable_id
 from orion.substrate.attention.salience import SalienceHistory, compute_salience
+
+logger = logging.getLogger("orion.substrate.attention.scoring")
 
 _EMOTION_RE = re.compile(r"\b(frustrated|pissed|worried|excited|afraid|stuck|blocked|confused|love|hate|urgent)\b", re.I)
 _PLAN_RE = re.compile(r"\b(plan|planning|going to|tomorrow|next|later|schedule|deadline|future)\b", re.I)
@@ -80,12 +83,55 @@ def build_open_loops(
     max_open: int,
     history: "SalienceHistory | None" = None,
     now: datetime | None = None,
+    verdict_lookup: "Callable[[list[str]], set[str]] | None" = None,
 ) -> list[OpenLoopV1]:
+    """Build the competing open loops for one tick.
+
+    ``verdict_lookup``, when given, is called once with the loop_ids of every
+    deduped candidate signal in play this tick (before the ``max_open`` cap --
+    see below) and must return the subset that a human has already
+    resolved/dismissed (see
+    ``orion.substrate.attention.verdicts.load_terminal_verdict_loop_ids``).
+    Those loops are excluded entirely -- not down-weighted -- so a closed loop
+    can never win ``selected_action`` again. Default ``None`` preserves prior
+    behavior exactly (chat-scoped callers do not currently pass this).
+    Never raises: any failure from the lookup is treated as "no verdicts
+    known" so a DB hiccup never blocks this tick.
+
+    Exclusion is applied to the full deduped signal pool, before truncating
+    to ``max_open`` -- not after -- so a resolved/dismissed loop that would
+    otherwise have made the cut frees its slot for the next-best candidate
+    instead of just shrinking the field by one. Callers that want this
+    backfill to matter (``attention_broadcast.py``) already pass in a signal
+    pool wider than ``max_open`` for exactly this reason.
+    """
     user_text = compact(ctx.get("user_message") or ctx.get("raw_user_text") or "", 600)
     known = known_blob(inputs, ctx)
     autonomy_value, autonomy_signals = autonomy_pressure_from_signals(signals)
+
+    # Dedupe by target_text without capping yet (limit=len(signals) is a
+    # no-op cap -- merge_signals can never produce more entries than its
+    # input). loop_id is computed exactly once per deduped signal here and
+    # threaded through everywhere below, so there is one source of truth for
+    # "what id does this candidate use" -- no risk of two call sites drifting
+    # apart if the id formula ever changes.
+    deduped = merge_signals(signals, limit=len(signals))
+    id_signal_pairs = [
+        (stable_id("open-loop", compact(s.target_text, 120).lower()), s) for s in deduped
+    ]
+
+    excluded_loop_ids: set[str] = set()
+    if verdict_lookup is not None and id_signal_pairs:
+        try:
+            excluded_loop_ids = set(verdict_lookup([lid for lid, _ in id_signal_pairs]))
+        except Exception:
+            logger.warning("attention_verdict_lookup_failed", exc_info=True)
+            excluded_loop_ids = set()
+
+    candidates = [pair for pair in id_signal_pairs if pair[0] not in excluded_loop_ids][:max_open]
+
     loops: list[OpenLoopV1] = []
-    for signal in merge_signals(signals, limit=max_open):
+    for loop_id, signal in candidates:
         phrase = compact(signal.target_text, 120)
         already_known = phrase.lower() in known
         target_type = target_type_for(signal, user_text)
@@ -99,7 +145,7 @@ def build_open_loops(
         if generic_reversal or stale_thread_active:
             askability = min(askability, 0.25)
         loop = OpenLoopV1(
-            id=stable_id("open-loop", phrase.lower()),
+            id=loop_id,
             target_type=target_type,  # type: ignore[arg-type]
             description=phrase,
             source_text=user_text,

--- a/orion/substrate/attention/verdicts.py
+++ b/orion/substrate/attention/verdicts.py
@@ -1,0 +1,84 @@
+"""Read-only lookup of human Resolve/Dismiss verdicts for the rung-3 workspace
+competition (``attention_loop_outcome``, written by a human action in the Hub
+via ``services/orion-hub/scripts/attention_loops_store.py``).
+
+Same table, same connection/query style as the two existing readers of this
+table (``attention_loops_store.py`` itself and
+``services/orion-thought/app/store.py::load_recent_loop_outcomes``) -- direct
+SQLAlchemy engine, ``POSTGRES_URI`` env with the same conjourney default,
+``DISTINCT ON (loop_id) ... ORDER BY created_at DESC`` for "most recent verdict
+per loop". This module only needs the verdict itself (not note/features), and
+is bounded to the loop_ids actually competing in a given tick -- never scans
+the whole table.
+
+Read-only, fail-open: any error (missing table, connection failure, bad env)
+returns an empty set so a DB hiccup never blocks a broadcast tick. Callers
+must treat the result as "loops known to be closed" and proceed as if no
+verdicts exist otherwise.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable
+
+logger = logging.getLogger("orion.substrate.attention.verdicts")
+
+# Verdicts that mean a human explicitly closed the loop; a third valid verdict,
+# "decayed_unattended" (see attention_loops_store.py's _VALID_VERDICTS), is an
+# implicit non-engagement signal, not an explicit closure -- left eligible to
+# compete.
+TERMINAL_VERDICTS = {"resolved", "dismissed"}
+
+
+def _database_url() -> str:
+    return (
+        os.getenv("POSTGRES_URI", "").strip()
+        or "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+    )
+
+
+_ENGINE = None
+
+
+def _engine():
+    global _ENGINE
+    if _ENGINE is None:
+        from sqlalchemy import create_engine
+
+        _ENGINE = create_engine(_database_url(), pool_pre_ping=True)
+    return _ENGINE
+
+
+def load_terminal_verdict_loop_ids(loop_ids: Iterable[str]) -> set[str]:
+    """Return the subset of ``loop_ids`` whose most recent verdict is terminal.
+
+    Bounded to the given loop_ids (the loops actually competing this tick).
+    Best-effort: returns an empty set on any failure, including an empty/None
+    input, so a lookup failure never blocks frame-building.
+    """
+    ids = sorted({str(i) for i in (loop_ids or []) if i})
+    if not ids:
+        return set()
+    try:
+        from sqlalchemy import bindparam, text
+
+        stmt = text(
+            """
+            SELECT DISTINCT ON (loop_id) loop_id, verdict
+            FROM attention_loop_outcome
+            WHERE loop_id IN :ids
+            ORDER BY loop_id, created_at DESC
+            """
+        ).bindparams(bindparam("ids", expanding=True))
+        with _engine().connect() as conn:
+            rows = conn.execute(stmt, {"ids": ids}).mappings().all()
+        return {
+            str(row["loop_id"])
+            for row in rows
+            if str(row.get("verdict") or "") in TERMINAL_VERDICTS
+        }
+    except Exception as exc:
+        logger.warning("attention_loop_outcome_verdict_lookup_failed ids=%s err=%s", ids, exc)
+        return set()

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -29,6 +29,7 @@ from orion.schemas.attention_frame import (
 from orion.substrate.attention.common import compact, stable_id
 from orion.substrate.attention.policy import select_actions
 from orion.substrate.attention.scoring import build_open_loops, merge_signals
+from orion.substrate.attention.verdicts import load_terminal_verdict_loop_ids
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -223,6 +224,15 @@ def build_substrate_attention_frame(
         max_open=max_open,
         history=history,
         now=resolved_now,
+        # Substrate broadcast is rung-3's continuous re-broadcast, the exact
+        # path a resolved/dismissed loop was found live still winning
+        # indefinitely (2026-07-14 investigation). Excludes those loops
+        # entirely rather than down-weighting them -- see
+        # orion.substrate.attention.verdicts. Not wired into the chat-scoped
+        # build_open_loops() caller (attention_frame.py): that path is
+        # per-turn and ephemeral, and this fix is scoped to the workspace
+        # competition that actually dominated indefinitely.
+        verdict_lookup=load_terminal_verdict_loop_ids,
     )
     actions, selected, suppressions, deferred = select_actions(
         open_loops=open_loops,

--- a/orion/substrate/tests/test_attention_verdict_exclusion.py
+++ b/orion/substrate/tests/test_attention_verdict_exclusion.py
@@ -1,0 +1,279 @@
+"""Verdict-aware selection: resolved/dismissed loops must not win the rung-3
+workspace competition.
+
+Deferred non-goal of PR #1061 (see
+docs/notes/2026-07-14-attention-salience-decay-bypass-investigation.md):
+excluding `attention_loop_outcome`-verdicted loops from `build_open_loops`
+entirely, not just down-weighting them. This suite covers both the pure
+scoring-path exclusion (`build_open_loops(verdict_lookup=...)`) and the DB
+lookup itself (`orion.substrate.attention.verdicts`), plus fail-open behavior
+end-to-end through `build_substrate_attention_frame`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.common import compact, stable_id
+from orion.substrate.attention.scoring import build_open_loops
+from orion.substrate.attention import verdicts as verdicts_mod
+
+_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _signal(text: str, *, salience: float = 0.9) -> AttentionSignalV1:
+    return AttentionSignalV1(
+        signal_id=f"sig-{text}",
+        source="current_turn",
+        target_text=text,
+        target_type_hint="concept",
+        signal_kind="test",
+        salience=salience,
+        confidence=0.9,
+        evidence_refs=[f"ref-{text}"],
+    )
+
+
+def _loop_id(text: str) -> str:
+    return stable_id("open-loop", compact(text, 120).lower())
+
+
+def _build(signals, verdict_lookup=None):
+    return build_open_loops(
+        signals=signals,
+        ctx={},
+        inputs={},
+        belief_lineage=[],
+        direct_turn=False,
+        generic_reversal=False,
+        stale_thread_active=False,
+        max_open=5,
+        now=_NOW,
+        verdict_lookup=verdict_lookup,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_open_loops(verdict_lookup=...) -- pure, no DB
+# ---------------------------------------------------------------------------
+
+
+def test_loop_with_no_verdict_competes_normally():
+    signals = [_signal("substrate:node:substrate.transport")]
+
+    loops = _build(signals, verdict_lookup=lambda ids: set())
+
+    assert len(loops) == 1
+    assert loops[0].id == _loop_id("substrate:node:substrate.transport")
+
+
+def test_loop_with_resolved_verdict_excluded_even_at_high_salience():
+    high_salience_text = "substrate:node:substrate.transport"
+    other_text = "a fresh unrelated concern"
+    signals = [
+        _signal(high_salience_text, salience=1.0),
+        _signal(other_text, salience=0.21),
+    ]
+    excluded_id = _loop_id(high_salience_text)
+
+    loops = _build(signals, verdict_lookup=lambda ids: {excluded_id})
+
+    ids = {loop.id for loop in loops}
+    assert excluded_id not in ids
+    assert _loop_id(other_text) in ids
+    assert len(loops) == 1
+
+
+def test_loop_with_dismissed_verdict_excluded():
+    text = "substrate:node:substrate.transport"
+    excluded_id = _loop_id(text)
+
+    loops = _build([_signal(text)], verdict_lookup=lambda ids: {excluded_id})
+
+    assert loops == []
+
+
+def test_excluded_loop_frees_its_slot_for_the_next_best_candidate():
+    """Exclusion must be applied before the max_open cap, not after.
+
+    With max_open=2 and 3 competing signals, excluding the top-ranked one
+    must promote the 3rd-ranked signal into the field instead of just
+    shrinking it to 1 -- attention_broadcast.py deliberately passes a wider
+    signal pool than max_open specifically so this backfill can happen."""
+    first, second, third = "first loop", "second loop", "third loop"
+    signals = [_signal(first), _signal(second), _signal(third)]
+    excluded_id = _loop_id(first)
+
+    loops = build_open_loops(
+        signals=signals,
+        ctx={},
+        inputs={},
+        belief_lineage=[],
+        direct_turn=False,
+        generic_reversal=False,
+        stale_thread_active=False,
+        max_open=2,
+        now=_NOW,
+        verdict_lookup=lambda ids: {excluded_id},
+    )
+
+    ids = {loop.id for loop in loops}
+    assert len(loops) == 2
+    assert excluded_id not in ids
+    assert ids == {_loop_id(second), _loop_id(third)}
+
+
+def test_verdict_lookup_receives_only_candidate_loop_ids():
+    """The lookup must be bounded to this tick's candidates -- never a
+    whole-table scan -- and called at most once per build_open_loops call."""
+    text = "substrate:node:substrate.transport"
+    seen: list[list[str]] = []
+
+    def _lookup(ids):
+        seen.append(list(ids))
+        return set()
+
+    _build([_signal(text)], verdict_lookup=_lookup)
+
+    assert len(seen) == 1
+    assert seen[0] == [_loop_id(text)]
+
+
+def test_no_verdict_lookup_preserves_prior_behavior():
+    """verdict_lookup=None (the default, used by chat-scoped callers) must
+    behave byte-identically to before this patch -- no exclusion at all."""
+    text = "substrate:node:substrate.transport"
+
+    loops = _build([_signal(text)])  # verdict_lookup defaults to None
+
+    assert len(loops) == 1
+    assert loops[0].id == _loop_id(text)
+
+
+def test_verdict_lookup_exception_does_not_crash_build_open_loops():
+    """A misbehaving verdict_lookup callable (raises instead of returning an
+    empty set) must not propagate -- build_open_loops treats it as 'no
+    verdicts known' and proceeds normally."""
+    text = "substrate:node:substrate.transport"
+
+    def _boom(ids):
+        raise RuntimeError("simulated DB failure")
+
+    loops = _build([_signal(text)], verdict_lookup=_boom)
+
+    assert len(loops) == 1
+    assert loops[0].id == _loop_id(text)
+
+
+# ---------------------------------------------------------------------------
+# orion.substrate.attention.verdicts -- the real DB lookup, mocked engine
+# ---------------------------------------------------------------------------
+
+
+def test_load_terminal_verdict_loop_ids_empty_input_short_circuits():
+    assert verdicts_mod.load_terminal_verdict_loop_ids([]) == set()
+    assert verdicts_mod.load_terminal_verdict_loop_ids(None) == set()  # type: ignore[arg-type]
+
+
+def test_load_terminal_verdict_loop_ids_filters_to_terminal_verdicts(monkeypatch):
+    rows = [
+        {"loop_id": "open-loop-a", "verdict": "resolved"},
+        {"loop_id": "open-loop-b", "verdict": "dismissed"},
+        {"loop_id": "open-loop-c", "verdict": "decayed_unattended"},
+    ]
+
+    class _FakeResult:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return rows
+
+    class _FakeConn:
+        def execute(self, stmt, params):
+            return _FakeResult()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    class _FakeEngine:
+        def connect(self):
+            return _FakeConn()
+
+    monkeypatch.setattr(verdicts_mod, "_engine", lambda: _FakeEngine())
+
+    result = verdicts_mod.load_terminal_verdict_loop_ids(
+        ["open-loop-a", "open-loop-b", "open-loop-c"]
+    )
+
+    assert result == {"open-loop-a", "open-loop-b"}
+
+
+def test_load_terminal_verdict_loop_ids_fails_open_on_db_error(monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated connection failure")
+
+    monkeypatch.setattr(verdicts_mod, "_engine", _boom)
+
+    result = verdicts_mod.load_terminal_verdict_loop_ids(["open-loop-9d84d08cddf5"])
+
+    assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through build_substrate_attention_frame
+# ---------------------------------------------------------------------------
+
+
+def _node(node_id: str, label: str, pressure: float = 0.9) -> SimpleNamespace:
+    return SimpleNamespace(
+        node_id=node_id,
+        label=label,
+        metadata={"dynamic_pressure": pressure},
+        signals=SimpleNamespace(confidence=0.8),
+    )
+
+
+def test_build_substrate_attention_frame_excludes_verdicted_loop(monkeypatch):
+    import orion.substrate.attention_broadcast as attention_broadcast
+
+    node = _node("node:transport", "substrate:node:substrate.transport", pressure=1.0)
+    excluded_id = _loop_id("substrate:node:substrate.transport")
+
+    monkeypatch.setattr(
+        attention_broadcast, "load_terminal_verdict_loop_ids", lambda ids: {excluded_id}
+    )
+
+    frame = attention_broadcast.build_substrate_attention_frame(nodes=[node], now=_NOW)
+
+    assert frame.open_loops == []
+    # select_actions() always returns a placeholder action rather than None;
+    # what matters is it has no open_loop_id to win with -- the excluded
+    # loop cannot become `selected_action`.
+    assert frame.selected_action is not None
+    assert frame.selected_action.open_loop_id is None
+
+
+def test_build_substrate_attention_frame_survives_verdict_lookup_db_failure(monkeypatch):
+    """DB failure during the verdict lookup must not crash frame-building --
+    the tick proceeds as if no verdicts exist (the loop stays eligible)."""
+    import orion.substrate.attention_broadcast as attention_broadcast
+
+    node = _node("node:transport", "substrate:node:substrate.transport", pressure=1.0)
+
+    def _boom(ids):
+        raise RuntimeError("simulated DB failure")
+
+    monkeypatch.setattr(attention_broadcast, "load_terminal_verdict_loop_ids", _boom)
+
+    frame = attention_broadcast.build_substrate_attention_frame(nodes=[node], now=_NOW)
+
+    assert len(frame.open_loops) == 1
+    assert frame.open_loops[0].id == _loop_id("substrate:node:substrate.transport")


### PR DESCRIPTION
## Summary

- Deferred non-goal of PR #1061 (`fix/attention-salience-decay-bypass`):
  a loop a human explicitly Resolved/Dismissed via the Hub could still win
  the substrate-broadcast workspace competition indefinitely, because
  `build_open_loops()` never consulted `attention_loop_outcome` verdicts.
- New `orion/substrate/attention/verdicts.py::load_terminal_verdict_loop_ids()`
  -- a bounded, read-only, fail-open SQL lookup against `attention_loop_outcome`,
  mirroring the exact connection/query style already used by
  `services/orion-hub/scripts/attention_loops_store.py` and
  `services/orion-thought/app/store.py::load_recent_loop_outcomes`.
- `build_open_loops()` gained an optional `verdict_lookup` parameter (default
  `None`, byte-identical prior behavior). When given, resolved/dismissed
  loops are excluded from `open_loops` entirely (not down-weighted), and the
  exclusion happens before the `max_open` cap so a freed slot backfills with
  the next-best candidate instead of just shrinking the field.
- Wired into `build_substrate_attention_frame` (rung-3's continuous
  30s-interval broadcast) only -- the chat-scoped `attention_frame.py` caller
  is deliberately untouched.
- Fails open on any DB error: a lookup failure never blocks a tick.

## Test plan

- [x] `pytest orion/substrate/tests/ -q` -- 218 passed (12 new tests in
      `test_attention_verdict_exclusion.py`)
- [x] `pytest services/orion-substrate-runtime/tests/test_worker_attention_broadcast_tick.py -q`
      -- 6 passed
- [x] Live query against real Postgres (`attention_loop_outcome`) confirms
      `load_terminal_verdict_loop_ids(["open-loop-9d84d08cddf5", ...])`
      correctly returns `{"open-loop-9d84d08cddf5"}` for the exact loop from
      the original PR #1061 investigation (verdicted resolved 07-08 /
      dismissed 07-10).
- [x] Code-review skill (high effort) run; both material findings (exclusion
      applied after the max_open cap instead of before; duplicate `loop_id`
      computation) fixed and re-verified.

See `docs/superpowers/pr-reports/2026-07-16-attention-verdict-aware-selection-pr.md`
for the full report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)