### PR TITLE
feat(sql-writer): persist drive audit tick_attribution and tension_kinds

### DIFF
--- a/services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql
+++ b/services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql
@@ -4,11 +4,12 @@
 -- fields; sql-writer previously dropped them at the mapper-column filter because
 -- they were not columns on DriveAuditSQL.
 --
--- New consumer: Hub Drives Analytics
--- (docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md) — windowed
--- contributor history and live/window attribution cards. Bounded payload:
--- tick_attribution is the 6 fixed DRIVE_KEYS floats; tension_kinds is a short
--- list of kind strings per tick.
+-- New consumer: Hub Drives Analytics (forthcoming operator surface; design
+-- lives as docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md
+-- on the docs/hub-drives-analytics branch until that lands on main) —
+-- windowed contributor history and live/window attribution cards. Bounded
+-- payload: tick_attribution is the 6 fixed DRIVE_KEYS floats; tension_kinds
+-- is a short list of kind strings per tick.
 --
 -- No backfill. Pre-migration rows remain NULL; the Hub UI must label windows
 -- that mix attributed and null rows ("attribution not recorded before <ts>").

--- a/services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql
+++ b/services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql
@@ -1,5 +1,26 @@
--- Drive audit v4: persist slim tick_attribution + tension_kinds for Hub Drives Analytics.
--- Wire schema DriveAuditV1 already carries these; sql-writer previously dropped them.
--- No backfill. Pre-migration rows remain NULL.
+-- Drive audit slim table v4: persist tick_attribution + tension_kinds.
+-- Producer: orion-spark-concept-induction (memory.drives.audit.v1 on
+-- orion:memory:drives:audit). Wire schema DriveAuditV1 already carries both
+-- fields; sql-writer previously dropped them at the mapper-column filter because
+-- they were not columns on DriveAuditSQL.
+--
+-- New consumer: Hub Drives Analytics
+-- (docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md) — windowed
+-- contributor history and live/window attribution cards. Bounded payload:
+-- tick_attribution is the 6 fixed DRIVE_KEYS floats; tension_kinds is a short
+-- list of kind strings per tick.
+--
+-- No backfill. Pre-migration rows remain NULL; the Hub UI must label windows
+-- that mix attributed and null rows ("attribution not recorded before <ts>").
+--
+-- On boot, sql-writer applies the same ALTER TABLE ... ADD COLUMN IF NOT EXISTS
+-- statements via app/main.py lifespan, so pre-existing deployments are upgraded
+-- automatically on restart. This file is the standalone equivalent for manual
+-- application against a running Postgres; it is a harmless no-op once applied.
+--
+-- Column ownership matches the convention in manual_migration_drive_audits_v1.sql
+-- / services/orion-sql-writer/app/models/drive_audit.py: model declares the
+-- columns; boot DDL + this migration keep live tables in sync.
+
 ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS tick_attribution JSONB;
 ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS tension_kinds JSONB;

--- a/services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql
+++ b/services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql
@@ -1,0 +1,5 @@
+-- Drive audit v4: persist slim tick_attribution + tension_kinds for Hub Drives Analytics.
+-- Wire schema DriveAuditV1 already carries these; sql-writer previously dropped them.
+-- No backfill. Pre-migration rows remain NULL.
+ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS tick_attribution JSONB;
+ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS tension_kinds JSONB;

--- a/services/orion-sql-writer/app/main.py
+++ b/services/orion-sql-writer/app/main.py
@@ -662,6 +662,12 @@ async def lifespan(app: FastAPI):
             conn.exec_driver_sql(
                 "ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS summary TEXT;"
             )
+            conn.exec_driver_sql(
+                "ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS tick_attribution JSONB;"
+            )
+            conn.exec_driver_sql(
+                "ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS tension_kinds JSONB;"
+            )
             # The autonomy measurement gate windows on COALESCE(observed_at,
             # created_at); a bare created_at index would never serve that
             # predicate (observed_at is nearly always set), so index the

--- a/services/orion-sql-writer/app/main.py
+++ b/services/orion-sql-writer/app/main.py
@@ -650,6 +650,8 @@ async def lifespan(app: FastAPI):
                     dominant_drive TEXT NULL,
                     summary TEXT NULL,
                     drive_pressures JSONB,
+                    tick_attribution JSONB,
+                    tension_kinds JSONB,
                     correlation_id TEXT NULL,
                     observed_at TIMESTAMPTZ NULL,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -662,6 +664,9 @@ async def lifespan(app: FastAPI):
             conn.exec_driver_sql(
                 "ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS summary TEXT;"
             )
+            # v4: Hub Drives Analytics contributor history. Wire DriveAuditV1 already
+            # carries these; older tables need the ALTER. Greenfield CREATE above
+            # already includes them; ADD COLUMN IF NOT EXISTS is a no-op there.
             conn.exec_driver_sql(
                 "ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS tick_attribution JSONB;"
             )

--- a/services/orion-sql-writer/app/models/drive_audit.py
+++ b/services/orion-sql-writer/app/models/drive_audit.py
@@ -24,10 +24,10 @@ class DriveAuditSQL(Base):
     miss).
 
     This is intentionally NOT an archive of the full artifact:
