### PR TITLE
fix(biometrics): surface memory/thermal/disk pressure + fix gpu/strain saturation

### DIFF
--- a/orion/substrate/biometrics_loop/grammar_extract.py
+++ b/orion/substrate/biometrics_loop/grammar_extract.py
@@ -117,6 +117,12 @@ def extract_node_state_from_events(
         elif atom.semantic_role == "capability_surface" and atom.salience is not None:
             if profile.capabilities.get("local_llm_heavy"):
                 pressure_hints["gpu"] = float(atom.salience)
+        elif atom.semantic_role == "memory_pressure_signal" and atom.salience is not None:
+            pressure_hints["memory_pressure"] = float(atom.salience)
+        elif atom.semantic_role == "thermal_pressure_signal" and atom.salience is not None:
+            pressure_hints["thermal_pressure"] = float(atom.salience)
+        elif atom.semantic_role == "disk_pressure_signal" and atom.salience is not None:
+            pressure_hints["disk_pressure"] = float(atom.salience)
 
     availability = _compute_availability(
         profile_expected_online=profile.expected_online,

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -62,18 +62,30 @@ these were previously only folded into the `strain` composite and never
 reached the field lattice, so the corresponding channels stayed pinned at
 `0.0`). This is additive: `strain`/`gpu` are unchanged.
 
-Their `Perturbation`s use `mode="replace"`, not the `strain`/`gpu` default
-`mode="add"`: `orion/substrate/biometrics_loop/node_reducer.py` emits one
-`StateDeltaV1` per *grammar event* in a trace (not just the atom that sets a
-given hint -- `trace_started`/edges/`trace_ended` all produce their own delta
-carrying the cumulative `pressure_hints` forward), so a single trace yields
-well over a dozen deltas that each still contain these hints once set. Under
-`"add"` mode that re-adds the same intensity that many times per telemetry
-cycle and saturates the channel to the `1.0` clamp almost immediately,
-independent of real load -- the same class of bug `execution_run`/`chat_turn`
-already hit and fixed with `mode="replace"` for their own `pressure_hints`
-snapshots. `strain`/`gpu` still use `mode="add"` and are believed to already
-be affected by this; that is pre-existing and out of scope for this change.
+All five of these `Perturbation`s (`strain`/`gpu`/`memory_pressure`/
+`thermal_pressure`/`disk_pressure`) use `mode="replace"`, not the library
+default `mode="add"`: `orion/substrate/biometrics_loop/node_reducer.py`
+emits one `StateDeltaV1` per *grammar event* in a trace (not just the atom
+that sets a given hint -- `trace_started`/edges/`trace_ended` all produce
+their own delta carrying the cumulative `pressure_hints` forward), so a
+single trace yields well over a dozen deltas that each still contain these
+hints once set. Under `"add"` mode that re-adds the same intensity that
+many times per telemetry cycle and saturates the channel to the `1.0` clamp
+almost immediately, independent of real load -- the same class of bug
+`execution_run`/`chat_turn` already hit and fixed with `mode="replace"` for
+their own `pressure_hints` snapshots.
+
+`strain`/`gpu` (2026-07-17 fix) were the pre-existing pattern this repeated
+-- and, per live verification, actually were saturating this way in
+production. Querying `/mnt/telemetry/field_channels/corpus/field_channels.jsonl`
+(133,968 rows spanning 2026-07-13..17) showed `cpu_pressure`/`gpu_pressure`
+sitting exactly at their post-decay ceiling (`1.0 * BIOMETRICS_FIELD_DECAY_RATE`
+= `0.92`) in 16.60%/12.98% of all rows -- vs. 0.01%/0.00% for
+`execution_load`/`execution_friction`, which already used `mode="replace"`
+-- and bit-identical to each other in 60.60% of rows despite deriving from
+independent `strain`/`gpu` hints. Both signatures match repeated
+re-saturation from add-mode duplicate deltas, not real, independent CPU/GPU
+utilization, so `strain`/`gpu` were switched to `mode="replace"` too.
 
 ## Running & Testing
 

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -62,6 +62,19 @@ these were previously only folded into the `strain` composite and never
 reached the field lattice, so the corresponding channels stayed pinned at
 `0.0`). This is additive: `strain`/`gpu` are unchanged.
 
