### PR TITLE
fix(drives): desaturation round 1 — signal-only competition tension + SATURATED gate verdict (O1+O4)

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-16-drive-economy-desaturation-o1-o4-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-drive-economy-desaturation-o1-o4-pr.md
@@ -1,0 +1,161 @@
+# PR report: drive-economy desaturation, round 1 (O1 + O4) + retrospective reconciliation
+
+Branch: `fix/drive-economy-desaturation`
+Series: follows the 2026-07-15 saturation deep dive (see the motor-nerve PR reports and
+`orion/autonomy/drives_and_autonomy_retrospective.md` §5a, updated in this branch). Scope
+approved by Juniper: O1 + O4 now; O3 (predictive re-grounding) and O2 (event-rate
+normalization) are named follow-ups, deliberately not in this patch.
+
+## Summary
+
+- **O1**: `derive_pressure_competition_tensions` is now signal-only — `drive_impacts={}`.
+  The event still fires (kind, magnitude=spread, related_nodes, provenance) so observers
+  keep the competition signal; it no longer feeds anything derived from itself.
+- **O4**: `measure_autonomy_gate.py` gains a `SATURATED` verdict — a completed measurement
+  that says the co-activation bar was met by an always-on monoculture, not an economy.
+  Precedence: UNMEASURABLE > SATURATED > NO-GO/GO, with the genuine low-coactivation NO-GO
+  short-circuiting first.
+- Retrospective §5 reconciled with the parallel motor-nerve stream (§5a addendum): the
+  actuator and router exist; the signal is the bottleneck.
+
+## Outcome moved
+
+The dominant-drive monoculture mechanism is dead. Live-verified pathology this fixes:
+`dominant_drive=relational` in 96% of 1,727 audited ticks and 1,643 byte-identical audit
+summaries ("orion pressure concentrates on relational") — and since PR #1085, dominance is
+what chat stance (`stance_react.j2`) and Mind consume. The gate can also never again bless
+this state as GO.
+
+## The diagnosis correction worth reading (found during O1's consumer trace)
+
+The 2026-07-15 deep dive framed the competition tension as pressure-feedback incest. The
+trace showed the impacts never actually re-entered `DriveEngine.update()` in-process (the
+worker doesn't consume its own tension channel; the channel's only live consumers are
+persistence sinks). What the impacts demonstrably poisoned, every tick, is
+`compute_tick_attribution`/`dominant_drive_from_attribution` — magnitude ~0.96 × weights
+0.9/0.75 dominated attribution, which is precisely the 96%-relational / identical-summary
+symptom. Two mechanisms, now correctly attributed:
+
+1. **Dominance/narrative poisoning** (the competition tension) — fixed by O1.
+2. **Pressure pinning** (~13 substrate events/min vs decay τ=1800s ≈ 0.3% decay between
+   events; three drives at median 0.975–0.986; `predictive` starved dead at 0.016) — NOT
+   fixed here; that is O2/O3. **Expect the gate to read SATURATED (via `all_active_frac`)
+   until they land — that is the instrument working.**
+
+O1 additionally guarantees zero pressure fold on every present-or-future consumer path
+(`DriveEngine.update`, `compute_tick_attribution`, autonomy's `_fold_tension_into_pressures`,
+wildcard channel consumers), so the incest class is closed regardless of future wiring.
+
+## Files changed
+
+- `orion/spark/concept_induction/tensions.py`: `drive_impacts={}` + load-bearing
+  do-not-re-add comment; docstring updated
+- `orion/spark/concept_induction/tests/test_pressure_tensions.py`: assertions flipped to
+  signal-only; alias-path regression test
+- `orion/spark/concept_induction/tests/test_drives_leaky.py`: two regression tests —
+  competition tension contributes exactly zero pressure change; competition-only tick ==
+  pure decay
+- `scripts/analysis/measure_autonomy_gate.py`: `SATURATED` + three visible constants
+  (`SATURATION_DOMINANT_SHARE=0.90`, `SATURATION_MIN_ACTIVE=5`,
+  `SATURATION_ALL_ACTIVE_FRAC=0.75`), `DriveStats.all_active_frac/dominant_counts/
+  top_dominant_share`, pure `parse_dominant_rows`/`apply_dominant_counts`, second
+  degrade-safe Postgres query (failure keeps the histogram result), report renders the new
+  stats and explains SATURATED; exit-code comment states SATURATED is not a pass
+- `orion/autonomy/drives_and_autonomy_retrospective.md`: §5 bullets annotated, §5a status
+  addendum (two-mechanism diagnosis, O1–O4 map), §6 item 2 closed
+
+## Consumer trace (all empty-impacts paths verified by the implementing agent)
+
+`DriveEngine.update` (zero iterations, tick still decays), `drive_attribution` (zero
+contribution; falls through cleanly), `orion/autonomy/reducer.py` (never receives this
+kind), `autonomy/summary.py` (computes from pressures directly), `tension_ratelimit`
+(safe signature), `substrate/adapters/autonomy.py` (empty metadata, no crash; live call
+passes no tension items), divergence audit / goals / dossier / rdf (zero references).
+
+## Schema / bus / API changes
+
+- None on the wire: `tension.drive_competition.v1` keeps its schema; `drive_impacts` was
+  always an arbitrary dict and `{}` is valid. Gate report format gains fields; verdict
+  string vocabulary gains `SATURATED`.
+
+## Env/config changes
+
+- None. No new keys, no flag flips.
+
+## Tests run
+
+```text
+pytest orion/spark/concept_induction/tests \
+       scripts/analysis/tests/test_measure_autonomy_gate.py \
+       tests/test_autonomy_summary.py -q
+  → 190 passed (one combined invocation)
+
+Also run standalone by the implementing agents:
+  concept_induction suite 142 passed; gate suite 44 passed (31 pre-existing + 13 new);
+  autonomy summary + substrate materialization 12 passed.
+```
+
+## Evals run
+
+```text
+No eval harness for these surfaces (tracked as issue #1066). The post-deploy live
+re-measurement below is the behavioral check.
+```
+
+## Review findings fixed
+
+Review verdict: **approve — no CRITICAL/HIGH/MEDIUM findings.** The headline risk
+(quiet ticks minting a NEW alphabetical monoculture once the competition tension left
+attribution) was checked and cleared: all-zero attribution degrades to an honest
+`dominant_drive=None`/`summary=None`, and the max-pressure fallback in `audit.py` that
+would have re-minted `relational` from the still-pinned pressures is unreachable from the
+live call site. No code anywhere parses the verdict strings, so `SATURATED` breaks no
+consumer.
+
+- Finding: (LOW, the one fix the reviewer recommended) the histogram and dominance
+  queries ran with no shared upper bound on an autocommit connection — rows landing
+  between the two statements would count in `dominant_counts` but not the share
+  denominator, letting `top_dominant_share` drift past 1.0 (fail-safe direction, but
+  breaks the ≤1 contract).
+  - Fix: `window_end` captured once, both queries bounded `>= start AND < end`; a test
+    asserts both statements carry the byte-identical upper bound.
+- Finding: (LOW, judgment call, accepted + softened) SATURATED returns before the
+  resource-pressure check, so a reader could infer "fix saturation → GO" when pressure
+  would still fail.
+  - Fix: when the pressure bar is also unmet, the SATURATED explanation now appends
+    "resolving saturation alone would read NO-GO, not GO."
+- Accepted without change: tie-break step 2 inert when the competition tension is lead
+  (pre-existing alphabetical fallback, only on exact float ties, and the old tie bias
+  was itself part of the removed loop); `SATURATION_MIN_ACTIVE=5` as a global constant
+  (correct for the actual 6-drive deployment; deriving from drive count is a
+  someday-refactor).
+
+## Restart required
+
+```bash
+# concept-induction picks up the signal-only competition tension (after merge)
+docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
+
+# The gate script is not a service; no restart. Post-deploy verification (clean window,
+# after the bus-core situation settles):
+psql -h localhost -p 55432 -U postgres -d conjourney -c \
+  "SELECT dominant_drive, count(*) FROM drive_audits WHERE created_at > now() - interval '6 hours' GROUP BY 1 ORDER BY 2 DESC;"
+python scripts/analysis/measure_autonomy_gate.py --window-hours 6
+# Success criteria: dominant_drive churns (no single drive >90%), summaries diversify,
+# gate reads SATURATED (not GO) while pressure pinning persists pre-O2/O3.
+```
+
+## Risks / concerns
+
+- Severity: MEDIUM. Concern: with the competition tension out of attribution, quiet ticks
+  could fall through to a new degenerate dominant (alphabetical tie-break). Mitigation:
+  flagged to the review pass explicitly; most ticks carry real extracted tensions with
+  non-zero impacts; post-deploy verification watches exactly this.
+- Severity: LOW. Concern: SATURATED thresholds (0.90/5/0.75) are first-pass calibrations.
+  Mitigation: visible module constants, trivially tunable; the live shape (0.96/0.74) sits
+  comfortably past both.
+
+## PR link
+
+(filled after push)

