### PR TITLE
feat(backup): local /mnt/scripts rsync snapshots to storage-warm

### DIFF
--- a/deploy/systemd/orion-backup-mnt-scripts.service
+++ b/deploy/systemd/orion-backup-mnt-scripts.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Orion local /mnt/scripts backup
+Documentation=file:/mnt/scripts/Orion-Sapienform/docs/operations/local-mnt-scripts-backup.md
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+TimeoutStartSec=infinity
+WorkingDirectory=/mnt/scripts/Orion-Sapienform
+EnvironmentFile=-/etc/orion-backup-mnt-scripts.env
+ExecStart=/mnt/scripts/Orion-Sapienform/venv/bin/python /mnt/scripts/Orion-Sapienform/scripts/orion_backup_mnt_scripts.py
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/deploy/systemd/orion-backup-mnt-scripts.timer
+++ b/deploy/systemd/orion-backup-mnt-scripts.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly Orion local /mnt/scripts backup
+
+[Timer]
+OnCalendar=*-*-* 03:15:00
+Persistent=true
+Unit=orion-backup-mnt-scripts.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/operations/local-mnt-scripts-backup.md
+++ b/docs/operations/local-mnt-scripts-backup.md
@@ -1,0 +1,107 @@
+# Local `/mnt/scripts` Backup Operations
+
+This runbook installs and operates the local-first backup for `/mnt/scripts`.
+
+## What It Does
+
+- Copies `/mnt/scripts/` to `/mnt/storage-warm/backups/<node-name>/mnt-scripts/snapshots/<run-id>/`, where `<run-id>` is UTC time to second resolution plus the process ID (for example `2026-05-09T22-39-35Z-966029`) so consecutive runs in the same second do not collide.
+- Uses `rsync --link-dest` after the first successful run.
+- Updates `latest` only after a successful snapshot.
+- Keeps the latest 14 successful snapshots.
+- Writes local status, logs, and manifests for every run.
+- Sends an Orion critical attention request on failure when `ORION_BACKUP_NOTIFY_URL` is configured.
+
+## Before Enabling
+
+Confirm mounts:
+
+```bash
+findmnt /mnt/scripts
+findmnt /mnt/storage-warm
+```
+
+Confirm rsync:
+
+```bash
+rsync --version
+```
+
+## Dry Run
+
+Dry-run does **not** acquire the backup lock. You can run it while a real backup is in progress to inspect configuration and observe state without blocking or conflicting with the active run.
+
+Dry-run validates that the backup root is writable by the user running the command, so operators should run it with the same privileges as the systemd service for the real `/mnt/storage-warm` target.
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+sudo PYTHONPATH=. ./venv/bin/python scripts/orion_backup_mnt_scripts.py --dry-run
+```
+
+## First Manual Run
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+sudo PYTHONPATH=. ./venv/bin/python scripts/orion_backup_mnt_scripts.py
+```
+
+Inspect:
+
+```bash
+readlink -f /mnt/storage-warm/backups/$(hostname)/mnt-scripts/latest
+jq . /mnt/storage-warm/backups/$(hostname)/mnt-scripts/status/latest.json
+```
+
+## Optional Orion Notification
+
+Create `/etc/orion-backup-mnt-scripts.env`:
+
+```bash
+ORION_BACKUP_NOTIFY_URL=http://localhost:7140/attention/request
+ORION_BACKUP_NOTIFY_TOKEN=<token-if-required>
+```
+
+Keep the file readable only by the service user if it contains a token.
+
+## Install Timer
+
+Copy the shipped units (paths are relative to the repo root):
+
+```bash
+sudo cp deploy/systemd/orion-backup-mnt-scripts.service /etc/systemd/system/
+sudo cp deploy/systemd/orion-backup-mnt-scripts.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now orion-backup-mnt-scripts.timer
+systemctl list-timers orion-backup-mnt-scripts.timer
+```
+
+### Timer schedule (host local time)
+
+The timer uses `OnCalendar=*-*-* 03:15:00`, which fires at **03:15** in the **host’s local timezone** (systemd calendar semantics). Adjust the unit file if you need a different wall-clock time or timezone policy.
+
+### Service runtime assumptions
+
+- **Interpreter:** `ExecStart` is `/mnt/scripts/Orion-Sapienform/venv/bin/python` (see `deploy/systemd/orion-backup-mnt-scripts.service`). Ensure that venv exists and has the dependencies the backup script needs.
+- **User:** A system-installed unit runs as **root** by default unless you override `User=` / `Group=` (or use a drop-in). Change deliberately if you want a dedicated service account.
+- **Long jobs:** `TimeoutStartSec=infinity` is set on purpose so large `rsync` snapshots are not killed by systemd’s default start timeout.
+
+## Restore A File Or Directory
+
+Choose a snapshot:
+
+```bash
+ls -1 /mnt/storage-warm/backups/$(hostname)/mnt-scripts/snapshots
+```
+
+Restore with metadata preservation:
+
+```bash
+sudo rsync -aHAX --numeric-ids /mnt/storage-warm/backups/$(hostname)/mnt-scripts/snapshots/<run-id>/<relative-path> /mnt/scripts/<restore-target>
+```
+
+The `-A` and `-X` flags preserve POSIX ACLs and extended attributes. These only work on Linux filesystems that support them (ext4, xfs, btrfs with `user_xattr`, zfs with appropriate properties). If you are restoring to a filesystem that does **not** support ACLs/xattrs, the command will fail or silently drop that metadata. Test the restore against a scratch path first, and either accept the metadata gap or drop the `-A`/`-X` flags from the invocation before restoring over real data.
+
+Do not restore over active service directories without deciding whether services need to stop first.
+
+## Cross-Node Note
+
+Do not copy `/etc/fstab` UUIDs from another node. Mount `/mnt/scripts` and `/mnt/storage-warm` using the destination node's own disk identifiers, then restore files from the chosen snapshot.

--- a/docs/superpowers/specs/2026-05-09-local-mnt-scripts-backup-design.md
+++ b/docs/superpowers/specs/2026-05-09-local-mnt-scripts-backup-design.md
@@ -21,7 +21,7 @@ Deliver a local-first backup strategy that:
 1. Creates nightly snapshots of the full `/mnt/scripts` filesystem tree.
 2. Stores those snapshots under `/mnt/storage-warm`.
 3. Keeps the last 14 successful daily snapshots once at least 14 exist.
