### PR TITLE
chore(hub): switch substrate store to FalkorDB per routing doctrine

### DIFF
--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -212,7 +212,11 @@ RECALL_PG_DSN=postgresql://postgres:postgres@127.0.0.1:55432/conjourney
 GRAPHITI_ENABLED=true
 # Deprecated fallback — prefer GRAPHITI_ADAPTER_URL below
 GRAPHITI_URL=
-FALKORDB_URI=
+# Shared with the substrate concept graph below (SUBSTRATE_STORE_BACKEND=falkor) --
+# one FalkorDB instance, differentiated by graph name (this feature's own internal
+# graph vs. FALKORDB_SUBSTRATE_GRAPH). Host-mode: 127.0.0.1 + published port (6380),
+# not orion-athena-falkordb:6379 (bridge-network-only Docker DNS).
+FALKORDB_URI=redis://127.0.0.1:6380
 
 # --- Memory crystallization projections ---
 CRYSTALLIZER_VECTOR_COLLECTION=orion_memory_crystallizations
@@ -455,16 +459,24 @@ SUBSTRATE_MUTATION_OPERATOR_TOKEN=
 # literal container path so it's correct regardless of what STORAGE_ROOT resolves to.
 FIELD_PLASTICITY_SQL_DB_PATH=/mnt/postgres/field_topology/learned_weights.sqlite3
 
-# --- Substrate semantic graph (Fuseki / SPARQL or legacy GraphDB) ---
-# RDF Store V1: Hub docker-compose defaults SUBSTRATE_STORE_BACKEND=sparql with Athena Fuseki URLs; override for host mode (127.0.0.1).
-# Query/update URLs fall back to RDF_STORE_QUERY_URL / RDF_STORE_UPDATE_URL when SUBSTRATE_GRAPH_* are unset.
-# With HUB_DOCKER_NETWORK_MODE=host, use 127.0.0.1 + published Fuseki port (3030), not Docker service DNS.
-# TEMP (2026-07-16): concept-atlas pipeline is proving out on in-memory storage first
-# (see orion/substrate/seed.py, orion/substrate/adapters/topic_foundry.py). The
-# SUBSTRATE_GRAPH_QUERY_URL/UPDATE_URL below also have a real host-vs-container-DNS
-# mismatch (use orion-athena-fuseki, should be 127.0.0.1 per the comment above) that
-# needs fixing before switching back to sparql -- tracked as tech debt, not yet fixed.
-SUBSTRATE_STORE_BACKEND=in_memory
+# --- Substrate semantic graph (FalkorDB property graph -- see
+# docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md) ---
+# 2026-07-17: RDF/Fuseki/SPARQL is explicitly rejected as the target for this seam per
+# that doctrine (append-heavy SPARQL UPDATE loops, index amplification, compaction
+# downtime -- see the doc's Arsonist summary). FalkorSubstrateStore / RoutedSubstrateGraphStore
+# already exist and are wired into build_substrate_store_from_env() (orion/substrate/graphdb_store.py).
+# Connects via the shared FALKORDB_URI below (same FalkorDB instance the Graphiti memory-
+# crystallization projection uses -- see "Memory crystallization Graphiti/FalkorDB" section --
+# differentiated by FALKORDB_SUBSTRATE_GRAPH, not a separate connection).
+# Host-mode note (Hub docker-compose defaults to host networking): use 127.0.0.1 + the
+# published FalkorDB port (6380 in services/orion-falkordb/docker-compose.yml), not
+# Docker service DNS (orion-athena-falkordb:6379 only resolves on the bridge network).
+SUBSTRATE_STORE_BACKEND=falkor
+FALKORDB_SUBSTRATE_GRAPH=orion_substrate
+# The SPARQL/Fuseki keys below are dead for this seam as of the FalkorDB cutover above --
+# left in place (unused when SUBSTRATE_STORE_BACKEND=falkor) rather than deleted, since
+# orion/substrate/graphdb_store.py still supports SUBSTRATE_STORE_BACKEND=sparql/graphdb
+# as a fallback path for anyone who explicitly opts back into it.
 SUBSTRATE_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
 SUBSTRATE_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
 SUBSTRATE_GRAPH_URI=http://conjourney.net/graph/substrate


