### PR TITLE
fix: gate substrate dynamics tick writes on real change, not every tick

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-16-substrate-dynamics-unconditional-upsert-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-substrate-dynamics-unconditional-upsert-pr.md
@@ -1,0 +1,94 @@
+# fix: gate substrate dynamics tick writes on real change, not every tick
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1098
+Branch: `fix/substrate-dynamics-unconditional-upsert`
+
+## Summary
+
+- `SubstrateDynamicsEngine.tick()` was calling `store.upsert_node()` unconditionally for every node on every 30s tick, regardless of whether anything changed.
+- On the SPARQL/Fuseki backend that's a full DELETE+INSERT transaction per node per tick. Traced live in production on 2026-07-16 to ~2.5 SPARQL updates/sec sustained (78 substrate nodes / 30s tick), a material contributor to `orion-rdf-store` running out of TDB2 compaction headroom (real incident: disk filled to the point `make compact` could no longer run).
+- Now only writes a node when its activation crosses the existing `1e-6` change threshold, its dormancy state flips, or its pressure changed.
+- Code review (8-angle) surfaced a real bug the guard exposed: the dormancy check read the stale, top-of-tick stored `recency_score` instead of the freshly computed value. The unconditional write had been masking this — once persistence stops for a quiescent node, the stored value never refreshes and the node could never transition to dormant via pure recency decay. Fixed in the same patch by having the dormancy check read fresh recency directly.
+- Enables the retention scheduler in `orion-rdf-writer` (already built, previously `RDF_RETENTION_ENABLED=false` with no policies) as an ongoing safety net against the unbounded `autonomy/{identity,goals}` accumulation found during the same incident.
+
+## Outcome moved
+
+Eliminates the dominant *active* source of TDB2 write-amplification found during the 2026-07-16 Fuseki disk-exhaustion incident. (The other 98% of that incident's disk usage was historical `autonomy/{drives,identity,goals}` accumulation via now-disabled/removed write paths — a one-off SPARQL cleanup, not a code change, tracked separately in the incident's own operational log.)
+
+## Current architecture
+
+`orion-substrate-runtime`'s `_dynamics_tick_loop` calls `SubstrateDynamicsEngine.tick()` every `SUBSTRATE_DYNAMICS_TICK_INTERVAL_SEC` (default 30s) when `SUBSTRATE_DYNAMICS_TICK_ENABLED=true`. `tick()` recomputes pressure and activation for every node in the store snapshot and previously persisted all of them back unconditionally.
+
+## Architecture touched
+
+`orion/substrate/dynamics.py` (the tick loop's write gate), `orion/substrate/tests/test_dynamics.py` (new), `services/orion-substrate-runtime/README.md` (docs), `services/orion-rdf-writer/.env_example` (retention config).
+
+## Files changed
+
+- `orion/substrate/dynamics.py`: gate `upsert_node()` on real change; fix dormancy check to use fresh recency instead of stale stored value; move `model_copy` construction inside the write-guard branch (avoids building objects that end up discarded).
+- `orion/substrate/tests/test_dynamics.py`: new — 4 tests covering the no-op case, activation-changed, pressure-changed, and the recency/dormancy regression.
+- `services/orion-substrate-runtime/README.md`: documents the write guard and the recency/dormancy gotcha for future maintainers.
+- `services/orion-rdf-writer/.env_example`: `RDF_RETENTION_ENABLED=true`, `RDF_RETENTION_INTERVAL_HOURS` 168→24, adds `RDF_RETENTION_POLICIES` for `autonomy/{identity,goals,drives}` with context comment.
+
+## Schema / bus / API changes
+
+None. `SubstrateDynamicsResultV1`'s shape is unchanged; this only changes when a node gets persisted, not what gets returned or logged.
+
+## Env/config changes
+
+- Changed: `RDF_RETENTION_ENABLED` (false→true), `RDF_RETENTION_INTERVAL_HOURS` (168→24) in `services/orion-rdf-writer/.env_example`.
+- Added: `RDF_RETENTION_POLICIES` in the same file.
+- Local `.env`: no `.env` exists for `orion-rdf-writer` in this worktree (expected — gitignored, worktrees don't inherit one). The **live** `.env` on the host running the actual `orion-rdf-writer` container was updated directly with matching values during incident response, outside this worktree/PR.
+- No skipped keys.
+
+## Tests run
+
+```
+cd orion/substrate && pytest tests/ -q
+265 passed, 17 warnings (pre-existing deprecation warnings, unrelated)
+```
+
+## Evals run
+
+No eval harness exists for `orion/substrate/dynamics.py` specifically; this service's `evals/` directory covers other reducers (brain-frame, biometrics). Not adding one here — out of scope for a targeted bug fix, flagged as a gap rather than silently skipped.
+
+## Review findings fixed
+
+- Finding: dormancy check read stale stored `recency_score` instead of the freshly computed value, a regression this PR's own write-guard would introduce (once a node's activation ratchets to a peak — the common case, since `decay_half_life_seconds` defaults to `None` — it can go dormant-check-blind indefinitely).
+  - Fix: dormancy check now reads `activations[f"{node_id}:recency"]` directly instead of `node.signals.activation.recency_score`.
+  - Evidence: new test `test_dormancy_uses_fresh_recency_not_stale_stored_value` reproduces the exact scenario (activation and pressure held constant across two ticks, only recency moves) and fails without the fix, passes with it.
+- Finding: `graph_cognition/features.py`'s `dormant_count` reads the same persisted `dormant` metadata flag exposed to the staleness bug above.
+  - Fix: resolved as a side effect of the dormancy-check fix above (same root cause).
+  - Evidence: same regression test.
+- Finding: `activation_bundle`/`updated_signal`/`updated_node` (three Pydantic `model_copy` calls) were built unconditionally every loop iteration even when the write guard ends up skipping that node.
+  - Fix: moved the construction inside the write-guard `if` branch.
+  - Evidence: existing tests still pass (265/265); no behavior change, pure efficiency cleanup.
+- Finding (not fixed, follow-up flagged): the actual unsafe primitive — `SparqlSubstrateStore.upsert_node()` doing an unconditional DELETE+INSERT — is untouched, and at least 4 other call sites (`orion/substrate/materializer.py:64`, `services/orion-substrate-runtime/app/worker.py:742,1057,1135`) still call it unconditionally and remain exposed to the same write-amplification bug class via a different trigger (perception messages, drive-state ticks, materializer re-runs). Scoped out of this patch deliberately — fixing the shared primitive is a bigger, riskier change than this incident's timeline allowed for; noting here so it isn't lost.
+
+## Docker/build/smoke checks
+
+Not run from this worktree — no live Fuseki/Docker access configured for a full smoke test here. The write-guard behavior itself was effectively live-verified during the incident: production `dynamics.py` was manually patched with an equivalent gate during firefighting, and Fuseki's `/update` request rate visibly dropped from ~2.5/sec sustained to near-zero for unchanged nodes.
+
+## Restart required
+
+```bash
+docker compose restart orion-substrate-runtime
+docker compose restart orion-rdf-writer
+```
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the follow-up (other unconditional `upsert_node()` callers) is real and unaddressed in this PR.
+- Mitigation: documented above and in review findings; the dynamics-tick path was the dominant, currently-active contributor per live traffic analysis, so this patch addresses the incident's actual cause even though the shared primitive remains generically unsafe.
+
+## Related: 2026-07-16 Fuseki disk-exhaustion incident (context, not part of this PR)
+
+This PR's root-cause investigation was part of a larger same-day incident response:
+
+- `autonomy/drives` graph (37.9M triples, orphaned since its writer was removed 2026-07-15) — cleared via Graph Store Protocol DELETE.
+- `autonomy/identity` graph (34.7M triples, `RDF_SKIP_KINDS` already gating new writes off) — pruned to latest-per-subject via a batched SPARQL DELETE script.
+- `autonomy/goals` graph (10.6M triples) — pruned via 30-day age-based batched SPARQL DELETE.
+- Two Fuseki OOM/unresponsive incidents occurred during cleanup attempts (an unbounded `+` transitive property-path DELETE evaluated from 400k+ free-variable bindings, then a batch size still too large); both self-corrected or were recovered via `make recover` / a direct `docker compose restart`. No data loss — TDB2 transactions are all-or-nothing, and a full server-side backup (`orion_2026-07-16_16-23-37.nq.gz`) was taken before the historical-data cleanup began (later deleted per operator instruction once the cleanup's correctness was established).
+- A hardened, bounded-memory batched-delete script (SELECT a small ground-term batch of stale artifact URIs, then DELETE only from that bounded VALUES set, retry-with-backoff on transient failures) was used for the final successful cleanup pass.
+- `make compact` still needs to run afterward to actually reclaim disk space — SPARQL DELETE alone doesn't shrink TDB2's on-disk footprint, only `tdbcompact` does.

--- a/orion/substrate/dynamics.py
+++ b/orion/substrate/dynamics.py
@@ -111,6 +111,7 @@ class SubstrateDynamicsEngine:
         activations = self._compute_activations(updated_nodes, outgoing, pressures, tick_at)
         activation_updates: list[ActivationUpdateV1] = []
         dormancy_transitions: list[DormancyTransitionV1] = []
+        pressure_changed_ids = {update.node_id for update in pressure_updates}
 
         for node_id, node in updated_nodes.items():
             prev_activation = node.signals.activation.activation
@@ -126,7 +127,17 @@ class SubstrateDynamicsEngine:
             dormant_prev = bool(metadata.get("dormant", False))
             dormant_new = dormant_prev
 
-            if new_activation <= self._dormancy_threshold and node.signals.activation.recency_score <= self._dormancy_threshold:
+            # Use the freshly-computed recency for this tick's dormancy decision, not
+            # node.signals.activation.recency_score (the value from the top-of-tick
+            # store snapshot). Recency decays continuously every tick regardless of
+            # whether this node's activation/pressure changed, so once the write guard
+            # below can skip persisting a node, the stored recency_score stops being
+            # refreshed -- a dormancy check reading the stale stored value would then
+            # never see a node's recency cross the threshold on its own, leaving it
+            # stuck non-dormant indefinitely even as real time keeps passing.
+            fresh_recency = activations.get(f"{node_id}:recency", node.signals.activation.recency_score)
+
+            if new_activation <= self._dormancy_threshold and fresh_recency <= self._dormancy_threshold:
                 dormant_new = True
             elif new_activation >= self._revival_threshold:
                 dormant_new = False
@@ -143,17 +154,26 @@ class SubstrateDynamicsEngine:
                     )
                 )
 
