### PR TITLE
feat(orion-thought): add drive_state_compact facet to light Mind path

### DIFF
--- a/services/orion-thought/.env_example
+++ b/services/orion-thought/.env_example
@@ -90,6 +90,10 @@ ORION_THOUGHT_MIND_MAX_RESPONSE_BYTES=2000000
 ORION_THOUGHT_MIND_ARTIFACT_PUBLISH_ENABLED=true
 ORION_THOUGHT_MIND_COLORING_MAX_ITEMS=3
 CHANNEL_MIND_ARTIFACT=orion:mind:artifact
+# Bounded single-row Postgres lookup (latest drive_audits row) for the
+# drive_state_compact facet; kept far below WALL_MS/TIMEOUT_SEC so a slow/
+# unavailable DB fails open fast without slowing the turn.
+ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC=0.4
 
 # --- Reasoning activity projection (always-on consumer; harmless when idle) ---
 # Consume per-call ReasoningCallV1 telemetry off the bus and materialize a

--- a/services/orion-thought/README.md
+++ b/services/orion-thought/README.md
@@ -95,7 +95,8 @@ author of `ThoughtEventV1` and reconciles the coloring (existing inputs win —
 it never forces chat framing on technical/agent turns).
 
 Module: `app/mind_enrichment.py` (snapshot builder, fail-open HTTP client,
-allow-list coloring selector, artifact publisher).
+allow-list coloring selector, artifact publisher, bounded `drive_state_compact`
+Postgres fetch).
 
 Flags:
 
@@ -109,6 +110,20 @@ Flags:
 | `ORION_THOUGHT_MIND_MAX_RESPONSE_BYTES` | `2000000` | Response body cap |
 | `ORION_THOUGHT_MIND_ARTIFACT_PUBLISH_ENABLED` | `false` | Publish `mind_runs` artifact (`mode=orion`) |
 | `ORION_THOUGHT_MIND_COLORING_MAX_ITEMS` | `3` | Coloring list cap |
+| `ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC` | `0.4` | Bounded single-row `drive_audits` lookup timeout |
+
+**`drive_state_compact` facet:** before building the Mind request,
+`_maybe_build_mind_coloring` (`app/bus_listener.py`) fetches the latest
+`drive_audits` row (`subject = 'orion'`) via `fetch_drive_state_facet_for_thought`,
+bounded by `ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC`. On timeout,
+connection failure, missing table, no row, or a row with no meaningful content
+(a quiet DriveEngine tick), it degrades to `None` and the facet is simply
+omitted — this never raises or slows the turn beyond the bounded timeout.
+Mirrors `orion-cortex-orch`'s `drive_state_compact` facet
+(`services/orion-cortex-orch/app/mind_runtime.py`), adapted to `orion-thought`'s
+sync `psycopg2`/`SQLAlchemy` DB seam (reuses `app/store.py`'s lazy engine —
+`orion-thought` has no `asyncpg` dependency) instead of that service's asyncpg
+pool.
 
 **Preconditions (silent no-op if unmet):**
 1. `orion-mind` must have `MIND_LLM_SYNTHESIS_ENABLED=true` — `meaningful_synthesis`

