### PR TITLE
feat(hub): wire topic-foundry ingestion into Concept Atlas

### DIFF
--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -25,6 +25,9 @@ from typing import Any, Optional
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
+from .settings import settings
+from .topic_foundry_client import TopicFoundryClientError, fetch_run_topics_and_keywords
+
 logger = logging.getLogger("orion-hub.concept_atlas")
 
 router = APIRouter(tags=["concept-atlas"])
@@ -294,6 +297,132 @@ async def concept_atlas_network(
         "truncated": bool(result.truncated),
         "degraded": degraded,
         "degraded_error": getattr(result, "error", None) if degraded else None,
+    }
+
+
+@router.post("/api/substrate/concepts/ingest-topic-foundry")
+def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
+    """Operator-triggered, on-demand ingestion of topic-foundry's latest completed run.
+
+    Deliberately a sync ``def`` (not ``async def``): the underlying HTTP calls
+    use the blocking ``requests`` library (see ``topic_foundry_client.py``),
+    and FastAPI runs sync route handlers in a worker thread pool automatically
+    -- an ``async def`` wrapper here would block the event loop for the
+    duration of every topic-foundry round trip instead.
+
+    Fetches the latest completed run + its topics + per-topic keywords from
+    topic-foundry over HTTP, converts them via
+    ``orion.substrate.adapters.topic_foundry.map_topic_foundry_run_to_substrate``,
+    and writes the resulting concept/evidence nodes and edges into the shared
+    ``SUBSTRATE_SEMANTIC_STORE``.
+
+    This is a manual trigger only -- not wired into Hub's startup event or any
+    scheduler, mirroring ``/api/substrate/review-runtime/debug-run``'s shape
+    (operator-triggered multi-step pipeline, not an automatic background job).
+    Every failure mode below degrades to an honest, non-500 response rather
+    than fabricating a success result.
+
+    Scoping note: ``segment_topic_map`` is passed as empty in this first cut,
+    so no ``co_occurs_with`` co-occurrence edges are produced yet -- only
+    concept nodes (+ backing evidence nodes/edges) per real topic. See the PR
+    report for why this was scoped out rather than attempted.
+    """
+    store = _get_substrate_store()
+    if store is None:
+        return _unavailable("substrate_store_unavailable", concepts_written=0, edges_written=0)
+
+    base_url = str(getattr(settings, "TOPIC_FOUNDRY_BASE_URL", "") or "").strip()
+    if not base_url:
+        return _unavailable(
+            "topic_foundry_base_url_not_configured",
+            concepts_written=0,
+            edges_written=0,
+        )
+
+    try:
+        fetched = fetch_run_topics_and_keywords(base_url)
+    except TopicFoundryClientError as exc:
+        logger.warning("concept_atlas_ingest_topic_foundry_fetch_failed error=%s", exc)
+        return _unavailable(
+            "topic_foundry_fetch_failed",
+            str(exc),
+            concepts_written=0,
+            edges_written=0,
+        )
+    except Exception as exc:  # pragma: no cover - defensive, never let a client bug 500 this route
+        logger.warning("concept_atlas_ingest_topic_foundry_unexpected_fetch_error error=%s", exc)
+        return _unavailable(
+            "topic_foundry_unexpected_error",
+            str(exc),
+            concepts_written=0,
+            edges_written=0,
+        )
+
+    run_id = fetched["run_id"]
+    topics = fetched["topics"]
+    keywords_by_topic = fetched["keywords_by_topic"]
+
+    try:
+        from orion.substrate.adapters.topic_foundry import map_topic_foundry_run_to_substrate
+
+        record = map_topic_foundry_run_to_substrate(
+            run_id=run_id,
+            topics=topics,
+            keywords_by_topic=keywords_by_topic,
+            segment_topic_map={},
+        )
+    except Exception as exc:  # pragma: no cover - the adapter itself never raises, but don't trust across the boundary
+        logger.warning("concept_atlas_ingest_topic_foundry_adapter_failed run_id=%s error=%s", run_id, exc)
+        return _unavailable(
+            "topic_foundry_adapter_failed",
+            str(exc),
+            run_id=run_id,
+            concepts_written=0,
+            edges_written=0,
+        )
+
+    if not record.nodes:
+        return _unavailable(
+            "topic_foundry_no_usable_topics",
+            run_id=run_id,
+            topics_fetched=len(topics),
+            concepts_written=0,
+            edges_written=0,
+        )
+
+    concept_count = 0
+    evidence_count = 0
+    edge_count = 0
+    try:
+        for node in record.nodes:
+            store.upsert_node(identity_key=node.node_id, node=node)
+            if node.node_kind == "concept":
+                concept_count += 1
+            elif node.node_kind == "evidence":
+                evidence_count += 1
+        for edge in record.edges:
+            identity_key = f"{edge.source.node_id}|{edge.predicate}|{edge.target.node_id}"
+            store.upsert_edge(identity_key=identity_key, edge=edge)
+            edge_count += 1
+    except Exception as exc:
+        logger.warning("concept_atlas_ingest_topic_foundry_store_write_failed run_id=%s error=%s", run_id, exc)
+        return _unavailable(
+            "substrate_store_write_failed",
+            str(exc),
+            run_id=run_id,
+            concepts_written=concept_count,
+            evidence_nodes_written=evidence_count,
+            edges_written=edge_count,
+        )
+
+    return {
+        "available": True,
+        "run_id": run_id,
+        "topics_fetched": len(topics),
+        "concepts_written": concept_count,
+        "evidence_nodes_written": evidence_count,
+        "edges_written": edge_count,
+        "co_occurrence_edges_skipped": "segment_topic_map not supplied in this ingestion route (empty by design)",
     }
 
 

