### PR TITLE
fix(field-digester): availability recovers from active_node_pressure evidence, not just floors

### DIFF
--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -42,6 +42,24 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     channel="availability",
                     intensity=max(0.0, 1.0 - min(1.0, score + 0.2)),
                     label=delta.delta_id,
+                    # mode="replace" (2026-07-17 fix, live post-deploy finding):
+                    # this intensity is a full current-availability estimate
+                    # recomputed fresh from this tick's pressure_score, not an
+                    # incremental delta -- same "current reading" shape as
+                    # bus_health/delivery_confidence/execution_load elsewhere
+                    # in this file. Without mode="replace",
+                    # apply_perturbations() special-cases channel=="availability"
+                    # to floor-only (min(current, intensity)): can decrease but
+                    # never recover, even when a LATER event reports genuinely
+                    # improved conditions (a higher intensity just gets min()'d
+                    # away against the old low value). Confirmed live:
+                    # node:atlas's availability was pinned at exactly 0.0 with
+                    # staleness ~0 and gpu_pressure=0.72 (fresh, plausible
+                    # telemetry) -- not a real ongoing outage, a one-way ratchet
+                    # with the same shape as expected_offline_suppression's
+                    # original bug (PR #1109), just via min()-floor instead of
+                    # add-no-decay.
+                    mode="replace",
                 )
             )
         if delta.operation == "suppress":

--- a/services/orion-field-digester/tests/test_field_channel_ratchets.py
+++ b/services/orion-field-digester/tests/test_field_channel_ratchets.py
@@ -65,6 +65,22 @@ def _transport_bus_delta(*, node_id: str = "athena", hints: dict) -> StateDeltaV
     )
 
 
+def _active_node_pressure_delta(
+    *, node_id: str = "atlas", score: float, delta_id: str = "delta_pressure_1"
+) -> StateDeltaV1:
+    after = {"node_id": node_id, "pressure_score": score, "active_pressures": ["availability"]}
+    return StateDeltaV1(
+        delta_id=delta_id,
+        target_projection="active_node_pressure",
+        target_kind="active_node_pressure",
+        target_id=f"node:{node_id}",
+        operation="update",
+        after=after,
+        caused_by_event_ids=["gev_pressure_1"],
+        reducer_id="active_node_pressure_reducer",
+    )
+
+
 # ---------------------------------------------------------------------------
 # expected_offline_suppression clear path (item 1)
 # ---------------------------------------------------------------------------
@@ -380,3 +396,51 @@ def test_other_transport_bus_channels_still_default_add_mode() -> None:
     perturbations = delta_to_perturbations(delta)
     for p in perturbations:
         assert p.mode == "add", f"{p.channel} unexpectedly changed mode to {p.mode}"
