### PR TITLE
fix(harness): degrade gracefully instead of hard-failing on substrate finalize-appraisal RPC timeout

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-16-substrate-finalize-degrade-passthrough-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-substrate-finalize-degrade-passthrough-pr.md
@@ -1,0 +1,118 @@
+# PR Report: substrate finalize-appraisal RPC timeout degrades gracefully instead of hard-failing the turn
+
+## Summary
+
+- Root-caused a live `Turn error (harness): RPC timeout waiting on orion:substrate:finalize_appraisal:result:*` — traced end to end to `orion-athena-fuseki`'s JVM (`-Xmx96g`) sitting at 94.88GiB/110GiB with 185% CPU (GC thrashing), 17 consecutive Docker healthcheck failures. Confirmed this is unrelated to the same-day `chore/kill-knowledge-forge` merge (PR #1088) — that PR touched zero bus channels/schemas per its own commit message and the graph, and Fuseki had already been running (and degrading) for 42 hours before it merged.
+- Added a scoped fallback: when the harness-governor's substrate finalize-appraisal RPC times out specifically (infra unavailable, not a content/logic failure), the harness draft is passed through as the final response instead of hard-failing the turn.
+- New `SubstrateAppraisalUnavailableError` in `orion-harness-governor` distinguishes this one failure mode from all other finalize-chain exceptions, which continue to hard-fail exactly as before.
+- New optional `HarnessRunV1.finalize_degraded_reason` field carries the cause through the RPC reply/artifact so Hub can tell "degraded success" apart from "hard failure" without inventing a new sentinel on top of existing fields.
+- Hub (`turn_orchestrator.py`) now treats a degraded run as a success: publishes chat history normally, returns a new `turn_degraded` frame (soft, non-red) instead of `turn_error`, then the normal success frames.
+- `app.js` renders `turn_degraded` as a yellow system note: "Response delivered without reflection (\<reason\>)".
+
+## Outcome moved
+
+Previously: any finalize failure (including simple infra hiccups) hard-failed the whole turn, showed a red "Turn error" banner, and — critically — **never persisted the turn to chat history** (the early-return in `turn_orchestrator.py` happened before the chat-history publish call), so the user-visible partial-draft response was never actually remembered by Orion. Now: a substrate RPC timeout still delivers the response, still writes it to chat history, and only shows a soft non-blocking notice.
+
+## Current architecture
+
+`orion-harness-governor`'s `handle_harness_run_request` runs the harness motor (produces `draft_text`), then `run_harness_finalize_chain` (5a substrate appraisal → 5b reflection → 5c voice-finalize → 6b turn-outcome). The chain's own docstring: "The motor draft is not the final Hub response; this chain is what may change it." Any exception from that chain fell into one of two existing branches: `HarnessFinalizeFailedError` (partial state after 5a/5b succeeded, 5c failed) or a generic `except Exception` (anything else, including a bare 5a RPC timeout) — both set `final_text=None`, `finalize_ran=False`, and Hub's `execute_unified_turn` turned that into a hard `turn_error` frame whenever `not run.finalize_ran or not run.final_text`.
+
+## Architecture touched
+
+- `orion/schemas/harness_finalize.py` — `HarnessRunV1` (already registered in `orion/schemas/registry.py`; new field is optional/backward-compatible, no registry change needed).
+- `services/orion-harness-governor/app/bus_listener.py` — new exception class, new except branch in `handle_harness_run_request`.
+- `orion/hub/turn_orchestrator.py` — new gate in `execute_unified_turn`.
+- `services/orion-hub/static/js/app.js` — new websocket frame handler (same pattern as the existing `turn_deferred` type; not a registered bus channel, this is Hub↔browser websocket protocol only).
+
+## Files changed
+
+- `orion/schemas/harness_finalize.py`: added `HarnessRunV1.finalize_degraded_reason: str | None = None`.
+- `services/orion-harness-governor/app/bus_listener.py`: added `SubstrateAppraisalUnavailableError`; `_substrate_client` now wraps `TimeoutError` from the substrate RPC into it; new `except SubstrateAppraisalUnavailableError` branch builds a degraded-success `HarnessRunV1` (`final_text=motor.draft_text`, `finalize_ran=False`, `finalize_degraded_reason` set) and emits a `system.error` event (`phase="substrate_appraisal_unavailable"`) for durable observability before replying.
+- `orion/hub/turn_orchestrator.py`: new branch ahead of the existing hard-fail gate — when `finalize_degraded_reason` and `final_text` are both present, publish chat history and return `[turn_degraded frame, *success_frames]` instead of an error frame.
+- `services/orion-hub/static/js/app.js`: new `turn_degraded` websocket message handler, yellow (non-red) system note.
+- `services/orion-harness-governor/tests/test_harness_governor_rpc.py`: new regression test — substrate client raising `TimeoutError` degrades to draft-passthrough, `finalize_ran=False`, `finalize_degraded_reason` set, system-error emitted.
+- `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py`: new regression test — a degraded `HarnessRunV1` produces `turn_degraded` + `final` frames (never `turn_error`), and chat history still gets published.
+
+## Schema / bus / API changes
+
+- Added: `HarnessRunV1.finalize_degraded_reason: str | None = None` (backward-compatible; old RPC replies without the field validate fine via `HarnessRunV1.model_validate(...)`, which is exactly how `HarnessGovernorClient.run()` decodes it in `services/orion-hub/scripts/harness_governor_client.py:142`).
+- Added: `turn_degraded` websocket frame type (Hub↔browser protocol, not a registered `orion/bus/channels.yaml` channel — same category as the existing `turn_deferred`/`connection_ready` types).
+- Removed: none.
+- Renamed: none.
+- Behavior changed: a substrate finalize-appraisal RPC timeout no longer hard-fails the turn; it delivers the harness draft as the final response with a soft notice.
+- Compatibility notes: none needed — purely additive/optional field, scoped exception handling.
+
+## Env/config changes
+
+None. No new env keys; `.env_example` unaffected.
+
+## Tests run
+
+```text
+PYTHONPATH=services/orion-harness-governor:. ./orion_dev/bin/python -m pytest services/orion-harness-governor/tests/test_harness_governor_rpc.py -q
+10 passed
+
+PYTHONPATH=services/orion-harness-governor:. ./orion_dev/bin/python -m pytest services/orion-harness-governor/tests/ -q
+14 passed
+
+PYTHONPATH=services/orion-hub:. ./orion_dev/bin/python -m pytest services/orion-hub/tests/test_turn_orchestrator_ws_frames.py -q
+19 passed
+
+PYTHONPATH=. ./orion_dev/bin/python -m pytest tests/test_unified_turn_schemas.py tests/test_unified_turn_bus_catalog.py orion/harness/tests/ -q
+193 passed, 3 pre-existing failures (test_grounding_capsule_consumers.py x2, test_harness_runner.py x1 —
+confirmed failing identically on unmodified main, unrelated to this patch)
+
+PYTHONPATH=services/orion-hub:. ./orion_dev/bin/python -m pytest services/orion-hub/tests/ -q
+814 passed, 33 pre-existing failures (memory-consolidation/substrate-effect/recall-strategy suites —
+confirmed the same failures reproduce on unmodified main in isolation; missing DB/schema
+fixtures in this sandbox, unrelated to turn_orchestrator/finalize code touched here)
+```
+
+## Evals run
+
+No dedicated eval harness exists for harness-governor or hub turn orchestration beyond the pytest suites above; none added — this is a scoped error-handling patch, not a quality/behavior dimension an eval would score.
+
+## Docker/build/smoke checks
+
+Not run — no config/dependency/Docker/port changes in this patch. Live diagnosis (not part of this patch's own smoke) confirmed the failure signature directly from running containers: `docker logs orion-athena-harness-governor` showed the exact `[rpc] timeout waiting for reply ... orion:substrate:finalize_appraisal:result:c881be8b-...` line this patch now degrades gracefully instead of hard-failing.
+
+## Review findings fixed
+
+Review was run as direct multi-angle manual review (line-by-line, removed-behavior, cross-file tracer, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) — the 8 code-review subagents dispatched for this all failed immediately on launch with "session limit · resets 8:20pm (UTC)" (an account-level rate limit, not a code issue), so the review was done directly instead of re-attempting the subagent dispatch.
+
+No correctness bugs found. Two non-blocking observations carried forward rather than fixed (out of scope for what was asked):
+
+- **Altitude**: every turn still pays the full `SUBSTRATE_FINALIZE_TIMEOUT_SEC` (default 5.0s) before degrading, for as long as the underlying outage persists — this patch stops the turn from hard-failing but doesn't add a circuit breaker to fail fast after repeated timeouts. Worth a follow-up if sustained substrate outages become common.
+- **Efficiency**: the new `emit_harness_finalize_system_error` call publishes one `orion:system:error` event per degraded turn; during a sustained outage this is one event per turn, same cadence as the existing voice-finalize failure path already uses for the same channel — not a new problem this patch introduces, but worth knowing if that channel's consumers (`consumer_services: ["*"]` per `channels.yaml`) are sensitive to volume.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-harness-governor/.env \
+  -f services/orion-harness-governor/docker-compose.yml \
+  up -d --build
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-hub/.env \
+  -f services/orion-hub/docker-compose.yml \
+  up -d --build
+```
+
+Separately, and not part of this patch: `orion-athena-fuseki` is currently unhealthy (94.88GiB/110GiB heap, GC-thrashing, 17 consecutive failed healthchecks) — this patch stops that condition from hard-failing chat turns, but the underlying Fuseki memory pressure is still live and unaddressed. Juniper asked specifically for the pass-through fix in this session; Fuseki itself was not restarted or otherwise touched.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `finalize_ran=False` combined with a UI-visible "successful" turn is a dual-meaning state — a future reader of `HarnessRunV1` in isolation could misread "finalize didn't run" as "this must be an error state" without knowing about `finalize_degraded_reason`.
+- Mitigation: field has an explicit doc-comment in the schema explaining the exact semantics and pointing at how Hub uses it; the new tests encode the expected combination directly.
+
+- Severity: low
+- Concern: reflection/appraisal are genuinely skipped for degraded turns — this is a real (if narrow and infra-triggered) change to Orion's cognition pipeline for that turn, not just error-handling polish.
+- Mitigation: scoped tightly to `TimeoutError` on the substrate RPC only (verified all three raise sites in `orion/core/bus/async_service.py` are genuine "no reply within timeout" cases, never a masked connection/subscribe error); every other finalize failure mode (voice-finalize content failures, cortex reflection timeouts, malformed payloads) still hard-fails exactly as before. Scope was confirmed with Juniper before implementation given this touches the finalize/cognition chain.
+
+## PR link
+
+<!-- filled in after push -->

--- a/docs/superpowers/pr-reports/2026-07-16-substrate-finalize-degrade-passthrough-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-substrate-finalize-degrade-passthrough-pr.md
@@ -23,15 +23,18 @@ Previously: any finalize failure (including simple infra hiccups) hard-failed th
 - `services/orion-harness-governor/app/bus_listener.py` — new exception class, new except branch in `handle_harness_run_request`.
 - `orion/hub/turn_orchestrator.py` — new gate in `execute_unified_turn`.
 - `services/orion-hub/static/js/app.js` — new websocket frame handler (same pattern as the existing `turn_deferred` type; not a registered bus channel, this is Hub↔browser websocket protocol only).
+- `services/orion-hub/scripts/api_routes.py` — the HTTP `mode=="orion"` chat route now also carries the degraded reason.
 
 ## Files changed
 
 - `orion/schemas/harness_finalize.py`: added `HarnessRunV1.finalize_degraded_reason: str | None = None`.
-- `services/orion-harness-governor/app/bus_listener.py`: added `SubstrateAppraisalUnavailableError`; `_substrate_client` now wraps `TimeoutError` from the substrate RPC into it; new `except SubstrateAppraisalUnavailableError` branch builds a degraded-success `HarnessRunV1` (`final_text=motor.draft_text`, `finalize_ran=False`, `finalize_degraded_reason` set) and emits a `system.error` event (`phase="substrate_appraisal_unavailable"`) for durable observability before replying.
+- `services/orion-harness-governor/app/bus_listener.py`: added `SubstrateAppraisalUnavailableError`; `_substrate_client` now wraps `TimeoutError` from the substrate RPC into it; new `except SubstrateAppraisalUnavailableError` branch builds a degraded-success `HarnessRunV1` (`final_text=motor.draft_text`, `finalize_ran=False`, `finalize_degraded_reason` set to a sanitized constant, `compliance_verdict` downgraded from "completed" to "partial"), emits a grammar lifecycle event (no fabricated appraisal/reflection molecules), and does **not** emit a `system.error` event (see review findings below).
 - `orion/hub/turn_orchestrator.py`: new branch ahead of the existing hard-fail gate — when `finalize_degraded_reason` and `final_text` are both present, publish chat history and return `[turn_degraded frame, *success_frames]` instead of an error frame.
 - `services/orion-hub/static/js/app.js`: new `turn_degraded` websocket message handler, yellow (non-red) system note.
-- `services/orion-harness-governor/tests/test_harness_governor_rpc.py`: new regression test — substrate client raising `TimeoutError` degrades to draft-passthrough, `finalize_ran=False`, `finalize_degraded_reason` set, system-error emitted.
-- `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py`: new regression test — a degraded `HarnessRunV1` produces `turn_degraded` + `final` frames (never `turn_error`), and chat history still gets published.
+- `services/orion-hub/scripts/api_routes.py`: the `mode=="orion"` HTTP chat route now merges the `turn_degraded` frame's reason onto the returned final-frame dict instead of silently dropping it via `frames[-1]`.
+- `services/orion-harness-governor/tests/test_harness_governor_rpc.py`: regression test — substrate client raising `TimeoutError` degrades to draft-passthrough with the sanitized reason, downgraded compliance_verdict, and no system-error emission.
+- `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py`: regression test — a degraded `HarnessRunV1` produces `turn_degraded` + `final` frames (never `turn_error`), and chat history still gets published.
+- `services/orion-hub/tests/test_handle_chat_request_orion_mode_degraded.py` (new): regression tests for the HTTP route's degraded-reason passthrough and normal-success no-op.
 
 ## Schema / bus / API changes
 
@@ -62,10 +65,14 @@ PYTHONPATH=. ./orion_dev/bin/python -m pytest tests/test_unified_turn_schemas.py
 193 passed, 3 pre-existing failures (test_grounding_capsule_consumers.py x2, test_harness_runner.py x1 —
 confirmed failing identically on unmodified main, unrelated to this patch)
 
+PYTHONPATH=services/orion-hub:. ./orion_dev/bin/python -m pytest services/orion-hub/tests/test_handle_chat_request_orion_mode_degraded.py -q
+2 passed (new)
+
 PYTHONPATH=services/orion-hub:. ./orion_dev/bin/python -m pytest services/orion-hub/tests/ -q
-814 passed, 33 pre-existing failures (memory-consolidation/substrate-effect/recall-strategy suites —
-confirmed the same failures reproduce on unmodified main in isolation; missing DB/schema
-fixtures in this sandbox, unrelated to turn_orchestrator/finalize code touched here)
+818 passed, 31 pre-existing failures (memory-consolidation/substrate-effect/recall-strategy/
+llm-route-selector/fcc-model-labels suites — confirmed the same failures reproduce on
+unmodified main in isolation; missing DB/schema fixtures in this sandbox, unrelated to
+turn_orchestrator/finalize code touched here)
 ```
 
 ## Evals run
@@ -78,12 +85,31 @@ Not run — no config/dependency/Docker/port changes in this patch. Live diagnos
 
 ## Review findings fixed
 
-Review was run as direct multi-angle manual review (line-by-line, removed-behavior, cross-file tracer, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) — the 8 code-review subagents dispatched for this all failed immediately on launch with "session limit · resets 8:20pm (UTC)" (an account-level rate limit, not a code issue), so the review was done directly instead of re-attempting the subagent dispatch.
+`/code-review high` ran for real this time (8 independent finder-angle subagents + direct verification against the actual code, after an earlier attempt in this same session hit an account-level rate limit and had to be done manually instead). 8 findings reported; 5 fixed in this pass per explicit instruction, 3 carried forward as known/lower-severity.
 
-No correctness bugs found. Two non-blocking observations carried forward rather than fixed (out of scope for what was asked):
+- Finding: internal RPC error text (bus channel name + correlation UUID) leaked verbatim to the end user via `finalize_degraded_reason` -> `turn_degraded` frame -> rendered directly in the chat UI, on every single degraded turn.
+  - Fix: `finalize_degraded_reason` now uses a sanitized module-level constant (`"substrate appraisal unavailable (RPC timeout)"`); the real exception detail stays in the operator-facing log line only.
+  - Evidence: `test_harness_run_substrate_timeout_degrades_to_draft_passthrough` now asserts the channel name and correlation id are absent from `finalize_degraded_reason`.
 
-- **Altitude**: every turn still pays the full `SUBSTRATE_FINALIZE_TIMEOUT_SEC` (default 5.0s) before degrading, for as long as the underlying outage persists — this patch stops the turn from hard-failing but doesn't add a circuit breaker to fail fast after repeated timeouts. Worth a follow-up if sustained substrate outages become common.
-- **Efficiency**: the new `emit_harness_finalize_system_error` call publishes one `orion:system:error` event per degraded turn; during a sustained outage this is one event per turn, same cadence as the existing voice-finalize failure path already uses for the same channel — not a new problem this patch introduces, but worth knowing if that channel's consumers (`consumer_services: ["*"]` per `channels.yaml`) are sensitive to volume.
+- Finding: the new `emit_harness_finalize_system_error` call shares one global tension-rate-limit bucket (cap=3/60s, verified via `orion/autonomy/tension_ratelimit.py`'s `(kind, drive_names)` signature and `orion/autonomy/signal_tension.py`'s fixed `sdm.match("failure_event","severity")` rule) with every other failure_event across ~20 producer services. A sustained substrate outage — the exact scenario this patch targets — would exhaust that budget within 2-3 turns, silently starving out unrelated failure visibility mesh-wide.
+  - Fix: removed the `emit_harness_finalize_system_error` call (and its now-unused import) from the degraded branch entirely; the warning log line is the durable operator-facing trace for this path instead.
+  - Evidence: `test_harness_run_substrate_timeout_degrades_to_draft_passthrough` now asserts `channel_system_error` is absent from published channels.
+
+- Finding: degraded turns never emitted `turn_outcome_molecule`/`post_turn_closure`/grammar `result_assembled`/`result_emitted` lifecycle events, unlike every other exception path in this function — verified `run_substrate_finalize_appraisal` (5a) sits with zero exception handling as the first statement of `run_harness_finalize_chain`, so `SubstrateAppraisalUnavailableError` propagates before any of those emissions.
+  - Fix: added a `_emit_finalize_lifecycle_grammar` call (`status="degraded_passthrough"`, `reflection_ran=False`) to close the honest, no-fabrication-required grammar trace. Deliberately did **not** attempt `turn_outcome_molecule`/`post_turn_closure`: `emit_turn_outcome_molecule`'s `substrate_appraisal`/`reflection` params are non-optional and its `surprise_resolved` computation reads both — fabricating placeholder ones to force the emission would be exactly the empty-shell-cognition anti-pattern this repo prohibits. Documented in code comments as a deliberate scope boundary, not an oversight.
+
+- Finding: `compliance_verdict=motor.compliance_verdict` passed through unmodified, unlike every other exception branch in this function (all force `compliance_verdict="failed"`) — so `compliance_verdict=="completed"` could now coexist with `finalize_ran=False`, a combination previously impossible here. Verified against `orion/harness/runner.py`'s own state machine that a real motor failure/refusal can *not* be smuggled through this way (both require empty `draft_text`, already hard-gated earlier), but "completed" alongside a skipped finalize chain would still mislead any wildcard consumer of `orion:harness:run:artifact` that treats `compliance_verdict=="completed"` as shorthand for "finalize genuinely ran."
+  - Fix: downgrade `compliance_verdict` from `"completed"` to `"partial"` in the degraded branch (leaves `"partial"` as `"partial"` — already honest), restoring the invariant that `compliance_verdict=="completed"` never coexists with `finalize_ran=False` anywhere in this function.
+
+- Finding: the HTTP (`mode=="orion"`) chat route (`services/orion-hub/scripts/api_routes.py`) returned only `frames[-1]`, silently discarding the `turn_degraded` notice for any caller not using the websocket (response text and chat history were unaffected — only the soft notice was lost).
+  - Fix: the route now merges the `turn_degraded` frame's reason onto the returned final-frame dict as `finalize_degraded_reason`, matching the existing convention of carrying `finalize_ran` on that same dict.
+  - Evidence: new `test_handle_chat_request_orion_mode_degraded.py` covers both the degraded and normal-success cases for this route.
+
+Carried forward (lower severity, not fixed this pass):
+
+- **Altitude**: only `TimeoutError` on the substrate RPC is treated as infra-unavailable; a late-but-garbled reply (decode failure or a `system.error` envelope, both raising plain `RuntimeError` in `orion/harness/substrate_client.py`) still hard-fails under the identical Fuseki-overload scenario. Likely intentional (a `RuntimeError` could also indicate a real substrate-side bug worth surfacing loudly), but worth confirming as deliberate rather than assumed.
+- **Conventions**: this PR report's "Evals run" section reports the missing eval harness but doesn't separately file a tracked follow-up issue, which CLAUDE.md section 11 technically also requires ("report ... and create a follow-up issue"). Noting it here in lieu of a separate issue.
+- **Simplification**: `_publish_unified_turn_chat_history(...)` is called identically from both the degraded branch and the normal-success branch in `turn_orchestrator.py` — a future kwarg change to that call has two sites to keep in sync. Left as-is since collapsing the two branches would touch more of the existing control flow than this patch's scope warranted.
 
 ## Restart required
 
@@ -107,7 +133,7 @@ Separately, and not part of this patch: `orion-athena-fuseki` is currently unhea
 
 - Severity: low
 - Concern: `finalize_ran=False` combined with a UI-visible "successful" turn is a dual-meaning state — a future reader of `HarnessRunV1` in isolation could misread "finalize didn't run" as "this must be an error state" without knowing about `finalize_degraded_reason`.
-- Mitigation: field has an explicit doc-comment in the schema explaining the exact semantics and pointing at how Hub uses it; the new tests encode the expected combination directly.
+- Mitigation: field has an explicit doc-comment in the schema explaining the exact semantics and pointing at how Hub uses it; the new tests encode the expected combination directly. Review additionally confirmed `compliance_verdict` needed the same protection (see findings above) — it's now downgraded to `"partial"` rather than left as `"completed"`, so the one other field a naive consumer might check is also honest.
 
 - Severity: low
 - Concern: reflection/appraisal are genuinely skipped for degraded turns — this is a real (if narrow and infra-triggered) change to Orion's cognition pipeline for that turn, not just error-handling polish.

--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -449,6 +449,23 @@ async def execute_unified_turn(
                 "error": "harness_rpc_timeout",
             }
         ]
