### PR TITLE
chore: host-level bus-core crash-loop watchdog (no Redis/Postgres dependency)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,11 @@ check-daily-schedule-collisions:
 # or a systemd timer (see that script's docstring / scripts/README.md for install
 # instructions), not from inside a container.
 bus-core-health-watchdog:
-	@python scripts/bus_core_health_watchdog.py $(if $(PROJECT),--project $(PROJECT),)
+	@python scripts/bus_core_health_watchdog.py $(if $(PROJECT),--project $(PROJECT),) \
+		$(if $(TELEMETRY_ROOT),--telemetry-root $(TELEMETRY_ROOT),) \
+		$(if $(UNHEALTHY_STREAK_THRESHOLD),--unhealthy-streak-threshold $(UNHEALTHY_STREAK_THRESHOLD),) \
+		$(if $(RESTART_COUNT_THRESHOLD),--restart-count-threshold $(RESTART_COUNT_THRESHOLD),) \
+		$(if $(RESTART_WINDOW_MINUTES),--restart-window-minutes $(RESTART_WINDOW_MINUTES),)
 
 # Reconciled worktree view -- path, branch, merged-into-main status, open PR,
 # disk size -- regardless of which of this repo's several worktree location

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ check-daily-schedule-collisions:
 # or a systemd timer (see that script's docstring / scripts/README.md for install
 # instructions), not from inside a container.
 bus-core-health-watchdog:
-	@python scripts/bus_core_health_watchdog.py $(if $(PROJECT),--project $(PROJECT),) \
+	@python3 scripts/bus_core_health_watchdog.py $(if $(PROJECT),--project $(PROJECT),) \
 		$(if $(TELEMETRY_ROOT),--telemetry-root $(TELEMETRY_ROOT),) \
 		$(if $(UNHEALTHY_STREAK_THRESHOLD),--unhealthy-streak-threshold $(UNHEALTHY_STREAK_THRESHOLD),) \
 		$(if $(RESTART_COUNT_THRESHOLD),--restart-count-threshold $(RESTART_COUNT_THRESHOLD),) \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
+.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions bus-core-health-watchdog worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
 
 SERVICE ?=
 ARGS ?=
@@ -87,6 +87,18 @@ check-journal-dispatch-registry:
 # this isn't a hard gate today.
 check-daily-schedule-collisions:
 	@python scripts/check_daily_schedule_collisions.py $(if $(THRESHOLD_MINUTES),--threshold-minutes $(THRESHOLD_MINUTES),) $(if $(FAIL_ON_COLLISION),--fail-on-collision,)
+
+# Host-level crash-loop detector for bus-core (Redis, services/orion-bus/docker-
+# compose.yml). Reads container health/restart-count via `docker inspect` ONLY --
+# no Redis connection, no Postgres connection -- so it still works when both are
+# down at the same time (a confirmed, not hypothetical, dev failure mode). Writes
+# local JSON state and, on a crash-loop signature, a plain marker file (this repo
+# has no notify-send/osascript/desktop-notification mechanism to reuse -- see
+# scripts/bus_core_health_watchdog.py's docstring). Intended to run via host cron
+# or a systemd timer (see that script's docstring / scripts/README.md for install
+# instructions), not from inside a container.
+bus-core-health-watchdog:
+	@python scripts/bus_core_health_watchdog.py $(if $(PROJECT),--project $(PROJECT),)
 
 # Reconciled worktree view -- path, branch, merged-into-main status, open PR,
 # disk size -- regardless of which of this repo's several worktree location