-    evidence_items/source_event_refs/tick_attribution are dropped by the
-    generic `_write_row` column filter. `summary` (one bounded sentence per
-    audit, `DriveAuditV1.summary`) IS stored — the one archive-ish exception —
-    because `scripts/drive_history_reflection_synthesis.py` reads it as its
+    evidence_items/source_event_refs are dropped by the generic `_write_row`
+    column filter. Bounded `tick_attribution`/`tension_kinds` and `summary`
+    (one bounded sentence per audit, `DriveAuditV1.summary`) are stored;
+    `scripts/drive_history_reflection_synthesis.py` reads the summary as its
     per-audit text input. `active_count` is derived in the
     sql-writer worker as `len(active_drives)` (0 when malformed/absent) — it is
     not on the wire payload. `active_drives`/`drive_pressures` are already
@@ -52,6 +52,8 @@ class DriveAuditSQL(Base):
     dominant_drive = Column(String, nullable=True)
     summary = Column(String, nullable=True)
     drive_pressures = Column(_JSONB, nullable=True)
+    tick_attribution = Column(_JSONB, nullable=True)
+    tension_kinds = Column(_JSONB, nullable=True)
     correlation_id = Column(String, nullable=True)
     observed_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/services/orion-sql-writer/app/models/drive_audit.py
+++ b/services/orion-sql-writer/app/models/drive_audit.py
@@ -30,8 +30,9 @@ class DriveAuditSQL(Base):
     `scripts/drive_history_reflection_synthesis.py` reads the summary as its
     per-audit text input. `active_count` is derived in the
     sql-writer worker as `len(active_drives)` (0 when malformed/absent) — it is
