### PR TITLE
chore(hub): sync .env_example SUBSTRATE_STORE_BACKEND with live in_memory override

### DIFF
--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -456,7 +456,12 @@ FIELD_PLASTICITY_SQL_DB_PATH=/mnt/postgres/field_topology/learned_weights.sqlite
 # RDF Store V1: Hub docker-compose defaults SUBSTRATE_STORE_BACKEND=sparql with Athena Fuseki URLs; override for host mode (127.0.0.1).
 # Query/update URLs fall back to RDF_STORE_QUERY_URL / RDF_STORE_UPDATE_URL when SUBSTRATE_GRAPH_* are unset.
 # With HUB_DOCKER_NETWORK_MODE=host, use 127.0.0.1 + published Fuseki port (3030), not Docker service DNS.
-SUBSTRATE_STORE_BACKEND=sparql
+# TEMP (2026-07-16): concept-atlas pipeline is proving out on in-memory storage first
+# (see orion/substrate/seed.py, orion/substrate/adapters/topic_foundry.py). The
+# SUBSTRATE_GRAPH_QUERY_URL/UPDATE_URL below also have a real host-vs-container-DNS
+# mismatch (use orion-athena-fuseki, should be 127.0.0.1 per the comment above) that
+# needs fixing before switching back to sparql -- tracked as tech debt, not yet fixed.
+SUBSTRATE_STORE_BACKEND=in_memory
 SUBSTRATE_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
 SUBSTRATE_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
 SUBSTRATE_GRAPH_URI=http://conjourney.net/graph/substrate


### PR DESCRIPTION
## Summary

- `.env_example` still documented `SUBSTRATE_STORE_BACKEND=sparql` even though the live Hub `.env` was switched to `in_memory` earlier today to prove out the concept-atlas pipeline (#1079, #1086) before migrating to a persistent GraphDB/Fuseki backend.
- `.env_example` is this repo's operator contract — it needs to reflect what's actually running, not just the original long-term intent, or the next person/agent reading it gets misled.

## Outcome moved

Closes the drift Juniper flagged directly: live config and the checked-in example had diverged after a manual production `.env` edit.

## Files changed

- `services/orion-hub/.env_example`: `SUBSTRATE_STORE_BACKEND` value updated to `in_memory`, with an inline comment explaining this is temporary (tracked as tech debt to migrate back to GraphDB) and documenting the real `SUBSTRATE_GRAPH_QUERY_URL`/`UPDATE_URL` host-vs-container-DNS mismatch found while live-debugging this pipeline (not fixed in this patch).

## Schema / bus / API changes

None — comment and value change only, no key added/removed/renamed.

## Env/config changes

- No keys added/removed/renamed.
- `.env_example` updated: yes (this is the fix).
- Local `.env` synced: the live Hub `.env` already has `in_memory` (set directly, earlier today); this patch brings `.env_example` in line with it, not the other way around.

## Tests run

Not applicable — comment/value-only change to an env template file, no code touched. No env-parity check script exists in this repo (`scripts/check_env_template_parity.py` referenced in `AGENTS.md` isn't actually present) to run automatically.

## Restart required

None — this only affects `.env_example` (the template), not the live running `.env` or the Hub container.

## Risks / concerns

- Severity: low
- Concern: a fresh deployment following `.env_example` will now also default to `in_memory` rather than the originally-intended `sparql`/Fuseki-backed store, until the tracked GraphDB migration happens.
- Mitigation: this matches the actual current state of the live deployment; the inline comment makes the temporary nature and the still-open Fuseki hostname bug explicit for whoever picks up the migration.

## PR link

(filled in after creation)