-            activation_bundle = node.signals.activation.model_copy(
-                update={
-                    "activation": round(new_activation, 6),
-                    "recency_score": round(activations.get(f"{node_id}:recency", node.signals.activation.recency_score), 6),
-                }
-            )
-            updated_signal = node.signals.model_copy(update={"activation": activation_bundle})
-            updated_node = node.model_copy(update={"signals": updated_signal, "metadata": metadata})
-            self._store.upsert_node(identity_key=identity_by_node_id.get(node_id), node=updated_node)
+            activation_changed = abs(new_activation - prev_activation) >= 1e-6
 
-            if abs(new_activation - prev_activation) >= 1e-6:
+            # Guard: only persist a node this tick if something about it actually moved.
+            # upsert_node() is a full DELETE+INSERT SPARQL transaction against the store;
+            # calling it unconditionally for every node on every tick (previously the
+            # case here) churns TDB2's journal at the tick cadence regardless of whether
+            # any node changed, which is indistinguishable on disk from real growth and
+            # forces far more frequent compaction than actual data volume warrants.
+            if activation_changed or dormant_new != dormant_prev or node_id in pressure_changed_ids:
+                activation_bundle = node.signals.activation.model_copy(
+                    update={
+                        "activation": round(new_activation, 6),
+                        "recency_score": round(fresh_recency, 6),
+                    }
+                )
+                updated_signal = node.signals.model_copy(update={"activation": activation_bundle})
+                updated_node = node.model_copy(update={"signals": updated_signal, "metadata": metadata})
+                self._store.upsert_node(identity_key=identity_by_node_id.get(node_id), node=updated_node)
+
+            if activation_changed:
                 activation_updates.append(
                     ActivationUpdateV1(
                         node_id=node_id,

--- a/orion/substrate/tests/test_dynamics.py
+++ b/orion/substrate/tests/test_dynamics.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.cognitive_substrate import (
+    BaseSubstrateNodeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+)
+from orion.substrate.dynamics import SubstrateDynamicsEngine
+from orion.substrate.store import InMemorySubstrateGraphStore
+
+_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _steady_node(node_id: str = "sub-node-1", *, activation: float = 0.3, pressure: float = 0.0) -> BaseSubstrateNodeV1:
+    return BaseSubstrateNodeV1(
+        node_id=node_id,
+        node_kind="concept",
+        anchor_scope="orion",
+        temporal={"observed_at": _NOW},
+        signals=SubstrateSignalBundleV1(
+            confidence=0.8,
+            salience=0.4,
+            activation={
+                "activation": activation,
+                "recency_score": 0.5,
+                "decay_half_life_seconds": None,
+                "decay_floor": 0.0,
+            },
+        ),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="test",
+            producer="test",
+        ),
+        metadata={"dynamic_pressure": pressure},
+    )
+
+
+class _CountingStore(InMemorySubstrateGraphStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.upsert_node_calls: list[str] = []
+
+    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
+        self.upsert_node_calls.append(node.node_id)
+        super().upsert_node(identity_key=identity_key, node=node)
+
+
+def _engine_with(store: InMemorySubstrateGraphStore, *, activations: dict[str, float], pressures: dict[str, float]) -> SubstrateDynamicsEngine:
+    engine = SubstrateDynamicsEngine(store=store)
+    engine._compute_pressures = lambda nodes, outgoing, tick_at: (pressures, {})  # type: ignore[method-assign]
+    engine._compute_activations = lambda updated_nodes, outgoing, pressures, tick_at: activations  # type: ignore[method-assign]
+    return engine
+
+
+def test_tick_does_not_rewrite_unchanged_node() -> None:
+    store = _CountingStore()
+    node = _steady_node(activation=0.3, pressure=0.0)
+    store.upsert_node(identity_key="identity-1", node=node)
+    store.upsert_node_calls.clear()
+
+    engine = _engine_with(store, activations={node.node_id: 0.3}, pressures={node.node_id: 0.0})
+    result = engine.tick(now=_NOW)
+
+    assert store.upsert_node_calls == []
+    assert result.activation_updates == []
+    assert result.pressure_updates == []
+
+
+def test_tick_rewrites_node_when_activation_changes() -> None:
+    store = _CountingStore()
+    node = _steady_node(activation=0.3, pressure=0.0)
+    store.upsert_node(identity_key="identity-1", node=node)
+    store.upsert_node_calls.clear()
+
+    engine = _engine_with(store, activations={node.node_id: 0.5}, pressures={node.node_id: 0.0})
+    result = engine.tick(now=_NOW)
+
+    assert store.upsert_node_calls == [node.node_id]
+    assert len(result.activation_updates) == 1
+
+
+def test_tick_rewrites_node_when_pressure_changes_even_if_activation_steady() -> None:
+    store = _CountingStore()
+    node = _steady_node(activation=0.3, pressure=0.0)
+    store.upsert_node(identity_key="identity-1", node=node)
+    store.upsert_node_calls.clear()
+
+    engine = _engine_with(store, activations={node.node_id: 0.3}, pressures={node.node_id: 0.8})
+    result = engine.tick(now=_NOW)
+
+    assert store.upsert_node_calls == [node.node_id]
+    assert result.activation_updates == []
+    assert len(result.pressure_updates) == 1
+
+
+def test_dormancy_uses_fresh_recency_not_stale_stored_value() -> None:
+    """Regression: the dormancy check must read this tick's freshly computed
+    recency (activations[f"{node_id}:recency"]), not node.signals.activation
+    .recency_score off the top-of-tick store snapshot. Activation and pressure
+    stay identical across both ticks here -- only recency moves -- so a version
+    that reads the stale stored value would never see recency cross the
+    dormancy threshold and would never transition the node to dormant.
+    """
+    store = _CountingStore()
+    node = _steady_node(activation=0.05, pressure=0.0)  # at/below dormancy_threshold (0.08 default)
+    store.upsert_node(identity_key="identity-1", node=node)
+    store.upsert_node_calls.clear()
+
+    engine = SubstrateDynamicsEngine(store=store)
+    engine._compute_pressures = lambda nodes, outgoing, tick_at: ({node.node_id: 0.0}, {})  # type: ignore[method-assign]
+
+    recency_by_tick = iter([0.5, 0.05])  # tick 1: above threshold; tick 2: at/below threshold
+
+    def fake_compute_activations(updated_nodes, outgoing, pressures, tick_at):
+        return {node.node_id: 0.05, f"{node.node_id}:recency": next(recency_by_tick)}
+
+    engine._compute_activations = fake_compute_activations  # type: ignore[method-assign]
+
+    result1 = engine.tick(now=_NOW)
+    assert store.upsert_node_calls == []
+    assert result1.dormancy_transitions == []
+
+    result2 = engine.tick(now=_NOW)
+    assert store.upsert_node_calls == [node.node_id]
+    assert len(result2.dormancy_transitions) == 1
+    assert result2.dormancy_transitions[0].to_state == "dormant"

--- a/services/orion-rdf-writer/.env_example
+++ b/services/orion-rdf-writer/.env_example
@@ -126,13 +126,25 @@ RDF_DURABLE_ONLY=false
 # --- RDF retention / pruning (SPARQL UPDATE against Fuseki) ---
 # Writer runs a background pass every RDF_RETENTION_INTERVAL_HOURS when enabled.
 # Operator cron (recommended in addition): cd services/orion-rdf-store && make prune
-RDF_RETENTION_ENABLED=false
+RDF_RETENTION_ENABLED=true
 RDF_RETENTION_DRY_RUN=false
-RDF_RETENTION_INTERVAL_HOURS=168
+RDF_RETENTION_INTERVAL_HOURS=24
 RDF_RETENTION_TIMEOUT_SEC=3600
 # Optional SPARQL DELETE for specific graphs only — does NOT touch memory by default.
 # TDB bloat is reclaimed with `make compact` in orion-rdf-store, not retention.
 # RDF_RETENTION_POLICIES=[{"graph":"http://conjourney.net/graph/orion/cognition","max_age_days":30}]
+#
+# 2026-07-16: autonomy/{drives,identity,goals} accumulated 83M of 85M total triples in
+# this store with zero retention (drives: write path removed 2026-07-15, orphaned;
+# identity+goals: RDF_SKIP_KINDS currently gates their writes off entirely, see below —
+# so this is not an active leak today, but is the reason it happened once already).
+# Caps sized generously vs. current subject cardinality (identity: 5 distinct subjects,
+# goals: 4) so a resumed write path can't starve a rarely-updated subject's latest row
+# before the next daily pass catches up. One-off historical cleanup for the 2026-07-16
+# incident was done directly via SPARQL, not through this policy list (batch_size=200
+# default makes bulk catch-up of hundreds of thousands of stale artifacts impractically
+# slow one-artifact-at-a-time) — see docs/superpowers/pr-reports/2026-07-16-fuseki-disk-cleanup-pr.md.
+RDF_RETENTION_POLICIES=[{"graph":"http://conjourney.net/graph/autonomy/identity","max_artifacts":500,"batch_size":500},{"graph":"http://conjourney.net/graph/autonomy/goals","max_artifacts":2000,"batch_size":500},{"graph":"http://conjourney.net/graph/autonomy/drives","max_artifacts":1,"batch_size":500}]
 
 WORLD_PULSE_GRAPH_ENABLED=false
 WORLD_PULSE_GRAPH_DRY_RUN=true

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -152,6 +152,27 @@ Only meaningful once `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true` and
 `SUBSTRATE_STORE_BACKEND=sparql` (Fuseki) are set — with the in-memory default store the
 prediction-error nodes are process-local and this tick has nothing durable to consume.
 
+**Write guard:** `SubstrateDynamicsEngine.tick()` (`orion/substrate/dynamics.py`) only calls
+`store.upsert_node()` for a node when its activation crossed the existing `1e-6` change
+threshold, its dormancy state flipped, or its pressure actually moved — not unconditionally
+for every node on every tick. On the SPARQL backend each `upsert_node()` is a full
+DELETE+INSERT transaction; with the tick's default 30s cadence, writing every node
+regardless of change was found (2026-07-16) driving ~2.5 SPARQL updates/sec against Fuseki
+sustained (78 substrate nodes / 30s), which is indistinguishable from real data growth on
+disk until the next `tdbcompact` and was a material contributor to `orion-rdf-store` running
+out of compaction headroom. If you add new per-node fields to the tick, route their writes
+through this same changed-gate rather than bypassing it.
+
+Gotcha the guard exposed: `recency_score` decays every tick regardless of whether activation
+changed, so a node whose activation has ratcheted to a peak (common — `decay_half_life_seconds`
+defaults to `None`, i.e. no time-based decay) can go indefinitely without a real write once the
+guard skips it. The dormancy check in the same loop must read *this tick's* freshly computed
+recency (`activations[f"{node_id}:recency"]`), not `node.signals.activation.recency_score` off
+the top-of-tick store snapshot — otherwise a node can never cross into dormant via pure recency
+decay once persistence stops, since the stale stored value never moves. Fixed in the same patch
+that added the guard; if you touch this loop again, keep the dormancy decision reading fresh
+recency even though the stored copy may lag.
+
 ## Unified turn bus listeners
 
 Besides grammar poll reducers, substrate-runtime subscribes to RPC-style harness channels:


### PR DESCRIPTION
## Summary

- `SubstrateDynamicsEngine.tick()` was calling `store.upsert_node()` unconditionally for every node on every 30s tick, regardless of whether anything changed.
- On the SPARQL/Fuseki backend that's a full DELETE+INSERT transaction per node per tick. Traced live in production on 2026-07-16 to ~2.5 SPARQL updates/sec sustained (78 substrate nodes / 30s tick), a material contributor to `orion-rdf-store` running out of TDB2 compaction headroom (real incident: disk filled to the point `make compact` could no longer run).
- Now only writes a node when its activation crosses the existing `1e-6` change threshold, its dormancy state flips, or its pressure changed.
- Code review (8-angle, see below) surfaced a real bug the guard exposed: the dormancy check read the stale, top-of-tick stored `recency_score` instead of the freshly computed value. The unconditional write had been masking this — once persistence stops for a quiescent node, the stored value never refreshes and the node could never transition to dormant via pure recency decay. Fixed in the same patch by having the dormancy check read fresh recency directly.
- Enables the retention scheduler in `orion-rdf-writer` (already built, previously `RDF_RETENTION_ENABLED=false` with no policies) as an ongoing safety net against the unbounded `autonomy/{identity,goals}` accumulation found during the same incident.

## Outcome moved

Eliminates the dominant *active* source of TDB2 write-amplification found during the 2026-07-16 Fuseki disk-exhaustion incident. (The other 98% of that incident's disk usage was historical `autonomy/{drives,identity,goals}` accumulation via now-disabled/removed write paths — a one-off SPARQL cleanup, not a code change, tracked separately.)

## Current architecture

`orion-substrate-runtime`'s `_dynamics_tick_loop` calls `SubstrateDynamicsEngine.tick()` every `SUBSTRATE_DYNAMICS_TICK_INTERVAL_SEC` (default 30s) when `SUBSTRATE_DYNAMICS_TICK_ENABLED=true`. `tick()` recomputes pressure and activation for every node in the store snapshot and previously persisted all of them back unconditionally.

## Architecture touched

`orion/substrate/dynamics.py` (the tick loop's write gate), `orion/substrate/tests/test_dynamics.py` (new), `services/orion-substrate-runtime/README.md` (docs), `services/orion-rdf-writer/.env_example` (retention config).

## Files changed

- `orion/substrate/dynamics.py`: gate `upsert_node()` on real change; fix dormancy check to use fresh recency instead of stale stored value; move `model_copy` construction inside the write-guard branch (avoids building objects that end up discarded).
- `orion/substrate/tests/test_dynamics.py`: new — 4 tests covering the no-op case, activation-changed, pressure-changed, and the recency/dormancy regression.
- `services/orion-substrate-runtime/README.md`: documents the write guard and the recency/dormancy gotcha for future maintainers.
- `services/orion-rdf-writer/.env_example`: `RDF_RETENTION_ENABLED=true`, `RDF_RETENTION_INTERVAL_HOURS` 168→24, adds `RDF_RETENTION_POLICIES` for `autonomy/{identity,goals,drives}` with context comment.

## Schema / bus / API changes

None. `SubstrateDynamicsResultV1`'s shape is unchanged; this only changes when a node gets persisted, not what gets returned or logged.

## Env/config changes

- Changed: `RDF_RETENTION_ENABLED` (false→true), `RDF_RETENTION_INTERVAL_HOURS` (168→24) in `services/orion-rdf-writer/.env_example`.
- Added: `RDF_RETENTION_POLICIES` in the same file.
- Local `.env`: no `.env` exists for `orion-rdf-writer` in this worktree (expected — gitignored, worktrees don't inherit one), so `sync_local_env_from_example.py` has nothing to sync there. The **live** `.env` on the host running the actual `orion-rdf-writer` container was updated directly with matching values during the incident response, outside this worktree/PR.
- No skipped keys.

## Tests run

```
cd orion/substrate && pytest tests/ -q
265 passed, 17 warnings (pre-existing deprecation warnings, unrelated)
```

## Evals run

No eval harness exists for `orion/substrate/dynamics.py` specifically; this service's `evals/` directory covers other reducers (brain-frame, biometrics). Not adding one here — out of scope for a targeted bug fix, flagged as a gap rather than silently skipped.

## Review findings fixed

- Finding: dormancy check read stale stored `recency_score` instead of the freshly computed value, a regression this PR's own write-guard would introduce (once a node's activation ratchets to a peak — the common case, since `decay_half_life_seconds` defaults to `None` — it can go dormant-check-blind indefinitely).
  - Fix: dormancy check now reads `activations[f"{node_id}:recency"]` directly instead of `node.signals.activation.recency_score`.
  - Evidence: new test `test_dormancy_uses_fresh_recency_not_stale_stored_value` reproduces the exact scenario (activation and pressure held constant across two ticks, only recency moves) and fails without the fix, passes with it.
- Finding: `graph_cognition/features.py`'s `dormant_count` reads the same persisted `dormant` metadata flag exposed to the staleness bug above.
  - Fix: resolved as a side effect of the dormancy-check fix above (same root cause).
  - Evidence: same regression test.
- Finding: `activation_bundle`/`updated_signal`/`updated_node` (three Pydantic `model_copy` calls) were built unconditionally every loop iteration even when the write guard ends up skipping that node.
  - Fix: moved the construction inside the write-guard `if` branch.
  - Evidence: existing tests still pass (265/265); no behavior change, pure efficiency cleanup.
- Finding (not fixed, follow-up flagged): the actual unsafe primitive — `SparqlSubstrateStore.upsert_node()` doing an unconditional DELETE+INSERT — is untouched, and at least 4 other call sites (`orion/substrate/materializer.py:64`, `services/orion-substrate-runtime/app/worker.py:742,1057,1135`) still call it unconditionally and remain exposed to the same write-amplification bug class via a different trigger (perception messages, drive-state ticks, materializer re-runs). Scoped out of this patch deliberately — fixing the shared primitive is a bigger, riskier change than this incident's timeline allowed for; noting here so it isn't lost.

## Docker/build/smoke checks

Not run — this worktree has no live Fuseki/Docker access configured for a full smoke test. Restart of `orion-substrate-runtime` (to pick up the code fix) and `orion-rdf-writer` (to pick up the retention config) required in the running environment; commands below. The write-guard behavior itself was effectively live-verified during the incident: production `dynamics.py` was manually patched with an equivalent gate during firefighting, and Fuseki's `/update` request rate visibly dropped from ~2.5/sec sustained to near-zero for unchanged nodes.

## Restart required

```bash
docker compose restart orion-substrate-runtime
docker compose restart orion-rdf-writer
```

## Risks / concerns

- Severity: low
- Concern: the follow-up (other unconditional `upsert_node()` callers) is real and unaddressed in this PR.
- Mitigation: documented above and in review findings; the dynamics-tick path was the dominant, currently-active contributor per live traffic analysis, so this patch addresses the incident's actual cause even though the shared primitive remains generically unsafe.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/substrate-dynamics-unconditional-upsert