### PR TITLE
fix(field-digester): default bus_health/delivery_confidence to 1.0, not 0.0

### DIFF
--- a/services/orion-field-digester/app/tensor/channels.py
+++ b/services/orion-field-digester/app/tensor/channels.py
@@ -36,6 +36,23 @@ CAPABILITY_CHANNELS = [
 
 DEFAULT_NODE_VECTOR = {ch: 0.0 for ch in NODE_CHANNELS}
 DEFAULT_NODE_VECTOR["availability"] = 1.0
+# Merge-polarity fix follow-up (2026-07-17, live post-deploy verification).
+# bus_health/delivery_confidence are HIGHER_IS_BETTER_CHANNELS
+# (orion/self_state/scoring.py) -- collect_field_channel_pressures() merges
+# them via min() (worst node wins), same as availability above. Only
+# node:athena (the transport-bus observer node) ever actually reports these;
+# every other lattice node inherited the blanket 0.0 default every other
+# channel in NODE_CHANNELS gets. Under the OLD max()-merge this was inert (a
+# real report always beat 0.0). Under min()-merge it's actively wrong: any
+# untouched node's meaningless 0.0 always wins over athena's real 1.0,
+# permanently masking real bus-health data with a false "unhealthy" reading
+# -- confirmed live: substrate_transport_bus_projection showed
+# bus_health=1.0/delivery_confidence=1.0 for node:athena while the merged
+# field_channel_corpus.v1 row read 0.0 for both, 100% of rows, for the
+# entire post-deploy window. Match availability's existing precedent: a node
+# that has never reported is "presumed healthy," not "worst possible."
+DEFAULT_NODE_VECTOR["bus_health"] = 1.0
+DEFAULT_NODE_VECTOR["delivery_confidence"] = 1.0
 
 DEFAULT_CAPABILITY_VECTOR = {ch: 0.0 for ch in CAPABILITY_CHANNELS}
 DEFAULT_CAPABILITY_VECTOR["confidence"] = 1.0

--- a/tests/test_field_topology_reconciliation.py
+++ b/tests/test_field_topology_reconciliation.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from orion.schemas.field_state import FieldEdgeV1, FieldStateV1
+from orion.self_state.scoring import collect_field_channel_pressures
 
 from app.graph.lattice import load_lattice
 from app.tensor.reconcile import reconcile_field_state_with_lattice
@@ -92,3 +93,37 @@ def test_reconciled_state_validates() -> None:
     reconciled = reconcile_field_state_with_lattice(_stale_athena_state(), lattice=lattice)
     roundtrip = FieldStateV1.model_validate(reconciled.model_dump(mode="json"))
     assert roundtrip.tick_id == "tick_stale"
+
+
+def test_reconcile_seeds_bus_health_and_delivery_confidence_to_one_not_zero() -> None:
+    # Regression guard, live post-deploy finding (2026-07-17): bus_health/
+    # delivery_confidence are HIGHER_IS_BETTER_CHANNELS (min()-wins merge,
+    # orion/self_state/scoring.py) but were missing from DEFAULT_NODE_VECTOR's
+    # per-channel override table -- every node got the generic 0.0 default
+    # from `{ch: 0.0 for ch in NODE_CHANNELS}`. Only node:athena (the
+    # transport-bus observer) ever reports a real value for these two
+    # channels; every other lattice node's untouched 0.0 always won the
+    # min()-merge, permanently masking athena's real reading regardless of
+    # actual bus health. Confirmed live: substrate_transport_bus_projection
+    # showed bus_health=1.0 for node:athena while the merged
+    # field_channel_corpus.v1 row read 0.0, 100% of rows, for the entire
+    # post-deploy window -- this test reproduces that exact shape.
+    lattice = load_lattice(LATTICE_PATH)
+    state = FieldStateV1(
+        generated_at=FIXED_TS,
+        tick_id="tick_bus_health_default",
+        node_vectors={"node:athena": {"bus_health": 1.0, "delivery_confidence": 1.0}},
+    )
+    reconciled = reconcile_field_state_with_lattice(state, lattice=lattice)
+    # Every other lattice node must be seeded to 1.0 (presumed healthy until
+    # reported otherwise), matching `availability`'s existing precedent --
+    # not the generic 0.0 every other untouched channel gets.
+    for node_id, vec in reconciled.node_vectors.items():
+        if node_id == "node:athena":
+            continue
+        assert vec.get("bus_health") == 1.0, f"{node_id} bus_health should default to 1.0, not mask a real report"
+        assert vec.get("delivery_confidence") == 1.0, f"{node_id} delivery_confidence should default to 1.0"
+
+    channels, _ = collect_field_channel_pressures(reconciled)
+    assert channels["bus_health"] == 1.0
+    assert channels["delivery_confidence"] == 1.0


### PR DESCRIPTION
## Summary
- Live post-deploy verification of the merge-polarity fix (PR #1110, merged) found `bus_health`/`delivery_confidence` still permanently reading 0.0 in the live `field_channel_corpus.v1` corpus, despite `node:athena` genuinely reporting 1.0 in `substrate_transport_bus_projection` (confirmed via direct Postgres query, both stayed at 0.0 for 100% of rows across a 7+ minute post-deploy window).
- Root cause: these two channels are `HIGHER_IS_BETTER_CHANNELS` (min()-wins merge across nodes, per PR #1110). Only `node:athena` (the transport-bus observer) ever reports a real value for them — every other lattice node (`atlas`, `circe`, `prometheus`) inherited the generic `0.0` default from `DEFAULT_NODE_VECTOR = {ch: 0.0 for ch in NODE_CHANNELS}`, since these two channels were missing from the per-channel override table that `availability` already has. Under the old max()-merge this was harmless (0.0 never won against a real report). Under the new min()-merge, the untouched nodes' meaningless 0.0 always wins, permanently masking athena's real signal.

## Outcome moved
`bus_health`/`delivery_confidence` can now actually reflect real transport-bus health instead of reading permanently unhealthy regardless of the true state — closes the loop on PR #1109/#1110's fixes, verified against live data rather than assumed from tests alone.

## Files changed
- `services/orion-field-digester/app/tensor/channels.py`: `DEFAULT_NODE_VECTOR["bus_health"] = 1.0`, `DEFAULT_NODE_VECTOR["delivery_confidence"] = 1.0` — matches `availability`'s existing precedent (a node that's never reported is presumed healthy, not worst-possible).
- `tests/test_field_topology_reconciliation.py`: new regression test reproducing the exact live bug shape (reconcile against the real lattice, confirm untouched nodes seed to 1.0 not 0.0, confirm the merged corpus value is 1.0).

## Tests run
```
145 passed (services/orion-field-digester/tests + cross-cutting field/self-state suites)
```
New regression test verified to fail without the fix (reverted `channels.py`, confirmed `node:atlas bus_health should default to 1.0` assertion fails with `0.0 == 1.0`, restored and confirmed pass).

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-field-digester/.env -f services/orion-field-digester/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: Low
- Concern: none identified — this only affects the two channels found broken; `availability`/`confidence`/`available_capacity` already had correct 1.0 defaults via existing code, unaffected by this change.

## Merge-order note
No overlap with other open PRs — clean, standalone fix on top of current main (which already includes #1108-1112).