--- a/services/orion-hub/scripts/topic_foundry_client.py
+++ b/services/orion-hub/scripts/topic_foundry_client.py
@@ -1,0 +1,182 @@
+"""Small HTTP client for topic-foundry's read-only run/topic/keyword endpoints.
+
+Phase 9 of ``docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md``.
+
+This module performs the actual network calls that
+``orion.substrate.adapters.topic_foundry.map_topic_foundry_run_to_substrate``
+expects its caller to have already made (that adapter is a pure conversion
+function with no HTTP/bus I/O of its own -- see its docstring). It is
+deliberately thin: a handful of small functions, capped work, short
+timeouts, and a single exception type callers can catch. No retries, no
+connection pooling beyond ``requests``'s defaults, no general-purpose
+external-source plugin framework.
+
+Every function here either raises ``TopicFoundryClientError`` (for failures
+that make the overall result unusable) or degrades to an empty/default value
+(for failures scoped to a single topic's keywords, where the adapter already
+tolerates missing keywords). Nothing here ever lets a raw ``requests``
+exception escape -- callers (route handlers) should only ever need to catch
+``TopicFoundryClientError``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+logger = logging.getLogger("orion-hub.topic_foundry_client")
+
+DEFAULT_TIMEOUT_SEC = 5.0
+
+# Bounds worst-case fan-out of the per-topic keywords calls -- mirrors the
+# "cap all collections" instruction and the adapter's own
+# MAX_TOPICS_PER_RUN-style caps (orion/substrate/adapters/topic_foundry.py).
+MAX_TOPICS_FOR_KEYWORDS = 50
+
+# HDBSCAN's noise/outlier bucket. The adapter already excludes it, but there
+# is no reason to spend an HTTP call fetching keywords for it either.
+OUTLIER_TOPIC_ID = -1
+
+
+class TopicFoundryClientError(Exception):
+    """Raised for a topic-foundry HTTP/parsing failure that makes the result unusable.
+
+    Callers (route handlers) should catch this and degrade to an honest
+    error response -- never let it propagate to a raw 500.
+    """
+
+
+def fetch_latest_completed_run(base_url: str, *, timeout: float = DEFAULT_TIMEOUT_SEC) -> dict[str, Any]:
+    """Return the most recently completed run's summary dict (``RunListItem`` shape).
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure, or
+    if no completed run exists yet.
+    """
+    url = f"{base_url.rstrip('/')}/runs"
+    try:
+        resp = requests.get(
+            url,
+            params={"format": "wrapped", "status": "complete", "limit": 1},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_runs_request_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_runs_invalid_json: {exc}") from exc
+
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not items:
+        raise TopicFoundryClientError("topic_foundry_no_completed_run")
+    run = items[0]
+    if not isinstance(run, dict) or not run.get("run_id"):
+        raise TopicFoundryClientError("topic_foundry_run_missing_run_id")
+    return run
+
+
+def fetch_topics_for_run(
+    base_url: str,
+    run_id: str,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """Return the raw ``TopicSummaryItem`` dicts for ``run_id``.
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure or a
+    response missing the expected ``items`` list. An empty ``items`` list
+    (a real run with zero topics) is not an error -- returns ``[]``.
+    """
+    url = f"{base_url.rstrip('/')}/topics"
+    try:
+        resp = requests.get(url, params={"run_id": run_id, "limit": limit}, timeout=timeout)
+        resp.raise_for_status()
+        payload = resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_topics_request_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_topics_invalid_json: {exc}") from exc
+
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if items is None:
+        raise TopicFoundryClientError("topic_foundry_topics_malformed_response")
+    return [item for item in items if isinstance(item, dict)]
+
+
+def fetch_keywords_for_topic(
+    base_url: str,
+    run_id: str,
+    topic_id: int,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+) -> list[str]:
+    """Best-effort per-topic keyword fetch.
+
+    Returns ``[]`` on any failure rather than raising -- one topic's
+    keywords being unavailable should not abort the whole ingestion; the
+    adapter already tolerates an empty keyword list for a topic (it falls
+    back to a synthetic ``topic_{id}`` label).
+    """
+    url = f"{base_url.rstrip('/')}/topics/{topic_id}/keywords"
+    try:
+        resp = requests.get(url, params={"run_id": run_id}, timeout=timeout)
+        resp.raise_for_status()
+        payload = resp.json()
+    except requests.RequestException as exc:
+        logger.warning("topic_foundry_keywords_fetch_failed topic_id=%s error=%s", topic_id, exc)
+        return []
+    except ValueError as exc:
+        logger.warning("topic_foundry_keywords_invalid_json topic_id=%s error=%s", topic_id, exc)
+        return []
+
+    keywords = payload.get("keywords") if isinstance(payload, dict) else None
+    if not isinstance(keywords, list):
+        return []
+    return [str(k) for k in keywords if isinstance(k, (str, int, float))]
+
+
+def fetch_run_topics_and_keywords(
+    base_url: str,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    max_topics_for_keywords: int = MAX_TOPICS_FOR_KEYWORDS,
+) -> dict[str, Any]:
+    """Orchestrate the 3-call sequence: latest run -> topics -> per-topic keywords.
+
+    Raises ``TopicFoundryClientError`` only for the two calls that make the
+    whole result unusable (no completed run, or the topics list itself is
+    unreachable/malformed). Individual keyword-fetch failures degrade to an
+    empty keyword list for that topic (see ``fetch_keywords_for_topic``)
+    rather than aborting the run.
+
+    Returns:
+        ``{"run_id": str, "run": dict, "topics": list[dict], "keywords_by_topic": {int: [str]}}``
+    """
+    run = fetch_latest_completed_run(base_url, timeout=timeout)
+    run_id = str(run["run_id"])
+    topics = fetch_topics_for_run(base_url, run_id, timeout=timeout)
+
+    real_topic_ids: list[int] = []
+    for item in topics:
+        raw_topic_id = item.get("topic_id")
+        try:
+            topic_id = int(raw_topic_id)
+        except (TypeError, ValueError):
+            continue
+        if topic_id == OUTLIER_TOPIC_ID:
+            continue
+        real_topic_ids.append(topic_id)
+
+    keywords_by_topic: dict[int, list[str]] = {}
+    for topic_id in real_topic_ids[:max_topics_for_keywords]:
+        keywords_by_topic[topic_id] = fetch_keywords_for_topic(base_url, run_id, topic_id, timeout=timeout)
+
+    return {
+        "run_id": run_id,
+        "run": run,
+        "topics": topics,
+        "keywords_by_topic": keywords_by_topic,
+    }

--- a/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
+++ b/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
@@ -1,0 +1,393 @@
+"""Tests for the topic-foundry -> concept-atlas ingestion route.
+
+Covers ``POST /api/substrate/concepts/ingest-topic-foundry``
+(``services/orion-hub/scripts/concept_atlas_routes.py``) and its HTTP client
+(``services/orion-hub/scripts/topic_foundry_client.py``). Mirrors the
+isolated-router testing convention already used by
+``test_concept_atlas_routes.py``: build a minimal FastAPI app that only
+includes ``concept_atlas_routes.router`` and monkeypatch collaborators
+directly, rather than pulling in the full ``scripts.main`` app or requiring
+a live topic-foundry service.
+
+All topic-foundry HTTP calls are mocked at the ``requests.get`` boundary
+inside ``scripts.topic_foundry_client`` using fixture payloads shaped exactly
+like the real ``GET /runs``, ``GET /topics``, and
+``GET /topics/{topic_id}/keywords`` responses (see
+``services/orion-topic-foundry/app/routers/runs.py`` and
+``.../routers/topics.py`` for the real shapes).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+import requests
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+for key, value in {
+    "CHANNEL_VOICE_TRANSCRIPT": "orion:voice:transcript",
+    "CHANNEL_VOICE_LLM": "orion:voice:llm",
+    "CHANNEL_VOICE_TTS": "orion:voice:tts",
+    "CHANNEL_COLLAPSE_INTAKE": "orion:collapse:intake",
+    "CHANNEL_COLLAPSE_TRIAGE": "orion:collapse:triage",
+}.items():
+    os.environ.setdefault(key, value)
+
+
+def _concept_atlas_test_app() -> FastAPI:
+    from scripts.concept_atlas_routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    _ensure_hub_scripts_import_path()
+    return TestClient(_concept_atlas_test_app())
+
+
+FAKE_BASE_URL = "http://fake-topic-foundry:8615"
+FAKE_RUN_ID = "11111111-1111-1111-1111-111111111111"
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"status {self.status_code}")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _runs_payload(run_id: str = FAKE_RUN_ID) -> dict[str, Any]:
+    # Shaped exactly like RunListPage/RunListItem from
+    # services/orion-topic-foundry/app/models.py, as returned by
+    # GET /runs?format=wrapped&status=complete&limit=1
+    return {
+        "items": [
+            {
+                "run_id": run_id,
+                "status": "complete",
+                "stage": "complete",
+                "created_at": "2026-07-15T00:00:00Z",
+                "started_at": "2026-07-15T00:00:01Z",
+                "completed_at": "2026-07-15T00:05:00Z",
+                "model": {"model_id": "22222222-2222-2222-2222-222222222222", "name": "m", "version": "v1", "stage": "active"},
+                "dataset": {"dataset_id": "33333333-3333-3333-3333-333333333333", "name": "d", "source_table": "t"},
+                "window": {"start_at": None, "end_at": None},
+                "stats_summary": {
+                    "docs_generated": 611,
+                    "segments_generated": 611,
+                    "cluster_count": 2,
+                    "outlier_pct": 0.67,
+                    "segments_enriched": 0,
+                },
+            }
+        ],
+        "limit": 1,
+        "offset": 0,
+        "total": 1,
+    }
+
+
+def _topics_payload_normal() -> dict[str, Any]:
+    # Shaped exactly like TopicSummaryPage/TopicSummaryItem from
+    # GET /topics?run_id=...&limit=200. Includes the HDBSCAN noise bucket
+    # (topic_id=-1) and a below-min_doc_count topic (count=2 < default floor
+    # of 3) to confirm both are excluded downstream.
+    return {
+        "items": [
+            {"topic_id": -1, "count": 411, "outlier_pct": 1.0, "label": None},
+            {"topic_id": 0, "count": 200, "outlier_pct": 0.0, "label": None},
+            {"topic_id": 1, "count": 50, "outlier_pct": 0.1, "label": None},
+            {"topic_id": 2, "count": 2, "outlier_pct": 0.0, "label": None},
+        ],
+        "limit": 200,
+        "offset": 0,
+        "total": 4,
+    }
+
+
+def _topics_payload_empty() -> dict[str, Any]:
+    return {"items": [], "limit": 200, "offset": 0, "total": 0}
+
+
+def _keywords_payload(topic_id: int) -> dict[str, Any]:
+    fixtures = {
+        0: ["like", "meow", "just", "user", "assistant", "juniper", "let", "hi"],
+        1: ["python", "code", "bug"],
+        2: ["rare", "stray"],
+    }
+    return {"topic_id": topic_id, "keywords": fixtures.get(topic_id, [])}
+
+
+def _make_fake_get(*, topics_payload: dict[str, Any], run_id: str = FAKE_RUN_ID, unreachable: bool = False):
+    calls: list[tuple[str, Optional[dict[str, Any]]]] = []
+
+    def fake_get(url: str, params: Optional[dict[str, Any]] = None, timeout: Optional[float] = None):
+        calls.append((url, params))
+        if unreachable:
+            raise requests.exceptions.ConnectionError("connection refused")
+        if url.endswith("/runs"):
+            return _FakeResponse(200, _runs_payload(run_id))
+        if url.endswith("/topics"):
+            return _FakeResponse(200, topics_payload)
+        if "/topics/" in url and url.endswith("/keywords"):
+            topic_id = int(url.rsplit("/", 2)[1])
+            return _FakeResponse(200, _keywords_payload(topic_id))
+        raise AssertionError(f"unexpected URL in fake_get: {url}")
+
+    return fake_get, calls
+
+
+def _patch_topic_foundry_client(monkeypatch: pytest.MonkeyPatch, fake_get) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+
+
+def _patch_base_url(monkeypatch: pytest.MonkeyPatch, url: str) -> None:
+    from scripts import concept_atlas_routes
+
+    monkeypatch.setattr(concept_atlas_routes.settings, "TOPIC_FOUNDRY_BASE_URL", url)
+
+
+def _patch_store(monkeypatch: pytest.MonkeyPatch, store) -> None:
+    from scripts import concept_atlas_routes
+
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+
+
+# --- normal run: real concept nodes written, outlier + below-floor excluded ---
+
+
+def test_ingest_normal_run_writes_concepts_excludes_outlier_and_below_floor(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+
+    assert body["available"] is True
+    assert body["run_id"] == FAKE_RUN_ID
+    assert body["topics_fetched"] == 4
+    # Only topic_id 0 and 1 survive: -1 is HDBSCAN noise, topic_id 2 (count=2)
+    # is below the adapter's default min_doc_count floor of 3.
+    assert body["concepts_written"] == 2
+    assert body["evidence_nodes_written"] == 2
+    assert body["edges_written"] == 2  # supports edges only; no co_occurs_with (empty segment_topic_map)
+
+    snapshot = store.snapshot()
+    concept_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "concept"]
+    evidence_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "evidence"]
+    assert len(concept_nodes) == 2
+    assert len(evidence_nodes) == 2
+    concept_topic_ids = {n.metadata.get("topic_id") for n in concept_nodes}
+    assert concept_topic_ids == {0, 1}
+    assert -1 not in concept_topic_ids
+    assert 2 not in concept_topic_ids
+    labels = {n.label for n in concept_nodes}
+    assert any("like" in label or "python" in label for label in labels)
+
+    # Never fetch keywords for the outlier bucket -- no HTTP call wasted on it.
+    keyword_call_urls = [url for url, _params in calls if url.endswith("/keywords")]
+    assert all("/topics/-1/" not in url for url in keyword_call_urls)
+    assert len(keyword_call_urls) == 3  # topics 0, 1, 2 (adapter drops 2 later, but client fetches before filtering)
+
+
+def test_ingest_is_idempotent_on_repeated_calls(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-running ingestion for the same run must upsert, not duplicate, nodes/edges."""
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r1 = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    r2 = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r1.status_code == 200 and r2.status_code == 200
+
+    snapshot = store.snapshot()
+    concept_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "concept"]
+    assert len(concept_nodes) == 2  # not 4 -- deterministic node_ids upsert in place
+
+
+# --- degraded paths: never a 500, never a fabricated success ---
+
+
+def test_ingest_topic_foundry_unreachable_degrades_honestly(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal(), unreachable=True)
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200  # never a raw 500
+    body = r.json()
+    assert body["available"] is False
+    assert body["reason"] == "topic_foundry_fetch_failed"
+    assert "error" in body
+    assert body["concepts_written"] == 0
+    assert store.snapshot().nodes == {}  # nothing fabricated into the store
+
+
+def test_ingest_empty_run_no_topics_degrades_honestly(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_empty())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["reason"] == "topic_foundry_no_usable_topics"
+    assert body["run_id"] == FAKE_RUN_ID
+    assert body["topics_fetched"] == 0
+    assert body["concepts_written"] == 0
+    assert store.snapshot().nodes == {}
+
+
+def test_ingest_no_completed_run_degrades_honestly(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+
+    def fake_get(url: str, params: Optional[dict[str, Any]] = None, timeout: Optional[float] = None):
+        if url.endswith("/runs"):
+            return _FakeResponse(200, {"items": [], "limit": 1, "offset": 0, "total": 0})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["reason"] == "topic_foundry_fetch_failed"
+    assert "topic_foundry_no_completed_run" in body["error"]
+
+
+def test_ingest_substrate_store_unavailable_degrades_honestly(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts import concept_atlas_routes
+
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: None)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["reason"] == "substrate_store_unavailable"
+    assert body["concepts_written"] == 0
+
+
+def test_ingest_topic_foundry_base_url_not_configured_degrades_honestly(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    _patch_base_url(monkeypatch, "")
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["reason"] == "topic_foundry_base_url_not_configured"
+
+
+# --- client-layer unit tests -------------------------------------------------
+
+
+def test_client_fetch_run_topics_and_keywords_skips_outlier_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    fake_get, calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+
+    result = tfc.fetch_run_topics_and_keywords(FAKE_BASE_URL)
+    assert result["run_id"] == FAKE_RUN_ID
+    assert -1 not in result["keywords_by_topic"]
+    assert set(result["keywords_by_topic"].keys()) == {0, 1, 2}  # client fetches keywords before the adapter's min_doc_count filter
+
+
+def test_client_keyword_fetch_failure_degrades_to_empty_list_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url: str, params=None, timeout=None):
+        if url.endswith("/runs"):
+            return _FakeResponse(200, _runs_payload())
+        if url.endswith("/topics"):
+            return _FakeResponse(200, _topics_payload_normal())
+        if url.endswith("/keywords"):
+            raise requests.exceptions.Timeout("slow")
+        raise AssertionError(url)
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    result = tfc.fetch_run_topics_and_keywords(FAKE_BASE_URL)
+    assert result["keywords_by_topic"] == {0: [], 1: [], 2: []}
+
+
+def test_client_no_completed_run_raises_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url: str, params=None, timeout=None):
+        assert url.endswith("/runs")
+        return _FakeResponse(200, {"items": [], "limit": 1, "offset": 0, "total": 0})
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    with pytest.raises(tfc.TopicFoundryClientError):
+        tfc.fetch_run_topics_and_keywords(FAKE_BASE_URL)


### PR DESCRIPTION
## Summary

- New `POST /api/substrate/concepts/ingest-topic-foundry`: an operator-triggered, on-demand route that fetches topic-foundry's latest completed run + topics + per-topic keywords over HTTP, converts them via the existing `map_topic_foundry_run_to_substrate()` adapter, and writes the resulting concept/evidence nodes and edges into the live `SUBSTRATE_SEMANTIC_STORE`.
- New `services/orion-hub/scripts/topic_foundry_client.py`: thin HTTP client (5s timeouts, capped keyword fan-out at 50 topics, single `TopicFoundryClientError` exception type, individual keyword failures degrade to `[]` rather than aborting the whole run).
- Not wired into Hub's startup or any scheduler — manual trigger only, mirroring `/api/substrate/review-runtime/debug-run`'s shape, deliberately avoiding adding a network dependency to Hub's boot path (the exact risk flagged and fixed in the prior seed-loader PR, #1092).

## Outcome moved

Concept Atlas can now show organically-discovered concepts from real topic-foundry clusters, not just the 3 fixed golden seeds (#1092). This is the first live path from topic-foundry's clustering into the substrate graph.

## Current architecture

`orion/substrate/adapters/topic_foundry.py::map_topic_foundry_run_to_substrate()` has existed since Wave 1 (#1079) as a pure, tested conversion function with no HTTP/bus I/O of its own. Nothing previously called it against real topic-foundry data in a live path. This PR is that caller.

## Files changed

- `services/orion-hub/scripts/topic_foundry_client.py` (new)
- `services/orion-hub/scripts/concept_atlas_routes.py`: new route (additive; existing summary/network routes untouched)
- `services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py` (new, 10 cases)

## Schema / bus / API changes

- Added: `POST /api/substrate/concepts/ingest-topic-foundry`
- No env changes — reuses the existing `TOPIC_FOUNDRY_BASE_URL` setting.

## Tests run

```
pytest services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py -q
10 passed

pytest services/orion-hub/tests/test_substrate_concept_seed_startup.py services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py -q
13 passed
```
Mocks `requests.get` with fixtures shaped exactly like topic-foundry's real `/runs`, `/topics`, `/topics/{id}/keywords` responses (verified against this same service earlier this session). Covers: normal ingestion with outlier/below-floor exclusion, same-run re-ingestion doesn't duplicate, topic-foundry unreachable, no completed run, empty-topics run, store unavailable, base URL unconfigured.

One pre-existing, unrelated test failure confirmed on unmodified `main` too (`test_concept_atlas_page_renders` — missing `rdflib` in the test venv, not this diff's fault).

## Review findings fixed

Reviewed by the orchestrator directly (not a separate review-skill subagent pass — noted as a gap by the implementing agent, addressed here):

- **Finding (material, not blocking, tracked separately)**: the route writes via `store.upsert_node(identity_key=node.node_id, ...)` directly, bypassing `orion/substrate/reconcile.py`'s `SubstrateIdentityResolver`/`SubstrateGraphMaterializer` entirely. Since `map_topic_foundry_run_to_substrate()` embeds `run_id` into every node_id, re-running this route against a *new* topic-foundry training run produces entirely new node_ids — nothing merges against concepts ingested from a previous run, even if they represent the same idea. Phase 3's identity-merge fix (#1092... actually landed earlier, the paraphrase-merging fix) is never exercised via this route.
  - Fix: not fixed in this PR — flagged as a real, tracked follow-up rather than silently shipped as if resolved. Wiring this route through the materializer (so repeated ingestion actually deduplicates/merges over time) is the natural next step once there's more than one real ingestion to test merging against.
  - Evidence: confirmed by reading `store.upsert_node`'s signature directly (a plain identity-key upsert, no resolver logic) and the adapter's node-id construction (`f"sub-concept-topicfoundry-{run_id_str}-{topic_id}"`).
- Verified: `segment_topic_map={}` scoping decision (no `co_occurs_with` edges from this route yet) is honestly reported in the response (`co_occurrence_edges_skipped` field), not silently omitted.

## Restart required

```bash
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 scripts/safe_docker_build.sh orion-hub up -d --build
```
(Escape hatch only because this session has been redeploying a live Hub instance directly from the shared checkout by necessity; ordinarily from a worktree.)

## Risks / concerns

- Severity: medium (functional gap, not a correctness bug)
- Concern: repeated ingestion across multiple topic-foundry runs will accumulate duplicate/fragmented concept nodes rather than merging via the identity resolver, undermining the "durable, evolving concept" goal for anything ingested through this route specifically (golden seeds and single-run ingestion are both fine).
- Mitigation: tracked as explicit follow-up (see Review findings above) rather than treated as done; fine to use for single/occasional manual ingestion in the meantime, not for repeated/scheduled ingestion yet.

## PR link

(filled in after creation)