### PR DESCRIPTION
## Summary

- `SUBSTRATE_STORE_BACKEND`: `in_memory` → `falkor`. RDF/Fuseki/SPARQL is explicitly rejected as the target for this seam per `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md` (doctrine merged via #1099).
- `FalkorSubstrateStore`/`RoutedSubstrateGraphStore` already existed and were already wired into `build_substrate_store_from_env()` — this patch is config-only, no new code.
- New key: `FALKORDB_SUBSTRATE_GRAPH=orion_substrate`.
- `FALKORDB_URI` (previously empty, used only by the separate Graphiti crystallization feature) now set to `redis://127.0.0.1:6380` — shared with that feature via the doctrine's graph-name-differentiation design, not a separate connection.

## Outcome moved

Concept Atlas's concept graph now persists across Hub restarts through a real backend, not Hub process memory. This is the doctrine's own literal "success for the wedge" criterion.

## Current architecture

Hub ran `SUBSTRATE_STORE_BACKEND=in_memory` since earlier this session (a deliberate temporary choice to prove the pipeline out before this migration). FalkorDB itself (`orion-athena-falkordb`) has been live throughout. The store implementations were merged separately (#1099) but never pointed at from Hub.

## Files changed

- `services/orion-hub/.env_example`: backend switched to `falkor`, new `FALKORDB_SUBSTRATE_GRAPH` key, `FALKORDB_URI` given a real (host-mode-correct) value, comments updated to point at the doctrine doc instead of the old Fuseki/in-memory framing.

## Env/config changes

- Added keys: `FALKORDB_SUBSTRATE_GRAPH`
- Changed values: `SUBSTRATE_STORE_BACKEND` (`in_memory`→`falkor`), `FALKORDB_URI` (empty→`redis://127.0.0.1:6380`)
- `.env_example` updated: yes
- Local `.env` synced: yes, applied directly to the live Hub `.env` and redeployed as part of this same session (see Docker/build/smoke checks below)

## Tests run

Not applicable — config-only change, no code touched. `FalkorSubstrateStore`/`RoutedSubstrateGraphStore` already have their own test coverage from #1099 (`orion/substrate/tests/test_falkor_store.py`, `test_routed_store.py`), unaffected by this patch.

## Docker/build/smoke checks

Live-verified end to end against the real running services, not assumed:

```
docker exec orion-athena-falkordb redis-cli GRAPH.QUERY orion_substrate "MATCH (n) RETURN count(n)"
count(n): 3

docker exec orion-athena-falkordb redis-cli GRAPH.QUERY orion_substrate "MATCH ()-[e]->() RETURN type(e), count(e)"
associated_with: 2
```

Matches Hub's own `/api/substrate/concepts/summary`/`/network` responses exactly (`total_concepts: 3`, `edge_counts_by_predicate: {"associated_with": 2}`, `degraded: false`) — confirmed data actually landed in FalkorDB itself, not just Hub's process memory (both would show identical API output on the old `in_memory` backend, so the API response alone wasn't sufficient proof).

**Restart persistence test**: restarted the Hub container a second time with no further config changes. FalkorDB's node count stayed at exactly 3 (not 6) — same `node_id`s (`sub-concept-seed-orion`, `sub-concept-seed-juniper`, `sub-concept-seed-orion_juniper_relationship`), confirming the idempotent seed-loader upsert works correctly against a real persistent backend, not just against a store that gets wiped and recreated on every boot.

## Risks / concerns

- Severity: low
- Concern: setting `FALKORDB_URI` also activates `crystallization_routes.py`'s previously-dormant Graphiti/FalkorDB read path (it was effectively disabled with an empty URI before). Not tested or scoped in this patch — a known, likely-intended side effect of the shared-instance design in the doctrine, not something this patch verifies separately.
- Mitigation: flagged here explicitly rather than silently shipped; worth a quick look at that feature's behavior post-deploy if anything seems off there.

## Restart required

Already applied and verified live in this session:
```bash
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 scripts/safe_docker_build.sh orion-hub up -d
```

## PR link

(filled in after creation)