--- a/orion/autonomy/drives_and_autonomy_retrospective.md
+++ b/orion/autonomy/drives_and_autonomy_retrospective.md
@@ -134,25 +134,71 @@ The founding charter's actual bar for success was self-initiated, sometimes-subo
 behavior — Orion doing something nobody asked for, or declining the smooth answer to protect
 its own coherence. As of this writing, that has never been built:
 
-- `autonomous_cycle_v1` doesn't exist.
-- The one mechanism that could produce true self-origination (`endogenous_origination.py`)
+- `autonomous_cycle_v1` doesn't exist. *(Still literally true as a scheduled cycle — but
+  see §5a: substantial pieces of its function shipped 2026-07-13/15 on other rails.)*
+- ~~The one mechanism that could produce true self-origination (`endogenous_origination.py`)
   is code-complete but flag-disabled on a NO-GO whose underlying measurement needs
-  re-verification against fresh (non-stale) data.
+  re-verification against fresh (non-stale) data.~~ Stale as written — see §5a: the flag
+  was operator-flipped ON 2026-07-15 after the measurement was re-run against fresh data.
 - The one live consumer of drive state (`chat_stance.py`) is reactive by construction — it
   only runs inside a turn something else already triggered — and reads from the
   turn-scoped, non-decaying `AutonomyStateV2`, not the tested, persistent `DriveEngine`.
+  *(Resolved by §9/§10's own patch: DriveEngine now feeds stance and Mind live;
+  AutonomyStateV2 retired.)*
 
 The instrument (pressure measurement) is real and well-built. The actuator (unprompted
 action) was never built. That is the single most load-bearing fact in this document.