--- a/docs/superpowers/pr-reports/2026-07-16-bus-core-health-watchdog-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-bus-core-health-watchdog-pr.md
@@ -1,0 +1,320 @@
+# PR report — host-level bus-core crash-loop watchdog
+
+PR: (create at https://github.com/junebug-junie/Orion-Sapienform/pull/new/chore/bus-core-health-watchdog)
+Branch: `chore/bus-core-health-watchdog`
+Status: **DONE**
+
+## Summary
+
+- `bus-core` (Redis, `services/orion-bus/docker-compose.yml`) periodically
+  crash-loops from AOF corruption (a parallel task is adding auto-repair for
+  that -- not touched here). The real gap: detecting "bus is stuck in a crash
+  loop" today depends on either a human noticing cascading failures across
+  many *other* services, or on signals that themselves route through the bus
+  or Postgres -- both of which can be down *at the same time* in dev
+  (confirmed by Juniper, not hypothetical).
+- Added `scripts/bus_core_health_watchdog.py`: a standalone, host-level
+  (non-containerized) script that reads `docker inspect`'s
+  `.State.Health.Status`/`.RestartCount` for the real
+  `orion-orion-athena-bus-core` container only -- zero Redis connection, zero
+  Postgres connection, ever. Two independent crash-loop signatures (either
+  fires an alert): a consecutive-unhealthy streak (default 3), and a
+  restart-count-within-window (default 3 restarts / 10 minutes) that catches
+  a loop fast enough it never settles into `unhealthy` between polls.
+- Grepped the repo first for an existing desktop-notification mechanism
+  (`notify-send`, `osascript`) or house alerting pattern -- none exists.
+  The one HTTP alert path that does exist (`orion-notify`'s
+  `/attention/request`, used by `orion-mesh-guardian` and the Fuseki
+  recover job) is itself infrastructure that could plausibly be down in the
+  same incident this watchdog exists to catch, so it was deliberately not
+  reused. On alert: a plain, loud, never-auto-deleted marker file at
+  `${TELEMETRY_ROOT}/${PROJECT}/bus/ORION_BUS_CRASH_LOOP_ALERT.txt`.
+- State persists to `${TELEMETRY_ROOT}/${PROJECT}/bus/watchdog/health_watchdog_state.json`
+  -- a sibling of, not inside, the AOF data mount at `.../bus/data` that a
+  parallel AOF-repair task may also be touching.
+- Matched this repo's dominant existing convention for this exact job shape
+  (`scripts/check_concept_relation_digest_liveness.py` +
+  `services/orion-rdf-store/README.md`'s "Scheduled maintenance" crontab
+  section) rather than the one systemd-timer precedent found (a single
+  long-running nightly backup job, not this repeated-fast-poll shape, and
+  only present in a gitignored worktree, not a fresh checkout).
+- A high-effort code-review subagent pass found 5 real Important-severity
+  gaps (state-file/marker-file concurrency race, an uncaught-exception
+  exit-code collision, an unguarded `KeyError` on malformed persisted data)
+  -- all fixed, with new regression tests locking each fix in. See "Review
+  findings fixed" below.
+
+## Outcome moved
+
+Detecting a `bus-core` crash loop no longer requires the bus or Postgres to
+be reachable. Previously: nothing. Now: a host cron job that reads container
+health directly from Docker, persists its own state to local disk, and
+writes an impossible-to-miss marker file the moment a crash-loop signature
+is met -- verified end to end against both the real, currently-running
+`orion-orion-athena-bus-core` container (healthy path) and a fake `docker`
+binary simulating 3 consecutive unhealthy checks (alert path, including
+recovery clearing the state but not deleting the marker).
+
+## Current architecture
+
+`services/orion-bus/docker-compose.yml` defines `bus-core` (Redis 7, AOF
+persistence, `container_name: orion-${PROJECT}-bus-core`) with a native
+Docker healthcheck (`redis-cli ping`, 5s interval, 5 retries -> ~25s to
+`unhealthy`), plus `bus-exporter` (Prometheus) and `bus-observer` (a
+containerized service that itself depends on the bus being up to observe
+it -- exactly the blind spot this watchdog exists outside of). No prior
+host-level, bus/Postgres-independent liveness check existed for this
+container. The closest analogous pattern in this repo is
+`scripts/check_concept_relation_digest_liveness.py`, a standalone
+Postgres-backed liveness gate for a different cron job, run the same way
+(host cron, not a live service loop).
+
+## Architecture touched
+
+Host-level only. No container, service, schema, or bus contract was
+touched. `services/orion-bus/docker-compose.yml`'s own definition and
+`bus-core`'s entrypoint were explicitly left alone per the task brief (a
+parallel task owns AOF auto-repair there).
+
+## Files changed
+
+- `scripts/bus_core_health_watchdog.py` (new): the watchdog. Pure
+  `evaluate()` function (no I/O, takes `now` as a parameter) for the
+  threshold/alert logic; `inspect_container()` wraps `docker inspect` via
+  `subprocess`; `run()`/`main()` wire persistence, locking, and the CLI.
+- `tests/test_bus_core_health_watchdog.py` (new, 40 tests): pure-logic
+  tests against fake health-check sequences (streaks, neutral statuses,
+  restart-count windows including a container-recreation/RestartCount-reset
+  scenario, malformed persisted samples), mocked-subprocess tests for the
+  `docker inspect` parsing boundary (including the real lowercase
+  `"no such object"` wording observed from this host's docker CLI), and
+  end-to-end tests against real temp files for state persistence, atomic
+  writes, locking, and `main()`'s exit codes.
+- `Makefile`: new `bus-core-health-watchdog` target, mirroring the existing
+  `concept-relation-digest` / `check-concept-relation-digest-liveness`
+  pattern (`PROJECT` passthrough).
+- `services/orion-bus/README.md`: new "Host-level crash-loop watchdog"
+  section under Monitoring -- what it detects and why, default paths, the
+  first-install permission gotcha on this host, and the crontab install
+  block.
+- `scripts/README.md`: short discoverability entry alongside this repo's
+  other host-level gate/check scripts.
+
+## Schema / bus / API changes
+
+None. This script has no bus, schema, or API surface -- it is intentionally
+outside all of those (that independence is the entire point).
+
+## Env/config changes
+
+None added. The script reads `$PROJECT`/`$TELEMETRY_ROOT` (both already
+present in `.env_example`/`.env`, no new keys) purely as CLI-flag defaults,
+overridable via `--project`/`--telemetry-root`/`--container`/`--state-file`/
+`--alert-marker`.
+
+## Tests run
+
+```text
+/mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest tests/test_bus_core_health_watchdog.py -q
+=> 40 passed
+
+/mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest tests/test_bus_core_health_watchdog.py tests/test_check_concept_relation_digest_liveness.py -q
+=> 48 passed
+
+/mnt/scripts/Orion-Sapienform/venv/bin/python -m py_compile scripts/bus_core_health_watchdog.py
+=> OK
+
+git diff --check
+=> clean
+```
+
+Full `tests/` collection was also run for context: 33 pre-existing
+collection errors on unrelated service test files (missing per-service
+`conftest`/path setup), confirmed identical on `main` before this branch --
+not caused by this patch.
+
+## Evals run
+
+None applicable -- this is a deterministic gate script (matches
+`AGENTS.md` §11's "Gate tests" category, same as
+`check_concept_relation_digest_liveness.py`), not a quality/behavior
+measurement that needs an eval harness.
+
+## Docker/build/smoke checks
+
+Live, read-only `docker inspect` smoke against the real running container:
+
+```text
+$ python3 scripts/bus_core_health_watchdog.py --state-file <scratch>/state.json --alert-marker <scratch>/ALERT.txt --json
+{"container": "orion-orion-athena-bus-core", ..., "crash_loop_detected": false,
+ "last_health_status": "healthy", "last_restart_count": 0, "container_status": "running", ...}
+exit: 0
+```
+
+Confirmed real container name is `orion-orion-athena-bus-core`
+(`orion-${PROJECT}-bus-core` with `PROJECT=orion-athena` from `.env`,
+matching `services/orion-bus/docker-compose.yml`'s `container_name`), and
+the resulting state-file JSON has the exact shape asserted by the test
+suite's shape-regression test.
+
+End-to-end crash-loop simulation via a fake `docker` binary (real
+subprocess, real file writes, not mocked):
+
+```text
+run 1: unhealthy, streak=1 -> exit 0
+run 2: unhealthy, streak=2 -> exit 0
+run 3: unhealthy, streak=3 -> CRASH LOOP DETECTED, marker written -> exit 1
+recovery run: healthy -> exit 0, marker NOT deleted, RESOLVED footer appended
+```
+
+No Docker build/compose changes -- nothing to build; this script runs
+outside any container.
+
+`scripts/safe_graphify_update.sh` was run per repo convention: it correctly
+refused (node count 32529 -> 2522, ~92% drop -- the same known,
+root-cause-unidentified `graphify update .` bug from the 2026-07-14
+incident, unrelated to this patch) and auto-restored `graph.json`. Stray
+generated artifacts from the refused run (`GRAPH_REPORT.md` diff,
+`.graphify_labels.json`, `.graphify_root`, `graph.html`) were reverted/removed
+so they don't pollute this PR. Per the documented guidance, did not force a
+full re-extraction (out of scope, expensive, and the wrapper's own note says
+not to just re-run it blindly).
+
+## Review findings fixed
+
+High-effort code-review subagent (`orion-repo-agent`, git-range
+`020501bf` vs its parent), full findings below:
+
+- **Finding (Important #1)**: No lock guarded the state-file
+  read-evaluate-write cycle in `run()`. Two overlapping cron invocations
+  (e.g. one run still waiting on a hung `docker inspect`, up to the 15s
+  subprocess timeout, when the next minute's cron fires) could silently
+  clobber each other's streak increment -- the exact race shape
+  `services/orion-rdf-store/README.md` documents a real incident from (a
+  plain existence-check lock, not `flock`, raced its own cron job).
+  - **Fix**: added `_StateLock`, a non-blocking `flock` on
+    `<state_file>.lock`. A run that can't acquire it raises
+    `WatchdogLockedError` and `main()` treats that as a clean skip (exit 0,
+    no state mutation) rather than a failure.
+  - **Evidence**: `test_state_lock_blocks_concurrent_acquisition`,
+    `test_state_lock_is_released_after_context_exit`,
+    `test_run_skips_cleanly_when_lock_already_held`,
+    `test_main_exits_zero_when_lock_already_held` -- all pass.
+- **Finding (Important #2)**: the alert marker (`write_alert_marker`,
+  `append_resolved_footer`) used plain `write_text()`/`open(..., "a")`,
+  unlike the state file's atomic `mkstemp`+`os.replace`, despite being the
+  file a human reads live during an incident.
+  - **Fix**: extracted a shared `_atomic_write_text()` helper; both marker
+    functions now use it (the resolved-footer append reads existing
+    content, concatenates, and atomically replaces rather than appending in
+    place).
+  - **Evidence**: `test_alert_marker_write_is_atomic_no_leftover_temp_files`,
+    `test_resolved_footer_append_is_atomic_and_preserves_original_content`.
+- **Finding (Important #3)**: uncaught `OSError`/`PermissionError` from
+  `mkdir`/write (e.g. the telemetry directory not yet created/chowned on a
+  fresh host -- confirmed live and already documented in
+  `services/orion-bus/README.md` as a real first-install gotcha on this
+  exact host) would exit 1 by Python's default uncaught-exception behavior,
+  indistinguishable from "crash loop detected" (also exit 1) to anything
+  consuming only the exit code.
+  - **Fix**: `main()` now explicitly catches `OSError` and maps it to exit
+    2 (same family as `DockerUnavailableError`), with a message pointing at
+    the README's permissions section.
+  - **Evidence**: `test_main_exits_two_not_one_on_permission_error_writing_state`.
+- **Finding (Important #4)**: `evaluate()`'s
+  `min(s["restart_count"] for s in samples)` would raise `KeyError` on a
+  persisted sample missing/with a non-int `restart_count` (e.g. a
+  hand-edited or partially-migrated state file) -- the one place in the
+  module that didn't match the "never raises except for genuine tooling
+  failure" contract already established for `inspect_container`/`load_state`.
+  - **Fix**: `prune_restart_samples()` now validates `restart_count` is an
+    `int`, not just that `at` parses, dropping malformed samples instead of
+    letting them reach `min()`.
+  - **Evidence**: `test_evaluate_ignores_malformed_restart_samples_without_crashing`.
+- **Finding (Important #5)**: no test exercised the RestartCount-reset
+  (container recreation, not just restart) scenario, even though the task
+  brief specifically flagged it -- the reviewer confirmed by hand-tracing
+  that the existing `min()`-over-window logic happens to handle it
+  correctly, but nothing locked that in against a future "simplification"
+  that would silently break it.
+  - **Fix**: added an explicit code comment on why `min()` over the
+    window's values (not the earliest sample) is deliberate, plus a
+    regression test simulating a real recreation (`RestartCount` climbing
+    47->48->49, then resetting to 0, then climbing 1->2->3, correctly
+    re-baselining and firing at the right point).
+  - **Evidence**: `test_restart_count_reset_from_container_recreation_rebaselines`.
+- **Finding (Minor)**: `services/orion-bus/README.md` cited
+  `.worktrees/local-mnt-scripts-backup/deploy/systemd/` as the repo's
+  systemd-timer precedent -- that path only exists in a gitignored worktree
+  on this host, not on a fresh checkout, making the citation fragile.
+  - **Fix**: now cites the tracked plan doc
+    (`docs/superpowers/plans/2026-05-09-local-mnt-scripts-backup-implementation.md`)
+    instead.
+  - **Evidence**: confirmed via `find` that the `.worktrees/` path is
+    real-but-gitignored on this host, while the plan doc is tracked.
+- **Finding (Minor, not fixed)**: `entry = parsed[0]` in
+  `inspect_container()` assumes `docker inspect <name>` on a single name
+  always returns exactly one array element matching a container. If a
+  differently-namespaced Docker object (volume, network) happened to share
+  the exact name, this would silently read as `health_status="none"`
+  rather than surfacing anything unusual. Reviewer flagged this as
+  extremely unlikely given the container name is
+  `orion-${PROJECT}-bus-core` -- accepted as-is, not worth the added
+  complexity for a near-zero-probability collision.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+This is a new, standalone host-level script -- nothing to restart. It only
+becomes live once the crontab line below is installed by hand (see
+"Confusion protocol"-adjacent note below: host crontab is shared
+infrastructure and was deliberately not modified automatically, per
+`AGENTS.md`).
+
+**Exact install command (report only, not run by this session):**
+
+```bash
+crontab -e
+# then paste:
+* * * * * cd /mnt/scripts/Orion-Sapienform && make bus-core-health-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-bus-core-health-watchdog.log 2>&1
+```
+
+**One-time prerequisite** (the default state/marker directory is
+`root:root` 755 on this host):
+
+```bash
+sudo mkdir -p /mnt/telemetry/orion-athena/bus/watchdog
+sudo chown "$(whoami)":"$(whoami)" /mnt/telemetry/orion-athena/bus/watchdog
+```
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the every-minute cron cadence assumes cron itself and the host's
+  clock are reliable -- if cron is not running (a different failure mode
+  entirely, outside this patch's scope), this watchdog is silent, same as
+  every other cron-based gate in this repo (`check_concept_relation_digest_liveness.py`
+  included). Not a new gap, an inherited one.
+- Severity: low
+- Concern: the alert marker is never auto-deleted by design (so an incident
+  is never silently lost), which means a human must remember to `rm` it
+  after reviewing. If that's forgotten, a *second*, unrelated crash loop
+  weeks later would still write into (technically: atomically replace) the
+  same marker file, but the `detected_first_at` timestamp inside it would
+  be stale/misleading relative to the new incident until a human notices
+  the marker already existed. Acceptable tradeoff per the task's explicit
+  "impossible to miss, human decides when to clear" design goal, but worth
+  flagging as a manual-process dependency.
+- Severity: low
+- Concern: `entry = parsed[0]` in `inspect_container()` assumes exactly one
+  matching Docker object for the given name (see Review findings, last
+  Minor item, not fixed) -- near-zero real-world probability given the
+  container-naming convention, documented as an accepted gap rather than
+  silently ignored.
+
+## PR link
+
+`gh` is authenticated in this environment; PR to be opened from this branch.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,6 +63,18 @@ Expected output when the registry is complete:
 check_journal_dispatch_registry: OK -- all 8 trigger_kind(s) in _TRIGGER_TO_MODE have a JOURNAL_DISPATCH_REGISTRY row.
 ```
 
+## Bus-Core Health Watchdog (crash-loop detector, no Redis/Postgres dependency)
+`bus-core` (`services/orion-bus/docker-compose.yml`, Redis) periodically crash-loops from AOF corruption. Detecting this today depends on a human noticing cascading failures elsewhere, or on signals that themselves route through the bus or Postgres — both of which can be down at the same time in dev. This is a host-level detection floor that survives both being down simultaneously: it reads `docker inspect`'s `.State.Health.Status`/`.RestartCount` for the real `orion-${PROJECT}-bus-core` container only, no Redis or Postgres connection at all. Persists state to a local JSON file; on a crash-loop signature (default: 3 consecutive unhealthy checks, or 3 restarts within a 10-minute window), writes a loud, never-auto-deleted marker file — see `services/orion-bus/README.md`'s "Host-level crash-loop watchdog" section for the exact marker path and cron install instructions.
+```bash
+python scripts/bus_core_health_watchdog.py
+# or: make bus-core-health-watchdog
+```
+Expected output when healthy:
+```
+bus_core_health_watchdog: orion-orion-athena-bus-core health=healthy consecutive_unhealthy=0 restarts_in_window=0
+bus_core_health_watchdog: OK -- no crash-loop signature.
+```
+
 ## Daily Schedule Collision Check (orion-actions cadences)
 `services/orion-actions/.env_example` gives Daily Pulse, World Pulse, and Daily Metacog their own hour/minute pairs, but Daily Journal has no env var of its own — `services/orion-actions/app/main.py`'s `journal_should_run` call (~line 2125-2131) reuses `settings.actions_daily_pulse_hour_local`/`minute_local` verbatim, so Daily Journal always fires at the exact same local minute as Daily Pulse, by config. Two independently-LLM-generated daily artifacts landing in the same notification slot reads as duplication even though they're genuinely different pipelines. This script computes pairwise time-of-day distance across all four cadences and flags any pair within `--threshold-minutes` (default 30) of each other. Report-only by default (always exits 0); pass `--fail-on-collision` to make it a real gate.
 ```bash

--- a/scripts/bus_core_health_watchdog.py
+++ b/scripts/bus_core_health_watchdog.py
@@ -111,6 +111,11 @@ DEFAULT_RESTART_WINDOW_MINUTES = 10.0
 
 _UNHEALTHY_LIKE_STATUSES = {"unhealthy", "missing", "docker_unreachable"}
 _NEUTRAL_STATUSES = {"starting", "none"}
+# inspect_container() reports restart_count=0 for these two statuses as a
+# PLACEHOLDER, not a real `docker inspect` reading (the container wasn't
+# found, or docker itself couldn't be reached) -- never treat that 0 as a
+# genuine RestartCount sample.
+_UNKNOWN_RESTART_COUNT_STATUSES = {"missing", "docker_unreachable"}
 
 
 def container_name_for_project(project: str) -> str:
@@ -322,11 +327,32 @@ def evaluate(
         )
 
     samples = prune_restart_samples(list(state.get("restart_samples", [])), now, restart_window_minutes)
-    samples.append({"at": now_iso, "restart_count": restart_count})
+    # inspect_container() reports restart_count=0 as a PLACEHOLDER (not a
+    # real reading) whenever the container is "missing" or Docker itself was
+    # "docker_unreachable" -- see its docstring. Recording that placeholder
+    # as a real sample poisons the window's min() the moment a real
+    # observation returns: a container that was genuinely at restart_count=5
+    # before a transient docker-unreachable blip would compute
+    # restarts_in_window = 5 - min(..., 0) = 5 on the very next healthy poll,
+    # a false crash-loop positive from a blip that caused zero real restarts.
+    # Reproduced: healthy(5) -> docker_unreachable(0) -> healthy(5) yielded
+    # crash_loop_detected=True before this fix. Simply not recording the
+    # placeholder sample keeps the window's min() anchored to real
+    # RestartCount readings only.
+    if health_status not in _UNKNOWN_RESTART_COUNT_STATUSES:
+        samples.append({"at": now_iso, "restart_count": restart_count})
     new_state["restart_samples"] = samples
 
-    restarts_in_window = 0
-    if samples:
+    # Carry forward the last known real restarts_in_window during a
+    # placeholder tick (see the _UNKNOWN_RESTART_COUNT_STATUSES note above)
+    # rather than recomputing off the current call's fake restart_count=0 --
+    # that would otherwise transiently zero out a real in-progress restart
+    # count for the duration of the blip, masking the restart-count signature
+    # right when a docker hiccup coincides with a genuine crash loop.
+    restarts_in_window = _safe_int(
+        state.get("restarts_in_window", 0), 0, "restarts_in_window from state file"
+    )
+    if samples and health_status not in _UNKNOWN_RESTART_COUNT_STATUSES:
         # Deliberately min() over the window's *values*, not the
         # chronologically-earliest sample's value -- RestartCount is only
         # monotonic within one container's lifetime. If bus-core is removed

--- a/scripts/bus_core_health_watchdog.py
+++ b/scripts/bus_core_health_watchdog.py
@@ -77,6 +77,12 @@ Exit codes: 0 = healthy, no crash-loop signature met (also returned if this run
                 services/orion-bus/README.md's watchdog section). Deliberately
                 distinct from exit 1 so a permissions failure can never be
                 misread as "crash loop detected."
+            3 = the watchdog itself broke on an unexpected/unhandled exception
+                (a bug in this script, not a signal about bus-core). Deliberately
+                distinct from BOTH exit 1 and exit 2 so a monitoring wrapper
+                keying off exit code can tell "watchdog crashed" apart from
+                "real crash loop detected" -- an uncaught exception must never
+                silently alias exit 1's meaning.
 """
 from __future__ import annotations
 
@@ -127,6 +133,26 @@ class DockerUnavailableError(RuntimeError):
     themselves alarming signals, not script errors)."""
 
 
+def _safe_int(value: Any, default: int, warn_label: str) -> int:
+    """Coerce `value` to int, degrading to `default` with a logged warning
+    instead of raising. Used anywhere an int is read from a source this
+    script does not fully control (docker inspect's JSON output, a
+    hand-edited or partially-migrated state file) -- a malformed/non-numeric
+    value there must never crash the check path, matching the "never raises,
+    only genuine tooling failure surfaces as a distinct signal" contract
+    documented on inspect_container() and enforced end-to-end via main()'s
+    catch-all (see its docstring's Exit codes section)."""
+    try:
+        return int(value if value is not None else default)
+    except (TypeError, ValueError) as exc:
+        print(
+            f"bus_core_health_watchdog: WARNING -- could not parse {warn_label} "
+            f"({value!r}: {exc}), defaulting to {default}.",
+            file=sys.stderr,
+        )
+        return default
+
+
 def inspect_container(container: str, docker_bin: str = "docker") -> dict[str, Any]:
     """Runs `docker inspect <container>` and returns a normalized dict:
 
@@ -167,7 +193,7 @@ def inspect_container(container: str, docker_bin: str = "docker") -> dict[str, A
         return {"health_status": "docker_unreachable", "restart_count": 0, "container_status": f"unparseable docker inspect output: {exc}"}
 
     state = entry.get("State", {}) or {}
-    restart_count = int(entry.get("RestartCount", 0) or 0)
+    restart_count = _safe_int(entry.get("RestartCount", 0), 0, "RestartCount from docker inspect output")
     container_status = state.get("Status", "unknown")
     health = state.get("Health")
     if not health:
@@ -283,13 +309,17 @@ def evaluate(
         new_state["consecutive_unhealthy_count"] = 0
         new_state["last_known_healthy_at"] = now_iso
     elif health_status in _UNHEALTHY_LIKE_STATUSES:
-        new_state["consecutive_unhealthy_count"] = int(state.get("consecutive_unhealthy_count", 0)) + 1
+        new_state["consecutive_unhealthy_count"] = (
+            _safe_int(state.get("consecutive_unhealthy_count", 0), 0, "consecutive_unhealthy_count from state file") + 1
+        )
     elif health_status in _NEUTRAL_STATUSES:
         pass  # leave streak unchanged -- ambiguous signal (e.g. just restarted)
     else:
         # Unknown health_status string -- treat conservatively like "unhealthy"
         # rather than silently ignoring it (no empty-shell success states).
-        new_state["consecutive_unhealthy_count"] = int(state.get("consecutive_unhealthy_count", 0)) + 1
+        new_state["consecutive_unhealthy_count"] = (
+            _safe_int(state.get("consecutive_unhealthy_count", 0), 0, "consecutive_unhealthy_count from state file") + 1
+        )
 
     samples = prune_restart_samples(list(state.get("restart_samples", [])), now, restart_window_minutes)
     samples.append({"at": now_iso, "restart_count": restart_count})
@@ -337,11 +367,39 @@ def evaluate(
     return new_state, crash_loop_detected, reasons
 
 
-def write_alert_marker(path: Path, container: str, state: dict[str, Any], reasons: list[str], now: datetime) -> None:
+def write_alert_marker(
+    path: Path,
+    container: str,
+    state: dict[str, Any],
+    reasons: list[str],
+    now: datetime,
+    is_new_incident: bool = True,
+) -> None:
+    """Writes the crash-loop alert marker.
+
+    `is_new_incident` distinguishes "this tick just transitioned into a crash
+    loop" (state.crash_loop_active flipped False -> True) from "this tick is
+    just re-confirming an crash loop already flagged on a prior tick." `run()`
+    calls this on every tick while crash_loop_detected stays True -- if this
+    function always clobbered the file from scratch, any investigation notes
+    a human appended to the marker mid-incident would silently vanish on the
+    very next poll (reproduced before this fix). So: a brand-new incident
+    always gets fresh content (even if a stale marker from a PAST, already-
+    resolved incident still exists on disk -- that stale content must not
+    survive into a new incident's report); an ONGOING incident leaves an
+    already-existing marker file untouched entirely.
+    """
+    if not is_new_incident and path.exists():
+        return
+
+    last_health_status = state.get("last_health_status")
+    docker_unreachable = last_health_status == "docker_unreachable"
+
     lines = [
         "ORION BUS-CORE CRASH-LOOP ALERT",
         "================================",
         f"container:            {container}",
+        f"last_health_status:   {last_health_status}",
         f"detected_first_at:    {state.get('crash_loop_first_detected_at')}",
         f"last_check_at:        {now.isoformat()}",
         f"last_known_healthy_at:{state.get('last_known_healthy_at')}",
@@ -351,22 +409,47 @@ def write_alert_marker(path: Path, container: str, state: dict[str, Any], reason
         "Reason(s):",
     ]
     lines += [f"  - {r}" for r in reasons]
-    lines += [
-        "",
-        "This means bus-core (Redis) is very likely stuck in a crash loop.",
-        "Everything routed through the bus, and anything that depends on the",
-        "bus to report its own failures, may be silently degraded right now.",
-        "",
-        "Check:",
-        f"  docker logs --tail=200 {container}",
-        f"  docker inspect {container} --format '{{{{json .State}}}}'",
-        "  services/orion-bus/docker-compose.yml (AOF corruption is the known",
-        "  recurring cause -- a separate task is adding auto-repair for that).",
-        "",
-        "This file is written by scripts/bus_core_health_watchdog.py and is",
-        "NOT auto-deleted. Once you've looked, delete it by hand:",
-        f"  rm {path}",
-    ]
+
+    if docker_unreachable:
+        # The Docker daemon itself was unreachable -- this is NOT necessarily
+        # bus-core crash-looping (health could not be checked at all), and
+        # `docker logs`/`docker inspect` would fail for the exact same reason
+        # that produced this alert, so recommending them as next steps here
+        # would be actively misleading.
+        lines += [
+            "",
+            "This means the Docker daemon itself was unreachable from this host --",
+            "NOT necessarily that bus-core is crash-looping (its health could not",
+            "even be checked). `docker logs`/`docker inspect` will likely also fail",
+            "for the same reason, so they are not useful next steps right now.",
+            "",
+            "Check instead:",
+            "  systemctl status docker   (or the equivalent for this host's init system)",
+            "  Disk space / permissions on the Docker daemon socket",
+            "  Host-level resource exhaustion (e.g. OOM) that could have killed dockerd",
+            "",
+            "This file is written by scripts/bus_core_health_watchdog.py and is",
+            "NOT auto-deleted. Once you've looked, delete it by hand:",
+            f"  rm {path}",
+        ]
+    else:
+        lines += [
+            "",
+            "This means bus-core (Redis) is very likely stuck in a crash loop.",
+            "Everything routed through the bus, and anything that depends on the",
+            "bus to report its own failures, may be silently degraded right now.",
+            "",
+            "Check:",
+            f"  docker logs --tail=200 {container}",
+            f"  docker inspect {container} --format '{{{{json .State}}}}'",
+            "  services/orion-bus/docker-compose.yml (AOF corruption is the known",
+            "  recurring cause -- a separate task is adding auto-repair for that).",
+            "",
+            "This file is written by scripts/bus_core_health_watchdog.py and is",
+            "NOT auto-deleted. Once you've looked, delete it by hand:",
+            f"  rm {path}",
+        ]
+
     # Atomic (mkstemp + os.replace), matching _atomic_write_json -- this file
     # is human-read during a live incident, so it gets the same no-torn-write
     # guarantee as the state file rather than a plain write().
@@ -457,7 +540,10 @@ def run(
         _atomic_write_json(state_file, new_state)
 
         if crash_loop_detected:
-            write_alert_marker(alert_marker, container, new_state, reasons, now)
+            write_alert_marker(
+                alert_marker, container, new_state, reasons, now,
+                is_new_incident=not was_active,
+            )
         elif was_active and not crash_loop_detected:
             append_resolved_footer(alert_marker, now)
 
@@ -543,6 +629,18 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    except Exception as exc:  # noqa: BLE001 -- deliberate catch-all, see docstring's Exit codes
+        # Anything not covered by the specific except clauses above is a bug
+        # in this script, not a signal about bus-core. Must never exit 1 --
+        # that would be indistinguishable from a genuine crash-loop detection
+        # to anything consuming only the exit code.
+        print(
+            f"bus_core_health_watchdog: UNEXPECTED ERROR -- {type(exc).__name__}: {exc}. "
+            "This is a bug in the watchdog itself, not a crash-loop detection. "
+            "See scripts/bus_core_health_watchdog.py docstring's Exit codes section.",
+            file=sys.stderr,
+        )
+        return 3
 
     if args.json:
         print(json.dumps({

--- a/scripts/bus_core_health_watchdog.py
+++ b/scripts/bus_core_health_watchdog.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Host-level crash-loop watchdog for `bus-core` (the Redis container behind
+`services/orion-bus/docker-compose.yml`).
+
+Context: `bus-core` periodically crash-loops from AOF corruption (auto-repair
+for that is a separate, parallel piece of work -- this script does not touch
+`bus-core`'s own container definition or entrypoint). The real gap this
+closes: detecting "bus is stuck in a crash loop" currently depends on either
+a human noticing cascading failures across many *other* services, or on
+signals that themselves route through the bus or Postgres -- both of which
+can be down *at the same time* (confirmed, not hypothetical). This script is
+a detection floor that survives both being down simultaneously:
+
+- No Redis connection, ever. Health comes from `docker inspect` only.
+- No Postgres connection, ever. State is a local JSON file, not a DB row.
+- No bus publish. Alerting is a marker file on local disk, not an event.
+
+Same category as `scripts/check_concept_relation_digest_liveness.py`
+(standalone script, run on demand or via cron/systemd timer, not a live
+service loop) but for container liveness instead of a Postgres backlog.
+
+Two independent crash-loop signatures, either one fires an alert:
+
+1. **Consecutive-unhealthy streak**: `--unhealthy-streak-threshold`
+   (default 3) consecutive watchdog runs where `docker inspect`'s
+   `.State.Health.Status` was not `healthy` (`unhealthy`, the container was
+   missing, or the Docker daemon itself was unreachable -- all three count
+   against the streak; `starting`/`none` are neutral and leave the streak
+   unchanged, since a normal restart briefly reports `starting` and that
+   alone should not false-positive).
+2. **Restart-count-in-window**: `--restart-count-threshold` (default 3)
+   container restarts (per `docker inspect`'s `.RestartCount`, a monotonic
+   cumulative counter) within `--restart-window-minutes` (default 10). This
+   catches a crash loop that never settles into `unhealthy` between polls
+   (e.g. the container dies and restarts faster than the poll interval).
+
+State (consecutive-unhealthy count, last-known-healthy-at, a pruned rolling
+window of `(timestamp, restart_count)` samples) is persisted to
+`--state-file` (default `${TELEMETRY_ROOT}/${PROJECT}/bus/watchdog/
+health_watchdog_state.json` -- a sibling of, not inside, the AOF data mount
+at `${TELEMETRY_ROOT}/${PROJECT}/bus/data` that a parallel AOF-repair task
+may also be touching).
+
+On a crash-loop signature: this repo has no notify-send/osascript/desktop-
+notification script anywhere (checked before writing this one) and the one
+HTTP alerting path that exists (`orion-notify`'s `/attention/request`, used
+by `orion-mesh-guardian` and the Fuseki recover job) is itself infrastructure
+that can plausibly be down in the same incident this script exists to catch.
+So the alert is a plain, loud, impossible-to-miss marker file:
+`--alert-marker` (default `${TELEMETRY_ROOT}/${PROJECT}/bus/
+ORION_BUS_CRASH_LOOP_ALERT.txt`, a sibling of `bus/data/` so it shows up the
+moment anyone lists the bus telemetry directory). The marker is never
+auto-deleted -- if the condition later clears, the file is updated in place
+with a RESOLVED footer rather than removed, so a human still sees that an
+incident happened. A human removes the file once they've looked.
+
+Usage:
+    python scripts/bus_core_health_watchdog.py
+    python scripts/bus_core_health_watchdog.py --project orion-athena --json
+    python scripts/bus_core_health_watchdog.py --container orion-orion-athena-bus-core \\
+        --unhealthy-streak-threshold 3 --restart-count-threshold 3 --restart-window-minutes 10
+
+Exit codes: 0 = healthy, no crash-loop signature met.
+            1 = crash-loop signature met -- alert marker written/updated.
+            2 = could not run the check at all (docker binary missing).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/bus_core_health_watchdog.py` puts scripts/ on
+# sys.path[0], which can shadow stdlib modules (same issue documented in
+# scripts/check_inner_state_registry.py / scripts/check_activation_saturation.py
+# / scripts/check_concept_relation_digest_liveness.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+DEFAULT_UNHEALTHY_STREAK_THRESHOLD = 3
+DEFAULT_RESTART_COUNT_THRESHOLD = 3
+DEFAULT_RESTART_WINDOW_MINUTES = 10.0
+
+_UNHEALTHY_LIKE_STATUSES = {"unhealthy", "missing", "docker_unreachable"}
+_NEUTRAL_STATUSES = {"starting", "none"}
+
+
+def container_name_for_project(project: str) -> str:
+    """Matches services/orion-bus/docker-compose.yml's
+    `container_name: orion-${PROJECT}-bus-core`."""
+    return f"orion-{project}-bus-core"
+
+
+def default_state_file(telemetry_root: str, project: str) -> Path:
+    return Path(telemetry_root) / project / "bus" / "watchdog" / "health_watchdog_state.json"
+
+
+def default_alert_marker(telemetry_root: str, project: str) -> Path:
+    return Path(telemetry_root) / project / "bus" / "ORION_BUS_CRASH_LOOP_ALERT.txt"
+
+
+class DockerUnavailableError(RuntimeError):
+    """The `docker` binary itself could not be run -- a hard tooling failure,
+    distinct from the container being missing or unhealthy (both of which are
+    themselves alarming signals, not script errors)."""
+
+
+def inspect_container(container: str, docker_bin: str = "docker") -> dict[str, Any]:
+    """Runs `docker inspect <container>` and returns a normalized dict:
+
+        {"health_status": "healthy"|"unhealthy"|"starting"|"none"|"missing"|"docker_unreachable",
+         "restart_count": int,
+         "container_status": str}  # docker's .State.Status, informational only
+
+    Never raises for "the container isn't in the state we want" -- only for
+    genuine tooling failure (docker binary not found).
+    """
+    try:
+        proc = subprocess.run(
+            [docker_bin, "inspect", container],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError as exc:
+        raise DockerUnavailableError(f"'{docker_bin}' binary not found on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        # A hung docker daemon is functionally the same signal as "can't reach
+        # it" for our purposes, not a hard tooling failure -- keep going.
+        return {"health_status": "docker_unreachable", "restart_count": 0, "container_status": f"timeout: {exc}"}
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        # Observed real docker CLI wording is lowercase ("error: no such
+        # object: <name>"), matched case-insensitively so older/newer docker
+        # versions using "No such container"/"No such object" still match.
+        if "no such object" in stderr.lower() or "no such container" in stderr.lower():
+            return {"health_status": "missing", "restart_count": 0, "container_status": stderr or "missing"}
+        return {"health_status": "docker_unreachable", "restart_count": 0, "container_status": stderr or "docker inspect failed"}
+
+    try:
+        parsed = json.loads(proc.stdout)
+        entry = parsed[0]
+    except (json.JSONDecodeError, IndexError, KeyError) as exc:
+        return {"health_status": "docker_unreachable", "restart_count": 0, "container_status": f"unparseable docker inspect output: {exc}"}
+
+    state = entry.get("State", {}) or {}
+    restart_count = int(entry.get("RestartCount", 0) or 0)
+    container_status = state.get("Status", "unknown")
+    health = state.get("Health")
+    if not health:
+        health_status = "none"
+    else:
+        health_status = health.get("Status", "none")
+
+    return {
+        "health_status": health_status,
+        "restart_count": restart_count,
+        "container_status": container_status,
+    }
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return _empty_state()
+    try:
+        with path.open("r") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            raise ValueError("state file did not contain a JSON object")
+        return data
+    except (json.JSONDecodeError, ValueError, OSError) as exc:
+        print(
+            f"bus_core_health_watchdog: WARNING -- state file {path} unreadable/corrupt "
+            f"({exc}), starting from a fresh state.",
+            file=sys.stderr,
+        )
+        return _empty_state()
+
+
+def _empty_state() -> dict[str, Any]:
+    return {
+        "consecutive_unhealthy_count": 0,
+        "last_known_healthy_at": None,
+        "restart_samples": [],
+        "crash_loop_active": False,
+        "crash_loop_first_detected_at": None,
+    }
+
+
+def _parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def prune_restart_samples(
+    samples: list[dict[str, Any]], now: datetime, window_minutes: float
+) -> list[dict[str, Any]]:
+    cutoff = now.timestamp() - (window_minutes * 60.0)
+    kept = []
+    for sample in samples:
+        try:
+            at = _parse_iso(sample["at"])
+        except (KeyError, ValueError):
+            continue
+        if at.timestamp() >= cutoff:
+            kept.append(sample)
+    return kept
+
+
+def evaluate(
+    state: dict[str, Any],
+    health_status: str,
+    restart_count: int,
+    now: datetime,
+    unhealthy_streak_threshold: int = DEFAULT_UNHEALTHY_STREAK_THRESHOLD,
+    restart_count_threshold: int = DEFAULT_RESTART_COUNT_THRESHOLD,
+    restart_window_minutes: float = DEFAULT_RESTART_WINDOW_MINUTES,
+) -> tuple[dict[str, Any], bool, list[str]]:
+    """Pure function: given the current persisted state plus one fresh
+    (health_status, restart_count) observation, returns
+    (updated_state, crash_loop_detected, reasons).
+
+    Deliberately takes no docker/filesystem/clock dependency directly so it
+    can be unit-tested against a fake sequence of health-check results
+    without touching a real container or the real clock.
+    """
+    new_state = dict(state)
+    new_state.setdefault("restart_samples", [])
+    now_iso = now.isoformat()
+
+    if health_status == "healthy":
+        new_state["consecutive_unhealthy_count"] = 0
+        new_state["last_known_healthy_at"] = now_iso
+    elif health_status in _UNHEALTHY_LIKE_STATUSES:
+        new_state["consecutive_unhealthy_count"] = int(state.get("consecutive_unhealthy_count", 0)) + 1
+    elif health_status in _NEUTRAL_STATUSES:
+        pass  # leave streak unchanged -- ambiguous signal (e.g. just restarted)
+    else:
+        # Unknown health_status string -- treat conservatively like "unhealthy"
+        # rather than silently ignoring it (no empty-shell success states).
+        new_state["consecutive_unhealthy_count"] = int(state.get("consecutive_unhealthy_count", 0)) + 1
+
+    samples = prune_restart_samples(list(state.get("restart_samples", [])), now, restart_window_minutes)
+    samples.append({"at": now_iso, "restart_count": restart_count})
+    new_state["restart_samples"] = samples
+
+    restarts_in_window = 0
+    if samples:
+        oldest_in_window = min(s["restart_count"] for s in samples)
+        restarts_in_window = max(0, restart_count - oldest_in_window)
+
+    reasons: list[str] = []
+    streak = new_state["consecutive_unhealthy_count"]
+    if streak >= unhealthy_streak_threshold:
+        reasons.append(
+            f"{streak} consecutive unhealthy check(s) (threshold {unhealthy_streak_threshold})"
+        )
+    if restarts_in_window >= restart_count_threshold:
+        reasons.append(
+            f"{restarts_in_window} restart(s) within {restart_window_minutes:.1f} minute window "
+            f"(threshold {restart_count_threshold})"
+        )
+
+    crash_loop_detected = bool(reasons)
+    new_state["restarts_in_window"] = restarts_in_window
+    new_state["last_health_status"] = health_status
+    new_state["last_restart_count"] = restart_count
+    new_state["last_check_at"] = now_iso
+
+    if crash_loop_detected and not state.get("crash_loop_active", False):
+        new_state["crash_loop_first_detected_at"] = now_iso
+    new_state["crash_loop_active"] = crash_loop_detected
+
+    return new_state, crash_loop_detected, reasons
+
+
+def write_alert_marker(path: Path, container: str, state: dict[str, Any], reasons: list[str], now: datetime) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "ORION BUS-CORE CRASH-LOOP ALERT",
+        "================================",
+        f"container:            {container}",
+        f"detected_first_at:    {state.get('crash_loop_first_detected_at')}",
+        f"last_check_at:        {now.isoformat()}",
+        f"last_known_healthy_at:{state.get('last_known_healthy_at')}",
+        f"consecutive_unhealthy_count: {state.get('consecutive_unhealthy_count')}",
+        f"restarts_in_window:   {state.get('restarts_in_window')}",
+        "",
+        "Reason(s):",
+    ]
+    lines += [f"  - {r}" for r in reasons]
+    lines += [
+        "",
+        "This means bus-core (Redis) is very likely stuck in a crash loop.",
+        "Everything routed through the bus, and anything that depends on the",
+        "bus to report its own failures, may be silently degraded right now.",
+        "",
+        "Check:",
+        f"  docker logs --tail=200 {container}",
+        f"  docker inspect {container} --format '{{{{json .State}}}}'",
+        "  services/orion-bus/docker-compose.yml (AOF corruption is the known",
+        "  recurring cause -- a separate task is adding auto-repair for that).",
+        "",
+        "This file is written by scripts/bus_core_health_watchdog.py and is",
+        "NOT auto-deleted. Once you've looked, delete it by hand:",
+        f"  rm {path}",
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def append_resolved_footer(path: Path, now: datetime) -> None:
+    if not path.exists():
+        return
+    with path.open("a") as fh:
+        fh.write(f"\n[RESOLVED as of {now.isoformat()} -- watchdog no longer sees a crash-loop signature.\n")
+        fh.write(" This file is left in place so the incident isn't silently lost. Delete by hand once reviewed.]\n")
+
+
+def run(
+    container: str,
+    state_file: Path,
+    alert_marker: Path,
+    docker_bin: str = "docker",
+    unhealthy_streak_threshold: int = DEFAULT_UNHEALTHY_STREAK_THRESHOLD,
+    restart_count_threshold: int = DEFAULT_RESTART_COUNT_THRESHOLD,
+    restart_window_minutes: float = DEFAULT_RESTART_WINDOW_MINUTES,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], bool, list[str]]:
+    now = now or datetime.now(timezone.utc)
+    observation = inspect_container(container, docker_bin=docker_bin)
+    state = load_state(state_file)
+    was_active = bool(state.get("crash_loop_active", False))
+
+    new_state, crash_loop_detected, reasons = evaluate(
+        state,
+        observation["health_status"],
+        observation["restart_count"],
+        now,
+        unhealthy_streak_threshold=unhealthy_streak_threshold,
+        restart_count_threshold=restart_count_threshold,
+        restart_window_minutes=restart_window_minutes,
+    )
+    new_state["container_status"] = observation["container_status"]
+    _atomic_write_json(state_file, new_state)
+
+    if crash_loop_detected:
+        write_alert_marker(alert_marker, container, new_state, reasons, now)
+    elif was_active and not crash_loop_detected:
+        append_resolved_footer(alert_marker, now)
+
+    return new_state, crash_loop_detected, reasons
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--project",
+        default=os.getenv("PROJECT", "orion-athena"),
+        help="Compose project name, matches $PROJECT (see .env). Used to derive the default "
+        "container name and telemetry paths. Default: $PROJECT or 'orion-athena'.",
+    )
+    parser.add_argument(
+        "--telemetry-root",
+        default=os.getenv("TELEMETRY_ROOT", "/mnt/telemetry"),
+        help="Root of the telemetry tree, matches $TELEMETRY_ROOT. Default: $TELEMETRY_ROOT or /mnt/telemetry.",
+    )
+    parser.add_argument(
+        "--container",
+        default=None,
+        help="Exact container name to inspect. Default: orion-<project>-bus-core "
+        "(matches services/orion-bus/docker-compose.yml's container_name).",
+    )
+    parser.add_argument("--state-file", default=None, help="Path to the watchdog's own state JSON file.")
+    parser.add_argument("--alert-marker", default=None, help="Path to the crash-loop alert marker file.")
+    parser.add_argument("--docker-bin", default="docker", help="docker binary to invoke. Default: docker.")
+    parser.add_argument(
+        "--unhealthy-streak-threshold",
+        type=int,
+        default=DEFAULT_UNHEALTHY_STREAK_THRESHOLD,
+        help=f"Consecutive unhealthy checks before alerting. Default: {DEFAULT_UNHEALTHY_STREAK_THRESHOLD}.",
+    )
+    parser.add_argument(
+        "--restart-count-threshold",
+        type=int,
+        default=DEFAULT_RESTART_COUNT_THRESHOLD,
+        help=f"Restarts within the window before alerting. Default: {DEFAULT_RESTART_COUNT_THRESHOLD}.",
+    )
+    parser.add_argument(
+        "--restart-window-minutes",
+        type=float,
+        default=DEFAULT_RESTART_WINDOW_MINUTES,
+        help=f"Window (minutes) the restart-count threshold is measured over. Default: {DEFAULT_RESTART_WINDOW_MINUTES}.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of prose.")
+    args = parser.parse_args(argv)
+
+    container = args.container or container_name_for_project(args.project)
+    state_file = Path(args.state_file) if args.state_file else default_state_file(args.telemetry_root, args.project)
+    alert_marker = Path(args.alert_marker) if args.alert_marker else default_alert_marker(args.telemetry_root, args.project)
+
+    try:
+        state, crash_loop_detected, reasons = run(
+            container=container,
+            state_file=state_file,
+            alert_marker=alert_marker,
+            docker_bin=args.docker_bin,
+            unhealthy_streak_threshold=args.unhealthy_streak_threshold,
+            restart_count_threshold=args.restart_count_threshold,
+            restart_window_minutes=args.restart_window_minutes,
+        )
+    except DockerUnavailableError as exc:
+        print(f"bus_core_health_watchdog: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({
+            "container": container,
+            "state_file": str(state_file),
+            "alert_marker": str(alert_marker),
+            "crash_loop_detected": crash_loop_detected,
+            "reasons": reasons,
+            **{k: v for k, v in state.items() if k != "restart_samples"},
+        }))
+    else:
+        print(
+            f"bus_core_health_watchdog: {container} health={state.get('last_health_status')} "
+            f"consecutive_unhealthy={state.get('consecutive_unhealthy_count')} "
+            f"restarts_in_window={state.get('restarts_in_window')}"
+        )
+        if crash_loop_detected:
+            print(f"CRASH LOOP DETECTED -- see {alert_marker}", file=sys.stderr)
+            for r in reasons:
+                print(f"  - {r}", file=sys.stderr)
+        else:
+            print("bus_core_health_watchdog: OK -- no crash-loop signature.")
+
+    return 1 if crash_loop_detected else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bus_core_health_watchdog.py
+++ b/scripts/bus_core_health_watchdog.py
@@ -54,19 +54,34 @@ auto-deleted -- if the condition later clears, the file is updated in place
 with a RESOLVED footer rather than removed, so a human still sees that an
 incident happened. A human removes the file once they've looked.
 
+Concurrency: a lockfile (`--state-file` + `.lock`, `flock`-based, non-blocking)
+guards the read-evaluate-write cycle against overlapping cron invocations (e.g.
+one run still waiting on a hung `docker inspect` when the next minute's cron
+fires). If the lock is already held, this run skips cleanly (exit 0, no state
+mutation) rather than racing the in-progress run for the write -- the repo's
+own `services/orion-rdf-store/README.md` documents a real incident from a
+plain existence-check lock (not `flock`) racing its own cron job.
+
 Usage:
     python scripts/bus_core_health_watchdog.py
     python scripts/bus_core_health_watchdog.py --project orion-athena --json
     python scripts/bus_core_health_watchdog.py --container orion-orion-athena-bus-core \\
         --unhealthy-streak-threshold 3 --restart-count-threshold 3 --restart-window-minutes 10
 
-Exit codes: 0 = healthy, no crash-loop signature met.
+Exit codes: 0 = healthy, no crash-loop signature met (also returned if this run
+                was skipped because another run already holds the lock).
             1 = crash-loop signature met -- alert marker written/updated.
-            2 = could not run the check at all (docker binary missing).
+            2 = could not run or complete the check (docker binary missing, or
+                a filesystem error writing state/marker -- e.g. the telemetry
+                directory not yet created/chowned on a fresh host, see
+                services/orion-bus/README.md's watchdog section). Deliberately
+                distinct from exit 1 so a permissions failure can never be
+                misread as "crash loop detected."
 """
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import subprocess
@@ -168,12 +183,20 @@ def inspect_container(container: str, docker_bin: str = "docker") -> dict[str, A
 
 
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    _atomic_write_text(path, json.dumps(data, indent=2, sort_keys=True) + "\n", suffix=".json")
+
+
+def _atomic_write_text(path: Path, content: str, suffix: str = ".txt") -> None:
+    """Shared by the state file and the alert marker -- both get the same
+    no-torn-write guarantee (mkstemp in the same directory + os.replace, which
+    is atomic on the same filesystem). The marker file is human-read during a
+    live incident, so it gets the identical treatment as the state file rather
+    than a plain write()/append()."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=str(path.parent))
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=suffix, dir=str(path.parent))
     try:
         with os.fdopen(fd, "w") as fh:
-            json.dump(data, fh, indent=2, sort_keys=True)
-            fh.write("\n")
+            fh.write(content)
         os.replace(tmp_path, path)
     except BaseException:
         try:
@@ -218,12 +241,17 @@ def _parse_iso(ts: str) -> datetime:
 def prune_restart_samples(
     samples: list[dict[str, Any]], now: datetime, window_minutes: float
 ) -> list[dict[str, Any]]:
+    """Drops both out-of-window samples and malformed ones (missing/non-int
+    `restart_count`, unparseable `at`) -- a hand-edited or partially-migrated
+    state file must never crash evaluate()'s later `min()` over this list."""
     cutoff = now.timestamp() - (window_minutes * 60.0)
     kept = []
     for sample in samples:
         try:
             at = _parse_iso(sample["at"])
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError):
+            continue
+        if not isinstance(sample.get("restart_count"), int):
             continue
         if at.timestamp() >= cutoff:
             kept.append(sample)
@@ -269,6 +297,18 @@ def evaluate(
 
     restarts_in_window = 0
     if samples:
+        # Deliberately min() over the window's *values*, not the
+        # chronologically-earliest sample's value -- RestartCount is only
+        # monotonic within one container's lifetime. If bus-core is removed
+        # and recreated mid-window (not just restarted), Docker resets
+        # RestartCount to 0, and a fixed "earliest sample" baseline would
+        # read as a huge *negative* restart burst (clamped to 0 below,
+        # silently hiding a real recreation event) followed by an
+        # under-counted climb back toward the old high-water mark. Using the
+        # window's minimum instead re-baselines automatically the moment the
+        # counter resets, so post-recreation restarts are counted correctly
+        # from the new baseline. Covered by
+        # test_restart_count_reset_from_container_recreation_rebaselines.
         oldest_in_window = min(s["restart_count"] for s in samples)
         restarts_in_window = max(0, restart_count - oldest_in_window)
 
@@ -298,7 +338,6 @@ def evaluate(
 
 
 def write_alert_marker(path: Path, container: str, state: dict[str, Any], reasons: list[str], now: datetime) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
         "ORION BUS-CORE CRASH-LOOP ALERT",
         "================================",
@@ -328,15 +367,64 @@ def write_alert_marker(path: Path, container: str, state: dict[str, Any], reason
         "NOT auto-deleted. Once you've looked, delete it by hand:",
         f"  rm {path}",
     ]
-    path.write_text("\n".join(lines) + "\n")
+    # Atomic (mkstemp + os.replace), matching _atomic_write_json -- this file
+    # is human-read during a live incident, so it gets the same no-torn-write
+    # guarantee as the state file rather than a plain write().
+    _atomic_write_text(path, "\n".join(lines) + "\n", suffix=".txt")
 
 
 def append_resolved_footer(path: Path, now: datetime) -> None:
     if not path.exists():
         return
-    with path.open("a") as fh:
-        fh.write(f"\n[RESOLVED as of {now.isoformat()} -- watchdog no longer sees a crash-loop signature.\n")
-        fh.write(" This file is left in place so the incident isn't silently lost. Delete by hand once reviewed.]\n")
+    # Read + concatenate + atomic replace, rather than open(path, "a") --
+    # append() is not safe against a concurrent write to the same path (see
+    # write_alert_marker's atomic replace), and this function can run
+    # immediately after a prior alert-marker write in the same process.
+    existing = path.read_text()
+    footer = (
+        f"\n[RESOLVED as of {now.isoformat()} -- watchdog no longer sees a crash-loop signature.\n"
+        " This file is left in place so the incident isn't silently lost. Delete by hand once reviewed.]\n"
+    )
+    _atomic_write_text(path, existing + footer, suffix=".txt")
+
+
+class WatchdogLockedError(RuntimeError):
+    """Another watchdog run already holds the state-file lock. Not an error in
+    the "couldn't run the check" sense -- it means a run IS in progress right
+    now, so this run skips cleanly rather than racing it for the write."""
+
+
+class _StateLock:
+    """Non-blocking flock on `<state_file>.lock`, guarding the
+    load_state -> evaluate -> write read-modify-write cycle against
+    overlapping cron invocations (e.g. one run still waiting on a hung
+    `docker inspect` -- up to the 15s subprocess timeout -- when the next
+    minute's cron fires). See services/orion-rdf-store/README.md for the
+    real incident this pattern is modeled after: a plain existence-check
+    lock (not flock) raced its own cron job and corrupted a shutdown
+    sequence. `flock` is kernel-atomic -- no check-then-act gap."""
+
+    def __init__(self, state_file: Path) -> None:
+        self._lock_path = state_file.with_suffix(state_file.suffix + ".lock")
+        self._fh = None
+
+    def __enter__(self) -> "_StateLock":
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(self._lock_path, "w")
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            fh.close()
+            raise WatchdogLockedError(
+                f"lock {self._lock_path} already held -- another watchdog run is in progress, skipping"
+            ) from exc
+        self._fh = fh
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        if self._fh is not None:
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            self._fh.close()
 
 
 def run(
@@ -351,25 +439,27 @@ def run(
 ) -> tuple[dict[str, Any], bool, list[str]]:
     now = now or datetime.now(timezone.utc)
     observation = inspect_container(container, docker_bin=docker_bin)
-    state = load_state(state_file)
-    was_active = bool(state.get("crash_loop_active", False))
 
-    new_state, crash_loop_detected, reasons = evaluate(
-        state,
-        observation["health_status"],
-        observation["restart_count"],
-        now,
-        unhealthy_streak_threshold=unhealthy_streak_threshold,
-        restart_count_threshold=restart_count_threshold,
-        restart_window_minutes=restart_window_minutes,
-    )
-    new_state["container_status"] = observation["container_status"]
-    _atomic_write_json(state_file, new_state)
+    with _StateLock(state_file):
+        state = load_state(state_file)
+        was_active = bool(state.get("crash_loop_active", False))
 
-    if crash_loop_detected:
-        write_alert_marker(alert_marker, container, new_state, reasons, now)
-    elif was_active and not crash_loop_detected:
-        append_resolved_footer(alert_marker, now)
+        new_state, crash_loop_detected, reasons = evaluate(
+            state,
+            observation["health_status"],
+            observation["restart_count"],
+            now,
+            unhealthy_streak_threshold=unhealthy_streak_threshold,
+            restart_count_threshold=restart_count_threshold,
+            restart_window_minutes=restart_window_minutes,
+        )
+        new_state["container_status"] = observation["container_status"]
+        _atomic_write_json(state_file, new_state)
+
+        if crash_loop_detected:
+            write_alert_marker(alert_marker, container, new_state, reasons, now)
+        elif was_active and not crash_loop_detected:
+            append_resolved_footer(alert_marker, now)
 
     return new_state, crash_loop_detected, reasons
 
@@ -433,6 +523,25 @@ def main(argv: list[str] | None = None) -> int:
         )
     except DockerUnavailableError as exc:
         print(f"bus_core_health_watchdog: {exc}", file=sys.stderr)
+        return 2
+    except WatchdogLockedError as exc:
+        # Another run is already in progress -- not a failure, just skip this
+        # cycle cleanly. No state mutation happened, so nothing to report.
+        print(f"bus_core_health_watchdog: SKIPPED -- {exc}", file=sys.stderr)
+        return 0
+    except OSError as exc:
+        # Covers permission errors creating/writing the state file, lock
+        # file, or alert marker directories (e.g. the telemetry tree not yet
+        # created/chowned on a fresh host -- see services/orion-bus/README.md).
+        # Deliberately a distinct, non-1 exit code: a filesystem error here
+        # must never be misread as "crash loop detected" (exit 1) by anything
+        # consuming only the exit code.
+        print(
+            f"bus_core_health_watchdog: FAILED -- could not write state/marker files: {exc}. "
+            "Check directory ownership/permissions -- see services/orion-bus/README.md's "
+            "'Host-level crash-loop watchdog' section.",
+            file=sys.stderr,
+        )
         return 2
 
     if args.json:

--- a/services/orion-bus/README.md
+++ b/services/orion-bus/README.md
@@ -114,7 +114,7 @@ crash-looping and other symptoms (bus-dependent services failing, Postgres also
 possibly down) are inconclusive.
 
 ```bash
-python scripts/bus_core_health_watchdog.py
+python3 scripts/bus_core_health_watchdog.py
 # or: make bus-core-health-watchdog
 ```
 
@@ -164,6 +164,16 @@ same caveat noted in the concept-relation-digest precedent.
 Not installed automatically -- per this repo's safety rules, host crontab is
 host-level shared infrastructure and is not modified without explicit sign-off.
 Install the line above by hand.
+
+The `>> ... 2>&1` redirect to a log file is deliberate, not an alerting gap:
+this script prints a status line on *every* run, healthy or not, so an
+unredirected cron job would mail on every single invocation (every minute)
+rather than only on failure. The real alert path for a human is the
+`ORION_BUS_CRASH_LOOP_ALERT.txt` marker file described above (survives both
+Redis and Postgres being down, which cron's own MTA-dependent mail delivery
+does not) plus this exit code (1 = crash loop, 2/3 = watchdog itself
+failed) -- a wrapper that needs to escalate further should key off those,
+not off cron's mail-on-output behavior.
 
 ---
 

--- a/services/orion-bus/README.md
+++ b/services/orion-bus/README.md
@@ -77,6 +77,94 @@ To quickly view the top of the metrics stream:
 make metrics
 ```
 
+### Host-level crash-loop watchdog (survives bus AND Postgres both being down)
+
+`bus-core` periodically crash-loops from AOF corruption (auto-repair for that is a
+separate, parallel piece of work -- not covered here). The gap this closes:
+detecting "bus is stuck in a crash loop" today depends on either a human noticing
+cascading failures across many *other* services, or on signals that themselves
+route through the bus or Postgres -- both of which can be down at the same time in
+dev (confirmed, not hypothetical). `scripts/bus_core_health_watchdog.py` is a
+detection floor that survives both being down simultaneously: it reads
+`docker inspect`'s `.State.Health.Status` / `.RestartCount` for the real
+`orion-${PROJECT}-bus-core` container only -- **no Redis connection, no Postgres
+connection, ever**. It persists its own state as a local JSON file and, on a
+crash-loop signature, writes a plain, impossible-to-miss marker file (this repo
+has no `notify-send`/`osascript`/desktop-notification mechanism to reuse; the one
+HTTP alert path that exists, `orion-notify`'s `/attention/request`, is itself
+infrastructure that can plausibly be down in the same incident this watchdog
+exists to catch).
+
+Two independent crash-loop signatures, either fires an alert (both overridable):
+
+- **Consecutive-unhealthy streak** -- default 3 consecutive watchdog runs where
+  health was not `healthy` (`unhealthy`, the container missing, or the Docker
+  daemon itself unreachable all count; `starting`/`none` are neutral).
+- **Restart-count-in-window** -- default 3 restarts within a 10-minute rolling
+  window, from `docker inspect`'s cumulative `.RestartCount`. Catches a crash
+  loop that never settles into `unhealthy` between polls.
+
+State file (default): `${TELEMETRY_ROOT}/${PROJECT}/bus/watchdog/health_watchdog_state.json`
+-- a sibling of, not inside, the AOF data mount at `${TELEMETRY_ROOT}/${PROJECT}/bus/data`.
+
+Alert marker (default, never auto-deleted, updated with a RESOLVED footer instead
+of removed if the condition clears): `${TELEMETRY_ROOT}/${PROJECT}/bus/ORION_BUS_CRASH_LOOP_ALERT.txt`
+-- **this is where Juniper should look** if bus-core is suspected to be
+crash-looping and other symptoms (bus-dependent services failing, Postgres also
+possibly down) are inconclusive.
+
+```bash
+python scripts/bus_core_health_watchdog.py
+# or: make bus-core-health-watchdog
+```
+
+Both default to `$PROJECT`/`$TELEMETRY_ROOT` from `.env` (`orion-athena`/`/mnt/telemetry`
+today) if unset; override with `--project`/`--telemetry-root`, or pin exact paths
+with `--container`/`--state-file`/`--alert-marker`. See the script's own docstring
+for the full flag list and exit-code contract (0 healthy, 1 crash-loop detected, 2
+the `docker` binary itself could not be run).
+
+The default state/marker paths live under `/mnt/telemetry/${PROJECT}/bus/`, which
+on this host is owned by `root:root` (755) -- the first run needs the directory
+either pre-created and chowned to whichever user runs the cron job, or run once
+manually with `sudo` to create it:
+
+```bash
+sudo mkdir -p /mnt/telemetry/${PROJECT}/bus/watchdog
+sudo chown "$(whoami)":"$(whoami)" /mnt/telemetry/${PROJECT}/bus/watchdog
+```
+
+#### Scheduled maintenance (Athena cron)
+
+Install on the host that runs `bus-core` (`crontab -e` as `athena`), matching this
+repo's established pattern for host-level scheduled checks (see
+`services/orion-rdf-store/README.md`'s "Scheduled maintenance" section and
+`services/orion-memory-consolidation/README.md`'s, both crontab-based). The one
+systemd-timer precedent in this repo (`docs/superpowers/plans/2026-05-09-local-mnt-scripts-backup-implementation.md`,
+units generated into a gitignored `.worktrees/` path, not present in a fresh
+checkout) is for a single long-running nightly backup job, not this
+repeated-fast-poll shape -- crontab is the better fit here, and matches the
+dominant house convention:
+
+```cron
+# bus-core crash-loop watchdog -- docker-inspect only, no Redis/Postgres dependency
+* * * * * cd /mnt/scripts/Orion-Sapienform && make bus-core-health-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-bus-core-health-watchdog.log 2>&1
+```
+
+Every-minute cadence matches the default thresholds (3 consecutive unhealthy checks
+~= 3 minutes; 3 restarts within a 10-minute window) -- fast enough to catch a real
+crash loop within a few minutes, slow enough not to flap on a single transient
+health-check blip (`bus-core`'s own Docker healthcheck already requires 5
+consecutive internal failures at 5s intervals, ~25s, before it reports `unhealthy`
+in the first place). If you change the cron cadence, re-derive the threshold
+defaults (`--unhealthy-streak-threshold`, `--restart-count-threshold`,
+`--restart-window-minutes`) so they stay a real multiple of the new interval,
+same caveat noted in the concept-relation-digest precedent.
+
+Not installed automatically -- per this repo's safety rules, host crontab is
+host-level shared infrastructure and is not modified without explicit sign-off.
+Install the line above by hand.
+
 ---
 
 ## 🧩 Interacting with the Bus

--- a/tests/test_bus_core_health_watchdog.py
+++ b/tests/test_bus_core_health_watchdog.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import bus_core_health_watchdog as watchdog  # noqa: E402
+
+
+def _now(offset_minutes: float = 0.0) -> datetime:
+    return datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc) + timedelta(minutes=offset_minutes)
+
+
+# ---------------------------------------------------------------------------
+# container_name_for_project / default paths
+# ---------------------------------------------------------------------------
+
+
+def test_container_name_matches_compose_pattern():
+    # services/orion-bus/docker-compose.yml: container_name: orion-${PROJECT}-bus-core
+    assert watchdog.container_name_for_project("orion-athena") == "orion-orion-athena-bus-core"
+
+
+def test_default_state_and_marker_paths_do_not_collide_with_aof_data_mount():
+    state_file = watchdog.default_state_file("/mnt/telemetry", "orion-athena")
+    marker = watchdog.default_alert_marker("/mnt/telemetry", "orion-athena")
+    # services/orion-bus/docker-compose.yml mounts ${TELEMETRY_ROOT}/${PROJECT}/bus/data
+    # -- neither watchdog path may live inside that directory.
+    data_dir = Path("/mnt/telemetry/orion-athena/bus/data")
+    assert data_dir not in state_file.parents
+    assert data_dir not in marker.parents
+    assert str(state_file).startswith("/mnt/telemetry/orion-athena/bus/")
+    assert str(marker).startswith("/mnt/telemetry/orion-athena/bus/")
+
+
+# ---------------------------------------------------------------------------
+# evaluate() -- pure threshold/alert logic, no docker/filesystem/clock
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_observation_resets_streak_and_stamps_last_healthy():
+    state = watchdog._empty_state()
+    state["consecutive_unhealthy_count"] = 2
+    new_state, detected, reasons = watchdog.evaluate(state, "healthy", restart_count=0, now=_now())
+    assert new_state["consecutive_unhealthy_count"] == 0
+    assert new_state["last_known_healthy_at"] == _now().isoformat()
+    assert detected is False
+    assert reasons == []
+
+
+def test_unhealthy_streak_below_threshold_does_not_alert():
+    state = watchdog._empty_state()
+    for i in range(2):
+        state, detected, reasons = watchdog.evaluate(
+            state, "unhealthy", restart_count=0, now=_now(i), unhealthy_streak_threshold=3
+        )
+    assert state["consecutive_unhealthy_count"] == 2
+    assert detected is False
+
+
+def test_unhealthy_streak_crossing_threshold_alerts():
+    state = watchdog._empty_state()
+    for i in range(3):
+        state, detected, reasons = watchdog.evaluate(
+            state, "unhealthy", restart_count=0, now=_now(i), unhealthy_streak_threshold=3
+        )
+    assert state["consecutive_unhealthy_count"] == 3
+    assert detected is True
+    assert any("consecutive unhealthy" in r for r in reasons)
+
+
+def test_starting_status_is_neutral_does_not_increment_or_reset():
+    state = watchdog._empty_state()
+    state["consecutive_unhealthy_count"] = 2
+    new_state, detected, _ = watchdog.evaluate(state, "starting", restart_count=0, now=_now())
+    assert new_state["consecutive_unhealthy_count"] == 2  # unchanged
+    assert detected is False
+
+
+def test_none_health_status_is_neutral():
+    state = watchdog._empty_state()
+    state["consecutive_unhealthy_count"] = 1
+    new_state, detected, _ = watchdog.evaluate(state, "none", restart_count=0, now=_now())
+    assert new_state["consecutive_unhealthy_count"] == 1
+    assert detected is False
+
+
+def test_missing_container_counts_as_unhealthy():
+    state = watchdog._empty_state()
+    for i in range(3):
+        state, detected, reasons = watchdog.evaluate(
+            state, "missing", restart_count=0, now=_now(i), unhealthy_streak_threshold=3
+        )
+    assert detected is True
+
+
+def test_docker_unreachable_counts_as_unhealthy():
+    state = watchdog._empty_state()
+    for i in range(3):
+        state, detected, reasons = watchdog.evaluate(
+            state, "docker_unreachable", restart_count=0, now=_now(i), unhealthy_streak_threshold=3
+        )
+    assert detected is True
+
+
+def test_restart_count_within_window_crosses_threshold():
+    # Simulates a rapid crash loop that never settles into "unhealthy" between
+    # polls: health flaps back to "starting" each time but RestartCount climbs.
+    state = watchdog._empty_state()
+    restart_counts = [0, 1, 2, 3]
+    for i, rc in enumerate(restart_counts):
+        state, detected, reasons = watchdog.evaluate(
+            state,
+            "starting",
+            restart_count=rc,
+            now=_now(i),
+            restart_count_threshold=3,
+            restart_window_minutes=10,
+        )
+    assert detected is True
+    assert any("restart" in r for r in reasons)
+    assert state["restarts_in_window"] == 3
+
+
+def test_restart_count_samples_prune_outside_window():
+    state = watchdog._empty_state()
+    # First restart sample far outside the window...
+    state, _, _ = watchdog.evaluate(state, "healthy", restart_count=1, now=_now(0), restart_window_minutes=10)
+    # ...then a burst of restarts well after the window has rolled past the first sample.
+    state, detected, reasons = watchdog.evaluate(
+        state, "healthy", restart_count=2, now=_now(30), restart_count_threshold=1, restart_window_minutes=10
+    )
+    # Only the current sample is in-window (30min gap > 10min window), so the
+    # delta against the oldest in-window sample is 0, not 1.
+    assert state["restarts_in_window"] == 0
+    assert detected is False
+
+
+def test_restart_count_threshold_not_crossed_stays_healthy():
+    state = watchdog._empty_state()
+    for i, rc in enumerate([0, 1]):
+        state, detected, reasons = watchdog.evaluate(
+            state, "healthy", restart_count=rc, now=_now(i), restart_count_threshold=3, restart_window_minutes=10
+        )
+    assert detected is False
+
+
+def test_crash_loop_first_detected_at_is_set_once_and_persists():
+    state = watchdog._empty_state()
+    for i in range(3):
+        state, detected, _ = watchdog.evaluate(
+            state, "unhealthy", restart_count=0, now=_now(i), unhealthy_streak_threshold=3
+        )
+    first_detected = state["crash_loop_first_detected_at"]
+    assert first_detected is not None
+    # A subsequent still-unhealthy check must not reset first_detected_at.
+    state, detected, _ = watchdog.evaluate(
+        state, "unhealthy", restart_count=0, now=_now(3), unhealthy_streak_threshold=3
+    )
+    assert state["crash_loop_first_detected_at"] == first_detected
+    assert state["crash_loop_active"] is True
+
+
+def test_recovery_clears_crash_loop_active_but_keeps_first_detected_history():
+    state = watchdog._empty_state()
+    for i in range(3):
+        state, _, _ = watchdog.evaluate(state, "unhealthy", restart_count=0, now=_now(i), unhealthy_streak_threshold=3)
+    assert state["crash_loop_active"] is True
+    state, detected, reasons = watchdog.evaluate(state, "healthy", restart_count=0, now=_now(3))
+    assert detected is False
+    assert state["crash_loop_active"] is False
+
+
+def test_unknown_health_status_treated_conservatively_as_unhealthy():
+    state = watchdog._empty_state()
+    for i in range(3):
+        state, detected, _ = watchdog.evaluate(
+            state, "some-new-docker-status", restart_count=0, now=_now(i), unhealthy_streak_threshold=3
+        )
+    assert detected is True
+
+
+# ---------------------------------------------------------------------------
+# inspect_container() -- subprocess boundary, mocked
+# ---------------------------------------------------------------------------
+
+
+def _fake_completed(returncode=0, stdout="", stderr=""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+def test_inspect_container_parses_healthy_state():
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 2}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        result = watchdog.inspect_container("orion-orion-athena-bus-core")
+    assert result == {"health_status": "healthy", "restart_count": 2, "container_status": "running"}
+
+
+def test_inspect_container_no_health_block_reports_none():
+    payload = json.dumps([{"State": {"Status": "running"}, "RestartCount": 0}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        result = watchdog.inspect_container("some-container")
+    assert result["health_status"] == "none"
+
+
+def test_inspect_container_missing_container_lowercase_error():
+    # Real docker CLI observed wording (this host): "error: no such object: <name>"
+    with patch("subprocess.run", return_value=_fake_completed(1, "", "error: no such object: nope")):
+        result = watchdog.inspect_container("nope")
+    assert result["health_status"] == "missing"
+
+
+def test_inspect_container_docker_daemon_unreachable():
+    with patch("subprocess.run", return_value=_fake_completed(1, "", "Cannot connect to the Docker daemon")):
+        result = watchdog.inspect_container("some-container")
+    assert result["health_status"] == "docker_unreachable"
+
+
+def test_inspect_container_binary_not_found_raises():
+    with patch("subprocess.run", side_effect=FileNotFoundError("no docker")):
+        with pytest.raises(watchdog.DockerUnavailableError):
+            watchdog.inspect_container("some-container", docker_bin="/nonexistent/docker")
+
+
+def test_inspect_container_timeout_is_docker_unreachable_not_a_hard_failure():
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=15)):
+        result = watchdog.inspect_container("some-container")
+    assert result["health_status"] == "docker_unreachable"
+
+
+# ---------------------------------------------------------------------------
+# state persistence + alert marker, end to end via run()
+# ---------------------------------------------------------------------------
+
+
+def test_run_writes_state_file_and_no_marker_when_healthy(tmp_path):
+    state_file = tmp_path / "state.json"
+    marker = tmp_path / "ALERT.txt"
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        state, detected, reasons = watchdog.run(
+            container="fake-container", state_file=state_file, alert_marker=marker, now=_now()
+        )
+    assert detected is False
+    assert state_file.exists()
+    assert not marker.exists()
+    persisted = json.loads(state_file.read_text())
+    assert persisted["last_health_status"] == "healthy"
+
+
+def test_run_writes_alert_marker_on_crash_loop(tmp_path):
+    state_file = tmp_path / "state.json"
+    marker = tmp_path / "ALERT.txt"
+    payload = json.dumps([{"State": {"Status": "restarting", "Health": {"Status": "unhealthy"}}, "RestartCount": 5}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        for i in range(3):
+            state, detected, reasons = watchdog.run(
+                container="fake-container",
+                state_file=state_file,
+                alert_marker=marker,
+                unhealthy_streak_threshold=3,
+                now=_now(i),
+            )
+    assert detected is True
+    assert marker.exists()
+    content = marker.read_text()
+    assert "CRASH-LOOP ALERT" in content
+    assert "fake-container" in content
+    assert "consecutive unhealthy" in content
+
+
+def test_run_marker_is_not_deleted_on_recovery_but_gets_resolved_footer(tmp_path):
+    state_file = tmp_path / "state.json"
+    marker = tmp_path / "ALERT.txt"
+    unhealthy_payload = json.dumps([{"State": {"Status": "restarting", "Health": {"Status": "unhealthy"}}, "RestartCount": 5}])
+    healthy_payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 5}])
+    with patch("subprocess.run", return_value=_fake_completed(0, unhealthy_payload)):
+        for i in range(3):
+            watchdog.run(
+                container="fake-container",
+                state_file=state_file,
+                alert_marker=marker,
+                unhealthy_streak_threshold=3,
+                now=_now(i),
+            )
+    assert marker.exists()
+    original_content = marker.read_text()
+
+    with patch("subprocess.run", return_value=_fake_completed(0, healthy_payload)):
+        state, detected, _ = watchdog.run(
+            container="fake-container", state_file=state_file, alert_marker=marker, now=_now(3)
+        )
+    assert detected is False
+    assert marker.exists()  # never auto-deleted
+    new_content = marker.read_text()
+    assert new_content.startswith(original_content)
+    assert "RESOLVED" in new_content
+
+
+def test_run_state_file_is_valid_json_shape_against_real_container_semantics(tmp_path):
+    # Regression guard for the exact shape asserted by the live-container smoke
+    # test in this PR: consecutive_unhealthy_count, last_known_healthy_at,
+    # restart_samples, crash_loop_active must all be present.
+    state_file = tmp_path / "state.json"
+    marker = tmp_path / "ALERT.txt"
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        watchdog.run(container="fake-container", state_file=state_file, alert_marker=marker, now=_now())
+    persisted = json.loads(state_file.read_text())
+    for key in (
+        "consecutive_unhealthy_count",
+        "last_known_healthy_at",
+        "restart_samples",
+        "crash_loop_active",
+        "crash_loop_first_detected_at",
+        "last_check_at",
+        "last_health_status",
+        "last_restart_count",
+        "restarts_in_window",
+    ):
+        assert key in persisted
+
+
+def test_load_state_recovers_from_corrupt_file(tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text("{not valid json")
+    state = watchdog.load_state(state_file)
+    assert state == watchdog._empty_state()
+
+
+def test_atomic_write_survives_no_partial_file_on_success(tmp_path):
+    state_file = tmp_path / "nested" / "state.json"
+    watchdog._atomic_write_json(state_file, {"a": 1})
+    assert state_file.exists()
+    assert json.loads(state_file.read_text()) == {"a": 1}
+    # no leftover temp files
+    leftovers = list(state_file.parent.glob(".tmp-*"))
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# main() exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_zero_when_healthy(tmp_path):
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        exit_code = watchdog.main([
+            "--container", "fake-container",
+            "--state-file", str(tmp_path / "state.json"),
+            "--alert-marker", str(tmp_path / "ALERT.txt"),
+        ])
+    assert exit_code == 0
+
+
+def test_main_exits_one_when_crash_loop_detected(tmp_path):
+    payload = json.dumps([{"State": {"Status": "restarting", "Health": {"Status": "unhealthy"}}, "RestartCount": 9}])
+    state_file = tmp_path / "state.json"
+    marker = tmp_path / "ALERT.txt"
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        for _ in range(3):
+            exit_code = watchdog.main([
+                "--container", "fake-container",
+                "--state-file", str(state_file),
+                "--alert-marker", str(marker),
+                "--unhealthy-streak-threshold", "3",
+            ])
+    assert exit_code == 1
+    assert marker.exists()
+
+
+def test_main_exits_two_when_docker_binary_missing(tmp_path):
+    with patch("subprocess.run", side_effect=FileNotFoundError("no docker")):
+        exit_code = watchdog.main([
+            "--docker-bin", "/nonexistent/docker",
+            "--state-file", str(tmp_path / "state.json"),
+            "--alert-marker", str(tmp_path / "ALERT.txt"),
+        ])
+    assert exit_code == 2
+
+
+def test_main_uses_project_default_container_name(tmp_path):
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
+    captured_args = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured_args["cmd"] = cmd
+        return _fake_completed(0, payload)
+
+    with patch("subprocess.run", side_effect=_fake_run):
+        watchdog.main([
+            "--project", "orion-athena",
+            "--state-file", str(tmp_path / "state.json"),
+            "--alert-marker", str(tmp_path / "ALERT.txt"),
+        ])
+    assert "orion-orion-athena-bus-core" in captured_args["cmd"]

--- a/tests/test_bus_core_health_watchdog.py
+++ b/tests/test_bus_core_health_watchdog.py
@@ -180,6 +180,37 @@ def test_restart_count_reset_from_container_recreation_rebaselines():
     assert any("restart" in r for r in reasons)
 
 
+def test_docker_unreachable_blip_does_not_poison_restart_window():
+    """Regression: inspect_container() reports restart_count=0 as a
+    PLACEHOLDER (not a real reading) for "missing"/"docker_unreachable"
+    observations. Before this fix, evaluate() recorded that placeholder 0
+    as a real restart_samples entry, so a transient docker-unreachable blip
+    between two genuinely-unchanged healthy readings poisoned the window's
+    min() and produced a false crash-loop positive on the very next healthy
+    poll. Reproduced: healthy(rc=5) -> docker_unreachable(rc=0) ->
+    healthy(rc=5) used to yield crash_loop_detected=True despite zero real
+    restarts having occurred."""
+    state = watchdog._empty_state()
+    state, detected, _ = watchdog.evaluate(
+        state, "healthy", restart_count=5, now=_now(0), restart_count_threshold=3, restart_window_minutes=10
+    )
+    assert detected is False
+
+    state, detected, _ = watchdog.evaluate(
+        state, "docker_unreachable", restart_count=0, now=_now(1), restart_count_threshold=3, restart_window_minutes=10
+    )
+    assert state["restarts_in_window"] == 0
+    assert detected is False
+    # the placeholder 0 must not have been recorded as a real sample
+    assert all(s["restart_count"] != 0 for s in state["restart_samples"])
+
+    state, detected, reasons = watchdog.evaluate(
+        state, "healthy", restart_count=5, now=_now(2), restart_count_threshold=3, restart_window_minutes=10
+    )
+    assert state["restarts_in_window"] == 0
+    assert detected is False, f"false crash-loop positive from a docker-unreachable blip: {reasons}"
+
+
 def test_evaluate_ignores_malformed_restart_samples_without_crashing():
     # A hand-edited or partially-migrated state file could carry a sample
     # missing/with a non-int restart_count. evaluate() must never crash on
@@ -421,6 +452,64 @@ def test_resolved_footer_append_is_atomic_and_preserves_original_content(tmp_pat
     updated = marker.read_text()
     assert updated.startswith(original)
     assert "RESOLVED" in updated
+    leftovers = list(marker.parent.glob(".tmp-*"))
+    assert leftovers == []
+
+
+def test_atomic_write_leaves_destination_untouched_on_mid_write_failure(tmp_path, monkeypatch):
+    """The two tests above only exercise the success path -- they'd pass just
+    as well against a naive `open(path, "w")` write, so they don't actually
+    prove atomicity. The real guarantee _atomic_write_text/_atomic_write_json
+    claim is: a failure *during* the write must never leave the destination
+    path torn/partial, because the write lands in a same-directory tmp file
+    first and only `os.replace()`s it in on success. Simulate a crash
+    mid-write (after mkstemp, before the write completes) and confirm the
+    pre-existing destination content survives byte-for-byte, and the failed
+    temp file is cleaned up rather than left behind."""
+    path = tmp_path / "state.json"
+    path.write_text('{"original": true}')
+
+    real_fdopen = watchdog.os.fdopen
+
+    def crashing_fdopen(fd, mode):
+        fh = real_fdopen(fd, mode)
+        fh.write = MagicMock(side_effect=OSError("simulated crash mid-write"))
+        return fh
+
+    monkeypatch.setattr(watchdog.os, "fdopen", crashing_fdopen)
+
+    with pytest.raises(OSError):
+        watchdog._atomic_write_json(path, {"new": True})
+
+    # os.replace() never ran -- original content must survive untouched.
+    assert path.read_text() == '{"original": true}'
+    # the except-clause cleanup must have removed the half-written tmp file.
+    leftovers = list(path.parent.glob(".tmp-*"))
+    assert leftovers == []
+
+
+def test_resolved_footer_append_leaves_marker_untouched_on_mid_write_failure(tmp_path, monkeypatch):
+    """Same gap as above, applied to append_resolved_footer specifically:
+    a crash while writing the footer must not corrupt or truncate the
+    existing incident report -- a human reading the marker mid-incident must
+    never see a torn file."""
+    marker = tmp_path / "ALERT.txt"
+    watchdog.write_alert_marker(marker, "fake-container", watchdog._empty_state(), ["reason"], _now())
+    original = marker.read_text()
+
+    real_fdopen = watchdog.os.fdopen
+
+    def crashing_fdopen(fd, mode):
+        fh = real_fdopen(fd, mode)
+        fh.write = MagicMock(side_effect=OSError("simulated crash mid-write"))
+        return fh
+
+    monkeypatch.setattr(watchdog.os, "fdopen", crashing_fdopen)
+
+    with pytest.raises(OSError):
+        watchdog.append_resolved_footer(marker, _now(5))
+
+    assert marker.read_text() == original
     leftovers = list(marker.parent.glob(".tmp-*"))
     assert leftovers == []
 

--- a/tests/test_bus_core_health_watchdog.py
+++ b/tests/test_bus_core_health_watchdog.py
@@ -146,6 +146,58 @@ def test_restart_count_samples_prune_outside_window():
     assert detected is False
 
 
+def test_restart_count_reset_from_container_recreation_rebaselines():
+    # If bus-core is removed and recreated (not just restarted), Docker resets
+    # .RestartCount to 0. evaluate() must re-baseline against the new low
+    # value (via min() over the window), not keep comparing against the old
+    # pre-recreation high-water mark -- see the comment on `oldest_in_window`
+    # in evaluate() for why min() over values (not the earliest sample) is
+    # deliberate.
+    state = watchdog._empty_state()
+    # Pre-recreation: RestartCount climbing normally.
+    for i, rc in enumerate([47, 48, 49]):
+        state, detected, _ = watchdog.evaluate(
+            state, "healthy", restart_count=rc, now=_now(i), restart_count_threshold=3, restart_window_minutes=10
+        )
+    assert detected is False  # steady climb of 2 over 3 samples, below threshold=3
+
+    # Recreation: RestartCount resets to 0. Must not read as a "-49 restarts"
+    # anomaly, and must not silently keep comparing against 47.
+    state, detected, reasons = watchdog.evaluate(
+        state, "starting", restart_count=0, now=_now(3), restart_count_threshold=3, restart_window_minutes=10
+    )
+    assert state["restarts_in_window"] == 0
+    assert detected is False
+
+    # Post-recreation restarts climb from the new baseline and must be
+    # counted correctly (not muted by the stale old high-water mark).
+    for i, rc in enumerate([1, 2, 3], start=4):
+        state, detected, reasons = watchdog.evaluate(
+            state, "starting", restart_count=rc, now=_now(i), restart_count_threshold=3, restart_window_minutes=10
+        )
+    assert state["restarts_in_window"] == 3
+    assert detected is True
+    assert any("restart" in r for r in reasons)
+
+
+def test_evaluate_ignores_malformed_restart_samples_without_crashing():
+    # A hand-edited or partially-migrated state file could carry a sample
+    # missing/with a non-int restart_count. evaluate() must never crash on
+    # this (prune_restart_samples drops it), matching the "never raises
+    # except for genuine tooling failure" contract of the rest of this module.
+    state = watchdog._empty_state()
+    state["restart_samples"] = [
+        {"at": _now(0).isoformat(), "restart_count": "not-an-int"},
+        {"at": _now(0).isoformat()},  # missing restart_count entirely
+        {"restart_count": 5},  # missing "at" entirely
+    ]
+    new_state, detected, reasons = watchdog.evaluate(state, "healthy", restart_count=1, now=_now(1))
+    assert detected is False
+    assert new_state["restarts_in_window"] == 0
+    # Only the current, well-formed sample survives.
+    assert len(new_state["restart_samples"]) == 1
+
+
 def test_restart_count_threshold_not_crossed_stays_healthy():
     state = watchdog._empty_state()
     for i, rc in enumerate([0, 1]):
@@ -350,6 +402,90 @@ def test_atomic_write_survives_no_partial_file_on_success(tmp_path):
     # no leftover temp files
     leftovers = list(state_file.parent.glob(".tmp-*"))
     assert leftovers == []
+
+
+def test_alert_marker_write_is_atomic_no_leftover_temp_files(tmp_path):
+    marker = tmp_path / "nested" / "ALERT.txt"
+    watchdog.write_alert_marker(marker, "fake-container", watchdog._empty_state(), ["reason"], _now())
+    assert marker.exists()
+    assert "CRASH-LOOP ALERT" in marker.read_text()
+    leftovers = list(marker.parent.glob(".tmp-*"))
+    assert leftovers == []
+
+
+def test_resolved_footer_append_is_atomic_and_preserves_original_content(tmp_path):
+    marker = tmp_path / "ALERT.txt"
+    watchdog.write_alert_marker(marker, "fake-container", watchdog._empty_state(), ["reason"], _now())
+    original = marker.read_text()
+    watchdog.append_resolved_footer(marker, _now(5))
+    updated = marker.read_text()
+    assert updated.startswith(original)
+    assert "RESOLVED" in updated
+    leftovers = list(marker.parent.glob(".tmp-*"))
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# Locking -- overlapping-run protection
+# ---------------------------------------------------------------------------
+
+
+def test_state_lock_blocks_concurrent_acquisition(tmp_path):
+    state_file = tmp_path / "state.json"
+    with watchdog._StateLock(state_file):
+        with pytest.raises(watchdog.WatchdogLockedError):
+            with watchdog._StateLock(state_file):
+                pass  # pragma: no cover -- must raise before reaching here
+
+
+def test_state_lock_is_released_after_context_exit(tmp_path):
+    state_file = tmp_path / "state.json"
+    with watchdog._StateLock(state_file):
+        pass
+    # Lock released -- a second acquisition must succeed cleanly.
+    with watchdog._StateLock(state_file):
+        pass
+
+
+def test_run_skips_cleanly_when_lock_already_held(tmp_path):
+    state_file = tmp_path / "state.json"
+    alert_marker = tmp_path / "ALERT.txt"
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
+    with watchdog._StateLock(state_file):
+        with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+            with pytest.raises(watchdog.WatchdogLockedError):
+                watchdog.run(container="fake-container", state_file=state_file, alert_marker=alert_marker, now=_now())
+    # No state file was written by the skipped run.
+    assert not state_file.exists()
+
+
+def test_main_exits_zero_when_lock_already_held(tmp_path):
+    state_file = tmp_path / "state.json"
+    alert_marker = tmp_path / "ALERT.txt"
+    with watchdog._StateLock(state_file):
+        exit_code = watchdog.main([
+            "--container", "fake-container",
+            "--state-file", str(state_file),
+            "--alert-marker", str(alert_marker),
+        ])
+    assert exit_code == 0
+
+
+def test_main_exits_two_not_one_on_permission_error_writing_state(tmp_path):
+    # A filesystem permission error while writing state/marker files must
+    # never be misread as "crash loop detected" (exit 1) -- it gets its own
+    # distinct exit code (2), same family as DockerUnavailableError.
+    state_file = tmp_path / "state.json"
+    alert_marker = tmp_path / "ALERT.txt"
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        with patch.object(watchdog, "_atomic_write_json", side_effect=PermissionError("denied")):
+            exit_code = watchdog.main([
+                "--container", "fake-container",
+                "--state-file", str(state_file),
+                "--alert-marker", str(alert_marker),
+            ])
+    assert exit_code == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bus_core_health_watchdog.py
+++ b/tests/test_bus_core_health_watchdog.py
@@ -530,6 +530,101 @@ def test_main_exits_two_when_docker_binary_missing(tmp_path):
     assert exit_code == 2
 
 
+def test_main_exits_three_on_unexpected_exception(tmp_path):
+    # Anything not covered by the specific except clauses is a bug in the
+    # watchdog itself, not a crash-loop signal -- must get its own exit code
+    # (3), never alias exit 1's "crash loop detected" meaning.
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        with patch.object(watchdog, "evaluate", side_effect=RuntimeError("boom")):
+            exit_code = watchdog.main([
+                "--container", "fake-container",
+                "--state-file", str(tmp_path / "state.json"),
+                "--alert-marker", str(tmp_path / "ALERT.txt"),
+            ])
+    assert exit_code == 3
+
+
+def test_inspect_container_degrades_on_malformed_restart_count():
+    # A non-numeric RestartCount from docker inspect's own JSON must degrade
+    # to 0 with a warning, not raise -- matching inspect_container()'s
+    # documented "never raises" contract.
+    payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": "not-a-number"}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        result = watchdog.inspect_container("fake-container")
+    assert result["restart_count"] == 0
+
+
+def test_evaluate_degrades_on_malformed_consecutive_unhealthy_count():
+    # Same coercion gap, evaluate()'s side: a hand-edited/partially-migrated
+    # state file with a non-numeric consecutive_unhealthy_count must not
+    # crash the check path.
+    state = watchdog._empty_state()
+    state["consecutive_unhealthy_count"] = "garbage"
+    new_state, crash_loop_detected, _reasons = watchdog.evaluate(
+        state, "unhealthy", 0, _now(),
+        unhealthy_streak_threshold=3, restart_count_threshold=3, restart_window_minutes=10,
+    )
+    assert new_state["consecutive_unhealthy_count"] == 1  # degraded to 0, then incremented
+    assert crash_loop_detected is False
+
+
+def test_write_alert_marker_docker_unreachable_gets_distinct_guidance(tmp_path):
+    # docker logs/docker inspect would also fail for the same reason that
+    # produced this alert -- the marker must not recommend them, and must
+    # say plainly that health could not even be checked.
+    marker = tmp_path / "ALERT.txt"
+    state = watchdog._empty_state()
+    state["last_health_status"] = "docker_unreachable"
+    watchdog.write_alert_marker(marker, "fake-container", state, ["docker daemon unreachable"], _now())
+    text = marker.read_text()
+    assert "Docker daemon itself was unreachable" in text
+    assert "systemctl status docker" in text
+    # docker logs/inspect may still be mentioned to explain they won't help,
+    # but must not be presented as the recommended "Check:" next step the
+    # way the regular crash-loop branch presents them.
+    assert "Check:\n  docker logs" not in text
+
+
+def test_write_alert_marker_regular_crash_loop_keeps_original_guidance(tmp_path):
+    marker = tmp_path / "ALERT.txt"
+    state = watchdog._empty_state()
+    state["last_health_status"] = "unhealthy"
+    watchdog.write_alert_marker(marker, "fake-container", state, ["unhealthy streak"], _now())
+    text = marker.read_text()
+    assert "docker logs" in text
+    assert "docker inspect" in text
+
+
+def test_run_preserves_human_note_across_ongoing_incident_ticks(tmp_path):
+    # Regression: write_alert_marker used to clobber the file from scratch on
+    # every tick while the incident was still active, silently destroying
+    # any investigation note a human appended mid-incident.
+    state_file = tmp_path / "state.json"
+    marker = tmp_path / "ALERT.txt"
+    payload = json.dumps([{"State": {"Status": "restarting", "Health": {"Status": "unhealthy"}}, "RestartCount": 9}])
+    with patch("subprocess.run", return_value=_fake_completed(0, payload)):
+        for _ in range(3):
+            watchdog.main([
+                "--container", "fake-container",
+                "--state-file", str(state_file),
+                "--alert-marker", str(marker),
+                "--unhealthy-streak-threshold", "3",
+            ])
+        assert marker.exists()
+        with marker.open("a") as f:
+            f.write("\nfiled JIRA-123, do not delete yet\n")
+        # One more tick of the SAME ongoing incident (still unhealthy).
+        exit_code = watchdog.main([
+            "--container", "fake-container",
+            "--state-file", str(state_file),
+            "--alert-marker", str(marker),
+            "--unhealthy-streak-threshold", "3",
+        ])
+    assert exit_code == 1
+    assert "filed JIRA-123, do not delete yet" in marker.read_text()
+
+
 def test_main_uses_project_default_container_name(tmp_path):
     payload = json.dumps([{"State": {"Status": "running", "Health": {"Status": "healthy"}}, "RestartCount": 0}])
     captured_args = {}


### PR DESCRIPTION
## Summary

- `bus-core` (Redis, `services/orion-bus/docker-compose.yml`) periodically crash-loops from AOF corruption (a parallel task is adding auto-repair for that -- not touched here, only its own definition/entrypoint were explicitly left alone). The real gap: detecting "bus is stuck in a crash loop" today depends on either a human noticing cascading failures across many *other* services, or on signals that themselves route through the bus or Postgres -- both of which can be down *at the same time* in dev (confirmed, not hypothetical).
- Added `scripts/bus_core_health_watchdog.py`: a standalone, host-level script reading `docker inspect`'s `.State.Health.Status`/`.RestartCount` for the real `orion-orion-athena-bus-core` container only -- zero Redis connection, zero Postgres connection, ever. Two independent crash-loop signatures (either fires an alert): consecutive-unhealthy streak (default 3) and restart-count-within-window (default 3 restarts / 10 minutes, catches a loop fast enough it never settles into `unhealthy` between polls).
- No `notify-send`/`osascript`/desktop-notification mechanism exists anywhere in this repo (grepped first). The one HTTP alert path that does exist (`orion-notify`'s `/attention/request`) is itself infrastructure that could plausibly be down in the same incident this watchdog exists to catch, so on alert it writes a plain, loud, never-auto-deleted marker file instead: `${TELEMETRY_ROOT}/${PROJECT}/bus/ORION_BUS_CRASH_LOOP_ALERT.txt`.
- State persists to `${TELEMETRY_ROOT}/${PROJECT}/bus/watchdog/health_watchdog_state.json` -- a sibling of, not inside, the AOF data mount a parallel AOF-repair task may also be touching.
- Matched this repo's dominant convention for this job shape (crontab, mirroring `scripts/check_concept_relation_digest_liveness.py` + `services/orion-rdf-store/README.md`'s "Scheduled maintenance" section) over the one systemd-timer precedent (a single long-running backup job, different shape, only present in a gitignored worktree).
- High-effort code-review subagent pass found 5 real Important-severity gaps (state/marker-file concurrency race, an uncaught-exception exit-code collision, an unguarded `KeyError` on malformed persisted data) -- all fixed with new regression tests.

## Test plan

- [x] `pytest tests/test_bus_core_health_watchdog.py -q` -- 40 passed
- [x] `pytest tests/test_bus_core_health_watchdog.py tests/test_check_concept_relation_digest_liveness.py -q` -- 48 passed
- [x] `python -m py_compile scripts/bus_core_health_watchdog.py` -- OK
- [x] Live smoke against the real, currently-running `orion-orion-athena-bus-core` container (read-only `docker inspect`): correctly read `healthy`/0-restarts and wrote a correctly-shaped state file
- [x] End-to-end crash-loop simulation via a fake `docker` binary: 3 consecutive unhealthy checks -> marker written with correct reasons -> recovery -> RESOLVED footer appended, marker never deleted
- [x] `git diff --check` clean, no `.env` staged
- [x] Code review (high effort, subagent) run and all Important findings fixed

Full PR report: `docs/superpowers/pr-reports/2026-07-16-bus-core-health-watchdog-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)