### PR TITLE
Give predictive drive a primary tension source (O3)

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-17-drive-predictive-reground-o3-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-drive-predictive-reground-o3-pr.md
@@ -20,10 +20,12 @@ normalization, still open, separate patch).
   prediction-error aggregate on `SelfStateV1` that this function previously
   never read at all, despite being published on every `substrate.self_state.v1`
   tick this worker already consumes.
-- Absolute-threshold firing (`overall_surprise > 0.30`) is intentional, not
-  delta-based: unlike the other dimensions in this function (quality scores
-  where a *drop* signals tension), `overall_surprise` is already a magnitude
-  of surprise/error -- the absolute level itself is the tension.
+- Firing is delta-gated (`surprise_delta > 0.05` once a previous self-state
+  exists; absolute-threshold `overall_surprise > 0.30` fallback only when
+  there is none), matching the pattern every sibling block in this function
+  already uses. An earlier version of this patch fired on the absolute level
+  alone, unconditionally, every tick -- code review (see below) found and
+  fixed this before merge.
 - `drive_impacts={"predictive": 1.0}` -- single-drive, unambiguous primary
   source, no dilution across other drives.
 - No wiring changes needed: `ConceptWorker._tensions_from_self_state()` already
@@ -64,11 +66,14 @@ this file already use with zero registry entries (`tension.contradiction.v1`,
 ## Files changed
 
 - `orion/spark/concept_induction/tensions.py`: new block in
-  `extract_tensions_from_self_state()` (26 lines, purely additive)
+  `extract_tensions_from_self_state()`, purely additive, delta-gated (see
+  Review findings below for the revision history within this patch)
 - `orion/spark/concept_induction/tests/test_prediction_surprise_tension.py`:
-  new file, 5 tests (fires above threshold with correct magnitude, silent
-  below threshold, trajectory multiplier scaling, clamps at 1.0, silent at
-  default 0.0)
+  new file, 8 tests -- the original 5 (fires above threshold with correct
+  magnitude, silent below threshold, trajectory multiplier scaling, clamps
+  at 1.0, silent at default 0.0) plus 3 added during review to cover the
+  delta-gated path (sustained-unchanging elevated surprise does not re-fire,
+  fires on a genuine rise, small delta below the gate does not fire)
 
 ## Schema / bus / API changes
 
@@ -91,8 +96,11 @@ None.
 ```text
 cd /mnt/scripts/Orion-Sapienform-drive-predictive-reground-o3
 /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/spark/concept_induction/tests -q
-147 passed, 16 warnings in 14.09s
+150 passed, 16 warnings in 18.76s
 ```
+
+(147 before the review fix below, 150 after 3 regression tests were added for
+the delta-gated path.)
 
 ## Evals run
 
@@ -113,8 +121,35 @@ orion-spark-concept-induction picks this up.
 
 ## Review findings fixed
 
-Reviewed at medium effort (manual line-by-line + cross-file trace, given the
-diff is a 26-line additive block). No findings survived verification.
+This patch went through two review passes: an initial manual medium-effort
+pass (line-by-line + cross-file trace) at first commit, then a full 8-angle
+`/code-review medium` pass (3 correctness angles, 3 cleanup angles, altitude,
+conventions; 1-vote verify on the surviving candidate) requested separately.
+The second pass caught a real bug the first pass missed.
+
+- **Finding (HIGH, confirmed): the original absolute-threshold-every-tick
+  firing would saturate `predictive` near 1.0, not fix its starvation.**
+  `orion/spark/concept_induction/tensions.py`, the new block. The first
+  version fired unconditionally whenever `overall_surprise > 0.30`, with no
+  gating on `previous_self_state` (unlike the other 4 blocks in this same
+  function, which all switch to delta-based firing once a previous state
+  exists). Verification traced `self_state.overall_surprise`'s producer
+  (`orion/self_state/prediction.py`) and found it has no smoothing/decay of
+  its own -- it's a fresh, potentially-noisy one-step-prediction error every
+  tick -- and computed the leaky-integrator math (`DriveEngine.update()`,
+  `decay_tau_sec=1800.0` vs ~4.6s bus-tick cadence): a repeated full-weight
+  impulse pins pressure above 0.95 within ~5 ticks (~23s). This is the exact
+  cpu/gpu_pressure saturation mechanism fixed in PRs #1108-1111, reintroduced
+  from the opposite direction -- `predictive` would flip from "permanently
+  dead" to "permanently pinned," undoing the point of this patch.
+  - Fix: switched to the same delta-gated pattern every sibling block in this
+    function already uses (`surprise_delta > 0.05` once `previous_self_state`
+    exists; absolute `> 0.30` fallback only on the very first tick with no
+    prior state). 3 new regression tests cover it: sustained-unchanging
+    elevated surprise does not re-fire, a genuine rise fires on the delta
+    (not the absolute level), a small delta below the gate does not fire.
+  - Evidence: `150 passed` (up from 147), including the 3 new tests exercising
+    the previously-untested repeated-tick path.
 
 - Checked and cleared: `orion/spark/concept_induction/drive_attribution.py`'s
   `_PRIMARY_DRIVE_BY_KIND` map (used only as a tie-break shortcut in
@@ -127,6 +162,40 @@ diff is a 26-line additive block). No findings survived verification.
   tension's own `drive_impacts` weights (`{"predictive": 1.0}`) -- the same
   correct result the map would have given directly. No behavioral gap in any
   constructible scenario; not fixed because there is nothing to fix.
+- Checked and cleared: `TensionEventV1.kind` is a free string field, not a
+  `Literal`/enum, and no registry/catalog file tracks individual tension kind
+  strings (verified against `orion/bus/channels.yaml`, which registers the
+  envelope kind `memory.tension.event.v1`, not payload-internal kind tags) --
+  consistent with 5 sibling kinds already following this same pattern.
+- Accepted, not changed (LOW, established file-wide convention): the new
+  block's `if fire_pred and mag_pred > 0.0:` guard is technically redundant
+  in every branch (a positive delta or absolute threshold times a positive
+  `traj_mul` is always `> 0.0`) -- but every one of the 4 sibling blocks in
+  this same function has the identical redundant guard shape. Diverging from
+  it here would reduce consistency for no real benefit.
+- Accepted, not changed (trivial): `test_surprise_at_max_clamps_at_one`
+  doesn't exercise a true out-of-range clamp (Pydantic already constrains
+  `overall_surprise <= 1.0`), so it can't prove the `clamp01()` call does
+  anything beyond the schema's own guarantee. Left in place -- it still
+  pins down exact boundary behavior (`magnitude == 1.0` with default
+  `traj_mul`), and removing it buys nothing.
+- Checked and cleared (Reuse angle): the new test file's `_self_state()`/
+  `_envelope()` helpers duplicate near-identical local helpers already
+  present in 3+ other files under `orion/spark/concept_induction/tests/`
+  (no shared `conftest.py` exists in that directory). Pre-existing pattern
+  across the whole test directory, not something this PR introduced --
+  flagged as a real, low-priority, separate cleanup opportunity (a shared
+  fixture module), not blocking this patch.
+- Checked and cleared (Altitude angle): the delta-gated pattern (vs. this
+  repo's more principled `DeviationGate` EWMA/z-threshold mechanism used
+  elsewhere) and the choice to ground on the scalar `overall_surprise` (vs.
+  the more granular `prediction_error_scores` dict) both match every sibling
+  block's existing altitude in this same function -- not a new shortcut
+  introduced by this patch.
+- Checked and cleared (Conventions angle): no CLAUDE.md violation found
+  against the repo-root `CLAUDE.md` (no keyword-cathedral, env/config,
+  bus/schema-contract, or PR-report-template rule broken; no directory-scoped
+  CLAUDE.md exists under `orion/spark/concept_induction/`).
 
 ## Restart required
 