+Their `Perturbation`s use `mode="replace"`, not the `strain`/`gpu` default
+`mode="add"`: `orion/substrate/biometrics_loop/node_reducer.py` emits one
+`StateDeltaV1` per *grammar event* in a trace (not just the atom that sets a
+given hint -- `trace_started`/edges/`trace_ended` all produce their own delta
+carrying the cumulative `pressure_hints` forward), so a single trace yields
+well over a dozen deltas that each still contain these hints once set. Under
+`"add"` mode that re-adds the same intensity that many times per telemetry
+cycle and saturates the channel to the `1.0` clamp almost immediately,
+independent of real load -- the same class of bug `execution_run`/`chat_turn`
+already hit and fixed with `mode="replace"` for their own `pressure_hints`
+snapshots. `strain`/`gpu` still use `mode="add"` and are believed to already
+be affected by this; that is pre-existing and out of scope for this change.
+
 ## Running & Testing
 
 ### Run via Docker

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -38,6 +38,30 @@ Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
 
 Node identity for grammar traces is resolved via `config/biometrics/node_catalog.yaml` (aliases canonicalize hostnames, e.g. `prometheous` → `prometheus`).
 
+### Grammar node `pressure_hints` (consumed by `orion-field-digester`)
+
+`app/grammar_emit.py::build_biometrics_node_grammar_events` emits one atom per
+hardware-pressure signal on the `orion:grammar:event` trace. Each atom's
+`salience` is later read by `orion/substrate/biometrics_loop/grammar_extract.py`
+and surfaced on the `node_biometrics` projection's `pressure_hints` dict, which
+`services/orion-field-digester/app/ingest/state_deltas.py`'s `node_biometrics`
+block turns into lattice `Perturbation`s:
+
+| Atom `semantic_role` | `pressure_hints` key | Lattice channel (`NODE_CHANNELS`) |
+| :--- | :--- | :--- |
+| `body_state` (composite `strain`) | `strain` | `cpu_pressure` |
+| `capability_surface` (gated on `local_llm_heavy`) | `gpu` | `gpu_pressure` |
+| `memory_pressure_signal` | `memory_pressure` | `memory_pressure` |
+| `thermal_pressure_signal` | `thermal_pressure` | `thermal_pressure` |
+| `disk_pressure_signal` | `disk_pressure` | `disk_pressure` |
+
+`memory_pressure_signal`/`thermal_pressure_signal`/`disk_pressure_signal` carry
+the individually-computed `mem`/`thermal`/`disk` values from
+`orion/telemetry/biometrics_pipeline.py`'s `pressures` dict (2026-07-16 fix --
+these were previously only folded into the `strain` composite and never
+reached the field lattice, so the corresponding channels stayed pinned at
+`0.0`). This is additive: `strain`/`gpu` are unchanged.
+
 ## Running & Testing
 
 ### Run via Docker

--- a/services/orion-biometrics/app/grammar_emit.py
+++ b/services/orion-biometrics/app/grammar_emit.py
@@ -189,6 +189,52 @@ def build_biometrics_node_grammar_events(
             source_event_id=f"{node_id}:{ts}",
             payload_ref=f"biometrics.availability:{node_id}:{ts}",
         ),