+
+### 5a. Status update (2026-07-16): the actuator partially exists now, and the signal is the new bottleneck
+
+Written by the parallel motor-nerve work stream (PRs #1010/#1017/#1020, #1030, #1064, #1069
+— see `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md` and its PR
+reports), which §5 above predates. Corrections to the record:
+
+- **Unprompted action exists on two rails today.** Layer 9 (`orion-execution-dispatch-runtime`)
+  has been live in `dispatch_read_only` since 2026-07-14 — real cortex-exec dispatches
+  (`substrate.inspect/summarize/observe`), budget-capped per day, with honest statuses,
+  results persisted, and outcomes fed back as tensions (P3 relief). Separately, the
+  metabolism loop fires drive-goal-triggered readonly actions (web fetch, recall query,
+  episode journal) through the capability policy. Neither is `autonomous_cycle_v1` by name;
+  together they are most of its function. What remains genuinely unbuilt from the charter:
+  nothing fires on a `DriveEngine` threshold crossing *itself*, and dispatch timing is
+  clock/backlog-driven, not pressure-driven (a designed-but-unbuilt pacing patch exists).
+- **`ORION_ENDOGENOUS_ORIGINATION_ENABLED` is ON** (live operator flip, 2026-07-15;
+  `.env_example` default stays false). Gate (a) re-measured GO (0.0448 @ 1h / 0.0408 @ 7d vs
+  0.03). Gate (b) became measurable again the same day via the new Postgres `drive_audits`
+  instrument (the Fuseki graph path was killed end-to-end, #1064/#1069) and read GO
+  (coactivation 0.9506) — **but a same-day deep dive showed that GO is saturation, not
+  economy**, with two distinct mechanisms (the second pinned down precisely during the O1
+  fix's consumer trace): (1) `derive_pressure_competition_tensions` — a derived meta-signal
+  over the pressure vector, minted with near-max magnitude on every tick because a dead
+  `predictive` drive (median 0.016, never active) kept the spread permanently above
+  threshold — dominated `compute_tick_attribution`/`dominant_drive_from_attribution` every
+  tick, producing `dominant_drive=relational` in 96% of ticks and 1,643 byte-identical
+  audit summaries (and dominance is what stance/Mind consume post-§10); (2) independently,
+  the event-rate/decay mismatch (~13 substrate events/min vs decay τ=1800s ≈ 0.3% decay
+  between events) pins three drives' *pressures* at median 0.975–0.986. The fix branch this
+  note ships in makes the competition tension signal-only (O1 — cleans dominance
+  attribution, and guarantees zero pressure fold on every present or future consumer path)
+  and teaches the gate a distinct `SATURATED` verdict (O4). The pressure pinning itself
+  persists until the named follow-ups land: `predictive` re-grounding on the live
+  `prediction_error` signal (O3) and event-rate normalization (O2) — expect the gate to
+  read SATURATED, not GO, until then; that is the instrument working, not failing.
+- **Net restatement of §5's load-bearing fact:** the actuator now exists (trigger-starved
+  and clock-paced, but real and observed acting); the router exists (§9/§10). The bottleneck
+  has moved to the *signal*: until the drive economy desaturates, everything downstream —
+  origination bands, stance prompts, Mind facets — consumes a monoculture.
 
 ## 6. Open questions
 
 1. Is self-initiated, sometimes-suboptimal behavior still the actual target? If yes, the
    next concrete patch is narrow: wire something to fire without a prompt when `DriveEngine`
    pressure crosses threshold (a journal entry, a probing question) and observe what happens.
-2. Re-run the `coactivation_frac` gate against a source certified fresh before treating the
+2. ~~Re-run the `coactivation_frac` gate against a source certified fresh before treating the
    endogenous-origination NO-GO as still current — the original reading was proven stale once
-   already.
+   already.~~ Done 2026-07-15 — see §5a: fresh source built (Postgres `drive_audits`), gate
+   re-read GO, and the GO itself was then diagnosed as saturation; the gate now has a
+   `SATURATED` verdict so this failure class is instrument-visible.
 3. ~~Trace whether/how `services/orion-mind` actually consumes `DriveEngine` state today.~~
    Resolved 2026-07-16 — see §8. It doesn't consume `DriveEngine`; it consumes
    `AutonomyStateV2`.

--- a/orion/spark/concept_induction/tensions.py
+++ b/orion/spark/concept_induction/tensions.py
@@ -211,7 +211,8 @@ def derive_pressure_competition_tensions(
     entity_id: str,
     pressures: Dict[str, float],
 ) -> List[TensionEventV1]:
-    """Emit at most one tension when max-min drive pressure spread exceeds threshold (no turn_effect required)."""
+    """Emit at most one signal-only tension (empty drive_impacts) when max-min drive
+    pressure spread exceeds threshold (no turn_effect required)."""
     canon = _canonical_pressures_for_spread(pressures)
     vals = list(canon.values())
     if len(vals) < 2:
@@ -256,7 +257,17 @@ def derive_pressure_competition_tensions(
         provenance=prov,
         related_nodes=[f"drive:{top}", f"drive:{runner}", "tension.drive_competition.v1"],
         magnitude=clamp01(spread),
-        drive_impacts={top: 0.9, runner: 0.75},
+        # Signal-only BY DESIGN -- do not re-add drive_impacts here. This tension is
+        # a derived meta-signal computed FROM the drive pressure vector; feeding it
+        # back as pressure impacts is data incest (rich-get-richer). The 2026-07-15
+        # saturation diagnosis: with one dead drive (predictive, median 0.016) the
+        # spread sits permanently above threshold (~0.96 vs 0.06), this fired on
+        # essentially every tick, and the top drives were subsidized to a pinned
+        # fixed point (relational/autonomy/continuity at median 0.975-0.986,
+        # dominant_drive=relational 96% of ticks). Attention/projection/observers
+        # still get the competition signal via kind/magnitude/related_nodes; it just
+        # must never feed the pressure state that generated it.
+        drive_impacts={},
     )
     event.provenance.tension_refs = [event.artifact_id]
     return [event]

--- a/orion/spark/concept_induction/tests/test_drives_leaky.py
+++ b/orion/spark/concept_induction/tests/test_drives_leaky.py
@@ -214,6 +214,75 @@ def test_positive_only_tensions_unaffected_by_signed_clamp() -> None:
     assert all(abs(p - 0.7309) > 0.01 for p in pressures.values()), pressures
 
 
+def test_signal_only_competition_tension_contributes_zero_pressure() -> None:
+    """Regression (2026-07-15 saturation): tension.drive_competition.v1 is
+    signal-only -- empty drive_impacts. Fed to update() alongside a normal
+    tension, it must contribute exactly zero pressure change: the result is
+    identical to running update() with the normal tension alone."""
+    competition = TensionEventV1(
+        artifact_id="t-competition",
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        kind="tension.drive_competition.v1",
+        magnitude=0.96,  # the live pinned spread from the diagnosis
+        drive_impacts={},  # signal-only by design
+        provenance={"intake_channel": "test:leaky"},
+    )
+    normal = _tension({"capability": 0.6, "coherence": 0.2})
+
+    with_competition, act_with = _leaky_engine().update(
+        previous_pressures={k: 0.1 for k in DRIVE_KEYS},
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[normal, competition],
+        now=T0 + timedelta(seconds=10),
+        previous_ts=T0,
+    )
+    without_competition, act_without = _leaky_engine().update(
+        previous_pressures={k: 0.1 for k in DRIVE_KEYS},
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[normal],
+        now=T0 + timedelta(seconds=10),
+        previous_ts=T0,
+    )
+    assert with_competition == without_competition
+    assert act_with == act_without
+    # And the normal tension really did move something (the tick happened).
+    assert with_competition["capability"] > 0.1
+
+
+def test_competition_tension_alone_is_pure_decay() -> None:
+    """A tick carrying ONLY the competition tension behaves exactly like an
+    empty tick: pure wall-clock decay, no subsidy to any drive."""
+    competition = TensionEventV1(
+        artifact_id="t-competition-solo",
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        kind="tension.drive_competition.v1",
+        magnitude=0.96,
+        drive_impacts={},
+        provenance={"intake_channel": "test:leaky"},
+    )
+    start = {k: 0.5 for k in DRIVE_KEYS}
+    with_tension, _ = _leaky_engine().update(
+        previous_pressures=dict(start),
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[competition],
+        now=T0 + timedelta(seconds=60),
+        previous_ts=T0,
+    )
+    empty_tick, _ = _leaky_engine().update(
+        previous_pressures=dict(start),
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[],
+        now=T0 + timedelta(seconds=60),
+        previous_ts=T0,
+    )
+    assert with_tension == empty_tick
+    assert all(with_tension[k] < start[k] for k in DRIVE_KEYS)  # decay happened
+
+
 def test_legacy_path_preserved() -> None:
     """Flag off ⇒ soft_saturate path drives the fixed-point inflation."""
     legacy = DriveEngine(DriveMathConfig(leaky_math_enabled=False))

--- a/orion/spark/concept_induction/tests/test_pressure_tensions.py
+++ b/orion/spark/concept_induction/tests/test_pressure_tensions.py
@@ -64,4 +64,30 @@ def test_pressure_competition_emits_when_spread_high() -> None:
     assert len(out) == 1
     assert out[0].kind == "tension.drive_competition.v1"
     assert out[0].magnitude >= 0.12
-    assert "autonomy" in out[0].drive_impacts
+    # Signal-only by design: the event still carries the competition (magnitude,
+    # related_nodes, provenance) but must NOT mint pressure impacts -- it is a
+    # derived meta-signal over the pressure vector, and feeding it back as
+    # pressure is data incest (2026-07-15 saturation diagnosis).
+    assert out[0].drive_impacts == {}
+    assert "drive:autonomy" in out[0].related_nodes
+    assert out[0].related_nodes[0] == "drive:autonomy"  # top drive first
+    assert out[0].provenance.tension_refs == [out[0].artifact_id]
+
+
+def test_pressure_competition_is_signal_only_never_impacts() -> None:
+    """Regression: drive_impacts stays empty even under the stability-alias path."""
+    env = _envelope()
+    out = derive_pressure_competition_tensions(
+        envelope=env,
+        intake_channel="orion:chat:intake",
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        pressures={
+            "relational_stability": 0.8,
+            "predictive": 0.65,
+            "continuity": 0.6,
+        },
+    )
+    assert len(out) == 1
+    assert out[0].drive_impacts == {}

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -755,7 +755,12 @@ def fetch_drive_stats_postgres(conn, window_start: datetime) -> tuple[DriveStats
     dominance fields for the SATURATED verdict; if it fails, the histogram
     result stands with empty ``dominant_counts`` and a note.
     Windowing follows the table contract:
-    ``COALESCE(observed_at, created_at) >= window_start``.
+    ``window_start <= COALESCE(observed_at, created_at) < window_end``, where
+    ``window_end`` is captured ONCE and shared by both queries — on an
+    autocommit connection they are separate statements, and without a shared
+    upper bound rows landing between them would appear in ``dominant_counts``
+    but not in ``record_count`` (the share denominator), letting
+    ``top_dominant_share`` drift past its ≤1 contract (review finding).
 
     Reuses the script's existing read-only connection. Returns
     ``(DriveStats, note)`` and degrades to ``(DriveStats(), note)`` — never
@@ -766,6 +771,7 @@ def fetch_drive_stats_postgres(conn, window_start: datetime) -> tuple[DriveStats
 
     if conn is None:
         return DriveStats(), "postgres drive_audits unavailable: no read-only postgres connection"
+    window_end = datetime.now(timezone.utc)
     try:
         with conn.cursor() as cur:
             cur.execute(
@@ -773,9 +779,10 @@ def fetch_drive_stats_postgres(conn, window_start: datetime) -> tuple[DriveStats
                 SELECT active_count, COUNT(*)
                 FROM drive_audits
                 WHERE COALESCE(observed_at, created_at) >= %s
+                  AND COALESCE(observed_at, created_at) < %s
                 GROUP BY active_count
                 """,
-                (window_start,),
+                (window_start, window_end),
             )
             rows = cur.fetchall()
     except Exception as exc:
@@ -807,9 +814,10 @@ def fetch_drive_stats_postgres(conn, window_start: datetime) -> tuple[DriveStats
                 SELECT dominant_drive, COUNT(*)
                 FROM drive_audits
                 WHERE COALESCE(observed_at, created_at) >= %s
+                  AND COALESCE(observed_at, created_at) < %s
                 GROUP BY dominant_drive
                 """,
-                (window_start,),
+                (window_start, window_end),
             )
             dominant_rows = cur.fetchall()
     except Exception:
@@ -964,8 +972,16 @@ def render_report(
             "always-on monoculture (one drive dominating nearly every audit and/or "
             "nearly all drives simultaneously active), not by a functioning economy "
             "with churn and turn-taking.",
-            "",
         ])
+        if pressure.frac_gt_level < RESOURCE_PRESSURE_MIN_FRAC:
+            # Review note: SATURATED returns before the pressure check, so
+            # without this line a reader could infer "fix saturation -> GO"
+            # while the pressure bar would still fail.
+            lines.append(
+                "Note: the resource_pressure bar is ALSO currently unmet -- "
+                "resolving saturation alone would read NO-GO, not GO."
+            )
+        lines.append("")
     lines.extend([
         "## Coverage caveats",
         "",

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -40,7 +40,7 @@ import logging
 import os
 import statistics
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
@@ -62,6 +62,15 @@ DRIFT_VARIANCE_RATIO: float = 0.25
 COACTIVATION_MIN_FRAC: float = 0.10
 RESOURCE_PRESSURE_LEVEL: float = 0.3
 RESOURCE_PRESSURE_MIN_FRAC: float = 0.05
+
+# Verdict (b) saturation guards. Co-activation >= COACTIVATION_MIN_FRAC is
+# trivially satisfied by an always-on saturated state (live 2026-07-15:
+# coactivation_frac 0.9506 with 74% of ticks at 5-of-6 drives active and one
+# drive dominant in 96% of ticks). GO must mean a functioning economy with
+# churn and turn-taking, so a monoculture surfaces as its own verdict.
+SATURATION_DOMINANT_SHARE: float = 0.90  # one drive dominant in >=90% of audits = no turn-taking
+SATURATION_MIN_ACTIVE: int = 5  # 5 of the 6 drives simultaneously active = near-all-on
+SATURATION_ALL_ACTIVE_FRAC: float = 0.75  # >=75% of audits in that near-all-on state
 
 # Hard cap so no query result set grows unbounded.
 MAX_ROWS: int = 500_000
@@ -132,6 +141,14 @@ class DriveStats:
     record_count: int = 0
     coactivation_frac: float = 0.0
     concurrent_active_hist: dict[int, int] = field(default_factory=dict)
+    # Fraction of audits with active_count >= SATURATION_MIN_ACTIVE (derived
+    # from the same histogram -- the "near-all-on" saturation signal).
+    all_active_frac: float = 0.0
+    # dominant_drive -> audit count over the window (NULL dominants excluded
+    # from the counts but still present in record_count's denominator).
+    dominant_counts: dict[str, int] = field(default_factory=dict)
+    # Share of the most common non-null dominant_drive over ALL records.
+    top_dominant_share: float = 0.0
 
 
 # ===========================================================================
@@ -310,10 +327,60 @@ def drive_stats_from_histogram(hist: dict[int, int]) -> DriveStats:
     if record_count == 0:
         return DriveStats()
     coactive = sum(n for k, n in hist.items() if k >= 2)
+    all_active = sum(n for k, n in hist.items() if k >= SATURATION_MIN_ACTIVE)
     return DriveStats(
         record_count=record_count,
         coactivation_frac=coactive / record_count,
         concurrent_active_hist=dict(hist),
+        all_active_frac=all_active / record_count,
+    )
+
+
+def parse_dominant_rows(rows: Iterable[Any]) -> dict[str, int]:
+    """Parse ``SELECT dominant_drive, count(*) ... GROUP BY dominant_drive``
+    rows into ``{dominant_drive: audits}``.
+
+    A NULL dominant_drive is allowed (rows where no drive dominated): it is
+    excluded from the returned counts but its rows still sit in the share
+    denominator via the histogram's ``record_count`` (live shape check:
+    84 of 1727 rows had NULL dominant). Malformed rows (short tuples,
+    non-numeric counts) and negative counts are skipped. Never raises.
+    Pure + unit-testable, mirrors ``parse_postgres_histogram_rows``.
+    """
+
+    out: dict[str, int] = {}
+    for row in rows:
+        try:
+            key = row[0]
+            audits = int(row[1])
+        except (TypeError, ValueError, IndexError, OverflowError):
+            continue
+        if audits < 0:
+            continue
+        if key is None:
+            continue
+        out[str(key)] = audits
+    return out
+
+
+def apply_dominant_counts(stats: DriveStats, dominant_counts: dict[str, int]) -> DriveStats:
+    """Return a copy of ``stats`` with dominance fields filled in.
+
+    ``top_dominant_share`` uses ``stats.record_count`` (ALL audits in the
+    window, NULL dominants included) as the denominator, not the sum of the
+    non-null dominant counts -- a drive dominating every row that HAS a
+    dominant must not be inflated by dropping the NULL rows. Empty counts or
+    zero records -> share 0.0 (the dominance clause simply can't fire).
+    Pure + unit-testable.
+    """
+
+    share = 0.0
+    if dominant_counts and stats.record_count > 0:
+        share = max(dominant_counts.values()) / stats.record_count
+    return replace(
+        stats,
+        dominant_counts=dict(dominant_counts),
+        top_dominant_share=share,
     )
 
 
@@ -361,6 +428,7 @@ def is_undefined_table_error(exc: BaseException) -> bool:
 
 
 UNMEASURABLE = "UNMEASURABLE"
+SATURATED = "SATURATED"
 
 
 def verdict_drift(silent: SelfStateMetrics, busy: SelfStateMetrics) -> str:
@@ -427,6 +495,23 @@ def verdict_economy(drive: DriveStats, pressure: ResourcePressureStats) -> str:
     function exists to prevent, just left open on whichever input isn't
     checked.
 
+    SATURATED iff the co-activation bar IS met but the underlying state is a
+    monoculture: one drive dominant in >= SATURATION_DOMINANT_SHARE of audits
+    (no turn-taking), OR >= SATURATION_ALL_ACTIVE_FRAC of audits have
+    >= SATURATION_MIN_ACTIVE drives simultaneously active (always-on). This is
+    the same "instrument blesses a degenerate state" failure class the
+    UNMEASURABLE guard fixed for zero rows -- live 2026-07-15 the gate read GO
+    with coactivation_frac 0.9506 while dominant_drive was "relational" in 96%
+    of ticks and 74% of ticks sat at 5-of-6 drives active. Co-activation alone
+    cannot distinguish an economy (churn, turn-taking) from saturation, so
+    saturation gets its own honest verdict. If dominance data degraded
+    (empty dominant_counts) the dominance clause can't fire, but the
+    histogram-only all_active_frac clause still can.
+
+    Precedence: UNMEASURABLE > SATURATED > NO-GO/GO (a coactivation shortfall
+    still short-circuits to NO-GO before the saturation check -- saturation is
+    only a meaningful diagnosis of a coactivation bar that was met).
+
     Otherwise, GO iff coactivation_frac >= COACTIVATION_MIN_FRAC
       AND frac_gt(resource_pressure >= level) >= RESOURCE_PRESSURE_MIN_FRAC.
     """
@@ -435,6 +520,11 @@ def verdict_economy(drive: DriveStats, pressure: ResourcePressureStats) -> str:
         return UNMEASURABLE
     if drive.coactivation_frac < COACTIVATION_MIN_FRAC:
         return "NO-GO"
+    if (
+        drive.top_dominant_share >= SATURATION_DOMINANT_SHARE
+        or drive.all_active_frac >= SATURATION_ALL_ACTIVE_FRAC
+    ):
+        return SATURATED
     if pressure.frac_gt_level < RESOURCE_PRESSURE_MIN_FRAC:
         return "NO-GO"
     return "GO"
@@ -660,7 +750,10 @@ def fetch_drive_stats_postgres(conn, window_start: datetime) -> tuple[DriveStats
     Fuseki DriveAudit graph).
 
     ``active_count`` is already derived at write time, so the histogram is a
-    single server-side ``GROUP BY active_count`` — no JSONB parsing here.
+    single server-side ``GROUP BY active_count`` — no JSONB parsing here. A
+    second cheap ``GROUP BY dominant_drive`` on the same connection fills the
+    dominance fields for the SATURATED verdict; if it fails, the histogram
+    result stands with empty ``dominant_counts`` and a note.
     Windowing follows the table contract:
     ``COALESCE(observed_at, created_at) >= window_start``.
 
@@ -701,9 +794,36 @@ def fetch_drive_stats_postgres(conn, window_start: datetime) -> tuple[DriveStats
             f"postgres drive_audits: table present but 0 rows in window since "
             f"{window_start.isoformat()}"
         )
+    # Second cheap query on the same connection: dominant-drive counts feeding
+    # the SATURATED dominance clause. Same degrade posture as the histogram
+    # query -- a dominance failure must NOT discard the histogram result, it
+    # just leaves dominant_counts empty (the all_active_frac clause still
+    # works histogram-only) with an honest note.
+    dominance_note = ""
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT dominant_drive, COUNT(*)
+                FROM drive_audits
+                WHERE COALESCE(observed_at, created_at) >= %s
+                GROUP BY dominant_drive
+                """,
+                (window_start,),
+            )
+            dominant_rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch drive_audits dominant-drive counts", exc_info=True)
+        dominant_rows = None
+        dominance_note = (
+            "; dominant_drive query failed -- dominance saturation check "
+            "unavailable (histogram result stands)"
+        )
+    if dominant_rows is not None:
+        stats = apply_dominant_counts(stats, parse_dominant_rows(dominant_rows))
     return stats, (
         f"drive source: postgres drive_audits ({stats.record_count} rows since "
-        f"{window_start.isoformat()})"
+        f"{window_start.isoformat()}){dominance_note}"
     )
 
 
@@ -778,6 +898,15 @@ def render_report(
     caveats: list[str],
 ) -> str:
     hist = ", ".join(f"{k}:{v}" for k, v in sorted(drive.concurrent_active_hist.items())) or "(none)"
+    dominants = ", ".join(
+        f"{name}:{count}"
+        for name, count in sorted(drive.dominant_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    ) or "(none)"
+    if drive.dominant_counts:
+        top_name = max(drive.dominant_counts.items(), key=lambda kv: kv[1])[0]
+        top_dominant = f"{top_name} (share {_fmt(drive.top_dominant_share)} of all audits)"
+    else:
+        top_dominant = "(none -- dominance data empty or unavailable)"
     lines = [
         "# Autonomy Origination Measurement Gate",
         "",
@@ -813,6 +942,9 @@ def render_report(
         f"- drive audit records: {drive.record_count}",
         f"- coactivation_frac (active_count >= 2): {_fmt(drive.coactivation_frac)}",
         f"- concurrent_active_hist: {hist}",
+        f"- all_active_frac (active_count >= {SATURATION_MIN_ACTIVE}): {_fmt(drive.all_active_frac)}",
+        f"- dominant_drive counts: {dominants}",
+        f"- top dominant drive: {top_dominant}",
         f"- resource_pressure rows: {pressure.row_count}",
         f"- resource_pressure median: {_fmt(pressure.median)}",
         f"- resource_pressure p90: {_fmt(pressure.p90)}",
@@ -821,10 +953,23 @@ def render_report(
         "Rule (b) GO iff coactivation_frac >= "
         f"{COACTIVATION_MIN_FRAC} AND resource_pressure frac >= "
         f"{RESOURCE_PRESSURE_LEVEL} is >= {RESOURCE_PRESSURE_MIN_FRAC}.",
-        "",
-        "## Coverage caveats",
+        f"Rule (b) {SATURATED} iff the co-activation bar is met but "
+        f"top_dominant_share >= {SATURATION_DOMINANT_SHARE} OR "
+        f"all_active_frac >= {SATURATION_ALL_ACTIVE_FRAC}.",
         "",
     ]
+    if verdict_b == SATURATED:
+        lines.extend([
+            f"Verdict {SATURATED} means the co-activation bar was met only by an "
+            "always-on monoculture (one drive dominating nearly every audit and/or "
+            "nearly all drives simultaneously active), not by a functioning economy "
+            "with churn and turn-taking.",
+            "",
+        ])
+    lines.extend([
+        "## Coverage caveats",
+        "",
+    ])
     if caveats:
         lines.extend(f"- {c}" for c in caveats)
     else:
@@ -967,7 +1112,10 @@ def run(window: timedelta, window_label: str) -> int:
     # Exit code distinguishes "the instrument didn't work" (2) from a
     # completed measurement, whichever way it came out (0) -- a caller
     # (cron, CI, a human) must not have to parse the report text to tell
-    # a dead sensor from a real GO/NO-GO.
+    # a dead sensor from a real GO/NO-GO. SATURATED is a completed
+    # measurement (the sensor worked; the economy is degenerate), so it
+    # exits 0 exactly like NO-GO -- it is NOT a pass, and nothing here
+    # or downstream may treat it as GO.
     if UNMEASURABLE in (verdict_a, verdict_b):
         return 2
     return 0

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -476,3 +476,205 @@ def test_verdict_b_unmeasurable_when_pressure_empty_even_with_live_drive_data():
     assert drive.coactivation_frac >= mod.COACTIVATION_MIN_FRAC
     assert empty_pressure.row_count == 0
     assert mod.verdict_economy(drive, empty_pressure) == mod.UNMEASURABLE
+
+
+# ---------------------------------------------------------------------------
+# 12. SATURATED -- verdict (b) must never bless a monoculture as an economy
+# ---------------------------------------------------------------------------
+def _passing_pressure():
+    """Pressure rows that clear the RESOURCE_PRESSURE_MIN_FRAC bar."""
+
+    rows = [
+        _self_state(i, {"resource_pressure": 0.5 if i < 3 else 0.1}, {})
+        for i in range(20)
+    ]
+    return mod.compute_resource_pressure_stats(rows)
+
+
+def test_verdict_b_saturated_by_dominance():
+    # Co-activation clears the bar and all_active_frac stays low, but one
+    # drive is dominant in 96% of audits -- the live 2026-07-15 monoculture.
+    drive = mod.drive_stats_from_histogram({2: 50, 1: 50})
+    drive = mod.apply_dominant_counts(drive, {"relational": 96, "novelty": 4})
+    pressure = _passing_pressure()
+    assert drive.coactivation_frac >= mod.COACTIVATION_MIN_FRAC
+    assert drive.all_active_frac < mod.SATURATION_ALL_ACTIVE_FRAC
+    assert drive.top_dominant_share >= mod.SATURATION_DOMINANT_SHARE
+    assert mod.verdict_economy(drive, pressure) == mod.SATURATED
+
+
+def test_verdict_b_saturated_by_all_active_even_without_dominance_data():
+    # Histogram mostly 5s/6s (near-all-on). Dominant data degraded (empty
+    # dominant_counts, e.g. the second query failed) -- the histogram-only
+    # all_active_frac clause must still fire.
+    drive = mod.drive_stats_from_histogram({5: 80, 6: 10, 1: 10})
+    assert drive.dominant_counts == {}
+    assert drive.top_dominant_share == 0.0
+    assert drive.all_active_frac == pytest.approx(0.9)
+    assert drive.all_active_frac >= mod.SATURATION_ALL_ACTIVE_FRAC
+    assert mod.verdict_economy(drive, _passing_pressure()) == mod.SATURATED
+
+
+def test_verdict_b_healthy_churn_is_still_go():
+    # Real turn-taking: co-activation clears the bar, dominance is spread
+    # across drives, and the near-all-on state is rare -> GO, not SATURATED.
+    drive = mod.drive_stats_from_histogram({1: 60, 2: 25, 3: 10, 5: 5})
+    drive = mod.apply_dominant_counts(
+        drive, {"relational": 30, "novelty": 25, "predictive": 25, "homeostatic": 15}
+    )
+    assert drive.coactivation_frac >= mod.COACTIVATION_MIN_FRAC
+    assert drive.top_dominant_share < mod.SATURATION_DOMINANT_SHARE
+    assert drive.all_active_frac < mod.SATURATION_ALL_ACTIVE_FRAC
+    assert mod.verdict_economy(drive, _passing_pressure()) == "GO"
+
+
+def test_verdict_b_unmeasurable_takes_precedence_over_saturated():
+    # Zero rows must stay UNMEASURABLE even if saturation-shaped fields are
+    # somehow set -- a dead sensor is never diagnosed as a degenerate economy.
+    drive = mod.DriveStats(
+        record_count=0,
+        coactivation_frac=0.95,
+        all_active_frac=0.9,
+        dominant_counts={"relational": 96},
+        top_dominant_share=0.96,
+    )
+    assert mod.verdict_economy(drive, _passing_pressure()) == mod.UNMEASURABLE
+    # And the natural zero-rows path stays UNMEASURABLE too.
+    empty = mod.drive_stats_from_histogram({})
+    assert mod.verdict_economy(empty, _passing_pressure()) == mod.UNMEASURABLE
+
+
+def test_verdict_b_low_coactivation_no_go_unaffected_by_saturation_fields():
+    # Low co-activation short-circuits to NO-GO before the saturation check:
+    # saturation only diagnoses a co-activation bar that was actually met.
+    drive = mod.drive_stats_from_histogram({1: 19, 5: 1})  # 5% co-active
+    drive = mod.apply_dominant_counts(drive, {"relational": 19})  # 95% dominant
+    assert drive.coactivation_frac < mod.COACTIVATION_MIN_FRAC
+    assert drive.top_dominant_share >= mod.SATURATION_DOMINANT_SHARE
+    assert mod.verdict_economy(drive, _passing_pressure()) == "NO-GO"
+
+
+def test_drive_stats_from_histogram_all_active_frac():
+    # 74% of ticks at >= SATURATION_MIN_ACTIVE drives -- the live shape.
+    stats = mod.drive_stats_from_histogram({5: 60, 6: 14, 2: 16, 1: 10})
+    assert stats.all_active_frac == pytest.approx(0.74)
+    # Empty histogram keeps the default.
+    assert mod.drive_stats_from_histogram({}).all_active_frac == 0.0
+
+
+def test_parse_dominant_rows():
+    rows = [
+        ("relational", 1600),
+        ("novelty", "43"),    # driver returning string counts still parses
+        (None, 84),           # NULL dominant -> excluded from counts (still in record_count denominator)
+        ("junk",),            # short row -> skipped
+        ("epistemic", "bad"), # non-numeric count -> skipped
+        ("negative", -3),     # negative -> skipped
+    ]
+    assert mod.parse_dominant_rows(rows) == {"relational": 1600, "novelty": 43}
+    assert mod.parse_dominant_rows([]) == {}
+
+
+def test_apply_dominant_counts_uses_all_records_as_denominator():
+    # Live shape: 1727 audits, 84 NULL dominants -- the NULL rows stay in the
+    # denominator, so the share is 1643/1727, not 1643/1643.
+    stats = mod.drive_stats_from_histogram({5: 1278, 4: 200, 1: 249})
+    assert stats.record_count == 1727
+    stats = mod.apply_dominant_counts(stats, {"relational": 1643})
+    assert stats.top_dominant_share == pytest.approx(1643 / 1727)
+    assert stats.dominant_counts == {"relational": 1643}
+    # Empty counts -> share 0.0 (dominance clause simply can't fire).
+    cleared = mod.apply_dominant_counts(stats, {})
+    assert cleared.top_dominant_share == 0.0
+    assert cleared.dominant_counts == {}
+    # Histogram fields survive untouched.
+    assert cleared.record_count == 1727
+    assert cleared.coactivation_frac == stats.coactivation_frac
+
+
+class _SequenceConn:
+    """Conn handing out one canned cursor per .cursor() call (multi-query fetch)."""
+
+    def __init__(self, cursors):
+        self._cursors = list(cursors)
+
+    def cursor(self):
+        return self._cursors.pop(0)
+
+
+def test_fetch_drive_stats_postgres_dominant_query_happy_path():
+    hist_cursor = _FakeCursor(rows=[(1, 20), (2, 4), (3, 1)])
+    dom_cursor = _FakeCursor(rows=[("relational", 20), (None, 3), ("novelty", 2)])
+    stats, note = mod.fetch_drive_stats_postgres(_SequenceConn([hist_cursor, dom_cursor]), BASE)
+    assert stats.record_count == 25
+    assert stats.dominant_counts == {"relational": 20, "novelty": 2}
+    assert stats.top_dominant_share == pytest.approx(20 / 25)
+    assert "drive source: postgres drive_audits (25 rows" in note
+    sql, params = dom_cursor.executed[0]
+    assert "FROM drive_audits" in sql
+    assert "COALESCE(observed_at, created_at) >= %s" in sql
+    assert "GROUP BY dominant_drive" in sql
+    assert params == (BASE,)
+
+
+def test_fetch_drive_stats_postgres_dominant_query_failure_keeps_histogram():
+    # A dominance failure must NOT discard the histogram result: the stats
+    # keep their real record_count/coactivation, dominance stays empty (so
+    # only the all_active_frac clause can fire), and the note says so.
+    hist_cursor = _FakeCursor(rows=[(1, 20), (5, 5)])
+    dom_cursor = _FakeCursor(exc=RuntimeError("connection reset"))
+    stats, note = mod.fetch_drive_stats_postgres(_SequenceConn([hist_cursor, dom_cursor]), BASE)
+    assert stats.record_count == 25
+    assert stats.coactivation_frac == pytest.approx(5 / 25)
+    assert stats.all_active_frac == pytest.approx(5 / 25)
+    assert stats.dominant_counts == {}
+    assert stats.top_dominant_share == 0.0
+    assert "drive source: postgres drive_audits (25 rows" in note
+    assert "dominant_drive query failed" in note
+
+
+def test_render_report_names_saturation_fields_and_explains_saturated():
+    drive = mod.drive_stats_from_histogram({5: 74, 6: 6, 2: 10, 1: 10})
+    drive = mod.apply_dominant_counts(drive, {"relational": 96, "novelty": 4})
+    report = mod.render_report(
+        window_label="7 day(s)",
+        window_start=BASE,
+        window_end=BASE + timedelta(days=7),
+        silent=mod.SelfStateMetrics(),
+        busy=mod.SelfStateMetrics(),
+        drive=drive,
+        drive_source="postgres drive_audits (100 rows)",
+        pressure=_passing_pressure(),
+        verdict_a="NO-GO",
+        verdict_b=mod.SATURATED,
+        caveats=[],
+    )
+    assert f"- all_active_frac (active_count >= {mod.SATURATION_MIN_ACTIVE}): 0.8000" in report
+    assert "- dominant_drive counts: relational:96, novelty:4" in report
+    assert "- top dominant drive: relational (share 0.9600 of all audits)" in report
+    assert f"**{mod.SATURATED}**" in report
+    # Rule text names the saturation thresholds...
+    assert f"top_dominant_share >= {mod.SATURATION_DOMINANT_SHARE}" in report
+    assert f"all_active_frac >= {mod.SATURATION_ALL_ACTIVE_FRAC}" in report
+    # ...and the SATURATED verdict is explained in plain language.
+    assert "always-on" in report and "monoculture" in report and "turn-taking" in report
+
+
+def test_render_report_no_saturated_explanation_when_not_saturated():
+    report = mod.render_report(
+        window_label="7 day(s)",
+        window_start=BASE,
+        window_end=BASE + timedelta(days=7),
+        silent=mod.SelfStateMetrics(),
+        busy=mod.SelfStateMetrics(),
+        drive=mod.drive_stats_from_histogram({1: 10, 2: 5}),
+        drive_source="postgres drive_audits (15 rows)",
+        pressure=_passing_pressure(),
+        verdict_a="GO",
+        verdict_b="GO",
+        caveats=[],
+    )
+    # Empty dominance renders honestly rather than fabricating a top drive.
+    assert "- dominant_drive counts: (none)" in report
+    assert "- top dominant drive: (none -- dominance data empty or unavailable)" in report
+    assert "monoculture" not in report

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -387,8 +387,11 @@ def test_fetch_drive_stats_postgres_histogram_path():
     sql, params = cursor.executed[0]
     assert "FROM drive_audits" in sql
     assert "COALESCE(observed_at, created_at) >= %s" in sql
+    assert "COALESCE(observed_at, created_at) < %s" in sql
     assert "GROUP BY active_count" in sql
-    assert params == (BASE,)
+    # (window_start, window_end): the upper bound is captured once and shared
+    # with the dominant query so the two statements see the same row set.
+    assert params[0] == BASE and len(params) == 2
 
 
 def test_fetch_drive_stats_postgres_table_missing_degrades():
@@ -613,8 +616,13 @@ def test_fetch_drive_stats_postgres_dominant_query_happy_path():
     sql, params = dom_cursor.executed[0]
     assert "FROM drive_audits" in sql
     assert "COALESCE(observed_at, created_at) >= %s" in sql
+    assert "COALESCE(observed_at, created_at) < %s" in sql
     assert "GROUP BY dominant_drive" in sql
-    assert params == (BASE,)
+    assert params[0] == BASE and len(params) == 2
+    # Snapshot-skew guard: BOTH queries must carry the exact same upper bound
+    # (captured once), or rows landing between the two statements would count
+    # in dominant_counts but not in the share denominator.
+    assert params[1] == hist_cursor.executed[0][1][1]
 
 
 def test_fetch_drive_stats_postgres_dominant_query_failure_keeps_histogram():


### PR DESCRIPTION
Implements the first two fixes from the 2026-07-15 drive-saturation deep dive (approved scope: O1+O4 now, O3/O2 follow-ups).

## Summary

- **O1**: `derive_pressure_competition_tensions` mints `drive_impacts={}` — the event still fires with magnitude/related_nodes/provenance for observers, but a derived meta-signal no longer feeds anything computed from itself. **Diagnosis correction found during the consumer trace**: the impacts never re-entered `DriveEngine.update()` in-process; what they demonstrably poisoned every tick is `compute_tick_attribution`/`dominant_drive_from_attribution` — the direct mechanism behind `dominant_drive=relational` in 96% of ticks and 1,643 byte-identical audit summaries (and dominance is what stance/Mind consume since #1085). Pressure *pinning* (three drives at 0.975–0.986) is the separate event-rate/τ mismatch — O2/O3 territory, deliberately not touched here.
- **O4**: the autonomy gate gains a `SATURATED` verdict — coactivation bar met but `top_dominant_share ≥ 0.90` or `all_active_frac ≥ 0.75` → a completed measurement that is NOT a pass. Precedence `UNMEASURABLE > SATURATED > NO-GO/GO` with the genuine low-coactivation NO-GO short-circuiting first. Dominance comes from a second degrade-safe query sharing a byte-identical window with the histogram.
- Retrospective §5 reconciled (§5a): actuator + router exist; the signal is the bottleneck. **Expect the gate to read SATURATED, not GO, until O2/O3 land — that's the instrument working.**

## Tests / review

190 green in one combined invocation (142 concept-induction + 44 gate + summary/materialization); 186 re-confirmed after review polish. Review: approve, no material findings; both recommended LOW polish items applied (shared query upper bound, SATURATED pressure note). Report: `docs/superpowers/pr-reports/2026-07-16-drive-economy-desaturation-o1-o4-pr.md`.

## After merge

Restart `orion-spark-concept-induction`; then on a clean window (post bus-core settling): watch `dominant_drive` churn + summaries diversify, and run `measure_autonomy_gate.py --window-hours 6` expecting SATURATED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)