### PR TITLE
fix: reconcile Topic Foundry ingest identities

### DIFF
--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -434,7 +434,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             store=counting_store,
             identity_resolver=SubstrateIdentityResolver(store=counting_store),
         )
-        result = materializer.apply_record(record)
+        materializer.apply_record(record)
     except Exception as exc:
         logger.warning("concept_atlas_ingest_topic_foundry_store_write_failed run_id=%s error=%s", run_id, exc)
         return _unavailable(
@@ -446,19 +446,15 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             edges_written=counting_store.edges_written,
         )
 
-    # Response fields remain total record items processed/written (not unique
-    # durable nodes after merge). Materializer edges_seen matches that meaning.
-    concept_count = sum(1 for n in record.nodes if n.node_kind == "concept")
-    evidence_count = sum(1 for n in record.nodes if n.node_kind == "evidence")
-    edge_count = result.edges_seen
-
+    # Same counter owns success and failure accounting. Counts are successful
+    # upserts (including merges), not unique durable nodes after merge.
     return {
         "available": True,
         "run_id": run_id,
         "topics_fetched": len(topics),
-        "concepts_written": concept_count,
-        "evidence_nodes_written": evidence_count,
-        "edges_written": edge_count,
+        "concepts_written": counting_store.concepts_written,
+        "evidence_nodes_written": counting_store.evidence_nodes_written,
+        "edges_written": counting_store.edges_written,
         "co_occurrence_edges_skipped": "segment_topic_map not supplied in this ingestion route (empty by design)",
     }
 

--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -79,6 +79,38 @@ def _unavailable(reason: str, error: Optional[str] = None, **extra: Any) -> dict
     return payload
 
 
+class _CountingSubstrateStore:
+    """Thin store wrapper that counts successful concept/evidence/edge upserts.
+
+    ``SubstrateGraphMaterializer.apply_record`` writes incrementally and raises
+    without returning a partial ``MaterializationResultV1``. Delegating through
+    this wrapper lets the ingest route report precise successful counts on
+    mid-record failure, while preserving all other store operations (including
+    identity-resolver reads) via ``__getattr__``.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.concepts_written = 0
+        self.evidence_nodes_written = 0
+        self.edges_written = 0
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def upsert_node(self, *, identity_key: str | None, node: Any) -> None:
+        self._inner.upsert_node(identity_key=identity_key, node=node)
+        kind = getattr(node, "node_kind", None)
+        if kind == "concept":
+            self.concepts_written += 1
+        elif kind == "evidence":
+            self.evidence_nodes_written += 1
+
+    def upsert_edge(self, *, identity_key: str, edge: Any) -> None:
+        self._inner.upsert_edge(identity_key=identity_key, edge=edge)
+        self.edges_written += 1
+
+
 def _concept_nodes(store: Any) -> list[Any]:
     """All concept-kind nodes from the store's snapshot, or [] on any failure."""
     try:
@@ -390,30 +422,35 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             edges_written=0,
         )
 
-    concept_count = 0
-    evidence_count = 0
-    edge_count = 0
+    counting_store = _CountingSubstrateStore(store)
     try:
-        for node in record.nodes:
-            store.upsert_node(identity_key=node.node_id, node=node)
-            if node.node_kind == "concept":
-                concept_count += 1
-            elif node.node_kind == "evidence":
-                evidence_count += 1
-        for edge in record.edges:
-            identity_key = f"{edge.source.node_id}|{edge.predicate}|{edge.target.node_id}"
-            store.upsert_edge(identity_key=identity_key, edge=edge)
-            edge_count += 1
+        from orion.substrate.materializer import SubstrateGraphMaterializer
+        from orion.substrate.reconcile import SubstrateIdentityResolver
+
+        # Exact-label identity works through the resolver's legacy key path;
+        # explicitly wiring the store also activates embedding matches whenever
+        # a caller supplies metadata['concept_embedding'].
+        materializer = SubstrateGraphMaterializer(
+            store=counting_store,
+            identity_resolver=SubstrateIdentityResolver(store=counting_store),
+        )
+        result = materializer.apply_record(record)
     except Exception as exc:
         logger.warning("concept_atlas_ingest_topic_foundry_store_write_failed run_id=%s error=%s", run_id, exc)
         return _unavailable(
             "substrate_store_write_failed",
             str(exc),
             run_id=run_id,
-            concepts_written=concept_count,
-            evidence_nodes_written=evidence_count,
-            edges_written=edge_count,
+            concepts_written=counting_store.concepts_written,
+            evidence_nodes_written=counting_store.evidence_nodes_written,
+            edges_written=counting_store.edges_written,
         )