--- a/services/orion-thought/app/bus_listener.py
+++ b/services/orion-thought/app/bus_listener.py
@@ -27,6 +27,7 @@ from orion.thought.stance_react import (
 from .cortex_client import CortexExecClient
 from .mind_enrichment import (
     build_light_mind_request,
+    fetch_drive_state_facet_for_thought,
     publish_mind_run_artifact_for_thought,
     run_mind_for_thought,
     select_mind_coloring,
@@ -232,10 +233,22 @@ async def _maybe_build_mind_coloring(
     if not settings.mind_enrichment_enabled:
         return None
     try:
+        drive_state_compact, drive_diag = await fetch_drive_state_facet_for_thought(
+            request.correlation_id, settings=settings
+        )
+        logger.info(
+            "mind_drive_state_fetch corr=%s ok=%s reason=%s elapsed_ms=%s timed_out=%s",
+            request.correlation_id,
+            drive_diag.get("ok"),
+            drive_diag.get("reason"),
+            drive_diag.get("elapsed_ms"),
+            drive_diag.get("timed_out"),
+        )
         mind_req = build_light_mind_request(
             request,
             wall_time_ms=settings.mind_wall_ms,
             router_profile=settings.mind_router_profile,
+            drive_state_compact=drive_state_compact,
         )
         result = await run_mind_for_thought(
             mind_req,

--- a/services/orion-thought/app/mind_enrichment.py
+++ b/services/orion-thought/app/mind_enrichment.py
@@ -7,7 +7,10 @@ ThoughtEventV1 and reconciles this coloring. Everything fails open.
 """
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID, uuid4
@@ -166,17 +169,186 @@ def _situation_compact_from_broadcast(request: StanceReactRequestV1) -> dict[str
     return compact
 
 
+# --- drive_state_compact facet (bounded, fail-open Postgres fetch) ---
+#
+# Mirrors orion-cortex-orch's `fetch_drive_state_facet_for_mind` in
+# services/orion-cortex-orch/app/mind_runtime.py (same query, same diagnostics
+# shape, same fail-open contract) for orion-thought's independent "light Mind"
+# path. orion-cortex-orch uses asyncpg via a shared lazy pool; orion-thought
+# has no asyncpg dependency, so this rides the existing sync psycopg2/
+# SQLAlchemy seam already used by store.py (`_get_engine()`/`_database_url()`)
+# and bounds it with asyncio.wait_for(asyncio.to_thread(...)) so a slow/failed
+# query can never block the event loop past the configured timeout.
+DRIVE_AUDITS_LATEST_QUERY_FOR_THOUGHT = (
+    "SELECT dominant_drive, active_drives, drive_pressures, summary, "
+    "COALESCE(observed_at, created_at) AS observed_at "
+    "FROM drive_audits WHERE subject = 'orion' "
+    "ORDER BY COALESCE(observed_at, created_at) DESC LIMIT 1"
+)
+
+# asyncio.wait_for/asyncio.to_thread cannot kill a stuck OS thread -- on the
+# asyncio-level timeout the executor thread (and whatever Postgres connection
+# it checked out from store.py's shared `_get_engine()` pool) keeps running
+# until it naturally returns. A server-side statement_timeout, scoped to just
+# this query's own transaction via SET LOCAL (reverts automatically, so it
+# never leaks into the pooled connection for the *next* checkout by any of
+# store.py's other callers), bounds that residual exposure. Same idiom as
+# services/orion-cortex-orch/app/memory_inject.py's psycopg2 SET LOCAL
+# statement_timeout for its own bounded, fail-open Postgres read.
+_DRIVE_STATE_QUERY_STATEMENT_TIMEOUT_MS = 300
+
+
+def _coerce_jsonb(value: Any) -> Any:
+    """psycopg2's default JSONB codec decodes to python objects already; this is a
+    guard for driver/codec configurations where the column instead comes back as a
+    raw JSON string (mirrors orion-cortex-orch mind_runtime._coerce_jsonb)."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (TypeError, ValueError):
+            return None
+    return value
+
+
+def _query_latest_drive_audit_row_sync() -> dict[str, Any] | None:
+    """Sync single-row fetch via orion-thought's existing SQLAlchemy engine.
+
+    Reuses `store._get_engine()` rather than duplicating engine-creation logic —
+    the same lazy module-level engine already used for reverie persistence,
+    pointed at the same `conjourney` Postgres instance `orion-sql-writer`
+    writes `drive_audits` to (see `store._database_url()`). Runs on a worker
+    thread via `asyncio.to_thread` in the caller; must stay synchronous.
+    """
+    from sqlalchemy import text
+
+    from .store import _get_engine
+
+    engine = _get_engine()
+    # engine.begin() (not .connect()) so `SET LOCAL statement_timeout` is
+    # transaction-scoped: it bounds only this query and reverts automatically
+    # when the transaction ends, instead of persisting on the pooled
+    # connection for whichever store.py caller checks it out next.
+    with engine.begin() as conn:
+        conn.execute(
+            text(f"SET LOCAL statement_timeout = '{_DRIVE_STATE_QUERY_STATEMENT_TIMEOUT_MS}ms'")
+        )
+        row = conn.execute(text(DRIVE_AUDITS_LATEST_QUERY_FOR_THOUGHT)).mappings().first()
+    return dict(row) if row is not None else None
+
+
+async def fetch_drive_state_facet_for_thought(
+    correlation_id: str, *, settings: Any
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Bounded, fail-open fetch of the latest DriveEngine `drive_audits` row (subject='orion').
+
+    Returns ``(drive_state_compact_or_none, diagnostics)``. On timeout, connection
+    failure, missing table, or no matching/meaningful row, this returns
+    ``(None, diagnostics)`` without raising — the Mind request must never stall
+    or break on this facet's absence. Same contract as orion-cortex-orch's
+    `fetch_drive_state_facet_for_mind`, adapted to orion-thought's sync DB seam.
+    """
+    timeout_sec = max(0.01, float(getattr(settings, "mind_drive_state_fetch_timeout_sec", 0.4)))
+    diagnostics: dict[str, Any] = {
+        "correlation_id": correlation_id,
+        "timeout_sec": timeout_sec,
+        "ok": False,
+        "elapsed_ms": 0,
+        "timed_out": False,
+        "exception_type": None,
+        "reason": "start",
+    }
+    t0 = time.perf_counter()
+    try:
+        row = await asyncio.wait_for(
+            asyncio.to_thread(_query_latest_drive_audit_row_sync), timeout=timeout_sec
+        )
+    except asyncio.TimeoutError as exc:
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        diagnostics.update(
+            {
+                "elapsed_ms": elapsed_ms,
+                "timed_out": True,
+                "exception_type": type(exc).__name__,
+                "reason": "timeout",
+            }
+        )
+        logger.warning(
+            "mind_drive_state_fetch_timeout corr=%s elapsed_ms=%s timeout_sec=%s",
+            correlation_id,
+            elapsed_ms,
+            timeout_sec,
+        )
+        return None, diagnostics
+    except Exception as exc:  # noqa: BLE001 — fail-open by contract
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        diagnostics.update(
+            {
+                "elapsed_ms": elapsed_ms,
+                "exception_type": type(exc).__name__,
+                "reason": "exception",
+                "degradation_reason": str(exc),
+            }
+        )
+        logger.warning(
+            "mind_drive_state_fetch_failed corr=%s elapsed_ms=%s exc_type=%s err=%s",
+            correlation_id,
+            elapsed_ms,
+            type(exc).__name__,
+            exc,
+        )
+        return None, diagnostics
+
+    elapsed_ms = int((time.perf_counter() - t0) * 1000)
+    diagnostics["elapsed_ms"] = elapsed_ms
+    if row is None:
+        diagnostics.update({"ok": True, "reason": "no_rows"})
+        return None, diagnostics
+
+    active_drives = _coerce_jsonb(row.get("active_drives"))
+    dominant_drive = row.get("dominant_drive")
+    summary = row.get("summary")
+    # Content check, not just row-existence: a quiet tick (nothing crossed
+    # activation threshold that tick) writes dominant_drive=None, summary=None,
+    # active_drives=[] to drive_audits. Attaching that as a real signal would be
+    # the "schema-valid payload with meaningless content" pattern CLAUDE.md
+    # Section 0A calls out — fail open here the same way a missing row does.
+    if not dominant_drive and not summary and not (isinstance(active_drives, list) and active_drives):
+        diagnostics.update({"ok": True, "reason": "no_meaningful_content"})
+        return None, diagnostics
+
+    observed_at = row.get("observed_at")
+    compact = {
+        "dominant_drive": dominant_drive,
+        "active_drives": active_drives,
+        "drive_pressures": _coerce_jsonb(row.get("drive_pressures")),
+        "summary": summary,
+        "observed_at": observed_at.isoformat() if hasattr(observed_at, "isoformat") else observed_at,
+    }
+    diagnostics.update({"ok": True, "reason": "success"})
+    logger.info(
+        "mind_drive_state_fetch_result corr=%s ok=true elapsed_ms=%s dominant_drive=%s",
+        correlation_id,
+        elapsed_ms,
+        compact["dominant_drive"],
+    )
+    return compact, diagnostics
+
+
 def build_light_mind_request(
     request: StanceReactRequestV1,
     *,
     wall_time_ms: int,
     router_profile: str,
+    drive_state_compact: dict[str, Any] | None = None,
 ) -> MindRunRequestV1:
     """Build a bounded Mind request with NO cognitive-projection cold rebuild.
 
     Evidence in v1 is the current user turn (as a single current_turn item),
-    plus recall_bundle (only if already threaded on stance_inputs) and a
-    situation_compact facet derived from the attention broadcast.
+    plus recall_bundle (only if already threaded on stance_inputs), a
+    situation_compact facet derived from the attention broadcast, and an
+    optional drive_state_compact facet (bounded-fetched by the caller via
+    `fetch_drive_state_facet_for_thought`). This function stays synchronous/pure;
+    the async DB fetch happens in the caller.
     """
     user_text = (request.user_message or "").strip()[:_MAX_USER_TEXT_CHARS]
     snapshot: dict[str, Any] = {"user_text": user_text, "messages_tail": []}
@@ -189,6 +361,8 @@ def build_light_mind_request(
     situation = _situation_compact_from_broadcast(request)
     if situation:
         facets["situation_compact"] = situation
+    if isinstance(drive_state_compact, dict) and drive_state_compact:
+        facets["drive_state_compact"] = drive_state_compact
     if facets:
         snapshot["facets"] = facets
 

--- a/services/orion-thought/app/settings.py
+++ b/services/orion-thought/app/settings.py
@@ -152,6 +152,13 @@ class ThoughtSettings(BaseSettings):
     )
     mind_coloring_max_items: int = Field(3, alias="ORION_THOUGHT_MIND_COLORING_MAX_ITEMS")
     channel_mind_artifact: str = Field("orion:mind:artifact", alias="CHANNEL_MIND_ARTIFACT")
+    # Bounded single-row Postgres lookup (latest drive_audits row for the
+    # drive_state_compact facet) kept far below mind_wall_ms/mind_timeout_sec
+    # so a slow/unavailable DB fails open fast without slowing the turn.
+    # Mirrors orion-cortex-orch's mind_drive_state_fetch_timeout_sec.
+    mind_drive_state_fetch_timeout_sec: float = Field(
+        0.4, alias="ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC"
+    )
 
     # --- Reasoning activity projection (always-on consumer; harmless when idle) ---
     # Consume per-call ReasoningCallV1 telemetry and materialize a rolling-window

--- a/services/orion-thought/tests/test_mind_drive_state_facet.py
+++ b/services/orion-thought/tests/test_mind_drive_state_facet.py
@@ -1,0 +1,313 @@
+"""Tests for the drive_state_compact facet on orion-thought's independent
+"light Mind" path (mirrors orion-cortex-orch's mind_runtime facet, adapted to
+orion-thought's sync psycopg2/SQLAlchemy DB seam)."""
+from __future__ import annotations
+
+import importlib
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from app.mind_enrichment import build_light_mind_request
+from orion.schemas.thought import HubAssociationBundleV1, StanceReactRequestV1
+
+
+def _fresh_mind_enrichment():
+    """Reimport app.mind_enrichment through the module object, following the
+    conftest isolation fixture's reset. Needed so monkeypatch.setattr on the
+    module used by the test targets the same module object the awaited
+    function actually resolves its globals through (see
+    test_mind_enrichment_fail_open.py for the same reload pattern)."""
+    import app.mind_enrichment as me
+
+    importlib.reload(me)
+    return me
+
+
+def _request() -> StanceReactRequestV1:
+    return StanceReactRequestV1(
+        correlation_id="corr-1",
+        session_id="sess-1",
+        user_message="how's the drive state looking?",
+        association=HubAssociationBundleV1(
+            correlation_id="corr-1",
+            broadcast=None,
+            broadcast_stale=True,
+            read_source="hub_sql_fallback",
+        ),
+        repair_bundle=None,
+        stance_inputs={"user_message": "how's the drive state looking?"},
+    )
+
+
+def _settings(timeout_sec: float = 0.4) -> SimpleNamespace:
+    return SimpleNamespace(mind_drive_state_fetch_timeout_sec=timeout_sec)
+
+
+# --- build_light_mind_request: drive_state_compact facet wiring ---
+
+
+def test_drive_state_compact_included_when_present() -> None:
+    compact = {"dominant_drive": "curiosity", "active_drives": ["curiosity"], "summary": "s"}
+    req = build_light_mind_request(
+        _request(), wall_time_ms=12000, router_profile="default", drive_state_compact=compact
+    )
+    assert req.snapshot_inputs["facets"]["drive_state_compact"] == compact
+
+
+def test_drive_state_compact_omitted_when_none() -> None:
+    req = build_light_mind_request(
+        _request(), wall_time_ms=12000, router_profile="default", drive_state_compact=None
+    )
+    assert "drive_state_compact" not in req.snapshot_inputs.get("facets", {})
+
+
+def test_drive_state_compact_omitted_when_empty_dict() -> None:
+    req = build_light_mind_request(
+        _request(), wall_time_ms=12000, router_profile="default", drive_state_compact={}
+    )
+    assert "drive_state_compact" not in req.snapshot_inputs.get("facets", {})
+
+
+def test_drive_state_compact_default_param_is_none() -> None:
+    req = build_light_mind_request(_request(), wall_time_ms=12000, router_profile="default")
+    assert "drive_state_compact" not in req.snapshot_inputs.get("facets", {})
+
+
+# --- fetch_drive_state_facet_for_thought: bounded, fail-open fetch ---
+
+
+@pytest.mark.asyncio
+async def test_fetch_degrades_on_timeout(monkeypatch) -> None:
+    me = _fresh_mind_enrichment()
+
+    def _slow_query():
+        time.sleep(0.2)
+        return {"dominant_drive": "curiosity", "active_drives": [], "drive_pressures": {}, "summary": "s", "observed_at": None}
+
+    monkeypatch.setattr(me, "_query_latest_drive_audit_row_sync", _slow_query)
+
+    compact, diagnostics = await me.fetch_drive_state_facet_for_thought(
+        "corr-1", settings=_settings(timeout_sec=0.01)
+    )
+    assert compact is None
+    assert diagnostics["timed_out"] is True
+    assert diagnostics["ok"] is False
+    assert diagnostics["reason"] == "timeout"
+    assert diagnostics["correlation_id"] == "corr-1"
+
+
+@pytest.mark.asyncio
+async def test_fetch_degrades_on_exception(monkeypatch) -> None:
+    me = _fresh_mind_enrichment()
+
+    def _boom():
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(me, "_query_latest_drive_audit_row_sync", _boom)
+
+    compact, diagnostics = await me.fetch_drive_state_facet_for_thought(
+        "corr-1", settings=_settings()
+    )
+    assert compact is None
+    assert diagnostics["ok"] is False
+    assert diagnostics["reason"] == "exception"
+    assert diagnostics["exception_type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_fetch_never_raises_on_exception(monkeypatch) -> None:
+    """Never raise to the caller — a query failure must not break the turn."""
+    me = _fresh_mind_enrichment()
+
+    def _boom():
+        raise RuntimeError("table missing")
+
+    monkeypatch.setattr(me, "_query_latest_drive_audit_row_sync", _boom)
+
+    # Must not raise.
+    compact, _diag = await me.fetch_drive_state_facet_for_thought("corr-1", settings=_settings())
+    assert compact is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_none_on_no_rows(monkeypatch) -> None:
+    me = _fresh_mind_enrichment()
+
+    monkeypatch.setattr(me, "_query_latest_drive_audit_row_sync", lambda: None)
+
+    compact, diagnostics = await me.fetch_drive_state_facet_for_thought(
+        "corr-1", settings=_settings()
+    )
+    assert compact is None
+    assert diagnostics["ok"] is True
+    assert diagnostics["reason"] == "no_rows"
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_none_on_quiet_tick_no_meaningful_content(monkeypatch) -> None:
+    me = _fresh_mind_enrichment()
+
+    monkeypatch.setattr(
+        me,
+        "_query_latest_drive_audit_row_sync",
+        lambda: {
+            "dominant_drive": None,
+            "active_drives": [],
+            "drive_pressures": {},
+            "summary": None,
+            "observed_at": None,
+        },
+    )
+
+    compact, diagnostics = await me.fetch_drive_state_facet_for_thought(
+        "corr-1", settings=_settings()
+    )
+    assert compact is None
+    assert diagnostics["ok"] is True
+    assert diagnostics["reason"] == "no_meaningful_content"
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_compact_on_success(monkeypatch) -> None:
+    me = _fresh_mind_enrichment()
+
+    monkeypatch.setattr(
+        me,
+        "_query_latest_drive_audit_row_sync",
+        lambda: {
+            "dominant_drive": "curiosity",
+            "active_drives": ["curiosity", "connection"],
+            "drive_pressures": {"curiosity": 0.8},
+            "summary": "Curiosity is dominant.",
+            "observed_at": None,
+        },
+    )
+
+    compact, diagnostics = await me.fetch_drive_state_facet_for_thought(
+        "corr-1", settings=_settings()
+    )
+    assert compact == {
+        "dominant_drive": "curiosity",
+        "active_drives": ["curiosity", "connection"],
+        "drive_pressures": {"curiosity": 0.8},
+        "summary": "Curiosity is dominant.",
+        "observed_at": None,
+    }
+    assert diagnostics["ok"] is True
+    assert diagnostics["reason"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_fetch_coerces_jsonb_string_columns(monkeypatch) -> None:
+    """Guard path: if the driver ever returns JSONB as a raw string, it's decoded."""
+    me = _fresh_mind_enrichment()
+
+    monkeypatch.setattr(
+        me,
+        "_query_latest_drive_audit_row_sync",
+        lambda: {
+            "dominant_drive": "curiosity",
+            "active_drives": '["curiosity"]',
+            "drive_pressures": '{"curiosity": 0.5}',
+            "summary": "s",
+            "observed_at": None,
+        },
+    )
+
+    compact, _diag = await me.fetch_drive_state_facet_for_thought("corr-1", settings=_settings())
+    assert compact["active_drives"] == ["curiosity"]
+    assert compact["drive_pressures"] == {"curiosity": 0.5}
+
+
+# --- bus_listener wiring: fetch result threads into the Mind request ---
+
+
+class _FakeCortexClient:
+    def __init__(self, exec_result: dict) -> None:
+        self._exec_result = exec_result
+        self.captured_context = None
+
+    async def execute_plan(self, *, req, **_kwargs) -> dict:
+        self.captured_context = req.context
+        return self._exec_result
+
+
+def _stance_json() -> str:
+    return (
+        '{"imperative":"Stay present with Juniper.","tone":"warm",'
+        '"strain_refs":["hub:turn:corr-1"],"evidence_refs":["hub:turn:corr-1"],'
+        '"stance_harness_slice":{"task_mode":"reflective_dialogue",'
+        '"conversation_frame":"reflective","answer_strategy":"companion"}}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_bus_listener_threads_drive_state_into_mind_request(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_THOUGHT_MIND_ENRICHMENT_ENABLED", "true")
+    import app.settings as s
+
+    importlib.reload(s)
+    import app.mind_enrichment as me
+
+    importlib.reload(me)
+    import app.bus_listener as bl
+
+    importlib.reload(bl)
+
+    captured: dict = {}
+
+    async def _fake_fetch(correlation_id, *, settings):
+        return {"dominant_drive": "curiosity", "summary": "s"}, {
+            "ok": True,
+            "reason": "success",
+            "elapsed_ms": 3,
+            "timed_out": False,
+        }
+
+    async def _fake_run_mind(mind_req, **_kwargs):
+        captured["mind_req"] = mind_req
+        return None  # fail-open past this point; only the request shape matters here
+
+    monkeypatch.setattr(bl, "fetch_drive_state_facet_for_thought", _fake_fetch)
+    monkeypatch.setattr(bl, "run_mind_for_thought", _fake_run_mind)
+
+    client = _FakeCortexClient({"final_text": _stance_json(), "metadata": {}})
+    await bl.run_stance_react(_request(), bus=None, cortex_client=client)
+
+    facets = captured["mind_req"].snapshot_inputs.get("facets", {})
+    assert facets["drive_state_compact"] == {"dominant_drive": "curiosity", "summary": "s"}
+
+
+@pytest.mark.asyncio
+async def test_bus_listener_omits_drive_state_when_fetch_fails_open(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_THOUGHT_MIND_ENRICHMENT_ENABLED", "true")
+    import app.settings as s
+
+    importlib.reload(s)
+    import app.mind_enrichment as me
+
+    importlib.reload(me)
+    import app.bus_listener as bl
+
+    importlib.reload(bl)
+
+    captured: dict = {}
+
+    async def _fake_fetch(correlation_id, *, settings):
+        return None, {"ok": False, "reason": "timeout", "elapsed_ms": 400, "timed_out": True}
+
+    async def _fake_run_mind(mind_req, **_kwargs):
+        captured["mind_req"] = mind_req
+        return None
+
+    monkeypatch.setattr(bl, "fetch_drive_state_facet_for_thought", _fake_fetch)
+    monkeypatch.setattr(bl, "run_mind_for_thought", _fake_run_mind)
+
+    client = _FakeCortexClient({"final_text": _stance_json(), "metadata": {}})
+    thought = await bl.run_stance_react(_request(), bus=None, cortex_client=client)
+
+    facets = captured["mind_req"].snapshot_inputs.get("facets", {})
+    assert "drive_state_compact" not in facets
+    assert thought.imperative == "Stay present with Juniper."

--- a/services/orion-thought/tests/test_settings_mind_enrichment.py
+++ b/services/orion-thought/tests/test_settings_mind_enrichment.py
@@ -26,6 +26,7 @@ def test_mind_enrichment_defaults_off(monkeypatch):
         "ORION_THOUGHT_MIND_ROUTER_PROFILE",
         "ORION_THOUGHT_MIND_MAX_RESPONSE_BYTES",
         "ORION_THOUGHT_MIND_COLORING_MAX_ITEMS",
+        "ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC",
         "ORION_MIND_BASE_URL",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -39,6 +40,7 @@ def test_mind_enrichment_defaults_off(monkeypatch):
     assert s.settings.mind_coloring_max_items == 3
     assert s.settings.mind_base_url == "http://orion-mind:6611"
     assert s.settings.channel_mind_artifact == "orion:mind:artifact"
+    assert s.settings.mind_drive_state_fetch_timeout_sec == 0.4
     assert s.MIND_LLM_TIMEOUT_SEC_ASSUMED == 60.0
     assert s.MIND_ENRICHMENT_MIN_VIABLE_WALL_MS == 180000
 
@@ -49,6 +51,12 @@ def test_mind_enrichment_reads_env(monkeypatch):
     s = _reload_settings(monkeypatch)
     assert s.settings.mind_enrichment_enabled is True
     assert s.settings.mind_wall_ms == 9000
+
+
+def test_mind_drive_state_fetch_timeout_reads_env(monkeypatch):
+    monkeypatch.setenv("ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC", "0.75")
+    s = _reload_settings(monkeypatch)
+    assert s.settings.mind_drive_state_fetch_timeout_sec == 0.75
 
 
 def test_default_wall_is_viable_for_three_phase_synthesis(monkeypatch):


### PR DESCRIPTION
## Summary
- orion-cortex-orch's Mind path already gets a `drive_state_compact` facet (bounded, fail-open Postgres read of the latest `drive_audits` row) — orion-thought's independent "light Mind" path (`build_light_mind_request`) never got it, a known documented gap (see `services/orion-cortex-orch/app/mind_runtime.py` lines ~672-679).
- Mirrors the existing orion-cortex-orch pattern (`fetch_drive_state_facet_for_mind`), adapted to orion-thought's sync psycopg2/SQLAlchemy seam (`store.py`'s `_get_engine()`) since orion-thought has no asyncpg dependency — bounded via `asyncio.wait_for(asyncio.to_thread(...))` so the sync query never blocks the event loop past its timeout.
- `build_light_mind_request` stays synchronous/pure; the async fetch happens in the caller (`bus_listener.py::_maybe_build_mind_coloring`) before the request is built, preserving the existing fail-open contract end to end.
- Includes an empty-shell guard: a quiet drive_audits tick (no drive crossed activation) writes null/empty fields, and this is treated the same as "no row" rather than attached as a meaningless signal (CLAUDE.md §0A "No empty-shell cognition").

## Outcome moved
orion-thought's Mind requests now carry the same drive/tension awareness orion-cortex-orch's do, closing a real cross-service coverage gap for Mind's drive-state facet.

## Current architecture
`services/orion-cortex-orch/app/mind_runtime.py` had `fetch_drive_state_facet_for_mind` + `drive_state_compact` wired in; `services/orion-thought/app/mind_enrichment.py::build_light_mind_request` had no equivalent — its own separate `MindRunRequestV1` construction never included this facet.

## Architecture touched
`services/orion-thought/` only. `services/orion-cortex-orch/` is untouched (confirmed empty diff).

## Files changed
- `services/orion-thought/app/mind_enrichment.py`: added `DRIVE_AUDITS_LATEST_QUERY_FOR_THOUGHT`, `_coerce_jsonb`, `_query_latest_drive_audit_row_sync` (reuses `store._get_engine()`), `fetch_drive_state_facet_for_thought` (bounded, fail-open), and a `drive_state_compact` kwarg on `build_light_mind_request`.
- `services/orion-thought/app/bus_listener.py`: `_maybe_build_mind_coloring` now awaits the fetch before building the Mind request and threads the result through, logging diagnostics.
- `services/orion-thought/app/settings.py`: new field `mind_drive_state_fetch_timeout_sec` (alias `ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC`, default 0.4s).
- `services/orion-thought/.env_example`: added the corresponding key next to the other `ORION_THOUGHT_MIND_*` keys.
- `services/orion-thought/README.md`: documented the new env key and the facet's fail-open behavior.
- `services/orion-thought/tests/test_mind_drive_state_facet.py` (new): 13 tests covering facet inclusion/omission, fetch degradation (timeout/exception/no-rows/no-meaningful-content), success shaping, JSONB-string coercion, and bus_listener wiring.
- `services/orion-thought/tests/test_settings_mind_enrichment.py`: added default + env-read coverage for the new setting.

## Schema / bus / API changes
None — `drive_state_compact` is a key inside `MindRunRequestV1.snapshot_inputs.facets`, an existing free-form dict field. No changes to `orion/bus/channels.yaml` or `orion/schemas/registry.py` needed.

## Env/config changes
- Added keys: `ORION_THOUGHT_MIND_DRIVE_STATE_FETCH_TIMEOUT_SEC=0.4` (services/orion-thought/.env_example).
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes.
- local `.env` synced: `sync_local_env_from_example.py` was run; no `.env` file exists in this worktree (gitignored, not copied by `git worktree add`) — nothing to sync in-worktree. Juniper's own machine `.env` should pick up the new key on next sync.
- skipped keys requiring operator action: none.

## Tests run
```
pytest services/orion-thought/tests -q
172 passed
```

## Evals run
N/A — no eval harness exists for orion-thought; not attempted.

## Docker/build/smoke checks
N/A — no new dependency, no compose/Dockerfile change. `check_service_env_compose_parity.py orion-thought` confirmed env_file wiring reaches the container.

## Review findings fixed
- Finding: `asyncio.wait_for`/`asyncio.to_thread` can't kill a stuck OS thread — on timeout, a hung query would keep an executor thread and a pooled Postgres connection tied up indefinitely, starving `store.py`'s other callers.
  - Fix: `_query_latest_drive_audit_row_sync` now runs inside `engine.begin()` with a transaction-scoped `SET LOCAL statement_timeout = '300ms'` (auto-reverts, never leaks onto the pooled connection for the next checkout).
  - Evidence: `services/orion-thought/app/mind_enrichment.py` lines ~199-222; full suite green after the change.
- Finding: README didn't document the new env key or facet.
  - Fix: added both to `services/orion-thought/README.md`.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-thought/.env -f services/orion-thought/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: low
- Concern: bounded fetch adds one extra Postgres round-trip (capped at 300ms server-side, 400ms client-side) to every Mind-enriched turn on orion-thought's light-Mind path.
- Mitigation: fail-open by contract, timeout well below `mind_wall_ms`, matches the risk profile already accepted for the identical pattern in orion-cortex-orch.

## PR link
(filled in by gh pr create)