-    not on the wire payload. `active_drives`/`drive_pressures` are already
-    bounded upstream to the 6 fixed DRIVE_KEYS, so no capping is needed here.
+    not on the wire payload. `active_drives`/`drive_pressures`/`tick_attribution`
+    are already bounded upstream to the 6 fixed DRIVE_KEYS (and tension_kinds
+    is a short per-tick list), so no capping is needed here.
 
     Secondary indexes are intentionally NOT declared here via `index=True`.
     They are owned by the boot DDL in `app/main.py` (and the standalone

--- a/services/orion-sql-writer/tests/test_drive_audit_sql_shape.py
+++ b/services/orion-sql-writer/tests/test_drive_audit_sql_shape.py
@@ -104,6 +104,24 @@ def test_column_shape_is_the_slim_measurement_contract() -> None:
     assert {attr.key for attr in mapper.attrs} == EXPECTED_COLUMNS
 
 
+def test_boot_ddl_create_and_alter_include_attribution_columns() -> None:
+    """Greenfield CREATE and upgrade ALTER must both name the v4 columns.
+
+    CREATE TABLE IF NOT EXISTS alone does not upgrade live tables, so ALTER
+    ADD COLUMN IF NOT EXISTS must stay. CREATE must also list the columns so
+    a fresh DB matches the model without relying on ALTER alone.
+    """
+    main_py = (SERVICE_ROOT / "app" / "main.py").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS drive_audits" in main_py
+    create_block = main_py.split("CREATE TABLE IF NOT EXISTS drive_audits", 1)[1].split(
+        ");", 1
+    )[0]
+    assert "tick_attribution JSONB" in create_block
+    assert "tension_kinds JSONB" in create_block
+    assert "ADD COLUMN IF NOT EXISTS tick_attribution JSONB" in main_py
+    assert "ADD COLUMN IF NOT EXISTS tension_kinds JSONB" in main_py
+
+
 def test_bounded_attribution_fields_are_columns_but_archive_fields_are_not() -> None:
     # summary is deliberately NOT in this list: it and the bounded attribution
     # fields are stored, while the full evidence archive remains excluded.

--- a/services/orion-sql-writer/tests/test_drive_audit_sql_shape.py
+++ b/services/orion-sql-writer/tests/test_drive_audit_sql_shape.py
@@ -134,6 +134,14 @@ def test_tick_attribution_and_tension_kinds_pass_through() -> None:
     assert obj.tick_attribution["predictive"] == 0.5
     assert obj.tension_kinds[0] == "substrate.world_coverage_gap"
 
+    # Schema defaults (empty dict / empty list) also survive the mapper filter.
+    row_empty = _row_dict(_make_audit(tick_attribution={}, tension_kinds=[]))
+    assert row_empty["tick_attribution"] == {}
+    assert row_empty["tension_kinds"] == []
+    obj_empty = DriveAuditSQL(**row_empty)
+    assert obj_empty.tick_attribution == {}
+    assert obj_empty.tension_kinds == []
+
 
 def test_summary_passes_through_to_column() -> None:
     """`summary` is a plain `DriveAuditV1` field, so once the mapper column

--- a/services/orion-sql-writer/tests/test_drive_audit_sql_shape.py
+++ b/services/orion-sql-writer/tests/test_drive_audit_sql_shape.py
@@ -36,6 +36,8 @@ EXPECTED_COLUMNS = {
     "dominant_drive",
     "summary",
     "drive_pressures",
+    "tick_attribution",
+    "tension_kinds",
     "correlation_id",
     "observed_at",
     "created_at",
@@ -102,13 +104,35 @@ def test_column_shape_is_the_slim_measurement_contract() -> None:
     assert {attr.key for attr in mapper.attrs} == EXPECTED_COLUMNS
 
 
-def test_archive_fields_are_not_columns() -> None:
-    # summary is deliberately NOT in this list: it is the one archive-ish
-    # field stored (drive_history_reflection_synthesis reads it).
+def test_bounded_attribution_fields_are_columns_but_archive_fields_are_not() -> None:
+    # summary is deliberately NOT in this list: it and the bounded attribution
+    # fields are stored, while the full evidence archive remains excluded.
     mapper = inspect(DriveAuditSQL)
     cols = {attr.key for attr in mapper.attrs}
-    for archive_field in ("evidence_items", "source_event_refs", "tick_attribution"):
+    for archive_field in ("evidence_items", "source_event_refs"):
         assert archive_field not in cols
+    for bounded_field in ("tick_attribution", "tension_kinds"):
+        assert bounded_field in cols
+
+
+def test_tick_attribution_and_tension_kinds_pass_through() -> None:
+    attribution = {
+        "coherence": 0.1,
+        "continuity": 0.0,
+        "capability": 0.0,
+        "relational": 0.2,
+        "predictive": 0.5,
+        "autonomy": 0.0,
+    }
+    kinds = ["substrate.world_coverage_gap", "tension.contradiction.v1"]
+    row = _row_dict(
+        _make_audit(tick_attribution=attribution, tension_kinds=kinds)
+    )
+    assert row["tick_attribution"] == attribution
+    assert row["tension_kinds"] == kinds
+    obj = DriveAuditSQL(**row)
+    assert obj.tick_attribution["predictive"] == 0.5
+    assert obj.tension_kinds[0] == "substrate.world_coverage_gap"
 
 
 def test_summary_passes_through_to_column() -> None:


### PR DESCRIPTION
## Summary

- PR 1 of 3 for the Hub Drives Analytics operator surface.
- Persist the slim attribution fields `tick_attribution` and `tension_kinds` on the `drive_audits` table so the upcoming Drives dashboard has real contributor history instead of proxies.
- These fields are already on the wire schema `DriveAuditV1`; the SQL sink was silently dropping them.
- Adds boot DDL (`ADD COLUMN IF NOT EXISTS`) and a standalone v4 migration.

## Outcome moved

Drive-audit contributor attribution becomes durable in Postgres (was discarded at the sql-writer sink). Downstream: PR 2 (read APIs) and PR 3 (Hub tab) can render real per-drive contributor history.

## Architecture touched

- `DriveAuditSQL` model gains two nullable JSONB columns.
- sql-writer boot DDL + manual migration keep table shape in sync.
- No bus/schema/registry change — `DriveAuditV1` already defines both fields. The generic `_write_row` mapper-column filter passes them through automatically (no worker special-casing).

## Files changed

- `services/orion-sql-writer/app/models/drive_audit.py`: add `tick_attribution`, `tension_kinds` (`_JSONB`, nullable); docstring updated.
- `services/orion-sql-writer/app/main.py`: `ALTER TABLE drive_audits ADD COLUMN IF NOT EXISTS ...` for both, in the existing drive_audits DDL block.
- `services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql`: new, both ALTERs + no-backfill note.
- `services/orion-sql-writer/tests/test_drive_audit_sql_shape.py`: `EXPECTED_COLUMNS` includes the two columns; archive-fields test flipped to require them while still forbidding `evidence_items`/`source_event_refs`; new pass-through test.

## Schema / bus / API changes

- Added columns: `drive_audits.tick_attribution` (JSONB, null), `drive_audits.tension_kinds` (JSONB, null).
- No wire/bus/registry change. No backfill — pre-migration rows stay NULL (UI will label coverage).

## Env/config changes

- None.

## Tests run

```text
services/orion-sql-writer/.venv (shared) -m pytest tests/test_drive_audit_sql_shape.py -q
15 passed, 16 warnings
```

## Review

- Subagent task review: Spec ✅, code quality Approved (pass-through test asserts real mapper-filter behavior; archive test still forbids evidence_items/source_event_refs; DDL + migration match v1–v3 conventions).

## Restart required

```bash
# Boot DDL applies columns automatically on sql-writer start; or apply the migration manually first.
scripts/safe_docker_build.sh orion-sql-writer up -d --build
```

## Design docs

- Spec: `docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md`
- Plan: `docs/superpowers/plans/2026-07-16-hub-drives-analytics.md`
(both on branch `docs/hub-drives-analytics`)

## Risks / concerns

- Severity: Low. Concern: marginal row-size increase (6 floats + short kinds list per tick). Mitigation: bounded fields; existing 90-day retention.

Made with [Cursor](https://cursor.com)