### PR TITLE
feat: concept-atlas graph pipeline — Wave 2 (relation classification, salience-gated recall, Concept Atlas Hub tab)

### DIFF
--- a/orion/substrate/relation_classification.py
+++ b/orion/substrate/relation_classification.py
@@ -1,0 +1,346 @@
+"""Layer 3 relation-classification decision logic (Phase 4).
+
+Phase 4 of docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md.
+
+Clustering (topic-foundry, via `orion/substrate/adapters/topic_foundry.py`)
+produces free `co_occurs_with` `SubstrateEdgeV1` records by pure counting --
+cheap, no inference. Typed relationships (`supports`/`contradicts`/`refines`,
+see `SubstrateEdgePredicateV1` in `orion/core/schemas/cognitive_substrate.py`)
+require actual semantic judgment that counting cannot produce -- that is
+genuinely worth an LLM call, but only for node pairs that have already proven
+themselves worth the cost via strong co-occurrence.
+
+This module is the *decision logic* for "is this pair worth classifying" (three
+interchangeable threshold strategies) plus the *shape* of the classification
+step itself. It does NOT call an LLM: the classification step takes an
+injected callable (`RelationClassifier`) supplied by the caller. Wiring a real
+classifier and hooking this into a live promotion-state-transition trigger is
+explicitly out of scope here -- see the spec's Phase 4 acceptance check and
+"Recommended next patch" item 5. Mirrors how the Phase 2 topic-foundry adapter
+(`orion/substrate/adapters/topic_foundry.py`) stayed a pure conversion
+function with no HTTP/bus I/O.
+
+Three strategies, one entry point:
+
+- **count** (Option A, baseline): raw `edge.metadata["co_occurrence_count"]`
+  against a threshold. Deliberately naive -- exists to give the other two
+  strategies something to be compared against, not because it is expected to
+  win.
+- **pmi** (Option B): pointwise mutual information, `log(P(A,B) / (P(A)*P(B)))`,
+  using each node's `signals.salience` as the marginal-frequency proxy and the
+  edge's own normalized co-occurrence strength (`salience`/`confidence`,
+  already normalized in [0, 1] relative to the run's max pair count by
+  `map_topic_foundry_run_to_substrate`) as the joint-probability proxy.
+- **activation** (Option C): a recency-weighted signal built from
+  `SubstrateActivationV1`'s existing `activation`/`decay_half_life_seconds`/
+  `decay_floor`/`recency_score` fields on both nodes, reusing the same
+  validated half-life decay helper `orion/substrate/dynamics.py` already uses
+  in its tick loop (`orion.core.activation_decay.decay_activation`) rather
+  than reinventing decay math.
+
+Option D (piggyback purely on the promotion-state transition, with no
+co-occurrence signal at all) is explicitly **deferred** per the spec's
+Non-goals -- not built here.
+
+All three strategies degrade gracefully on missing/malformed input: they
+return `False` (not-worth-classifying) rather than raising. `classify_relation`
+never raises either -- an exception from the injected classifier is caught,
+not propagated.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Callable, Literal, Optional
+
+from orion.core.activation_decay import decay_activation
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateEdgePredicateV1,
+    SubstrateEdgeV1,
+)
+
+from .adapters._common import make_provenance, make_temporal
+
+RelationClassifierStrategy = Literal["count", "pmi", "activation"]
+
+# Injected classifier signature. The caller owns the actual LLM call (or any
+# other judgment source); this module only decides *whether* to invoke it and
+# *what* to do with the result. Returning `None` means "no confident
+# classification" -- treated the same as an exception: no edge is produced.
+RelationClassifier = Callable[
+    [ConceptNodeV1, ConceptNodeV1, SubstrateEdgeV1], Optional[SubstrateEdgePredicateV1]
+]
+
+DEFAULT_COUNT_THRESHOLD = 5
+# PMI > 0 means the pair co-occurs more than chance would predict given each
+# concept's individual salience -- the natural "worth it" cutoff for Option B.
+DEFAULT_PMI_THRESHOLD = 0.0
+DEFAULT_ACTIVATION_THRESHOLD = 0.3
+
+
+# --------------------------------------------------------------------------
+# Option A -- raw count baseline.
+# --------------------------------------------------------------------------
+
+
+def count_score(edge: Optional[SubstrateEdgeV1]) -> Optional[int]:
+    """Read `edge.metadata["co_occurrence_count"]`. `None` if missing/malformed."""
+    if edge is None:
+        return None
+    metadata = getattr(edge, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    raw = metadata.get("co_occurrence_count")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def worth_classifying_count(
+    edge: Optional[SubstrateEdgeV1], *, threshold: int = DEFAULT_COUNT_THRESHOLD
+) -> bool:
+    """Option A: worth classifying iff the raw co-occurrence count >= threshold."""
+    count = count_score(edge)
+    if count is None:
+        return False
+    return count >= threshold
+
+
+# --------------------------------------------------------------------------
+# Option B -- PMI-style normalized association.
+# --------------------------------------------------------------------------
+
+
+def pmi_score(
+    node_a: Optional[ConceptNodeV1],
+    node_b: Optional[ConceptNodeV1],
+    edge: Optional[SubstrateEdgeV1],
+) -> Optional[float]:
+    """log(P(A,B) / (P(A) * P(B))), using salience as the marginal proxy.
+
+    `P(A)`/`P(B)` come from each node's `signals.salience` (topic-foundry's
+    adapter already sets this to `count / total_docs` -- a real marginal-
+    frequency proxy, not an invented one). `P(A,B)` comes from the edge's own
+    normalized co-occurrence strength (`salience`, falling back to
+    `confidence` if `salience` is unset), which `map_topic_foundry_run_to_substrate`
+    already normalizes to [0, 1] relative to the run's max pair count.
+
+    Returns `None` (never raises) on any missing field, non-positive marginal,
+    non-positive joint term, or a `math.log` domain error -- all sentinel for
+    "not worth classifying" under this strategy.
+    """
+    try:
+        marginal_a = node_a.signals.salience
+        marginal_b = node_b.signals.salience
+        joint = edge.salience if edge.salience > 0.0 else edge.confidence
+    except AttributeError:
+        return None
+
+    if marginal_a is None or marginal_b is None or joint is None:
+        return None
+    if marginal_a <= 0.0 or marginal_b <= 0.0 or joint <= 0.0:
+        return None
+
+    try:
+        return math.log(joint / (marginal_a * marginal_b))
+    except (ValueError, ZeroDivisionError):
+        return None
+
+
+def worth_classifying_pmi(
+    node_a: Optional[ConceptNodeV1],
+    node_b: Optional[ConceptNodeV1],
+    edge: Optional[SubstrateEdgeV1],
+    *,
+    threshold: float = DEFAULT_PMI_THRESHOLD,
+) -> bool:
+    """Option B: worth classifying iff PMI(A, B) >= threshold."""
+    score = pmi_score(node_a, node_b, edge)
+    if score is None:
+        return False
+    return score >= threshold
+
+
+# --------------------------------------------------------------------------
+# Option C -- decayed activation crossing a threshold.
+# --------------------------------------------------------------------------
+
+
+def decayed_activation_score(
+    node: Optional[ConceptNodeV1], *, now: Optional[datetime] = None
+) -> Optional[float]:
+    """Recency-weighted activation for one node.
+
+    Combines the half-life-decayed `activation` value (via the same
+    `orion.core.activation_decay.decay_activation` helper
+    `orion/substrate/dynamics.py`'s tick loop already uses -- reusing
+    validated decay math rather than reinventing it) with the node's own
+    `recency_score`, averaged equally.
+
+    Returns `None` (degrade, never raise/guess) if the node's activation
+    bundle is missing or at its schema default (`activation <= 0.0` is
+    indistinguishable from "never seeded" under this schema, so it is treated
+    as unset rather than as a real zero-activation reading).
+    """
+    if node is None:
+        return None
+    try:
+        activation_signal = node.signals.activation
+        observed_at = node.temporal.observed_at
+    except AttributeError:
+        return None
+    if activation_signal is None or observed_at is None:
+        return None
+    if activation_signal.activation <= 0.0:
+        return None
+
+    reference = now or datetime.now(timezone.utc)
+    if observed_at.tzinfo is None:
+        observed_at = observed_at.replace(tzinfo=timezone.utc)
+    elapsed_seconds = max(0.0, (reference - observed_at).total_seconds())
+
+    try:
+        decayed = decay_activation(
+            current=activation_signal.activation,
+            elapsed_seconds=elapsed_seconds,
+            half_life_seconds=activation_signal.decay_half_life_seconds,
+            floor=activation_signal.decay_floor,
+        )
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+
+    combined = (0.5 * decayed) + (0.5 * activation_signal.recency_score)
+    return max(activation_signal.decay_floor, min(1.0, combined))
+
+
+def worth_classifying_activation(
+    node_a: Optional[ConceptNodeV1],
+    node_b: Optional[ConceptNodeV1],
+    edge: Optional[SubstrateEdgeV1] = None,  # noqa: ARG001 -- kept for a uniform 3-strategy signature
+    *,
+    threshold: float = DEFAULT_ACTIVATION_THRESHOLD,
+    now: Optional[datetime] = None,
+) -> bool:
+    """Option C: worth classifying iff both nodes' decayed activation crosses threshold.
+
+    Uses `min()` across the pair -- one node showing recent activity does not
+    make an otherwise-dormant partner worth an LLM call.
+    """
+    score_a = decayed_activation_score(node_a, now=now)
+    score_b = decayed_activation_score(node_b, now=now)
+    if score_a is None or score_b is None:
+        return False
+    return min(score_a, score_b) >= threshold
+
+
+# --------------------------------------------------------------------------
+# Single dispatch entry point (A/B/C behind one flag, for empirical
+# comparison -- Option D is explicitly deferred, see module docstring).
+# --------------------------------------------------------------------------
+
+
+def is_worth_classifying(
+    node_a: Optional[ConceptNodeV1],
+    node_b: Optional[ConceptNodeV1],
+    edge: Optional[SubstrateEdgeV1],
+    *,
+    strategy: RelationClassifierStrategy = "count",
+    count_threshold: int = DEFAULT_COUNT_THRESHOLD,
+    pmi_threshold: float = DEFAULT_PMI_THRESHOLD,
+    activation_threshold: float = DEFAULT_ACTIVATION_THRESHOLD,
+    now: Optional[datetime] = None,
+) -> bool:
+    """Dispatch to the requested strategy. Unknown strategy or any internal
+    error degrades to `False` -- never raises."""
+    try:
+        if strategy == "count":
+            return worth_classifying_count(edge, threshold=count_threshold)
+        if strategy == "pmi":
+            return worth_classifying_pmi(node_a, node_b, edge, threshold=pmi_threshold)
+        if strategy == "activation":
+            return worth_classifying_activation(
+                node_a, node_b, edge, threshold=activation_threshold, now=now
+            )
+    except Exception:
+        return False
+    return False
+
+
+# --------------------------------------------------------------------------
+# The classification step's shape (no live LLM call -- classifier injected).
+# --------------------------------------------------------------------------
+
+
+def classify_relation(
+    node_a: ConceptNodeV1,
+    node_b: ConceptNodeV1,
+    edge: SubstrateEdgeV1,
+    *,
+    classifier: RelationClassifier,
+    strategy: RelationClassifierStrategy = "count",
+    count_threshold: int = DEFAULT_COUNT_THRESHOLD,
+    pmi_threshold: float = DEFAULT_PMI_THRESHOLD,
+    activation_threshold: float = DEFAULT_ACTIVATION_THRESHOLD,
+    now: Optional[datetime] = None,
+) -> Optional[SubstrateEdgeV1]:
+    """Decide whether `edge` is worth an LLM classification call, and if so,
+    call the caller-injected `classifier` and build a typed `SubstrateEdgeV1`
+    from its result.
+
+    `classifier` is invoked with `(node_a, node_b, edge)` and must return a
+    `SubstrateEdgePredicateV1` (e.g. "supports"/"contradicts"/"refines") or
+    `None`. This function never calls a real LLM itself -- that is live
+    infrastructure wiring, out of scope for this phase.
+
+    Returns `None` (no new edge) if:
+    - the pair is not worth classifying under `strategy` (see `is_worth_classifying`);
+    - `classifier` returns `None`;
+    - `classifier` raises (the exception is caught, never propagated);
+    - the returned predicate fails schema validation when building the edge.
+    """
+    if not is_worth_classifying(
+        node_a,
+        node_b,
+        edge,
+        strategy=strategy,
+        count_threshold=count_threshold,
+        pmi_threshold=pmi_threshold,
+        activation_threshold=activation_threshold,
+        now=now,
+    ):
+        return None
+
+    try:
+        predicate = classifier(node_a, node_b, edge)
+    except Exception:
+        return None
+
+    if predicate is None:
+        return None
+
+    try:
+        return SubstrateEdgeV1(
+            source=NodeRefV1(node_id=node_a.node_id, node_kind=node_a.node_kind),
+            target=NodeRefV1(node_id=node_b.node_id, node_kind=node_b.node_kind),
+            predicate=predicate,
+            temporal=make_temporal(observed_at=now),
+            confidence=edge.confidence,
+            salience=edge.salience,
+            provenance=make_provenance(
+                source_kind="relation_classification.llm_judgment",
+                source_channel=f"orion:substrate:relation_classification:{strategy}",
+                producer="relation_classification",
+                evidence_refs=[edge.edge_id],
+            ),
+            metadata={"strategy": strategy, "source_edge_id": edge.edge_id},
+        )
+    except Exception:
+        # Malformed predicate (e.g. a stub classifier returning garbage) or
+        # any other schema-validation failure -- degrade, never raise.
+        return None

--- a/orion/substrate/tests/test_relation_classification.py
+++ b/orion/substrate/tests/test_relation_classification.py
@@ -1,0 +1,383 @@
+"""Tests for Phase 4 relation-classification decision logic.
+
+Covers docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
+Phase 4: the three interchangeable threshold strategies (A count baseline, B
+PMI, C decayed activation) and the `classify_relation` entry point that
+decides whether to invoke a caller-injected classifier callable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateActivationV1,
+    SubstrateEdgeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.relation_classification import (
+    DEFAULT_COUNT_THRESHOLD,
+    classify_relation,
+    count_score,
+    decayed_activation_score,
+    is_worth_classifying,
+    pmi_score,
+    worth_classifying_activation,
+    worth_classifying_count,
+    worth_classifying_pmi,
+)
+
+NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _provenance(producer: str = "test") -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="test",
+        source_channel="test",
+        producer=producer,
+    )
+
+
+def _concept(
+    *,
+    node_id: str,
+    label: str,
+    salience: float = 0.1,
+    observed_at: datetime = NOW,
+    activation: SubstrateActivationV1 | None = None,
+) -> ConceptNodeV1:
+    return ConceptNodeV1(
+        node_id=node_id,
+        anchor_scope="world",
+        label=label,
+        temporal=SubstrateTemporalWindowV1(observed_at=observed_at),
+        provenance=_provenance(),
+        signals=SubstrateSignalBundleV1(
+            salience=salience,
+            activation=activation or SubstrateActivationV1(),
+        ),
+    )
+
+
+def _edge(
+    *,
+    source_id: str = "concept-a",
+    target_id: str = "concept-b",
+    co_occurrence_count: int | None = 10,
+    salience: float = 0.5,
+    confidence: float = 0.5,
+    extra_metadata: dict | None = None,
+) -> SubstrateEdgeV1:
+    metadata = dict(extra_metadata or {})
+    if co_occurrence_count is not None:
+        metadata["co_occurrence_count"] = co_occurrence_count
+    return SubstrateEdgeV1(
+        source=NodeRefV1(node_id=source_id, node_kind="concept"),
+        target=NodeRefV1(node_id=target_id, node_kind="concept"),
+        predicate="co_occurs_with",
+        temporal=SubstrateTemporalWindowV1(observed_at=NOW),
+        confidence=confidence,
+        salience=salience,
+        provenance=_provenance(),
+        metadata=metadata,
+    )
+
+
+# --------------------------------------------------------------------------
+# Option A -- count baseline.
+# --------------------------------------------------------------------------
+
+
+def test_count_below_threshold_not_worth_classifying() -> None:
+    edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD - 1)
+    assert worth_classifying_count(edge) is False
+
+
+def test_count_at_threshold_is_worth_classifying() -> None:
+    edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD)
+    assert worth_classifying_count(edge) is True
+
+
+def test_count_above_threshold_is_worth_classifying() -> None:
+    edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD + 5)
+    assert worth_classifying_count(edge) is True
+
+
+def test_count_custom_threshold() -> None:
+    edge = _edge(co_occurrence_count=3)
+    assert worth_classifying_count(edge, threshold=3) is True
+    assert worth_classifying_count(edge, threshold=4) is False
+
+
+def test_count_degrades_gracefully_on_missing_metadata() -> None:
+    edge = _edge(co_occurrence_count=None)
+    assert count_score(edge) is None
+    assert worth_classifying_count(edge) is False
+
+
+def test_count_degrades_gracefully_on_malformed_metadata() -> None:
+    edge = _edge(co_occurrence_count=None, extra_metadata={"co_occurrence_count": "not-a-number"})
+    assert count_score(edge) is None
+    assert worth_classifying_count(edge) is False
+
+
+def test_count_degrades_gracefully_on_none_edge() -> None:
+    assert worth_classifying_count(None) is False
+
+
+# --------------------------------------------------------------------------
+# Option B -- PMI.
+# --------------------------------------------------------------------------
+
+
+def test_pmi_associated_pair_scores_higher_than_coincidental_pair() -> None:
+    # Clearly associated: both concepts individually rare, but they co-occur
+    # at a high normalized strength relative to the run's max pair count.
+    associated_a = _concept(node_id="concept-a", label="rare-topic-a", salience=0.1)
+    associated_b = _concept(node_id="concept-b", label="rare-topic-b", salience=0.1)
+    associated_edge = _edge(salience=0.5, confidence=0.5)
+
+    # Clearly coincidental: both concepts individually very common (high
+    # salience -- they show up everywhere), but their joint co-occurrence
+    # strength is low, i.e. no more than chance would predict.
+    coincidental_a = _concept(node_id="concept-c", label="common-topic-c", salience=0.5)
+    coincidental_b = _concept(node_id="concept-d", label="common-topic-d", salience=0.5)
+    coincidental_edge = _edge(salience=0.05, confidence=0.05)
+
+    associated_score = pmi_score(associated_a, associated_b, associated_edge)
+    coincidental_score = pmi_score(coincidental_a, coincidental_b, coincidental_edge)
+
+    assert associated_score is not None
+    assert coincidental_score is not None
+    assert associated_score > coincidental_score
+    # The associated pair should also cross the default "worth it" cutoff
+    # while the coincidental pair should not.
+    assert worth_classifying_pmi(associated_a, associated_b, associated_edge) is True
+    assert worth_classifying_pmi(coincidental_a, coincidental_b, coincidental_edge) is False
+
+
+def test_pmi_degrades_gracefully_on_zero_salience() -> None:
+    node_a = _concept(node_id="concept-a", label="a", salience=0.0)
+    node_b = _concept(node_id="concept-b", label="b", salience=0.1)
+    edge = _edge()
+    assert pmi_score(node_a, node_b, edge) is None
+    assert worth_classifying_pmi(node_a, node_b, edge) is False
+
+
+def test_pmi_degrades_gracefully_on_zero_joint_term() -> None:
+    node_a = _concept(node_id="concept-a", label="a", salience=0.1)
+    node_b = _concept(node_id="concept-b", label="b", salience=0.1)
+    edge = _edge(salience=0.0, confidence=0.0)
+    assert pmi_score(node_a, node_b, edge) is None
+    assert worth_classifying_pmi(node_a, node_b, edge) is False
+
+
+def test_pmi_degrades_gracefully_on_none_node() -> None:
+    edge = _edge()
+    assert pmi_score(None, None, edge) is None
+    assert worth_classifying_pmi(None, None, edge) is False
+
+
+def test_pmi_falls_back_to_confidence_when_salience_unset() -> None:
+    node_a = _concept(node_id="concept-a", label="a", salience=0.1)
+    node_b = _concept(node_id="concept-b", label="b", salience=0.1)
+    edge = _edge(salience=0.0, confidence=0.6)
+    score = pmi_score(node_a, node_b, edge)
+    assert score is not None
+
+
+# --------------------------------------------------------------------------
+# Option C -- decayed activation.
+# --------------------------------------------------------------------------
+
+
+def test_activation_recent_reinforced_crosses_threshold() -> None:
+    reinforced = SubstrateActivationV1(
+        activation=0.9,
+        recency_score=0.9,
+        decay_half_life_seconds=3600,
+        decay_floor=0.1,
+    )
+    node_a = _concept(node_id="concept-a", label="a", observed_at=NOW, activation=reinforced)
+    node_b = _concept(node_id="concept-b", label="b", observed_at=NOW, activation=reinforced)
+
+    score_a = decayed_activation_score(node_a, now=NOW)
+    assert score_a is not None
+    assert score_a >= 0.3
+    assert worth_classifying_activation(node_a, node_b, now=NOW) is True
+
+
+def test_activation_stale_decayed_does_not_cross_threshold() -> None:
+    # Short half-life, observed long ago -- heavily decayed by "now".
+    stale_bundle = SubstrateActivationV1(
+        activation=0.9,
+        recency_score=0.0,
+        decay_half_life_seconds=60,
+        decay_floor=0.0,
+    )
+    long_ago = NOW - timedelta(hours=1)
+    node_a = _concept(node_id="concept-a", label="a", observed_at=long_ago, activation=stale_bundle)
+    node_b = _concept(node_id="concept-b", label="b", observed_at=long_ago, activation=stale_bundle)
+
+    score_a = decayed_activation_score(node_a, now=NOW)
+    assert score_a is not None
+    assert score_a < 0.3
+    assert worth_classifying_activation(node_a, node_b, now=NOW) is False
+
+
+def test_activation_unset_degrades_gracefully() -> None:
+    # Default SubstrateActivationV1() has activation=0.0 -- schema default,
+    # indistinguishable from "never seeded"; must degrade, not raise/guess.
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+
+    assert decayed_activation_score(node_a) is None
+    assert worth_classifying_activation(node_a, node_b) is False
+
+
+def test_activation_one_node_unset_still_degrades() -> None:
+    reinforced = SubstrateActivationV1(
+        activation=0.9, recency_score=0.9, decay_half_life_seconds=3600, decay_floor=0.1
+    )
+    node_a = _concept(node_id="concept-a", label="a", observed_at=NOW, activation=reinforced)
+    node_b = _concept(node_id="concept-b", label="b")  # unset activation
+
+    assert worth_classifying_activation(node_a, node_b, now=NOW) is False
+
+
+def test_activation_degrades_gracefully_on_none_node() -> None:
+    assert decayed_activation_score(None) is None
+    assert worth_classifying_activation(None, None) is False
+
+
+# --------------------------------------------------------------------------
+# is_worth_classifying dispatch.
+# --------------------------------------------------------------------------
+
+
+def test_dispatch_unknown_strategy_returns_false() -> None:
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+    edge = _edge()
+    assert is_worth_classifying(node_a, node_b, edge, strategy="not-a-real-strategy") is False  # type: ignore[arg-type]
+
+
+def test_dispatch_routes_to_count() -> None:
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+    edge = _edge(co_occurrence_count=100)
+    assert is_worth_classifying(node_a, node_b, edge, strategy="count") is True
+    assert is_worth_classifying(node_a, node_b, edge, strategy="count", count_threshold=1000) is False
+
+
+# --------------------------------------------------------------------------
+# classify_relation entry point.
+# --------------------------------------------------------------------------
+
+
+def test_classify_relation_calls_classifier_only_when_worth_it() -> None:
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+    calls: list[tuple] = []
+
+    def fake_classifier(a, b, e):
+        calls.append((a.node_id, b.node_id, e.edge_id))
+        return "supports"
+
+    below_edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD - 1)
+    result_below = classify_relation(node_a, node_b, below_edge, classifier=fake_classifier)
+    assert result_below is None
+    assert calls == []
+
+    above_edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD)
+    result_above = classify_relation(node_a, node_b, above_edge, classifier=fake_classifier)
+    assert result_above is not None
+    assert result_above.predicate == "supports"
+    assert result_above.source.node_id == "concept-a"
+    assert result_above.target.node_id == "concept-b"
+    assert calls == [("concept-a", "concept-b", above_edge.edge_id)]
+
+
+def test_classify_relation_none_result_produces_no_edge() -> None:
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+    edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD)
+
+    def none_classifier(a, b, e):
+        return None
+
+    assert classify_relation(node_a, node_b, edge, classifier=none_classifier) is None
+
+
+def test_classify_relation_catches_classifier_exception() -> None:
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+    edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD)
+
+    def raising_classifier(a, b, e):
+        raise RuntimeError("boom")
+
+    result = classify_relation(node_a, node_b, edge, classifier=raising_classifier)
+    assert result is None
+
+
+def test_classify_relation_catches_invalid_predicate_from_classifier() -> None:
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+    edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD)
+
+    def bogus_classifier(a, b, e):
+        return "not-a-real-predicate"
+
+    result = classify_relation(node_a, node_b, edge, classifier=bogus_classifier)
+    assert result is None
+
+
+def test_classify_relation_with_pmi_strategy() -> None:
+    node_a = _concept(node_id="concept-a", label="a", salience=0.1)
+    node_b = _concept(node_id="concept-b", label="b", salience=0.1)
+    edge = _edge(salience=0.5, confidence=0.5)
+
+    def fake_classifier(a, b, e):
+        return "refines"
+
+    result = classify_relation(node_a, node_b, edge, classifier=fake_classifier, strategy="pmi")
+    assert result is not None
+    assert result.predicate == "refines"
+    assert result.metadata["strategy"] == "pmi"
+
+
+def test_classify_relation_with_activation_strategy() -> None:
+    reinforced = SubstrateActivationV1(
+        activation=0.9, recency_score=0.9, decay_half_life_seconds=3600, decay_floor=0.1
+    )
+    node_a = _concept(node_id="concept-a", label="a", observed_at=NOW, activation=reinforced)
+    node_b = _concept(node_id="concept-b", label="b", observed_at=NOW, activation=reinforced)
+    edge = _edge()
+
+    def fake_classifier(a, b, e):
+        return "contradicts"
+
+    result = classify_relation(
+        node_a, node_b, edge, classifier=fake_classifier, strategy="activation", now=NOW
+    )
+    assert result is not None
+    assert result.predicate == "contradicts"
+
+
+def test_classify_relation_degrades_gracefully_never_raises() -> None:
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+    malformed_edge = _edge(co_occurrence_count=None, extra_metadata={"co_occurrence_count": object()})
+
+    def fake_classifier(a, b, e):
+        return "supports"
+
+    # Should not raise even with a malformed edge metadata value.
+    result = classify_relation(node_a, node_b, malformed_edge, classifier=fake_classifier)
+    assert result is None

