### PR TITLE
feat(substrate): concept-atlas graph pipeline — Wave 1 (seed, adapter, identity fix, stub fix)

### DIFF
--- a/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
@@ -1,0 +1,335 @@
+# Concept graph pipeline + Concept Atlas Hub tab — design spec
+
+Status: DESIGN, not implemented. Ground truth verified live 2026-07-15
+against `main` via direct file reads (not grep-only) for every load-bearing
+claim below.
+
+Scope decided by Juniper: replace concept-induction's NLP extractor with the
+already-built, already-unsupervised `orion-topic-foundry` clustering
+pipeline, fix the concept-identity merge bug, add a thin typed-edge layer on
+top (tuning options A baseline + B and C as real candidates, D explicitly
+deferred), retire a confirmed-fake stub signal adapter, and ship a read-only
+"Concept Atlas" Hub tab for operator interpretability. No new graph
+infrastructure — reuse the in-memory substrate store that is already the
+default.
+
+## Arsonist summary
+
+Orion already has almost everything this effort needs, built by three
+different past efforts that never got connected to each other:
+
+1. `orion/substrate/` — a real node/edge/decay/promotion-state schema and an
+   `InMemorySubstrateGraphStore`, wired to exactly one producer: the spaCy
+   noun-chunk extractor in `orion/spark/concept_induction/`, which is
+   currently switched off (`CONCEPT_AUTONOMOUS_TRIGGER_ENABLED=false` in
+   `services/orion-spark-concept-induction/.env:35`) and has a known,
+   unfixed defect (no stopword/POS filtering).
+2. `services/orion-topic-foundry/` — a real, maintained, unsupervised
+   embedding→UMAP→HDBSCAN→BERTopic clustering service with model
+   promotion (`candidate/active/archived`) and drift detection, reading
+   directly from `chat_history_log`
+   (`app/pipelines/chat_corpus_builder/repository.py:26`). This already
+   solves concept induction's hardest problem — forming candidate concepts
+   without a predefined label vocabulary — but its output (`KgEdgeIngestV1`
+   on `orion:kg:edge:ingest.v1`) only reaches `orion-rdf-writer`/
+   `orion-graphdb` (`orion/bus/channels.yaml:340-346`), never
+   `orion/substrate/`.
+3. The one place topic-foundry's output does reach the signal layer,
+   `orion/signals/adapters/topic_foundry.py::TopicFoundryAdapter.adapt()`,
+   is a confirmed stub: it hardcodes
+   `dimensions={"level": 0.5, "confidence": 0.5}` and its own `notes` field
+   says `"stub adapter — not yet implemented"`. Independently corroborated
+   client-side: `organ-signals-graph-ui.js` ships a
+   `STUB_ORGAN_IDS` set that already lists `topic_foundry` and
+   `concept_induction` by name, with the identical placeholder constant
+   `GENERIC_PLACEHOLDER_DIMS = { level: 0.5, confidence: 0.5 }`. Someone
+   already knew.
+4. `orion/substrate/reconcile.py::SubstrateIdentityResolver.canonical_node_key`
+   resolves concept identity by exact-lowercased-string match on `label`
+   (line 47-49) — no embedding fallback. Two paraphrases of the same
+   concept become two permanent nodes. This bug exists independent of which
+   extractor feeds it, so swapping extractors alone would not have fixed
+   it.
+
+The sharp reframing from the original ask: this is not "build a concept
+graph with organic growth, decay, and HITL review" — that already exists as
+a schema+store+materializer+review-queue. It is "connect a clustering
+engine that already works to a graph that already works, fix one identity
+bug, kill one fake signal, and add a thin typed-relationship layer that
+clustering structurally cannot produce on its own."
+
+## Current architecture
+
+- **Node candidate formation (to be repointed)**: `orion/spark/concept_induction/extractor.py::SpacyConceptExtractor`
+  — spaCy `noun_chunks`, no `is_stop`/`PRON` filtering (confirmed absent
+  from the file). Feeds `orion/spark/concept_induction/inducer.py` →
+  `ConceptProfile` (`orion/core/schemas/concept_induction.py:103-119`).
+- **Existing intra-batch clustering**: `orion/spark/concept_induction/clusterer.py::ConceptClusterer`
+  — real cosine-similarity clustering (threshold 0.8) with a Jaccard
+  string fallback, but scoped to one extraction window only; its output is
+  a plain label string, memoryless across time.
+- **Substrate schema**: `orion/core/schemas/cognitive_substrate.py` —
+  `SubstrateNodeKindV1` includes `"concept"` (L11-23);
+  `SubstrateAnchorScopeV1` = `orion/juniper/relationship/world/session`
+  (L42); `ConceptNodeV1` (L152-157); `SubstrateEdgeV1` with predicates
+  `supports/contradicts/refines/co_occurs_with` (L24-40, L232-243);
+  `SubstratePromotionStateV1` = `proposed/provisional/canonical/deprecated/rejected`
+  (L41); `SubstrateActivationV1` with `decay_half_life_seconds`/
+  `decay_floor` (L78-84) — present in schema, no confirmed live writer.
+- **Store selection**: `orion/substrate/graphdb_store.py::build_substrate_store_from_env()`
+  (L822-849) defaults to `InMemorySubstrateGraphStore` unless
+  `SUBSTRATE_STORE_BACKEND` explicitly requests `sparql`/`graphdb`. Docstring
+  states this default exists specifically "to avoid accidental duplicate
+  RDF surfaces during backend-neutral RDF writer cutover" — the codebase's
+  own authors already flagged the redundancy risk this spec is navigating
+  around.
+- **Existing producer registration**: `orion/substrate/adapters/concept_induction.py::map_concept_profile_to_substrate()`
+  registered in `services/orion-cortex-exec/app/chat_stance.py::_build_unification_registry()`
+  (L163-170) as an always-on (`pull_on_cold=True`) lane — the wrong
+  consumption shape for salience-gated recall, see Phase 6 below.
+- **HITL review**: `orion/substrate/review_bootstrap.py`, `review_queue.py`,
+  `review_runtime.py`, `review_schedule.py`, `review_telemetry.py` exist;
+  whether an operator-facing Hub route already consumes them is unconfirmed
+  (see Missing questions).
+- **Topic-foundry pipeline**: `services/orion-topic-foundry/app/topic_engine.py`
+  — `VectorHostEmbeddingModel` → `UMAP` (`n_components` default 5, not 2 —
+  `app/settings.py:53`) → `HDBSCAN` → representation
+  (`KeyBERTInspired`/`MaximalMarginalRelevance`/`PartOfSpeech`/`ctfidf`/`llm`).
+  Model lifecycle: `POST /models/{model_id}/promote` to
+  `candidate/active/archived`. Training triggered via `POST /runs/train`
+  (no cron/scheduler found — only the drift daemon runs continuously,
+  checking an existing active model, not retraining). Dataset source is
+  real: `chat_history_log`. **Unconfirmed**: whether it has ever completed
+  a training run against real data (see Missing questions / Phase 0).
+- **Existing Hub operator surface for topic-foundry**: a full "Topic Studio"
+  tab already exists (`index.html` `data-panel="topic-studio"`, L1330+),
+  proxying `/api/topic-foundry` — dataset builder, model status
+  (pg/embedding/model-dir health), debug drawer for preview/train/enrich/
+  segments. This is a **management/control surface**, not an
+  interpretability view of the concept graph's current state. Concept
+  Atlas (Phase 8) must not duplicate it — link out to it instead.
+- **Established Hub graph-viz patterns** (two, both real, serving different
+  isolation needs):
+  - *Inline panel + IIFE module*: Organ Signals
+    (`organ-signals-graph-ui.js`, Cytoscape.js via CDN). Exposes
+    `window.OrionOrganSignalsGraphUI = { attach, ... }`; `attach()` returns
+    a controller `{ refresh, destroy, getLastPayload }`. `app.js::ensureOrganSignalsGraph()`
+    lazily creates the controller once and calls `.refresh()` on tab-show
+    (`app.js:1018-1023`); panel visibility is a CSS `hidden` class toggle,
+    Cytoscape instance persists in the DOM across tab switches.
+    **Known gap, do not replicate**: `destroy()` is defined (stops the
+    poll interval, calls `cy.destroy()`) but `app.js` never calls it on
+    tab-hide — if auto-refresh was checked, the `setInterval` keeps firing
+    while the tab is hidden.
+  - *iframe-embedded standalone page*: Substrate Atlas
+    (`substrate_atlas.html` + `substrate-atlas.js`, also Cytoscape.js).
+    Fully separate document; parent pings
+    `contentWindow.OrionSubstrateAtlas.activate()` on tab-show
+    (`app.js:996-1005`). Strongest possible isolation — a JS error in the
+    embedded graph cannot touch `app.js`'s global scope at all, by
+    construction, since it's a different document.
+  - Note: "Substrate Atlas" is the grammar/schema_kernel trace explorer
+    (`orion/schemas/grammar.py`), **not** the `cognitive_substrate.py`
+    concept graph this spec is about, despite the name collision. Concept
+    Atlas must be named distinctly (see below) to not compound this
+    confusion.
+
+## Missing questions
+
+- Has `orion-topic-foundry` ever completed a training run against real
+  `chat_history_log` data, or is it built-and-never-invoked? (Phase 0,
+  blocks everything downstream — a live `GET /runs` check, not a code
+  change.)
+- Does `GraphDBSubstrateStore` point at the same physical SPARQL/Fuseki
+  backend as `orion-rdf-writer`, or a separate one? (Answered enough to
+  proceed: default is in-memory, so this only matters if/when a future
+  patch opts into `SUBSTRATE_STORE_BACKEND=graphdb` — not blocking this
+  spec.)
+- Is there a distinct `EntityNodeV1` in `cognitive_substrate.py` separate
+  from `ConceptNodeV1`? Determines whether Orion/Juniper seed as entities
+  or concepts. Must resolve before Phase 1 seeding, not before this spec.
+- Does an operator-facing Hub route already exist for
+  `orion/substrate/review_queue.py`, or is HITL review purely backend
+  today? Blocks Phase 7, not earlier phases.
+- What co-occurrence threshold actually separates signal from noise for
+  Layer 3 classification (Tuning options B/C below)? Cannot be answered
+  without Phase 0's real run data — this is explicitly an empirical
+  question the phased rollout is designed to answer, not a pre-decision.
+
+## Proposed schema / API changes
+
+- **New**: `orion/substrate/adapters/topic_foundry.py` — converts
+  topic-foundry cluster/topic/keyword records into `ConceptNodeV1` +
+  free `co_occurs_with` `SubstrateEdgeV1` records (same-segment
+  co-membership), written at `promotion_state="proposed"`. Parallel in
+  shape to the existing `concept_induction.py` adapter.
+- **Changed**: `orion/substrate/reconcile.py::SubstrateIdentityResolver.canonical_node_key`
+  — for `node_kind == "concept"`, add an embedding-nearest-neighbor lookup
+  (same cosine-threshold pattern `ConceptClusterer` already validates,
+  0.8 starting point) against existing canonical/provisional concept
+  embeddings, falling back to the current exact-string key only when no
+  embedding is available.
+- **Changed**: `orion/core/schemas/cognitive_substrate.py::ConceptNodeV1` —
+  needs an embedding/centroid field if one does not already exist, so
+  `reconcile.py` has something to compare against without a new embedding
+  call (topic-foundry already computes cluster centroids).
+- **New**: Layer 3 relation classification — triggered on
+  `promotion_state` transition `proposed → provisional` for node pairs
+  whose `co_occurs_with` edge crosses the tuning threshold (Options A/B/C
+  below, D deferred). One scoped LLM call per qualifying pair, classifying
+  `supports/contradicts/refines`, not raw per-turn extraction.
+- **Changed**: `orion/signals/adapters/topic_foundry.py::TopicFoundryAdapter.adapt()`
+  — either wire to a real value (e.g. count/salience of concepts newly
+  promoted this cycle, or drift magnitude already computed by
+  `services/orion-topic-foundry/app/services/drift.py`) or remove the
+  entry from `ORGAN_REGISTRY` entirely. Leaving the constant-0.5 stub live
+  while this effort ships is not acceptable per this repo's own
+  no-empty-shell-cognition rule.
+- **New**: `GET /api/substrate/concepts/summary` — counts by
+  `promotion_state`, by `anchor_scope`, edge counts by predicate, an
+  "at risk" list (decayed activation nearing `decay_floor`).
+- **New**: `GET /api/substrate/concepts/network?scope=&min_activation=&focus=`
+  — nodes+edges JSON for Cytoscape, same response shape family as
+  `/api/signals/active`, backed by `InMemorySubstrateGraphStore.query_concept_region()`.
+  Server computes degree/activation-weighted-degree at request time and
+  flags top-N nodes as `god_node: true` (store is in-memory and small; no
+  precomputed ranking job needed yet).
+- **New (thin proxy, or reuse existing)**: read-only summary of the latest
+  topic-foundry run (`topics_summary.json`/`topics_keywords.json`) for the
+  Concept Atlas clustering card — check whether `/api/topic-foundry`
+  proxying already used by Topic Studio can be reused as-is before adding
+  a new route.
+
+## Files likely to touch
+
+- `orion/substrate/adapters/topic_foundry.py` (new)
+- `orion/substrate/reconcile.py`
+- `orion/substrate/store.py` (embedding index for nearest-neighbor lookup)
+- `orion/core/schemas/cognitive_substrate.py`
+- `services/orion-cortex-exec/app/chat_stance.py` (registry entry —
+  gate, don't `pull_on_cold`, see Phase 6)
+- `orion/signals/adapters/topic_foundry.py`
+- `orion/signals/registry.py` (`ORGAN_REGISTRY`, if removing the stub
+  entry instead of fixing it)
+- `services/orion-recall/app/collectors/concept_region.py` (new,
+  salience-gated recall, modeled on `active_packet.py::fetch_active_packet_fragments`)
+- `services/orion-hub/scripts/api_routes.py` (new summary/network routes)
+- `services/orion-hub/templates/index.html` (new `data-panel="concept-atlas"`
+  section + `#hubPrimaryNav` entry)
+- `services/orion-hub/static/js/concept-atlas.js` (new, own file per
+  established convention — see Phase 8 for the isolation-pattern decision)
+- `orion/spark/concept_induction/rdf_materialization.py`, `graph_mapper.py`,
+  `graph_query.py` (audit for deletion — competing, likely-dead second
+  graph-projection path found inside `concept_induction/` itself)
+- `orion/substrate/seed_concepts.yaml` (new, golden concept fixture)
+- new `docs/superpowers/specs/` follow-up or `orion/substrate/decay_reducer.py`
+  if Phase 4's decay wiring needs its own module
+
+## Non-goals
+
+- No new graph infrastructure. `InMemorySubstrateGraphStore` (already the
+  default) is the target store. Do not wire this effort into
+  `GraphDBSubstrateStore`/SPARQL or `orion-rdf-writer` — that would
+  recreate the exact "accidental duplicate RDF surface" the store's own
+  default-selection code already warns against.
+- No RDF/OWL formal ontology reasoning, no federated SPARQL queries — not
+  asked for, real infra cost, solves a problem this effort doesn't have.
+- No per-turn LLM extraction call. Node formation stays batch/clustering-
+  based; LLM calls are reserved for Layer 3 relation classification,
+  scoped to already-established, already-co-occurring node pairs.
+- No GLiNER, no predefined entity-type label vocabulary — the whole point
+  of routing through topic-foundry's clustering is to avoid needing one.
+- Tuning option D (piggyback relation-classification purely on the
+  promotion-lifecycle transition, no co-occurrence signal) is explicitly
+  **deferred**, not selected. Build A/B/C behind a flag for comparison;
+  revisit D only if B/C prove not worth their complexity.
+- Concept Atlas is read-only interpretability. It must not duplicate
+  Topic Studio's dataset/model/training management surface — link to it,
+  don't rebuild it.
+- No temporal scrubber in this patch. The underlying data
+  (`materialization_lineage` timestamps already appended by
+  `reconcile.py::merge_node`/`merge_edge`, capped at 50/100 entries) is
+  already being recorded, so a future temporal view is not blocked on new
+  instrumentation — but it is out of scope here.
+
+## Acceptance checks
+
+- Phase 0: a real topic-foundry `run_id` exists against real
+  `chat_history_log` data, with non-garbage `topics_summary.json` —
+  verified by eyeball, not just "the endpoint responds."
+- Phase 1 (seed): `query_concept_region()` returns the 3 seeded golden
+  concept nodes at `promotion_state="canonical"`.
+- Phase 2 (adapter): a topic-foundry run's clusters produce
+  `ConceptNodeV1` rows in the substrate store at `promotion_state="proposed"`,
+  each carrying evidence refs back to source chat turns (no empty-shell
+  nodes — every node must cite an `EvidenceNodeV1`/evidence ref).
+  Free `co_occurs_with` edges appear for concepts sharing a segment.
+- Phase 3 (reconcile fix): two paraphrases of the same concept
+  (synthetic test: "surface encodings" / "surface-level representations"
+  with a known-similar embedding pair) resolve to one node, not two —
+  regression test required.
+- Phase 4 (Layer 3): for a manufactured co-occurrence-heavy pair (e.g.
+  seeded Orion/Juniper), each of A/B/C produces a relation classification
+  within one promotion cycle; results are comparable side by side (same
+  pair, three threshold strategies, logged separately).
+- Phase 5 (stub kill): `TopicFoundryAdapter.adapt()` either emits a value
+  that changes when its input changes (test with two different payloads,
+  assert different output) or the organ is removed from `ORGAN_REGISTRY`
+  and `STUB_ORGAN_IDS` client-side list is updated to match.
+- Phase 6 (salience-gated recall): a turn containing a seeded concept's
+  label triggers a context-block injection; a turn without it does not;
+  neither turn causes a permanent stance-registry write.
+- Phase 8 (Concept Atlas): tab is reachable from `#hubPrimaryNav`; opening
+  it does not throw in the console; switching to another tab and back
+  does not duplicate Cytoscape instances or leak intervals (verified via
+  the `destroy()`-on-hide fix noted in Non-goals/Current architecture);
+  the four cards (summary, network, clustering, filters) each load from
+  their own endpoint independently — one card's failure must not blank
+  the others.
+
+## Recommended next patch
+
+**Phase 0 first, as a live check, not a code change.** Everything else is
+contingent on topic-foundry's clustering actually being trustworthy on
+real Orion chat data — if it's never been run for real, that becomes the
+actual first patch (register a dataset, run a training pass, eyeball the
+output) before any adapter work starts.
+
+Then, in order (each phase independently shippable and checkable, per
+Juniper's stated preference for phased checkpoints over one upfront plan
+approval):
+
+1. Phase 0 — verify topic-foundry has real run output.
+2. Phase 1 — seed golden concepts (Orion, Juniper, Orion-Juniper-relationship)
+   directly, independent of everything else.
+3. Phase 2 — `orion/substrate/adapters/topic_foundry.py`, node conversion +
+   free co-occurrence edges.
+4. Phase 3 — fix `reconcile.py` identity resolution (embedding
+   nearest-neighbor).
+5. Phase 4 — Layer 3 relation classification, tuning options A (baseline)
+   + B + C built behind a flag for empirical comparison; D documented as
+   deferred future work, not built.
+6. Phase 5 — kill or fix the `TopicFoundryAdapter` stub.
+7. Phase 6 — salience-gated recall collector (`concept_region.py`),
+   modeled on `active_packet.py`, registered as a gated lane, not folded
+   into `chat_stance.py`'s always-on registry.
+8. Phase 7 — confirm/build the HITL review Hub surface.
+9. Phase 8 — Concept Atlas Hub tab: own `concept-atlas.js` file (own
+   namespace, e.g. `window.OrionConceptAtlas`), decision needed at build
+   time between the two established isolation patterns —
+   **recommend the Substrate Atlas iframe pattern** (strongest isolation,
+   matches the explicit "clicking out of the tab doesn't kill Hub and vice
+   versa" requirement by construction) over Organ Signals' inline-panel
+   pattern, but fix the observed gap either way: call the equivalent of
+   `destroy()`/`stopPolling()` on tab-hide, don't just leave it defined
+   and uncalled like the Organ Signals reference implementation does
+   today. Four cards (summary stats, network drill-down with god-node
+   flagging, clustering — read-only, links out to Topic Studio for
+   management — and global filters including a focus-concept selector);
+   temporal view explicitly deferred but not blocked, per Non-goals.
+
+Also flagged for cleanup, not blocking: `orion/spark/concept_induction/rdf_materialization.py`/
+`graph_mapper.py`/`graph_query.py` appear to be a second, competing,
+likely-dead graph-projection attempt inside `concept_induction/` itself —
+audit and delete in the same changeset as Phase 2 to avoid three
+concept-graph-shaped code paths existing simultaneously.

--- a/orion/signals/adapters/tests/test_topic_foundry_adapter.py
+++ b/orion/signals/adapters/tests/test_topic_foundry_adapter.py
@@ -1,0 +1,104 @@
+"""Topic Foundry adapter — canonical location ``orion/signals/adapters/tests/`` (phase-5)."""
+
+from uuid import uuid4
+
+import pytest
+
+from orion.signals.adapters.topic_foundry import TopicFoundryAdapter
+from orion.signals.normalization import NormalizationContext
+from orion.signals.registry import ORGAN_REGISTRY
+
+
+@pytest.fixture
+def adapter() -> TopicFoundryAdapter:
+    return TopicFoundryAdapter()
+
+
+@pytest.fixture
+def norm_ctx() -> NormalizationContext:
+    return NormalizationContext()
+
+
+def _drift_payload(js_divergence: float, **overrides) -> dict:
+    payload = {
+        "drift_id": str(uuid4()),
+        "model_id": str(uuid4()),
+        "model_name": "chat-topics-v1",
+        "window_start": "2026-07-15T00:00:00+00:00",
+        "window_end": "2026-07-16T00:00:00+00:00",
+        "js_divergence": js_divergence,
+        "outlier_pct_delta": 0.02,
+        "top_topic_share_delta": -0.01,
+        "created_at": "2026-07-16T00:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_can_handle_real_dotted_kind(adapter: TopicFoundryAdapter) -> None:
+    # Real envelope kind published by orion-topic-foundry's bus publisher.
+    assert adapter.can_handle("topic.foundry.drift.alert.v1", {})
+    assert adapter.can_handle("topic.foundry.run.complete.v1", {})
+    assert adapter.can_handle("topic.foundry.enrich.complete.v1", {})
+
+
+def test_not_a_stub_anymore(adapter: TopicFoundryAdapter, norm_ctx: NormalizationContext) -> None:
+    payload = _drift_payload(0.7)
+    signal = adapter.adapt("topic.foundry.drift.alert.v1", payload, ORGAN_REGISTRY, {}, norm_ctx)
+    assert signal is not None
+    assert "stub adapter" not in " ".join(signal.notes)
+
+
+def test_different_payloads_produce_different_dimensions(
+    adapter: TopicFoundryAdapter, norm_ctx: NormalizationContext
+) -> None:
+    low = adapter.adapt("topic.foundry.drift.alert.v1", _drift_payload(0.05), ORGAN_REGISTRY, {}, norm_ctx)
+    high = adapter.adapt("topic.foundry.drift.alert.v1", _drift_payload(0.9), ORGAN_REGISTRY, {}, norm_ctx)
+    assert low is not None and high is not None
+    assert low.dimensions != high.dimensions
+    assert low.dimensions["level"] < high.dimensions["level"]
+    assert low.signal_kind == "topic_drift"
+    assert high.signal_kind == "topic_drift"
+
+
+def test_drift_level_tracks_js_divergence(adapter: TopicFoundryAdapter, norm_ctx: NormalizationContext) -> None:
+    signal = adapter.adapt("topic.foundry.drift.alert.v1", _drift_payload(0.42), ORGAN_REGISTRY, {}, norm_ctx)
+    assert signal is not None
+    assert signal.dimensions["level"] == pytest.approx(0.42)
+    assert signal.dimensions["confidence"] > 0.5
+
+
+def test_enrich_complete_payload_uses_success_ratio(
+    adapter: TopicFoundryAdapter, norm_ctx: NormalizationContext
+) -> None:
+    payload = {
+        "run_id": str(uuid4()),
+        "model_id": str(uuid4()),
+        "dataset_id": str(uuid4()),
+        "model_name": "chat-topics-v1",
+        "model_version": "1",
+        "status": "complete",
+        "enriched_count": 90,
+        "failed_count": 10,
+    }
+    signal = adapter.adapt("topic.foundry.enrich.complete.v1", payload, ORGAN_REGISTRY, {}, norm_ctx)
+    assert signal is not None
+    assert signal.signal_kind == "topic_state"
+    assert signal.dimensions["level"] == pytest.approx(0.9)
+
+
+def test_malformed_payload_degrades_gracefully_without_raising(
+    adapter: TopicFoundryAdapter, norm_ctx: NormalizationContext
+) -> None:
+    signal = adapter.adapt("topic.foundry.run.complete.v1", {}, ORGAN_REGISTRY, {}, norm_ctx)
+    assert signal is not None
+    assert signal.dimensions["level"] == 0.5
+    assert signal.dimensions["confidence"] < 0.5
+    assert any("neutral reading" in n for n in signal.notes)
+
+
+def test_unknown_organ_returns_none(adapter: TopicFoundryAdapter, norm_ctx: NormalizationContext) -> None:
+    signal = adapter.adapt("topic.foundry.drift.alert.v1", _drift_payload(0.5), {}, {}, norm_ctx)
+    # ORGAN_REGISTRY module-level fallback still resolves the entry even
+    # when an empty registry dict is passed, matching other adapters' pattern.
+    assert signal is not None

--- a/orion/signals/adapters/topic_foundry.py
+++ b/orion/signals/adapters/topic_foundry.py
@@ -1,17 +1,96 @@
+"""Topic Foundry drift/run telemetry -> topic_foundry OrionSignalV1 (Phase 5).
+
+Real signal source: ``services/orion-topic-foundry/app/services/drift.py``
+computes a Jensen-Shannon divergence (``js_divergence``, bounded [0, 1]) plus
+outlier/top-topic-share deltas between the baseline and current topic
+distributions and publishes them as ``TopicFoundryDriftAlertV1`` on
+``orion:topic:foundry:drift:alert.v1`` (envelope kind
+``topic.foundry.drift.alert.v1``). That divergence is the strongest, most
+direct measure of "how much has the topic landscape moved" that topic-foundry
+emits, so it drives ``dimensions["level"]`` here. Run/enrich-completion
+payloads (no drift fields) fall back to a success-ratio or status-based
+reading. Anything unrecognized degrades to a neutral, low-confidence,
+explicitly-noted reading -- this adapter never raises.
+"""
+from __future__ import annotations
+
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
+
+from orion.schemas.topic_foundry import TopicFoundryDriftAlertV1
 from orion.signals.adapters.base import OrionSignalAdapter
 from orion.signals.signal_ids import make_signal_id
 from orion.signals.models import OrionOrganRegistryEntry, OrionSignalV1
-from orion.signals.normalization import NormalizationContext
+from orion.signals.normalization import NormalizationContext, clamp01
 from orion.signals.registry import ORGAN_REGISTRY
+
+
+def _as_float(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _dimensions_from_payload(payload: dict) -> Tuple[Dict[str, float], str, List[str]]:
+    """Return (dimensions, signal_kind, notes) derived from a real payload.
+
+    Preference order:
+    1. ``TopicFoundryDriftAlertV1``-shaped payload -> js_divergence drives
+       ``level``; corroborating outlier/top-share deltas raise ``confidence``.
+    2. Raw drift fields present but schema validation failed (partial
+       payload) -> same derivation, lower confidence, note the fallback.
+    3. Enrich-complete style payload (``enriched_count``/``failed_count``)
+       -> success ratio drives ``level``.
+    4. Run-complete style payload (``status`` string) -> binary level.
+    5. Nothing recognized -> neutral 0.5/low-confidence reading, noted.
+    """
+    notes: List[str] = []
+
+    drift: Optional[TopicFoundryDriftAlertV1] = None
+    try:
+        drift = TopicFoundryDriftAlertV1.model_validate(payload)
+    except Exception:
+        drift = None
+
+    js_divergence = drift.js_divergence if drift is not None else _as_float(payload.get("js_divergence"))
+    if js_divergence is not None:
+        level = clamp01(js_divergence)
+        outlier_delta = drift.outlier_pct_delta if drift is not None else _as_float(payload.get("outlier_pct_delta"))
+        top_share_delta = (
+            drift.top_topic_share_delta if drift is not None else _as_float(payload.get("top_topic_share_delta"))
+        )
+        corroborating = sum(1 for v in (outlier_delta, top_share_delta) if v is not None and abs(v) > 0.0)
+        confidence = clamp01((0.85 if drift is not None else 0.6) + 0.05 * corroborating)
+        if drift is None:
+            notes.append("partial drift-alert payload; schema validation skipped")
+        return {"level": level, "confidence": confidence}, "topic_drift", notes
+
+    enriched = _as_float(payload.get("enriched_count"))
+    failed = _as_float(payload.get("failed_count"))
+    if enriched is not None and failed is not None and (enriched + failed) > 0:
+        level = clamp01(enriched / (enriched + failed))
+        return {"level": level, "confidence": 0.6}, "topic_state", notes
+
+    status = payload.get("status")
+    if isinstance(status, str) and status:
+        level = 1.0 if status.lower() in ("complete", "completed", "success", "succeeded") else 0.0
+        return {"level": level, "confidence": 0.5}, "topic_state", notes
+
+    notes.append("no recognized topic-foundry drift/run/enrich fields; neutral reading")
+    return {"level": 0.5, "confidence": 0.2}, "topic_state", notes
 
 
 class TopicFoundryAdapter(OrionSignalAdapter):
     organ_id = "topic_foundry"
 
     def can_handle(self, channel: str, payload: dict) -> bool:
-        return "topic_foundry" in channel
+        # Real envelope kinds use dots (e.g. "topic.foundry.drift.alert.v1");
+        # keep the underscore form too for callers/tests that pass the raw
+        # organ id as the channel.
+        return "topic_foundry" in channel or "topic.foundry" in channel
 
     def adapt(
         self,
@@ -24,7 +103,12 @@ class TopicFoundryAdapter(OrionSignalAdapter):
         entry = registry.get(self.organ_id) or ORGAN_REGISTRY.get(self.organ_id)
         if entry is None:
             return None
-        src_raw = payload.get("correlation_id") or payload.get("id")
+        src_raw = (
+            payload.get("drift_id")
+            or payload.get("run_id")
+            or payload.get("correlation_id")
+            or payload.get("id")
+        )
         src_id = str(src_raw) if src_raw is not None else None
         now = datetime.now(timezone.utc)
         sig_id = make_signal_id(self.organ_id, src_id)
@@ -33,15 +117,16 @@ class TopicFoundryAdapter(OrionSignalAdapter):
             for p in (entry.causal_parent_organs or [])
             if p in prior_signals
         ]
+        dimensions, signal_kind, notes = _dimensions_from_payload(payload)
         return OrionSignalV1(
             signal_id=sig_id,
             organ_id=self.organ_id,
             organ_class=entry.organ_class,
-            signal_kind=entry.signal_kinds[0] if entry.signal_kinds else "unknown",
-            dimensions={"level": 0.5, "confidence": 0.5},
+            signal_kind=signal_kind,
+            dimensions=dimensions,
             causal_parents=causal_parents,
             source_event_id=src_id,
             observed_at=now,
             emitted_at=now,
-            notes=["stub adapter — not yet implemented"],
+            notes=notes[:5],
         )

--- a/orion/substrate/adapters/topic_foundry.py
+++ b/orion/substrate/adapters/topic_foundry.py
@@ -1,0 +1,345 @@
+"""Pure conversion of orion-topic-foundry run output into cognitive-substrate records.
+
+Phase 2 of docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md.
+
+This module intentionally mirrors the construction patterns used by the sibling
+adapter `orion/substrate/adapters/concept_induction.py::map_concept_profile_to_substrate`
+(provenance via `_common.make_provenance`, temporal via `_common.make_temporal`,
+evidence-node + `supports`-edge pairing, `co_occurs_with` edges built from shared
+context). It does not perform any HTTP calls or bus I/O — callers are responsible
+for fetching topic-foundry's `/topics`, `/topics/{topic_id}/keywords`, and
+`segments.jsonl`-derived data and passing it in as plain Python data (dicts or
+objects with matching attributes).
+
+Wiring this adapter into a live producer/consumer/registry is explicitly out of
+scope for this phase — see the spec's Phase 6/7/8 for where that happens.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Mapping as ABCMapping
+from datetime import datetime
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    EvidenceNodeV1,
+    NodeRefV1,
+    SubstrateEdgeV1,
+    SubstrateGraphRecordV1,
+    SubstrateSignalBundleV1,
+)
+
+from ._common import make_provenance, make_temporal
+
+# --- Caps (this repo requires capped collections everywhere; see
+# docs/superpowers/pr-reports/... incident where an uncapped evidence-id list
+# grew unboundedly in a different subsystem). These are generous relative to a
+# single topic-foundry run (typically tens, not hundreds, of real topics) but
+# exist to bound worst-case work if malformed/adversarial data is passed. ---
+MAX_TOPICS_PER_RUN = 500
+MAX_KEYWORDS_PER_TOPIC = 20
+MAX_SEGMENTS_FOR_COOCCURRENCE = 5000
+MAX_TOPICS_PER_SEGMENT = 20
+MAX_COOCCURRENCE_EDGES = 2000
+
+# HDBSCAN's noise/outlier bucket. Never a real cluster — always excluded.
+OUTLIER_TOPIC_ID = -1
+
+# Topics with fewer than this many documents are treated as noise, not real
+# concepts. This mirrors the effective floor concept_induction's adapter gets
+# for free from requiring at least one evidence ref per concept, and keeps
+# single/double-document stray clusters (common near HDBSCAN's
+# min_cluster_size boundary) from polluting the substrate with spurious
+# "concepts."
+DEFAULT_MIN_DOC_COUNT = 3
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    """Read `key` from a dict-like or attribute-like object, defensively."""
+    if obj is None:
+        return default
+    if isinstance(obj, ABCMapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def map_topic_foundry_run_to_substrate(
+    *,
+    run_id: Any,
+    topics: Optional[Sequence[Any]],
+    keywords_by_topic: Optional[Mapping[int, Sequence[str]]] = None,
+    segment_topic_map: Optional[Mapping[Any, Iterable[int]]] = None,
+    topic_embeddings: Optional[Mapping[int, Sequence[float]]] = None,
+    observed_at: Optional[datetime] = None,
+    anchor_scope: str = "world",
+    subject_ref: Optional[str] = None,
+    min_doc_count: int = DEFAULT_MIN_DOC_COUNT,
+) -> SubstrateGraphRecordV1:
+    """Convert one topic-foundry run's topic/keyword/segment output into substrate records.
+
+    Args:
+        run_id: topic-foundry's run identifier (UUID or str). Used to namespace
+            node ids and as an evidence anchor.
+        topics: sequence of topic summary items, each dict-or-object-like with
+            `topic_id` (int), `count` (int), `outlier_pct` (float|None), and
+            `label` (str|None) — matching `GET /topics?run_id=...` items
+            (`TopicSummaryItem` in services/orion-topic-foundry/app/models.py).
+        keywords_by_topic: mapping of `topic_id -> keywords` (list of str),
+            typically assembled by the caller from repeated
+            `GET /topics/{topic_id}/keywords` calls (`TopicKeywordsResponse`).
+        segment_topic_map: mapping of a chat-window/segment grouping key to the
+            topic_ids observed together within that window — pure counting
+            input for `co_occurs_with` edge construction (no inference). A
+            topic-foundry `SegmentRecord` carries exactly one `topic_id`, so
+            this map is expected to already represent whatever "shared chat
+            window" grouping the caller cares about (e.g. segments grouped by
+            conversation/session), not a literal 1:1 segment_id -> topic_id
+            dump.
+        topic_embeddings: optional mapping of `topic_id -> centroid embedding`
+            (list of floats), if the caller has one available. If absent for a
+            given topic, `concept_embedding` is simply omitted from that
+            node's metadata — never fabricated.
+        observed_at: timestamp for the run; defaults to "now" (via
+            `_common.make_temporal`) if not supplied.
+        anchor_scope: defaults to "world" per the spec — organically-clustered
+            topics are not golden/seeded orion/juniper/relationship concepts.
+        subject_ref: optional subject reference to attach to all emitted nodes.
+        min_doc_count: topics with `count` below this floor are skipped as
+            noise (default 3; see `DEFAULT_MIN_DOC_COUNT`).
+
+    Returns:
+        A `SubstrateGraphRecordV1` with one `ConceptNodeV1` (+ backing
+        `EvidenceNodeV1` and `supports` edge) per real topic, and free
+        `co_occurs_with` `SubstrateEdgeV1` records between topics that share a
+        segment/window. Never raises — malformed or empty input degrades to an
+        empty (but valid) record.
+    """
+    run_id_str = str(run_id) if run_id is not None else "unknown-run"
+    graph_id = f"sub-graph-topicfoundry-{run_id_str}"
+
+    empty_record = SubstrateGraphRecordV1(
+        graph_id=graph_id,
+        anchor_scope=anchor_scope,
+        subject_ref=subject_ref,
+        nodes=[],
+        edges=[],
+    )
+
+    if not topics:
+        return empty_record
+
+    try:
+        return _build(
+            run_id_str=run_id_str,
+            graph_id=graph_id,
+            topics=topics,
+            keywords_by_topic=keywords_by_topic or {},
+            segment_topic_map=segment_topic_map or {},
+            topic_embeddings=topic_embeddings or {},
+            observed_at=observed_at,
+            anchor_scope=anchor_scope,
+            subject_ref=subject_ref,
+            min_doc_count=min_doc_count,
+        )
+    except Exception:
+        # Never raise — malformed topic-foundry data degrades to an empty,
+        # still-schema-valid record rather than taking down the caller.
+        return empty_record
+
+
+def _derive_label(label: Optional[str], keywords: Sequence[str], topic_id: int) -> str:
+    if label:
+        return str(label)
+    if keywords:
+        return " / ".join(str(k) for k in keywords[:3])
+    return f"topic_{topic_id}"
+
+
+def _build(
+    *,
+    run_id_str: str,
+    graph_id: str,
+    topics: Sequence[Any],
+    keywords_by_topic: Mapping[int, Sequence[str]],
+    segment_topic_map: Mapping[Any, Iterable[int]],
+    topic_embeddings: Mapping[int, Sequence[float]],
+    observed_at: Optional[datetime],
+    anchor_scope: str,
+    subject_ref: Optional[str],
+    min_doc_count: int,
+) -> SubstrateGraphRecordV1:
+    nodes: list = []
+    edges: list = []
+
+    temporal = make_temporal(observed_at=observed_at)
+    source_channel = f"orion:topic_foundry:run:{run_id_str}"
+
+    accepted: dict[int, dict[str, Any]] = {}
+
+    for raw_topic in topics[:MAX_TOPICS_PER_RUN]:
+        topic_id = _get(raw_topic, "topic_id")
+        if topic_id is None:
+            continue
+        try:
+            topic_id = int(topic_id)
+        except (TypeError, ValueError):
+            continue
+        if topic_id == OUTLIER_TOPIC_ID:
+            continue
+
+        count = _get(raw_topic, "count", 0) or 0
+        try:
+            count = int(count)
+        except (TypeError, ValueError):
+            count = 0
+        if count < min_doc_count:
+            continue
+
+        outlier_pct = _get(raw_topic, "outlier_pct")
+        label = _get(raw_topic, "label")
+        keywords = list(keywords_by_topic.get(topic_id, []) or [])[:MAX_KEYWORDS_PER_TOPIC]
+
+        accepted[topic_id] = {
+            "count": count,
+            "outlier_pct": outlier_pct,
+            "label": _derive_label(label, keywords, topic_id),
+            "keywords": keywords,
+        }
+
+    if not accepted:
+        return SubstrateGraphRecordV1(
+            graph_id=graph_id,
+            anchor_scope=anchor_scope,
+            subject_ref=subject_ref,
+            nodes=nodes,
+            edges=edges,
+        )
+
+    total_docs = sum(item["count"] for item in accepted.values()) or 1
+
+    for topic_id, info in accepted.items():
+        concept_node_id = f"sub-concept-topicfoundry-{run_id_str}-{topic_id}"
+        evidence_node_id = f"sub-evidence-topicfoundry-{run_id_str}-{topic_id}"
+        evidence_ref = f"{run_id_str}:topic:{topic_id}"
+
+        outlier_pct = info["outlier_pct"]
+        try:
+            confidence = 1.0 - float(outlier_pct) if outlier_pct is not None else 0.5
+        except (TypeError, ValueError):
+            confidence = 0.5
+        confidence = min(1.0, max(0.0, confidence))
+        salience = min(1.0, max(0.0, info["count"] / total_docs))
+
+        metadata: dict[str, Any] = {
+            "topic_id": topic_id,
+            "run_id": run_id_str,
+            "doc_count": info["count"],
+            "keywords": info["keywords"],
+            "source": "orion-topic-foundry",
+        }
+        embedding = topic_embeddings.get(topic_id)
+        if embedding:
+            metadata["concept_embedding"] = [float(x) for x in embedding]
+
+        nodes.append(
+            ConceptNodeV1(
+                node_id=concept_node_id,
+                anchor_scope=anchor_scope,
+                subject_ref=subject_ref,
+                promotion_state="proposed",
+                temporal=temporal,
+                provenance=make_provenance(
+                    source_kind="topic_foundry.topic",
+                    source_channel=source_channel,
+                    producer="topic_foundry_adapter",
+                    evidence_refs=[evidence_ref],
+                ),
+                label=info["label"],
+                definition=None,
+                taxonomy_path=[],
+                signals=SubstrateSignalBundleV1(confidence=confidence, salience=salience),
+                metadata=metadata,
+            )
+        )
+
+        nodes.append(
+            EvidenceNodeV1(
+                node_id=evidence_node_id,
+                anchor_scope=anchor_scope,
+                subject_ref=subject_ref,
+                temporal=temporal,
+                provenance=make_provenance(
+                    source_kind="topic_foundry.run_topic_ref",
+                    source_channel=source_channel,
+                    producer="topic_foundry_adapter",
+                ),
+                evidence_type="topic_foundry_run_topic",
+                content_ref=evidence_ref,
+                signals=SubstrateSignalBundleV1(confidence=confidence, salience=salience),
+                metadata={"topic_id": topic_id, "run_id": run_id_str},
+            )
+        )
+
+        edges.append(
+            SubstrateEdgeV1(
+                source=NodeRefV1(node_id=evidence_node_id, node_kind="evidence"),
+                target=NodeRefV1(node_id=concept_node_id, node_kind="concept"),
+                predicate="supports",
+                temporal=temporal,
+                confidence=confidence,
+                salience=salience,
+                provenance=make_provenance(
+                    source_kind="topic_foundry.support",
+                    source_channel=source_channel,
+                    producer="topic_foundry_adapter",
+                ),
+            )
+        )
+
+    # Free co_occurs_with edges: pure counting of topic pairs that co-appear
+    # within the same caller-supplied segment/window grouping. No inference.
+    pair_counts: dict[tuple[int, int], int] = {}
+    segment_items = list(segment_topic_map.items())[:MAX_SEGMENTS_FOR_COOCCURRENCE]
+    for _segment_key, raw_topic_ids in segment_items:
+        if len(pair_counts) >= MAX_COOCCURRENCE_EDGES:
+            break
+        try:
+            topic_ids = {int(t) for t in raw_topic_ids}
+        except (TypeError, ValueError):
+            continue
+        distinct = sorted(t for t in topic_ids if t in accepted)[:MAX_TOPICS_PER_SEGMENT]
+        for a, b in itertools.combinations(distinct, 2):
+            key = (a, b)
+            pair_counts[key] = pair_counts.get(key, 0) + 1
+            if len(pair_counts) >= MAX_COOCCURRENCE_EDGES:
+                break
+
+    max_count = max(pair_counts.values()) if pair_counts else 1
+    for (topic_a, topic_b), count in pair_counts.items():
+        strength = min(1.0, max(0.0, count / max_count))
+        edges.append(
+            SubstrateEdgeV1(
+                source=NodeRefV1(node_id=f"sub-concept-topicfoundry-{run_id_str}-{topic_a}", node_kind="concept"),
+                target=NodeRefV1(node_id=f"sub-concept-topicfoundry-{run_id_str}-{topic_b}", node_kind="concept"),
+                predicate="co_occurs_with",
+                temporal=temporal,
+                confidence=strength,
+                salience=strength,
+                provenance=make_provenance(
+                    source_kind="topic_foundry.co_occurrence",
+                    source_channel=source_channel,
+                    producer="topic_foundry_adapter",
+                ),
+                metadata={"co_occurrence_count": count, "run_id": run_id_str},
+            )
+        )
+
+    return SubstrateGraphRecordV1(
+        graph_id=graph_id,
+        anchor_scope=anchor_scope,
+        subject_ref=subject_ref,
+        nodes=nodes,
+        edges=edges,
+    )

--- a/orion/substrate/reconcile.py
+++ b/orion/substrate/reconcile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -8,6 +9,7 @@ from orion.core.schemas.cognitive_substrate import (
     BaseSubstrateNodeV1,
     SubstrateEdgeV1,
 )
+from .store import SubstrateGraphStore
 
 
 _TIER_RANK_NAMES: dict[int, str] = {
@@ -16,6 +18,46 @@ _TIER_RANK_NAMES: dict[int, str] = {
     3: "concept_induced",
     4: "snapshot_ephemeral",
 }
+
+# Fixed contract with the Phase 2 concept-embedding producer: an incoming concept
+# node may carry a plain list[float] embedding at this exact metadata key. Do not
+# rename -- do not promote to a typed schema field (see
+# docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md Phase 3).
+_CONCEPT_EMBEDDING_METADATA_KEY = "concept_embedding"
+
+# Mirrors ConceptClusterer.threshold in orion/spark/concept_induction/clusterer.py --
+# reused deliberately for consistency with that already-validated behavior, not
+# re-derived.
+_CONCEPT_EMBEDDING_SIMILARITY_THRESHOLD = 0.8
+
+# How many existing concept nodes to scan for an embedding match per incoming node.
+# Mirrors the 500-node cap GraphDBSubstrateStore.snapshot() already uses -- a
+# familiar order of magnitude for this store, not a new tuning knob.
+_CONCEPT_REGION_SCAN_LIMIT = 500
+
+
+def _cosine(a: Any, b: Any) -> float:
+    """Plain-Python cosine similarity -- copied from
+    ConceptClusterer._cosine (orion/spark/concept_induction/clusterer.py) rather than
+    imported, to avoid coupling orion.substrate to orion.spark.concept_induction for a
+    ten-line helper. Keep in sync if that implementation changes."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _is_valid_embedding(value: Any) -> bool:
+    """A concept embedding must be a non-empty list/tuple of real numbers. Anything
+    else (missing, wrong type, empty, non-numeric elements) is treated as "no
+    embedding available" so callers degrade to string match instead of raising."""
+    if not isinstance(value, (list, tuple)) or not value:
+        return False
+    return all(isinstance(component, (int, float)) and not isinstance(component, bool) for component in value)
 
 
 @dataclass(frozen=True)
@@ -35,19 +77,39 @@ class EdgeMergeDecision:
 
 
 class SubstrateIdentityResolver:
-    """Conservative deterministic identity resolver for substrate materialization."""
+    """Conservative deterministic identity resolver for substrate materialization.
+
+    Concept identity has two layers:
+
+    1. Embedding similarity (when the incoming node and a same-scope/subject
+       existing concept node both carry ``metadata["concept_embedding"]`` and
+       cosine similarity is >= ``_CONCEPT_EMBEDDING_SIMILARITY_THRESHOLD``): the
+       incoming node resolves to the *existing* node's identity, so paraphrases
+       ("surface encodings" vs "surface-level representations") merge instead of
+       becoming permanent duplicates.
+    2. The original exact-string match on ``concept_id`` then ``label`` -- used
+       whenever no embedding is available on the incoming node, an existing
+       match, or this resolver was constructed without a ``store`` (the default,
+       matching today's behavior for every existing caller).
+
+    ``store`` is optional and defaults to ``None`` so existing callers (e.g.
+    ``SubstrateGraphMaterializer``'s ``identity_resolver or
+    SubstrateIdentityResolver()`` default construction) see zero behavior change
+    unless a store is explicitly wired in.
+    """
+
+    def __init__(self, *, store: SubstrateGraphStore | None = None, concept_region_scan_limit: int = _CONCEPT_REGION_SCAN_LIMIT) -> None:
+        self._store = store
+        self._concept_region_scan_limit = concept_region_scan_limit
 
     def canonical_node_key(self, node: BaseSubstrateNodeV1) -> str | None:
         subject = str(node.subject_ref or "")
         scope = node.anchor_scope
         if node.node_kind == "concept":
-            concept_id = str(node.metadata.get("concept_id") or "").strip().lower()
-            if concept_id:
-                return f"concept|{scope}|{subject}|{concept_id}"
-            label = str(getattr(node, "label", "")).strip().lower()
-            if label:
-                return f"concept|{scope}|{subject}|label:{label}"
-            return None
+            embedding_match_key = self._concept_embedding_match_key(node, scope=scope, subject=subject)
+            if embedding_match_key is not None:
+                return embedding_match_key
+            return self._legacy_concept_key(node, scope=scope, subject=subject)
         if node.node_kind == "drive":
             drive_kind = str(getattr(node, "drive_kind", "")).strip().lower()
             return f"drive|{scope}|{subject}|{drive_kind}" if drive_kind else None
@@ -78,6 +140,67 @@ class SubstrateIdentityResolver:
             return None
         if node.node_kind == "hypothesis":
             return None
+        return None
+
+    def _concept_embedding_match_key(self, node: BaseSubstrateNodeV1, *, scope: str, subject: str) -> str | None:
+        """If ``node`` carries a usable embedding and a same-scope/subject existing
+        concept node in the store is similar enough (cosine >= threshold), return
+        THAT existing node's own identity key (recomputed via
+        ``_legacy_concept_key`` from its own concept_id/label) so the store's
+        identity-index lookup collides with it and the two merge. Returns ``None``
+        -- never raises -- for any reason this can't be determined: no store wired,
+        no/invalid embedding, or no candidate met the threshold."""
+        if self._store is None:
+            return None
+        embedding = node.metadata.get(_CONCEPT_EMBEDDING_METADATA_KEY)
+        if not _is_valid_embedding(embedding):
+            return None
+        try:
+            region = self._store.read_concept_region(limit_nodes=self._concept_region_scan_limit)
+            candidates = region.nodes if region is not None else []
+        except Exception:
+            return None
+
+        best_candidate: BaseSubstrateNodeV1 | None = None
+        best_similarity = 0.0
+        for candidate in candidates:
+            if candidate is None or candidate.node_kind != "concept":
+                continue
+            if candidate.node_id == node.node_id:
+                continue
+            if candidate.anchor_scope != scope or str(candidate.subject_ref or "") != subject:
+                continue
+            candidate_embedding = candidate.metadata.get(_CONCEPT_EMBEDDING_METADATA_KEY)
+            if not _is_valid_embedding(candidate_embedding):
+                continue
+            try:
+                similarity = _cosine(embedding, candidate_embedding)
+            except Exception:
+                continue
+            if similarity >= _CONCEPT_EMBEDDING_SIMILARITY_THRESHOLD and similarity > best_similarity:
+                best_similarity = similarity
+                best_candidate = candidate
+
+        if best_candidate is None:
+            return None
+        return self._legacy_concept_key(
+            best_candidate,
+            scope=best_candidate.anchor_scope,
+            subject=str(best_candidate.subject_ref or ""),
+        )
+
+    @staticmethod
+    def _legacy_concept_key(node: BaseSubstrateNodeV1, *, scope: str, subject: str) -> str | None:
+        """The original exact-string concept identity: ``concept_id`` first, then
+        ``label``. Extracted unchanged so both the plain string-match path and the
+        embedding-match path (which recomputes an existing node's own key) share
+        exactly one implementation."""
+        concept_id = str(node.metadata.get("concept_id") or "").strip().lower()
+        if concept_id:
+            return f"concept|{scope}|{subject}|{concept_id}"
+        label = str(getattr(node, "label", "")).strip().lower()
+        if label:
+            return f"concept|{scope}|{subject}|label:{label}"
         return None
 
     @staticmethod

--- a/orion/substrate/seed.py
+++ b/orion/substrate/seed.py
@@ -1,0 +1,174 @@
+"""Loader for the golden concept seed fixture (Phase 1, concept-atlas).
+
+Reads `orion/substrate/seed_concepts.yaml` and writes a fixed set of
+hand-authored, canonical `ConceptNodeV1` nodes (plus their cross-reference
+edges) directly into a `SubstrateGraphStore`. This bypasses any
+extraction/clustering pipeline entirely -- it exists to give Orion's
+cognition an immediate, inspectable self/other/relationship floor
+(Orion, Juniper, and the Orion-Juniper relationship) before organic
+concept induction has produced anything.
+
+This is intentionally a fixed 3-row fixture loader, not a general-purpose
+seeding framework. Do not extend it into a plugin system for future seed
+sets -- add a new fixture + loader when that need actually exists.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateEdgeV1,
+    SubstrateProvenanceV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.store import SubstrateGraphStore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SEED_CONCEPTS_PATH = Path(__file__).with_name("seed_concepts.yaml")
+
+
+def _seed_provenance(*, key: str) -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="human_verified",
+        source_kind="golden_seed_fixture",
+        source_channel="orion:substrate:seed_concepts",
+        producer="seed_concepts_loader",
+        evidence_refs=[f"seed_concepts.yaml#{key}"],
+    )
+
+
+def _seed_temporal() -> SubstrateTemporalWindowV1:
+    return SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc))
+
+
+def load_seed_concept_nodes(
+    fixture_path: str | Path | None = None,
+) -> tuple[list[ConceptNodeV1], list[SubstrateEdgeV1]]:
+    """Parse the seed fixture into ConceptNodeV1/SubstrateEdgeV1 objects.
+
+    Degrades gracefully: any missing file, unreadable YAML, or malformed
+    entry is logged and skipped rather than raised, so callers never crash
+    on a bad fixture. Returns (nodes, edges); either or both may be empty.
+    """
+
+    path = Path(fixture_path) if fixture_path is not None else DEFAULT_SEED_CONCEPTS_PATH
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("seed_concepts: could not read fixture at %s: %s", path, exc)
+        return [], []
+
+    try:
+        parsed: Any = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        logger.warning("seed_concepts: could not parse YAML at %s: %s", path, exc)
+        return [], []
+
+    entries = parsed.get("concepts") if isinstance(parsed, dict) else None
+    if not isinstance(entries, list):
+        logger.warning("seed_concepts: fixture at %s has no `concepts` list; skipping", path)
+        return [], []
+
+    nodes: list[ConceptNodeV1] = []
+    node_id_by_key: dict[str, str] = {}
+    pending_edges: list[tuple[str, list[str]]] = []
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            logger.warning("seed_concepts: skipping non-mapping entry %r", entry)
+            continue
+
+        key = str(entry.get("key") or "").strip()
+        label = str(entry.get("label") or "").strip()
+        anchor_scope = entry.get("anchor_scope")
+        if not key or not label or not anchor_scope:
+            logger.warning("seed_concepts: skipping entry missing key/label/anchor_scope: %r", entry)
+            continue
+
+        node_id = f"sub-concept-seed-{key}"
+        try:
+            node = ConceptNodeV1(
+                node_id=node_id,
+                anchor_scope=anchor_scope,
+                subject_ref=entry.get("subject_ref") or key,
+                promotion_state="canonical",
+                temporal=_seed_temporal(),
+                provenance=_seed_provenance(key=key),
+                label=label,
+                definition=entry.get("definition"),
+            )
+        except Exception as exc:  # noqa: BLE001 - malformed fixture row must not crash callers
+            logger.warning("seed_concepts: skipping invalid entry %r: %s", entry, exc)
+            continue
+
+        nodes.append(node)
+        node_id_by_key[key] = node_id
+
+        related_keys = entry.get("related_concept_keys") or []
+        if isinstance(related_keys, list) and related_keys:
+            pending_edges.append((key, [str(item) for item in related_keys]))
+
+    edges: list[SubstrateEdgeV1] = []
+    for source_key, related_keys in pending_edges:
+        source_node_id = node_id_by_key.get(source_key)
+        if not source_node_id:
+            continue
+        for related_key in related_keys:
+            target_node_id = node_id_by_key.get(related_key)
+            if not target_node_id:
+                logger.warning(
+                    "seed_concepts: skipping edge %s -> %s (unknown related key)",
+                    source_key,
+                    related_key,
+                )
+                continue
+            edges.append(
+                SubstrateEdgeV1(
+                    edge_id=f"sub-edge-seed-{source_key}-{related_key}",
+                    source=NodeRefV1(node_id=source_node_id, node_kind="concept"),
+                    target=NodeRefV1(node_id=target_node_id, node_kind="concept"),
+                    predicate="associated_with",
+                    temporal=_seed_temporal(),
+                    provenance=_seed_provenance(key=f"{source_key}-{related_key}"),
+                )
+            )
+
+    return nodes, edges
+
+
+def load_seed_concepts_into_store(
+    store: SubstrateGraphStore,
+    *,
+    fixture_path: str | Path | None = None,
+) -> int:
+    """Write the golden seed concepts (+ edges) into `store`.
+
+    Returns the number of concept nodes written. Never raises on a
+    missing/malformed fixture -- logs and returns 0 instead.
+    """
+
+    nodes, edges = load_seed_concept_nodes(fixture_path)
+
+    for node in nodes:
+        store.upsert_node(
+            identity_key=f"concept|{node.anchor_scope}|{node.subject_ref}|seed",
+            node=node,
+        )
+
+    for edge in edges:
+        store.upsert_edge(
+            identity_key=f"{edge.source.node_id}|{edge.predicate}|{edge.target.node_id}",
+            edge=edge,
+        )
+
+    return len(nodes)

--- a/orion/substrate/seed_concepts.yaml
+++ b/orion/substrate/seed_concepts.yaml
@@ -1,0 +1,49 @@
+# Golden concept seed fixture (Phase 1, concept-atlas-graph-pipeline).
+#
+# Fixed, hand-authored concepts written directly into the substrate graph
+# store at promotion_state="canonical" -- bypassing extraction/clustering.
+# Gives Orion's cognition an immediate, inspectable self/other/relationship
+# floor before organic concept induction produces anything.
+#
+# Loaded by orion/substrate/seed.py::load_seed_concepts_into_store().
+#
+# Each entry under `concepts` maps 1:1 to a ConceptNodeV1
+# (orion/core/schemas/cognitive_substrate.py). `key` is a short local
+# identifier used only within this fixture to build node ids and to wire
+# `related_concept_keys` into SubstrateEdgeV1 edges -- it is not itself a
+# schema field.
+concepts:
+  - key: orion
+    anchor_scope: orion
+    subject_ref: orion
+    label: "Orion"
+    definition: >-
+      Orion is the persistent, inspectable digital-mind system this codebase
+      builds: a cognitive architecture with memory, self-coherence,
+      introspection, world contact, and operational agency, developed
+      collaboratively with Juniper.
+
+  - key: juniper
+    anchor_scope: juniper
+    subject_ref: juniper
+    label: "Juniper"
+    definition: >-
+      Juniper is Orion's primary human collaborator and operator: the person
+      who directs, reviews, and works alongside Orion's development and
+      day-to-day operation.
+
+  - key: orion_juniper_relationship
+    anchor_scope: relationship
+    subject_ref: orion_juniper
+    label: "Orion-Juniper relationship"
+    definition: >-
+      The ongoing collaborative relationship between Orion and Juniper:
+      Juniper directs and operates Orion, and Orion is built to develop
+      increasing continuity, perception, memory, and coherent agency through
+      that collaboration.
+    # Local seed-only field (not a ConceptNodeV1 field): keys of the other
+    # concepts in this fixture that this concept should be linked to via
+    # SubstrateEdgeV1(predicate="associated_with") edges.
+    related_concept_keys:
+      - orion
+      - juniper

--- a/orion/substrate/tests/test_reconcile.py
+++ b/orion/substrate/tests/test_reconcile.py
@@ -1,0 +1,248 @@
+"""Regression tests for embedding-aware concept identity resolution.
+
+Covers the Phase 3 fix to SubstrateIdentityResolver.canonical_node_key:
+paraphrased concept labels ("surface encodings" vs "surface-level
+representations") with similar embeddings must resolve to the same canonical
+node identity, while the pre-existing exact-string fallback (for nodes with no
+embedding) must remain unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateProvenanceV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.reconcile import SubstrateIdentityResolver
+from orion.substrate.store import InMemorySubstrateGraphStore
+
+
+def _concept_node(
+    *,
+    node_id: str,
+    label: str,
+    anchor_scope: str = "orion",
+    subject_ref: str = "project:atlas",
+    embedding: list[float] | None = None,
+) -> ConceptNodeV1:
+    metadata: dict = {}
+    if embedding is not None:
+        metadata["concept_embedding"] = embedding
+    return ConceptNodeV1(
+        node_id=node_id,
+        anchor_scope=anchor_scope,
+        subject_ref=subject_ref,
+        label=label,
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="test",
+            producer="test_reconcile",
+        ),
+        metadata=metadata,
+    )
+
+
+def test_similar_embeddings_resolve_to_same_identity_across_paraphrased_labels() -> None:
+    store = InMemorySubstrateGraphStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    # Cosine similarity of these two vectors is ~0.9986, comfortably >= the 0.8
+    # threshold reused from ConceptClusterer.
+    existing = _concept_node(
+        node_id="node-a",
+        label="surface encodings",
+        embedding=[1.0, 1.0, 0.0],
+    )
+    incoming = _concept_node(
+        node_id="node-b",
+        label="surface-level representations",
+        embedding=[1.0, 0.9, 0.0],
+    )
+
+    existing_key = resolver.canonical_node_key(existing)
+    assert existing_key is not None
+    store.upsert_node(identity_key=existing_key, node=existing)
+
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key == existing_key, (
+        "paraphrased concept with a similar embedding must resolve to the "
+        "existing node's identity key so materialization merges them"
+    )
+
+
+def test_dissimilar_embeddings_do_not_merge() -> None:
+    store = InMemorySubstrateGraphStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    existing = _concept_node(
+        node_id="node-a",
+        label="surface encodings",
+        embedding=[1.0, 0.0, 0.0],
+    )
+    incoming = _concept_node(
+        node_id="node-b",
+        label="totally unrelated topic",
+        embedding=[0.0, 1.0, 0.0],
+    )
+
+    existing_key = resolver.canonical_node_key(existing)
+    assert existing_key is not None
+    store.upsert_node(identity_key=existing_key, node=existing)
+
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key != existing_key
+
+
+def test_no_embedding_falls_back_to_exact_label_match_unchanged() -> None:
+    """Regression guard: two nodes with different labels and NO embeddings must
+    still resolve to different identities -- the pre-existing exact-string
+    behavior must not be broken by the embedding-match addition."""
+    store = InMemorySubstrateGraphStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    existing = _concept_node(node_id="node-a", label="surface encodings")
+    incoming = _concept_node(node_id="node-b", label="surface-level representations")
+
+    existing_key = resolver.canonical_node_key(existing)
+    assert existing_key is not None
+    store.upsert_node(identity_key=existing_key, node=existing)
+
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key != existing_key
+    assert incoming_key == f"concept|orion|project:atlas|label:surface-level representations"
+
+
+def test_no_embedding_same_label_still_merges() -> None:
+    """Same-label nodes with no embeddings keep matching via the legacy path."""
+    store = InMemorySubstrateGraphStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    existing = _concept_node(node_id="node-a", label="coherence")
+    incoming = _concept_node(node_id="node-b", label="Coherence")
+
+    existing_key = resolver.canonical_node_key(existing)
+    assert existing_key is not None
+    store.upsert_node(identity_key=existing_key, node=existing)
+
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key == existing_key
+
+
+def test_resolver_without_store_behaves_exactly_like_legacy_resolver() -> None:
+    """Default construction (no store) -- what every existing caller does today
+    (e.g. SubstrateGraphMaterializer's ``identity_resolver or
+    SubstrateIdentityResolver()``) -- must be unaffected even when nodes DO carry
+    embeddings, since there is no store to compare against."""
+    resolver = SubstrateIdentityResolver()
+
+    node_a = _concept_node(node_id="node-a", label="surface encodings", embedding=[1.0, 1.0, 0.0])
+    node_b = _concept_node(node_id="node-b", label="surface-level representations", embedding=[1.0, 0.9, 0.0])
+
+    key_a = resolver.canonical_node_key(node_a)
+    key_b = resolver.canonical_node_key(node_b)
+
+    assert key_a != key_b
+    assert key_a == "concept|orion|project:atlas|label:surface encodings"
+    assert key_b == "concept|orion|project:atlas|label:surface-level representations"
+
+
+def test_malformed_embedding_degrades_to_label_match_without_raising() -> None:
+    store = InMemorySubstrateGraphStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    existing = _concept_node(node_id="node-a", label="surface encodings")
+    store.upsert_node(
+        identity_key="concept|orion|project:atlas|label:surface encodings",
+        node=existing,
+    )
+
+    incoming = _concept_node(node_id="node-b", label="surface-level representations")
+    # Malformed embedding: not a list of numbers.
+    incoming = incoming.model_copy(update={"metadata": {"concept_embedding": "not-a-vector"}})
+
+    # Must not raise, and must fall back to the legacy label-based key.
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key == "concept|orion|project:atlas|label:surface-level representations"
+
+
+def test_store_read_error_degrades_to_label_match_without_raising() -> None:
+    """If the store's read_concept_region raises (e.g. a graphdb backend that's
+    temporarily unreachable), the resolver must degrade to the legacy label match
+    rather than propagate the error."""
+
+    class _ExplodingStore(InMemorySubstrateGraphStore):
+        def read_concept_region(self, *, limit_nodes: int = 32, limit_edges: int = 64):  # noqa: D401
+            raise RuntimeError("store unreachable")
+
+    store = _ExplodingStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    incoming = _concept_node(
+        node_id="node-b",
+        label="surface-level representations",
+        embedding=[1.0, 0.9, 0.0],
+    )
+
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key == "concept|orion|project:atlas|label:surface-level representations"
+
+
+def test_one_sided_embedding_presence_falls_back_to_label_match() -> None:
+    """An existing node with no embedding cannot be embedding-matched even when the
+    incoming node has one -- there's nothing to compare cosine similarity against."""
+    store = InMemorySubstrateGraphStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    existing = _concept_node(node_id="node-a", label="surface encodings")  # no embedding
+    existing_key = resolver.canonical_node_key(existing)
+    assert existing_key is not None
+    store.upsert_node(identity_key=existing_key, node=existing)
+
+    incoming = _concept_node(
+        node_id="node-b",
+        label="surface-level representations",
+        embedding=[1.0, 0.9, 0.0],
+    )
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key != existing_key
+    assert incoming_key == "concept|orion|project:atlas|label:surface-level representations"
+
+
+def test_embedding_match_only_considers_same_scope_and_subject() -> None:
+    store = InMemorySubstrateGraphStore()
+    resolver = SubstrateIdentityResolver(store=store)
+
+    existing = _concept_node(
+        node_id="node-a",
+        label="surface encodings",
+        anchor_scope="orion",
+        subject_ref="project:atlas",
+        embedding=[1.0, 1.0, 0.0],
+    )
+    existing_key = resolver.canonical_node_key(existing)
+    assert existing_key is not None
+    store.upsert_node(identity_key=existing_key, node=existing)
+
+    # Same embedding, but a different subject_ref -- must NOT merge across subjects.
+    incoming = _concept_node(
+        node_id="node-b",
+        label="surface-level representations",
+        anchor_scope="orion",
+        subject_ref="project:other",
+        embedding=[1.0, 0.9, 0.0],
+    )
+    incoming_key = resolver.canonical_node_key(incoming)
+
+    assert incoming_key != existing_key

--- a/orion/substrate/tests/test_seed_concepts.py
+++ b/orion/substrate/tests/test_seed_concepts.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orion.substrate.seed import (
+    DEFAULT_SEED_CONCEPTS_PATH,
+    load_seed_concept_nodes,
+    load_seed_concepts_into_store,
+)
+from orion.substrate.store import InMemorySubstrateGraphStore
+
+
+def test_load_seed_concepts_into_store_writes_three_canonical_concepts() -> None:
+    store = InMemorySubstrateGraphStore()
+
+    written = load_seed_concepts_into_store(store)
+    assert written == 3
+
+    result = store.query_concept_region(limit_nodes=32, limit_edges=64)
+    assert result.query_kind == "concept_region"
+
+    labels = {node.label for node in result.slice.nodes}
+    assert labels == {"Orion", "Juniper", "Orion-Juniper relationship"}
+
+    scopes = {node.anchor_scope for node in result.slice.nodes}
+    assert scopes == {"orion", "juniper", "relationship"}
+
+    assert len(result.slice.nodes) == 3
+    for node in result.slice.nodes:
+        assert node.promotion_state == "canonical"
+        assert node.node_kind == "concept"
+        assert node.definition
+
+
+def test_load_seed_concepts_into_store_wires_relationship_edges() -> None:
+    store = InMemorySubstrateGraphStore()
+    load_seed_concepts_into_store(store)
+
+    result = store.query_concept_region(limit_nodes=32, limit_edges=64)
+    edge_pairs = {(edge.source.node_id, edge.target.node_id, edge.predicate) for edge in result.slice.edges}
+
+    assert (
+        "sub-concept-seed-orion_juniper_relationship",
+        "sub-concept-seed-orion",
+        "associated_with",
+    ) in edge_pairs
+    assert (
+        "sub-concept-seed-orion_juniper_relationship",
+        "sub-concept-seed-juniper",
+        "associated_with",
+    ) in edge_pairs
+
+
+def test_load_seed_concept_nodes_missing_file_degrades_gracefully() -> None:
+    nodes, edges = load_seed_concept_nodes(Path("/nonexistent/seed_concepts.yaml"))
+    assert nodes == []
+    assert edges == []
+
+
+def test_load_seed_concept_nodes_malformed_yaml_degrades_gracefully(tmp_path: Path) -> None:
+    bad_file = tmp_path / "bad.yaml"
+    bad_file.write_text("not_a_concepts_list: true\n", encoding="utf-8")
+
+    nodes, edges = load_seed_concept_nodes(bad_file)
+    assert nodes == []
+    assert edges == []
+
+
+def test_default_seed_concepts_path_exists() -> None:
+    assert DEFAULT_SEED_CONCEPTS_PATH.exists()

--- a/tests/test_cognitive_substrate_topic_foundry_adapter.py
+++ b/tests/test_cognitive_substrate_topic_foundry_adapter.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.cognitive_substrate import SubstrateGraphRecordV1
+from orion.substrate.adapters.topic_foundry import map_topic_foundry_run_to_substrate
+
+
+def _topics() -> list[dict]:
+    return [
+        {"topic_id": -1, "count": 411, "outlier_pct": 1.0, "label": None},
+        {"topic_id": 0, "count": 200, "outlier_pct": 0.0, "label": None},
+        {"topic_id": 1, "count": 39, "outlier_pct": 0.0, "label": None},
+        {"topic_id": 2, "count": 2, "outlier_pct": 0.0, "label": None},  # below min_doc_count floor
+    ]
+
+
+def _keywords_by_topic() -> dict[int, list[str]]:
+    return {
+        0: ["like", "meow", "just", "user", "assistant", "juniper", "let", "hi"],
+        1: ["memory", "recall", "context", "graph"],
+        2: ["stray", "noise"],
+    }
+
+
+def test_outlier_bucket_never_produces_a_node() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+    )
+    concept_ids = {n.metadata.get("topic_id") for n in out.nodes if n.node_kind == "concept"}
+    assert -1 not in concept_ids
+
+
+def test_thin_topic_below_floor_produces_no_node() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        min_doc_count=3,
+    )
+    concept_ids = {n.metadata.get("topic_id") for n in out.nodes if n.node_kind == "concept"}
+    assert 2 not in concept_ids
+    assert concept_ids == {0, 1}
+
+
+def test_shared_segment_produces_co_occurs_with_edge() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        segment_topic_map={
+            "window-a": [0, 1],
+            "window-b": [0],
+        },
+    )
+    cooccur_edges = [e for e in out.edges if e.predicate == "co_occurs_with"]
+    assert len(cooccur_edges) == 1
+    edge = cooccur_edges[0]
+    assert {edge.source.node_id, edge.target.node_id} == {
+        "sub-concept-topicfoundry-run-1-0",
+        "sub-concept-topicfoundry-run-1-1",
+    }
+    assert edge.metadata["co_occurrence_count"] == 1
+
+
+def test_cooccurrence_excludes_outlier_and_below_floor_topics() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        segment_topic_map={
+            "window-a": [-1, 0, 2],  # outlier + below-floor topic must not form edges
+        },
+    )
+    cooccur_edges = [e for e in out.edges if e.predicate == "co_occurs_with"]
+    assert cooccur_edges == []
+
+
+def test_every_concept_node_has_non_empty_evidence_ref() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+    )
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert concept_nodes
+    for node in concept_nodes:
+        assert len(node.provenance.evidence_refs) > 0
+        assert all(ref for ref in node.provenance.evidence_refs)
+
+
+def test_evidence_node_and_supports_edge_emitted_per_concept() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+    )
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    evidence_nodes = [n for n in out.nodes if n.node_kind == "evidence"]
+    supports_edges = [e for e in out.edges if e.predicate == "supports"]
+    assert len(evidence_nodes) == len(concept_nodes)
+    assert len(supports_edges) == len(concept_nodes)
+
+
+def test_promotion_state_proposed_and_anchor_scope_world_by_default() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+    )
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert concept_nodes
+    for node in concept_nodes:
+        assert node.promotion_state == "proposed"
+        assert node.anchor_scope == "world"
+
+
+def test_label_falls_back_to_keywords_when_label_is_null() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+    )
+    concept_nodes = {n.metadata["topic_id"]: n for n in out.nodes if n.node_kind == "concept"}
+    assert concept_nodes[0].label == "like / meow / just"
+
+
+def test_uses_label_field_when_non_null() -> None:
+    topics = [{"topic_id": 5, "count": 10, "outlier_pct": 0.0, "label": "Explicit Label"}]
+    out = map_topic_foundry_run_to_substrate(run_id="run-1", topics=topics, keywords_by_topic={})
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert concept_nodes[0].label == "Explicit Label"
+
+
+def test_concept_embedding_stored_in_metadata_when_provided() -> None:
+    topics = [{"topic_id": 7, "count": 10, "outlier_pct": 0.0, "label": "vec topic"}]
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=topics,
+        keywords_by_topic={},
+        topic_embeddings={7: [0.1, 0.2, 0.3]},
+    )
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert concept_nodes[0].metadata["concept_embedding"] == [0.1, 0.2, 0.3]
+
+
+def test_concept_embedding_omitted_when_not_provided() -> None:
+    topics = [{"topic_id": 8, "count": 10, "outlier_pct": 0.0, "label": "no vec topic"}]
+    out = map_topic_foundry_run_to_substrate(run_id="run-1", topics=topics, keywords_by_topic={})
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert "concept_embedding" not in concept_nodes[0].metadata
+
+
+def test_empty_topics_returns_empty_but_valid_record() -> None:
+    out = map_topic_foundry_run_to_substrate(run_id="run-1", topics=[])
+    assert isinstance(out, SubstrateGraphRecordV1)
+    assert out.nodes == []
+    assert out.edges == []
+
+    out_none = map_topic_foundry_run_to_substrate(run_id="run-1", topics=None)
+    assert isinstance(out_none, SubstrateGraphRecordV1)
+    assert out_none.nodes == []
+
+
+def test_malformed_topic_entries_are_skipped_not_raised() -> None:
+    malformed = [
+        {"topic_id": "not-an-int", "count": 10},
+        {"topic_id": None, "count": 10},
+        {"count": 10},  # missing topic_id entirely
+        object(),  # no attributes at all
+        {"topic_id": 3, "count": "also-not-an-int"},  # count coerces to 0, below floor
+    ]
+    out = map_topic_foundry_run_to_substrate(run_id="run-1", topics=malformed)
+    assert isinstance(out, SubstrateGraphRecordV1)
+    assert out.nodes == []
+    assert out.edges == []
+
+
+def test_malformed_segment_topic_map_degrades_gracefully() -> None:
+    topics = [{"topic_id": 0, "count": 10, "outlier_pct": 0.0, "label": "ok"}]
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=topics,
+        keywords_by_topic={},
+        segment_topic_map={"bad-window": "not-iterable-of-ints"},
+    )
+    assert isinstance(out, SubstrateGraphRecordV1)
+    # The single concept node still forms; the malformed window is simply skipped.
+    assert len([n for n in out.nodes if n.node_kind == "concept"]) == 1
+
+
+def test_observed_at_and_subject_ref_propagate() -> None:
+    ts = datetime(2026, 7, 15, 12, 0, 0, tzinfo=timezone.utc)
+    topics = [{"topic_id": 0, "count": 10, "outlier_pct": 0.0, "label": "ok"}]
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=topics,
+        observed_at=ts,
+        subject_ref="project:orion_sapienform",
+    )
+    assert out.subject_ref == "project:orion_sapienform"
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert concept_nodes[0].subject_ref == "project:orion_sapienform"
+    assert concept_nodes[0].temporal.observed_at == ts


