### PR TITLE
Causal Geometry v1 follow-up: scheduled producer + shared postgres-disk store path

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-16-causal-geometry-producer-wiring-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-causal-geometry-producer-wiring-pr.md
@@ -1,0 +1,120 @@
+# Causal Geometry v1 follow-up: scheduled producer + shared postgres-disk store path
+
+## Summary
+
+- Extracted Phase A's core measurement logic (`scripts/causal_geometry_report.py`) into an importable module, `orion/substrate/causal_geometry_engine.py`, so it can be called from more than one place without duplication.
+- Added `orion/substrate/causal_geometry_producer.py`: `run_causal_geometry_production_cycle()`, the missing link between Phase A measurement and Phase B's HITL proposal queue -- measures a snapshot, proposes `field_topology_weight_patch` candidates, and enqueues only non-duplicate ones.
+- Wired a new scheduled loop into `services/orion-field-digester/app/worker.py` (`_causal_geometry_producer_loop`, same shape as the pre-existing prune/health loops), off by default via `FIELD_PLASTICITY_PRODUCER_ENABLED`, default cadence 24h.
+- Fixed `FIELD_PLASTICITY_SQL_DB_PATH` to a real default (previously empty/in-memory-only) on a shared, durable disk alongside Postgres (`/mnt/postgres/field_topology`, not `/mnt/telemetry`), per operator direction, so the HITL store genuinely persists cross-process between `orion-hub` and `orion-field-digester`.
+- Code review (8 parallel angles) found and fixed 5 real issues, most notably an intra-cycle proposal-dedup bug (reproduced live) and a `STORAGE_ROOT`-templating bug that would have silently broken cross-process store sharing the moment an operator relocated Postgres's disk.
+
+## Outcome moved
+
+Prior to this branch (PR #1087, merged), the Phase B plasticity HITL queue was real and correctly gated but permanently empty in production -- nothing ever called `propose_field_topology_patches()`/`store.propose()` on a schedule, and the learned-weights store had no real persisted-path default. This PR closes both remaining gaps from that PR's own documented follow-up list: a scheduled producer now exists, and the store's persistence path is real and correctly shared between both containers.
+
+## Current architecture
+
+Before this PR: `scripts/causal_geometry_report.py` was a standalone CLI script, runnable manually but never scheduled. `orion/substrate/field_topology_plasticity.py`'s `propose_field_topology_patches()` had zero production callers. `FIELD_PLASTICITY_SQL_DB_PATH` defaulted to empty (in-memory only, scoped to whichever single process constructed the store).
+
+## Architecture touched
+
+- `orion/substrate/causal_geometry_engine.py` (new) -- Phase A's measurement engine, extracted for reuse.
+- `orion/substrate/causal_geometry_producer.py` (new) -- the scheduled producer function.
+- `scripts/causal_geometry_report.py` -- trimmed to CLI-only, re-exporting only the engine names its own code or `tests/test_causal_geometry_report.py` actually use.
+- `services/orion-field-digester/app/worker.py`, `app/settings.py`, `app/digestion/diffusion.py` (`get_learned_store()`, now public and thread-safe).
+- Both services' `.env_example` and `docker-compose.yml` (new producer env keys, corrected `FIELD_PLASTICITY_SQL_DB_PATH` default, `/mnt/postgres/field_topology` volume mount replacing the earlier `/mnt/telemetry` mount on `orion-hub`).
+- `services/orion-field-digester/requirements.txt` (added `numpy==1.26.4`).
+
+## Files changed
+
+- `orion/substrate/causal_geometry_engine.py`: new, Phase A core logic extracted from the CLI script.
+- `orion/substrate/causal_geometry_producer.py`: new, the scheduled measure-propose-enqueue cycle.
+- `orion/substrate/tests/test_causal_geometry_producer.py`: new, 7 tests (success, cross-cycle dedup, intra-cycle dedup regression, measurement failure, proposal-stage failure, insufficient-data, AST guard against `PatchApplier`).
+- `scripts/causal_geometry_report.py`: trimmed to CLI-only + a minimal, accurate re-export list.
+- `services/orion-field-digester/app/worker.py`: new `_causal_geometry_producer_tick`/`_causal_geometry_producer_loop`.
+- `services/orion-field-digester/app/settings.py`: 3 new fields (`field_plasticity_producer_enabled`/`_interval_hours`/`_window_hours`).
+- `services/orion-field-digester/app/digestion/diffusion.py`: `_get_learned_store` renamed to public `get_learned_store`, now thread-safe (double-checked locking).
+- `services/orion-field-digester/tests/test_worker_causal_geometry_producer.py`: new, 3 tests (disabled no-op, enabled call-with-expected-args, failure-never-raises).
+- `services/orion-field-digester/requirements.txt`: added `numpy==1.26.4`.
+- `services/orion-field-digester/.env_example`, `docker-compose.yml`: new producer keys; `FIELD_PLASTICITY_SQL_DB_PATH` corrected to a fixed container-internal path; new `/mnt/postgres/field_topology` volume mount.
+- `services/orion-hub/.env_example`, `docker-compose.yml`: `FIELD_PLASTICITY_SQL_DB_PATH` corrected the same way; `/mnt/telemetry` mount replaced with `/mnt/postgres/field_topology`.
+
+## Schema / bus / API changes
+
+None. No schema, channel, or API surface changed in this PR.
+
+## Env/config changes
+
+- Added keys (`orion-field-digester`): `FIELD_PLASTICITY_PRODUCER_ENABLED` (`false`), `FIELD_PLASTICITY_PRODUCER_INTERVAL_HOURS` (`24`), `FIELD_PLASTICITY_PRODUCER_WINDOW_HOURS` (`168`).
+- Changed default: `FIELD_PLASTICITY_SQL_DB_PATH` (both services) -- was empty, now `/mnt/postgres/field_topology/learned_weights.sqlite3` (a fixed container-internal path; the real host-side location is controlled by `STORAGE_ROOT` via the new volume mount, not by this variable).
+- `.env_example` updated: both services.
+- Local `.env` synced: `python scripts/sync_local_env_from_example.py --all-keys` run in the worktree; both services' local `.env` files carry the new keys and corrected default. Also copied to the live deployment's `.env` files (see Restart required).
+- Skipped keys requiring operator action: none -- everything defaults safely off/inert (`FIELD_PLASTICITY_PRODUCER_ENABLED=false` means the producer never runs unless explicitly enabled).
+
+## Tests run
+
+```text
+orion/substrate/tests + orion/schemas/tests + tests/test_causal_geometry_report.py: 333 passed
+services/orion-field-digester/tests (run from its own dir): 63 passed
+services/orion-hub/tests/test_causal_geometry_{api,page}.py: 22 passed
+```
+
+## Evals run
+
+No eval harness exists for this service tree (same gap noted in PR #1087). `docker compose config` was used as a live-config verification step (see Docker/build/smoke checks) -- not a substitute for a real eval, but the closest available check for the config-correctness bugs this review round found.
+
+## Docker/build/smoke checks
+
+```text
+scripts/safe_docker_build.sh orion-field-digester config --quiet   # exit 0
+scripts/safe_docker_build.sh orion-hub config --quiet              # exit 0
+# Empirically verified FIELD_PLASTICITY_SQL_DB_PATH resolves to the fixed
+# container path (/mnt/postgres/field_topology/learned_weights.sqlite3) in
+# both services' rendered config, including under an overridden STORAGE_ROOT
+# (confirms the review-fix for the STORAGE_ROOT bug).
+scripts/safe_docker_build.sh orion-field-digester build   # built cleanly (pre-review-fix commit; not rebuilt after review fixes since none touch runtime image contents beyond source already COPYed)
+scripts/safe_docker_build.sh orion-hub build              # built cleanly (same)
+```
+
+## Review findings fixed
+
+- Finding: intra-cycle dedup only checked the store's pre-loop state, so two capability channels aliasing one physical edge could both enqueue a proposal in the same cycle.
+  - Fix: add each newly-enqueued `target_ref` to the dedup set as it's proposed.
+  - Evidence: new regression test `test_intra_cycle_duplicate_candidates_for_the_same_edge_enqueue_only_one_proposal`, passes.
+- Finding: `FIELD_PLASTICITY_SQL_DB_PATH`'s default templated the container-visible env var with `${STORAGE_ROOT}`, but the container-side mount destination is fixed -- an operator override would silently break cross-process store sharing.
+  - Fix: corrected to a literal container path in both `.env_example` files.
+  - Evidence: `docker compose config` re-verified under an overridden `STORAGE_ROOT` -- env var now stays correctly pinned to `/mnt/postgres/field_topology/learned_weights.sqlite3` regardless.
+- Finding: `get_learned_store()`'s singleton construction had an unguarded race once a second asyncio loop could call it concurrently.
+  - Fix: `threading.Lock` with double-checked locking.
+  - Evidence: full `orion-field-digester` test suite (63) still passes.
+- Finding: `scripts/causal_geometry_report.py` re-exported 12 names with zero real callers anywhere in the repo.
+  - Fix: trimmed to the 16 names actually used.
+  - Evidence: `tests/test_causal_geometry_report.py` (10 tests) still passes unchanged.
+- Finding: stale comment (old default, pre-rename function name) and a docstring PR-misattribution.
+  - Fix: both corrected.
+  - Evidence: read-through confirmation.
+
+Not fixed (documented as known, low-severity gaps):
+- Proposal-stage exception handler undercounts already-persisted work in its failure summary -- currently unreachable (`store.propose()` can't raise today), so left as-is rather than adding a guard for an impossible case.
+- No health/staleness monitoring for the new 24h producer loop, unlike the existing poll/prune loops -- proportionate-scope follow-up, not every existing loop has this either.
+
+## Restart required
+
+```bash
+# New volume mounts require recreate (up -d), not a plain restart.
+docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-field-digester/.env -f services/orion-field-digester/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: Low
+  - Concern: the producer's real proposal surface is currently only 2 designed `capability_capability` edges in `config/field/orion_field_topology.v1.yaml` -- even with everything correctly wired, a cycle may legitimately produce zero proposals indefinitely if those two channels don't diverge past the 0.02 meaningful-delta threshold in a given week. "Technically wired" isn't the same as "practically active."
+  - Mitigation: none needed -- this is expected, honest behavior (`ok=True, proposals_created=0`), not a bug. Worth knowing when judging whether the feature "works" from the hub UI alone.
+- Severity: Low
+  - Concern: no per-loop health/staleness alerting for the new producer (unlike poll/prune's coverage in `health_monitor.py`).
+  - Mitigation: deferred as a proportionate-scope follow-up.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/causal-geometry-producer-wiring

--- a/orion/substrate/causal_geometry_engine.py
+++ b/orion/substrate/causal_geometry_engine.py
@@ -1,0 +1,593 @@
+"""Causal Geometry v1, Phase A core engine: observed-geometry measurement.
+
+Extracted from `scripts/causal_geometry_report.py` (which now imports from here
+and keeps only its CLI wrapper) so the new Phase B producer
+(`orion/substrate/causal_geometry_producer.py`, called periodically from
+`services/orion-field-digester/app/worker.py`) can call the exact same
+measurement logic the standalone report script uses, instead of duplicating it.
+
+See docs/superpowers/specs/2026-07-16-causal-geometry-v1-design.md for the full
+three-phase design, and `scripts/causal_geometry_report.py`'s own (still
+present) module docstring for the detailed rationale behind the fixed
+constants, the four source tables, resampling, lagged cross-correlation, the
+Bonferroni-corrected surrogate significance test, and the designed-vs-observed
+divergence matching rule (including the `#<capability_channel>` target_id
+disambiguation suffix -- see `orion/substrate/field_topology_plasticity.py`'s
+`_base_target_id()` for the corresponding join-side fix).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import yaml
+
+from orion.schemas.causal_geometry import (
+    CausalGeometryDivergenceEntryV1,
+    CausalGeometryEdgeV1,
+    CausalGeometrySnapshotV1,
+)
+
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+
+# --- documented, fixed knobs (see scripts/causal_geometry_report.py's module
+# docstring for the full rationale behind each of these) -------------------
+
+BUCKET_SECONDS = 300
+LAG_GRID_SECONDS: Tuple[int, ...] = (0, 300, 600, 900, 1800)
+
+DEFAULT_WINDOW_HOURS = 168.0
+DEFAULT_MIN_SAMPLES = 30
+DEFAULT_N_SURROGATES = 200
+DEFAULT_ALPHA = 0.05
+DEFAULT_BIOMETRICS_NODE = "athena"
+DEFAULT_SEED = 1337
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@127.0.0.1:55432/conjourney"
+
+DEFAULT_FIELD_TOPOLOGY_PATH = str(
+    Path(_REPO_ROOT) / "config" / "field" / "orion_field_topology.v1.yaml"
+)
+
+ChannelPoints = List[Tuple[datetime, float]]
+ChannelSeries = Dict[str, ChannelPoints]
+
+
+# --- data fetch (real DB) ---------------------------------------------------
+
+
+def fetch_channels(
+    postgres_uri: str,
+    window_start: datetime,
+    *,
+    biometrics_node: str = DEFAULT_BIOMETRICS_NODE,
+) -> Tuple[ChannelSeries, Dict[str, int]]:
+    """Pull and flatten all four organ signal tables into named channels.
+
+    Uses psycopg2 (already a dependency of several services; no new dependency
+    added when called from a service that already has it, e.g. orion-hub,
+    orion-field-digester). Each row's jsonb column is flattened into one
+    channel per key (`drive:<key>`, `biometrics:<key>`, `self_state:<key>`);
+    `attention_salience_trace.salience` has no sub-keys and becomes the single
+    scalar channel `attention:salience`.
+
+    Returns `(channels, table_row_counts)`. `table_row_counts` maps each source
+    table name to the raw row count pulled in the window -- a table with 0 rows
+    in the window contributes zero channels and would otherwise be silently
+    invisible from the rest of the report.
+    """
+    import psycopg2
+
+    channels: ChannelSeries = {}
+    table_row_counts: Dict[str, int] = {}
+
+    def _append(channel_id: str, ts: datetime, value: Any) -> None:
+        if value is None or isinstance(value, bool):
+            return
+        try:
+            fvalue = float(value)
+        except (TypeError, ValueError):
+            return
+        channels.setdefault(channel_id, []).append((ts, fvalue))
+
+    conn = psycopg2.connect(postgres_uri)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COALESCE(observed_at, created_at) AS ts, drive_pressures
+                FROM drive_audits
+                WHERE COALESCE(observed_at, created_at) >= %s
+                ORDER BY ts
+                """,
+                (window_start,),
+            )
+            rows = cur.fetchall()
+            table_row_counts["drive_audits"] = len(rows)
+            for ts, drive_pressures in rows:
+                for key, value in (drive_pressures or {}).items():
+                    _append(f"drive:{key}", ts, value)
+
+            cur.execute(
+                """
+                SELECT created_at AS ts, salience
+                FROM attention_salience_trace
+                WHERE created_at >= %s
+                ORDER BY ts
+                """,
+                (window_start,),
+            )
+            rows = cur.fetchall()
+            table_row_counts["attention_salience_trace"] = len(rows)
+            for ts, salience in rows:
+                _append("attention:salience", ts, salience)
+
+            cur.execute(
+                """
+                SELECT timestamp::timestamptz AS ts, pressures
+                FROM orion_biometrics_summary
+                WHERE node = %s AND timestamp::timestamptz >= %s
+                ORDER BY ts
+                """,
+                (biometrics_node, window_start),
+            )
+            rows = cur.fetchall()
+            table_row_counts["orion_biometrics_summary"] = len(rows)
+            for ts, pressures in rows:
+                for key, value in (pressures or {}).items():
+                    _append(f"biometrics:{key}", ts, value)
+
+            cur.execute(
+                """
+                SELECT generated_at AS ts, prediction_json->'predicted_dimension_scores' AS scores
+                FROM self_state_predictions
+                WHERE generated_at >= %s
+                ORDER BY ts
+                """,
+                (window_start,),
+            )
+            rows = cur.fetchall()
+            table_row_counts["self_state_predictions"] = len(rows)
+            for ts, scores in rows:
+                for key, value in (scores or {}).items():
+                    _append(f"self_state:{key}", ts, value)
+    finally:
+        conn.close()
+
+    for points in channels.values():
+        points.sort(key=lambda p: p[0])
+    return channels, table_row_counts
+
+
+# --- resampling + lagged correlation ----------------------------------------
+
+
+def bucketize(points: ChannelPoints, bucket_seconds: int = BUCKET_SECONDS) -> Dict[int, float]:
+    """Mean-aggregate raw (timestamp, value) points onto a bucket-index grid.
+
+    Bucket index is `int(ts.timestamp() // bucket_seconds)`. Empty buckets are
+    simply absent from the returned dict -- this never interpolates or
+    forward-fills, since a fabricated value in a gap could manufacture a
+    spurious correlation exactly opposite of this feature's purpose.
+    """
+    grouped: Dict[int, List[float]] = {}
+    for ts, value in points:
+        idx = int(ts.timestamp() // bucket_seconds)
+        grouped.setdefault(idx, []).append(value)
+    return {idx: float(np.mean(vals)) for idx, vals in grouped.items()}
+
+
+def _aligned_arrays(
+    source_buckets: Dict[int, float], target_buckets: Dict[int, float], lag_buckets: int
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Pair up source[idx] with target[idx + lag_buckets] for every idx present
+    in both, i.e. target observed `lag_buckets` buckets after source."""
+    xs: List[float] = []
+    ys: List[float] = []
+    for idx in sorted(source_buckets.keys()):
+        j = idx + lag_buckets
+        if j in target_buckets:
+            xs.append(source_buckets[idx])
+            ys.append(target_buckets[j])
+    return np.array(xs, dtype=float), np.array(ys, dtype=float)
+
+
+def _pearson(x: np.ndarray, y: np.ndarray) -> Optional[float]:
+    if len(x) < 2 or len(y) < 2:
+        return None
+    if np.std(x) == 0.0 or np.std(y) == 0.0:
+        return 0.0
+    r = float(np.corrcoef(x, y)[0, 1])
+    if np.isnan(r):
+        return 0.0
+    return r
+
+
+class DirectionResult:
+    __slots__ = ("source_id", "target_id", "lag_sec", "r", "n", "xs", "ys")
+
+    def __init__(self, source_id: str, target_id: str, lag_sec: int, r: float, n: int, xs: np.ndarray, ys: np.ndarray):
+        self.source_id = source_id
+        self.target_id = target_id
+        self.lag_sec = lag_sec
+        self.r = r
+        self.n = n
+        self.xs = xs
+        self.ys = ys
+
+
+def _best_direction(
+    source_id: str,
+    target_id: str,
+    source_buckets: Dict[int, float],
+    target_buckets: Dict[int, float],
+    lag_grid_seconds: Tuple[int, ...],
+    bucket_seconds: int,
+) -> Optional[DirectionResult]:
+    best: Optional[DirectionResult] = None
+    for lag_sec in lag_grid_seconds:
+        lag_buckets = lag_sec // bucket_seconds
+        xs, ys = _aligned_arrays(source_buckets, target_buckets, lag_buckets)
+        if len(xs) < 2:
+            continue
+        r = _pearson(xs, ys)
+        if r is None:
+            continue
+        if best is None or abs(r) > abs(best.r):
+            best = DirectionResult(source_id, target_id, lag_sec, r, len(xs), xs, ys)
+    return best
+
+
+def circular_shift_pvalue(
+    xs: np.ndarray,
+    ys: np.ndarray,
+    observed_r: float,
+    *,
+    n_surrogates: int = DEFAULT_N_SURROGATES,
+    rng: Optional[np.random.Generator] = None,
+) -> float:
+    """Circular time-shift surrogate p-value for a Pearson correlation.
+
+    Shifts `ys` by a uniformly-sampled non-zero circular offset (numpy.roll)
+    `n_surrogates` times, recomputes Pearson r against the fixed `xs` each
+    time, and returns the add-one-smoothed fraction of surrogate |r| >=
+    observed |r|. Add-one smoothing (standard permutation-test convention)
+    means this never reports p=0.0 off a finite surrogate sample.
+    """
+    n = len(ys)
+    if n < 2:
+        return 1.0
+    if rng is None:
+        rng = np.random.default_rng()
+    observed_abs = abs(observed_r)
+    count_ge = 0
+    for _ in range(n_surrogates):
+        shift = int(rng.integers(1, n)) if n > 1 else 0
+        shifted = np.roll(ys, shift)
+        r = _pearson(xs, shifted)
+        if r is not None and abs(r) >= observed_abs:
+            count_ge += 1
+    return (count_ge + 1) / (n_surrogates + 1)
+
+
+class PairResult:
+    __slots__ = ("channel_a", "channel_b", "n_lag0", "winner", "significant", "p_value")
+
+    def __init__(self, channel_a: str, channel_b: str, n_lag0: int):
+        self.channel_a = channel_a
+        self.channel_b = channel_b
+        self.n_lag0 = n_lag0
+        self.winner: Optional[DirectionResult] = None
+        self.significant = False
+        self.p_value: Optional[float] = None
+
+
+def compute_pairwise_results(
+    channel_buckets: Dict[str, Dict[int, float]],
+    *,
+    min_samples: int = DEFAULT_MIN_SAMPLES,
+    n_surrogates: int = DEFAULT_N_SURROGATES,
+    alpha: float = DEFAULT_ALPHA,
+    lag_grid_seconds: Tuple[int, ...] = LAG_GRID_SECONDS,
+    bucket_seconds: int = BUCKET_SECONDS,
+    seed: int = DEFAULT_SEED,
+) -> List[PairResult]:
+    """Compute lagged cross-correlation + surrogate significance for every
+    unordered pair of channels.
+
+    Eligibility gate: zero-lag co-sampled overlap size (the maximum possible n
+    for a pair, since positive lags only shrink alignment further). Pairs
+    below `min_samples` get a `PairResult` with `winner=None` and are never
+    given a fabricated edge -- callers must check `n_lag0 < min_samples`
+    before treating the absence of `winner` as "not correlated" instead of
+    "not enough data to know".
+    """
+    channel_ids = sorted(channel_buckets.keys())
+    results: List[PairResult] = []
+    rng = np.random.default_rng(seed)
+
+    for i, a in enumerate(channel_ids):
+        for b in channel_ids[i + 1 :]:
+            bucket_a = channel_buckets[a]
+            bucket_b = channel_buckets[b]
+            n_lag0 = len(set(bucket_a.keys()) & set(bucket_b.keys()))
+            result = PairResult(a, b, n_lag0)
+            if n_lag0 < min_samples:
+                results.append(result)
+                continue
+
+            fwd = _best_direction(a, b, bucket_a, bucket_b, lag_grid_seconds, bucket_seconds)
+            bwd = _best_direction(b, a, bucket_b, bucket_a, lag_grid_seconds, bucket_seconds)
+            candidates = [c for c in (fwd, bwd) if c is not None]
+            if not candidates:
+                results.append(result)
+                continue
+            winner = max(candidates, key=lambda c: abs(c.r))
+            p_raw = circular_shift_pvalue(
+                winner.xs, winner.ys, winner.r, n_surrogates=n_surrogates, rng=rng
+            )
+            # Bonferroni correction for the implicit multiple comparisons across
+            # both directions x the full lag grid (see scripts/causal_geometry_report.py's
+            # module docstring's "Significance: circular time-shift surrogates" section).
+            n_comparisons = 2 * len(lag_grid_seconds)
+            p_value = min(1.0, p_raw * n_comparisons)
+            result.winner = winner
+            result.p_value = p_value
+            result.significant = p_value < alpha
+            results.append(result)
+
+    return results
+
+
+def _bucket_idx_to_datetime(idx: int, bucket_seconds: int = BUCKET_SECONDS) -> datetime:
+    return datetime.fromtimestamp(idx * bucket_seconds, tz=timezone.utc)
+
+
+def build_edges(
+    pair_results: List[PairResult],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    bucket_seconds: int = BUCKET_SECONDS,
+) -> List[CausalGeometryEdgeV1]:
+    edges: List[CausalGeometryEdgeV1] = []
+    for result in pair_results:
+        if not result.significant or result.winner is None or result.p_value is None:
+            continue
+        w = result.winner
+        edges.append(
+            CausalGeometryEdgeV1(
+                source_id=w.source_id,
+                target_id=w.target_id,
+                lag_sec=w.lag_sec,
+                strength=max(-1.0, min(1.0, w.r)),
+                significance=result.p_value,
+                n_samples=w.n,
+                window_start=window_start,
+                window_end=window_end,
+            )
+        )
+    return edges
+
+
+# --- designed topology loading + divergence ---------------------------------
+
+
+def load_field_topology(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def build_capability_channel_index(topology: Dict[str, Any]) -> Dict[str, List[Dict[str, Any]]]:
+    """Reverse index: capability channel name (e.g. "reasoning_pressure") ->
+    list of YAML edges (source_id, target_id, weight, edge_type) whose
+    channel_map maps some local channel onto that capability channel name."""
+    index: Dict[str, List[Dict[str, Any]]] = {}
+    for edge in topology.get("edges", []) or []:
+        channel_map = edge.get("channel_map") or {}
+        for _local_channel, cap_channel in channel_map.items():
+            index.setdefault(cap_channel, []).append(
+                {
+                    "source_id": edge.get("source_id"),
+                    "target_id": edge.get("target_id"),
+                    "weight": edge.get("weight"),
+                    "edge_type": edge.get("edge_type"),
+                }
+            )
+    return index
+
+
+def _best_strength_for_channel(channel_id: str, edges: List[CausalGeometryEdgeV1]) -> Optional[float]:
+    best: Optional[float] = None
+    for edge in edges:
+        if edge.source_id == channel_id or edge.target_id == channel_id:
+            if best is None or abs(edge.strength) > abs(best):
+                best = edge.strength
+    return best
+
+
+def build_divergence(
+    edges: List[CausalGeometryEdgeV1],
+    pair_results: List[PairResult],
+    topology: Dict[str, Any],
+    *,
+    min_samples: int = DEFAULT_MIN_SAMPLES,
+) -> List[CausalGeometryDivergenceEntryV1]:
+    """Compare observed edges against `config/field/orion_field_topology.v1.yaml`.
+
+    See `scripts/causal_geometry_report.py`'s module docstring's "Designed-vs-
+    observed divergence" section for the full matching rule. Summary: an
+    observed channel's suffix (after the first ':') is checked against every
+    capability channel name used in the YAML's edge channel_maps; an exact
+    string match is treated as a plausible alias. Divergence entries for YAML
+    edges get `#<capability_channel>` appended to target_id to disambiguate the
+    case where two different capability channels point at the same
+    (source_id, target_id) YAML edge -- callers matching against the physical
+    lattice edge (e.g. `orion/substrate/field_topology_plasticity.py`) must
+    strip that suffix before joining.
+    """
+    cap_index = build_capability_channel_index(topology)
+    entries: List[CausalGeometryDivergenceEntryV1] = []
+    consumed_cap_edges: set = set()
+
+    observed_channel_ids = {edge.source_id for edge in edges} | {edge.target_id for edge in edges}
+    for channel_id in sorted(observed_channel_ids):
+        suffix = channel_id.split(":", 1)[1] if ":" in channel_id else channel_id
+        if suffix not in cap_index:
+            continue
+        observed_strength = _best_strength_for_channel(channel_id, edges)
+        for designed_edge in cap_index[suffix]:
+            key = (designed_edge["source_id"], designed_edge["target_id"], suffix)
+            if key in consumed_cap_edges:
+                continue
+            consumed_cap_edges.add(key)
+            designed_weight = designed_edge["weight"]
+            entries.append(
+                CausalGeometryDivergenceEntryV1(
+                    source_id=designed_edge["source_id"],
+                    target_id=f"{designed_edge['target_id']}#{suffix}",
+                    observed_strength=observed_strength,
+                    designed_weight=designed_weight,
+                    delta=(observed_strength - designed_weight) if observed_strength is not None else None,
+                    status="both" if observed_strength is not None else "designed_only",
+                )
+            )
+
+    # Every remaining YAML edge/channel entry with no observed alias at all.
+    for cap_channel, designed_edge_list in cap_index.items():
+        for designed_edge in designed_edge_list:
+            key = (designed_edge["source_id"], designed_edge["target_id"], cap_channel)
+            if key in consumed_cap_edges:
+                continue
+            consumed_cap_edges.add(key)
+            entries.append(
+                CausalGeometryDivergenceEntryV1(
+                    source_id=designed_edge["source_id"],
+                    target_id=f"{designed_edge['target_id']}#{cap_channel}",
+                    observed_strength=None,
+                    designed_weight=designed_edge["weight"],
+                    delta=None,
+                    status="designed_only",
+                )
+            )
+
+    # Significant observed edges whose endpoints don't alias to any capability
+    # channel at all.
+    aliased_channel_ids = {
+        cid
+        for cid in observed_channel_ids
+        if (cid.split(":", 1)[1] if ":" in cid else cid) in cap_index
+    }
+    for edge in edges:
+        if edge.source_id in aliased_channel_ids or edge.target_id in aliased_channel_ids:
+            continue
+        entries.append(
+            CausalGeometryDivergenceEntryV1(
+                source_id=edge.source_id,
+                target_id=edge.target_id,
+                observed_strength=edge.strength,
+                designed_weight=None,
+                delta=None,
+                status="observed_only",
+            )
+        )
+
+    # Pairs that never had enough co-sampled data to test at all.
+    for result in pair_results:
+        if result.n_lag0 < min_samples:
+            entries.append(
+                CausalGeometryDivergenceEntryV1(
+                    source_id=result.channel_a,
+                    target_id=result.channel_b,
+                    observed_strength=None,
+                    designed_weight=None,
+                    delta=None,
+                    status="insufficient_data",
+                )
+            )
+
+    return entries
+
+
+# --- snapshot assembly -------------------------------------------------------
+
+
+def build_snapshot(
+    channels: ChannelSeries,
+    topology: Dict[str, Any],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    bucket_seconds: int = BUCKET_SECONDS,
+    lag_grid_seconds: Tuple[int, ...] = LAG_GRID_SECONDS,
+    min_samples: int = DEFAULT_MIN_SAMPLES,
+    n_surrogates: int = DEFAULT_N_SURROGATES,
+    alpha: float = DEFAULT_ALPHA,
+    seed: int = DEFAULT_SEED,
+    table_row_counts: Optional[Dict[str, int]] = None,
+) -> Tuple[CausalGeometrySnapshotV1, List[PairResult]]:
+    channel_buckets = {
+        channel_id: bucketize(points, bucket_seconds) for channel_id, points in channels.items()
+    }
+
+    pair_results = compute_pairwise_results(
+        channel_buckets,
+        min_samples=min_samples,
+        n_surrogates=n_surrogates,
+        alpha=alpha,
+        lag_grid_seconds=lag_grid_seconds,
+        bucket_seconds=bucket_seconds,
+        seed=seed,
+    )
+    edges = build_edges(
+        pair_results, window_start=window_start, window_end=window_end, bucket_seconds=bucket_seconds
+    )
+    divergence = build_divergence(edges, pair_results, topology, min_samples=min_samples)
+
+    notes: List[str] = []
+    if table_row_counts:
+        for table_name, row_count in table_row_counts.items():
+            if row_count == 0:
+                notes.append(
+                    f"source table {table_name!r} returned 0 rows in the requested window -- "
+                    "every channel it would have contributed is absent from this snapshot, "
+                    "not silently zero-valued."
+                )
+    n_pairs_tested = len(pair_results)
+    n_insufficient = sum(1 for r in pair_results if r.n_lag0 < min_samples)
+    n_pairs_with_data = n_pairs_tested - n_insufficient
+    notes.append(
+        f"{len(channels)} channels, {n_pairs_tested} channel pairs considered, "
+        f"{n_insufficient} below --min-samples={min_samples}, "
+        f"{n_pairs_with_data} tested for significance, {len(edges)} significant edges found."
+    )
+    insufficient_data = len(edges) == 0
+    if insufficient_data:
+        if n_pairs_with_data == 0:
+            notes.append(
+                "No channel pair had enough co-sampled data to test at all -- widen "
+                "--window-hours, lower --min-samples, or check that the source tables "
+                "actually have rows in the requested window."
+            )
+        else:
+            notes.append(
+                f"{n_pairs_with_data} pair(s) had enough data to test but none cleared "
+                f"--alpha={alpha} after {n_surrogates} circular-shift surrogates each -- "
+                "this is reported honestly as insufficient_data rather than a fabricated graph."
+            )
+
+    snapshot = CausalGeometrySnapshotV1(
+        snapshot_id=str(uuid.uuid4()),
+        generated_at=datetime.now(timezone.utc),
+        window_start=window_start,
+        window_end=window_end,
+        edges=edges,
+        designed_topology_version=topology.get("schema_version"),
+        divergence=divergence,
+        insufficient_data=insufficient_data,
+        notes=notes,
+    )
+    return snapshot, pair_results

--- a/orion/substrate/causal_geometry_producer.py
+++ b/orion/substrate/causal_geometry_producer.py
@@ -1,0 +1,150 @@
+"""Causal Geometry v1, follow-up rung: the scheduled Phase A -> Phase B producer.
+
+PR #1087 shipped Phase A (`orion/substrate/causal_geometry_engine.py`, observed-
+vs-designed measurement) and Phase B (`field_topology_plasticity.py` +
+`field_topology_learned_store.py`, HITL-gated weight-patch proposals), but
+nothing ever called them together on a schedule -- the HITL proposal queue was
+real but permanently empty. This module is that missing link: one function,
+`run_causal_geometry_production_cycle()`, that a periodic caller (see
+`services/orion-field-digester/app/worker.py`'s `_causal_geometry_producer_loop`)
+invokes to measure, propose, and enqueue.
+
+This module only *proposes* into the HITL queue via `store.propose()`. It never
+calls `store.adopt()` and never imports `orion.substrate.mutation_apply` --
+same hard constraint as `field_topology_plasticity.py` itself.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+from orion.schemas.field_state import FieldEdgeV1
+from orion.substrate.causal_geometry_engine import (
+    DEFAULT_ALPHA,
+    DEFAULT_BIOMETRICS_NODE,
+    DEFAULT_MIN_SAMPLES,
+    DEFAULT_N_SURROGATES,
+    DEFAULT_SEED,
+    DEFAULT_WINDOW_HOURS,
+    build_snapshot,
+    fetch_channels,
+    load_field_topology,
+)
+from orion.substrate.field_topology_learned_store import FieldTopologyLearnedWeightsStore
+from orion.substrate.field_topology_plasticity import (
+    MIN_MEANINGFUL_DELTA,
+    propose_field_topology_patches,
+)
+
+logger = logging.getLogger(__name__)
+
+# How many pending proposals to scan for de-duplication purposes. Generously
+# above any realistic queue size (proposals only exist for diverging cap->cap
+# edges with a real delta -- see MIN_MEANINGFUL_DELTA) so a legitimately large
+# backlog can't cause a duplicate to slip through list_pending()'s own default
+# limit of 50.
+DEDUP_SCAN_LIMIT = 1000
+
+
+def run_causal_geometry_production_cycle(
+    *,
+    postgres_uri: str,
+    topology_path: str,
+    field_edges: List[FieldEdgeV1],
+    store: FieldTopologyLearnedWeightsStore,
+    window_hours: float = DEFAULT_WINDOW_HOURS,
+    min_samples: int = DEFAULT_MIN_SAMPLES,
+    n_surrogates: int = DEFAULT_N_SURROGATES,
+    alpha: float = DEFAULT_ALPHA,
+    biometrics_node: str = DEFAULT_BIOMETRICS_NODE,
+    seed: int = DEFAULT_SEED,
+    min_meaningful_delta: float = MIN_MEANINGFUL_DELTA,
+    now: datetime | None = None,
+) -> Dict[str, Any]:
+    """Measure observed-vs-designed field topology and enqueue new HITL proposals.
+
+    Never raises -- every failure mode (Postgres unreachable, topology YAML
+    missing/malformed, a candidate-building error) degrades to a returned
+    summary dict with `ok: False` and an `error` string, exactly like
+    `services/orion-field-digester/app/digestion/diffusion.py`'s
+    `_load_learned_overlay()` degrades a read-path failure to an empty
+    overlay. A scheduled caller should log this summary, not propagate an
+    exception into its own tick loop.
+
+    De-duplication: a proposal is only enqueued for an edge_ref that has no
+    existing *pending* proposal already in the store (checked via
+    `store.list_pending()`). An edge whose prior proposal was already adopted
+    or rejected is eligible to be re-proposed if divergence still exists --
+    only an in-flight pending proposal blocks a new one for the same edge.
+    """
+    moment = now or datetime.now(timezone.utc)
+    window_start = moment - timedelta(hours=window_hours)
+
+    try:
+        channels, table_row_counts = fetch_channels(
+            postgres_uri, window_start, biometrics_node=biometrics_node
+        )
+        topology = load_field_topology(topology_path)
+        snapshot, _pair_results = build_snapshot(
+            channels,
+            topology,
+            window_start=window_start,
+            window_end=moment,
+            min_samples=min_samples,
+            n_surrogates=n_surrogates,
+            alpha=alpha,
+            seed=seed,
+            table_row_counts=table_row_counts,
+        )
+    except Exception as exc:
+        logger.warning("causal_geometry_production_cycle_measurement_failed: %s", exc, exc_info=True)
+        return {
+            "ok": False,
+            "stage": "measurement",
+            "error": str(exc),
+            "snapshot_id": None,
+            "insufficient_data": None,
+            "candidates_found": 0,
+            "proposals_created": 0,
+            "proposals_skipped_pending_duplicate": 0,
+        }
+
+    try:
+        proposals = propose_field_topology_patches(
+            snapshot, field_edges=field_edges, min_meaningful_delta=min_meaningful_delta
+        )
+        existing_pending_refs = {
+            proposal.patch.target_ref for proposal in store.list_pending(limit=DEDUP_SCAN_LIMIT)
+        }
+        created = 0
+        skipped = 0
+        for proposal in proposals:
+            if proposal.patch.target_ref in existing_pending_refs:
+                skipped += 1
+                continue
+            store.propose(proposal)
+            created += 1
+    except Exception as exc:
+        logger.warning("causal_geometry_production_cycle_proposal_stage_failed: %s", exc, exc_info=True)
+        return {
+            "ok": False,
+            "stage": "proposal",
+            "error": str(exc),
+            "snapshot_id": snapshot.snapshot_id,
+            "insufficient_data": snapshot.insufficient_data,
+            "candidates_found": 0,
+            "proposals_created": 0,
+            "proposals_skipped_pending_duplicate": 0,
+        }
+
+    return {
+        "ok": True,
+        "stage": "completed",
+        "error": None,
+        "snapshot_id": snapshot.snapshot_id,
+        "insufficient_data": snapshot.insufficient_data,
+        "candidates_found": len(proposals),
+        "proposals_created": created,
+        "proposals_skipped_pending_duplicate": skipped,
+    }

--- a/orion/substrate/causal_geometry_producer.py
+++ b/orion/substrate/causal_geometry_producer.py
@@ -1,10 +1,12 @@
 """Causal Geometry v1, follow-up rung: the scheduled Phase A -> Phase B producer.
 
-PR #1087 shipped Phase A (`orion/substrate/causal_geometry_engine.py`, observed-
-vs-designed measurement) and Phase B (`field_topology_plasticity.py` +
+PR #1087 shipped Phase A (`scripts/causal_geometry_report.py`, observed-vs-
+designed measurement) and Phase B (`field_topology_plasticity.py` +
 `field_topology_learned_store.py`, HITL-gated weight-patch proposals), but
 nothing ever called them together on a schedule -- the HITL proposal queue was
-real but permanently empty. This module is that missing link: one function,
+real but permanently empty. `orion/substrate/causal_geometry_engine.py` (Phase
+A's core logic, extracted into an importable module) is new in this same
+follow-up commit, alongside this module. This module is that missing link: one function,
 `run_causal_geometry_production_cycle()`, that a periodic caller (see
 `services/orion-field-digester/app/worker.py`'s `_causal_geometry_producer_loop`)
 invokes to measure, propose, and enqueue.
@@ -124,6 +126,12 @@ def run_causal_geometry_production_cycle(
                 skipped += 1
                 continue
             store.propose(proposal)
+            # Two different capability channels can alias to the same physical
+            # (source_id, target_id) edge (see causal_geometry_engine.build_divergence()'s
+            # docstring) -- without this, two such candidates in one `proposals` list would
+            # both pass the check above and both get enqueued, since existing_pending_refs
+            # is otherwise only ever checked against the store's *pre-loop* state.
+            existing_pending_refs.add(proposal.patch.target_ref)
             created += 1
     except Exception as exc:
         logger.warning("causal_geometry_production_cycle_proposal_stage_failed: %s", exc, exc_info=True)

--- a/orion/substrate/tests/test_causal_geometry_producer.py
+++ b/orion/substrate/tests/test_causal_geometry_producer.py
@@ -151,6 +151,44 @@ def test_insufficient_data_snapshot_yields_zero_candidates_not_an_error(monkeypa
     assert result["proposals_created"] == 0
 
 
+def test_intra_cycle_duplicate_candidates_for_the_same_edge_enqueue_only_one_proposal(monkeypatch) -> None:
+    """Regression: two different capability channels can alias to the same physical
+    (source_id, target_id) edge (causal_geometry_engine.build_divergence()'s
+    `#<capability_channel>` disambiguation suffix exists exactly for this case). If
+    both aliased channels diverge meaningfully in the same cycle,
+    propose_field_topology_patches() legitimately returns two candidates with the
+    identical (stripped) target_ref -- the producer's dedup must catch the second
+    one against the first *within* the same cycle, not just across cycles."""
+    rng = np.random.default_rng(11)
+    transport = rng.normal(size=200)
+    orch_a = transport * 0.95 + rng.normal(scale=0.05, size=200)
+    orch_b = transport * 0.9 + rng.normal(scale=0.08, size=200)
+    channels = {
+        "cap:transport": _points_for(transport),
+        "cap:orch_a": _points_for(orch_a),
+        "cap:orch_b": _points_for(orch_b),
+    }
+    topology = {
+        "schema_version": "field_lattice.v1.test",
+        "edges": [
+            {
+                "source_id": "cap:transport",
+                "target_id": "cap:orchestration",
+                "edge_type": "capability_capability",
+                "weight": 0.1,
+                "channel_map": {"orch_a": "orch_a", "orch_b": "orch_b"},
+            }
+        ],
+    }
+
+    result, store = _run(monkeypatch, channels=channels, topology=topology)
+
+    assert result["ok"] is True
+    pending = store.list_pending()
+    assert len(pending) == 1, f"expected exactly one pending proposal, got {len(pending)}: {[p.patch.target_ref for p in pending]}"
+    assert pending[0].patch.target_ref == "cap:transport->cap:orchestration"
+
+
 def test_module_never_imports_patch_applier() -> None:
     source = Path(producer_module.__file__).read_text(encoding="utf-8")
     tree = ast.parse(source)

--- a/orion/substrate/tests/test_causal_geometry_producer.py
+++ b/orion/substrate/tests/test_causal_geometry_producer.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pytest
+
+import orion.substrate.causal_geometry_producer as producer_module
+from orion.schemas.field_state import FieldEdgeV1
+from orion.substrate.causal_geometry_engine import BUCKET_SECONDS
+from orion.substrate.field_topology_learned_store import FieldTopologyLearnedWeightsStore
+
+BASE_TS = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def _points_for(values: np.ndarray, bucket_seconds: int = BUCKET_SECONDS) -> List[Tuple[datetime, float]]:
+    return [(BASE_TS + timedelta(seconds=i * bucket_seconds), float(v)) for i, v in enumerate(values)]
+
+
+def _divergent_channels(n_buckets: int = 200, seed: int = 7) -> Dict[str, List[Tuple[datetime, float]]]:
+    rng = np.random.default_rng(seed)
+    # Strongly correlated pair aliasing to a designed cap->cap edge's
+    # channel_map, with observed_strength far from designed_weight (0.9 vs
+    # 0.2) so it clears MIN_MEANINGFUL_DELTA and produces a real candidate.
+    x = rng.normal(size=n_buckets)
+    y = x * 0.95 + rng.normal(scale=0.05, size=n_buckets)
+    return {
+        "cap:transport": _points_for(x),
+        "cap:orchestration": _points_for(y),
+    }
+
+
+def _fixture_topology() -> Dict:
+    return {
+        "schema_version": "field_lattice.v1.test",
+        "edges": [
+            {
+                "source_id": "cap:transport",
+                "target_id": "cap:orchestration",
+                "edge_type": "capability_capability",
+                "weight": 0.2,
+                "channel_map": {"transport_pressure": "orchestration"},
+            }
+        ],
+    }
+
+
+def _field_edges() -> List[FieldEdgeV1]:
+    return [
+        FieldEdgeV1(
+            source_id="cap:transport",
+            target_id="cap:orchestration",
+            edge_type="capability_capability",
+            weight=0.2,
+        )
+    ]
+
+
+def _run(monkeypatch, *, channels=None, topology=None, store=None, fetch_raises=False, propose_raises=False):
+    if fetch_raises:
+        def _boom_fetch(*args, **kwargs):
+            raise RuntimeError("postgres unreachable")
+
+        monkeypatch.setattr(producer_module, "fetch_channels", _boom_fetch)
+    else:
+        monkeypatch.setattr(
+            producer_module,
+            "fetch_channels",
+            lambda *a, **k: (channels if channels is not None else _divergent_channels(), {}),
+        )
+    monkeypatch.setattr(
+        producer_module, "load_field_topology", lambda *a, **k: (topology if topology is not None else _fixture_topology())
+    )
+
+    if propose_raises:
+        def _boom_propose(*args, **kwargs):
+            raise RuntimeError("proposal construction failed")
+
+        monkeypatch.setattr(producer_module, "propose_field_topology_patches", _boom_propose)
+
+    used_store = store if store is not None else FieldTopologyLearnedWeightsStore()
+    return producer_module.run_causal_geometry_production_cycle(
+        postgres_uri="postgresql://unused/unused",
+        topology_path="/unused/path.yaml",
+        field_edges=_field_edges(),
+        store=used_store,
+        now=BASE_TS + timedelta(seconds=250 * BUCKET_SECONDS),
+    ), used_store
+
+
+def test_successful_cycle_creates_a_new_pending_proposal(monkeypatch) -> None:
+    result, store = _run(monkeypatch)
+
+    assert result["ok"] is True
+    assert result["stage"] == "completed"
+    assert result["proposals_created"] == 1
+    assert result["proposals_skipped_pending_duplicate"] == 0
+    pending = store.list_pending()
+    assert len(pending) == 1
+    assert pending[0].patch.target_ref == "cap:transport->cap:orchestration"
+
+
+def test_dedup_skips_edge_with_existing_pending_proposal(monkeypatch) -> None:
+    result_first, store = _run(monkeypatch)
+    assert result_first["proposals_created"] == 1
+
+    result_second, _store = _run(monkeypatch, store=store)
+
+    assert result_second["ok"] is True
+    assert result_second["proposals_created"] == 0
+    assert result_second["proposals_skipped_pending_duplicate"] == 1
+    # Still exactly one pending proposal for the edge, not two.
+    assert len(store.list_pending()) == 1
+
+
+def test_measurement_failure_degrades_without_raising(monkeypatch) -> None:
+    result, _store = _run(monkeypatch, fetch_raises=True)
+
+    assert result["ok"] is False
+    assert result["stage"] == "measurement"
+    assert "postgres unreachable" in result["error"]
+    assert result["proposals_created"] == 0
+
+
+def test_proposal_stage_failure_degrades_without_raising(monkeypatch) -> None:
+    result, _store = _run(monkeypatch, propose_raises=True)
+
+    assert result["ok"] is False
+    assert result["stage"] == "proposal"
+    assert "proposal construction failed" in result["error"]
+    # Measurement stage did succeed, so snapshot_id is populated even though
+    # the proposal stage failed.
+    assert result["snapshot_id"] is not None
+
+
+def test_insufficient_data_snapshot_yields_zero_candidates_not_an_error(monkeypatch) -> None:
+    # Independent random series -> no significant edges -> insufficient_data.
+    rng = np.random.default_rng(99)
+    channels = {
+        "cap:transport": _points_for(rng.normal(size=200)),
+        "cap:orchestration": _points_for(rng.normal(size=200)),
+    }
+    result, _store = _run(monkeypatch, channels=channels)
+
+    assert result["ok"] is True
+    assert result["insufficient_data"] is True
+    assert result["candidates_found"] == 0
+    assert result["proposals_created"] == 0
+
+
+def test_module_never_imports_patch_applier() -> None:
+    source = Path(producer_module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module != "orion.substrate.mutation_apply"
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "orion.substrate.mutation_apply"

--- a/scripts/causal_geometry_report.py
+++ b/scripts/causal_geometry_report.py
@@ -5,9 +5,18 @@ See docs/superpowers/specs/2026-07-16-causal-geometry-v1-design.md for the full
 three-phase design. This script is Phase A only -- it measures the *observed*
 causal structure between organ time-series already in Postgres and compares it
 against the *designed* structure in
-`config/field/orion_field_topology.v1.yaml`. It does not publish to the bus,
-does not write to Postgres, and runs no reducer/worker process (see the
-design doc's "Files likely to touch" -- Phase B/C are separate rungs).
+`config/field/orion_field_topology.v1.yaml`. It does not publish to the bus and
+does not write to Postgres.
+
+As of the follow-up producer-wiring change, the core measurement logic (data
+fetch, resampling, lagged correlation, surrogate significance, divergence) has
+moved to `orion/substrate/causal_geometry_engine.py`, an importable module, so
+`orion/substrate/causal_geometry_producer.py` (called periodically from
+`services/orion-field-digester/app/worker.py`) can call the exact same code
+this CLI uses instead of duplicating it. This file re-exports every engine
+name it previously defined, so existing callers/tests of this module are
+unaffected. What remains here is CLI-only: argument parsing and human/JSON
+output formatting.
 
 What this measures
 -------------------
@@ -99,34 +108,6 @@ corrected p < --alpha.
 
 Designed-vs-observed divergence
 --------------------------------
-`config/field/orion_field_topology.v1.yaml` edges carry a `channel_map` from
-a node/capability-local channel name (e.g. `reasoning_load`) to a shared
-*capability channel* name (e.g. `reasoning_pressure`) listed under
-`capability_channels`. This script builds a reverse index from capability
-channel name -> list of (source_id, target_id, weight) YAML edges, then
-checks every observed channel's suffix (the part after the first `:`, e.g.
-`self_state:reasoning_pressure` -> `reasoning_pressure`) against that index.
-A match is "plausible" purely by exact string identity -- e.g.
-`self_state:reasoning_pressure`, `self_state:execution_pressure`, and
-`self_state:reliability_pressure` all match capability channel names
-verbatim (verified against a live sample on 2026-07-16; see
-docs/PR-field-lattice-cap-cap-edges.md for how those specific capability
-channels are wired into the lattice). No other observed channel prefix
-(drive:*, attention:*, biometrics:*) happened to collide with a capability
-channel name in the live data sampled while building this script, but the
-matching is generic (name-based, not hardcoded to a fixed list), so it will
-pick up new collisions automatically if the schemas drift closer together.
-
-For a matched capability channel, if this script found a *significant*
-edge touching that observed channel, the divergence entry gets
-status="both" (observed_strength = that edge's strength, designed_weight =
-the YAML edge's weight). If no significant edge was found, status is
-"designed_only" (the YAML wiring exists but nothing observed backs it yet --
-that is still meaningfully different from "no YAML edge exists at all", but
-the divergence entry schema doesn't have a slot for "designed but
-unconfirmed" vs "designed and no attempt was even matched", so both cases
-collapse to designed_only; the human-readable table and JSON `notes` list
-which capability channels had zero co-sampled observed data behind them).
 Every other YAML edge/channel_map entry with no observed channel aliasing to
 it also becomes a designed_only entry. Every significant observed edge whose
 endpoints don't alias to any capability channel becomes observed_only.
@@ -183,589 +164,44 @@ if _REPO_ROOT not in sys.path:
 import argparse  # noqa: E402
 import json  # noqa: E402
 import os  # noqa: E402
-import uuid  # noqa: E402
 from datetime import datetime, timedelta, timezone  # noqa: E402
-from typing import Any, Callable, Dict, List, Optional, Tuple  # noqa: E402
+from typing import List, Optional  # noqa: E402
 
-import numpy as np  # noqa: E402
-import yaml  # noqa: E402
+from orion.schemas.causal_geometry import CausalGeometrySnapshotV1  # noqa: E402
 
-from orion.schemas.causal_geometry import (  # noqa: E402
-    CausalGeometryDivergenceEntryV1,
-    CausalGeometryEdgeV1,
-    CausalGeometrySnapshotV1,
+# Re-exported from the engine module so existing callers/tests of this file
+# (e.g. tests/test_causal_geometry_report.py, which references cgr.<name>)
+# keep working unchanged after the extraction.
+from orion.substrate.causal_geometry_engine import (  # noqa: E402,F401
+    BUCKET_SECONDS,
+    DEFAULT_ALPHA,
+    DEFAULT_BIOMETRICS_NODE,
+    DEFAULT_FIELD_TOPOLOGY_PATH,
+    DEFAULT_MIN_SAMPLES,
+    DEFAULT_N_SURROGATES,
+    DEFAULT_POSTGRES_URI,
+    DEFAULT_SEED,
+    DEFAULT_WINDOW_HOURS,
+    LAG_GRID_SECONDS,
+    ChannelPoints,
+    ChannelSeries,
+    DirectionResult,
+    PairResult,
+    _aligned_arrays,
+    _best_direction,
+    _best_strength_for_channel,
+    _bucket_idx_to_datetime,
+    _pearson,
+    build_capability_channel_index,
+    build_divergence,
+    build_edges,
+    build_snapshot,
+    bucketize,
+    circular_shift_pvalue,
+    compute_pairwise_results,
+    fetch_channels,
+    load_field_topology,
 )
-
-# --- documented, fixed knobs (see module docstring for rationale) ----------
-
-# 5-minute buckets: matches the sampling density of the sparsest channel that
-# matters for cross-correlation (attention_salience_trace, ~1 point per ~5
-# minutes over its full history as of 2026-07-16).
-BUCKET_SECONDS = 300
-
-# 0, 5, 10, 15, 30 minutes. Kept small: this is lagged correlation over
-# organ-scale signals, not a long-horizon forecast; the design doc explicitly
-# defers transfer entropy / Granger-style modeling to a later phase.
-LAG_GRID_SECONDS: Tuple[int, ...] = (0, 300, 600, 900, 1800)
-
-DEFAULT_WINDOW_HOURS = 168.0
-DEFAULT_MIN_SAMPLES = 30
-DEFAULT_N_SURROGATES = 200
-DEFAULT_ALPHA = 0.05
-DEFAULT_BIOMETRICS_NODE = "athena"
-DEFAULT_SEED = 1337
-
-# Local Postgres convention used across this repo for host-side access, e.g.
-# services/orion-hub/.env_example's RECALL_PG_DSN / POSTGRES_URI and
-# services/orion-cortex-orch/.env_example's commented RECALL_PG_DSN, both
-# postgresql://postgres:postgres@127.0.0.1:55432/conjourney (POSTGRES_PORT
-# default 55432 per services/orion-sql-db/.env_example and .env_example at
-# repo root).
-DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@127.0.0.1:55432/conjourney"
-
-DEFAULT_FIELD_TOPOLOGY_PATH = str(
-    Path(_REPO_ROOT) / "config" / "field" / "orion_field_topology.v1.yaml"
-)
-
-ChannelPoints = List[Tuple[datetime, float]]
-ChannelSeries = Dict[str, ChannelPoints]
-
-
-# --- data fetch (real DB) ---------------------------------------------------
-
-
-def fetch_channels(
-    postgres_uri: str,
-    window_start: datetime,
-    *,
-    biometrics_node: str = DEFAULT_BIOMETRICS_NODE,
-) -> Tuple[ChannelSeries, Dict[str, int]]:
-    """Pull and flatten all four organ signal tables into named channels.
-
-    Uses psycopg2 (already a dependency of several services, e.g.
-    services/orion-sql-writer, and available in this repo's shared dev venv;
-    no new dependency added). Each row's jsonb column is flattened into one
-    channel per key (`drive:<key>`, `biometrics:<key>`, `self_state:<key>`);
-    `attention_salience_trace.salience` has no sub-keys and becomes the
-    single scalar channel `attention:salience`.
-
-    Returns `(channels, table_row_counts)`. `table_row_counts` maps each
-    source table name to the raw row count pulled in the window -- a table
-    with 0 rows in the window contributes zero channels and would otherwise
-    be silently invisible from the rest of the report (verified live on
-    2026-07-16: an 8h window found 0 attention_salience_trace rows, since
-    that table's most recent row was already >8h old -- without this count,
-    "27 channels found" gives no hint that a whole source table went dark).
-    """
-    import psycopg2
-
-    channels: ChannelSeries = {}
-    table_row_counts: Dict[str, int] = {}
-
-    def _append(channel_id: str, ts: datetime, value: Any) -> None:
-        if value is None or isinstance(value, bool):
-            return
-        try:
-            fvalue = float(value)
-        except (TypeError, ValueError):
-            return
-        channels.setdefault(channel_id, []).append((ts, fvalue))
-
-    conn = psycopg2.connect(postgres_uri)
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT COALESCE(observed_at, created_at) AS ts, drive_pressures
-                FROM drive_audits
-                WHERE COALESCE(observed_at, created_at) >= %s
-                ORDER BY ts
-                """,
-                (window_start,),
-            )
-            rows = cur.fetchall()
-            table_row_counts["drive_audits"] = len(rows)
-            for ts, drive_pressures in rows:
-                for key, value in (drive_pressures or {}).items():
-                    _append(f"drive:{key}", ts, value)
-
-            cur.execute(
-                """
-                SELECT created_at AS ts, salience
-                FROM attention_salience_trace
-                WHERE created_at >= %s
-                ORDER BY ts
-                """,
-                (window_start,),
-            )
-            rows = cur.fetchall()
-            table_row_counts["attention_salience_trace"] = len(rows)
-            for ts, salience in rows:
-                _append("attention:salience", ts, salience)
-
-            cur.execute(
-                """
-                SELECT timestamp::timestamptz AS ts, pressures
-                FROM orion_biometrics_summary
-                WHERE node = %s AND timestamp::timestamptz >= %s
-                ORDER BY ts
-                """,
-                (biometrics_node, window_start),
-            )
-            rows = cur.fetchall()
-            table_row_counts["orion_biometrics_summary"] = len(rows)
-            for ts, pressures in rows:
-                for key, value in (pressures or {}).items():
-                    _append(f"biometrics:{key}", ts, value)
-
-            cur.execute(
-                """
-                SELECT generated_at AS ts, prediction_json->'predicted_dimension_scores' AS scores
-                FROM self_state_predictions
-                WHERE generated_at >= %s
-                ORDER BY ts
-                """,
-                (window_start,),
-            )
-            rows = cur.fetchall()
-            table_row_counts["self_state_predictions"] = len(rows)
-            for ts, scores in rows:
-                for key, value in (scores or {}).items():
-                    _append(f"self_state:{key}", ts, value)
-    finally:
-        conn.close()
-
-    for points in channels.values():
-        points.sort(key=lambda p: p[0])
-    return channels, table_row_counts
-
-
-# --- resampling + lagged correlation ----------------------------------------
-
-
-def bucketize(points: ChannelPoints, bucket_seconds: int = BUCKET_SECONDS) -> Dict[int, float]:
-    """Mean-aggregate raw (timestamp, value) points onto a bucket-index grid.
-
-    Bucket index is `int(ts.timestamp() // bucket_seconds)`. Empty buckets are
-    simply absent from the returned dict -- this script never interpolates or
-    forward-fills, since a fabricated value in a gap could manufacture a
-    spurious correlation exactly opposite of this feature's purpose.
-    """
-    grouped: Dict[int, List[float]] = {}
-    for ts, value in points:
-        idx = int(ts.timestamp() // bucket_seconds)
-        grouped.setdefault(idx, []).append(value)
-    return {idx: float(np.mean(vals)) for idx, vals in grouped.items()}
-
-
-def _aligned_arrays(
-    source_buckets: Dict[int, float], target_buckets: Dict[int, float], lag_buckets: int
-) -> Tuple[np.ndarray, np.ndarray]:
-    """Pair up source[idx] with target[idx + lag_buckets] for every idx present
-    in both, i.e. target observed `lag_buckets` buckets after source."""
-    xs: List[float] = []
-    ys: List[float] = []
-    for idx in sorted(source_buckets.keys()):
-        j = idx + lag_buckets
-        if j in target_buckets:
-            xs.append(source_buckets[idx])
-            ys.append(target_buckets[j])
-    return np.array(xs, dtype=float), np.array(ys, dtype=float)
-
-
-def _pearson(x: np.ndarray, y: np.ndarray) -> Optional[float]:
-    if len(x) < 2 or len(y) < 2:
-        return None
-    if np.std(x) == 0.0 or np.std(y) == 0.0:
-        return 0.0
-    r = float(np.corrcoef(x, y)[0, 1])
-    if np.isnan(r):
-        return 0.0
-    return r
-
-
-class DirectionResult:
-    __slots__ = ("source_id", "target_id", "lag_sec", "r", "n", "xs", "ys")
-
-    def __init__(self, source_id: str, target_id: str, lag_sec: int, r: float, n: int, xs: np.ndarray, ys: np.ndarray):
-        self.source_id = source_id
-        self.target_id = target_id
-        self.lag_sec = lag_sec
-        self.r = r
-        self.n = n
-        self.xs = xs
-        self.ys = ys
-
-
-def _best_direction(
-    source_id: str,
-    target_id: str,
-    source_buckets: Dict[int, float],
-    target_buckets: Dict[int, float],
-    lag_grid_seconds: Tuple[int, ...],
-    bucket_seconds: int,
-) -> Optional[DirectionResult]:
-    best: Optional[DirectionResult] = None
-    for lag_sec in lag_grid_seconds:
-        lag_buckets = lag_sec // bucket_seconds
-        xs, ys = _aligned_arrays(source_buckets, target_buckets, lag_buckets)
-        if len(xs) < 2:
-            continue
-        r = _pearson(xs, ys)
-        if r is None:
-            continue
-        if best is None or abs(r) > abs(best.r):
-            best = DirectionResult(source_id, target_id, lag_sec, r, len(xs), xs, ys)
-    return best
-
-
-def circular_shift_pvalue(
-    xs: np.ndarray,
-    ys: np.ndarray,
-    observed_r: float,
-    *,
-    n_surrogates: int = DEFAULT_N_SURROGATES,
-    rng: Optional[np.random.Generator] = None,
-) -> float:
-    """Circular time-shift surrogate p-value for a Pearson correlation.
-
-    Shifts `ys` by a uniformly-sampled non-zero circular offset (numpy.roll)
-    `n_surrogates` times, recomputes Pearson r against the fixed `xs` each
-    time, and returns the add-one-smoothed fraction of surrogate |r| >=
-    observed |r|. Add-one smoothing (standard permutation-test convention)
-    means this never reports p=0.0 off a finite surrogate sample.
-    """
-    n = len(ys)
-    if n < 2:
-        return 1.0
-    if rng is None:
-        rng = np.random.default_rng()
-    observed_abs = abs(observed_r)
-    count_ge = 0
-    for _ in range(n_surrogates):
-        shift = int(rng.integers(1, n)) if n > 1 else 0
-        shifted = np.roll(ys, shift)
-        r = _pearson(xs, shifted)
-        if r is not None and abs(r) >= observed_abs:
-            count_ge += 1
-    return (count_ge + 1) / (n_surrogates + 1)
-
-
-class PairResult:
-    __slots__ = ("channel_a", "channel_b", "n_lag0", "winner", "significant", "p_value")
-
-    def __init__(self, channel_a: str, channel_b: str, n_lag0: int):
-        self.channel_a = channel_a
-        self.channel_b = channel_b
-        self.n_lag0 = n_lag0
-        self.winner: Optional[DirectionResult] = None
-        self.significant = False
-        self.p_value: Optional[float] = None
-
-
-def compute_pairwise_results(
-    channel_buckets: Dict[str, Dict[int, float]],
-    *,
-    min_samples: int = DEFAULT_MIN_SAMPLES,
-    n_surrogates: int = DEFAULT_N_SURROGATES,
-    alpha: float = DEFAULT_ALPHA,
-    lag_grid_seconds: Tuple[int, ...] = LAG_GRID_SECONDS,
-    bucket_seconds: int = BUCKET_SECONDS,
-    seed: int = DEFAULT_SEED,
-) -> List[PairResult]:
-    """Compute lagged cross-correlation + surrogate significance for every
-    unordered pair of channels.
-
-    Eligibility gate: zero-lag co-sampled overlap size (the maximum possible
-    n for a pair, since positive lags only shrink alignment further). Pairs
-    below `min_samples` get a `PairResult` with `winner=None` and are never
-    given a fabricated edge -- callers must check `n_lag0 < min_samples`
-    before treating the absence of `winner` as "not correlated" instead of
-    "not enough data to know".
-    """
-    channel_ids = sorted(channel_buckets.keys())
-    results: List[PairResult] = []
-    rng = np.random.default_rng(seed)
-
-    for i, a in enumerate(channel_ids):
-        for b in channel_ids[i + 1 :]:
-            bucket_a = channel_buckets[a]
-            bucket_b = channel_buckets[b]
-            n_lag0 = len(set(bucket_a.keys()) & set(bucket_b.keys()))
-            result = PairResult(a, b, n_lag0)
-            if n_lag0 < min_samples:
-                results.append(result)
-                continue
-
-            fwd = _best_direction(a, b, bucket_a, bucket_b, lag_grid_seconds, bucket_seconds)
-            bwd = _best_direction(b, a, bucket_b, bucket_a, lag_grid_seconds, bucket_seconds)
-            candidates = [c for c in (fwd, bwd) if c is not None]
-            if not candidates:
-                results.append(result)
-                continue
-            winner = max(candidates, key=lambda c: abs(c.r))
-            p_raw = circular_shift_pvalue(
-                winner.xs, winner.ys, winner.r, n_surrogates=n_surrogates, rng=rng
-            )
-            # Bonferroni correction for the implicit multiple comparisons across
-            # both directions x the full lag grid (see module docstring's
-            # "Significance: circular time-shift surrogates" section).
-            n_comparisons = 2 * len(lag_grid_seconds)
-            p_value = min(1.0, p_raw * n_comparisons)
-            result.winner = winner
-            result.p_value = p_value
-            result.significant = p_value < alpha
-            results.append(result)
-
-    return results
-
-
-def _bucket_idx_to_datetime(idx: int, bucket_seconds: int = BUCKET_SECONDS) -> datetime:
-    return datetime.fromtimestamp(idx * bucket_seconds, tz=timezone.utc)
-
-
-def build_edges(
-    pair_results: List[PairResult],
-    *,
-    window_start: datetime,
-    window_end: datetime,
-    bucket_seconds: int = BUCKET_SECONDS,
-) -> List[CausalGeometryEdgeV1]:
-    edges: List[CausalGeometryEdgeV1] = []
-    for result in pair_results:
-        if not result.significant or result.winner is None or result.p_value is None:
-            continue
-        w = result.winner
-        edges.append(
-            CausalGeometryEdgeV1(
-                source_id=w.source_id,
-                target_id=w.target_id,
-                lag_sec=w.lag_sec,
-                strength=max(-1.0, min(1.0, w.r)),
-                significance=result.p_value,
-                n_samples=w.n,
-                window_start=window_start,
-                window_end=window_end,
-            )
-        )
-    return edges
-
-
-# --- designed topology loading + divergence ---------------------------------
-
-
-def load_field_topology(path: str) -> Dict[str, Any]:
-    with open(path, "r", encoding="utf-8") as fh:
-        return yaml.safe_load(fh) or {}
-
-
-def build_capability_channel_index(topology: Dict[str, Any]) -> Dict[str, List[Dict[str, Any]]]:
-    """Reverse index: capability channel name (e.g. "reasoning_pressure") ->
-    list of YAML edges (source_id, target_id, weight, edge_type) whose
-    channel_map maps some local channel onto that capability channel name."""
-    index: Dict[str, List[Dict[str, Any]]] = {}
-    for edge in topology.get("edges", []) or []:
-        channel_map = edge.get("channel_map") or {}
-        for _local_channel, cap_channel in channel_map.items():
-            index.setdefault(cap_channel, []).append(
-                {
-                    "source_id": edge.get("source_id"),
-                    "target_id": edge.get("target_id"),
-                    "weight": edge.get("weight"),
-                    "edge_type": edge.get("edge_type"),
-                }
-            )
-    return index
-
-
-def _best_strength_for_channel(channel_id: str, edges: List[CausalGeometryEdgeV1]) -> Optional[float]:
-    best: Optional[float] = None
-    for edge in edges:
-        if edge.source_id == channel_id or edge.target_id == channel_id:
-            if best is None or abs(edge.strength) > abs(best):
-                best = edge.strength
-    return best
-
-
-def build_divergence(
-    edges: List[CausalGeometryEdgeV1],
-    pair_results: List[PairResult],
-    topology: Dict[str, Any],
-    *,
-    min_samples: int = DEFAULT_MIN_SAMPLES,
-) -> List[CausalGeometryDivergenceEntryV1]:
-    """Compare observed edges against `config/field/orion_field_topology.v1.yaml`.
-
-    See the module docstring's "Designed-vs-observed divergence" section for
-    the full matching rule. Summary: an observed channel's suffix (after the
-    first ':') is checked against every capability channel name used in the
-    YAML's edge channel_maps; an exact string match is treated as a plausible
-    alias. Divergence entries for YAML edges get `#<capability_channel>`
-    appended to target_id to disambiguate the case where two different
-    capability channels point at the same (source_id, target_id) YAML edge.
-    """
-    cap_index = build_capability_channel_index(topology)
-    entries: List[CausalGeometryDivergenceEntryV1] = []
-    consumed_cap_edges: set = set()
-
-    observed_channel_ids = {edge.source_id for edge in edges} | {edge.target_id for edge in edges}
-    for channel_id in sorted(observed_channel_ids):
-        suffix = channel_id.split(":", 1)[1] if ":" in channel_id else channel_id
-        if suffix not in cap_index:
-            continue
-        observed_strength = _best_strength_for_channel(channel_id, edges)
-        for designed_edge in cap_index[suffix]:
-            key = (designed_edge["source_id"], designed_edge["target_id"], suffix)
-            if key in consumed_cap_edges:
-                continue
-            consumed_cap_edges.add(key)
-            designed_weight = designed_edge["weight"]
-            entries.append(
-                CausalGeometryDivergenceEntryV1(
-                    source_id=designed_edge["source_id"],
-                    target_id=f"{designed_edge['target_id']}#{suffix}",
-                    observed_strength=observed_strength,
-                    designed_weight=designed_weight,
-                    delta=(observed_strength - designed_weight) if observed_strength is not None else None,
-                    status="both" if observed_strength is not None else "designed_only",
-                )
-            )
-
-    # Every remaining YAML edge/channel entry with no observed alias at all.
-    for cap_channel, designed_edge_list in cap_index.items():
-        for designed_edge in designed_edge_list:
-            key = (designed_edge["source_id"], designed_edge["target_id"], cap_channel)
-            if key in consumed_cap_edges:
-                continue
-            consumed_cap_edges.add(key)
-            entries.append(
-                CausalGeometryDivergenceEntryV1(
-                    source_id=designed_edge["source_id"],
-                    target_id=f"{designed_edge['target_id']}#{cap_channel}",
-                    observed_strength=None,
-                    designed_weight=designed_edge["weight"],
-                    delta=None,
-                    status="designed_only",
-                )
-            )
-
-    # Significant observed edges whose endpoints don't alias to any capability
-    # channel at all.
-    aliased_channel_ids = {
-        cid
-        for cid in observed_channel_ids
-        if (cid.split(":", 1)[1] if ":" in cid else cid) in cap_index
-    }
-    for edge in edges:
-        if edge.source_id in aliased_channel_ids or edge.target_id in aliased_channel_ids:
-            continue
-        entries.append(
-            CausalGeometryDivergenceEntryV1(
-                source_id=edge.source_id,
-                target_id=edge.target_id,
-                observed_strength=edge.strength,
-                designed_weight=None,
-                delta=None,
-                status="observed_only",
-            )
-        )
-
-    # Pairs that never had enough co-sampled data to test at all.
-    for result in pair_results:
-        if result.n_lag0 < min_samples:
-            entries.append(
-                CausalGeometryDivergenceEntryV1(
-                    source_id=result.channel_a,
-                    target_id=result.channel_b,
-                    observed_strength=None,
-                    designed_weight=None,
-                    delta=None,
-                    status="insufficient_data",
-                )
-            )
-
-    return entries
-
-
-# --- snapshot assembly -------------------------------------------------------
-
-
-def build_snapshot(
-    channels: ChannelSeries,
-    topology: Dict[str, Any],
-    *,
-    window_start: datetime,
-    window_end: datetime,
-    bucket_seconds: int = BUCKET_SECONDS,
-    lag_grid_seconds: Tuple[int, ...] = LAG_GRID_SECONDS,
-    min_samples: int = DEFAULT_MIN_SAMPLES,
-    n_surrogates: int = DEFAULT_N_SURROGATES,
-    alpha: float = DEFAULT_ALPHA,
-    seed: int = DEFAULT_SEED,
-    table_row_counts: Optional[Dict[str, int]] = None,
-) -> Tuple[CausalGeometrySnapshotV1, List[PairResult]]:
-    channel_buckets = {
-        channel_id: bucketize(points, bucket_seconds) for channel_id, points in channels.items()
-    }
-
-    pair_results = compute_pairwise_results(
-        channel_buckets,
-        min_samples=min_samples,
-        n_surrogates=n_surrogates,
-        alpha=alpha,
-        lag_grid_seconds=lag_grid_seconds,
-        bucket_seconds=bucket_seconds,
-        seed=seed,
-    )
-    edges = build_edges(
-        pair_results, window_start=window_start, window_end=window_end, bucket_seconds=bucket_seconds
-    )
-    divergence = build_divergence(edges, pair_results, topology, min_samples=min_samples)
-
-    notes: List[str] = []
-    if table_row_counts:
-        for table_name, row_count in table_row_counts.items():
-            if row_count == 0:
-                notes.append(
-                    f"source table {table_name!r} returned 0 rows in the requested window -- "
-                    "every channel it would have contributed is absent from this snapshot, "
-                    "not silently zero-valued."
-                )
-    n_pairs_tested = len(pair_results)
-    n_insufficient = sum(1 for r in pair_results if r.n_lag0 < min_samples)
-    n_pairs_with_data = n_pairs_tested - n_insufficient
-    notes.append(
-        f"{len(channels)} channels, {n_pairs_tested} channel pairs considered, "
-        f"{n_insufficient} below --min-samples={min_samples}, "
-        f"{n_pairs_with_data} tested for significance, {len(edges)} significant edges found."
-    )
-    insufficient_data = len(edges) == 0
-    if insufficient_data:
-        if n_pairs_with_data == 0:
-            notes.append(
-                "No channel pair had enough co-sampled data to test at all -- widen "
-                "--window-hours, lower --min-samples, or check that the source tables "
-                "actually have rows in the requested window."
-            )
-        else:
-            notes.append(
-                f"{n_pairs_with_data} pair(s) had enough data to test but none cleared "
-                f"--alpha={alpha} after {n_surrogates} circular-shift surrogates each -- "
-                "this is reported honestly as insufficient_data rather than a fabricated graph."
-            )
-
-    snapshot = CausalGeometrySnapshotV1(
-        snapshot_id=str(uuid.uuid4()),
-        generated_at=datetime.now(timezone.utc),
-        window_start=window_start,
-        window_end=window_end,
-        edges=edges,
-        designed_topology_version=topology.get("schema_version"),
-        divergence=divergence,
-        insufficient_data=insufficient_data,
-        notes=notes,
-    )
-    return snapshot, pair_results
 
 
 # --- CLI ---------------------------------------------------------------------
@@ -923,4 +359,4 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())

--- a/scripts/causal_geometry_report.py
+++ b/scripts/causal_geometry_report.py
@@ -13,10 +13,15 @@ fetch, resampling, lagged correlation, surrogate significance, divergence) has
 moved to `orion/substrate/causal_geometry_engine.py`, an importable module, so
 `orion/substrate/causal_geometry_producer.py` (called periodically from
 `services/orion-field-digester/app/worker.py`) can call the exact same code
-this CLI uses instead of duplicating it. This file re-exports every engine
-name it previously defined, so existing callers/tests of this module are
-unaffected. What remains here is CLI-only: argument parsing and human/JSON
-output formatting.
+this CLI uses instead of duplicating it. This file re-exports the engine
+names actually needed by its own CLI code and by
+tests/test_causal_geometry_report.py, so existing callers/tests of this
+module are unaffected -- names the engine module defines but nothing outside
+it ever referenced (e.g. `PairResult`, `build_edges`, `build_divergence`,
+`compute_pairwise_results`) are not re-exported here; import them directly
+from `orion.substrate.causal_geometry_engine` if a future caller needs them.
+What remains here is CLI-only: argument parsing and human/JSON output
+formatting.
 
 What this measures
 -------------------
@@ -182,23 +187,11 @@ from orion.substrate.causal_geometry_engine import (  # noqa: E402,F401
     DEFAULT_POSTGRES_URI,
     DEFAULT_SEED,
     DEFAULT_WINDOW_HOURS,
-    LAG_GRID_SECONDS,
-    ChannelPoints,
-    ChannelSeries,
-    DirectionResult,
-    PairResult,
-    _aligned_arrays,
-    _best_direction,
-    _best_strength_for_channel,
-    _bucket_idx_to_datetime,
     _pearson,
     build_capability_channel_index,
-    build_divergence,
-    build_edges,
     build_snapshot,
     bucketize,
     circular_shift_pvalue,
-    compute_pairwise_results,
     fetch_channels,
     load_field_topology,
 )

--- a/services/orion-field-digester/.env_example
+++ b/services/orion-field-digester/.env_example
@@ -70,6 +70,23 @@ FIELD_PLASTICITY_DECAY_HALF_LIFE_HOURS=168
 # adopting a proposal via the orion-hub tab will NOT be visible here, since hub and
 # field-digester are separate containers with separate in-memory stores. Must be set
 # to the SAME path as orion-hub's FIELD_PLASTICITY_SQL_DB_PATH, on a volume mounted
-# into both containers (e.g. under the shared ${TELEMETRY_ROOT:-/mnt/telemetry} mount
-# this service already uses), for cross-process adoption to actually reach diffusion.
-FIELD_PLASTICITY_SQL_DB_PATH=
+# into both containers, for cross-process adoption to actually reach diffusion.
+# Lives on the same durable disk as Postgres (${STORAGE_ROOT:-/mnt/postgres}, see root
+# .env_example), in a sibling directory -- never inside postgres_data itself -- so this
+# small, low-write-volume sqlite file doesn't depend on ephemeral container storage or
+# an unrelated volume's retention/rotation policy.
+FIELD_PLASTICITY_SQL_DB_PATH=${STORAGE_ROOT:-/mnt/postgres}/field_topology/learned_weights.sqlite3
+# Scheduled Phase A -> Phase B producer (orion/substrate/causal_geometry_producer.py):
+# periodically measures observed-vs-designed field topology and enqueues new HITL
+# proposals. Independent of FIELD_PLASTICITY_ENABLED above (that one gates *consuming*
+# the learned overlay in diffusion; this one gates *producing* proposals into the
+# queue). Off by default -- an operator must opt in explicitly.
+FIELD_PLASTICITY_PRODUCER_ENABLED=false
+# Cadence in hours between production cycles. 24h matches the design spec's
+# "deterministic nightly job" framing -- this is a full Postgres pull plus
+# O(channels^2) lagged-correlation + surrogate-significance computation, not
+# something to run on this service's own ~2s tick cadence.
+FIELD_PLASTICITY_PRODUCER_INTERVAL_HOURS=24
+# Lookback window in hours for each production cycle. Matches
+# orion/substrate/causal_geometry_engine.py's DEFAULT_WINDOW_HOURS (168h / 7 days).
+FIELD_PLASTICITY_PRODUCER_WINDOW_HOURS=168

--- a/services/orion-field-digester/.env_example
+++ b/services/orion-field-digester/.env_example
@@ -71,11 +71,19 @@ FIELD_PLASTICITY_DECAY_HALF_LIFE_HOURS=168
 # field-digester are separate containers with separate in-memory stores. Must be set
 # to the SAME path as orion-hub's FIELD_PLASTICITY_SQL_DB_PATH, on a volume mounted
 # into both containers, for cross-process adoption to actually reach diffusion.
-# Lives on the same durable disk as Postgres (${STORAGE_ROOT:-/mnt/postgres}, see root
-# .env_example), in a sibling directory -- never inside postgres_data itself -- so this
-# small, low-write-volume sqlite file doesn't depend on ephemeral container storage or
-# an unrelated volume's retention/rotation policy.
-FIELD_PLASTICITY_SQL_DB_PATH=${STORAGE_ROOT:-/mnt/postgres}/field_topology/learned_weights.sqlite3
+#
+# This is a CONTAINER-internal path, always /mnt/postgres/field_topology/... regardless
+# of where the backing host directory actually lives -- do NOT template this with
+# ${STORAGE_ROOT}. STORAGE_ROOT is a HOST-side setting (see root .env_example, and this
+# file's docker-compose.yml volume mount: "${STORAGE_ROOT:-/mnt/postgres}/field_topology
+# :/mnt/postgres/field_topology" -- the container-side target after the ':' is fixed).
+# An earlier version of this default templated the app-visible value with
+# ${STORAGE_ROOT} too, which happened to work only because the default host and
+# container paths are textually identical -- overriding STORAGE_ROOT to a different
+# disk would have pointed this env var at a host path that doesn't exist inside either
+# container, silently degrading both to disconnected in-memory stores. Fixed to a
+# literal container path so it's correct regardless of what STORAGE_ROOT resolves to.
+FIELD_PLASTICITY_SQL_DB_PATH=/mnt/postgres/field_topology/learned_weights.sqlite3
 # Scheduled Phase A -> Phase B producer (orion/substrate/causal_geometry_producer.py):
 # periodically measures observed-vs-designed field topology and enqueues new HITL
 # proposals. Independent of FIELD_PLASTICITY_ENABLED above (that one gates *consuming*

--- a/services/orion-field-digester/app/digestion/diffusion.py
+++ b/services/orion-field-digester/app/digestion/diffusion.py
@@ -43,7 +43,7 @@ def _plasticity_enabled() -> bool:
     return str(os.getenv(FIELD_PLASTICITY_ENABLED_ENV, "false")).strip().lower() in _TRUTHY
 
 
-def _get_learned_store():
+def get_learned_store():
     """Lazily construct (once, not per-tick) the shared
     `FieldTopologyLearnedWeightsStore`, backed by `FIELD_PLASTICITY_SQL_DB_PATH` when
     set so adoptions made in the hub process are actually visible here.
@@ -51,6 +51,11 @@ def _get_learned_store():
     Constructing this once and caching it (rather than fresh per `apply_diffusion`
     call) avoids reconnecting + reloading the sqlite file on every diffusion tick for
     state that only changes on a rare HITL adopt/reject action.
+
+    Public (not `_`-prefixed): `app/worker.py`'s causal-geometry producer loop
+    calls this too, so the read side (this module) and the write side (the
+    producer's `store.propose()`) share one store instance/sqlite connection
+    within this process instead of each opening their own.
     """
     global _LEARNED_STORE
     if _LEARNED_STORE is None:
@@ -75,7 +80,7 @@ def _load_learned_overlay() -> dict[str, float]:
     designed weight, exactly as if `FIELD_PLASTICITY_ENABLED` were off.
     """
     try:
-        return _get_learned_store().current_overlay()
+        return get_learned_store().current_overlay()
     except Exception as exc:  # pragma: no cover - defensive, see docstring above
         logger.warning("field_plasticity_overlay_load_failed: %s", exc, exc_info=True)
         return {}

--- a/services/orion-field-digester/app/digestion/diffusion.py
+++ b/services/orion-field-digester/app/digestion/diffusion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from datetime import datetime, timezone
 
 from orion.schemas.field_state import FieldStateV1
@@ -21,11 +22,21 @@ FIELD_PLASTICITY_ENABLED_ENV = "FIELD_PLASTICITY_ENABLED"
 # Must resolve to the same file the hub's CAUSAL_GEOMETRY_PROPOSAL_STORE writes to
 # (services/orion-hub/scripts/api_routes.py) -- an operator's HITL adopt() only ever
 # reaches this process's diffusion tick if both processes point at the same sqlite
-# file. Unset (the .env_example default) means "in-memory, this process only" -- the
-# overlay will never see a cross-process adoption, matching pre-plasticity behavior.
+# file. Defaults (.env_example) to a real shared path on the same disk as Postgres;
+# unset/empty means "in-memory, this process only" -- the overlay will never see a
+# cross-process adoption, matching pre-plasticity behavior.
 FIELD_PLASTICITY_SQL_DB_PATH_ENV = "FIELD_PLASTICITY_SQL_DB_PATH"
 
-_LEARNED_STORE = None  # lazily constructed once; see _get_learned_store()
+_LEARNED_STORE = None  # lazily constructed once; see get_learned_store()
+# Guards first-construction of _LEARNED_STORE: app/worker.py's poll loop
+# (_load_learned_overlay, via apply_diffusion) and its causal-geometry producer
+# loop both call get_learned_store() from their own asyncio.to_thread thread, so
+# on cold start both can race the "if _LEARNED_STORE is None" check below before
+# either assigns. Without this lock that race would construct the store twice
+# (wasted, self-healing work, not a correctness bug -- __post_init__ doesn't hold
+# an open connection between calls) but still violates this function's own
+# "constructed once" contract.
+_LEARNED_STORE_LOCK = threading.Lock()
 
 # cap->cap edges only, per the Causal Geometry v1 design spec (Phase B) --
 # node_capability/node_service/etc. edges never consult the learned overlay,
@@ -59,12 +70,14 @@ def get_learned_store():
     """
     global _LEARNED_STORE
     if _LEARNED_STORE is None:
-        from orion.substrate.field_topology_learned_store import (
-            FieldTopologyLearnedWeightsStore,
-        )
+        with _LEARNED_STORE_LOCK:
+            if _LEARNED_STORE is None:  # re-check: another thread may have won the race
+                from orion.substrate.field_topology_learned_store import (
+                    FieldTopologyLearnedWeightsStore,
+                )
 
-        sql_db_path = str(os.getenv(FIELD_PLASTICITY_SQL_DB_PATH_ENV, "")).strip() or None
-        _LEARNED_STORE = FieldTopologyLearnedWeightsStore(sql_db_path=sql_db_path)
+                sql_db_path = str(os.getenv(FIELD_PLASTICITY_SQL_DB_PATH_ENV, "")).strip() or None
+                _LEARNED_STORE = FieldTopologyLearnedWeightsStore(sql_db_path=sql_db_path)
     return _LEARNED_STORE
 
 

--- a/services/orion-field-digester/app/settings.py
+++ b/services/orion-field-digester/app/settings.py
@@ -58,6 +58,26 @@ class Settings(BaseSettings):
     corpus_sink_max_bytes: int = Field(200_000_000, ge=1_000_000, alias="CORPUS_SINK_MAX_BYTES")
     corpus_sink_rotated_keep: int = Field(5, ge=0, alias="CORPUS_SINK_ROTATED_KEEP")
 
+    # Causal Geometry v1 follow-up: the scheduled Phase A -> Phase B producer
+    # (orion/substrate/causal_geometry_producer.py, run from
+    # app/worker.py's _causal_geometry_producer_loop). Independent of
+    # FIELD_PLASTICITY_ENABLED (which gates *consuming* the learned overlay in
+    # diffusion) -- this gates *producing* proposals into the HITL queue.
+    # Off by default: an operator must opt in explicitly, same posture as
+    # every other plasticity flag in this file.
+    field_plasticity_producer_enabled: bool = Field(False, alias="FIELD_PLASTICITY_PRODUCER_ENABLED")
+    # 24h: matches the design spec's "deterministic nightly job" framing for
+    # Phase A. This is a full Postgres pull + O(channels^2) lagged-correlation
+    # + surrogate-significance computation, not something to run on the
+    # digester's own ~2s tick cadence.
+    field_plasticity_producer_interval_hours: float = Field(
+        24.0, alias="FIELD_PLASTICITY_PRODUCER_INTERVAL_HOURS"
+    )
+    # Matches causal_geometry_engine.DEFAULT_WINDOW_HOURS (168h / 7 days).
+    field_plasticity_producer_window_hours: float = Field(
+        168.0, alias="FIELD_PLASTICITY_PRODUCER_WINDOW_HOURS"
+    )
+
 
 _settings: Settings | None = None
 

--- a/services/orion-field-digester/app/worker.py
+++ b/services/orion-field-digester/app/worker.py
@@ -10,6 +10,7 @@ from orion.schemas.telemetry.field_channel_corpus import FieldChannelCorpusRowV1
 from orion.self_state.scoring import collect_field_channel_pressures
 from orion.telemetry.corpus_sink import InnerStateCorpusSink
 
+from app.digestion.diffusion import get_learned_store
 from app.graph.lattice import load_lattice
 from app.health_monitor import HealthMonitor
 from app.ingest.state_deltas import Perturbation, delta_to_perturbations
@@ -18,6 +19,7 @@ from app.store import FieldDigesterStore, PendingDelta
 from app.tensor.field_state import empty_field_state, new_tick_id
 from app.tensor.reconcile import reconcile_field_state_with_lattice
 from app.tensor.update_rules import run_digestion_tick
+from orion.substrate.causal_geometry_producer import run_causal_geometry_production_cycle
 
 logger = logging.getLogger("orion.field.digester")
 
@@ -46,6 +48,9 @@ class FieldDigesterWorker:
         asyncio.create_task(self._poll_loop(), name="field-digester-poll")
         asyncio.create_task(self._prune_loop(), name="field-digester-prune")
         asyncio.create_task(self._health_loop(), name="field-digester-health")
+        asyncio.create_task(
+            self._causal_geometry_producer_loop(), name="field-digester-causal-geometry-producer"
+        )
 
     async def stop(self) -> None:
         self._stop.set()
@@ -94,6 +99,50 @@ class FieldDigesterWorker:
                 await asyncio.wait_for(
                     self._stop.wait(),
                     timeout=float(self._settings.field_state_prune_interval_sec),
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    def _causal_geometry_producer_tick(self) -> None:
+        if not self._settings.field_plasticity_producer_enabled:
+            return
+        result = run_causal_geometry_production_cycle(
+            postgres_uri=self._settings.postgres_uri,
+            topology_path=self._settings.lattice_path,
+            field_edges=self._lattice.edges,
+            store=get_learned_store(),
+            window_hours=self._settings.field_plasticity_producer_window_hours,
+        )
+        if result["ok"]:
+            logger.info(
+                "causal_geometry_production_cycle_completed snapshot_id=%s "
+                "insufficient_data=%s candidates_found=%d proposals_created=%d "
+                "proposals_skipped_pending_duplicate=%d",
+                result["snapshot_id"],
+                result["insufficient_data"],
+                result["candidates_found"],
+                result["proposals_created"],
+                result["proposals_skipped_pending_duplicate"],
+            )
+        else:
+            logger.warning(
+                "causal_geometry_production_cycle_failed stage=%s error=%s",
+                result["stage"],
+                result["error"],
+            )
+
+    async def _causal_geometry_producer_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await asyncio.to_thread(self._causal_geometry_producer_tick)
+            except Exception:
+                logger.exception("field_digester_causal_geometry_producer_tick_failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=float(self._settings.field_plasticity_producer_interval_hours) * 3600.0,
                 )
             except asyncio.TimeoutError:
                 continue

--- a/services/orion-field-digester/docker-compose.yml
+++ b/services/orion-field-digester/docker-compose.yml
@@ -38,6 +38,9 @@ services:
       - FIELD_PLASTICITY_MAX_DRIFT=${FIELD_PLASTICITY_MAX_DRIFT:-0.15}
       - FIELD_PLASTICITY_DECAY_HALF_LIFE_HOURS=${FIELD_PLASTICITY_DECAY_HALF_LIFE_HOURS:-168}
       - FIELD_PLASTICITY_SQL_DB_PATH=${FIELD_PLASTICITY_SQL_DB_PATH:-}
+      - FIELD_PLASTICITY_PRODUCER_ENABLED=${FIELD_PLASTICITY_PRODUCER_ENABLED:-false}
+      - FIELD_PLASTICITY_PRODUCER_INTERVAL_HOURS=${FIELD_PLASTICITY_PRODUCER_INTERVAL_HOURS:-24}
+      - FIELD_PLASTICITY_PRODUCER_WINDOW_HOURS=${FIELD_PLASTICITY_PRODUCER_WINDOW_HOURS:-168}
 
     volumes:
       # FIELD_CHANNEL_CORPUS_PATH defaults under /mnt/telemetry (same host
@@ -45,6 +48,11 @@ services:
       # paths) -- without this mount the path resolves inside the
       # container's ephemeral filesystem and silently vanishes on restart.
       - ${TELEMETRY_ROOT:-/mnt/telemetry}:/mnt/telemetry
+      # FIELD_PLASTICITY_SQL_DB_PATH lives on the same disk as Postgres (a
+      # sibling directory to postgres_data, never inside it) -- shared with
+      # orion-hub's identical mount below so both containers see the same
+      # sqlite file.
+      - ${STORAGE_ROOT:-/mnt/postgres}/field_topology:/mnt/postgres/field_topology
 
 networks:
   app-net:

--- a/services/orion-field-digester/requirements.txt
+++ b/services/orion-field-digester/requirements.txt
@@ -4,5 +4,6 @@ pydantic==2.10.3
 pydantic-settings==2.6.1
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
+numpy==1.26.4
 PyYAML==6.0.2
 requests==2.31.0

--- a/services/orion-field-digester/tests/test_worker_causal_geometry_producer.py
+++ b/services/orion-field-digester/tests/test_worker_causal_geometry_producer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import app.worker as worker_module
+from app.worker import FieldDigesterWorker
+
+
+def _make_worker(monkeypatch, *, producer_enabled: str = "false") -> FieldDigesterWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused/unused")
+    monkeypatch.setenv("FIELD_PLASTICITY_PRODUCER_ENABLED", producer_enabled)
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+
+    worker = FieldDigesterWorker.__new__(FieldDigesterWorker)
+    worker._settings = settings_mod.get_settings()
+    worker._lattice = MagicMock(edges=["fake-edge-1", "fake-edge-2"])
+    return worker
+
+
+def test_producer_tick_is_a_noop_when_disabled(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch, producer_enabled="false")
+    mock_cycle = MagicMock()
+    monkeypatch.setattr(worker_module, "run_causal_geometry_production_cycle", mock_cycle)
+    monkeypatch.setattr(worker_module, "get_learned_store", MagicMock())
+
+    worker._causal_geometry_producer_tick()
+
+    mock_cycle.assert_not_called()
+
+
+def test_producer_tick_calls_production_cycle_with_expected_args_when_enabled(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch, producer_enabled="true")
+    mock_cycle = MagicMock(
+        return_value={
+            "ok": True,
+            "snapshot_id": "snap-1",
+            "insufficient_data": False,
+            "candidates_found": 2,
+            "proposals_created": 1,
+            "proposals_skipped_pending_duplicate": 1,
+        }
+    )
+    monkeypatch.setattr(worker_module, "run_causal_geometry_production_cycle", mock_cycle)
+    mock_store = MagicMock(name="learned-store")
+    monkeypatch.setattr(worker_module, "get_learned_store", lambda: mock_store)
+
+    worker._causal_geometry_producer_tick()
+
+    mock_cycle.assert_called_once()
+    kwargs = mock_cycle.call_args.kwargs
+    assert kwargs["postgres_uri"] == worker._settings.postgres_uri
+    assert kwargs["topology_path"] == worker._settings.lattice_path
+    assert kwargs["field_edges"] == worker._lattice.edges
+    assert kwargs["store"] is mock_store
+    assert kwargs["window_hours"] == worker._settings.field_plasticity_producer_window_hours
+
+
+def test_producer_tick_never_raises_on_a_failed_cycle(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch, producer_enabled="true")
+    monkeypatch.setattr(
+        worker_module,
+        "run_causal_geometry_production_cycle",
+        MagicMock(
+            return_value={
+                "ok": False,
+                "stage": "measurement",
+                "error": "postgres unreachable",
+                "snapshot_id": None,
+                "insufficient_data": None,
+                "candidates_found": 0,
+                "proposals_created": 0,
+                "proposals_skipped_pending_duplicate": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(worker_module, "get_learned_store", MagicMock())
+
+    # Must not raise.
+    worker._causal_geometry_producer_tick()

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -437,10 +437,20 @@ SUBSTRATE_MUTATION_OPERATOR_TOKEN=
 # in-memory only, this process only -- adopting a proposal here will NOT reach
 # orion-field-digester's diffusion tick. Must be set to the SAME path as
 # orion-field-digester's FIELD_PLASTICITY_SQL_DB_PATH, on a volume mounted into both
-# containers, for an adoption to actually take effect. Lives on the same durable disk
-# as Postgres (${STORAGE_ROOT:-/mnt/postgres}, see root .env_example), in a sibling
-# directory -- never inside postgres_data itself.
-FIELD_PLASTICITY_SQL_DB_PATH=${STORAGE_ROOT:-/mnt/postgres}/field_topology/learned_weights.sqlite3
+# containers, for an adoption to actually take effect.
+#
+# This is a CONTAINER-internal path, always /mnt/postgres/field_topology/... regardless
+# of where the backing host directory actually lives -- do NOT template this with
+# ${STORAGE_ROOT}. STORAGE_ROOT is a HOST-side setting (see root .env_example, and this
+# file's docker-compose.yml volume mount: "${STORAGE_ROOT:-/mnt/postgres}/field_topology
+# :/mnt/postgres/field_topology" -- the container-side target after the ':' is fixed).
+# An earlier version of this default templated the app-visible value with
+# ${STORAGE_ROOT} too, which happened to work only because the default host and
+# container paths are textually identical -- overriding STORAGE_ROOT to a different
+# disk would have pointed this env var at a host path that doesn't exist inside either
+# container, silently degrading both to disconnected in-memory stores. Fixed to a
+# literal container path so it's correct regardless of what STORAGE_ROOT resolves to.
+FIELD_PLASTICITY_SQL_DB_PATH=/mnt/postgres/field_topology/learned_weights.sqlite3
 
 # --- Substrate semantic graph (Fuseki / SPARQL or legacy GraphDB) ---
 # RDF Store V1: Hub docker-compose defaults SUBSTRATE_STORE_BACKEND=sparql with Athena Fuseki URLs; override for host mode (127.0.0.1).

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -437,8 +437,10 @@ SUBSTRATE_MUTATION_OPERATOR_TOKEN=
 # in-memory only, this process only -- adopting a proposal here will NOT reach
 # orion-field-digester's diffusion tick. Must be set to the SAME path as
 # orion-field-digester's FIELD_PLASTICITY_SQL_DB_PATH, on a volume mounted into both
-# containers, for an adoption to actually take effect.
-FIELD_PLASTICITY_SQL_DB_PATH=
+# containers, for an adoption to actually take effect. Lives on the same durable disk
+# as Postgres (${STORAGE_ROOT:-/mnt/postgres}, see root .env_example), in a sibling
+# directory -- never inside postgres_data itself.
+FIELD_PLASTICITY_SQL_DB_PATH=${STORAGE_ROOT:-/mnt/postgres}/field_topology/learned_weights.sqlite3
 
 # --- Substrate semantic graph (Fuseki / SPARQL or legacy GraphDB) ---
 # RDF Store V1: Hub docker-compose defaults SUBSTRATE_STORE_BACKEND=sparql with Athena Fuseki URLs; override for host mode (127.0.0.1).

--- a/services/orion-hub/docker-compose.yml
+++ b/services/orion-hub/docker-compose.yml
@@ -33,11 +33,12 @@ services:
       - ${HUB_AGENT_CLAUDE_BIN_HOST:-${HOME}/.local/bin/claude}:/usr/local/bin/claude:ro
       - /var/run/docker.sock:/var/run/docker.sock
       #- /mnt/telemetry/models/whisper/${WHISPER_MODEL_SIZE}:/root/.cache/huggingface/hub/models--distil-whisper--${WHISPER_MODEL_SIZE}
-      # Same host mount orion-field-digester already uses for FIELD_CHANNEL_CORPUS_PATH --
-      # shared here so FIELD_PLASTICITY_SQL_DB_PATH can point both containers at one sqlite
-      # file (otherwise a Causal Geometry proposal adopted in this container is invisible
-      # to orion-field-digester's diffusion tick, which runs in a separate container).
-      - ${TELEMETRY_ROOT:-/mnt/telemetry}:/mnt/telemetry
+      # FIELD_PLASTICITY_SQL_DB_PATH lives on the same disk as Postgres (a sibling
+      # directory to postgres_data, never inside it), shared with orion-field-digester's
+      # identical mount so both containers see the same sqlite file -- otherwise a Causal
+      # Geometry proposal adopted in this container is invisible to orion-field-digester's
+      # diffusion tick, which runs in a separate container.
+      - ${STORAGE_ROOT:-/mnt/postgres}/field_topology:/mnt/postgres/field_topology
     environment:
       # Core service identity
       - PROJECT=${PROJECT}


### PR DESCRIPTION
## Summary

Follow-up to #1087. That PR shipped Phase A (measurement) and Phase B (bounded, HITL-gated plasticity) but left one documented gap: nothing ever scheduled a producer to call `propose_field_topology_patches()`/`store.propose()` in production, so the HITL queue stayed permanently empty. This PR closes that gap, and also fixes the learned-weights store's persistence path per operator direction (shared disk alongside Postgres, not `/mnt/telemetry`).

- Extracted Phase A's core logic into an importable module (`orion/substrate/causal_geometry_engine.py`) so it isn't duplicated between the CLI script and the new producer.
- Added `orion/substrate/causal_geometry_producer.py`: measures a snapshot, proposes candidates, enqueues only non-duplicates.
- Wired a new scheduled loop into `orion-field-digester`'s worker (off by default, `FIELD_PLASTICITY_PRODUCER_ENABLED=false`, 24h cadence).
- Fixed `FIELD_PLASTICITY_SQL_DB_PATH` to a real default on `/mnt/postgres/field_topology` (shared with Postgres's disk), replacing the earlier empty/in-memory-only default.
- 8-parallel-angle code review found and fixed 5 real issues, most notably an intra-cycle proposal-dedup bug (reproduced live by one review angle) and a `STORAGE_ROOT`-templating bug that would have silently broken cross-process store sharing the moment an operator relocated Postgres's disk (also empirically verified by 2 review angles).

Full report (required by this repo's convention that PR reports are committed files): `docs/superpowers/pr-reports/2026-07-16-causal-geometry-producer-wiring-pr.md`

## Test plan

- [x] `orion/substrate/tests` + `orion/schemas/tests` + `tests/test_causal_geometry_report.py`: 333 passed
- [x] `services/orion-field-digester/tests` (own dir): 63 passed
- [x] `services/orion-hub/tests/test_causal_geometry_{api,page}.py`: 22 passed
- [x] `docker compose config` validated for both services, including under an overridden `STORAGE_ROOT` (confirms the review-fix)
- [x] `docker compose build` clean for both services
- [ ] Live deploy + verification (planned as a follow-up action after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)