+        # Individually-computed hardware pressures (memory/thermal/disk).
+        # These are already computed as named intermediates in
+        # orion/telemetry/biometrics_pipeline.py's `pressures` dict (keys
+        # "mem"/"thermal"/"disk") but were previously only folded into the
+        # composite "strain" salience on `body_state` above -- no downstream
+        # consumer could ever see them individually. Additive: `strain` and
+        # `capability_surface`'s "gpu" hint are untouched.
+        "memory_pressure_signal": GrammarAtomV1(
+            atom_id=atom_id("memory_pressure_signal"),
+            trace_id=trace_id,
+            atom_type="signal",
+            semantic_role="memory_pressure_signal",
+            layer="organ_signal",
+            dimensions=["physiology", "telemetry", "node", "resource"],
+            summary=f"{node_id} memory pressure observed",
+            confidence=0.9,
+            salience=float((summary.pressures or {}).get("mem", 0.0)),
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.pressure.memory:{node_id}:{ts}",
+        ),
+        "thermal_pressure_signal": GrammarAtomV1(
+            atom_id=atom_id("thermal_pressure_signal"),
+            trace_id=trace_id,
+            atom_type="signal",
+            semantic_role="thermal_pressure_signal",
+            layer="organ_signal",
+            dimensions=["physiology", "telemetry", "node", "resource"],
+            summary=f"{node_id} thermal pressure observed",
+            confidence=0.9,
+            salience=float((summary.pressures or {}).get("thermal", 0.0)),
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.pressure.thermal:{node_id}:{ts}",
+        ),
+        "disk_pressure_signal": GrammarAtomV1(
+            atom_id=atom_id("disk_pressure_signal"),
+            trace_id=trace_id,
+            atom_type="signal",
+            semantic_role="disk_pressure_signal",
+            layer="organ_signal",
+            dimensions=["physiology", "telemetry", "node", "resource"],
+            summary=f"{node_id} disk pressure observed",
+            confidence=0.9,
+            salience=float((summary.pressures or {}).get("disk", 0.0)),
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.pressure.disk:{node_id}:{ts}",
+        ),
     }
 
     edge_specs = [
@@ -198,6 +244,12 @@ def build_biometrics_node_grammar_events(
         ("body_state", "capability_surface", "influenced"),
         ("node_availability", "capability_surface", "influenced"),
         ("node_context", "capability_surface", "supports"),
+        ("telemetry_sample", "memory_pressure_signal", "derived_from"),
+        ("telemetry_sample", "thermal_pressure_signal", "derived_from"),
+        ("telemetry_sample", "disk_pressure_signal", "derived_from"),
+        ("memory_pressure_signal", "capability_surface", "influenced"),
+        ("thermal_pressure_signal", "capability_surface", "influenced"),
+        ("disk_pressure_signal", "capability_surface", "influenced"),
     ]
 
     events: list[GrammarEventV1] = [root_event]

--- a/services/orion-biometrics/tests/test_biometrics_grammar_emit.py
+++ b/services/orion-biometrics/tests/test_biometrics_grammar_emit.py
@@ -26,11 +26,12 @@ def catalog() -> NodeCatalog:
     return NodeCatalog.load(CATALOG_PATH)
 
 
-def _fixtures(node: str, *, strain: float = 0.42):
+def _fixtures(node: str, *, strain: float = 0.42, pressures: dict | None = None):
     sample = BiometricsSampleV1(timestamp=FIXED_TS, node=node, cpu={"util": 0.1})
     summary = BiometricsSummaryV1(
         timestamp=FIXED_TS,
         node=node,
+        pressures=pressures or {},
         composites={"strain": strain},
         telemetry_error_rate=0.0,
     )
@@ -134,6 +135,50 @@ def test_trace_has_start_atoms_edges_end(catalog: NodeCatalog) -> None:
     assert "edge_emitted" in kinds
     assert kinds[-1] == "trace_ended"
     assert events[0].trace_id.startswith("biometrics.node:prometheus:")
+
+
+def test_memory_thermal_disk_pressure_signals_carry_individual_values(
+    catalog: NodeCatalog,
+) -> None:
+    sample, summary, induction = _fixtures(
+        "atlas", pressures={"mem": 0.61, "thermal": 0.33, "disk": 0.12, "cpu": 0.9}
+    )
+    profile = catalog.resolve("atlas")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    atoms_by_role = {
+        e.atom.semantic_role: e.atom for e in events if e.atom is not None
+    }
+    assert atoms_by_role["memory_pressure_signal"].salience == pytest.approx(0.61)
+    assert atoms_by_role["thermal_pressure_signal"].salience == pytest.approx(0.33)
+    assert atoms_by_role["disk_pressure_signal"].salience == pytest.approx(0.12)
+    # strain/gpu remain the composite/capability-derived values, unaffected.
+    assert atoms_by_role["body_state"].salience == pytest.approx(summary.composites["strain"])
+
+
+def test_memory_thermal_disk_pressure_signals_default_to_zero_when_absent(
+    catalog: NodeCatalog,
+) -> None:
+    sample, summary, induction = _fixtures("atlas")
+    profile = catalog.resolve("atlas")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    atoms_by_role = {
+        e.atom.semantic_role: e.atom for e in events if e.atom is not None
+    }
+    assert atoms_by_role["memory_pressure_signal"].salience == 0.0
+    assert atoms_by_role["thermal_pressure_signal"].salience == 0.0
+    assert atoms_by_role["disk_pressure_signal"].salience == 0.0
 
 
 def test_circe_node_availability_reflects_expected_offline(catalog: NodeCatalog) -> None:

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -74,6 +74,38 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     label=delta.delta_id,
                 )
             )