--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -1,0 +1,317 @@
+"""Concept Atlas — read-only interpretability routes for the substrate concept graph.
+
+Phase 8 of the concept-graph-pipeline design
+(``docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md``).
+
+This module owns exactly two GET routes plus the standalone page route for the
+iframe-embedded Concept Atlas Hub tab. It deliberately does not construct its
+own substrate store instance: ``scripts.api_routes`` already builds one shared
+``SUBSTRATE_SEMANTIC_STORE`` at import time via ``build_substrate_store_from_env()``
+(see ``services/orion-hub/scripts/api_routes.py``), and ``memory_graph_routes.py``
+already establishes the convention of importing ``scripts.api_routes`` inside
+route functions (deferred import) rather than at module load time to reuse that
+shared instance. This module follows the same convention.
+
+If that store is ever not attached / not importable, every route here degrades
+to an honest "unavailable" response instead of fabricating data or raising a
+500 — this is a debug/interpretability surface, not a critical path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import HTMLResponse
+
+logger = logging.getLogger("orion-hub.concept_atlas")
+
+router = APIRouter(tags=["concept-atlas"])
+
+# Top-N nodes by (activation-weighted) degree flagged as "god nodes" in the
+# network response. The store is small and in-memory (per the design spec's
+# explicit non-goal of no precomputed ranking job), so this is computed fresh
+# on every request rather than cached.
+_GOD_NODE_TOP_N = 5
+
+_VALID_ANCHOR_SCOPES = {"orion", "juniper", "relationship", "world", "session"}
+# promotion_state is not a network-route query param per the design spec's
+# route contract (scope/min_activation/focus only); the Concept Atlas UI
+# applies its promotion_state global filter client-side against this
+# endpoint's response instead of round-tripping it server-side.
+
+# Concept nodes sitting within this margin of their own decay_floor are
+# treated as "at risk" in the summary response. This is only meaningful once
+# a node's activation has moved off its schema default of 0.0 — see the
+# comment in ``_at_risk_concepts`` below.
+_AT_RISK_MARGIN = 0.05
+
+
+def _get_substrate_store() -> Any:
+    """Best-effort resolution of the shared substrate store, never raises.
+
+    Deferred import mirrors ``memory_graph_routes.py``'s established pattern
+    (``import scripts.api_routes as api_mod`` inside route functions) so this
+    module does not force a heavy import of ``scripts.api_routes`` at module
+    load time -- useful for isolated router tests, and consistent with the
+    existing convention rather than inventing a new one.
+    """
+    try:
+        import scripts.api_routes as api_mod
+    except Exception as exc:  # pragma: no cover - defensive, mirrors route-level degrade
+        logger.warning("concept_atlas_store_import_failed error=%s", exc)
+        return None
+    store = getattr(api_mod, "SUBSTRATE_SEMANTIC_STORE", None)
+    if store is None:
+        logger.info("concept_atlas_store_not_attached")
+    return store
+
+
+def _unavailable(reason: str, error: Optional[str] = None, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"available": False, "reason": reason}
+    if error:
+        payload["error"] = error
+    payload.update(extra)
+    return payload
+
+
+def _concept_nodes(store: Any) -> list[Any]:
+    """All concept-kind nodes from the store's snapshot, or [] on any failure."""
+    try:
+        snapshot = store.snapshot()
+    except Exception as exc:
+        logger.warning("concept_atlas_snapshot_failed error=%s", exc)
+        return []
+    return [n for n in snapshot.nodes.values() if getattr(n, "node_kind", None) == "concept"]
+
+
+def _at_risk_concepts(concept_nodes: list[Any]) -> tuple[list[dict[str, Any]], Optional[str]]:
+    """Concepts whose activation is decaying toward their decay_floor.
+
+    Honesty note: ``SubstrateActivationV1.activation`` defaults to 0.0 and no
+    live writer currently drives concept-node decay in the default
+    ``InMemorySubstrateGraphStore`` path (per the design spec's Current
+    architecture section: "present in schema, no confirmed live writer").
+    Returning every node at the default as "at risk" would be a fabricated
+    signal, not a real one. So: if every concept node's activation is exactly
+    the same value (almost always 0.0 today), this returns an empty list and
+    an explanatory note instead of pretending the field carries real
+    information yet.
+    """
+    if not concept_nodes:
+        return [], None
+    activations = {float(n.signals.activation.activation) for n in concept_nodes}
+    if len(activations) <= 1:
+        return [], (
+            "activation shows no variance across concept nodes yet (no live decay "
+            "writer wired to this store today) -- at_risk is intentionally empty "
+            "rather than fabricated"
+        )
+    at_risk: list[dict[str, Any]] = []
+    for n in concept_nodes:
+        act = n.signals.activation
+        if float(act.activation) <= float(act.decay_floor) + _AT_RISK_MARGIN:
+            at_risk.append(
+                {
+                    "node_id": n.node_id,
+                    "label": getattr(n, "label", n.node_id),
+                    "activation": float(act.activation),
+                    "decay_floor": float(act.decay_floor),
+                    "promotion_state": n.promotion_state,
+                }
+            )
+    at_risk.sort(key=lambda row: row["activation"])
+    return at_risk[:20], None
+
+
+@router.get("/api/substrate/concepts/summary")
+async def concept_atlas_summary() -> dict[str, Any]:
+    store = _get_substrate_store()
+    if store is None:
+        return _unavailable(
+            "substrate_store_unavailable",
+            total_concepts=0,
+            by_promotion_state={},
+            by_anchor_scope={},
+            edge_counts_by_predicate={},
+            at_risk=[],
+        )
+
+    concept_nodes = _concept_nodes(store)
+
+    by_promotion_state: dict[str, int] = {}
+    by_anchor_scope: dict[str, int] = {}
+    for node in concept_nodes:
+        by_promotion_state[node.promotion_state] = by_promotion_state.get(node.promotion_state, 0) + 1
+        by_anchor_scope[node.anchor_scope] = by_anchor_scope.get(node.anchor_scope, 0) + 1
+
+    edge_counts_by_predicate: dict[str, int] = {}
+    try:
+        snapshot = store.snapshot()
+        concept_ids = {n.node_id for n in concept_nodes}
+        for edge in snapshot.edges.values():
+            if edge.source.node_id in concept_ids or edge.target.node_id in concept_ids:
+                edge_counts_by_predicate[edge.predicate] = edge_counts_by_predicate.get(edge.predicate, 0) + 1
+    except Exception as exc:
+        logger.warning("concept_atlas_summary_edge_scan_failed error=%s", exc)
+
+    at_risk, at_risk_note = _at_risk_concepts(concept_nodes)
+
+    return {
+        "available": True,
+        "total_concepts": len(concept_nodes),
+        "by_promotion_state": by_promotion_state,
+        "by_anchor_scope": by_anchor_scope,
+        "edge_counts_by_predicate": edge_counts_by_predicate,
+        "at_risk": at_risk,
+        "at_risk_note": at_risk_note,
+    }
+
+
+@router.get("/api/substrate/concepts/network")
+async def concept_atlas_network(
+    scope: Optional[str] = Query(None),
+    min_activation: Optional[str] = Query(None),
+    focus: Optional[str] = Query(None),
+) -> dict[str, Any]:
+    store = _get_substrate_store()
+    if store is None:
+        return _unavailable("substrate_store_unavailable", nodes=[], edges=[], god_node_count=0)
+
+    try:
+        result = store.query_concept_region(limit_nodes=300, limit_edges=600)
+    except Exception as exc:
+        logger.warning("concept_atlas_network_query_failed error=%s", exc)
+        return _unavailable("substrate_store_error", str(exc), nodes=[], edges=[], god_node_count=0)
+
+    nodes = list(result.slice.nodes)
+    edges = list(result.slice.edges)
+
+    # --- filters: degrade sanely on malformed input, never 500 ---
+    scope_norm = scope.strip() if isinstance(scope, str) else ""
+    if scope_norm and scope_norm in _VALID_ANCHOR_SCOPES:
+        nodes = [n for n in nodes if n.anchor_scope == scope_norm]
+    elif scope_norm:
+        logger.info("concept_atlas_network_ignored_bad_scope value=%s", scope_norm)
+
+    min_act_value: Optional[float] = None
+    if isinstance(min_activation, str) and min_activation.strip():
+        try:
+            parsed_min_act = float(min_activation)
+        except ValueError:
+            parsed_min_act = None
+        # float("nan")/float("inf") parse without raising ValueError but are
+        # not a meaningful activation threshold -- nan comparisons are always
+        # False (silently empties the graph) and treating them as malformed
+        # (i.e. ignored) is more honest than a confusing empty result.
+        if parsed_min_act is None or not (0.0 <= parsed_min_act <= 1.0):
+            logger.info("concept_atlas_network_ignored_bad_min_activation value=%s", min_activation)
+        else:
+            min_act_value = parsed_min_act
+    if min_act_value is not None:
+        nodes = [n for n in nodes if float(n.signals.activation.activation) >= min_act_value]
+
+    node_ids = {n.node_id for n in nodes}
+    edges = [e for e in edges if e.source.node_id in node_ids and e.target.node_id in node_ids]
+
+    focus_norm = focus.strip() if isinstance(focus, str) else ""
+    if focus_norm:
+        focus_lower = focus_norm.lower()
+        focus_id = next(
+            (
+                n.node_id
+                for n in nodes
+                if n.node_id == focus_norm or str(getattr(n, "label", "") or "").lower() == focus_lower
+            ),
+            None,
+        )
+        if focus_id is not None:
+            neighbor_ids = {focus_id}
+            for e in edges:
+                if e.source.node_id == focus_id:
+                    neighbor_ids.add(e.target.node_id)
+                if e.target.node_id == focus_id:
+                    neighbor_ids.add(e.source.node_id)
+            nodes = [n for n in nodes if n.node_id in neighbor_ids]
+            node_ids = {n.node_id for n in nodes}
+            edges = [e for e in edges if e.source.node_id in node_ids and e.target.node_id in node_ids]
+        else:
+            logger.info("concept_atlas_network_focus_not_found value=%s", focus_norm)
+
+    # --- degree (activation-weighted) computed fresh at request time ---
+    degree: dict[str, float] = {n.node_id: 0.0 for n in nodes}
+    for e in edges:
+        weight = 1.0 + float(e.salience or 0.0)
+        if e.source.node_id in degree:
+            degree[e.source.node_id] += weight
+        if e.target.node_id in degree:
+            degree[e.target.node_id] += weight
+
+    ranked = sorted((nid for nid in degree if degree[nid] > 0.0), key=lambda nid: degree[nid], reverse=True)
+    god_ids = set(ranked[:_GOD_NODE_TOP_N])
+
+    node_payload = [
+        {
+            "id": n.node_id,
+            "label": getattr(n, "label", n.node_id),
+            "node_kind": n.node_kind,
+            "anchor_scope": n.anchor_scope,
+            "promotion_state": n.promotion_state,
+            "activation": float(n.signals.activation.activation),
+            "salience": float(n.signals.salience),
+            "confidence": float(n.signals.confidence),
+            "degree": degree.get(n.node_id, 0.0),
+            "god_node": n.node_id in god_ids,
+        }
+        for n in nodes
+    ]
+    edge_payload = [
+        {
+            "id": e.edge_id,
+            "source": e.source.node_id,
+            "target": e.target.node_id,
+            "predicate": e.predicate,
+            "confidence": float(e.confidence),
+            "salience": float(e.salience),
+        }
+        for e in edges
+    ]
+
+    # Non-default backends (e.g. GraphDBSubstrateStore under
+    # SUBSTRATE_STORE_BACKEND=graphdb) can return a non-raising result that is
+    # nonetheless backed by a stale fallback snapshot after an upstream query
+    # failure (see query_concept_region()'s own degraded/error fields). The
+    # default in-memory store never sets these, but surface them honestly
+    # when a backend does -- "available: true" alone would otherwise hide a
+    # real degraded-data condition (runtime truth beats config truth).
+    degraded = bool(getattr(result, "degraded", False))
+    return {
+        "available": True,
+        "nodes": node_payload,
+        "edges": edge_payload,
+        "god_node_count": len(god_ids),
+        "truncated": bool(result.truncated),
+        "degraded": degraded,
+        "degraded_error": getattr(result, "error", None) if degraded else None,
+    }
+
+
+@router.get("/concept-atlas")
+async def concept_atlas_page() -> HTMLResponse:
+    from .main import TEMPLATES_DIR, build_hub_ui_asset_version
+
+    template_path = TEMPLATES_DIR / "concept_atlas.html"
+    if not template_path.is_file():
+        raise HTTPException(status_code=404, detail="concept_atlas_template_missing")
+    template = template_path.read_text(encoding="utf-8")
+    rendered = template.replace("{{HUB_UI_ASSET_VERSION}}", build_hub_ui_asset_version())
+    return HTMLResponse(
+        content=rendered,
+        status_code=200,
+        headers={
+            "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
+    )

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -22,6 +22,7 @@ from scripts.mind_routes import router as mind_router
 from scripts.memory_graph_routes import router as memory_graph_router
 from scripts.memory_consolidation_draft_routes import router as memory_consolidation_draft_router
 from scripts.proposal_review_routes import router as proposal_review_router
+from scripts.concept_atlas_routes import router as concept_atlas_router
 import scripts.api_routes as api_routes_runtime
 from scripts.websocket_handler import websocket_endpoint
 from scripts.service_logs_ws import service_logs_websocket_endpoint
@@ -614,6 +615,7 @@ app.include_router(mind_router)
 app.include_router(memory_graph_router)
 app.include_router(memory_consolidation_draft_router)
 app.include_router(proposal_review_router)
+app.include_router(concept_atlas_router)
 
 # Real-time WS endpoint (also /hub/ws for path-prefixed reverse proxies where the browser path includes /hub)
 app.add_websocket_route("/ws", websocket_endpoint)

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -678,6 +678,10 @@ document.addEventListener("DOMContentLoaded", () => {
   const substrateAtlasPanel = document.getElementById("substrate-atlas");
   const substrateAtlasPanelFrame = document.getElementById("substrateAtlasPanelFrame");
   const substrateAtlasPanelRefresh = document.getElementById("substrateAtlasPanelRefresh");
+  const conceptAtlasTabButton = document.getElementById("conceptAtlasTabButton");
+  const conceptAtlasPanel = document.getElementById("concept-atlas");
+  const conceptAtlasPanelFrame = document.getElementById("conceptAtlasPanelFrame");
+  const conceptAtlasPanelRefresh = document.getElementById("conceptAtlasPanelRefresh");
   const pressureAnalyticsTabButton = document.getElementById("pressureAnalyticsTabButton");
   const pressurePanel = document.getElementById("pressure");
   const collapseMirrorTabButton = document.getElementById("collapseMirrorTabButton");
@@ -962,6 +966,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (tabKey === "substrate-atlas" && !substrateAtlasPanel) {
       effectiveTab = "hub";
     }
+    if (tabKey === "concept-atlas" && !conceptAtlasPanel) {
+      effectiveTab = "hub";
+    }
     if (tabKey === "substrate-lattice" && !substrateLatticePanelEl) {
       effectiveTab = "hub";
     }
@@ -976,6 +983,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const isServiceLogs = effectiveTab === "service-logs";
     const isSubstrate = effectiveTab === "substrate";
     const isSubstrateAtlas = effectiveTab === "substrate-atlas";
+    const isConceptAtlas = effectiveTab === "concept-atlas";
     const isMemory = effectiveTab === "memory";
     const isPressure = effectiveTab === "pressure";
     const isSubstrateLattice = effectiveTab === "substrate-lattice";
@@ -1002,6 +1010,35 @@ document.addEventListener("DOMContentLoaded", () => {
           }
         };
         setTimeout(pingAtlasFrame, 150);
+      }
+    }
+    if (conceptAtlasPanel) {
+      const wasConceptAtlasVisible = !conceptAtlasPanel.classList.contains("hidden");
+      conceptAtlasPanel.classList.toggle("hidden", !isConceptAtlas);
+      if (isConceptAtlas && conceptAtlasPanelFrame) {
+        const pingConceptAtlasFrame = () => {
+          try {
+            const atlasWin = conceptAtlasPanelFrame.contentWindow;
+            if (atlasWin && atlasWin.OrionConceptAtlas && typeof atlasWin.OrionConceptAtlas.activate === "function") {
+              atlasWin.OrionConceptAtlas.activate();
+            }
+          } catch {
+            /* iframe not ready */
+          }
+        };
+        setTimeout(pingConceptAtlasFrame, 150);
+      } else if (!isConceptAtlas && wasConceptAtlasVisible && conceptAtlasPanelFrame) {
+        // Actually invoke cleanup on tab-hide (Organ Signals' reference
+        // implementation defines destroy() but never calls it here on
+        // tab-switch -- this closes that gap for Concept Atlas).
+        try {
+          const atlasWin = conceptAtlasPanelFrame.contentWindow;
+          if (atlasWin && atlasWin.OrionConceptAtlas && typeof atlasWin.OrionConceptAtlas.deactivate === "function") {
+            atlasWin.OrionConceptAtlas.deactivate();
+          }
+        } catch {
+          /* iframe not ready */
+        }
       }
     }
     if (memoryPanel) {
@@ -1060,6 +1097,9 @@ document.addEventListener("DOMContentLoaded", () => {
     styleTabButton(substrateTabButton, isSubstrate);
     if (substrateAtlasTabButton) {
       styleTabButton(substrateAtlasTabButton, isSubstrateAtlas);
+    }
+    if (conceptAtlasTabButton) {
+      styleTabButton(conceptAtlasTabButton, isConceptAtlas);
     }
     if (memoryTabButton) {
       styleTabButton(memoryTabButton, isMemory);
@@ -1647,6 +1687,8 @@ document.addEventListener("DOMContentLoaded", () => {
       setActiveTab("substrate");
     } else if (h === "#substrate-atlas" && substrateAtlasPanel && substrateAtlasTabButton) {
       setActiveTab("substrate-atlas");
+    } else if (h === "#concept-atlas" && conceptAtlasPanel && conceptAtlasTabButton) {
+      setActiveTab("concept-atlas");
     } else if (h === "#pressure" && pressurePanel && pressureAnalyticsTabButton) {
       setActiveTab("pressure");
     } else if (h === "#substrate-lattice" && substrateLatticePanelEl && substrateLatticeTabButton) {
@@ -1672,6 +1714,7 @@ document.addEventListener("DOMContentLoaded", () => {
         || h === "#signals"
         || h === "#forge"
         || h === "#substrate-atlas"
+        || h === "#concept-atlas"
         || h === "#collapse-mirror"
         || h === "#ai-town"
       ) {
@@ -11750,6 +11793,13 @@ document.addEventListener("DOMContentLoaded", () => {
         history.replaceState(null, "", "#substrate-atlas");
       });
     }
+    if (conceptAtlasTabButton && conceptAtlasPanel) {
+      conceptAtlasTabButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        setActiveTab("concept-atlas");
+        history.replaceState(null, "", "#concept-atlas");
+      });
+    }
     if (memoryTabButton) {
       memoryTabButton.addEventListener("click", (event) => {
         event.preventDefault();
@@ -11822,6 +11872,21 @@ document.addEventListener("DOMContentLoaded", () => {
     substrateAtlasPanelRefresh.addEventListener("click", () => {
       try {
         substrateAtlasPanelFrame.contentWindow?.location.reload();
+      } catch {
+        /* ignore */
+      }
+    });
+  }
+
+  if (conceptAtlasPanelRefresh && conceptAtlasPanelFrame) {
+    conceptAtlasPanelRefresh.addEventListener("click", () => {
+      try {
+        const atlasWin = conceptAtlasPanelFrame.contentWindow;
+        if (atlasWin && atlasWin.OrionConceptAtlas && typeof atlasWin.OrionConceptAtlas.refresh === "function") {
+          atlasWin.OrionConceptAtlas.refresh();
+        } else {
+          atlasWin?.location.reload();
+        }
       } catch {
         /* ignore */
       }

--- a/services/orion-hub/static/js/concept-atlas.js
+++ b/services/orion-hub/static/js/concept-atlas.js
@@ -1,0 +1,442 @@
+"use strict";
+
+/**
+ * Concept Atlas — standalone iframe-embedded page (Phase 8 of the concept-graph
+ * pipeline design). Structurally mirrors substrate-atlas.js: own IIFE module,
+ * Cytoscape.js via CDN, exposes window.OrionConceptAtlas = { activate, ... }
+ * for the parent Hub page to ping on tab-show (see app.js's
+ * conceptAtlasPanelFrame block, parallel to substrateAtlasPanelFrame).
+ *
+ * Lifecycle note: unlike Substrate Atlas, this page has no notion of a "live"
+ * trace, so there is no setInterval-based auto-refresh to leak in the first
+ * place — activate() just does an on-demand fetch of all four cards each
+ * time the tab is shown. destroy()/deactivate() exists for symmetry and to
+ * abort any in-flight fetches so a rapid tab-away doesn't race a stale
+ * response into the DOM after the panel is hidden again.
+ */
+
+async function apiFetch(path, opts) {
+  const r = await fetch(path, { headers: { Accept: "application/json" }, ...(opts || {}) });
+  const text = await r.text();
+
+  let payload = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = null;
+    }
+  }
+
+  if (!r.ok) {
+    const detail =
+      payload && payload.detail
+        ? payload.detail
+        : payload
+          ? JSON.stringify(payload)
+          : text || r.statusText;
+    throw new Error(`${r.status}: ${detail}`);
+  }
+
+  return payload || {};
+}
+
+if (typeof document !== "undefined") {
+(function () {
+  const STATUS = document.getElementById("caStatus");
+  const REFRESH_BTN = document.getElementById("caRefreshBtn");
+
+  const FILTER_SCOPE = document.getElementById("caFilterScope");
+  const FILTER_PROMOTION_STATE = document.getElementById("caFilterPromotionState");
+  const FILTER_FOCUS = document.getElementById("caFilterFocus");
+  const APPLY_FILTERS_BTN = document.getElementById("caApplyFiltersBtn");
+  const CLEAR_FILTERS_BTN = document.getElementById("caClearFiltersBtn");
+
+  const SUMMARY_STATUS = document.getElementById("caSummaryStatus");
+  const SUMMARY_STATS = document.getElementById("caSummaryStats");
+  const PROMOTION_STATE_BREAKDOWN = document.getElementById("caPromotionStateBreakdown");
+  const ANCHOR_SCOPE_BREAKDOWN = document.getElementById("caAnchorScopeBreakdown");
+  const PREDICATE_BREAKDOWN = document.getElementById("caPredicateBreakdown");
+  const AT_RISK_LIST = document.getElementById("caAtRiskList");
+
+  const NETWORK_STATUS = document.getElementById("caNetworkStatus");
+  const NETWORK_CY_HOST = document.getElementById("caNetworkCy");
+  const NETWORK_INSPECTOR = document.getElementById("caNetworkInspector");
+
+  const CLUSTERING_BODY = document.getElementById("caClusteringBody");
+
+  const PREDICATE_COLORS = {
+    contradicts: "#ef4444",
+    co_occurs_with: "#64748b",
+    supports: "#22c55e",
+    refines: "#0ea5e9",
+  };
+  const DEFAULT_EDGE_COLOR = "#22c55e";
+
+  let cy = null;
+  let activated = false;
+  let fetchGeneration = 0;
+
+  function setStatus(msg, isErr) {
+    if (!STATUS) return;
+    STATUS.textContent = msg;
+    STATUS.classList.toggle("text-red-400", !!isErr);
+    STATUS.classList.toggle("text-gray-400", !isErr);
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function currentFilters() {
+    return {
+      scope: (FILTER_SCOPE && FILTER_SCOPE.value) || "",
+      promotionState: (FILTER_PROMOTION_STATE && FILTER_PROMOTION_STATE.value) || "",
+      focus: (FILTER_FOCUS && FILTER_FOCUS.value.trim()) || "",
+    };
+  }
+
+  // --- Summary card -------------------------------------------------------
+
+  function statTile(label, value) {
+    const div = document.createElement("div");
+    div.className = "rounded-lg border border-gray-800 bg-gray-900/60 px-3 py-2";
+    div.innerHTML = `<div class="text-[10px] uppercase tracking-wide text-gray-500">${escapeHtml(label)}</div><div class="text-lg font-semibold text-white">${escapeHtml(value)}</div>`;
+    return div;
+  }
+
+  function renderBreakdown(host, counts, activeKey) {
+    if (!host) return;
+    host.innerHTML = "";
+    const entries = Object.entries(counts || {});
+    if (!entries.length) {
+      host.innerHTML = '<p class="text-gray-600">none</p>';
+      return;
+    }
+    entries.forEach(([key, count]) => {
+      const row = document.createElement("div");
+      const isActive = activeKey && key === activeKey;
+      row.className = "flex items-center justify-between " + (isActive ? "text-indigo-300 font-semibold" : "text-gray-300");
+      row.innerHTML = `<span>${escapeHtml(key)}</span><span>${escapeHtml(count)}</span>`;
+      host.appendChild(row);
+    });
+  }
+
+  function renderAtRisk(payload) {
+    if (!AT_RISK_LIST) return;
+    AT_RISK_LIST.innerHTML = "";
+    const rows = payload.at_risk || [];
+    if (!rows.length) {
+      const note = payload.at_risk_note || "no at-risk concepts";
+      AT_RISK_LIST.innerHTML = `<p class="text-gray-600">${escapeHtml(note)}</p>`;
+      return;
+    }
+    rows.forEach((row) => {
+      const div = document.createElement("div");
+      div.className = "flex items-center justify-between text-gray-300";
+      div.innerHTML = `<span>${escapeHtml(row.label || row.node_id)}</span><span class="text-amber-400">activation ${Number(row.activation).toFixed(2)} (floor ${Number(row.decay_floor).toFixed(2)})</span>`;
+      AT_RISK_LIST.appendChild(div);
+    });
+  }
+
+  async function fetchSummary() {
+    if (SUMMARY_STATUS) SUMMARY_STATUS.textContent = "Loading…";
+    try {
+      const payload = await apiFetch("/api/substrate/concepts/summary");
+      if (!payload.available) {
+        if (SUMMARY_STATUS) SUMMARY_STATUS.textContent = `unavailable (${payload.reason || "unknown"})`;
+        if (SUMMARY_STATS) SUMMARY_STATS.innerHTML = "";
+        renderBreakdown(PROMOTION_STATE_BREAKDOWN, {});
+        renderBreakdown(ANCHOR_SCOPE_BREAKDOWN, {});
+        renderBreakdown(PREDICATE_BREAKDOWN, {});
+        renderAtRisk({ at_risk: [], at_risk_note: payload.reason ? `unavailable: ${payload.reason}` : null });
+        return;
+      }
+      if (SUMMARY_STATS) {
+        SUMMARY_STATS.innerHTML = "";
+        SUMMARY_STATS.appendChild(statTile("Total concepts", payload.total_concepts || 0));
+        SUMMARY_STATS.appendChild(statTile("Promotion states", Object.keys(payload.by_promotion_state || {}).length));
+        SUMMARY_STATS.appendChild(statTile("Anchor scopes", Object.keys(payload.by_anchor_scope || {}).length));
+        SUMMARY_STATS.appendChild(statTile("At risk", (payload.at_risk || []).length));
+      }
+      const { scope, promotionState } = currentFilters();
+      renderBreakdown(PROMOTION_STATE_BREAKDOWN, payload.by_promotion_state || {}, promotionState || null);
+      renderBreakdown(ANCHOR_SCOPE_BREAKDOWN, payload.by_anchor_scope || {}, scope || null);
+      renderBreakdown(PREDICATE_BREAKDOWN, payload.edge_counts_by_predicate || {});
+      renderAtRisk(payload);
+      if (SUMMARY_STATUS) SUMMARY_STATUS.textContent = "";
+    } catch (e) {
+      if (SUMMARY_STATUS) SUMMARY_STATUS.textContent = `error: ${e.message || e}`;
+    }
+  }
+
+  // --- Network card --------------------------------------------------------
+
+  function destroyCy() {
+    if (cy) {
+      try {
+        cy.destroy();
+      } catch {
+        /* ignore */
+      }
+      cy = null;
+    }
+    if (NETWORK_CY_HOST) NETWORK_CY_HOST.textContent = "";
+  }
+
+  function edgeColor(predicate) {
+    return PREDICATE_COLORS[predicate] || DEFAULT_EDGE_COLOR;
+  }
+
+  function applyClientPromotionStateFilter(nodes, edges, promotionState) {
+    if (!promotionState) return { nodes, edges };
+    const kept = nodes.filter((n) => n.promotion_state === promotionState);
+    const keptIds = new Set(kept.map((n) => n.id));
+    const keptEdges = edges.filter((e) => keptIds.has(e.source) && keptIds.has(e.target));
+    return { nodes: kept, edges: keptEdges };
+  }
+
+  function graphToElements(nodes, edges) {
+    const cyNodes = nodes.map((n) => ({
+      data: {
+        id: n.id,
+        label: n.label || n.id,
+        nodeKind: n.node_kind,
+        anchorScope: n.anchor_scope,
+        promotionState: n.promotion_state,
+        activation: n.activation,
+        salience: n.salience,
+        confidence: n.confidence,
+        degree: n.degree,
+        godNode: !!n.god_node,
+      },
+    }));
+    const cyEdges = edges.map((e) => ({
+      data: {
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        label: e.predicate,
+        predicate: e.predicate,
+      },
+    }));
+    return [...cyNodes, ...cyEdges];
+  }
+
+  function renderInspector(nodeData) {
+    if (!NETWORK_INSPECTOR) return;
+    if (!nodeData) {
+      NETWORK_INSPECTOR.innerHTML = '<p class="text-gray-500">Select a node to inspect fields.</p>';
+      return;
+    }
+    const fields = [
+      ["id", nodeData.id],
+      ["label", nodeData.label],
+      ["node_kind", nodeData.nodeKind],
+      ["anchor_scope", nodeData.anchorScope],
+      ["promotion_state", nodeData.promotionState],
+      ["activation", nodeData.activation],
+      ["salience", nodeData.salience],
+      ["confidence", nodeData.confidence],
+      ["degree", nodeData.degree],
+      ["god_node", nodeData.godNode],
+    ];
+    let html = '<dl class="grid grid-cols-2 gap-x-3 gap-y-1">';
+    fields.forEach(([k, v]) => {
+      html += `<dt class="text-gray-500">${escapeHtml(k)}</dt><dd class="text-gray-200 break-all">${escapeHtml(v)}</dd>`;
+    });
+    html += "</dl>";
+    NETWORK_INSPECTOR.innerHTML = html;
+  }
+
+  function mountCytoscape(elements) {
+    destroyCy();
+    if (!NETWORK_CY_HOST || typeof window.cytoscape !== "function") {
+      if (NETWORK_CY_HOST) NETWORK_CY_HOST.textContent = "Cytoscape failed to load.";
+      return;
+    }
+    NETWORK_CY_HOST.textContent = "";
+    if (!elements.length) {
+      NETWORK_CY_HOST.textContent = "No concept nodes match the current filters.";
+      return;
+    }
+    cy = window.cytoscape({
+      container: NETWORK_CY_HOST,
+      elements,
+      style: [
+        {
+          selector: "node",
+          style: {
+            label: "data(label)",
+            "font-size": 9,
+            color: "#e2e8f0",
+            "text-valign": "bottom",
+            "text-margin-y": 4,
+            "background-color": (ele) => (ele.data("godNode") ? "#a855f7" : "#0ea5e9"),
+            width: (ele) => (ele.data("godNode") ? 42 : 24),
+            height: (ele) => (ele.data("godNode") ? 42 : 24),
+            "border-width": 2,
+            "border-color": "#1e293b",
+          },
+        },
+        {
+          selector: "node:selected",
+          style: { "border-color": "#818cf8", "border-width": 3 },
+        },
+        {
+          selector: "edge",
+          style: {
+            width: 1.5,
+            "line-color": (ele) => edgeColor(ele.data("predicate")),
+            "target-arrow-color": (ele) => edgeColor(ele.data("predicate")),
+            "target-arrow-shape": "triangle",
+            "curve-style": "bezier",
+            label: "data(label)",
+            "font-size": 7,
+            color: "#94a3b8",
+          },
+        },
+      ],
+      layout: { name: "cose", animate: false, padding: 24 },
+      wheelSensitivity: 0.3,
+    });
+    cy.on("tap", "node", (evt) => {
+      renderInspector(evt.target.data());
+    });
+    try {
+      cy.resize();
+      cy.fit(undefined, 32);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function fetchNetwork() {
+    if (NETWORK_STATUS) NETWORK_STATUS.textContent = "Loading…";
+    const { scope, promotionState, focus } = currentFilters();
+    const params = new URLSearchParams();
+    if (scope) params.set("scope", scope);
+    if (focus) params.set("focus", focus);
+    try {
+      const payload = await apiFetch(`/api/substrate/concepts/network?${params.toString()}`);
+      if (!payload.available) {
+        destroyCy();
+        if (NETWORK_CY_HOST) NETWORK_CY_HOST.textContent = `Network unavailable (${payload.reason || "unknown"}).`;
+        if (NETWORK_STATUS) NETWORK_STATUS.textContent = payload.reason || "unavailable";
+        return;
+      }
+      const filtered = applyClientPromotionStateFilter(payload.nodes || [], payload.edges || [], promotionState);
+      mountCytoscape(graphToElements(filtered.nodes, filtered.edges));
+      renderInspector(null);
+      if (NETWORK_STATUS) {
+        const base = `${filtered.nodes.length} node(s), ${filtered.edges.length} edge(s), ${payload.god_node_count || 0} god node(s)`;
+        // Surfaced when a non-default store backend (e.g. graphdb) fell back
+        // to a stale snapshot after an upstream query failure -- see
+        // concept_atlas_routes.py's "degraded" comment. The default
+        // in-memory store never sets this.
+        NETWORK_STATUS.textContent = payload.degraded ? `${base} — DEGRADED: ${payload.degraded_error || "stale data"}` : base;
+        NETWORK_STATUS.classList.toggle("text-amber-400", !!payload.degraded);
+      }
+    } catch (e) {
+      destroyCy();
+      if (NETWORK_CY_HOST) NETWORK_CY_HOST.textContent = `Network error: ${e.message || e}`;
+      if (NETWORK_STATUS) NETWORK_STATUS.textContent = "error";
+    }
+  }
+
+  // --- Clustering card (read-only topic-foundry summary) -------------------
+
+  function renderClusteringPlaceholder(message) {
+    if (!CLUSTERING_BODY) return;
+    CLUSTERING_BODY.innerHTML = `<p class="text-gray-500">${escapeHtml(message)}</p>`;
+  }
+
+  async function fetchClustering() {
+    if (!CLUSTERING_BODY) return;
+    CLUSTERING_BODY.innerHTML = '<p class="text-gray-500">Loading latest topic-foundry run…</p>';
+    try {
+      const payload = await apiFetch("/api/topic-foundry/runs");
+      const runs = Array.isArray(payload) ? payload : payload.items || payload.runs || [];
+      if (!runs.length) {
+        renderClusteringPlaceholder("not yet connected — no topic-foundry runs found");
+        return;
+      }
+      const latest = runs[0];
+      const fields = [
+        ["run_id", latest.run_id || latest.id],
+        ["status", latest.status || latest.state],
+        ["dataset", latest.dataset_id || latest.dataset],
+        ["created_at", latest.created_at || latest.started_at],
+      ];
+      let html = '<dl class="grid grid-cols-2 gap-x-3 gap-y-1">';
+      fields.forEach(([k, v]) => {
+        if (v == null) return;
+        html += `<dt class="text-gray-500">${escapeHtml(k)}</dt><dd class="text-gray-200 break-all">${escapeHtml(v)}</dd>`;
+      });
+      html += "</dl>";
+      CLUSTERING_BODY.innerHTML = html;
+    } catch (e) {
+      renderClusteringPlaceholder(`not yet connected — ${e.message || e}`);
+    }
+  }
+
+  // --- Orchestration ---------------------------------------------------------
+
+  async function refreshAll() {
+    const myGeneration = ++fetchGeneration;
+    setStatus("Loading…");
+    // Independent try/catch per card so one failing endpoint never blanks
+    // the others (Phase 8 acceptance check).
+    const results = await Promise.allSettled([fetchSummary(), fetchNetwork(), fetchClustering()]);
+    if (myGeneration !== fetchGeneration) return; // superseded by a newer refresh
+    const failed = results.filter((r) => r.status === "rejected").length;
+    setStatus(failed ? `Loaded with ${failed} card error(s)` : "Loaded", failed > 0);
+  }
+
+  function activate() {
+    activated = true;
+    refreshAll();
+  }
+
+  function deactivate() {
+    // No recurring timers exist today (see module header), so this only
+    // bumps the fetch generation so any in-flight refreshAll() from before
+    // the tab was hidden no-ops instead of writing into a hidden DOM.
+    fetchGeneration += 1;
+  }
+
+  function init() {
+    if (REFRESH_BTN) REFRESH_BTN.addEventListener("click", refreshAll);
+    if (APPLY_FILTERS_BTN) APPLY_FILTERS_BTN.addEventListener("click", refreshAll);
+    if (CLEAR_FILTERS_BTN) {
+      CLEAR_FILTERS_BTN.addEventListener("click", () => {
+        if (FILTER_SCOPE) FILTER_SCOPE.value = "";
+        if (FILTER_PROMOTION_STATE) FILTER_PROMOTION_STATE.value = "";
+        if (FILTER_FOCUS) FILTER_FOCUS.value = "";
+        refreshAll();
+      });
+    }
+    window.addEventListener("beforeunload", deactivate);
+    window.OrionConceptAtlas = { activate, deactivate, destroy: deactivate, refresh: refreshAll };
+    if (!activated) {
+      // Load once eagerly too, in case the page is opened standalone
+      // (not just via the Hub iframe, which pings activate() itself).
+      activate();
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { apiFetch };
+}

--- a/services/orion-hub/templates/concept_atlas.html
+++ b/services/orion-hub/templates/concept_atlas.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Orion Hub — Concept Atlas</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/static/css/style.css?v=1.0.8" />
+</head>
+<body class="bg-black text-gray-200 min-h-screen flex flex-col">
+  <header class="shrink-0 border-b border-gray-800 bg-gray-950/90 px-4 py-3 flex items-center justify-between gap-3">
+    <div>
+      <h1 class="text-lg font-semibold text-white">Concept Atlas</h1>
+      <p class="text-xs text-gray-500">Read-only interpretability view of the substrate concept graph — not a management surface.</p>
+    </div>
+    <div class="flex items-center gap-2">
+      <span id="caStatus" class="text-xs text-gray-400">Loading…</span>
+      <button id="caRefreshBtn" type="button" class="px-3 py-1.5 text-xs rounded border border-gray-700 bg-gray-900 hover:bg-gray-800">Refresh</button>
+      <a href="/" target="_top" class="px-3 py-1.5 text-xs rounded border border-gray-700 bg-gray-900 hover:bg-gray-800">Back to Hub</a>
+    </div>
+  </header>
+
+  <div class="flex flex-wrap items-end gap-3 px-4 py-2 border-b border-gray-800 bg-gray-900/40 text-xs">
+    <div class="flex flex-col gap-1">
+      <label for="caFilterScope" class="text-[10px] uppercase tracking-wide text-gray-500">Anchor scope</label>
+      <select id="caFilterScope" class="bg-gray-900 border border-gray-700 rounded px-2 py-1 text-gray-200">
+        <option value="">All scopes</option>
+        <option value="orion">orion</option>
+        <option value="juniper">juniper</option>
+        <option value="relationship">relationship</option>
+        <option value="world">world</option>
+        <option value="session">session</option>
+      </select>
+    </div>
+    <div class="flex flex-col gap-1">
+      <label for="caFilterPromotionState" class="text-[10px] uppercase tracking-wide text-gray-500">Promotion state</label>
+      <select id="caFilterPromotionState" class="bg-gray-900 border border-gray-700 rounded px-2 py-1 text-gray-200">
+        <option value="">All states</option>
+        <option value="proposed">proposed</option>
+        <option value="provisional">provisional</option>
+        <option value="canonical">canonical</option>
+        <option value="deprecated">deprecated</option>
+        <option value="rejected">rejected</option>
+      </select>
+    </div>
+    <div class="flex flex-col gap-1 flex-1 min-w-[12rem]">
+      <label for="caFilterFocus" class="text-[10px] uppercase tracking-wide text-gray-500">Focus concept (id or label)</label>
+      <input id="caFilterFocus" type="text" placeholder="e.g. Orion" class="bg-gray-900 border border-gray-700 rounded px-2 py-1 text-gray-200" />
+    </div>
+    <button id="caApplyFiltersBtn" type="button" class="px-3 py-1.5 rounded border border-indigo-600 bg-indigo-900/40 text-indigo-100 hover:bg-indigo-900/70">Apply filters</button>
+    <button id="caClearFiltersBtn" type="button" class="px-3 py-1.5 rounded border border-gray-700 bg-gray-900 hover:bg-gray-800 text-gray-300">Clear</button>
+  </div>
+
+  <main class="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+    <section id="caSummaryCard" class="rounded-xl border border-gray-800 bg-gray-950/60 p-4">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-sm font-semibold text-white">Summary</h2>
+        <span id="caSummaryStatus" class="text-[10px] text-gray-500"></span>
+      </div>
+      <div id="caSummaryStats" class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-3"></div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">By promotion state</div>
+          <div id="caPromotionStateBreakdown" class="text-xs text-gray-300 space-y-0.5"></div>
+        </div>
+        <div>
+          <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">By anchor scope</div>
+          <div id="caAnchorScopeBreakdown" class="text-xs text-gray-300 space-y-0.5"></div>
+        </div>
+      </div>
+      <div class="mt-3">
+        <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Edge counts by predicate</div>
+        <div id="caPredicateBreakdown" class="text-xs text-gray-300 space-y-0.5"></div>
+      </div>
+      <div class="mt-3">
+        <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">At risk (decaying activation)</div>
+        <div id="caAtRiskList" class="text-xs text-gray-300 space-y-0.5"></div>
+      </div>
+    </section>
+
+    <section id="caNetworkCard" class="rounded-xl border border-gray-800 bg-gray-950/60 p-4 flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <h2 class="text-sm font-semibold text-white">Network drill-down</h2>
+        <span id="caNetworkStatus" class="text-[10px] text-gray-500"></span>
+      </div>
+      <div class="flex items-center gap-3 text-[10px] text-gray-400">
+        <span class="flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full" style="background:#a855f7"></span> god node (top degree)</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full" style="background:#0ea5e9"></span> concept node</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-4 h-0.5" style="background:#ef4444"></span> contradicts</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-4 h-0.5" style="background:#64748b"></span> co_occurs_with</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-4 h-0.5" style="background:#22c55e"></span> other predicate</span>
+      </div>
+      <div
+        id="caNetworkCy"
+        class="w-full rounded-lg border border-gray-800 bg-gray-950/80"
+        style="min-height: 420px;"
+      ></div>
+      <aside id="caNetworkInspector" class="text-xs text-gray-300 border-t border-gray-800 pt-2">
+        <p class="text-gray-500">Select a node to inspect fields.</p>
+      </aside>
+    </section>
+
+    <section id="caClusteringCard" class="rounded-xl border border-gray-800 bg-gray-950/60 p-4">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="text-sm font-semibold text-white">Clustering (topic-foundry)</h2>
+        <a href="/#topic-studio" target="_top" class="text-[10px] px-2 py-1 rounded border border-gray-700 bg-gray-900 hover:bg-gray-800 text-gray-300">Open Topic Studio →</a>
+      </div>
+      <p class="text-[10px] text-gray-500 mb-2">Read-only summary of the latest topic-foundry run. For dataset/model/training management, use Topic Studio.</p>
+      <div id="caClusteringBody" class="text-xs text-gray-300"></div>
+    </section>
+  </main>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="/static/js/concept-atlas.js?v={{HUB_UI_ASSET_VERSION}}"></script>
+</body>
+</html>

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -56,6 +56,13 @@
             role="button"
           >Substrate Atlas</a>
           <a
+            id="conceptAtlasTabButton"
+            href="#concept-atlas"
+            data-hash-target="#concept-atlas"
+            class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
+            role="button"
+          >Concept Atlas</a>
+          <a
             id="memoryTabButton"
             href="#memory"
             data-hash-target="#memory"
@@ -2715,6 +2722,28 @@
             class="w-full h-full border-0 min-h-[40rem]"
             loading="lazy"
             title="Substrate Atlas"
+          ></iframe>
+        </div>
+      </section>
+
+      <section id="concept-atlas" data-panel="concept-atlas" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-xl font-bold text-white">Concept Atlas</h2>
+            <p class="text-xs text-gray-400">Read-only interpretability view of the substrate concept graph.</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <button id="conceptAtlasPanelRefresh" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700" type="button">Refresh</button>
+            <a id="conceptAtlasPanelStandaloneLink" href="/concept-atlas" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Open standalone</a>
+          </div>
+        </div>
+        <div class="rounded-xl border border-gray-800 bg-gray-950/40 overflow-hidden flex-1 min-h-[40rem]">
+          <iframe
+            id="conceptAtlasPanelFrame"
+            src="/concept-atlas"
+            class="w-full h-full border-0 min-h-[40rem]"
+            loading="lazy"
+            title="Concept Atlas"
           ></iframe>
         </div>
       </section>

--- a/services/orion-hub/tests/test_concept_atlas_routes.py
+++ b/services/orion-hub/tests/test_concept_atlas_routes.py
@@ -1,0 +1,369 @@
+"""Concept Atlas read routes (Phase 8 of the concept-graph-pipeline design).
+
+Mirrors the isolated-router testing convention used by
+``test_grammar_atlas_api.py``: build a minimal FastAPI app that only includes
+``concept_atlas_routes.router`` and monkeypatch the module's store resolver
+directly, rather than pulling in the full ``scripts.main`` app.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+for key, value in {
+    "CHANNEL_VOICE_TRANSCRIPT": "orion:voice:transcript",
+    "CHANNEL_VOICE_LLM": "orion:voice:llm",
+    "CHANNEL_VOICE_TTS": "orion:voice:tts",
+    "CHANNEL_COLLAPSE_INTAKE": "orion:collapse:intake",
+    "CHANNEL_COLLAPSE_TRIAGE": "orion:collapse:triage",
+}.items():
+    os.environ.setdefault(key, value)
+
+
+def _concept_atlas_test_app() -> FastAPI:
+    from scripts.concept_atlas_routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    _ensure_hub_scripts_import_path()
+    return TestClient(_concept_atlas_test_app())
+
+
+def _provenance():
+    from orion.core.schemas.cognitive_substrate import SubstrateProvenanceV1
+
+    return SubstrateProvenanceV1(
+        authority="human_verified",
+        source_kind="test_fixture",
+        source_channel="test:concept_atlas",
+        producer="test_concept_atlas_routes",
+    )
+
+
+def _temporal():
+    from orion.core.schemas.cognitive_substrate import SubstrateTemporalWindowV1
+
+    return SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc))
+
+
+def _concept_node(node_id, label, *, anchor_scope="orion", promotion_state="proposed", activation=0.0, decay_floor=0.0):
+    from orion.core.schemas.cognitive_substrate import ConceptNodeV1, SubstrateActivationV1, SubstrateSignalBundleV1
+
+    return ConceptNodeV1(
+        node_id=node_id,
+        label=label,
+        anchor_scope=anchor_scope,
+        promotion_state=promotion_state,
+        temporal=_temporal(),
+        provenance=_provenance(),
+        signals=SubstrateSignalBundleV1(
+            confidence=0.7,
+            salience=0.5,
+            activation=SubstrateActivationV1(activation=activation, decay_floor=decay_floor),
+        ),
+    )
+
+
+def _edge(edge_id, source_id, target_id, *, predicate="co_occurs_with", salience=0.5):
+    from orion.core.schemas.cognitive_substrate import NodeRefV1, SubstrateEdgeV1
+
+    return SubstrateEdgeV1(
+        edge_id=edge_id,
+        source=NodeRefV1(node_id=source_id, node_kind="concept"),
+        target=NodeRefV1(node_id=target_id, node_kind="concept"),
+        predicate=predicate,
+        temporal=_temporal(),
+        confidence=0.6,
+        salience=salience,
+        provenance=_provenance(),
+    )
+
+
+def _build_store():
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    orion = _concept_node("concept-orion", "Orion", anchor_scope="orion", promotion_state="canonical")
+    juniper = _concept_node("concept-juniper", "Juniper", anchor_scope="juniper", promotion_state="canonical")
+    misc = _concept_node("concept-misc", "Misc topic", anchor_scope="world", promotion_state="proposed")
+    store.upsert_node(identity_key="concept:orion", node=orion)
+    store.upsert_node(identity_key="concept:juniper", node=juniper)
+    store.upsert_node(identity_key="concept:misc", node=misc)
+    store.upsert_edge(
+        identity_key="edge:orion-juniper",
+        edge=_edge("edge-orion-juniper", "concept-orion", "concept-juniper", predicate="co_occurs_with"),
+    )
+    store.upsert_edge(
+        identity_key="edge:orion-misc",
+        edge=_edge("edge-orion-misc", "concept-orion", "concept-misc", predicate="contradicts"),
+    )
+    return store
+
+
+# --- summary ---------------------------------------------------------------
+
+
+def test_summary_empty_store_degrades_gracefully(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: None)
+    r = client.get("/api/substrate/concepts/summary")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["total_concepts"] == 0
+    assert body["by_promotion_state"] == {}
+    assert body["at_risk"] == []
+
+
+def test_summary_counts_with_seeded_nodes(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+
+    store = _build_store()
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+    r = client.get("/api/substrate/concepts/summary")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["total_concepts"] == 3
+    assert body["by_promotion_state"]["canonical"] == 2
+    assert body["by_promotion_state"]["proposed"] == 1
+    assert body["by_anchor_scope"]["orion"] == 1
+    assert body["by_anchor_scope"]["juniper"] == 1
+    assert body["by_anchor_scope"]["world"] == 1
+    assert body["edge_counts_by_predicate"]["co_occurs_with"] == 1
+    assert body["edge_counts_by_predicate"]["contradicts"] == 1
+    # All three seeded nodes share activation=0.0 -> no fabricated at_risk signal.
+    assert body["at_risk"] == []
+    assert body["at_risk_note"]
+
+
+def test_summary_at_risk_reported_when_activation_has_real_variance(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts import concept_atlas_routes
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    healthy = _concept_node("concept-healthy", "Healthy", activation=0.9, decay_floor=0.1)
+    decaying = _concept_node("concept-decaying", "Decaying", activation=0.05, decay_floor=0.02)
+    store.upsert_node(identity_key="concept:healthy", node=healthy)
+    store.upsert_node(identity_key="concept:decaying", node=decaying)
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+
+    r = client.get("/api/substrate/concepts/summary")
+    assert r.status_code == 200
+    body = r.json()
+    at_risk_ids = {row["node_id"] for row in body["at_risk"]}
+    assert "concept-decaying" in at_risk_ids
+    assert "concept-healthy" not in at_risk_ids
+
+
+# --- network -----------------------------------------------------------------
+
+
+def test_network_empty_store_degrades_gracefully(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: None)
+    r = client.get("/api/substrate/concepts/network")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["nodes"] == []
+    assert body["edges"] == []
+
+
+def test_network_god_node_flag_on_highest_degree_node(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    # A small hub-and-spoke graph plus one isolated node: "orion" touches every
+    # edge (highest degree, must be flagged), the isolated node touches none
+    # (must never be flagged regardless of the top-N cutoff).
+    store = InMemorySubstrateGraphStore()
+    hub = _concept_node("concept-orion", "Orion")
+    store.upsert_node(identity_key="concept:orion", node=hub)
+    spokes = []
+    for i in range(4):
+        spoke = _concept_node(f"concept-spoke-{i}", f"Spoke {i}")
+        spokes.append(spoke)
+        store.upsert_node(identity_key=f"concept:spoke-{i}", node=spoke)
+        store.upsert_edge(
+            identity_key=f"edge:orion-spoke-{i}",
+            edge=_edge(f"edge-orion-spoke-{i}", "concept-orion", f"concept-spoke-{i}"),
+        )
+    isolate = _concept_node("concept-isolate", "Isolate")
+    store.upsert_node(identity_key="concept:isolate", node=isolate)
+
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+    r = client.get("/api/substrate/concepts/network")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    nodes_by_id = {n["id"]: n for n in body["nodes"]}
+    assert nodes_by_id["concept-orion"]["god_node"] is True
+    assert nodes_by_id["concept-orion"]["degree"] == pytest.approx(4 * 1.5)
+    assert nodes_by_id["concept-isolate"]["god_node"] is False
+    assert nodes_by_id["concept-isolate"]["degree"] == 0
+    assert body["god_node_count"] >= 1
+
+
+def test_network_malformed_query_params_do_not_500(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+
+    store = _build_store()
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+    r = client.get(
+        "/api/substrate/concepts/network",
+        params={"scope": "not-a-real-scope", "min_activation": "not-a-number", "focus": "does-not-exist"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    # Bad scope/min_activation are ignored (no-op), bad focus is ignored too --
+    # all three seeded nodes should still be present, not filtered to nothing.
+    assert len(body["nodes"]) == 3
+
+
+def test_network_focus_filters_to_neighborhood(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+
+    store = _build_store()
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+    r = client.get("/api/substrate/concepts/network", params={"focus": "Juniper"})
+    assert r.status_code == 200
+    body = r.json()
+    node_ids = {n["id"] for n in body["nodes"]}
+    assert node_ids == {"concept-orion", "concept-juniper"}
+
+
+def test_network_nan_min_activation_is_ignored_not_silently_emptied(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """float('nan') parses without raising ValueError, but nan comparisons are
+    always False -- without an explicit range check this would silently
+    filter out every node instead of being treated as malformed input."""
+    from scripts import concept_atlas_routes
+
+    store = _build_store()
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+    r = client.get("/api/substrate/concepts/network", params={"min_activation": "nan"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert len(body["nodes"]) == 3
+
+
+def test_network_surfaces_degraded_backend_result(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+    from orion.substrate.store import SubstrateNeighborhoodSliceV1, SubstrateQueryResultV1
+
+    class _DegradedStore:
+        def query_concept_region(self, **kwargs):
+            return SubstrateQueryResultV1(
+                query_kind="concept_region",
+                slice=SubstrateNeighborhoodSliceV1(nodes=[], edges=[]),
+                source_kind="graphdb",
+                degraded=True,
+                error="sparql_timeout",
+            )
+
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: _DegradedStore())
+    r = client.get("/api/substrate/concepts/network")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["degraded"] is True
+    assert body["degraded_error"] == "sparql_timeout"
+
+
+def test_network_store_error_degrades_gracefully(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+
+    class _ExplodingStore:
+        def query_concept_region(self, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: _ExplodingStore())
+    r = client.get("/api/substrate/concepts/network")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["nodes"] == []
+
+
+# --- page route + template/static-asset wiring --------------------------------
+
+
+def test_concept_atlas_page_renders(client: TestClient) -> None:
+    r = client.get("/concept-atlas")
+    assert r.status_code == 200
+    assert "concept-atlas.js" in r.text
+    assert "OrionConceptAtlas" not in r.text  # that symbol lives in the JS file, not the template
+
+
+def test_concept_atlas_template_references_correct_static_asset() -> None:
+    template_path = HUB_ROOT / "templates" / "concept_atlas.html"
+    js_path = HUB_ROOT / "static" / "js" / "concept-atlas.js"
+    assert template_path.is_file()
+    assert js_path.is_file()
+    template_text = template_path.read_text(encoding="utf-8")
+    assert "/static/js/concept-atlas.js" in template_text
+    assert "cytoscape" in template_text.lower()
+
+
+def test_concept_atlas_js_exposes_expected_namespace() -> None:
+    js_path = HUB_ROOT / "static" / "js" / "concept-atlas.js"
+    js_text = js_path.read_text(encoding="utf-8")
+    assert "window.OrionConceptAtlas" in js_text
+    assert "activate" in js_text
+    assert "deactivate" in js_text
+
+
+def test_index_html_wires_concept_atlas_tab() -> None:
+    index_path = HUB_ROOT / "templates" / "index.html"
+    index_text = index_path.read_text(encoding="utf-8")
+    assert 'id="conceptAtlasTabButton"' in index_text
+    assert 'data-panel="concept-atlas"' in index_text
+    assert 'id="conceptAtlasPanelFrame"' in index_text
+    assert 'src="/concept-atlas"' in index_text
+
+
+def test_app_js_pings_activate_and_deactivate_for_concept_atlas() -> None:
+    app_js_path = HUB_ROOT / "static" / "js" / "app.js"
+    app_js_text = app_js_path.read_text(encoding="utf-8")
+    assert "conceptAtlasPanelFrame" in app_js_text
+    assert "OrionConceptAtlas.activate" in app_js_text
+    assert "OrionConceptAtlas.deactivate" in app_js_text

--- a/services/orion-recall/app/collectors/concept_region.py
+++ b/services/orion-recall/app/collectors/concept_region.py
@@ -1,0 +1,164 @@
+"""Turn-scoped concept-region collector (Phase 6, concept-atlas pipeline).
+
+Mirrors the salience/intent-gated shape of `active_packet.py`, not the
+always-on producer shape of `chat_stance.py`. This module never runs
+unconditionally and never registers a standing stance: it is a pure,
+per-call function that, only when the current turn's text cheaply and
+deterministically matches a concept label already materialized in the
+substrate graph, returns a bounded neighborhood fragment scoped to that
+single turn. If nothing matches, it returns empty without doing a store
+read at all.
+
+Matching is intentionally dumb: case-insensitive substring matching of
+stored concept labels against the turn text, with a minimum label length
+to avoid noise-matching on very short labels (e.g. "Go", "AI"). No
+embedding or LLM call belongs in this module -- that is a separate,
+heavier design decision explicitly deferred out of this phase.
+
+Wiring this collector into the live turn-assembly pipeline (deciding
+when/how it gets invoked during a real chat turn, and whether its output
+feeds `chat_stance.py` or something else) is out of scope here. This file
+only builds and tests the collector function in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
+from orion.substrate.store import SubstrateGraphStore
+
+logger = logging.getLogger(__name__)
+
+# Search breadth for the label-match pass. `read_concept_region` ranks and
+# truncates by salience/confidence, so a low-salience concept could be cut
+# before we ever get to compare its label against the turn text unless we
+# ask for a generous slice up front. This is still a single bounded call
+# into the store's existing region-read API -- no new traversal method.
+_DEFAULT_SEARCH_LIMIT_NODES = 500
+_DEFAULT_SEARCH_LIMIT_EDGES = 500
+
+# Minimum concept-label length eligible for substring matching. Labels
+# shorter than this match too much incidental text (e.g. "Go", "It", "A")
+# to be a useful cheap-and-deterministic signal. Documented judgment call
+# for this phase, not a tuned threshold.
+_MIN_LABEL_CHARS = 3
+
+
+def _turn_text(query: Any) -> str:
+    """Extract the current turn's text from `query`.
+
+    Mirrors `active_packet.py`'s `_intent`/fragment-extraction convention:
+    `query` is typed loosely (`Any`) and the turn text lives on a
+    `.fragment` attribute. A bare string is also accepted directly so
+    callers that already have raw turn text don't need to wrap it.
+    """
+
+    if query is None:
+        return ""
+    if isinstance(query, str):
+        return query.strip()
+    return str(getattr(query, "fragment", None) or "").strip()
+
+
+def _node_label(node: Any) -> str:
+    return str(getattr(node, "label", "") or "")
+
+
+def _label_matches(label: str, turn_text_lower: str) -> bool:
+    label_norm = label.strip().lower()
+    if len(label_norm) < _MIN_LABEL_CHARS:
+        return False
+    return label_norm in turn_text_lower
+
+
+def _node_to_fragment(node: BaseSubstrateNodeV1) -> dict[str, Any]:
+    label = _node_label(node)
+    definition = str(getattr(node, "definition", "") or "").strip()
+    snippet = f"{label}: {definition}".strip(": ").strip() if definition else label
+    promotion_state = str(getattr(node, "promotion_state", "") or "")
+    try:
+        salience = float(getattr(getattr(node, "signals", None), "salience", 0.0) or 0.0)
+    except Exception:
+        salience = 0.0
+    return {
+        "id": f"concept_region:node:{getattr(node, 'node_id', '')}",
+        "source": "concept_region",
+        "snippet": snippet,
+        "text": snippet,
+        "score": max(0.0, min(1.0, salience)),
+        "tags": ["kind:concept", f"promotion_state:{promotion_state}"],
+    }
+
+
+def _edge_to_fragment(edge: SubstrateEdgeV1) -> dict[str, Any]:
+    predicate = str(getattr(edge, "predicate", "") or "associated_with")
+    source_id = str(getattr(getattr(edge, "source", None), "node_id", "") or "")
+    target_id = str(getattr(getattr(edge, "target", None), "node_id", "") or "")
+    snippet = f"{source_id} {predicate} {target_id}".strip()
+    try:
+        salience = float(getattr(edge, "salience", 0.0) or 0.0)
+    except Exception:
+        salience = 0.0
+    return {
+        "id": f"concept_region:edge:{getattr(edge, 'edge_id', '')}",
+        "source": "concept_region",
+        "snippet": snippet,
+        "text": snippet,
+        "score": max(0.0, min(1.0, salience)),
+        "tags": ["kind:concept_edge", f"predicate:{predicate}"],
+    }
+
+
+def fetch_concept_region_fragment(
+    query: Any,
+    *,
+    store: SubstrateGraphStore | None,
+    limit_nodes: int = _DEFAULT_SEARCH_LIMIT_NODES,
+    limit_edges: int = _DEFAULT_SEARCH_LIMIT_EDGES,
+) -> list[dict[str, Any]]:
+    """Return a turn-scoped concept-region fragment, or [] if nothing matched.
+
+    Never persists anything, never raises, and never runs a store read
+    unless there is turn text to match against. This is a per-call
+    function only -- it must not be registered as a standing/always-on
+    stance producer (see `chat_stance.py::_build_unification_registry`
+    for the pattern this deliberately does NOT follow).
+    """
+
+    turn_text = _turn_text(query)
+    if not turn_text:
+        return []
+    if store is None:
+        return []
+
+    turn_text_lower = turn_text.lower()
+
+    try:
+        region = store.read_concept_region(limit_nodes=limit_nodes, limit_edges=limit_edges)
+    except Exception as exc:  # noqa: BLE001 - collector must degrade, never raise
+        logger.debug("concept_region collector: store read failed: %s", exc)
+        return []
+
+    nodes = list(getattr(region, "nodes", None) or [])
+    edges = list(getattr(region, "edges", None) or [])
+
+    matched_nodes = [node for node in nodes if _label_matches(_node_label(node), turn_text_lower)]
+    if not matched_nodes:
+        return []
+
+    matched_node_ids = {getattr(node, "node_id", None) for node in matched_nodes}
+    matched_edges = [
+        edge
+        for edge in edges
+        if getattr(getattr(edge, "source", None), "node_id", None) in matched_node_ids
+        or getattr(getattr(edge, "target", None), "node_id", None) in matched_node_ids
+    ]
+
+    fragments: list[dict[str, Any]] = [_node_to_fragment(node) for node in matched_nodes]
+    fragments.extend(_edge_to_fragment(edge) for edge in matched_edges)
+    return fragments
+
+
+__all__ = ["fetch_concept_region_fragment"]

--- a/services/orion-recall/tests/test_concept_region_collector.py
+++ b/services/orion-recall/tests/test_concept_region_collector.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from app.collectors.concept_region import fetch_concept_region_fragment
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateEdgeV1,
+    SubstrateProvenanceV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.store import InMemorySubstrateGraphStore
+
+
+def _provenance(*, key: str) -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="human_verified",
+        source_kind="test_fixture",
+        source_channel="test:concept_region",
+        producer="test_concept_region_collector",
+        evidence_refs=[f"fixture#{key}"],
+    )
+
+
+def _temporal() -> SubstrateTemporalWindowV1:
+    return SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc))
+
+
+def _concept_node(*, node_id: str, label: str, anchor_scope: str = "orion") -> ConceptNodeV1:
+    return ConceptNodeV1(
+        node_id=node_id,
+        anchor_scope=anchor_scope,
+        subject_ref=node_id,
+        promotion_state="canonical",
+        temporal=_temporal(),
+        provenance=_provenance(key=node_id),
+        label=label,
+        definition=f"Definition of {label}",
+    )
+
+
+def _seeded_store() -> InMemorySubstrateGraphStore:
+    """Mirrors orion/substrate/seed.py's shape: a couple of concept nodes
+    plus a cross-reference edge, written via upsert_node/upsert_edge."""
+
+    store = InMemorySubstrateGraphStore()
+
+    orion_node = _concept_node(node_id="sub-concept-seed-orion", label="Orion", anchor_scope="orion")
+    juniper_node = _concept_node(node_id="sub-concept-seed-juniper", label="Juniper", anchor_scope="juniper")
+
+    store.upsert_node(identity_key="concept|orion|orion|seed", node=orion_node)
+    store.upsert_node(identity_key="concept|juniper|juniper|seed", node=juniper_node)
+
+    edge = SubstrateEdgeV1(
+        edge_id="sub-edge-seed-orion-juniper",
+        source=NodeRefV1(node_id=orion_node.node_id, node_kind="concept"),
+        target=NodeRefV1(node_id=juniper_node.node_id, node_kind="concept"),
+        predicate="associated_with",
+        temporal=_temporal(),
+        provenance=_provenance(key="orion-juniper"),
+    )
+    store.upsert_edge(identity_key=f"{orion_node.node_id}|associated_with|{juniper_node.node_id}", edge=edge)
+
+    return store
+
+
+class _Query:
+    """Minimal stand-in for the loosely-typed `query` object active_packet.py
+    and worker.py pass around (`.fragment` carries the turn text)."""
+
+    def __init__(self, fragment: str) -> None:
+        self.fragment = fragment
+
+
+class _CountingStore:
+    """Wraps a real store and counts calls to read_concept_region, so we can
+    assert the collector never reads the store when there's no turn text."""
+
+    def __init__(self, inner: InMemorySubstrateGraphStore) -> None:
+        self._inner = inner
+        self.read_calls = 0
+
+    def read_concept_region(self, *, limit_nodes: int = 32, limit_edges: int = 64):
+        self.read_calls += 1
+        return self._inner.read_concept_region(limit_nodes=limit_nodes, limit_edges=limit_edges)
+
+
+class _RaisingStore:
+    def read_concept_region(self, *, limit_nodes: int = 32, limit_edges: int = 64):
+        raise RuntimeError("boom: store unavailable")
+
+
+def test_turn_mentioning_seeded_label_returns_nonempty_fragment():
+    store = _seeded_store()
+
+    fragments = fetch_concept_region_fragment(_Query("tell me about Juniper today"), store=store)
+
+    assert fragments
+    ids = [f["id"] for f in fragments]
+    assert any("sub-concept-seed-juniper" in i for i in ids)
+    # matched node's immediate edge should also come back, bounded to the match
+    assert any(f["source"] == "concept_region" and "kind:concept_edge" in f["tags"] for f in fragments)
+
+
+def test_turn_with_no_relevant_mention_returns_empty_and_skips_store_read():
+    store = _seeded_store()
+    counting_store = _CountingStore(store)
+
+    fragments = fetch_concept_region_fragment(_Query("what's the weather like"), store=counting_store)
+
+    assert fragments == []
+    # non-empty fragment text still triggers a read (that's expected -- the
+    # cheap-skip-on-empty-input path is covered separately below); a store
+    # read happening here but finding no label match is correct behavior.
+    assert counting_store.read_calls == 1
+
+
+def test_empty_turn_text_skips_store_read_entirely():
+    store = _seeded_store()
+    counting_store = _CountingStore(store)
+
+    fragments = fetch_concept_region_fragment(_Query(""), store=counting_store)
+
+    assert fragments == []
+    assert counting_store.read_calls == 0
+
+
+def test_none_query_skips_store_read_entirely():
+    store = _seeded_store()
+    counting_store = _CountingStore(store)
+
+    fragments = fetch_concept_region_fragment(None, store=counting_store)
+
+    assert fragments == []
+    assert counting_store.read_calls == 0
+
+
+def test_bare_string_query_is_accepted_directly():
+    store = _seeded_store()
+
+    fragments = fetch_concept_region_fragment("say hi to Orion for me", store=store)
+
+    assert fragments
+    assert any("sub-concept-seed-orion" in f["id"] for f in fragments)
+
+
+@pytest.mark.parametrize(
+    "turn_text",
+    [
+        "JUNIPER is around",
+        "juniper is around",
+        "JuNiPeR is around",
+        "juniper's calendar is full",  # substring match: label is a prefix of a longer token
+    ],
+)
+def test_matching_is_case_insensitive_and_substring_based(turn_text: str):
+    store = _seeded_store()
+
+    fragments = fetch_concept_region_fragment(_Query(turn_text), store=store)
+
+    assert fragments
+    assert any("sub-concept-seed-juniper" in f["id"] for f in fragments)
+
+
+def test_short_labels_below_minimum_length_do_not_match_everything():
+    store = InMemorySubstrateGraphStore()
+    short_node = _concept_node(node_id="sub-concept-seed-go", label="Go")
+    store.upsert_node(identity_key="concept|orion|go|seed", node=short_node)
+
+    # "Go" is a substring of tons of unrelated text; the 3-char minimum
+    # documented in concept_region.py should prevent this from matching.
+    fragments = fetch_concept_region_fragment(_Query("Going to the store later"), store=store)
+
+    assert fragments == []
+
+
+def test_missing_store_degrades_to_empty_without_raising():
+    fragments = fetch_concept_region_fragment(_Query("mentions Juniper"), store=None)
+
+    assert fragments == []
+
+
+def test_raising_store_degrades_to_empty_without_raising():
+    fragments = fetch_concept_region_fragment(_Query("mentions Juniper"), store=_RaisingStore())
+
+    assert fragments == []
+
+
+def test_empty_store_returns_empty():
+    store = InMemorySubstrateGraphStore()
+
+    fragments = fetch_concept_region_fragment(_Query("mentions Juniper"), store=store)
+
+    assert fragments == []
+
+
+def test_malformed_query_object_without_fragment_attr_degrades_to_empty():
+    store = _seeded_store()
+
+    class _NotAQuery:
+        pass
+
+    fragments = fetch_concept_region_fragment(_NotAQuery(), store=store)
+
+    assert fragments == []


### PR DESCRIPTION
## Summary

Wave 2 of the concept-atlas graph pipeline (spec: `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md`, Wave 1 merged via #1079), built as four independent parallel subagent tasks and verified/merged by the orchestrator.

- Adds `orion/substrate/relation_classification.py`: three interchangeable strategies (raw count baseline, PMI-style normalized association, decayed-activation) deciding whether a `co_occurs_with` node pair is worth an LLM relation-classification call, plus `classify_relation()` wiring a caller-injected classifier callable behind that decision. No live LLM call anywhere — the classifier is always injected. Option D (piggyback purely on promotion-state transition) is explicitly deferred, not built, per spec.
- Adds `services/orion-recall/app/collectors/concept_region.py`: a salience-gated collector mirroring `active_packet.py`'s pattern (not `chat_stance.py`'s always-on shape) — only reads the substrate store and returns a fragment when the current turn's text matches a stored concept label; returns empty with zero store access otherwise.
- Investigated (Phase 7) whether an operator-facing HITL review surface for the substrate promotion queue already existed — it did (`/substrate` page, `substrate.js`, real routes in `api_routes.py`), verified against exact line numbers. No new code needed.
- Ships the **Concept Atlas** Hub tab: `services/orion-hub/scripts/concept_atlas_routes.py` (`GET /api/substrate/concepts/summary`, `GET /api/substrate/concepts/network`), `templates/concept_atlas.html` + `static/js/concept-atlas.js` (four cards: summary stats, network drill-down with server-computed god-node flagging, read-only clustering summary linking to Topic Studio instead of duplicating it, global filters), embedded via the iframe isolation pattern (mirroring Substrate Atlas, not Organ Signals) per the spec's explicit recommendation.

## Outcome moved

The substrate concept graph (seeded + fed by real topic-foundry clusters, Wave 1) now has: a decision layer for when raw co-occurrence is worth upgrading to a typed relationship, a way to pull it into a live turn only when actually salient (not as a permanent stance), and an operator-facing interpretability surface to see what's actually in the graph. Also closes a real bug found along the way: the reference tab-isolation pattern (Organ Signals) defines a `destroy()`/cleanup method that's never invoked on tab-switch — Concept Atlas actually calls its `deactivate()` on tab-hide, not just defines one.

## Current architecture

Wave 1 (merged, #1079) gave the substrate graph real producers (seed concepts + topic-foundry adapter) and fixed identity resolution. Nothing yet consumed it into a live turn, classified relationships beyond free co-occurrence counting, or gave an operator a way to see it. This wave adds those three pieces as independent, pure/testable units — none wired into a live bus consumer or promotion-transition hook yet (deliberately, matching Wave 1's pattern of pure functions + tests before live wiring).

## Architecture touched

- `orion/substrate/` — new relation-classification module
- `services/orion-recall/app/collectors/` — new collector
- `services/orion-hub/` — new router, template, JS, additive tab wiring in `index.html`/`app.js`/`main.py`
- No bus/schema contract changes

## Files changed

- `orion/substrate/relation_classification.py`, `orion/substrate/tests/test_relation_classification.py`: Layer-3 relation-classification decision logic
- `services/orion-recall/app/collectors/concept_region.py`, `services/orion-recall/tests/test_concept_region_collector.py`: salience-gated concept recall collector
- `services/orion-hub/scripts/concept_atlas_routes.py`, `templates/concept_atlas.html`, `static/js/concept-atlas.js`, `tests/test_concept_atlas_routes.py`: Concept Atlas Hub tab
- `services/orion-hub/templates/index.html`, `static/js/app.js`, `scripts/main.py`: additive tab registration/wiring only

## Schema / bus / API changes

- Added: `GET /api/substrate/concepts/summary`, `GET /api/substrate/concepts/network`, `GET /concept-atlas` (new Hub routes, read-only, degrade to an honest "unavailable" response rather than a 500 on any missing/erroring store or malformed query param)
- Removed: none
- Renamed: none
- Behavior changed: none to existing endpoints
- Compatibility notes: `relation_classification.py` and `concept_region.py` are both new, uncalled-by-anything-live modules — pure library code, safe to land without any runtime behavior change

## Env/config changes

None.

## Tests run

```
PYTHONPATH=. pytest orion/substrate/tests --ignore=orion/substrate/tests/test_refit_salience_stub.py -q
259 passed

(cd services/orion-recall && PYTHONPATH=. pytest tests/test_concept_region_collector.py -q)
14 passed

PYTHONPATH=. pytest services/orion-hub/tests/test_concept_atlas_routes.py -q
15 passed
```

(`test_refit_salience_stub.py` is excluded above as a pre-existing, unrelated test with its own import-path requirements — confirmed untouched by this diff.) Each of the four sub-tasks was also verified individually by the orchestrator against the actual schema/store/route code before merging — the PMI/activation math, the `SUBSTRATE_SEMANTIC_STORE` reuse, the god-node degree computation, and the tab-switch `deactivate()` wiring were all cross-checked directly against source, not trusted from agent reports.

## Evals run

No eval harness exists yet for this seam (carried over gap from Wave 1, not newly introduced).

## Docker/build/smoke checks

Not applicable — pure library/route-level Python and static frontend assets, no new runtime wiring, no container/compose changes.

## Review findings fixed

- Finding (Phase 8): `SubstrateQueryResultV1.degraded`/`.error` were computed by non-default store backends but discarded by the network route, so an operator would see `"available": true` even when the store silently fell back to stale data.
  - Fix: route now surfaces `degraded`/`degraded_error`; `concept-atlas.js` renders an amber "DEGRADED" status when set.
  - Evidence: `test_network_surfaces_degraded_backend_result`.
- Finding (Phase 8): `float("nan")`/`float("inf")` for `min_activation` parsed without raising, silently emptying the graph instead of being treated as malformed.
  - Fix: added a `0.0 <= x <= 1.0` range check; out-of-range values are now ignored like other malformed input.
  - Evidence: `test_network_nan_min_activation_is_ignored_not_silently_emptied`.

## Restart required

No restart required. No live services consume any of this yet — Concept Atlas's routes are new and additive, no existing behavior changed.

## Risks / concerns

- Severity: low
- Concern: none of the three new capabilities (relation classification, salience-gated recall, Concept Atlas) are wired into a live bus consumer, promotion-transition hook, or turn-assembly pipeline yet — they're built, tested, and correct in isolation, but Orion's live cognition doesn't call any of them today.
- Mitigation: this mirrors Wave 1's own deliberate scoping (pure functions + tests before live wiring) and is the natural next-wave item, not an oversight.

## PR link

(filled in after creation)