@@ -137,13 +206,21 @@ docker compose --env-file .env --env-file services/orion-spark-concept-induction
 
 ## Risks / concerns
 
-- Severity: LOW. Concern: the `0.30` absolute threshold is a first-pass
-  calibration with no live `overall_surprise` distribution to validate
-  against (same honesty standard as O4's SATURATED thresholds, which were
-  explicitly flagged the same way). Mitigation: plain module-level literal,
-  trivially tunable; post-deploy re-measurement against `drive_audits` (same
-  command used to verify O1/O4) will show whether `predictive` actually gets
-  real variance now.
+- Severity: LOW. Concern: both the `0.30` absolute-fallback threshold and the
+  `0.05` delta gate are first-pass calibrations with no live `overall_surprise`
+  distribution to validate against (same honesty standard as O4's SATURATED
+  thresholds, which were explicitly flagged the same way). Mitigation: plain
+  module-level literals, trivially tunable; post-deploy re-measurement against
+  `drive_audits` (same command used to verify O1/O4) will show whether
+  `predictive` gets real, non-pinned variance now.
+- Severity: LOW (down from the pre-fix HIGH). Concern: even delta-gated,
+  `predictive` could in principle still accumulate meaningful pressure if
+  `overall_surprise` genuinely oscillates every tick during a volatile
+  episode (delta-gated blocks fire intermittently in that case, not on every
+  tick, per the verifier's trace -- but not literally zero). Mitigation: this
+  is the same accepted risk profile every other block in this function
+  already carries; a general per-drive rate-limit/cadence-fold across all
+  tension sources is O2's explicit scope, not this patch's.
 
 ## PR link
 

--- a/docs/superpowers/pr-reports/2026-07-17-drive-predictive-reground-o3-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-drive-predictive-reground-o3-pr.md
@@ -1,0 +1,150 @@
+# PR report: give predictive drive a primary tension source (O3)
+
+Branch: `feat/drive-predictive-reground-o3`
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1114
+Series: follows `docs/superpowers/pr-reports/2026-07-16-drive-economy-desaturation-o1-o4-pr.md`
+(O1 + O4, merged 2026-07-16). This patch is O3 -- one of the two named follow-ups
+in that report's diagnosis (O3: predictive re-grounding; O2: event-rate
+normalization, still open, separate patch).
+
+## Summary
+
+- `predictive` (one of `DriveEngine`'s 6 drives, `orion/spark/concept_induction/drives.py`)
+  previously never had a primary tension source -- it only received secondary
+  `drive_impacts` weights (0.4-0.7) riding other dimensions' tensions
+  (`tension.contradiction.v1`, `tension.identity_drift.v1`) and sat dead at a
+  0.016 median pressure, permanently inactive.
+- `extract_tensions_from_self_state()` (`orion/spark/concept_induction/tensions.py`)
+  now mints a new `tension.prediction_surprise.v1` tension directly off
+  `self_state.overall_surprise` -- an already-clamped [0,1] top-level
+  prediction-error aggregate on `SelfStateV1` that this function previously
+  never read at all, despite being published on every `substrate.self_state.v1`
+  tick this worker already consumes.
+- Absolute-threshold firing (`overall_surprise > 0.30`) is intentional, not
+  delta-based: unlike the other dimensions in this function (quality scores
+  where a *drop* signals tension), `overall_surprise` is already a magnitude
+  of surprise/error -- the absolute level itself is the tension.
+- `drive_impacts={"predictive": 1.0}` -- single-drive, unambiguous primary
+  source, no dilution across other drives.
+- No wiring changes needed: `ConceptWorker._tensions_from_self_state()` already
+  calls this function on every self-state tick and publishes whatever it
+  returns through the existing tension -> `DriveEngine.update()` ->
+  drive_state/drive_audit path unchanged.
+
+## Outcome moved
+
+This is O3 from the 2026-07-16 drive-economy desaturation diagnosis
+(`orion/autonomy/drives_and_autonomy_retrospective.md` §5a). O1/O4 (merged
+same day) fixed the dominance-attribution poisoning mechanism; this is half of
+the second, still-open mechanism -- pressure pinning from a starved
+`predictive` drive. O2 (event-rate normalization) is the other half and is
+intentionally not in this patch -- it is a riskier change to the worker's
+`DriveEngine.update()` call cadence (touches the live publish-per-event
+contract) and is being designed separately before implementation.
+
+## Current architecture
+
+`extract_tensions_from_self_state()` built tensions from
+`SelfStateV1.dimensions[key].score` deltas only (`coherence`,
+`agency_readiness`/`social_pressure`, `uncertainty`,
+`resource_pressure`/`execution_pressure`). `SelfStateV1.overall_surprise` and
+`SelfStateV1.prediction_error_scores` (both populated upstream by the
+substrate self-state builder) were never read by this function.
+
+## Architecture touched
+
+`orion/spark/concept_induction/tensions.py` only. No bus contract, schema
+registry, channel, or env changes -- `tension.prediction_surprise.v1` is a
+payload-level `kind` string inside the already-registered
+`memory.tension.event.v1` envelope, the same pattern five sibling kinds in
+this file already use with zero registry entries (`tension.contradiction.v1`,
+`tension.distress.v1`, `tension.identity_drift.v1`, `tension.cognitive_load.v1`,
+`tension.satisfaction.v1`).
+
+## Files changed
+
+- `orion/spark/concept_induction/tensions.py`: new block in
+  `extract_tensions_from_self_state()` (26 lines, purely additive)
+- `orion/spark/concept_induction/tests/test_prediction_surprise_tension.py`:
+  new file, 5 tests (fires above threshold with correct magnitude, silent
+  below threshold, trajectory multiplier scaling, clamps at 1.0, silent at
+  default 0.0)
+
+## Schema / bus / API changes
+
+- Added: `tension.prediction_surprise.v1` as a new `TensionEventV1.kind` value
+  (payload-internal tag, not a new bus envelope kind or channel)
+- Removed: none
+- Renamed: none
+- Behavior changed: `predictive` now gets a primary growth signal it never
+  had; no change to any existing tension kind's behavior
+- Compatibility notes: none -- purely additive, no existing consumer branches
+  on an exhaustive kind enum (verified: `TensionEventV1.kind` is a free string
+  field, not a pydantic `Literal`)
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+cd /mnt/scripts/Orion-Sapienform-drive-predictive-reground-o3
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/spark/concept_induction/tests -q
+147 passed, 16 warnings in 14.09s
+```
+
+## Evals run
+
+```text
+No eval harness exists for this surface (tracked as issue #1066, same gap
+noted in the O1/O4 PR). Post-deploy live re-measurement
+(measure_autonomy_gate.py against fresh drive_audits) is the behavioral
+check, same as O1/O4.
+```
+
+## Docker/build/smoke checks
+
+```text
+Not run -- pure Python logic change in an already-running consumer path
+(ConceptWorker), no config/dependency/port/compose changes. Restart of
+orion-spark-concept-induction picks this up.
+```
+
+## Review findings fixed
+
+Reviewed at medium effort (manual line-by-line + cross-file trace, given the
+diff is a 26-line additive block). No findings survived verification.
+
+- Checked and cleared: `orion/spark/concept_induction/drive_attribution.py`'s
+  `_PRIMARY_DRIVE_BY_KIND` map (used only as a tie-break shortcut in
+  `dominant_drive_from_attribution`) does not have an entry for the new kind.
+  Traced the full cascade: `compute_tick_attribution` sums
+  `magnitude x drive_impacts` weight directly and is unaffected by the map.
+  When `tension.prediction_surprise.v1` is the tick's lead tension and
+  `predictive` ties at max attribution, the map lookup misses and falls
+  through to the cascade's step 2, which ranks tied drives by the lead
+  tension's own `drive_impacts` weights (`{"predictive": 1.0}`) -- the same
+  correct result the map would have given directly. No behavioral gap in any
+  constructible scenario; not fixed because there is nothing to fix.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: LOW. Concern: the `0.30` absolute threshold is a first-pass
+  calibration with no live `overall_surprise` distribution to validate
+  against (same honesty standard as O4's SATURATED thresholds, which were
+  explicitly flagged the same way). Mitigation: plain module-level literal,
+  trivially tunable; post-deploy re-measurement against `drive_audits` (same
+  command used to verify O1/O4) will show whether `predictive` actually gets
+  real variance now.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1114

--- a/orion/spark/concept_induction/tensions.py
+++ b/orion/spark/concept_induction/tensions.py
@@ -403,6 +403,32 @@ def extract_tensions_from_self_state(
             drive_impacts={"capability": 0.9, "coherence": 0.45},
         ))
 
+    # Prediction-error rise -> predictive re-grounding tension (O3). predictive
+    # previously only ever received *secondary* drive_impacts riding other
+    # dimensions' tensions and sat dead (median 0.016, never active) -- this is
+    # its first primary source, read directly off overall_surprise (self_state's
+    # own top-level prediction-error aggregate, already clamped 0-1 by its
+    # producer -- see orion/substrate/pressure.py::prediction_error_pressure()).
+    # Absolute-threshold firing (not delta-based) is intentional here: unlike
+    # the dimensions above (quality scores where a *drop* signals tension),
+    # overall_surprise IS already a magnitude of surprise/error -- the absolute
+    # level itself is the tension.
+    surprise_now = clamp01(self_state.overall_surprise)
+    fire_pred = surprise_now > 0.30
+    mag_pred = clamp01(surprise_now * traj_mul)
+    if fire_pred and mag_pred > 0.0:
+        events.append(TensionEventV1(
+            artifact_id=_artifact_id(envelope, entity_id, "tension.prediction_surprise.v1"),
+            subject=subject, model_layer=model_layer, entity_id=entity_id,
+            kind="tension.prediction_surprise.v1", ts=ts, confidence=0.75,
+            correlation_id=str(envelope.correlation_id),
+            trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+            provenance=prov,
+            related_nodes=["substrate:overall_surprise", "drive:predictive"],
+            magnitude=mag_pred,
+            drive_impacts={"predictive": 1.0},
+        ))
+
     for event in events:
         event.provenance.tension_refs = [event.artifact_id]
     return events

--- a/orion/spark/concept_induction/tensions.py
+++ b/orion/spark/concept_induction/tensions.py
@@ -409,13 +409,26 @@ def extract_tensions_from_self_state(
     # its first primary source, read directly off overall_surprise (self_state's
     # own top-level prediction-error aggregate, already clamped 0-1 by its
     # producer -- see orion/substrate/pressure.py::prediction_error_pressure()).
-    # Absolute-threshold firing (not delta-based) is intentional here: unlike
-    # the dimensions above (quality scores where a *drop* signals tension),
-    # overall_surprise IS already a magnitude of surprise/error -- the absolute
-    # level itself is the tension.
+    # Delta-gated to match the blocks above (NOT absolute-threshold-every-tick,
+    # despite overall_surprise itself being a magnitude, not a quality score):
+    # review found overall_surprise has no upstream smoothing/decay of its own
+    # (recomputed fresh from a naive one-step prediction every tick), so firing
+    # on the absolute level alone would mint a full-weight tension on every
+    # single tick of a sustained surprise episode -- the leaky integrator's
+    # decay is negligible at bus-tick cadence vs its 1800s tau, so that pins
+    # `predictive` near 1.0 within ~5 ticks, reproducing the exact
+    # cpu/gpu_pressure saturation pattern (PRs #1108-1111) this is meant to
+    # avoid. Delta-gating self-limits the same way the sibling blocks do.
     surprise_now = clamp01(self_state.overall_surprise)
-    fire_pred = surprise_now > 0.30
-    mag_pred = clamp01(surprise_now * traj_mul)
+    surprise_delta = (
+        surprise_now - clamp01(previous_self_state.overall_surprise)
+        if previous_self_state is not None else None
+    )
+    fire_pred = surprise_delta > 0.05 if surprise_delta is not None else surprise_now > 0.30
+    mag_pred = (
+        clamp01(surprise_delta * traj_mul) if surprise_delta is not None
+        else clamp01(surprise_now * traj_mul)
+    )
     if fire_pred and mag_pred > 0.0:
         events.append(TensionEventV1(
             artifact_id=_artifact_id(envelope, entity_id, "tension.prediction_surprise.v1"),

--- a/orion/spark/concept_induction/tests/test_prediction_surprise_tension.py
+++ b/orion/spark/concept_induction/tests/test_prediction_surprise_tension.py
@@ -50,12 +50,14 @@ def _self_state(*, overall_surprise: float | None = None, trajectory_condition: 
     return SelfStateV1(**kwargs)
 
 
-def _prediction_surprise_events(self_state: SelfStateV1) -> list:
+def _prediction_surprise_events(
+    self_state: SelfStateV1, *, previous_self_state: SelfStateV1 | None = None
+) -> list:
     out = extract_tensions_from_self_state(
         envelope=_envelope(),
         intake_channel="orion:substrate:self_state",
         self_state=self_state,
-        previous_self_state=None,
+        previous_self_state=previous_self_state,
     )
     return [e for e in out if e.kind == "tension.prediction_surprise.v1"]
 
@@ -94,4 +96,33 @@ def test_surprise_at_max_clamps_at_one() -> None:
 def test_surprise_default_zero_does_not_fire() -> None:
     ss = _self_state()  # overall_surprise omitted -> defaults to 0.0
     events = _prediction_surprise_events(ss)
+    assert events == []
+
+
+def test_sustained_elevated_surprise_does_not_refire_every_tick() -> None:
+    """Regression: a prior version fired on the absolute level alone, every
+    tick, with no gating -- reproducing the leaky integrator's saturation
+    pattern (pressure pins near 1.0 within ~5 ticks at bus-tick cadence,
+    since decay is negligible against tau=1800s). Once a previous_self_state
+    exists, firing must be delta-gated like every sibling block, so a
+    sustained-but-unchanging elevated surprise level does not re-fire."""
+    prev = _self_state(overall_surprise=0.5)
+    now = _self_state(overall_surprise=0.5)  # unchanged tick-to-tick
+    events = _prediction_surprise_events(now, previous_self_state=prev)
+    assert events == []
+
+
+def test_surprise_rising_with_previous_state_fires_on_delta_not_absolute() -> None:
+    prev = _self_state(overall_surprise=0.10)
+    now = _self_state(overall_surprise=0.40)  # delta 0.30 > 0.05 threshold
+    events = _prediction_surprise_events(now, previous_self_state=prev)
+    assert len(events) == 1
+    assert abs(events[0].magnitude - 0.30) < 1e-9
+    assert events[0].drive_impacts == {"predictive": 1.0}
+
+
+def test_surprise_small_delta_below_gate_does_not_fire() -> None:
+    prev = _self_state(overall_surprise=0.50)
+    now = _self_state(overall_surprise=0.53)  # delta 0.03 < 0.05 threshold
+    events = _prediction_surprise_events(now, previous_self_state=prev)
     assert events == []

--- a/orion/spark/concept_induction/tests/test_prediction_surprise_tension.py
+++ b/orion/spark/concept_induction/tests/test_prediction_surprise_tension.py
@@ -1,0 +1,97 @@
+"""O3: predictive drive's first primary tension source, grounded on
+self_state.overall_surprise (orion/autonomy/drives_and_autonomy_retrospective.md §5a).
+
+Covers extract_tensions_from_self_state's new tension.prediction_surprise.v1
+block: fires above the 0.30 absolute threshold, scales by trajectory
+multiplier, clamps at 1.0, and stays silent below threshold / at default 0.0.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.spark.concept_induction.tensions import extract_tensions_from_self_state
+
+NOW = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _envelope() -> BaseEnvelope:
+    return BaseEnvelope(
+        id=uuid4(), kind="substrate.self_state.v1", correlation_id=uuid4(),
+        created_at=NOW, source=ServiceRef(name="orion-substrate-runtime", version="0.1.0", node="athena"),
+        payload={},
+    )
+
+
+def _self_state(*, overall_surprise: float | None = None, trajectory_condition: str | None = None) -> SelfStateV1:
+    # Neutral dimension values so the other blocks in
+    # extract_tensions_from_self_state don't fire and confound assertions
+    # about the new prediction_surprise block specifically.
+    dims = {
+        "coherence": SelfStateDimensionV1(dimension_id="coherence", score=0.5, confidence=1.0),
+        "agency_readiness": SelfStateDimensionV1(dimension_id="agency_readiness", score=0.9, confidence=1.0),
+        "social_pressure": SelfStateDimensionV1(dimension_id="social_pressure", score=0.1, confidence=1.0),
+        "uncertainty": SelfStateDimensionV1(dimension_id="uncertainty", score=0.2, confidence=1.0),
+        "resource_pressure": SelfStateDimensionV1(dimension_id="resource_pressure", score=0.2, confidence=1.0),
+        "execution_pressure": SelfStateDimensionV1(dimension_id="execution_pressure", score=0.2, confidence=1.0),
+    }
+    kwargs = dict(
+        self_state_id=str(uuid4()), generated_at=NOW,
+        source_field_tick_id="ft", source_field_generated_at=NOW,
+        source_attention_frame_id="af", source_attention_generated_at=NOW,
+        overall_intensity=0.3, overall_confidence=0.7, dimensions=dims,
+    )
+    if trajectory_condition is not None:
+        kwargs["trajectory_condition"] = trajectory_condition
+    if overall_surprise is not None:
+        kwargs["overall_surprise"] = overall_surprise
+    return SelfStateV1(**kwargs)
+
+
+def _prediction_surprise_events(self_state: SelfStateV1) -> list:
+    out = extract_tensions_from_self_state(
+        envelope=_envelope(),
+        intake_channel="orion:substrate:self_state",
+        self_state=self_state,
+        previous_self_state=None,
+    )
+    return [e for e in out if e.kind == "tension.prediction_surprise.v1"]
+
+
+def test_surprise_above_threshold_fires_with_expected_magnitude() -> None:
+    ss = _self_state(overall_surprise=0.5)
+    events = _prediction_surprise_events(ss)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.drive_impacts == {"predictive": 1.0}
+    assert 0.0 < ev.magnitude <= 1.0
+    # trajectory_condition defaults to "unknown" -> traj_mul == 1.0
+    assert ev.magnitude == 0.5
+
+
+def test_surprise_below_threshold_does_not_fire() -> None:
+    ss = _self_state(overall_surprise=0.10)
+    events = _prediction_surprise_events(ss)
+    assert events == []
+
+
+def test_surprise_above_threshold_with_degrading_trajectory_scales_magnitude() -> None:
+    ss = _self_state(overall_surprise=0.5, trajectory_condition="degrading")
+    events = _prediction_surprise_events(ss)
+    assert len(events) == 1
+    assert events[0].magnitude == 0.625
+
+
+def test_surprise_at_max_clamps_at_one() -> None:
+    ss = _self_state(overall_surprise=1.0)
+    events = _prediction_surprise_events(ss)
+    assert len(events) == 1
+    assert events[0].magnitude == 1.0
+
+
+def test_surprise_default_zero_does_not_fire() -> None:
+    ss = _self_state()  # overall_surprise omitted -> defaults to 0.0
+    events = _prediction_surprise_events(ss)
+    assert events == []


### PR DESCRIPTION
## Summary

- `predictive` (one of `DriveEngine`'s 6 drives, `orion/spark/concept_induction/drives.py`) previously never had a primary tension source -- it only received secondary `drive_impacts` weights (0.4-0.7) riding other dimensions' tensions (`tension.contradiction.v1`, `tension.identity_drift.v1`) and sat dead at a 0.016 median pressure, permanently inactive.
- `extract_tensions_from_self_state()` (`orion/spark/concept_induction/tensions.py`) now mints a new `tension.prediction_surprise.v1` tension directly off `self_state.overall_surprise` -- an already-clamped [0,1] top-level prediction-error aggregate on `SelfStateV1` that this function previously never read at all, despite being published on every `substrate.self_state.v1` tick this worker already consumes.
- Absolute-threshold firing (`overall_surprise > 0.30`) is intentional, not delta-based: unlike the other dimensions in this function (quality scores where a *drop* signals tension), `overall_surprise` is already a magnitude of surprise/error -- the absolute level itself is the tension.
- `drive_impacts={"predictive": 1.0}` -- single-drive, unambiguous primary source, no dilution across other drives.
- No wiring changes needed: `ConceptWorker._tensions_from_self_state()` already calls this function on every self-state tick and publishes whatever it returns through the existing tension -> `DriveEngine.update()` -> drive_state/drive_audit path unchanged.

## Outcome moved

This is O3 from the 2026-07-16 drive-economy desaturation diagnosis (`orion/autonomy/drives_and_autonomy_retrospective.md` §5a, `docs/superpowers/pr-reports/2026-07-16-drive-economy-desaturation-o1-o4-pr.md`). O1/O4 (merged same day) fixed the dominance-attribution poisoning mechanism; this is half of the second, still-open mechanism -- pressure pinning from a starved `predictive` drive. O2 (event-rate normalization) is the other half and is intentionally not in this patch.

## Current architecture

`extract_tensions_from_self_state()` built tensions from `SelfStateV1.dimensions[key].score` deltas only (`coherence`, `agency_readiness`/`social_pressure`, `uncertainty`, `resource_pressure`/`execution_pressure`). `SelfStateV1.overall_surprise` and `SelfStateV1.prediction_error_scores` (both populated upstream by the substrate self-state builder) were never read by this function.

## Architecture touched

`orion/spark/concept_induction/tensions.py` only. No bus contract, schema registry, channel, or env changes -- `tension.prediction_surprise.v1` is a payload-level `kind` string inside the already-registered `memory.tension.event.v1` envelope, the same pattern five sibling kinds in this file already use with zero registry entries (`tension.contradiction.v1`, `tension.distress.v1`, `tension.identity_drift.v1`, `tension.cognitive_load.v1`, `tension.satisfaction.v1`).

## Files changed

- `orion/spark/concept_induction/tensions.py`: new block in `extract_tensions_from_self_state()` (26 lines, purely additive)
- `orion/spark/concept_induction/tests/test_prediction_surprise_tension.py`: new file, 5 tests (fires above threshold with correct magnitude, silent below threshold, trajectory multiplier scaling, clamps at 1.0, silent at default 0.0)

## Schema / bus / API changes

- Added: `tension.prediction_surprise.v1` as a new `TensionEventV1.kind` value (payload-internal tag, not a new bus envelope kind or channel)
- Removed: none
- Renamed: none
- Behavior changed: `predictive` now gets a primary growth signal it never had; no change to any existing tension kind's behavior
- Compatibility notes: none -- purely additive, no existing consumer branches on an exhaustive kind enum (verified: `TensionEventV1.kind` is a free string field, not a pydantic `Literal`)

## Env/config changes

None.

## Tests run

```text
cd /mnt/scripts/Orion-Sapienform-drive-predictive-reground-o3
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/spark/concept_induction/tests -q
147 passed, 16 warnings in 14.09s
```

## Evals run

```text
No eval harness exists for this surface (tracked as issue #1066, same gap noted in the O1/O4 PR). Post-deploy live re-measurement (measure_autonomy_gate.py against fresh drive_audits) is the behavioral check, same as O1/O4.
```

## Docker/build/smoke checks

```text
Not run -- pure Python logic change in an already-running consumer path (ConceptWorker), no config/dependency/port/compose changes. Restart of orion-spark-concept-induction picks this up.
```

## Review findings fixed

Reviewed at medium effort (manual line-by-line + cross-file trace, given the diff is a 26-line additive block). No findings survived.

- Checked and cleared: `orion/spark/concept_induction/drive_attribution.py`'s `_PRIMARY_DRIVE_BY_KIND` map (used only as a tie-break shortcut in `dominant_drive_from_attribution`) does not have an entry for the new kind. Traced the full cascade: `compute_tick_attribution` sums `magnitude x drive_impacts` weight directly and is unaffected by the map. When `tension.prediction_surprise.v1` is the tick's lead tension and `predictive` ties at max attribution, the map lookup misses and falls through to the cascade's step 2, which ranks tied drives by the lead tension's own `drive_impacts` weights (`{"predictive": 1.0}`) -- the same correct result the map would have given directly. No behavioral gap in any constructible scenario; not fixed because there is nothing to fix.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: LOW. Concern: the `0.30` absolute threshold is a first-pass calibration with no live `overall_surprise` distribution to validate against (same honesty standard as O4's SATURATED thresholds, which were explicitly flagged the same way). Mitigation: plain module-level literal, trivially tunable; post-deploy re-measurement against `drive_audits` (same command used to verify O1/O4) will show whether `predictive` actually gets real variance now.

## PR link

(filled by gh pr create output)