-4. Supports simple file and directory restore from timestamped snapshot directories.
+4. Supports simple file and directory restore from run-ID snapshot directories.
 5. Writes local machine-readable evidence for every run.
 6. Attempts an Orion critical notification on failure when notification settings are configured.
 7. Avoids hardcoded disk UUIDs or copied `fstab` assumptions in the backup logic.
@@ -43,7 +43,7 @@ Deliver a local-first backup strategy that:
 
 Adopt **Approach B: local snapshot runner with status and alert sidecar**.
 
-The runner uses `rsync --link-dest` to create complete-looking timestamped snapshot directories while hard-linking unchanged files to the previous successful snapshot. It writes local status, logs, and manifests for every run. On failure, it also attempts to notify Orion through the existing notification/attention surface.
+The runner uses `rsync --link-dest` to create complete-looking run-ID snapshot directories while hard-linking unchanged files to the previous successful snapshot. It writes local status, logs, and manifests for every run. On failure, it also attempts to notify Orion through the existing notification/attention surface.
 
 Why this approach:
 
@@ -86,20 +86,22 @@ The backup root is:
 Directory layout:
 
 ```text
-snapshots/<timestamp>/
+snapshots/<run-id>/
 snapshots/.incomplete-<run-id>/
-latest -> snapshots/<timestamp>
+latest -> snapshots/<run-id>
 status/latest.json
 status/runs/<run-id>.json
 logs/<run-id>.log
 manifests/<run-id>.json
 ```
 
-Snapshot timestamps use a sortable UTC format, for example:
+A `<run-id>` is a sortable UTC timestamp suffixed with the runner's process ID, for example:
 
 ```text
-2026-05-09T22-00-00Z
+2026-05-09T22-00-00Z-12345
 ```
+
+The PID suffix exists so two runs that start in the same UTC second on the same node cannot collide on the same snapshot directory name. Without the suffix, a tight retry loop or a manual rerun started in the same second as the timer would either fail with a name conflict or stomp the prior snapshot.
 
 `latest` points only to the newest successful snapshot. Failed or interrupted runs never update `latest`.
 
@@ -118,7 +120,7 @@ Each run:
 7. Finds the previous successful snapshot through `latest` or the newest valid snapshot directory.
 8. Creates `snapshots/.incomplete-<run-id>/`.
 9. Runs `rsync` into the incomplete directory.
-10. If `rsync` succeeds, renames the incomplete directory to `snapshots/<timestamp>/`.
+10. If `rsync` succeeds, renames the incomplete directory to `snapshots/<run-id>/`.
 11. Updates `latest` to point at the new snapshot.
 12. Prunes successful snapshots when more than 14 exist.
 13. Writes status, manifest, and log evidence.
@@ -132,17 +134,17 @@ rsync -aHAX --numeric-ids --delete --link-dest "$previous_snapshot" /mnt/scripts
 
 On the first successful run, omit `--link-dest` because there is no previous snapshot.
 
-If a target filesystem or environment does not support `-A` or `-X`, implementation should detect and document the fallback rather than silently claiming full metadata preservation.
+`-A` and `-X` preserve POSIX ACLs and extended attributes on Linux filesystems that support them (ext4, xfs, btrfs with `user_xattr`, zfs with the right properties). On filesystems that do not, those flags will fail or silently drop metadata. If a target filesystem or environment does not support `-A` or `-X`, implementation should detect and document the fallback rather than silently claiming full metadata preservation. Operators restoring to a filesystem that does not support ACLs/xattrs should test the restore command first, and either accept the metadata gap or remove the `-A`/`-X` flags from the restore invocation.
 
 ---
 
 ## Retention Policy
 
-Retention keeps up to the last 14 successful snapshot directories, sorted by timestamp. After the fifteenth successful run, every successful run prunes older snapshots so only the latest 14 remain.
+Retention keeps up to the last 14 successful snapshot directories, sorted by run ID. After the fifteenth successful run, every successful run prunes older snapshots so only the latest 14 remain.
 
 Rules:
 
-- Only finalized `snapshots/<timestamp>/` directories count.
+- Only finalized `snapshots/<run-id>/` directories count.
 - `.incomplete-*` directories do not count as successful snapshots.
 - Retention runs only after a successful new snapshot.
 - Pruned snapshots are recorded in the run manifest.
@@ -228,13 +230,15 @@ Restore is manual in v1.
 
 Basic flow:
 
-1. Choose a snapshot under `snapshots/<timestamp>/`.
+1. Choose a snapshot under `snapshots/<run-id>/`.
 2. Inspect the file or directory to restore.
 3. Restore with `rsync`, preserving metadata when appropriate:
 
 ```bash
-rsync -aHAX --numeric-ids /mnt/storage-warm/backups/<node-name>/mnt-scripts/snapshots/<timestamp>/<relative-path> /mnt/scripts/<restore-target>
+rsync -aHAX --numeric-ids /mnt/storage-warm/backups/<node-name>/mnt-scripts/snapshots/<run-id>/<relative-path> /mnt/scripts/<restore-target>
 ```
+
+`-A` and `-X` preserve ACLs and xattrs. They only succeed on Linux filesystems that support those metadata classes. If you are restoring to a filesystem that does not (or you are not sure), test the restore command on a scratch path first, and either drop `-A`/`-X` or accept the metadata loss before restoring over real data.
 
 Operators should not restore over actively used service directories without deciding whether services need to be stopped first.
 

