### PR TITLE
fix: correct stale defaults in topic-foundry smoke script

### DIFF
--- a/services/orion-topic-foundry/scripts/smoke_topic_foundry_train_and_poll.sh
+++ b/services/orion-topic-foundry/scripts/smoke_topic_foundry_train_and_poll.sh
@@ -12,10 +12,10 @@ SLEEP_SECS=${SLEEP_SECS:-2}
 MAX_CHARS=${MAX_CHARS:-6000}
 
 SOURCE_TABLE=${SOURCE_TABLE:-chat_history_log}
-ID_COLUMN=${ID_COLUMN:-chat_id}
+ID_COLUMN=${ID_COLUMN:-correlation_id}
 TIME_COLUMN=${TIME_COLUMN:-created_at}
 TEXT_COLUMNS=${TEXT_COLUMNS:-prompt,response}
-EMBEDDING_URL=${EMBEDDING_URL:-"http://orion-vector-host:8320/embedding"}
+EMBEDDING_URL=${EMBEDDING_URL:-"http://orion-athena-vector-host:8320/embedding"}
 MODEL_NAME=${MODEL_NAME:-topic-foundry}
 MODEL_VERSION=${MODEL_VERSION:-v1}
 
@@ -62,7 +62,7 @@ if [[ -z "$MODEL_ID" ]]; then
         algorithm: "hdbscan",
         embedding_source_url: $embedding_url,
         min_cluster_size: 15,
-        metric: "cosine",
+        metric: "euclidean",
         params: {}
       },
       windowing_spec: {


### PR DESCRIPTION
## Summary

Three confirmed-live-broken stale defaults in `services/orion-topic-foundry/scripts/smoke_topic_foundry_train_and_poll.sh`, all root-caused via live debugging earlier this session (not guessed):

1. `ID_COLUMN` defaulted to `chat_id` — no such column on `chat_history_log` (confirmed via `\d chat_history_log`; the real columns are `id`/`correlation_id`). Fixed to `correlation_id`, matching every dataset ever successfully registered.
2. `EMBEDDING_URL` defaulted to `http://orion-vector-host:8320/embedding` — wrong hostname for this node's `orion-athena-*` container naming. Fixed to `http://orion-athena-vector-host:8320/embedding`, matching the service's own env default.
3. Hardcoded `"metric": "cosine"` in the `/models` payload — HDBSCAN doesn't accept this directly, produces a live `"Unrecognized metric 'cosine'"` error. Fixed to `"euclidean"`, matching the service's own settings default and README guidance.

## Outcome moved

All three bugs are confirmed fixed end-to-end via a live run against the running `orion-athena-topic-foundry` service: dataset registration, embedding calls, and HDBSCAN training all now succeed with pure default env vars (previously all three failed in sequence).

## Files changed

- `services/orion-topic-foundry/scripts/smoke_topic_foundry_train_and_poll.sh`: 3 default values corrected, nothing structural changed

## Tests run

Live verification against the real running service (not a mock):
```
run_id: 90193cae-a2dc-4211-ad14-a0fce85ea9cb
status: complete, stage: trained
docs_generated=93, segment_count=93, cluster_count=0, outlier_pct=1.0
```

## Risks / concerns

- Severity: informational, not a defect in this patch
- Concern: with the script's default 30-day window, only 93 docs were found, and HDBSCAN (`min_cluster_size=15`) treated all of them as outliers — the run still fails the script's own `cluster_count <= 1` threshold check, even though all three targeted bugs are fixed. This is a live data-availability/clustering-parameter question, not something this patch silently papered over by widening the window.
- Mitigation: reporting as-is for a decision — either lower `min_cluster_size` for sparse windows, or accept a wider default `START_AT`, or treat "smoke passes cleanly against the last 30 days" as not yet expected given current chat volume. Not resolved in this patch.

## PR link

(filled in after creation)