### PR TITLE
docs: update FalkorDB doctrine + concept-atlas spec with live status

### DIFF
--- a/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
@@ -4,8 +4,12 @@ Status: DESIGN, not implemented. Ground truth verified live 2026-07-15
 against `main` via direct file reads (not grep-only) for every load-bearing
 claim below.
 
-**Update (2026-07-17):** all 8 phases below shipped across PRs #1079, #1086,
-#1092, #1094, #1096, #1097, #1101. This spec's own non-goal ("no new graph
+**Update (2026-07-17):** all 8 phases below shipped — Wave 1 (phases 1/2/3/5)
+via #1079, Wave 2 (phases 4/6/7/8) via #1086. Follow-on hardening landed
+separately, not as additional phases: seed-startup wiring (#1092), an
+`.env_example` sync (#1094), a topic-foundry smoke-script fix (#1096), the
+topic-foundry ingestion route (#1097), and its identity-merge fix (#1101).
+This spec's own non-goal ("no new graph
 infrastructure ... do not wire into `GraphDBSubstrateStore`/SPARQL") held —
 the persistence backend that actually shipped is FalkorDB, not SPARQL/RDF,
 per `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md`

--- a/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
@@ -4,6 +4,16 @@ Status: DESIGN, not implemented. Ground truth verified live 2026-07-15
 against `main` via direct file reads (not grep-only) for every load-bearing
 claim below.
 
+**Update (2026-07-17):** all 8 phases below shipped across PRs #1079, #1086,
+#1092, #1094, #1096, #1097, #1101. This spec's own non-goal ("no new graph
+infrastructure ... do not wire into `GraphDBSubstrateStore`/SPARQL") held —
+the persistence backend that actually shipped is FalkorDB, not SPARQL/RDF,
+per `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md`
+(PR #1105) — a decision made after this spec was written, superseding the
+"in-memory for now" framing in the original Phase 8/Concept Atlas sections
+below. Live-verified: Concept Atlas's concept graph persists in FalkorDB
+across Hub restarts, not just Hub process memory.
+
 Scope decided by Juniper: replace concept-induction's NLP extractor with the
 already-built, already-unsupervised `orion-topic-foundry` clustering
 pipeline, fix the concept-identity merge bug, add a thin typed-edge layer on

--- a/docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md
+++ b/docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md
@@ -1,7 +1,7 @@
 # FalkorDB property-graph doctrine + persistence router — design spec
 
 **Date:** 2026-07-16
-**Status:** WEDGE LIVE — guts implemented on `feat/falkordb-property-graph-routing` (intent, routes, property guard, Falkor/routed stores, `services/orion-falkordb/`), merged via #1099. **2026-07-16:** graphiti `--profile falkordb` removed; live Falkor cutover to shared stack documented in `services/orion-falkordb/README.md`. **2026-07-17:** Concept Atlas / Hub wiring done and live-verified (`SUBSTRATE_STORE_BACKEND=falkor`, PR #1105) — no longer deferred; see the acceptance-checks update below. `substrate-runtime`'s own cutover (still `sparql` as of this note) and the `orion:kg:edge:ingest.v1` → rdf-writer deprecation remain open, tracked separately.
+**Status:** WEDGE LIVE — guts implemented on `feat/falkordb-property-graph-routing` (intent, routes, property guard, Falkor/routed stores, `services/orion-falkordb/`), merged via #1099. **2026-07-16:** graphiti `--profile falkordb` removed; live Falkor cutover to shared stack documented in `services/orion-falkordb/README.md`. **2026-07-17:** Concept Atlas / Hub wiring done and live-verified (`SUBSTRATE_STORE_BACKEND=falkor`, PR #1105) — no longer deferred; see the acceptance-checks update below. `substrate-runtime`'s own cutover remains open (freshly re-checked 2026-07-17, not just carried over from the ground-truth table above: `services/orion-substrate-runtime/.env` still reads `SUBSTRATE_STORE_BACKEND=sparql`) and the `orion:kg:edge:ingest.v1` → rdf-writer deprecation remain open, tracked separately.
 **Mode:** Proposal (touches memory / cognitive-graph persistence; AGENTS.md §0A proposal mode)
 **Related:**
 - `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md` (first consumer seam)

--- a/docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md
+++ b/docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md
@@ -1,7 +1,7 @@
 # FalkorDB property-graph doctrine + persistence router — design spec
 
 **Date:** 2026-07-16
-**Status:** DESIGN — guts implemented on `feat/falkordb-property-graph-routing` (intent, routes, property guard, Falkor/routed stores, `services/orion-falkordb/`). **2026-07-16:** graphiti `--profile falkordb` removed; live Falkor cutover to shared stack documented in `services/orion-falkordb/README.md`. Concept Atlas / concept-induction wiring and live SPARQL cutover deferred.
+**Status:** WEDGE LIVE — guts implemented on `feat/falkordb-property-graph-routing` (intent, routes, property guard, Falkor/routed stores, `services/orion-falkordb/`), merged via #1099. **2026-07-16:** graphiti `--profile falkordb` removed; live Falkor cutover to shared stack documented in `services/orion-falkordb/README.md`. **2026-07-17:** Concept Atlas / Hub wiring done and live-verified (`SUBSTRATE_STORE_BACKEND=falkor`, PR #1105) — no longer deferred; see the acceptance-checks update below. `substrate-runtime`'s own cutover (still `sparql` as of this note) and the `orion:kg:edge:ingest.v1` → rdf-writer deprecation remain open, tracked separately.
 **Mode:** Proposal (touches memory / cognitive-graph persistence; AGENTS.md §0A proposal mode)
 **Related:**
 - `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md` (first consumer seam)
@@ -366,10 +366,17 @@ Two Falkor *usages* may share one FalkorDB instance with **separate graph names*
 - [ ] Spec reviewed by Juniper
 - [ ] Implementation plan exists for wedge only (substrate + concept atlas), linking back to this doctrine
 - [ ] `GraphWriteIntentV1` (or equivalent) registered in schema registry with producer+consumer tests
-- [ ] Route table documented in `.env_example` for substrate-runtime and hub
+- [x] Route table documented in `.env_example` for substrate-runtime (#1099) and hub (#1105)
 - [ ] Property allowlist tests include a cathedral rejection case
 - [ ] Live metric: Fuseki update rate attribution by workload after wedge deploy
-- [ ] Concept Atlas durability demo (restart hub, concepts remain)
+- [x] Concept Atlas durability demo (restart hub, concepts remain) — 2026-07-17, live-verified against
+      the real `orion-athena-falkordb` container, not just Hub's API response (which would look
+      identical on the old `in_memory` backend): `redis-cli GRAPH.QUERY orion_substrate "MATCH (n)
+      RETURN count(n)"` → 3 nodes, `MATCH ()-[e]->() RETURN type(e), count(e)` → `associated_with`:
+      2, matching Hub's `/api/substrate/concepts/summary` exactly. Hub container restarted a second
+      time with no config change; FalkorDB's node count stayed at 3 (not 6, same `node_id`s) —
+      confirms idempotent upsert against a real persistent backend, not a store recreated fresh
+      on every boot.
 
 ---
 


### PR DESCRIPTION
## Summary

Both docs were stale relative to what actually shipped this session:

- `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md`: status line said Concept Atlas/Hub wiring was "deferred" — no longer true as of PR #1105. Checked off 2 of 7 acceptance-check boxes with real evidence, left the other 5 unchecked since I haven't personally verified them.
- `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md`: still said "Status: DESIGN, not implemented" despite all 8 phases having shipped across 7 PRs. Added a short update note, not a rewrite.

## Env/config changes

None — docs only.

## Tests run

Not applicable — docs only, no code touched.

## PR link

(filled in after creation)