+
+    # Response fields remain total record items processed/written (not unique
+    # durable nodes after merge). Materializer edges_seen matches that meaning.
+    concept_count = sum(1 for n in record.nodes if n.node_kind == "concept")
+    evidence_count = sum(1 for n in record.nodes if n.node_kind == "evidence")
+    edge_count = result.edges_seen
 
     return {
         "available": True,

--- a/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
+++ b/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
@@ -249,7 +249,8 @@ def test_ingest_is_idempotent_on_repeated_calls(client: TestClient, monkeypatch:
 
     snapshot = store.snapshot()
     concept_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "concept"]
-    assert len(concept_nodes) == 2  # not 4 -- deterministic node_ids upsert in place
+    # Not 4: identity-key merge upserts in place across repeated same-run ingest.
+    assert len(concept_nodes) == 2
 
 
 def test_ingest_cross_run_same_label_merges_to_one_durable_concept(
@@ -334,6 +335,101 @@ def test_ingest_cross_run_same_label_merges_to_one_durable_concept(
         assert edge.target.node_id != run_b_concept_id
 
 
+def test_ingest_cross_run_similar_embeddings_merge_paraphrased_labels(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Paraphrased labels with similar embeddings must merge at the Hub ingest route.
+
+    The Topic Foundry HTTP client does not expose centroids yet, so this test
+    injects ``topic_embeddings`` into the adapter call while keeping the real
+    route + materializer + store-backed resolver path.
+    """
+    import orion.substrate.adapters.topic_foundry as tf_adapter
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    run_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    run_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    topic_a = 0
+    topic_b = 7
+    # Cosine ~0.9986 — same pair as orion/substrate/tests/test_reconcile.py.
+    embeddings_by_run = {
+        run_a: {topic_a: [1.0, 1.0, 0.0]},
+        run_b: {topic_b: [1.0, 0.9, 0.0]},
+    }
+    labels_by_run = {
+        run_a: "surface encodings",
+        run_b: "surface-level representations",
+    }
+
+    real_map = tf_adapter.map_topic_foundry_run_to_substrate
+
+    def map_with_embeddings(*, run_id, topics, keywords_by_topic, segment_topic_map=None, **kwargs):
+        return real_map(
+            run_id=run_id,
+            topics=topics,
+            keywords_by_topic=keywords_by_topic,
+            segment_topic_map=segment_topic_map or {},
+            topic_embeddings=embeddings_by_run.get(str(run_id), {}),
+            **kwargs,
+        )
+
+    monkeypatch.setattr(tf_adapter, "map_topic_foundry_run_to_substrate", map_with_embeddings)
+
+    def _ingest_run(*, run_id: str, topic_id: int, label: str) -> None:
+        def fake_get(url: str, params: Optional[dict[str, Any]] = None, timeout: Optional[float] = None):
+            if url.endswith("/runs"):
+                return _FakeResponse(200, _runs_payload(run_id))
+            if url.endswith("/topics"):
+                return _FakeResponse(
+                    200,
+                    {
+                        "items": [
+                            {"topic_id": -1, "count": 10, "outlier_pct": 1.0, "label": None},
+                            {"topic_id": topic_id, "count": 50, "outlier_pct": 0.0, "label": label},
+                        ],
+                        "limit": 200,
+                        "offset": 0,
+                        "total": 2,
+                    },
+                )
+            if "/topics/" in url and url.endswith("/keywords"):
+                return _FakeResponse(200, {"topic_id": topic_id, "keywords": []})
+            raise AssertionError(f"unexpected URL in fake_get: {url}")
+
+        _patch_topic_foundry_client(monkeypatch, fake_get)
+        r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["available"] is True
+        assert body["run_id"] == run_id
+        assert body["concepts_written"] == 1
+
+    _ingest_run(run_id=run_a, topic_id=topic_a, label=labels_by_run[run_a])
+    canonical_concept_id = f"sub-concept-topicfoundry-{run_a}-{topic_a}"
+    run_b_concept_id = f"sub-concept-topicfoundry-{run_b}-{topic_b}"
+
+    _ingest_run(run_id=run_b, topic_id=topic_b, label=labels_by_run[run_b])
+
+    snapshot = store.snapshot()
+    concept_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "concept"]
+    assert len(concept_nodes) == 1, (
+        f"expected one durable concept after embedding merge, got {len(concept_nodes)}: "
+        f"{[n.node_id for n in concept_nodes]}"
+    )
+    durable = concept_nodes[0]
+    assert durable.node_id == canonical_concept_id
+    assert run_b_concept_id not in snapshot.nodes
+
+    supports_edges = [e for e in snapshot.edges.values() if e.predicate == "supports"]
+    assert len(supports_edges) == 2
+    for edge in supports_edges:
+        assert edge.target.node_id == canonical_concept_id
+
+
 # --- partial write honesty: counters must match durable upserts ---
 
 
@@ -397,6 +493,7 @@ def test_ingest_partial_store_write_reports_precise_successful_counts(
     assert body["available"] is False
     assert body["reason"] == "substrate_store_write_failed"
     assert body["run_id"] == FAKE_RUN_ID
+    assert "error" in body
     # Precise partial progress — not the pre-fix lie of all zeros.
     assert body["concepts_written"] == 1
     assert body["evidence_nodes_written"] == 0

--- a/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
+++ b/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
@@ -252,6 +252,157 @@ def test_ingest_is_idempotent_on_repeated_calls(client: TestClient, monkeypatch:
     assert len(concept_nodes) == 2  # not 4 -- deterministic node_ids upsert in place
 
 
+def test_ingest_cross_run_same_label_merges_to_one_durable_concept(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two completed runs with different run/topic IDs but the same semantic label
+    must reconcile to one durable concept node (not two run-scoped orphans).
+
+    Uses identical normalized labels (same keyword-derived label from the real
+    adapter) because the HTTP client does not expose topic centroids; exact-label
+    identity is the resolver contract that works without embeddings today.
+    """
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    run_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    run_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    # Same keyword set → same adapter-derived label ("coherence / identity / merge").
+    shared_keywords = ["coherence", "identity", "merge"]
+    topic_a = 0
+    topic_b = 7
+
+    def _single_topic_payload(topic_id: int) -> dict[str, Any]:
+        return {
+            "items": [
+                {"topic_id": -1, "count": 10, "outlier_pct": 1.0, "label": None},
+                {"topic_id": topic_id, "count": 50, "outlier_pct": 0.0, "label": None},
+            ],
+            "limit": 200,
+            "offset": 0,
+            "total": 2,
+        }
+
+    def _ingest_run(*, run_id: str, topic_id: int) -> dict[str, Any]:
+        def fake_get(url: str, params: Optional[dict[str, Any]] = None, timeout: Optional[float] = None):
+            if url.endswith("/runs"):
+                return _FakeResponse(200, _runs_payload(run_id))
+            if url.endswith("/topics"):
+                return _FakeResponse(200, _single_topic_payload(topic_id))
+            if "/topics/" in url and url.endswith("/keywords"):
+                fetched_topic_id = int(url.rsplit("/", 2)[1])
+                assert fetched_topic_id == topic_id
+                return _FakeResponse(200, {"topic_id": topic_id, "keywords": shared_keywords})
+            raise AssertionError(f"unexpected URL in fake_get: {url}")
+
+        _patch_topic_foundry_client(monkeypatch, fake_get)
+        r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["available"] is True
+        assert body["run_id"] == run_id
+        assert body["concepts_written"] == 1
+        return body
+
+    _ingest_run(run_id=run_a, topic_id=topic_a)
+    canonical_concept_id = f"sub-concept-topicfoundry-{run_a}-{topic_a}"
+    run_b_concept_id = f"sub-concept-topicfoundry-{run_b}-{topic_b}"
+
+    _ingest_run(run_id=run_b, topic_id=topic_b)
+
+    snapshot = store.snapshot()
+    concept_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "concept"]
+    assert len(concept_nodes) == 1, (
+        f"expected one durable concept after cross-run ingest, got {len(concept_nodes)}: "
+        f"{[n.node_id for n in concept_nodes]}"
+    )
+    durable = concept_nodes[0]
+    assert durable.node_id == canonical_concept_id
+    assert durable.node_id != run_b_concept_id
+    assert run_b_concept_id not in snapshot.nodes
+
+    supports_edges = [e for e in snapshot.edges.values() if e.predicate == "supports"]
+    assert len(supports_edges) == 2  # one evidence support per run
+    for edge in supports_edges:
+        assert edge.target.node_id == canonical_concept_id, (
+            f"supports edge must target durable concept {canonical_concept_id}, "
+            f"got {edge.target.node_id}"
+        )
+        assert edge.target.node_id != run_b_concept_id
+
+
+# --- partial write honesty: counters must match durable upserts ---
+
+
+class _FailAfterNUpsertsStore:
+    """Delegating store that succeeds for the first N upserts, then raises.
+
+    Used to prove the ingest route reports precise partial progress when
+    ``SubstrateGraphMaterializer.apply_record`` writes incrementally and then
+    raises mid-record (it does not roll back earlier upserts).
+    """
+
+    def __init__(self, inner: Any, *, fail_after: int) -> None:
+        self._inner = inner
+        self._fail_after = fail_after
+        self._upserts = 0
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def upsert_node(self, *, identity_key: str | None, node: Any) -> None:
+        if self._upserts >= self._fail_after:
+            raise RuntimeError("simulated upsert_node failure after partial write")
+        self._inner.upsert_node(identity_key=identity_key, node=node)
+        self._upserts += 1
+
+    def upsert_edge(self, *, identity_key: str, edge: Any) -> None:
+        if self._upserts >= self._fail_after:
+            raise RuntimeError("simulated upsert_edge failure after partial write")
+        self._inner.upsert_edge(identity_key=identity_key, edge=edge)
+        self._upserts += 1
+
+
+def test_ingest_partial_store_write_reports_precise_successful_counts(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If materialization fails mid-record after some upserts succeeded, the
+    response must report those successful counts — not lie with all zeros.
+    """
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    # Adapter order for the normal fixture: concept0, evidence0, concept1, ...
+    # Fail after the first upsert so one concept node is durable in the store.
+    inner = InMemorySubstrateGraphStore()
+    store = _FailAfterNUpsertsStore(inner, fail_after=1)
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+
+    snapshot = store.snapshot()
+    concept_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "concept"]
+    evidence_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "evidence"]
+    assert len(concept_nodes) == 1
+    assert len(evidence_nodes) == 0
+    assert snapshot.edges == {}
+
+    assert body["available"] is False
+    assert body["reason"] == "substrate_store_write_failed"
+    assert body["run_id"] == FAKE_RUN_ID
+    # Precise partial progress — not the pre-fix lie of all zeros.
+    assert body["concepts_written"] == 1
+    assert body["evidence_nodes_written"] == 0
+    assert body["edges_written"] == 0
+
+
 # --- degraded paths: never a 500, never a fabricated success ---
 
 


### PR DESCRIPTION
## Summary

- Routes Concept Atlas Topic Foundry ingestion through `SubstrateGraphMaterializer`.
- Wires `SubstrateIdentityResolver(store=store)` so repeated concepts use durable identities instead of run-scoped raw IDs.
- Canonicalizes support-edge endpoints when a concept merges across runs.
- Preserves precise partial-write counts when materialization fails mid-record.
- Adds cross-run and partial-failure regression coverage.

## Outcome moved

Repeated ingestion of the same normalized concept across different Topic Foundry run/topic IDs now reinforces one durable substrate concept instead of creating disconnected duplicate nodes.

## Current architecture

The adapter emits run-scoped node IDs. Phase 3 already provided exact-label and embedding-aware identity resolution plus a materializer that rewrites edge endpoints, but the Hub ingestion route bypassed both and raw-upserted those IDs.

## Architecture touched

- Service: `orion-hub`
- Runtime seam: Concept Atlas Topic Foundry ingestion route
- Existing shared contracts reused: `SubstrateGraphMaterializer`, `SubstrateIdentityResolver`, `SubstrateGraphStore`

## Files changed

- `services/orion-hub/scripts/concept_atlas_routes.py`: materialize through the store-aware resolver and count successful partial writes honestly.
- `services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py`: cover cross-run merge, canonical edge targets, and mid-write failure accounting.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: ingestion now resolves durable identity before writes; response shape is unchanged.
- Compatibility notes: current Topic Foundry HTTP responses do not expose centroid embeddings, so this live route merges exact normalized labels today. Store-aware embedding reconciliation is active whenever incoming records contain `metadata[\"concept_embedding\"]`.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: no.
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not applicable; no env template changed.
- skipped keys requiring operator action: none.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py services/orion-hub/tests/test_concept_atlas_routes.py orion/substrate/tests/test_reconcile.py tests/test_cognitive_substrate_topic_foundry_adapter.py tests/test_cognitive_substrate_phase3_materialization.py -q
56 passed, 20 pre-existing warnings
```

## Evals run

```text
No latent-quality behavior changed; this deterministic identity-routing fix is covered by regression tests. No dedicated Concept Atlas eval harness exists for this seam.
```

## Docker/build/smoke checks

```text
scripts/safe_docker_build.sh orion-hub config --quiet
Not run to completion: clean worktree has no local .env file; compose stopped before validation.

scripts/safe_graphify_update.sh
Safety wrapper refused a known-destructive 92% node-count shrink and restored graph state. No graph artifacts committed.
```

## Review findings fixed

- Finding: materializer writes incrementally, but the first patch reported zero writes after a partial failure.
  - Fix: added a thin delegating store counter that increments only after successful upserts.
  - Evidence: fail-after-one regression reports one durable concept and `concepts_written=1`; final re-review found no Critical or Important issues.

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

## Risks / concerns

- Severity: Low.
- Concern: paraphrase-level embedding merge depends on centroid metadata that the current Topic Foundry HTTP client does not expose.
- Mitigation: exact normalized labels merge now; the route uses the store-aware resolver, so embedding merge activates without another write-path change once embeddings are supplied.

## PR link

Created by this PR.

Made with [Cursor](https://cursor.com)