### PR DESCRIPTION
## Summary

Wave 1 of the concept-atlas graph pipeline (spec: `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md`), built as four independent parallel subagent tasks and verified/merged by the orchestrator.

- Seeds three golden concepts (Orion, Juniper, Orion-Juniper relationship) directly into the substrate store at `promotion_state="canonical"`, giving an immediate self/other/relationship floor.
- Adds `orion/substrate/adapters/topic_foundry.py`, converting `orion-topic-foundry`'s real (live-verified) cluster output into `ConceptNodeV1`/`SubstrateEdgeV1` records — free `co_occurs_with` edges from same-segment co-occurrence, every node backed by a real evidence ref.
- Fixes a real bug in `orion/substrate/reconcile.py`: concept identity resolution was exact-string match on label only, so paraphrases of the same concept became permanent duplicate nodes. Now does embedding-similarity matching (cosine >= 0.8, reusing `ConceptClusterer`'s already-validated threshold) before falling back to the original string match.
- Fixes `orion/signals/adapters/topic_foundry.py::TopicFoundryAdapter`, a confirmed-fake stub that hardcoded `{"level": 0.5, "confidence": 0.5}` regardless of input. Now derives real values from topic-foundry's drift/run telemetry. Also fixes a bonus bug found along the way: `can_handle()` checked for a literal `"topic_foundry"` substring, but real bus envelope kinds use dots (`topic.foundry.drift.alert.v1`) — the adapter would never have fired in production even with correct derivation logic.

## Outcome moved

The substrate graph schema/store/decay/promotion machinery already existed but had zero real producers (the only prior producer, spaCy-based concept induction, is switched off and has an unfixed noise-filtering defect). This wave gives it: (1) a real, live-verified producer via topic-foundry's unsupervised clustering, (2) a fix for the identity-fragmentation bug that would have undermined that producer regardless, and (3) a real signal instead of a hardcoded constant feeding the homeostatic layer.

## Current architecture

`orion/substrate/` (schema in `orion/core/schemas/cognitive_substrate.py`, `InMemorySubstrateGraphStore` in `orion/substrate/store.py`, materializer in `orion/substrate/materializer.py`) was fully built but fed by nothing live. `orion-topic-foundry` is a separate, real, maintained clustering service, live-verified against 650 real chat-history documents during this effort (2 real topics + outlier bucket, real legible keywords) — previously disconnected from the substrate graph entirely.

## Architecture touched

- `orion/substrate/` — new adapter, reconcile.py fix, seed fixture/loader
- `orion/signals/adapters/topic_foundry.py` — real signal derivation
- No bus/schema contract changes — this wave is deliberately scoped to pure, testable conversion/resolution functions, not wired into any live producer/consumer registry yet (that's Phase 6/8, a follow-up wave)

## Files changed

- `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md`: design spec driving this and the follow-up wave
- `orion/substrate/seed_concepts.yaml`, `orion/substrate/seed.py`, `orion/substrate/tests/test_seed_concepts.py`: golden concept seeding
- `orion/substrate/adapters/topic_foundry.py`, `tests/test_cognitive_substrate_topic_foundry_adapter.py`: topic-foundry → substrate conversion
- `orion/substrate/reconcile.py`, `orion/substrate/tests/test_reconcile.py`: embedding-aware identity resolution
- `orion/signals/adapters/topic_foundry.py`, `orion/signals/adapters/tests/test_topic_foundry_adapter.py`: real signal derivation + `can_handle()` fix

## Schema / bus / API changes

- Added: none (deliberately — `metadata["concept_embedding"]` is a free-form metadata key, not a new typed schema field, to avoid two parallel agents colliding on the same schema file)
- Removed: none
- Renamed: none
- Behavior changed: `SubstrateIdentityResolver.canonical_node_key` now does embedding-similarity matching for `node_kind=="concept"` when a `store` is wired in (optional kwarg, defaults to `None` — zero behavior change for existing callers, since `orion/substrate/materializer.py` is untouched in this wave and still constructs the resolver without a store)
- Compatibility notes: `TopicFoundryAdapter.can_handle()` now also matches dotted envelope kinds (`topic.foundry.*`) in addition to the old underscore substring check — additive, not breaking

## Env/config changes

None.

## Tests run

```
PYTHONPATH=. pytest orion/substrate/tests orion/signals/adapters/tests \
  tests/test_cognitive_substrate_topic_foundry_adapter.py \
  tests/test_cognitive_substrate_phase2_domain_mappings.py \
  tests/test_cognitive_substrate_phase3_materialization.py -q
302 passed, 17 warnings (pre-existing pydantic protected-namespace notices, unrelated)
```

Each of the four sub-tasks was also verified individually by the orchestrator against the actual schema/store/adapter code (not just trusted from agent reports) before merging — field names, method signatures, and the shared `metadata["concept_embedding"]` contract between the topic-foundry adapter and reconcile.py were all cross-checked directly against source.

## Evals run

No eval harness exists yet for this seam. Not building one in this wave — flagged as a gap for a follow-up.

## Docker/build/smoke checks

Not applicable — this wave is pure library-level Python (schema/store/adapter/resolver functions), no new runtime wiring, no service/container changes. `services/orion-topic-foundry` itself was separately live-verified working (real training run, real clusters) earlier in this effort, unrelated to this diff.

## Review findings fixed

- Finding: Phase 3's `_concept_embedding_match_key` initially had no test for the store-read-exception path or one-sided embedding presence.
  - Fix: Added `test_store_read_error_degrades_to_label_match_without_raising` and `test_one_sided_embedding_presence_falls_back_to_label_match`.
  - Evidence: full `orion/substrate/tests` suite re-run after the additions, 215/215 passed at that point (302/302 after merging all four sub-branches together).
- Finding: `TopicFoundryAdapter.can_handle()` checked for a literal `"topic_foundry"` substring; real envelope kinds use dots.
  - Fix: matches both forms now.
  - Evidence: confirmed against `services/orion-signal-gateway/app/processor.py`'s actual `env.kind` usage, plus new test `test_can_handle_real_dotted_kind`.

## Restart required

No restart required. No live services consume any of this yet.

## Risks / concerns

- Severity: low
- Concern: `orion/substrate/materializer.py` still constructs `SubstrateIdentityResolver()` without a store, so the embedding-based merge fix is dormant until a follow-up phase wires `store=self._store` through. Documented explicitly in `reconcile.py`'s docstring so it isn't silently forgotten.
- Mitigation: tracked as part of the Wave 2 follow-up (Phase 4/6/8 wiring), not silently deferred.

## PR link

(filled in after creation)