+    if run.finalize_degraded_reason and run.final_text:
+        await _publish_unified_turn_chat_history(
+            bus=bus,
+            correlation_id=correlation_id,
+            session_id=session_id,
+            user_message=user_message,
+            response_text=str(run.final_text),
+            payload=payload,
+            run=run,
+            source_label=str(payload.get("chat_history_source") or "hub_orion"),
+        )
+        degraded_frame = {
+            "type": "turn_degraded",
+            "correlation_id": correlation_id,
+            "reason": run.finalize_degraded_reason,
+        }
+        return [degraded_frame, *_success_frames(run, correlation_id=correlation_id)]
     if not run.finalize_ran or not run.final_text:
         return [_harness_error_frame(run, correlation_id=correlation_id)]
     await _publish_unified_turn_chat_history(

--- a/orion/schemas/harness_finalize.py
+++ b/orion/schemas/harness_finalize.py
@@ -161,6 +161,11 @@ class HarnessRunV1(BaseModel):
     finalize_ran: bool
     finalize_changed: bool = False
     quick_lane_skipped_5b: bool = False
+    # Set only when finalize (5a substrate appraisal) could not be reached due to an
+    # infra failure (e.g. substrate RPC timeout) and draft_text was used as final_text
+    # instead. finalize_ran stays False (the real chain did not run) so this is the
+    # signal Hub uses to treat the turn as a degraded success rather than a hard error.
+    finalize_degraded_reason: str | None = None
     step_count: int
     exit_code: int | None = None
     compliance_verdict: Literal["completed", "partial", "failed", "refused"]

--- a/services/orion-harness-governor/app/bus_listener.py
+++ b/services/orion-harness-governor/app/bus_listener.py
@@ -13,6 +13,7 @@ from orion.harness.cortex_client import HarnessCortexClient
 from orion.harness.finalize import (
     DEFAULT_FINALIZE_INTERLOCUTOR,
     HarnessFinalizeFailedError,
+    emit_harness_finalize_system_error,
     emit_post_turn_closure,
     run_harness_finalize_chain,
 )
@@ -30,6 +31,10 @@ from orion.schemas.harness_finalize import HarnessRunRequestV1, HarnessRunV1
 from .settings import settings
 
 logger = logging.getLogger("orion-harness-governor.bus")
+
+
+class SubstrateAppraisalUnavailableError(Exception):
+    """Substrate finalize-appraisal RPC timed out (infra outage, not a content failure)."""
 
 
 def _source() -> ServiceRef:
@@ -258,7 +263,10 @@ async def handle_harness_run_request(
         return run
 
     async def _substrate_client(molecule: Any) -> Any:
-        return await substrate.finalize_appraisal(molecule, correlation_id=corr)
+        try:
+            return await substrate.finalize_appraisal(molecule, correlation_id=corr)
+        except TimeoutError as exc:
+            raise SubstrateAppraisalUnavailableError(str(exc)) from exc
 
     try:
         chain = await run_harness_finalize_chain(
@@ -299,6 +307,35 @@ async def handle_harness_run_request(
             exit_code=motor.exit_code,
             compliance_verdict="failed",
             grounding_status=str(exc),
+            grammar_event_ids=_grammar_event_ids(motor.grammar_receipts),
+            recall_debug=recall_debug,
+            memory_digest=memory_digest,
+        )
+        await _reply_and_artifact(bus, run, reply_to=reply_to, corr=corr, causality=causality)
+        return run
+    except SubstrateAppraisalUnavailableError as exc:
+        logger.warning(
+            "harness finalize substrate unavailable corr=%s err=%s — passing draft through as final",
+            corr,
+            exc,
+        )
+        await emit_harness_finalize_system_error(
+            correlation_id=corr,
+            error=str(exc),
+            phase="substrate_appraisal_unavailable",
+            channel=settings.channel_system_error,
+            bus=bus,
+        )
+        run = HarnessRunV1(
+            correlation_id=corr,
+            final_text=motor.draft_text,
+            draft_text=motor.draft_text,
+            finalize_ran=False,
+            finalize_degraded_reason=str(exc),
+            step_count=motor.step_count,
+            exit_code=motor.exit_code,
+            compliance_verdict=motor.compliance_verdict,
+            grounding_status=motor.grounding_status,
             grammar_event_ids=_grammar_event_ids(motor.grammar_receipts),
             recall_debug=recall_debug,
             memory_digest=memory_digest,

--- a/services/orion-harness-governor/app/bus_listener.py
+++ b/services/orion-harness-governor/app/bus_listener.py
@@ -13,7 +13,6 @@ from orion.harness.cortex_client import HarnessCortexClient
 from orion.harness.finalize import (
     DEFAULT_FINALIZE_INTERLOCUTOR,
     HarnessFinalizeFailedError,
-    emit_harness_finalize_system_error,
     emit_post_turn_closure,
     run_harness_finalize_chain,
 )
@@ -35,6 +34,13 @@ logger = logging.getLogger("orion-harness-governor.bus")
 
 class SubstrateAppraisalUnavailableError(Exception):
     """Substrate finalize-appraisal RPC timed out (infra outage, not a content failure)."""
+
+
+# User-facing text for a degraded turn -- deliberately generic. The real exception
+# (bus channel name + correlation id) is logged for operators only; this constant is
+# what flows into HarnessRunV1.finalize_degraded_reason and the turn_degraded frame
+# rendered directly in the chat UI.
+_SUBSTRATE_UNAVAILABLE_USER_REASON = "substrate appraisal unavailable (RPC timeout)"
 
 
 def _source() -> ServiceRef:
@@ -314,27 +320,54 @@ async def handle_harness_run_request(
         await _reply_and_artifact(bus, run, reply_to=reply_to, corr=corr, causality=causality)
         return run
     except SubstrateAppraisalUnavailableError as exc:
+        # Log the real exception (bus channel + correlation id) for operators only --
+        # finalize_degraded_reason below is a sanitized constant because it flows
+        # verbatim into the user-visible turn_degraded frame (orion/hub/turn_orchestrator.py)
+        # and must not leak internal RPC plumbing to the chat UI.
         logger.warning(
             "harness finalize substrate unavailable corr=%s err=%s — passing draft through as final",
             corr,
             exc,
         )
-        await emit_harness_finalize_system_error(
-            correlation_id=corr,
-            error=str(exc),
-            phase="substrate_appraisal_unavailable",
-            channel=settings.channel_system_error,
-            bus=bus,
-        )
+        # No emit_harness_finalize_system_error here: that channel's one tension-rate-limit
+        # bucket (cap=3/60s, shared across every failure_event in the mesh -- see
+        # orion/autonomy/tension_ratelimit.py's kind+drive_names signature) would be
+        # exhausted within 2-3 turns of a sustained substrate outage, silently starving
+        # out unrelated failure visibility mesh-wide for the rest of each window. The
+        # warning log above is the durable operator-facing trace for this path instead.
+        #
+        # No turn_outcome_molecule/post_turn_closure emission here either: those require
+        # a real substrate_appraisal + reflection (emit_turn_outcome_molecule's params are
+        # non-optional and its surprise_resolved computation reads both) -- fabricating
+        # placeholder ones to force the emission would be exactly the empty-shell-cognition
+        # anti-pattern this repo prohibits. The grammar lifecycle event below is the honest,
+        # no-fabrication-required trace for this path.
+        if motor.grammar_collector is not None:
+            await _emit_finalize_lifecycle_grammar(
+                bus,
+                collector=motor.grammar_collector,
+                step_count=motor.step_count,
+                grammar_receipt_count=len(motor.grammar_receipts),
+                reflection_ran=False,
+                quick_lane_skipped_5b=False,
+                final_text_present=True,
+                status="degraded_passthrough",
+            )
         run = HarnessRunV1(
             correlation_id=corr,
             final_text=motor.draft_text,
             draft_text=motor.draft_text,
             finalize_ran=False,
-            finalize_degraded_reason=str(exc),
+            finalize_degraded_reason=_SUBSTRATE_UNAVAILABLE_USER_REASON,
             step_count=motor.step_count,
             exit_code=motor.exit_code,
-            compliance_verdict=motor.compliance_verdict,
+            # Finalize/reflection genuinely did not complete for this turn even though the
+            # motor stage did -- downgrade a "completed" motor verdict to "partial" so
+            # compliance_verdict=="completed" never coexists with finalize_ran=False here,
+            # matching every other branch in this function forcing a non-full-success verdict.
+            compliance_verdict=(
+                "partial" if motor.compliance_verdict == "completed" else motor.compliance_verdict
+            ),
             grounding_status=motor.grounding_status,
             grammar_event_ids=_grammar_event_ids(motor.grammar_receipts),
             recall_debug=recall_debug,

--- a/services/orion-harness-governor/tests/test_harness_governor_rpc.py
+++ b/services/orion-harness-governor/tests/test_harness_governor_rpc.py
@@ -229,11 +229,20 @@ async def test_harness_run_substrate_timeout_degrades_to_draft_passthrough() -> 
     assert run.final_text == "internal draft"
     assert run.draft_text == "internal draft"
     assert run.finalize_degraded_reason is not None
-    assert "RPC timeout" in run.finalize_degraded_reason
-    assert run.compliance_verdict == motor.compliance_verdict
+    # Sanitized: the raw exception text (bus channel name + correlation id) must never
+    # flow into this field, since it's rendered verbatim in the user-facing chat UI.
+    assert run.finalize_degraded_reason == "substrate appraisal unavailable (RPC timeout)"
+    assert "orion:substrate:finalize_appraisal" not in run.finalize_degraded_reason
+    assert "c-substrate-timeout" not in run.finalize_degraded_reason
+    # motor fixture's compliance_verdict defaults to "completed"; it must be downgraded
+    # to "partial" here since finalize genuinely did not run for this turn.
+    assert motor.compliance_verdict == "completed"
+    assert run.compliance_verdict == "partial"
     channels = [call.args[0] for call in bus.publish.await_args_list]
     assert "orion:harness:run:result:c-substrate-timeout" in channels
-    assert bus_listener.settings.channel_system_error in channels
+    # No system-error event: that channel's tension-rate-limit budget is shared mesh-wide
+    # and would be exhausted within a few turns of a sustained substrate outage.
+    assert bus_listener.settings.channel_system_error not in channels
 
 
 @pytest.mark.asyncio

--- a/services/orion-harness-governor/tests/test_harness_governor_rpc.py
+++ b/services/orion-harness-governor/tests/test_harness_governor_rpc.py
@@ -189,6 +189,54 @@ async def test_harness_finalize_chain_failure_preserves_draft_and_partial_finali
 
 
 @pytest.mark.asyncio
+async def test_harness_run_substrate_timeout_degrades_to_draft_passthrough() -> None:
+    """Substrate finalize-appraisal RPC timeout (e.g. Fuseki outage) should not hard-fail
+    the turn: the harness draft becomes final_text, finalize_ran stays False (honest —
+    the real chain didn't run), and finalize_degraded_reason carries the cause so Hub
+    can surface a soft notice instead of a red turn_error."""
+    from app import bus_listener
+
+    thought = make_thought()
+    req = HarnessRunRequestV1(
+        correlation_id="c-substrate-timeout",
+        thought_event=thought,
+        user_message="hello",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    motor = _motor_result(thought)
+
+    class _TimingOutSubstrateClient:
+        async def finalize_appraisal(self, molecule, *, correlation_id=None):
+            raise TimeoutError(
+                "RPC timeout waiting on orion:substrate:finalize_appraisal:result:c-substrate-timeout"
+            )
+
+    bus = AsyncMock()
+    with patch.object(
+        bus_listener,
+        "HarnessRunner",
+        return_value=AsyncMock(run=AsyncMock(return_value=motor)),
+    ):
+        run = await bus_listener.handle_harness_run_request(
+            bus,
+            req,
+            reply_to="orion:harness:run:result:c-substrate-timeout",
+            substrate_client=_TimingOutSubstrateClient(),
+        )
+
+    assert run.finalize_ran is False
+    assert run.final_text == "internal draft"
+    assert run.draft_text == "internal draft"
+    assert run.finalize_degraded_reason is not None
+    assert "RPC timeout" in run.finalize_degraded_reason
+    assert run.compliance_verdict == motor.compliance_verdict
+    channels = [call.args[0] for call in bus.publish.await_args_list]
+    assert "orion:harness:run:result:c-substrate-timeout" in channels
+    assert bus_listener.settings.channel_system_error in channels
+
+
+@pytest.mark.asyncio
 async def test_harness_run_carries_recall_from_grounding_capsule() -> None:
     from app import bus_listener
 

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -2386,12 +2386,20 @@ async def handle_chat_request(
             harness_rpc_bus=rpc_bus or bus,
             harness_step_relay=harness_step_relay,
         )
-        return frames[-1] if frames else {
+        final_frame = frames[-1] if frames else {
             "type": "turn_error",
             "phase": "harness",
             "correlation_id": corr_id,
             "finalize_ran": False,
         }
+        degraded_frame = next((f for f in frames if f.get("type") == "turn_degraded"), None)
+        if degraded_frame is not None:
+            # HTTP callers only ever see the last frame; without this, the soft
+            # degraded-turn notice (surfaced to websocket clients as its own frame)
+            # would silently vanish for this call path even though the response
+            # itself is delivered correctly.
+            final_frame = {**final_frame, "finalize_degraded_reason": degraded_frame.get("reason")}
+        return final_frame
 
     # ─── Hub presence (best-effort, never blocks chat) ──────────────────
     # One timestamp per turn; mirrors a liveness snapshot for self-state.

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -9998,6 +9998,14 @@ document.addEventListener("DOMContentLoaded", () => {
             );
             return;
           }
+          if (d.type === 'turn_degraded') {
+            appendMessage(
+              'System',
+              `Response delivered without reflection (${d.reason || 'substrate unavailable'})`,
+              'text-yellow-400',
+            );
+            return;
+          }
           if (d.type === 'turn_error') {
             const phase = d.phase ? ` (${d.phase})` : '';
             const detail = d.error || d.grounding_status || 'turn failed';

--- a/services/orion-hub/tests/test_handle_chat_request_orion_mode_degraded.py
+++ b/services/orion-hub/tests/test_handle_chat_request_orion_mode_degraded.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("CHANNEL_VOICE_TRANSCRIPT", "orion:voice:transcript")
+os.environ.setdefault("CHANNEL_VOICE_LLM", "orion:voice:llm")
+os.environ.setdefault("CHANNEL_VOICE_TTS", "orion:voice:tts")
+os.environ.setdefault("CHANNEL_COLLAPSE_INTAKE", "orion:collapse:intake")
+os.environ.setdefault("CHANNEL_COLLAPSE_TRIAGE", "orion:collapse:triage")
+
+
+def test_handle_chat_request_orion_mode_surfaces_degraded_reason(monkeypatch) -> None:
+    """The mode=="orion" HTTP branch collapses execute_unified_turn's frame list down to
+    a single dict (frames[-1]) for its JSON response. Without the fix, a degraded turn's
+    turn_degraded frame (delivered fine over the websocket, which sends every frame) would
+    silently vanish for this HTTP call path -- the caller would see finalize_ran=False with
+    no explanation. This confirms the reason survives via finalize_degraded_reason instead.
+
+    NOTE: scripts.api_routes/scripts.main must be imported fresh inside this test body, not
+    at module top level -- conftest.py's autouse _hub_service_isolation fixture clears
+    scripts.*/app.* from sys.modules before every test, so a module-level import here would
+    bind to a stale module/settings singleton the monkeypatches below never touch.
+    """
+    import scripts.api_routes as api_routes
+    import scripts.main as hub_main
+    from orion.hub import turn_orchestrator
+
+    monkeypatch.setattr(api_routes.settings, "ORION_UNIFIED_TURN_ENABLED", True, raising=False)
+    monkeypatch.setattr(api_routes.settings, "ORION_HARNESS_GOVERNOR_ENABLED", True, raising=False)
+
+    class _Bus:
+        enabled = True
+
+    monkeypatch.setattr(hub_main, "bus", _Bus(), raising=False)
+    monkeypatch.setattr(hub_main, "harness_step_relay", None, raising=False)
+    monkeypatch.setattr(hub_main, "rpc_bus", None, raising=False)
+
+    async def _fake_execute_unified_turn(**_kwargs):
+        return [
+            {
+                "type": "turn_degraded",
+                "correlation_id": "corr-degraded",
+                "reason": "substrate appraisal unavailable (RPC timeout)",
+            },
+            {
+                "type": "final",
+                "correlation_id": "corr-degraded",
+                "llm_response": "internal draft delivered as final",
+                "finalize_ran": False,
+            },
+        ]
+
+    monkeypatch.setattr(turn_orchestrator, "execute_unified_turn", _fake_execute_unified_turn)
+
+    payload = {"mode": "orion", "messages": [{"role": "user", "content": "hello"}]}
+    out = asyncio.run(api_routes.handle_chat_request(object(), payload, "sid-orion-degraded", no_write=True))
+
+    assert out["type"] == "final"
+    assert out["llm_response"] == "internal draft delivered as final"
+    assert out["finalize_ran"] is False
+    assert out["finalize_degraded_reason"] == "substrate appraisal unavailable (RPC timeout)"
+
+
+def test_handle_chat_request_orion_mode_normal_success_has_no_degraded_reason(monkeypatch) -> None:
+    import scripts.api_routes as api_routes
+    import scripts.main as hub_main
+    from orion.hub import turn_orchestrator
+
+    monkeypatch.setattr(api_routes.settings, "ORION_UNIFIED_TURN_ENABLED", True, raising=False)
+    monkeypatch.setattr(api_routes.settings, "ORION_HARNESS_GOVERNOR_ENABLED", True, raising=False)
+
+    class _Bus:
+        enabled = True
+
+    monkeypatch.setattr(hub_main, "bus", _Bus(), raising=False)
+    monkeypatch.setattr(hub_main, "harness_step_relay", None, raising=False)
+    monkeypatch.setattr(hub_main, "rpc_bus", None, raising=False)
+
+    async def _fake_execute_unified_turn(**_kwargs):
+        return [
+            {
+                "type": "final",
+                "correlation_id": "corr-normal",
+                "llm_response": "a fully reflected answer",
+                "finalize_ran": True,
+            }
+        ]
+
+    monkeypatch.setattr(turn_orchestrator, "execute_unified_turn", _fake_execute_unified_turn)
+
+    payload = {"mode": "orion", "messages": [{"role": "user", "content": "hello"}]}
+    out = asyncio.run(api_routes.handle_chat_request(object(), payload, "sid-orion-normal", no_write=True))
+
+    assert out["type"] == "final"
+    assert out["finalize_ran"] is True
+    assert "finalize_degraded_reason" not in out

--- a/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
+++ b/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
@@ -208,6 +208,55 @@ async def test_turn_orchestrator_skips_chat_history_when_no_write() -> None:
 
 
 @pytest.mark.asyncio
+async def test_turn_orchestrator_finalize_degraded_passes_through_draft() -> None:
+    """Substrate RPC timeout (finalize_degraded_reason set) should deliver the harness
+    draft as a normal final response with a soft turn_degraded notice, not a turn_error,
+    and it should still be written to chat history."""
+    degraded_run = HarnessRunV1(
+        correlation_id=_CORR_ID,
+        final_text="internal draft",
+        draft_text="internal draft",
+        finalize_ran=False,
+        finalize_degraded_reason=(
+            "RPC timeout waiting on orion:substrate:finalize_appraisal:result:corr"
+        ),
+        step_count=2,
+        compliance_verdict="completed",
+        grounding_status="grounded",
+    )
+    bus = MagicMock()
+    bus.enabled = True
+    publish_history = AsyncMock()
+    publish_turn = AsyncMock()
+    publish_spark = AsyncMock()
+    patches = _hub_client_patches(thought=_thought(), harness_run=degraded_run)
+    with patches[0], patches[1], patches[2], patch(
+        "scripts.chat_history.publish_chat_history", publish_history
+    ), patch(
+        "scripts.chat_history.publish_chat_turn", publish_turn
+    ), patch(
+        "scripts.spark_candidate.publish_spark_introspect_candidate", publish_spark
+    ):
+        frames = await execute_unified_turn(
+            bus=bus,
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="hello",
+            payload={},
+            emit_observation_fn=lambda **_kwargs: None,
+        )
+
+    assert all(frame.get("type") != "turn_error" for frame in frames)
+    assert frames[0]["type"] == "turn_degraded"
+    assert "RPC timeout" in frames[0]["reason"]
+    assert frames[-1]["type"] == "final"
+    assert frames[-1]["llm_response"] == "internal draft"
+    assert frames[-1]["finalize_ran"] is False
+    publish_history.assert_awaited_once()
+    publish_turn.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_turn_orchestrator_never_publishes_draft_text() -> None:
     failed_run = HarnessRunV1(
         correlation_id=_CORR_ID,


### PR DESCRIPTION
## Summary

- Root-caused the live `Turn error (harness): RPC timeout waiting on orion:substrate:finalize_appraisal:result:*` error — `orion-athena-fuseki`'s JVM (`-Xmx96g`) was at 94.88GiB/110GiB, 185% CPU (GC thrashing), 17 consecutive Docker healthcheck failures. **Not related to the same-day kill-knowledge-forge merge (#1088)** — that PR touched zero bus channels/schemas, and Fuseki had already been degrading for 42 hours before it merged.
- Added a scoped fallback: a substrate finalize-appraisal RPC timeout (infra outage) now passes the harness draft through as the final response instead of hard-failing the whole turn.
- New `SubstrateAppraisalUnavailableError` isolates this one failure mode; every other finalize failure (voice-finalize content errors, reflection timeouts, malformed payloads) still hard-fails exactly as before.
- New optional `HarnessRunV1.finalize_degraded_reason` field carries the cause through the RPC reply.
- Hub now treats a degraded run as success: publishes chat history (previously silently dropped on any finalize failure), shows a soft `turn_degraded` notice instead of a red `turn_error`.

## Test plan

- [x] `services/orion-harness-governor/tests/test_harness_governor_rpc.py` — 10 passed, incl. new `test_harness_run_substrate_timeout_degrades_to_draft_passthrough`
- [x] `services/orion-harness-governor/tests/` (full) — 14 passed
- [x] `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py` — 19 passed, incl. new `test_turn_orchestrator_finalize_degraded_passes_through_draft`
- [x] `tests/test_unified_turn_schemas.py`, `tests/test_unified_turn_bus_catalog.py`, `orion/harness/tests/` — 193 passed, 3 pre-existing failures confirmed unrelated (also fail on unmodified main)
- [x] `services/orion-hub/tests/` (full) — 814 passed, 33 pre-existing failures confirmed unrelated (also fail on unmodified main in isolation — missing DB/schema fixtures in this sandbox)
- [x] Manual multi-angle code review (line-by-line, removed-behavior, cross-file tracer, reuse/simplification/efficiency, altitude, CLAUDE.md conventions) — done directly after the 8 dispatched review subagents all failed on an account-level session rate limit; no correctness bugs found, 2 non-blocking design notes recorded in the PR report

Full PR report: `docs/superpowers/pr-reports/2026-07-16-substrate-finalize-degrade-passthrough-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)