+        # memory_pressure/thermal_pressure/disk_pressure (2026-07-16 fix):
+        # previously only computed upstream and folded into the composite
+        # "strain" hint above -- these three lattice channels sat pinned at
+        # 0.0 for the whole live corpus. Additive: unlike gpu/strain, these
+        # hint keys map 1:1 onto their own NODE_CHANNELS name (no remap).
+        if "memory_pressure" in hints:
+            out.append(
+                Perturbation(
+                    node_id=node_id,
+                    channel="memory_pressure",
+                    intensity=float(hints["memory_pressure"]),
+                    label=delta.delta_id,
+                )
+            )
+        if "thermal_pressure" in hints:
+            out.append(
+                Perturbation(
+                    node_id=node_id,
+                    channel="thermal_pressure",
+                    intensity=float(hints["thermal_pressure"]),
+                    label=delta.delta_id,
+                )
+            )
+        if "disk_pressure" in hints:
+            out.append(
+                Perturbation(
+                    node_id=node_id,
+                    channel="disk_pressure",
+                    intensity=float(hints["disk_pressure"]),
+                    label=delta.delta_id,
+                )
+            )
         status = str(after.get("availability_status") or "")
         if status == "stale":
             out.append(Perturbation(node_id=node_id, channel="staleness", intensity=0.5, label=delta.delta_id))

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -56,6 +56,19 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
 
     if delta.target_kind == "node_biometrics":
         hints = dict(after.get("pressure_hints") or {})
+        # mode="replace" (2026-07-17 fix, same reasoning as memory_pressure/
+        # thermal_pressure/disk_pressure below): live corpus verification
+        # (/mnt/telemetry/field_channels/corpus/field_channels.jsonl,
+        # 133,968 rows / 2026-07-13..17) confirmed gpu_pressure/cpu_pressure
+        # were hitting their post-decay ceiling of exactly
+        # BIOMETRICS_FIELD_DECAY_RATE (0.92) in 16.60%/12.98% of all rows --
+        # vs. 0.01%/0.00% for execution_load/execution_friction, which
+        # already use mode="replace" -- and were bit-identical to each other
+        # in 60.60% of rows despite deriving from independent strain/gpu
+        # hints. Both signatures match repeated re-saturation from add-mode
+        # duplicate deltas (see the memory/thermal/disk-pressure comment
+        # below for the full per-trace fan-out mechanism), not real,
+        # independent CPU/GPU utilization.
         if "gpu" in hints:
             out.append(
                 Perturbation(
@@ -63,6 +76,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     channel="gpu_pressure",
                     intensity=float(hints["gpu"]),
                     label=delta.delta_id,
+                    mode="replace",
                 )
             )
         if "strain" in hints:
@@ -72,6 +86,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     channel="cpu_pressure",
                     intensity=float(hints["strain"]),
                     label=delta.delta_id,
+                    mode="replace",
                 )
             )
         # memory_pressure/thermal_pressure/disk_pressure (2026-07-16 fix):
@@ -80,12 +95,12 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
         # 0.0 for the whole live corpus. Additive: unlike gpu/strain, these
         # hint keys map 1:1 onto their own NODE_CHANNELS name (no remap).
         #
-        # mode="replace" (not the gpu_pressure/cpu_pressure default "add"
-        # above): every grammar event in a node_biometrics trace -- not just
-        # the atom that first sets a given hint -- reaches this function with
-        # its own uniquely-keyed StateDeltaV1 (node_reducer.py runs once per
-        # trace event, including trace_started/edge_emitted/trace_ended, and
-        # each carries the cumulative merged.pressure_hints forward). A single
+        # mode="replace" (same reasoning as gpu_pressure/cpu_pressure above):
+        # every grammar event in a node_biometrics trace -- not just the atom
+        # that first sets a given hint -- reaches this function with its own
+        # uniquely-keyed StateDeltaV1 (node_reducer.py runs once per trace
+        # event, including trace_started/edge_emitted/trace_ended, and each
+        # carries the cumulative merged.pressure_hints forward). A single
         # ~22-event biometrics trace produces on the order of 14-16 separate
         # deltas that each still contain "memory_pressure"/"thermal_pressure"/
         # "disk_pressure" once those hints are first set. Under "add" mode

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -79,6 +79,23 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
         # "strain" hint above -- these three lattice channels sat pinned at
         # 0.0 for the whole live corpus. Additive: unlike gpu/strain, these
         # hint keys map 1:1 onto their own NODE_CHANNELS name (no remap).
+        #
+        # mode="replace" (not the gpu_pressure/cpu_pressure default "add"
+        # above): every grammar event in a node_biometrics trace -- not just
+        # the atom that first sets a given hint -- reaches this function with
+        # its own uniquely-keyed StateDeltaV1 (node_reducer.py runs once per
+        # trace event, including trace_started/edge_emitted/trace_ended, and
+        # each carries the cumulative merged.pressure_hints forward). A single
+        # ~22-event biometrics trace produces on the order of 14-16 separate
+        # deltas that each still contain "memory_pressure"/"thermal_pressure"/
+        # "disk_pressure" once those hints are first set. Under "add" mode
+        # (raw += with no cross-delta dedup, see apply_perturbations) that
+        # would re-add the same intensity that many times per telemetry
+        # cycle, saturating the channel to the 1.0 clamp almost immediately
+        # regardless of real load. execution_run/chat_turn below already hit
+        # this exact class of bug for their own pressure_hints snapshots and
+        # fixed it with mode="replace"; applying the same precedent here so
+        # these three new channels don't inherit it.
         if "memory_pressure" in hints:
             out.append(
                 Perturbation(
@@ -86,6 +103,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     channel="memory_pressure",
                     intensity=float(hints["memory_pressure"]),
                     label=delta.delta_id,
+                    mode="replace",
                 )
             )
         if "thermal_pressure" in hints:
@@ -95,6 +113,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     channel="thermal_pressure",
                     intensity=float(hints["thermal_pressure"]),
                     label=delta.delta_id,
+                    mode="replace",
                 )
             )
         if "disk_pressure" in hints:
@@ -104,6 +123,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     channel="disk_pressure",
                     intensity=float(hints["disk_pressure"]),
                     label=delta.delta_id,
+                    mode="replace",
                 )
             )
         status = str(after.get("availability_status") or "")

--- a/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
+from orion.schemas.field_state import FieldStateV1
 from orion.schemas.state_delta import StateDeltaV1
 
+from app.digestion.perturbation import apply_perturbations
 from app.ingest.state_deltas import delta_to_perturbations
 
 
@@ -76,3 +80,56 @@ def test_node_biometrics_noop_delta_skipped() -> None:
     )
     perturbations = delta_to_perturbations(delta)
     assert perturbations == []
+
+
+def test_memory_thermal_disk_perturbations_use_replace_mode() -> None:
+    # node_reducer.py emits one StateDeltaV1 per grammar event in a
+    # node_biometrics trace (trace_started/atoms/edges/trace_ended -- not
+    # just the atom that first sets a hint), and each carries the cumulative
+    # pressure_hints forward. A single ~22-event trace therefore produces
+    # well over a dozen deltas that all still contain "memory_pressure"/
+    # "thermal_pressure"/"disk_pressure" once those hints are first set. If
+    # these used the default mode="add", replaying all of those deltas in
+    # one field-digester tick would re-add the same intensity that many
+    # times and saturate the channel to 1.0 regardless of real load -- so
+    # they must use mode="replace" (same precedent as execution_run/
+    # chat_turn below).
+    delta = _make_node_biometrics_delta(
+        pressure_hints={
+            "memory_pressure": 0.61,
+            "thermal_pressure": 0.33,
+            "disk_pressure": 0.12,
+        }
+    )
+    perturbations = delta_to_perturbations(delta)
+    modes = {p.channel: p.mode for p in perturbations}
+    assert modes["memory_pressure"] == "replace"
+    assert modes["thermal_pressure"] == "replace"
+    assert modes["disk_pressure"] == "replace"
+
+
+def test_memory_thermal_disk_perturbations_do_not_saturate_across_repeated_deltas() -> None:
+    # Regression for the fan-out described above: simulate one field-digester
+    # tick that (correctly, per how node_reducer.py actually behaves) sees
+    # the same node_biometrics hint value repeated across many deltas from
+    # one trace, and confirm the lattice channel ends up at the real
+    # intensity -- not clamped to 1.0 by repeated addition.
+    delta = _make_node_biometrics_delta(
+        pressure_hints={"memory_pressure": 0.3, "thermal_pressure": 0.3, "disk_pressure": 0.3}
+    )
+    perturbations = []
+    for _ in range(16):  # representative of the per-trace event fan-out
+        perturbations.extend(delta_to_perturbations(delta))
+
+    state = FieldStateV1(
+        generated_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
+        tick_id="tick_saturation_regression",
+        node_vectors={},
+        capability_vectors={},
+        edges=[],
+    )
+    apply_perturbations(state, perturbations)
+    node_vec = state.node_vectors["node:atlas"]
+    assert node_vec["memory_pressure"] == 0.3
+    assert node_vec["thermal_pressure"] == 0.3
+    assert node_vec["disk_pressure"] == 0.3

--- a/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
@@ -6,7 +6,7 @@ from orion.schemas.field_state import FieldStateV1
 from orion.schemas.state_delta import StateDeltaV1
 
 from app.digestion.perturbation import apply_perturbations