--- a/scripts/orion_backup_mnt_scripts.py
+++ b/scripts/orion_backup_mnt_scripts.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+DEFAULT_SOURCE = Path("/mnt/scripts")
+DEFAULT_STORAGE_WARM = Path("/mnt/storage-warm")
+DEFAULT_KEEP_SUCCESSFUL = 14
+
+
+@dataclass(frozen=True)
+class BackupConfig:
+    source_path: Path = DEFAULT_SOURCE
+    storage_warm_path: Path = DEFAULT_STORAGE_WARM
+    node_name: str = socket.gethostname()
+    keep_successful: int = DEFAULT_KEEP_SUCCESSFUL
+    notify_url: str | None = None
+    notify_token: str | None = None
+    require_mounts: bool = True
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class BackupPaths:
+    base_root: Path
+    snapshots_dir: Path
+    incomplete_snapshot: Path
+    final_snapshot: Path
+    latest_symlink: Path
+    status_latest: Path
+    status_run: Path
+    log_path: Path
+    manifest_path: Path
+
+
+@dataclass(frozen=True)
+class RunOutcome:
+    run_id: str
+    status: str
+    node_name: str
+    started_at_utc: str
+    finished_at_utc: str
+    source_path: str
+    target_root: str
+    snapshot_path: str | None
+    latest_symlink: str
+    rsync_exit_code: int | None
+    error_summary: str | None
+    log_path: str
+    manifest_path: str
+    notification_attempt: dict[str, Any] | None
+    retention_actions: list[str]
+    previous_snapshot: str | None
+    mount_validation: dict[str, bool]
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", dir=str(path.parent), delete=False) as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        tmp_name = handle.name
+    Path(tmp_name).replace(path)
+
+
+def write_run_evidence(paths: BackupPaths, outcome: RunOutcome) -> None:
+    payload = asdict(outcome)
+    _write_json_atomic(paths.status_run, payload)
+    _write_json_atomic(paths.status_latest, payload)
+    _write_json_atomic(paths.manifest_path, payload)
+
+
+def prune_successful_snapshots(snapshots_dir: Path, *, keep: int) -> list[str]:
+    if keep < 1:
+        raise ValueError("keep must be at least 1")
+    if not snapshots_dir.exists():
+        return []
+    candidates = sorted(
+        path
+        for path in snapshots_dir.iterdir()
+        if path.is_dir() and not path.name.startswith(".incomplete-")
+    )
+    to_remove = candidates[:-keep]
+    removed: list[str] = []
+    for path in to_remove:
+        shutil.rmtree(path)
+        removed.append(str(path))
+    return removed
+
+
+def _coerce_datetime(value: str | dt.datetime | None) -> dt.datetime:
+    if value is None:
+        return dt.datetime.now(dt.timezone.utc)
+    if isinstance(value, dt.datetime):
+        parsed = value
+    else:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def snapshot_timestamp(value: str | dt.datetime | None = None) -> str:
+    return _coerce_datetime(value).strftime("%Y-%m-%dT%H-%M-%SZ")
+
+
+def _utc_iso(value: str | dt.datetime | None = None) -> str:
+    return _coerce_datetime(value).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _default_process_runner(cmd: list[str], log_path: Path) -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w") as log:
+        log.write("$ " + " ".join(cmd) + "\n")
+        proc = subprocess.run(cmd, stdout=log, stderr=subprocess.STDOUT, text=True)
+    return proc.returncode
+
+
+def _update_latest_symlink(latest: Path, target: Path) -> None:
+    latest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = latest.with_name(f".{latest.name}.tmp")
+    if tmp.exists() or tmp.is_symlink():
+        tmp.unlink()
+    tmp.symlink_to(target)
+    tmp.replace(latest)
+
+
+def find_previous_snapshot(paths: BackupPaths) -> Path | None:
+    latest = paths.latest_symlink
+    if latest.is_symlink():
+        target = latest.resolve()
+        if target.exists() and target.is_dir() and not target.name.startswith(".incomplete-"):
+            return target
+    if not paths.snapshots_dir.exists():
+        return None
+    candidates = sorted(
+        path
+        for path in paths.snapshots_dir.iterdir()
+        if path.is_dir() and not path.name.startswith(".incomplete-")
+    )
+    return candidates[-1] if candidates else None
+
+
+def build_rsync_command(cfg: BackupConfig, paths: BackupPaths, *, previous_snapshot: Path | None) -> list[str]:
+    cmd = ["rsync", "-aHAX", "--numeric-ids", "--delete"]
+    if previous_snapshot is not None:
+        cmd.extend(["--link-dest", str(previous_snapshot)])
+    cmd.extend([str(cfg.source_path) + "/", str(paths.incomplete_snapshot) + "/"])
+    return cmd
+
+
+def build_paths(cfg: BackupConfig, *, run_id: str) -> BackupPaths:
+    base_root = cfg.storage_warm_path / "backups" / cfg.node_name / "mnt-scripts"
+    snapshots_dir = base_root / "snapshots"
+    return BackupPaths(
+        base_root=base_root,
+        snapshots_dir=snapshots_dir,
+        incomplete_snapshot=snapshots_dir / f".incomplete-{run_id}",
+        final_snapshot=snapshots_dir / run_id,
+        latest_symlink=base_root / "latest",
+        status_latest=base_root / "status" / "latest.json",
+        status_run=base_root / "status" / "runs" / f"{run_id}.json",
+        log_path=base_root / "logs" / f"{run_id}.log",
+        manifest_path=base_root / "manifests" / f"{run_id}.json",
+    )
+
+
+def _nearest_existing_parent(path: Path) -> Path:
+    current = path
+    while not current.exists() and current != current.parent:
+        current = current.parent
+    return current
+
+
+def validate_environment(
+    cfg: BackupConfig,
+    *,
+    is_mount: Callable[[Path], bool] | None = None,
+    is_writable: Callable[[Path], bool] | None = None,
+    rsync_path: str | None = None,
+) -> None:
+    mount_check = is_mount or (lambda path: path.is_mount())
+    writable_check = is_writable or (lambda path: os.access(path, os.W_OK | os.X_OK))
+    if not cfg.source_path.exists():
+        raise RuntimeError(f"source path does not exist: {cfg.source_path}")
+    if not cfg.storage_warm_path.exists():
+        raise RuntimeError(f"target path does not exist: {cfg.storage_warm_path}")
+    if cfg.require_mounts and not mount_check(cfg.source_path):
+        raise RuntimeError(f"source path must be a mount point: {cfg.source_path}")
+    if cfg.require_mounts and not mount_check(cfg.storage_warm_path):
+        raise RuntimeError(f"target path must be a mount point: {cfg.storage_warm_path}")
+    if cfg.source_path.resolve() == cfg.storage_warm_path.resolve():
+        raise RuntimeError("source and target paths must be different")
+    if not (rsync_path or shutil.which("rsync")):
+        raise RuntimeError("rsync binary not found on PATH")
+    backup_root = cfg.storage_warm_path / "backups" / cfg.node_name / "mnt-scripts"
+    writable_parent = _nearest_existing_parent(backup_root)
+    if not writable_check(writable_parent):
+        raise RuntimeError(
+            f"backup root parent is not writable: {writable_parent}"
+        )
+
+
+def acquire_lock(lock_path: Path):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("w")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        handle.close()
+        raise RuntimeError(f"backup already running: {lock_path}") from exc
+    handle.write(str(os.getpid()))
+    handle.flush()
+    return handle
+
+
+def send_failure_notification(outcome: RunOutcome, cfg: BackupConfig) -> dict[str, Any]:
+    if not cfg.notify_url:
+        return {"attempted": False, "ok": False, "reason": "notify_url_not_configured"}
+    message = (
+        f"Backup failed on {outcome.node_name} "
+        f"(run_id={outcome.run_id}): "
+        f"source={outcome.source_path} -> target={outcome.target_root}: "
+        f"{outcome.error_summary}"
+    )
+    payload = {
+        "source_service": "orion-backup",
+        "reason": "backup_failed",
+        "severity": "critical",
+        "message": message,
+        "require_ack": True,
+        "context": {
+            "run_id": outcome.run_id,
+            "source_path": outcome.source_path,
+            "target_root": outcome.target_root,
+            "log_path": outcome.log_path,
+            "manifest_path": outcome.manifest_path,
+            "rsync_exit_code": outcome.rsync_exit_code,
+        },
+    }
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(cfg.notify_url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+    if cfg.notify_token:
+        request.add_header("X-Orion-Notify-Token", cfg.notify_token)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return {"attempted": True, "ok": 200 <= response.status < 300, "status": response.status}
+    except (urllib.error.URLError, TimeoutError) as exc:
+        return {"attempted": True, "ok": False, "error": str(exc)}
+
+
+def run_backup(
+    cfg: BackupConfig,
+    *,
+    now: str | dt.datetime | None = None,
+    process_runner: Callable[[list[str], Path], int] = _default_process_runner,
+    notifier: Callable[[RunOutcome, BackupConfig], dict[str, Any]] = send_failure_notification,
+) -> RunOutcome:
+    validate_environment(cfg)
+    started = _utc_iso(now)
+    timestamp = snapshot_timestamp(now)
+    run_id = f"{timestamp}-{os.getpid()}"
+    paths = build_paths(cfg, run_id=run_id)
+    lock_handle = acquire_lock(paths.base_root / "backup.lock")
+    try:
+        paths.snapshots_dir.mkdir(parents=True, exist_ok=True)
+        paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+        previous = find_previous_snapshot(paths)
+        cmd = build_rsync_command(cfg, paths, previous_snapshot=previous)
+        rsync_exit: int | None = None
+        error_summary: str | None = None
+        snapshot_path: str | None = None
+        retention_actions: list[str] = []
+        try:
+            if paths.final_snapshot.exists():
+                raise RuntimeError(f"snapshot already exists: {paths.final_snapshot}")
+            if paths.incomplete_snapshot.exists():
+                shutil.rmtree(paths.incomplete_snapshot)
+            paths.incomplete_snapshot.mkdir(parents=True)
+            rsync_exit = process_runner(cmd, paths.log_path)
+            if rsync_exit != 0:
+                raise RuntimeError(f"rsync exited with {rsync_exit}")
+            paths.incomplete_snapshot.replace(paths.final_snapshot)
+            _update_latest_symlink(paths.latest_symlink, paths.final_snapshot)
+            retention_actions = prune_successful_snapshots(paths.snapshots_dir, keep=cfg.keep_successful)
+            snapshot_path = str(paths.final_snapshot)
+            status = "success"
+        except Exception as exc:
+            status = "failure"
+            error_summary = str(exc)
+        outcome = RunOutcome(
+            run_id=run_id,
+            status=status,
+            node_name=cfg.node_name,
+            started_at_utc=started,
+            finished_at_utc=_utc_iso(None),
+            source_path=str(cfg.source_path),
+            target_root=str(paths.base_root),
+            snapshot_path=snapshot_path,
+            latest_symlink=str(paths.latest_symlink),
+            rsync_exit_code=rsync_exit,
+            error_summary=error_summary,
+            log_path=str(paths.log_path),
+            manifest_path=str(paths.manifest_path),
+            notification_attempt=None,
+            retention_actions=retention_actions,
+            previous_snapshot=str(previous) if previous else None,
+            mount_validation={
+                "source": (not cfg.require_mounts) or cfg.source_path.is_mount(),
+                "target": (not cfg.require_mounts) or cfg.storage_warm_path.is_mount(),
+            },
+        )
+        write_run_evidence(paths, outcome)
+        if outcome.status == "failure":
+            notify_result = notifier(outcome, cfg)
+            outcome = RunOutcome(**{**asdict(outcome), "notification_attempt": notify_result})
+            write_run_evidence(paths, outcome)
+        return outcome
+    finally:
+        lock_handle.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Create local hard-linked snapshots of /mnt/scripts.")
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--storage-warm", type=Path, default=DEFAULT_STORAGE_WARM)
+    parser.add_argument("--node-name", default=socket.gethostname())
+    parser.add_argument("--keep-successful", type=int, default=DEFAULT_KEEP_SUCCESSFUL)
+    parser.add_argument("--notify-url", default=os.environ.get("ORION_BACKUP_NOTIFY_URL"))
+    parser.add_argument("--notify-token", default=os.environ.get("ORION_BACKUP_NOTIFY_TOKEN"))
+    parser.add_argument("--no-require-mounts", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    cfg = BackupConfig(
+        source_path=args.source,
+        storage_warm_path=args.storage_warm,
+        node_name=args.node_name,
+        keep_successful=args.keep_successful,
+        notify_url=args.notify_url,
+        notify_token=args.notify_token,
+        require_mounts=not args.no_require_mounts,
+        dry_run=args.dry_run,
+    )
+    if cfg.dry_run:
+        validate_environment(cfg)
+        now = _coerce_datetime(None)
+        timestamp = snapshot_timestamp(now)
+        run_id = f"{timestamp}-{os.getpid()}"
+        paths = build_paths(cfg, run_id=run_id)
+        previous = find_previous_snapshot(paths)
+        cmd = build_rsync_command(cfg, paths, previous_snapshot=previous)
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "dry_run": True,
+                    "node_name": cfg.node_name,
+                    "base_root": str(paths.base_root),
+                    "previous_snapshot": str(previous) if previous else None,
+                    "rsync_command": cmd,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    outcome = run_backup(cfg)
+    print(json.dumps(asdict(outcome), sort_keys=True))
+    return 0 if outcome.status == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orion_backup_mnt_scripts.py
+++ b/scripts/orion_backup_mnt_scripts.py
@@ -102,6 +102,18 @@ def prune_successful_snapshots(snapshots_dir: Path, *, keep: int) -> list[str]:
     return removed
 
 
+def cleanup_incomplete_snapshots(snapshots_dir: Path) -> list[str]:
+    """Remove leftover .incomplete-* dirs from failed or interrupted runs."""
+    if not snapshots_dir.exists():
+        return []
+    removed: list[str] = []
+    for path in sorted(snapshots_dir.iterdir()):
+        if path.is_dir() and path.name.startswith(".incomplete-"):
+            shutil.rmtree(path)
+            removed.append(str(path))
+    return removed
+
+
 def _coerce_datetime(value: str | dt.datetime | None) -> dt.datetime:
     if value is None:
         return dt.datetime.now(dt.timezone.utc)
@@ -279,6 +291,7 @@ def run_backup(
     try:
         paths.snapshots_dir.mkdir(parents=True, exist_ok=True)
         paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+        cleanup_incomplete_snapshots(paths.snapshots_dir)
         previous = find_previous_snapshot(paths)
         cmd = build_rsync_command(cfg, paths, previous_snapshot=previous)
         rsync_exit: int | None = None
@@ -288,8 +301,6 @@ def run_backup(
         try:
             if paths.final_snapshot.exists():
                 raise RuntimeError(f"snapshot already exists: {paths.final_snapshot}")
-            if paths.incomplete_snapshot.exists():
-                shutil.rmtree(paths.incomplete_snapshot)
             paths.incomplete_snapshot.mkdir(parents=True)
             rsync_exit = process_runner(cmd, paths.log_path)
             if rsync_exit != 0:

--- a/tests/test_orion_backup_mnt_scripts.py
+++ b/tests/test_orion_backup_mnt_scripts.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.orion_backup_mnt_scripts import (
+    BackupConfig,
+    RunOutcome,
+    acquire_lock,
+    build_paths,
+    build_rsync_command,
+    find_previous_snapshot,
+    prune_successful_snapshots,
+    run_backup,
+    send_failure_notification,
+    snapshot_timestamp,
+    validate_environment,
+    write_run_evidence,
+)
+
+
+def test_snapshot_timestamp_is_sortable_utc() -> None:
+    assert snapshot_timestamp("2026-05-09T22:00:00+00:00") == "2026-05-09T22-00-00Z"
+
+
+def test_build_paths_uses_node_scoped_backup_root(tmp_path: Path) -> None:
+    cfg = BackupConfig(
+        source_path=tmp_path / "scripts",
+        storage_warm_path=tmp_path / "storage-warm",
+        node_name="node-a",
+    )
+
+    paths = build_paths(cfg, run_id="run-1")
+
+    assert paths.base_root == tmp_path / "storage-warm" / "backups" / "node-a" / "mnt-scripts"
+    assert paths.snapshots_dir == paths.base_root / "snapshots"
+    assert paths.incomplete_snapshot == paths.snapshots_dir / ".incomplete-run-1"
+    assert paths.final_snapshot == paths.snapshots_dir / "run-1"
+    assert paths.latest_symlink == paths.base_root / "latest"
+    assert paths.status_latest == paths.base_root / "status" / "latest.json"
+    assert paths.status_run == paths.base_root / "status" / "runs" / "run-1.json"
+    assert paths.log_path == paths.base_root / "logs" / "run-1.log"
+    assert paths.manifest_path == paths.base_root / "manifests" / "run-1.json"
+
+
+def test_validate_environment_requires_mounted_source_and_target(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    cfg = BackupConfig(source_path=source, storage_warm_path=target, node_name="node-a")
+
+    with pytest.raises(RuntimeError, match="/mnt/scripts.*mount point|source.*mount point"):
+        validate_environment(cfg, is_mount=lambda path: False, rsync_path="/usr/bin/rsync")
+
+
+def test_validate_environment_accepts_mounted_paths(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    cfg = BackupConfig(source_path=source, storage_warm_path=target, node_name="node-a")
+
+    validate_environment(cfg, is_mount=lambda path: True, rsync_path="/usr/bin/rsync")
+
+
+def test_validate_environment_requires_writable_backup_root_parent(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    cfg = BackupConfig(source_path=source, storage_warm_path=target, node_name="node-a")
+
+    with pytest.raises(RuntimeError, match="backup root.*writable"):
+        validate_environment(
+            cfg,
+            is_mount=lambda path: True,
+            is_writable=lambda path: False,
+            rsync_path="/usr/bin/rsync",
+        )
+
+
+def test_validate_environment_writable_check_uses_nearest_existing_parent(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    cfg = BackupConfig(source_path=source, storage_warm_path=target, node_name="node-a")
+    seen: list[Path] = []
+
+    def fake_is_writable(path: Path) -> bool:
+        seen.append(path)
+        return True
+
+    validate_environment(
+        cfg,
+        is_mount=lambda path: True,
+        is_writable=fake_is_writable,
+        rsync_path="/usr/bin/rsync",
+    )
+
+    assert seen == [target]
+
+
+def test_find_previous_snapshot_uses_latest_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "storage-warm" / "backups" / "node-a" / "mnt-scripts"
+    previous = root / "snapshots" / "2026-05-08T22-00-00Z"
+    previous.mkdir(parents=True)
+    (root / "latest").symlink_to(previous)
+
+    cfg = BackupConfig(source_path=tmp_path / "scripts", storage_warm_path=tmp_path / "storage-warm", node_name="node-a")
+    paths = build_paths(cfg, run_id="run-2")
+
+    assert find_previous_snapshot(paths) == previous
+
+
+def test_find_previous_snapshot_ignores_latest_if_it_points_to_incomplete(tmp_path: Path) -> None:
+    root = tmp_path / "storage-warm" / "backups" / "node-a" / "mnt-scripts"
+    snapshots = root / "snapshots"
+    complete = snapshots / "2026-05-08T22-00-00Z"
+    incomplete = snapshots / ".incomplete-run-9"
+    complete.mkdir(parents=True)
+    incomplete.mkdir()
+    (root / "latest").symlink_to(incomplete)
+
+    cfg = BackupConfig(source_path=tmp_path / "scripts", storage_warm_path=tmp_path / "storage-warm", node_name="node-a")
+    paths = build_paths(cfg, run_id="run-2")
+
+    assert find_previous_snapshot(paths) == complete
+
+
+def test_find_previous_snapshot_falls_back_to_newest_complete_snapshot(tmp_path: Path) -> None:
+    root = tmp_path / "storage-warm" / "backups" / "node-a" / "mnt-scripts"
+    snapshots = root / "snapshots"
+    older = snapshots / "2026-05-07T22-00-00Z"
+    newest = snapshots / "2026-05-08T22-00-00Z"
+    incomplete = snapshots / ".incomplete-run-9"
+    older.mkdir(parents=True)
+    newest.mkdir()
+    incomplete.mkdir()
+
+    cfg = BackupConfig(source_path=tmp_path / "scripts", storage_warm_path=tmp_path / "storage-warm", node_name="node-a")
+    paths = build_paths(cfg, run_id="run-2")
+
+    assert find_previous_snapshot(paths) == newest
+
+
+def test_build_rsync_command_omits_link_dest_without_previous(tmp_path: Path) -> None:
+    cfg = BackupConfig(source_path=tmp_path / "scripts", storage_warm_path=tmp_path / "storage-warm", node_name="node-a")
+    paths = build_paths(cfg, run_id="run-1")
+
+    cmd = build_rsync_command(cfg, paths, previous_snapshot=None)
+
+    assert cmd[:4] == ["rsync", "-aHAX", "--numeric-ids", "--delete"]
+    assert "--link-dest" not in cmd
+    assert str(cfg.source_path) + "/" in cmd
+    assert str(paths.incomplete_snapshot) + "/" in cmd
+
+
+def test_build_rsync_command_uses_previous_snapshot_for_link_dest(tmp_path: Path) -> None:
+    cfg = BackupConfig(source_path=tmp_path / "scripts", storage_warm_path=tmp_path / "storage-warm", node_name="node-a")
+    paths = build_paths(cfg, run_id="run-2")
+    previous = tmp_path / "storage-warm" / "backups" / "node-a" / "mnt-scripts" / "snapshots" / "2026-05-08T22-00-00Z"
+
+    cmd = build_rsync_command(cfg, paths, previous_snapshot=previous)
+
+    assert cmd[:4] == ["rsync", "-aHAX", "--numeric-ids", "--delete"]
+    assert "--link-dest" in cmd
+    assert str(previous) in cmd
+
+
+def test_write_run_evidence_updates_latest_status_and_manifest(tmp_path: Path) -> None:
+    cfg = BackupConfig(source_path=tmp_path / "scripts", storage_warm_path=tmp_path / "storage-warm", node_name="node-a")
+    paths = build_paths(cfg, run_id="run-1")
+    outcome = RunOutcome(
+        run_id="run-1",
+        status="success",
+        node_name="node-a",
+        started_at_utc="2026-05-09T22:00:00Z",
+        finished_at_utc="2026-05-09T22:01:00Z",
+        source_path=str(cfg.source_path),
+        target_root=str(paths.base_root),
+        snapshot_path=str(paths.final_snapshot),
+        latest_symlink=str(paths.latest_symlink),
+        rsync_exit_code=0,
+        error_summary=None,
+        log_path=str(paths.log_path),
+        manifest_path=str(paths.manifest_path),
+        notification_attempt=None,
+        retention_actions=[],
+        previous_snapshot=None,
+        mount_validation={"source": True, "target": True},
+    )
+
+    write_run_evidence(paths, outcome)
+
+    assert json.loads(paths.status_latest.read_text())["status"] == "success"
+    assert json.loads(paths.status_run.read_text())["run_id"] == "run-1"
+    assert json.loads(paths.manifest_path.read_text())["snapshot_path"] == str(paths.final_snapshot)
+
+
+def test_run_backup_finalizes_snapshot_and_latest_symlink(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    cfg = BackupConfig(source_path=source, storage_warm_path=target, node_name="node-a", require_mounts=False)
+
+    def fake_run(cmd: list[str], log_path: Path) -> int:
+        destination = Path(cmd[-1].rstrip("/"))
+        destination.mkdir(parents=True, exist_ok=True)
+        (destination / "hello.txt").write_text("world\n")
+        log_path.write_text("fake rsync ok\n")
+        return 0
+
+    outcome = run_backup(cfg, now="2026-05-09T22:00:00+00:00", process_runner=fake_run)
+
+    assert outcome.status == "success"
+    assert Path(outcome.snapshot_path or "").is_dir()
+    latest = target / "backups" / "node-a" / "mnt-scripts" / "latest"
+    assert latest.is_symlink()
+    assert latest.resolve() == Path(outcome.snapshot_path or "").resolve()
+
+
+def test_run_backup_writes_failure_evidence_before_notification(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    cfg = BackupConfig(
+        source_path=source,
+        storage_warm_path=target,
+        node_name="node-a",
+        require_mounts=False,
+        notify_url="http://notify.invalid/attention/request",
+    )
+    seen_status: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], log_path: Path) -> int:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("rsync failed\n")
+        return 23
+
+    def fake_notify(outcome: RunOutcome, cfg: BackupConfig) -> dict[str, Any]:
+        seen_status["exists"] = Path(outcome.manifest_path).exists()
+        return {"attempted": True, "ok": False, "error": "blocked"}
+
+    outcome = run_backup(cfg, now="2026-05-09T22:00:00+00:00", process_runner=fake_run, notifier=fake_notify)
+
+    assert outcome.status == "failure"
+    assert seen_status == {"exists": True}
+    assert Path(outcome.manifest_path).exists()
+
+
+def test_prune_successful_snapshots_keeps_latest_14(tmp_path: Path) -> None:
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir()
+    for day in range(1, 17):
+        (snapshots / f"2026-05-{day:02d}T22-00-00Z").mkdir()
+    (snapshots / ".incomplete-run").mkdir()
+
+    removed = prune_successful_snapshots(snapshots, keep=14)
+
+    assert removed == [
+        str(snapshots / "2026-05-01T22-00-00Z"),
+        str(snapshots / "2026-05-02T22-00-00Z"),
+    ]
+    assert not (snapshots / "2026-05-01T22-00-00Z").exists()
+    assert (snapshots / ".incomplete-run").exists()
+
+
+def test_acquire_lock_rejects_second_holder(tmp_path: Path) -> None:
+    lock_path = tmp_path / "backup.lock"
+    first = acquire_lock(lock_path)
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            acquire_lock(lock_path)
+    finally:
+        first.close()
+
+
+def test_send_failure_notification_message_includes_run_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = BackupConfig(
+        source_path=tmp_path / "scripts",
+        storage_warm_path=tmp_path / "storage-warm",
+        node_name="node-a",
+        notify_url="http://notify.invalid/attention/request",
+    )
+    target_root = str(tmp_path / "storage-warm" / "backups" / "node-a" / "mnt-scripts")
+    outcome = RunOutcome(
+        run_id="2026-05-09T22-00-00Z-12345",
+        status="failure",
+        node_name="node-a",
+        started_at_utc="2026-05-09T22:00:00Z",
+        finished_at_utc="2026-05-09T22:01:00Z",
+        source_path="/mnt/scripts",
+        target_root=target_root,
+        snapshot_path=None,
+        latest_symlink=str(tmp_path / "latest"),
+        rsync_exit_code=23,
+        error_summary="rsync exited with 23",
+        log_path=str(tmp_path / "log.log"),
+        manifest_path=str(tmp_path / "manifest.json"),
+        notification_attempt=None,
+        retention_actions=[],
+        previous_snapshot=None,
+        mount_validation={"source": True, "target": True},
+    )
+    captured: dict[str, Any] = {}
+
+    class _FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+    def fake_urlopen(request: Any, timeout: int = 10) -> _FakeResponse:
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        captured["url"] = request.full_url
+        return _FakeResponse()
+
+    monkeypatch.setattr(
+        "scripts.orion_backup_mnt_scripts.urllib.request.urlopen", fake_urlopen
+    )
+
+    result = send_failure_notification(outcome, cfg)
+
+    assert result == {"attempted": True, "ok": True, "status": 200}
+    payload = captured["payload"]
+    message = payload["message"]
+    assert "node-a" in message
+    assert "/mnt/scripts" in message
+    assert target_root in message
+    assert "2026-05-09T22-00-00Z-12345" in message
+    assert "rsync exited with 23" in message
+
+
+def test_cli_dry_run_allows_non_mount_fixture_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    from scripts.orion_backup_mnt_scripts import main
+
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+
+    rc = main([
+        "--source", str(source),
+        "--storage-warm", str(target),
+        "--node-name", "node-a",
+        "--no-require-mounts",
+        "--dry-run",
+    ])
+
+    assert rc == 0
+    assert '"dry_run": true' in capsys.readouterr().out

--- a/tests/test_orion_backup_mnt_scripts.py
+++ b/tests/test_orion_backup_mnt_scripts.py
@@ -12,6 +12,7 @@ from scripts.orion_backup_mnt_scripts import (
     acquire_lock,
     build_paths,
     build_rsync_command,
+    cleanup_incomplete_snapshots,
     find_previous_snapshot,
     prune_successful_snapshots,
     run_backup,
@@ -255,6 +256,85 @@ def test_run_backup_writes_failure_evidence_before_notification(tmp_path: Path) 
     assert Path(outcome.manifest_path).exists()
 
 
+def test_run_backup_failure_preserves_previous_latest_symlink(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    cfg = BackupConfig(source_path=source, storage_warm_path=target, node_name="node-a", require_mounts=False)
+
+    def fake_ok(cmd: list[str], log_path: Path) -> int:
+        destination = Path(cmd[-1].rstrip("/"))
+        destination.mkdir(parents=True, exist_ok=True)
+        (destination / "hello.txt").write_text("ok\n")
+        log_path.write_text("ok\n")
+        return 0
+
+    first = run_backup(cfg, now="2026-05-09T22:00:00+00:00", process_runner=fake_ok)
+    assert first.status == "success"
+    previous_snapshot = Path(first.snapshot_path or "")
+    latest = target / "backups" / "node-a" / "mnt-scripts" / "latest"
+    assert latest.resolve() == previous_snapshot.resolve()
+
+    def fake_fail(cmd: list[str], log_path: Path) -> int:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("rsync failed\n")
+        return 23
+
+    second = run_backup(cfg, now="2026-05-09T22:01:00+00:00", process_runner=fake_fail)
+    assert second.status == "failure"
+    assert latest.is_symlink()
+    assert latest.resolve() == previous_snapshot.resolve()
+
+
+def test_run_backup_cleans_stale_incomplete_dirs(tmp_path: Path) -> None:
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+    snapshots = target / "backups" / "node-a" / "mnt-scripts" / "snapshots"
+    snapshots.mkdir(parents=True)
+    stale = snapshots / ".incomplete-old-run"
+    stale.mkdir()
+    (stale / "partial.txt").write_text("leftover\n")
+    cfg = BackupConfig(source_path=source, storage_warm_path=target, node_name="node-a", require_mounts=False)
+
+    def fake_run(cmd: list[str], log_path: Path) -> int:
+        destination = Path(cmd[-1].rstrip("/"))
+        destination.mkdir(parents=True, exist_ok=True)
+        (destination / "hello.txt").write_text("world\n")
+        log_path.write_text("ok\n")
+        return 0
+
+    outcome = run_backup(cfg, now="2026-05-09T22:00:00+00:00", process_runner=fake_run)
+
+    assert outcome.status == "success"
+    assert not stale.exists()
+    assert cleanup_incomplete_snapshots(snapshots) == []
+
+
+def test_cli_dry_run_allows_non_mount_fixture_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    from scripts.orion_backup_mnt_scripts import main
+
+    source = tmp_path / "scripts"
+    target = tmp_path / "storage-warm"
+    source.mkdir()
+    target.mkdir()
+
+    rc = main([
+        "--source", str(source),
+        "--storage-warm", str(target),
+        "--node-name", "node-a",
+        "--no-require-mounts",
+        "--dry-run",
+    ])
+
+    assert rc == 0
+    assert '"dry_run": true' in capsys.readouterr().out
+    lock_path = target / "backups" / "node-a" / "mnt-scripts" / "backup.lock"
+    assert not lock_path.exists()
+
+
 def test_prune_successful_snapshots_keeps_latest_14(tmp_path: Path) -> None:
     snapshots = tmp_path / "snapshots"
     snapshots.mkdir()
@@ -341,23 +421,3 @@ def test_send_failure_notification_message_includes_run_context(
     assert target_root in message
     assert "2026-05-09T22-00-00Z-12345" in message
     assert "rsync exited with 23" in message
-
-
-def test_cli_dry_run_allows_non_mount_fixture_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    from scripts.orion_backup_mnt_scripts import main
-
-    source = tmp_path / "scripts"
-    target = tmp_path / "storage-warm"
-    source.mkdir()
-    target.mkdir()
-
-    rc = main([
-        "--source", str(source),
-        "--storage-warm", str(target),
-        "--node-name", "node-a",
-        "--no-require-mounts",
-        "--dry-run",
-    ])
-
-    assert rc == 0
-    assert '"dry_run": true' in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Adds `scripts/orion_backup_mnt_scripts.py`: hard-linked `rsync --link-dest` nightly snapshots of `/mnt/scripts` into `/mnt/storage-warm/backups/<node>/mnt-scripts/`.
- Stages into `.incomplete-<run-id>`, renames only on success, keeps 14 successful snapshots, writes status/manifest/log evidence, optional Orion failure notify.
- Ships systemd oneshot + Persistent timer (03:15 local) and an operator runbook under `docs/operations/`.

## Outcome moved

Local file-restore backup path exists and is testable; operators can dry-run / enable a timer without UUID/`fstab` assumptions.

## Current architecture

No automated `/mnt/scripts` → `/mnt/storage-warm` snapshot runner existed on main (prior May work lived on a stale nested worktree branch only).

## Architecture touched

- Runner script + unit tests (stdlib + rsync)
- `deploy/systemd/` unit templates
- Ops runbook + design wording for run-id snapshot dirs

## Files changed

- `scripts/orion_backup_mnt_scripts.py`: snapshot runner
- `tests/test_orion_backup_mnt_scripts.py`: layout, rsync planning, evidence, retention, lock, failure/notify, incomplete cleanup
- `deploy/systemd/orion-backup-mnt-scripts.service` / `.timer`: nightly schedule
- `docs/operations/local-mnt-scripts-backup.md`: install/restore
- `docs/superpowers/specs/2026-05-09-local-mnt-scripts-backup-design.md`: align with run-id dirs

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: none
- Compatibility notes: optional notify posts to existing Orion Notify `/attention/request`

## Env/config changes

- Added keys: `ORION_BACKUP_NOTIFY_URL`, `ORION_BACKUP_NOTIFY_TOKEN` (optional; via `/etc/orion-backup-mnt-scripts.env` or CLI)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced: n/a
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=. /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest tests/test_orion_backup_mnt_scripts.py -q
20 passed in 0.16s
```

## Evals run

```text
No eval harness for this ops script; unit + temp-dir smoke cover the seam.
```

## Docker/build/smoke checks

```text
Two-run temp smoke (fake source/target, --no-require-mounts): 2 snapshot dirs, latest symlink OK.
systemd-analyze verify deploy/systemd/orion-backup-mnt-scripts.{service,timer}: exit 0
Production --dry-run without sudo: fails writability on root-owned /mnt/storage-warm (documented; use sudo for real paths)
```

## Review findings fixed

- Finding: Failed runs left orphaned `.incomplete-*` dirs
  - Fix: `cleanup_incomplete_snapshots()` at run start
  - Evidence: `test_run_backup_cleans_stale_incomplete_dirs`
- Finding: No test that dry-run skips lock
  - Fix: assert no `backup.lock` in dry-run CLI test
  - Evidence: `test_cli_dry_run_allows_non_mount_fixture_paths`
- Finding: No test that failure preserves prior `latest`
  - Fix: success then fail; assert `latest` still points at first snapshot
  - Evidence: `test_run_backup_failure_preserves_previous_latest_symlink`

## Restart required

```bash
# After merge, on the host (operator):
sudo cp deploy/systemd/orion-backup-mnt-scripts.service /etc/systemd/system/
sudo cp deploy/systemd/orion-backup-mnt-scripts.timer /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now orion-backup-mnt-scripts.timer
# Optional first run:
sudo PYTHONPATH=. ./venv/bin/python scripts/orion_backup_mnt_scripts.py
```

## Risks / concerns

- Severity: low
- Concern: Live rsync is best-effort (no service quiesce); long copies need `TimeoutStartSec=infinity` (already set)
- Mitigation: evidence + Orion notify on failure; retain 14 dailies

## Test plan

- [ ] `pytest tests/test_orion_backup_mnt_scripts.py -q`
- [ ] Temp-dir smoke with `--no-require-mounts`
- [ ] `sudo` dry-run against real mounts
- [ ] Enable timer and confirm `systemctl list-timers orion-backup-mnt-scripts.timer`

## PR link

(filled after create)

Made with [Cursor](https://cursor.com)