+
+
+# ---------------------------------------------------------------------------
+# availability recovery path (item 3, live post-deploy finding 2026-07-17)
+# ---------------------------------------------------------------------------
+
+
+def test_active_node_pressure_availability_delta_uses_replace_mode() -> None:
+    delta = _active_node_pressure_delta(score=0.9)
+    perturbations = delta_to_perturbations(delta)
+    availability = next(p for p in perturbations if p.channel == "availability")
+    assert availability.mode == "replace"
+
+
+def test_high_pressure_then_recovery_reflects_current_reading_not_floor() -> None:
+    """Reproduces the live bug: node:atlas pinned at availability=0.0 with fresh,
+    non-stale telemetry elsewhere (staleness~0, real gpu_pressure) -- not an
+    ongoing outage, a one-way floor that could never recover. A later event
+    reporting genuinely improved conditions (low pressure_score) must now be
+    reflected, not min()'d away against the old low value."""
+    state = _state(node_vectors={"node:atlas": {"availability": 1.0}})
+
+    bad_delta = _active_node_pressure_delta(score=0.9, delta_id="delta_bad")
+    perturbations = delta_to_perturbations(bad_delta)
+    apply_perturbations(state, perturbations, now=NOW)
+    assert state.node_vectors["node:atlas"]["availability"] == 0.0, "sanity: high pressure drives availability to 0"
+
+    good_delta = _active_node_pressure_delta(score=0.0, delta_id="delta_good")
+    perturbations = delta_to_perturbations(good_delta)
+    apply_perturbations(state, perturbations, now=NOW)
+    assert state.node_vectors["node:atlas"]["availability"] == 0.8, (
+        "availability must recover to reflect the improved reading (1 - min(1, 0+0.2) = 0.8), "
+        "not stay floor-clamped at the old low value"
+    )
+
+
+def test_availability_can_still_drop_on_a_later_worse_reading() -> None:
+    """Not just one-way-up: mode="replace" reflects whatever the current
+    reading says, so a later genuinely worse score must still lower it."""
+    state = _state(node_vectors={"node:atlas": {"availability": 1.0}})
+
+    ok_delta = _active_node_pressure_delta(score=0.0, delta_id="delta_ok")
+    apply_perturbations(state, delta_to_perturbations(ok_delta), now=NOW)
+    assert state.node_vectors["node:atlas"]["availability"] == 0.8
+
+    worse_delta = _active_node_pressure_delta(score=0.9, delta_id="delta_worse")
+    apply_perturbations(state, delta_to_perturbations(worse_delta), now=NOW)
+    assert state.node_vectors["node:atlas"]["availability"] == 0.0


### PR DESCRIPTION
## Summary
- Live post-deploy verification found `node:atlas`'s `availability` pinned at exactly `0.0` despite fresh, non-stale telemetry elsewhere (`staleness`~0, plausible real `gpu_pressure`=0.72) — not an ongoing outage, a one-way floor with no recovery path.
- Root cause: the `active_node_pressure` "availability" perturbation computes a full current-availability estimate each time (`intensity = max(0.0, 1.0 - min(1.0, score + 0.2))`), but was applied via `apply_perturbations()`'s `channel=="availability"` special case — `min(current, intensity)`, floor-only. A later event reporting genuinely improved conditions (a higher intensity) gets `min()`'d away against the old low value, so it can decrease but never recover. Same shape as `expected_offline_suppression`'s original ratchet bug (PR #1109), a third distinct mechanism (min()-floor instead of add-no-decay).

## Outcome moved
`availability` can now reflect real, current node conditions in both directions — feeds `SelfStateV1.coherence` directly (weight 0.50 via `stabilizing_channels`) and the merge-polarity fix's min()-across-nodes merge (PR #1110), which is exactly what surfaced this: min()-merge correctly exposed the worst node's real value instead of letting a healthier node mask it, and that worst value turned out to be permanently stuck.

## Files changed
- `services/orion-field-digester/app/ingest/state_deltas.py`: `mode="replace"` on the `active_node_pressure` availability perturbation
- `services/orion-field-digester/tests/test_field_channel_ratchets.py`: new helper + 3 regression tests (mode check, high-pressure-then-recovery, still-drops-on-later-worse-reading)

## Tests run
```
170 passed (services/orion-field-digester/tests + cross-cutting field/self-state/attention suites)
```
New regression tests verified to fail without the fix (reverted `state_deltas.py`, confirmed `availability` stays at `0.0` instead of recovering to `0.8`, restored and confirmed pass).

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-field-digester/.env -f services/orion-field-digester/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: Low
- Concern: `perturbation.py`'s `channel=="availability"` min()-floor special case is left in place rather than removed — it's now unreachable from the only production call site (this one, now `mode="replace"`), but an existing test (`test_full_tick_no_longer_permanently_floors_once_cleared`) constructs a raw `Perturbation` without `mode="replace"` and still expects floor semantics. Left as-is rather than risk breaking that test's intent; flagging in case a future reviewer wants that dead-ish branch cleaned up separately.

## Merge-order note
No overlap with other open PRs (only #1113 is currently open, touching `channels.py`/`test_field_topology_reconciliation.py` — no file overlap with this PR's changes).