-from app.ingest.state_deltas import delta_to_perturbations
+from app.ingest.state_deltas import Perturbation, delta_to_perturbations
 
 
 def _make_node_biometrics_delta(
@@ -62,6 +62,19 @@ def test_node_biometrics_delta_still_produces_gpu_and_cpu_pressure() -> None:
     assert "memory_pressure" not in channels
     assert "thermal_pressure" not in channels
     assert "disk_pressure" not in channels
+
+
+def test_gpu_and_cpu_perturbations_use_replace_mode() -> None:
+    # 2026-07-17: live corpus verification (see state_deltas.py comment on
+    # this block) confirmed gpu_pressure/cpu_pressure were hitting the
+    # post-decay saturation ceiling far more often than a comparable
+    # mode="replace" channel (execution_load) -- the same fan-out mechanism
+    # as memory/thermal/disk below, just pre-existing. Fixed to match.
+    delta = _make_node_biometrics_delta(pressure_hints={"gpu": 0.75, "strain": 0.4})
+    perturbations = delta_to_perturbations(delta)
+    modes = {p.channel: p.mode for p in perturbations}
+    assert modes["gpu_pressure"] == "replace"
+    assert modes["cpu_pressure"] == "replace"
 
 
 def test_node_biometrics_delta_missing_hardware_hints_produces_no_perturbation() -> None:
@@ -133,3 +146,50 @@ def test_memory_thermal_disk_perturbations_do_not_saturate_across_repeated_delta
     assert node_vec["memory_pressure"] == 0.3
     assert node_vec["thermal_pressure"] == 0.3
     assert node_vec["disk_pressure"] == 0.3
+
+
+def test_old_add_mode_would_have_saturated_gpu_and_cpu_pressure() -> None:
+    # Empirical proof of the bug this branch fixes for gpu/strain, mirroring
+    # the live-corpus finding: replay the same per-trace fan-out (~14-19
+    # duplicate deltas per telemetry cycle, see state_deltas.py comment)
+    # through the OLD mode="add" behavior and confirm it saturates to the
+    # 1.0 clamp regardless of the real hint value -- exactly the pattern
+    # observed live (cpu_pressure/gpu_pressure pinned at their post-decay
+    # ceiling in 16.60%/12.98% of ~134k live corpus rows, vs. 0.01%/0.00%
+    # for the already-mode="replace" execution_load/execution_friction).
+    old_style_perturbations = [
+        Perturbation(node_id="node:atlas", channel="gpu_pressure", intensity=0.4, label=f"delta_{i}")
+        for i in range(18)
+    ]
+    state = FieldStateV1(
+        generated_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
+        tick_id="tick_old_add_mode_proof",
+        node_vectors={},
+        capability_vectors={},
+        edges=[],
+    )
+    apply_perturbations(state, old_style_perturbations)
+    # 18 additions of 0.4 would sum to 7.2 -- clamped to the ceiling,
+    # nowhere near the real 0.4 intensity.
+    assert state.node_vectors["node:atlas"]["gpu_pressure"] == 1.0
+
+
+def test_gpu_and_cpu_perturbations_do_not_saturate_across_repeated_deltas() -> None:
+    # Same regression as memory/thermal/disk above, for the pre-existing
+    # gpu/strain channels this cycle's fix also covers.
+    delta = _make_node_biometrics_delta(pressure_hints={"gpu": 0.4, "strain": 0.4})
+    perturbations = []
+    for _ in range(18):  # representative of the per-trace event fan-out
+        perturbations.extend(delta_to_perturbations(delta))
+
+    state = FieldStateV1(
+        generated_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
+        tick_id="tick_gpu_cpu_saturation_regression",
+        node_vectors={},
+        capability_vectors={},
+        edges=[],
+    )
+    apply_perturbations(state, perturbations)
+    node_vec = state.node_vectors["node:atlas"]
+    assert node_vec["gpu_pressure"] == 0.4
+    assert node_vec["cpu_pressure"] == 0.4

--- a/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from orion.schemas.state_delta import StateDeltaV1
+
+from app.ingest.state_deltas import delta_to_perturbations
+
+
+def _make_node_biometrics_delta(
+    *,
+    operation: str = "update",
+    node_id: str = "atlas",
+    pressure_hints: dict | None = None,
+    availability_status: str = "online",
+    expected_online: bool | None = True,
+) -> StateDeltaV1:
+    after: dict = {
+        "node_id": node_id,
+        "pressure_hints": pressure_hints or {},
+        "availability_status": availability_status,
+        "expected_online": expected_online,
+    }
+    return StateDeltaV1(
+        delta_id="delta_node_bio_1",
+        target_projection="node_biometrics",
+        target_kind="node_biometrics",
+        target_id=f"node:{node_id}",
+        operation=operation,  # type: ignore[arg-type]
+        after=after,
+        caused_by_event_ids=["gev_bio_1"],
+        reducer_id="biometrics_node_reducer",
+    )
+
+
+def test_node_biometrics_delta_produces_memory_thermal_disk_pressure() -> None:
+    delta = _make_node_biometrics_delta(
+        pressure_hints={
+            "memory_pressure": 0.61,
+            "thermal_pressure": 0.33,
+            "disk_pressure": 0.12,
+        }
+    )
+    perturbations = delta_to_perturbations(delta)
+    channels = {p.channel: p.intensity for p in perturbations}
+    assert channels["memory_pressure"] == 0.61
+    assert channels["thermal_pressure"] == 0.33
+    assert channels["disk_pressure"] == 0.12
+    assert all(p.node_id == "node:atlas" for p in perturbations)
+
+
+def test_node_biometrics_delta_still_produces_gpu_and_cpu_pressure() -> None:
+    # gpu/strain (-> cpu_pressure) are a different agent's precedent pattern;
+    # confirm the additive change did not disturb them.
+    delta = _make_node_biometrics_delta(pressure_hints={"gpu": 0.75, "strain": 0.4})
+    perturbations = delta_to_perturbations(delta)
+    channels = {p.channel: p.intensity for p in perturbations}
+    assert channels["gpu_pressure"] == 0.75
+    assert channels["cpu_pressure"] == 0.4
+    assert "memory_pressure" not in channels
+    assert "thermal_pressure" not in channels
+    assert "disk_pressure" not in channels
+
+
+def test_node_biometrics_delta_missing_hardware_hints_produces_no_perturbation() -> None:
+    delta = _make_node_biometrics_delta(pressure_hints={})
+    perturbations = delta_to_perturbations(delta)
+    channels = [p.channel for p in perturbations]
+    assert "memory_pressure" not in channels
+    assert "thermal_pressure" not in channels
+    assert "disk_pressure" not in channels
+
+
+def test_node_biometrics_noop_delta_skipped() -> None:
+    delta = _make_node_biometrics_delta(
+        operation="noop",
+        pressure_hints={"memory_pressure": 0.9, "thermal_pressure": 0.9, "disk_pressure": 0.9},
+    )
+    perturbations = delta_to_perturbations(delta)
+    assert perturbations == []

--- a/tests/test_biometrics_grammar_extract.py
+++ b/tests/test_biometrics_grammar_extract.py
@@ -112,6 +112,54 @@ def test_extract_sets_last_seen_and_event_ids(catalog: NodeCatalog) -> None:
     assert state.pressure_hints.get("strain") == 0.4
 
 
+def test_extract_sets_memory_thermal_disk_pressure_hints(catalog: NodeCatalog) -> None:
+    trace_id = "biometrics.node:atlas:2026-05-24T12:00:00Z"
+    events = [
+        _atom_event(
+            trace_id=trace_id,
+            event_id="gev_mem",
+            role="memory_pressure_signal",
+            observed_at=FIXED_TS,
+            salience=0.61,
+        ),
+        _atom_event(
+            trace_id=trace_id,
+            event_id="gev_thermal",
+            role="thermal_pressure_signal",
+            observed_at=FIXED_TS,
+            salience=0.33,
+        ),
+        _atom_event(
+            trace_id=trace_id,
+            event_id="gev_disk",
+            role="disk_pressure_signal",
+            observed_at=FIXED_TS,
+            salience=0.12,
+        ),
+    ]
+    state = extract_node_state_from_events(events, catalog, stale_after_sec=180, now=FIXED_TS)
+    assert state.pressure_hints.get("memory_pressure") == pytest.approx(0.61)
+    assert state.pressure_hints.get("thermal_pressure") == pytest.approx(0.33)
+    assert state.pressure_hints.get("disk_pressure") == pytest.approx(0.12)
+
+
+def test_extract_ignores_memory_thermal_disk_signals_with_no_salience(
+    catalog: NodeCatalog,
+) -> None:
+    trace_id = "biometrics.node:atlas:2026-05-24T12:00:00Z"
+    events = [
+        _atom_event(
+            trace_id=trace_id,
+            event_id="gev_mem",
+            role="memory_pressure_signal",
+            observed_at=FIXED_TS,
+            salience=None,
+        ),
+    ]
+    state = extract_node_state_from_events(events, catalog, stale_after_sec=180, now=FIXED_TS)
+    assert "memory_pressure" not in state.pressure_hints
+
+
 def test_extract_availability_online_when_fresh(catalog: NodeCatalog) -> None:
     trace_id = "biometrics.node:atlas:2026-05-24T12:00:00Z"
     events = [


### PR DESCRIPTION
## Summary
- `memory_pressure`/`thermal_pressure`/`disk_pressure` were computed individually in `orion/telemetry/biometrics_pipeline.py` but only ever reached the field-digester as a composite `"strain"` scalar — no code path emitted them by name. Added 3 new grammar atoms (`services/orion-biometrics/app/grammar_emit.py`), 3 new hint-extraction branches (`orion/substrate/biometrics_loop/grammar_extract.py`), and 3 new `Perturbation` blocks (`services/orion-field-digester/app/ingest/state_deltas.py`) — additive, `strain`/`gpu` hint keys and their existing consumers left untouched.
- Code review caught a critical bug in the new perturbations before merge: they used `mode="add"` with no cross-delta dedup. A single telemetry trace fans out to ~14-19 events (atoms + edges + trace_started/ended), each carrying the same cumulative hint forward as its own delta — so the new channels would have saturated to 1.0 almost every cycle regardless of real hardware load. Fixed with `mode="replace"`, empirically proven (replayed 16x, confirmed lands at real intensity not the clamp).
- That same review flagged the pre-existing `gpu`/`strain` perturbations likely had the identical bug already, live, in production. Investigated and confirmed via the live 134k-row corpus: `cpu_pressure`/`gpu_pressure` were pinned at exactly `0.92` (the decay-adjusted saturation ceiling) on 13-17% of all rows vs <0.01% for a real `mode="replace"` channel at comparable scale, and were bit-identical to each other in 60.6% of rows despite deriving from independent CPU/GPU hardware metrics. Fixed the same way.

## Outcome moved
Three previously fully-dead channels now produce real signal. Two previously-live channels (`cpu_pressure`/`gpu_pressure`) that were silently saturating instead of reflecting real hardware load now reflect real values — this is a bigger fix than originally scoped, found via live-data verification, not assumed from code alone.

## Files changed
- `orion/substrate/biometrics_loop/grammar_extract.py`, `services/orion-biometrics/app/grammar_emit.py`, `services/orion-field-digester/app/ingest/state_deltas.py`: new atom→hint→perturbation chain, all six perturbations (3 new + gpu/strain) now `mode="replace"`
- `services/orion-biometrics/README.md`: documents the atom→hint→lattice-channel mapping and the mode="replace" rationale with live-verification numbers
- Tests: `services/orion-biometrics/tests/test_biometrics_grammar_emit.py`, `tests/test_biometrics_grammar_extract.py`, `services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py` (new)

## Tests run
```
services/orion-field-digester/tests: 72 passed
services/orion-biometrics/tests: 12+8 passed
root-level biometrics/field-perturbation suites: 36+17 passed
```
Every saturation-bug regression test verified to fail under the old mode="add" behavior before the fix, pass after.

## Review findings fixed
- CRITICAL: new memory/thermal/disk perturbations would have saturated almost every cycle (mode="add", no dedup across duplicate deltas) — fixed, mode="replace".
- CRITICAL (expanded scope, live-confirmed): pre-existing gpu/strain perturbations had the identical bug in production — fixed, mode="replace", verified against live corpus.

## Known concerns (flagged, not fixed — need live re-verification after deploy, not blind fixing)
- `orion/field_coherence.py`'s coherence-dimension rules compare `cpu_pressure`/`gpu_pressure` against thresholds that were calibrated (implicitly, by observation) against the old saturated behavior — post-fix, these rules may fire more often, a real behavior change to `SelfStateV1.coherence`.
- `orion-spark-introspector`'s tissue-viz "energy" metric (Hub EKG) derives `resource_cap` from these same channels — likely artificially suppressed this whole time; should shift upward post-deploy. Not touched, needs its own before/after check.
- `services/orion-substrate-organs`' `pressure_organ.py` will now also react to the 3 new hint keys (untested, undocumented blast-radius expansion — plausibly correct, since it surfaces previously-invisible pressure, but worth knowing).

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-biometrics/.env -f services/orion-biometrics/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-field-digester/.env -f services/orion-field-digester/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: Medium
- Concern: this changes the live meaning of `cpu_pressure`/`gpu_pressure` — any downstream consumer implicitly calibrated against the old mostly-saturated behavior could misbehave. Two specific ones identified above, not fixed here.
- Mitigation: live before/after spot-check recommended post-deploy for `coherence` and tissue-viz energy specifically.

## Merge-order note
This branch and `fix/field-digester-ratchet-channels` both touch `services/orion-field-digester/app/ingest/state_deltas.py` — branched independently, will conflict on merge. Recommend merging the ratchet-channels PR first, then rebasing this one.