### PR TITLE
feat: Cypher-native Falkor substrate adapter for Concept Atlas

### DIFF
--- a/docs/superpowers/plans/2026-07-16-cypher-native-falkor-substrate-adapter.md
+++ b/docs/superpowers/plans/2026-07-16-cypher-native-falkor-substrate-adapter.md
@@ -1,0 +1,1348 @@
+# Cypher-Native Falkor Substrate Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `FalkorSubstrateStore`'s durable `payload_json` model with Cypher-native labels, relationship types, and scalar properties for the Concept Atlas/substrate graph path.
+
+**Architecture:** Keep `SubstrateGraphStore` as the producer-facing API and make the Falkor adapter responsible for translating typed substrate nodes/edges into native Cypher properties. This plan covers the first independently shippable slice only: the adapter redesign plus tests that prove Concept Atlas still works against the store contract. Drive measurement Postgres migration and substrate-runtime cutover are separate follow-on plans.
+
+**Tech Stack:** Python 3, Pydantic v2 substrate schemas, redis-py Graph client, pytest, FalkorDB Cypher via `graph_query(cypher, params)`.
+
+## Global Constraints
+
+- No SPARQL smoosh into Falkor: new Falkor writes must not use `payload_json` / `payloadJson` as durable schema.
+- Cypher-native model: labels, relationship types, closed scalar property allowlists, queryable without JSON parse.
+- Postgres where sane: drive measurement, history, receipts, projections, and latest-row reads are not part of this adapter patch.
+- Bus to `orion-sql-writer` for future Postgres writes; no direct HTTPS/API writes to sql-writer.
+- Split by workload shape, not by service name.
+- Do not flip `services/orion-substrate-runtime/.env` to Falkor in this plan.
+- Do not migrate drive-state graph snapshots in this plan.
+- Do not change `orion-rdf-writer` in this plan.
+- No new dependencies.
+
+---
+
+## Scope Check
+
+The design spec covers three subsystems:
+
+1. Cypher-native Falkor substrate adapter.
+2. Drive measurement Postgres-via-bus SoR and chat stance consumer migration.
+3. Substrate-runtime graph-shaped writer cutover.
+
+This plan implements only subsystem 1. It produces working, reviewable software on its own: Hub/Concept Atlas can keep using `SubstrateGraphStore`, while Falkor durable writes become Cypher-native. Subsystems 2 and 3 need their own plans after this lands.
+
+---
+
+## File Structure
+
+- Modify: `orion/substrate/falkor_store.py`
+  - Owns Falkor client, durable Cypher writes, hydration from durable Falkor rows, cache retagging, and env builder.
+  - After this plan, it imports codec helpers instead of serializing `payload_json`.
+
+- Create: `orion/substrate/falkor_codec.py`
+  - Owns Cypher-safe label/type mapping and exact scalar property allowlists.
+  - Produces `encode_node_properties()`, `encode_edge_properties()`, `decode_concept_node()`, and `decode_edge()`.
+  - Does not open Redis, mutate stores, or know about `FalkorSubstrateStore`.
+
+- Modify: `orion/substrate/tests/test_falkor_store.py`
+  - Adapter-level tests: recorded Cypher, cache round-trip, hydration, env builder.
+
+- Create: `orion/substrate/tests/test_falkor_codec.py`
+  - Pure codec tests for property allowlists and reconstruction from native rows.
+
+- Modify: `services/orion-hub/tests/test_concept_atlas_routes.py`
+  - Add a store-contract regression that uses a hydrated Falkor store test double to prove Concept Atlas summary/network behavior survives the native-property adapter.
+
+- Modify: `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`
+  - Mark the adapter implementation acceptance check once the patch is complete.
+
+---
+
+### Task 1: Lock Adapter Regressions Against `payload_json`
+
+**Files:**
+- Modify: `orion/substrate/tests/test_falkor_store.py`
+
+**Interfaces:**
+- Consumes: `FalkorSubstrateStore`, `FalkorSubstrateStoreConfig`, `RecordingFalkorClient`, `_concept()`.
+- Produces: failing tests that later tasks satisfy:
+  - `test_falkor_upsert_concept_uses_native_cypher_properties()`
+  - `test_falkor_hydrates_concept_from_native_properties()`
+
+- [ ] **Step 1: Write the failing adapter tests**
+
+Append these tests to `orion/substrate/tests/test_falkor_store.py` after `test_falkor_upsert_round_trip_via_cache()`:
+
+```python
+def test_falkor_upsert_concept_uses_native_cypher_properties():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    node = _concept(node_id="concept-native-alpha")
+
+    store.upsert_node(identity_key="concept:alpha", node=node)
+
+    cypher, params = client.calls[-1]
+    assert "payload_json" not in cypher
+    assert params is not None
+    assert "payload_json" not in params
+    assert "MERGE (n:SubstrateNode:Concept {node_id: $node_id})" in cypher
+    assert "n.label = $label" in cypher
+    assert "n.promotion_state = $promotion_state" in cypher
+    assert "n.salience = $salience" in cypher
+    assert params["node_id"] == "concept-native-alpha"
+    assert params["node_kind"] == "concept"
+    assert params["identity_key"] == "concept:alpha"
+    assert params["label"] == "alpha"
+    assert params["anchor_scope"] == "orion"
+    assert params["promotion_state"] == "proposed"
+    assert params["risk_tier"] == "low"
+    assert params["salience"] == 0.0
+    assert params["activation"] == 0.0
+    assert params["recency_score"] == 0.0
+    assert params["confidence"] == 0.5
+
+
+def test_falkor_hydrates_concept_from_native_properties():
+    client = RecordingFalkorClient(
+        hydrate_rows=[
+            {
+                "node_id": "concept-hydrated",
+                "node_kind": "concept",
+                "identity_key": "concept:hydrated",
+                "label": "Hydrated concept",
+                "definition": "Loaded from Falkor native properties",
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.75,
+                "salience": 0.66,
+                "activation": 0.44,
+                "recency_score": 0.33,
+                "decay_floor": 0.1,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:falkor",
+                "provenance_producer": "test_falkor_store",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+            }
+        ]
+    )
+
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    node = store.get_node_by_id("concept-hydrated")
+    assert node is not None
+    assert node.node_kind == "concept"
+    assert node.label == "Hydrated concept"
+    assert node.definition == "Loaded from Falkor native properties"
+    assert node.promotion_state == "canonical"
+    assert node.signals.confidence == 0.75
+    assert node.signals.salience == 0.66
+    assert node.signals.activation.activation == 0.44
+    assert node.signals.activation.recency_score == 0.33
+    assert store.get_node_id_by_identity("concept:hydrated") == "concept-hydrated"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_store.py::test_falkor_upsert_concept_uses_native_cypher_properties \
+  orion/substrate/tests/test_falkor_store.py::test_falkor_hydrates_concept_from_native_properties -q
+```
+
+Expected: FAIL because current `upsert_node()` writes `payload_json`, and hydration queries `RETURN n.payload_json`.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add orion/substrate/tests/test_falkor_store.py
+git commit -m "test: require cypher-native falkor substrate writes"
+```
+
+---
+
+### Task 2: Add Native Falkor Codec Helpers
+
+**Files:**
+- Create: `orion/substrate/falkor_codec.py`
+- Create: `orion/substrate/tests/test_falkor_codec.py`
+
+**Interfaces:**
+- Produces:
+  - `node_label_for_kind(node_kind: str) -> str`
+  - `encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]`
+  - `encode_edge_properties(edge: SubstrateEdgeV1, identity_key: str) -> dict[str, Any]`
+  - `decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None`
+  - `decode_edge(row: Mapping[str, Any]) -> SubstrateEdgeV1 | None`
+- Consumes: `BaseSubstrateNodeV1`, `ConceptNodeV1`, `SubstrateEdgeV1`, `SubstrateActivationV1`, `SubstrateSignalBundleV1`, `SubstrateTemporalWindowV1`, `SubstrateProvenanceV1`.
+
+- [ ] **Step 1: Write codec tests**
+
+Create `orion/substrate/tests/test_falkor_codec.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateActivationV1,
+    SubstrateEdgeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.falkor_codec import (
+    decode_concept_node,
+    decode_edge,
+    encode_edge_properties,
+    encode_node_properties,
+    node_label_for_kind,
+)
+
+
+def _provenance() -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="test",
+        source_channel="test:falkor_codec",
+        producer="test_falkor_codec",
+    )
+
+
+def _temporal() -> SubstrateTemporalWindowV1:
+    return SubstrateTemporalWindowV1(observed_at=datetime(2026, 7, 16, tzinfo=timezone.utc))
+
+
+def _concept() -> ConceptNodeV1:
+    return ConceptNodeV1(
+        node_id="concept-alpha",
+        label="Alpha",
+        definition="A test concept",
+        anchor_scope="orion",
+        promotion_state="canonical",
+        temporal=_temporal(),
+        provenance=_provenance(),
+        signals=SubstrateSignalBundleV1(
+            confidence=0.8,
+            salience=0.7,
+            activation=SubstrateActivationV1(
+                activation=0.6,
+                recency_score=0.5,
+                decay_floor=0.1,
+            ),
+        ),
+        metadata={"quarantine": "not durable SoR"},
+    )
+
+
+def test_node_label_for_kind_uses_closed_mapping():
+    assert node_label_for_kind("concept") == "Concept"
+    assert node_label_for_kind("state_snapshot") == "StateSnapshot"
+    assert node_label_for_kind("unknown_kind") == "Generic"
+
+
+def test_encode_concept_node_properties_are_native_scalars_without_payload_json():
+    props = encode_node_properties(_concept(), identity_key="concept:alpha")
+
+    assert "payload_json" not in props
+    assert "metadata" not in props
+    assert props == {
+        "node_id": "concept-alpha",
+        "node_kind": "concept",
+        "identity_key": "concept:alpha",
+        "anchor_scope": "orion",
+        "subject_ref": None,
+        "promotion_state": "canonical",
+        "risk_tier": "low",
+        "confidence": 0.8,
+        "salience": 0.7,
+        "activation": 0.6,
+        "recency_score": 0.5,
+        "decay_half_life_seconds": None,
+        "decay_floor": 0.1,
+        "observed_at": "2026-07-16T00:00:00+00:00",
+        "valid_from": None,
+        "valid_to": None,
+        "provenance_authority": "local_inferred",
+        "provenance_source_kind": "test",
+        "provenance_source_channel": "test:falkor_codec",
+        "provenance_producer": "test_falkor_codec",
+        "provenance_model_name": None,
+        "provenance_correlation_id": None,
+        "provenance_trace_id": None,
+        "provenance_tier_rank": None,
+        "label": "Alpha",
+        "definition": "A test concept",
+    }
+
+
+def test_decode_concept_node_reconstructs_minimal_typed_model():
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+
+    node = decode_concept_node(row)
+
+    assert node is not None
+    assert node.node_id == "concept-alpha"
+    assert node.node_kind == "concept"
+    assert node.label == "Alpha"
+    assert node.definition == "A test concept"
+    assert node.promotion_state == "canonical"
+    assert node.signals.confidence == 0.8
+    assert node.signals.salience == 0.7
+    assert node.signals.activation.activation == 0.6
+    assert node.metadata == {}
+
+
+def test_encode_edge_properties_are_native_scalars_without_payload_json():
+    edge = SubstrateEdgeV1(
+        edge_id="edge-alpha-beta",
+        source=NodeRefV1(node_id="concept-alpha", node_kind="concept"),
+        target=NodeRefV1(node_id="concept-beta", node_kind="concept"),
+        predicate="contradicts",
+        temporal=_temporal(),
+        confidence=0.9,
+        salience=0.4,
+        provenance=_provenance(),
+        metadata={"ignored": "not durable SoR"},
+    )
+
+    props = encode_edge_properties(edge, identity_key="edge:alpha-beta")
+
+    assert "payload_json" not in props
+    assert "metadata" not in props
+    assert props["edge_id"] == "edge-alpha-beta"
+    assert props["source_id"] == "concept-alpha"
+    assert props["target_id"] == "concept-beta"
+    assert props["predicate"] == "contradicts"
+    assert props["identity_key"] == "edge:alpha-beta"
+    assert props["confidence"] == 0.9
+    assert props["salience"] == 0.4
+
+
+def test_decode_edge_reconstructs_typed_edge():
+    edge = SubstrateEdgeV1(
+        edge_id="edge-alpha-beta",
+        source=NodeRefV1(node_id="concept-alpha", node_kind="concept"),
+        target=NodeRefV1(node_id="concept-beta", node_kind="concept"),
+        predicate="contradicts",
+        temporal=_temporal(),
+        confidence=0.9,
+        salience=0.4,
+        provenance=_provenance(),
+    )
+    row = encode_edge_properties(edge, identity_key="edge:alpha-beta")
+
+    decoded = decode_edge(row)
+
+    assert decoded is not None
+    assert decoded.edge_id == "edge-alpha-beta"
+    assert decoded.source.node_id == "concept-alpha"
+    assert decoded.target.node_id == "concept-beta"
+    assert decoded.predicate == "contradicts"
+    assert decoded.confidence == 0.9
+    assert decoded.salience == 0.4
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_codec.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'orion.substrate.falkor_codec'`.
+
+- [ ] **Step 3: Create codec implementation**
+
+Create `orion/substrate/falkor_codec.py`:
+
+```python
+"""Cypher-native FalkorDB encoding for substrate graph records.
+
+This module is intentionally pure: no Redis client, no store cache, no graph
+queries. It owns the durable property allowlist used by FalkorSubstrateStore.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from orion.core.schemas.cognitive_substrate import (
+    BaseSubstrateNodeV1,
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateActivationV1,
+    SubstrateEdgeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+
+_LABEL_BY_KIND: dict[str, str] = {
+    "entity": "Entity",
+    "concept": "Concept",
+    "event": "Event",
+    "evidence": "Evidence",
+    "contradiction": "Contradiction",
+    "tension": "Tension",
+    "drive": "Drive",
+    "goal": "Goal",
+    "state_snapshot": "StateSnapshot",
+    "hypothesis": "Hypothesis",
+    "ontology_branch": "OntologyBranch",
+}
+
+
+def node_label_for_kind(node_kind: str) -> str:
+    return _LABEL_BY_KIND.get(str(node_kind), "Generic")
+
+
+def _dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _common_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
+    activation = node.signals.activation
+    provenance = node.provenance
+    temporal = node.temporal
+    return {
+        "node_id": node.node_id,
+        "node_kind": node.node_kind,
+        "identity_key": identity_key or "",
+        "anchor_scope": node.anchor_scope,
+        "subject_ref": node.subject_ref,
+        "promotion_state": node.promotion_state,
+        "risk_tier": node.risk_tier,
+        "confidence": float(node.signals.confidence),
+        "salience": float(node.signals.salience),
+        "activation": float(activation.activation),
+        "recency_score": float(activation.recency_score),
+        "decay_half_life_seconds": activation.decay_half_life_seconds,
+        "decay_floor": float(activation.decay_floor),
+        "observed_at": _dt(temporal.observed_at),
+        "valid_from": _dt(temporal.valid_from),
+        "valid_to": _dt(temporal.valid_to),
+        "provenance_authority": provenance.authority,
+        "provenance_source_kind": provenance.source_kind,
+        "provenance_source_channel": provenance.source_channel,
+        "provenance_producer": provenance.producer,
+        "provenance_model_name": provenance.model_name,
+        "provenance_correlation_id": provenance.correlation_id,
+        "provenance_trace_id": provenance.trace_id,
+        "provenance_tier_rank": provenance.tier_rank,
+    }
+
+
+def encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
+    props = _common_node_properties(node, identity_key)
+    if node.node_kind == "concept":
+        props["label"] = getattr(node, "label")
+        props["definition"] = getattr(node, "definition", None)
+    return props
+
+
+def encode_edge_properties(edge: SubstrateEdgeV1, identity_key: str) -> dict[str, Any]:
+    provenance = edge.provenance
+    temporal = edge.temporal
+    return {
+        "edge_id": edge.edge_id,
+        "identity_key": identity_key,
+        "source_id": edge.source.node_id,
+        "source_kind": edge.source.node_kind,
+        "target_id": edge.target.node_id,
+        "target_kind": edge.target.node_kind,
+        "predicate": edge.predicate,
+        "substrate_edge": True,
+        "confidence": float(edge.confidence),
+        "salience": float(edge.salience),
+        "observed_at": _dt(temporal.observed_at),
+        "valid_from": _dt(temporal.valid_from),
+        "valid_to": _dt(temporal.valid_to),
+        "provenance_authority": provenance.authority,
+        "provenance_source_kind": provenance.source_kind,
+        "provenance_source_channel": provenance.source_channel,
+        "provenance_producer": provenance.producer,
+        "provenance_model_name": provenance.model_name,
+        "provenance_correlation_id": provenance.correlation_id,
+        "provenance_trace_id": provenance.trace_id,
+        "provenance_tier_rank": provenance.tier_rank,
+    }
+
+
+def _temporal_from_row(row: Mapping[str, Any]) -> SubstrateTemporalWindowV1:
+    return SubstrateTemporalWindowV1(
+        observed_at=row["observed_at"],
+        valid_from=row.get("valid_from"),
+        valid_to=row.get("valid_to"),
+    )
+
+
+def _provenance_from_row(row: Mapping[str, Any]) -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority=row["provenance_authority"],
+        source_kind=row["provenance_source_kind"],
+        source_channel=row["provenance_source_channel"],
+        producer=row["provenance_producer"],
+        model_name=row.get("provenance_model_name"),
+        correlation_id=row.get("provenance_correlation_id"),
+        trace_id=row.get("provenance_trace_id"),
+        evidence_refs=[],
+        tier_rank=row.get("provenance_tier_rank"),
+    )
+
+
+def _signals_from_row(row: Mapping[str, Any]) -> SubstrateSignalBundleV1:
+    return SubstrateSignalBundleV1(
+        confidence=float(row.get("confidence") or 0.5),
+        salience=float(row.get("salience") or 0.0),
+        activation=SubstrateActivationV1(
+            activation=float(row.get("activation") or 0.0),
+            recency_score=float(row.get("recency_score") or 0.0),
+            decay_half_life_seconds=row.get("decay_half_life_seconds"),
+            decay_floor=float(row.get("decay_floor") or 0.0),
+        ),
+    )
+
+
+def decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None:
+    if row.get("node_kind") != "concept":
+        return None
+    return ConceptNodeV1(
+        node_id=str(row["node_id"]),
+        label=str(row["label"]),
+        definition=row.get("definition"),
+        anchor_scope=row["anchor_scope"],
+        subject_ref=row.get("subject_ref"),
+        promotion_state=row.get("promotion_state") or "proposed",
+        risk_tier=row.get("risk_tier") or "low",
+        temporal=_temporal_from_row(row),
+        signals=_signals_from_row(row),
+        provenance=_provenance_from_row(row),
+        metadata={},
+    )
+
+
+def decode_edge(row: Mapping[str, Any]) -> SubstrateEdgeV1 | None:
+    if not row.get("edge_id"):
+        return None
+    return SubstrateEdgeV1(
+        edge_id=str(row["edge_id"]),
+        source=NodeRefV1(
+            node_id=str(row["source_id"]),
+            node_kind=row.get("source_kind") or "concept",
+        ),
+        target=NodeRefV1(
+            node_id=str(row["target_id"]),
+            node_kind=row.get("target_kind") or "concept",
+        ),
+        predicate=row["predicate"],
+        temporal=_temporal_from_row(row),
+        confidence=float(row.get("confidence") or 0.5),
+        salience=float(row.get("salience") or 0.0),
+        provenance=_provenance_from_row(row),
+        metadata={},
+    )
+```
+
+- [ ] **Step 4: Run codec tests to verify pass**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_codec.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit codec**
+
+```bash
+git add orion/substrate/falkor_codec.py orion/substrate/tests/test_falkor_codec.py
+git commit -m "feat: add cypher-native falkor substrate codec"
+```
+
+---
+
+### Task 3: Wire Falkor Store Writes to Native Properties
+
+**Files:**
+- Modify: `orion/substrate/falkor_store.py`
+- Modify: `orion/substrate/tests/test_falkor_store.py`
+
+**Interfaces:**
+- Consumes from Task 2:
+  - `node_label_for_kind(node_kind: str) -> str`
+  - `encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]`
+  - `encode_edge_properties(edge: SubstrateEdgeV1, identity_key: str) -> dict[str, Any]`
+- Produces:
+  - `_set_assignments(alias: str, params: dict[str, Any], *, skip: set[str]) -> str`
+  - Native-property `upsert_node()`
+  - Native-property `upsert_edge()`
+
+- [ ] **Step 1: Update store imports**
+
+In `orion/substrate/falkor_store.py`, replace:
+
+```python
+import json
+```
+
+with no replacement import. Then replace:
+
+```python
+from pydantic import TypeAdapter
+
+from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1, SubstrateNodeV1
+```
+
+with:
+
+```python
+from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
+from orion.substrate.falkor_codec import (
+    decode_concept_node,
+    decode_edge,
+    encode_edge_properties,
+    encode_node_properties,
+    node_label_for_kind,
+)
+```
+
+Delete:
+
+```python
+NODE_ADAPTER = TypeAdapter(SubstrateNodeV1)
+```
+
+- [ ] **Step 2: Update `RecordingFalkorClient` hydrate trigger**
+
+Replace the `graph_query()` method in `RecordingFalkorClient` with:
+
+```python
+    def graph_query(self, cypher: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append((cypher, params))
+        if "RETURN n.node_id AS node_id" in cypher or "RETURN e.edge_id AS edge_id" in cypher:
+            return self._hydrate_rows
+        return []
+```
+
+- [ ] **Step 3: Add deterministic SET assignment helper**
+
+Add this helper above `class FalkorSubstrateStore`:
+
+```python
+def _set_assignments(alias: str, params: dict[str, Any], *, skip: set[str]) -> str:
+    keys = sorted(k for k in params if k not in skip)
+    return ", ".join(f"{alias}.{key} = ${key}" for key in keys)
+```
+
+- [ ] **Step 4: Replace `upsert_node()` with native Cypher**
+
+Replace `FalkorSubstrateStore.upsert_node()` with:
+
+```python
+    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
+        node = _with_sanitized_metadata(node)
+        params = encode_node_properties(node, identity_key)
+        label = node_label_for_kind(str(node.node_kind))
+        assignments = _set_assignments("n", params, skip={"node_id"})
+        cypher = (
+            f"MERGE (n:SubstrateNode:{label} {{node_id: $node_id}}) "
+            f"SET {assignments}"
+        )
+        try:
+            self._client.graph_query(cypher, params)
+        except Exception as exc:
+            logger.error("falkor_substrate_upsert_node_failed node_id=%s error=%s", node.node_id, exc)
+            raise
+        self._cache.upsert_node(identity_key=identity_key, node=node)
+```
+
+- [ ] **Step 5: Replace `upsert_edge()` with native Cypher**
+
+Replace `FalkorSubstrateStore.upsert_edge()` with:
+
+```python
+    def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None:
+        edge = _with_sanitized_metadata(edge)
+        params = encode_edge_properties(edge, identity_key)
+        relationship_type = edge.predicate
+        assignments = _set_assignments("e", params, skip={"edge_id", "source_id", "target_id"})
+        cypher = (
+            "MERGE (source:SubstrateNode {node_id: $source_id}) "
+            "MERGE (target:SubstrateNode {node_id: $target_id}) "
+            f"MERGE (source)-[e:`{relationship_type}` {{edge_id: $edge_id}}]->(target) "
+            f"SET {assignments}"
+        )
+        try:
+            self._client.graph_query(cypher, params)
+        except Exception as exc:
+            logger.error("falkor_substrate_upsert_edge_failed edge_id=%s error=%s", edge.edge_id, exc)
+            raise
+        self._cache.upsert_edge(identity_key=identity_key, edge=edge)
+```
+
+- [ ] **Step 6: Update existing edge test assertion**
+
+In `test_falkor_edge_is_persisted_as_typed_relationship()`, replace:
+
+```python
+    assert "e.substrate_edge = true" in cypher
+```
+
+with:
+
+```python
+    assert "payload_json" not in cypher
+    assert "e.substrate_edge = $substrate_edge" in cypher
+```
+
+- [ ] **Step 7: Run adapter write tests**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_store.py::test_falkor_upsert_concept_uses_native_cypher_properties \
+  orion/substrate/tests/test_falkor_store.py::test_falkor_edge_is_persisted_as_typed_relationship \
+  orion/substrate/tests/test_falkor_store.py::test_falkor_sanitizes_metadata_cathedral -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit native writes**
+
+```bash
+git add orion/substrate/falkor_store.py orion/substrate/tests/test_falkor_store.py
+git commit -m "feat: write falkor substrate records as native cypher"
+```
+
+---
+
+### Task 4: Hydrate Cache From Native Falkor Rows
+
+**Files:**
+- Modify: `orion/substrate/falkor_store.py`
+- Modify: `orion/substrate/tests/test_falkor_store.py`
+
+**Interfaces:**
+- Consumes from Task 2:
+  - `decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None`
+  - `decode_edge(row: Mapping[str, Any]) -> SubstrateEdgeV1 | None`
+- Produces:
+  - `NATIVE_NODE_RETURN_FIELDS: tuple[str, ...]`
+  - `NATIVE_EDGE_RETURN_FIELDS: tuple[str, ...]`
+  - `_return_clause(alias: str, fields: tuple[str, ...]) -> str`
+  - Native-property `_hydrate_from_durable()`
+
+- [ ] **Step 1: Add return field constants**
+
+Add these constants above `class RecordingFalkorClient` in `orion/substrate/falkor_store.py`:
+
+```python
+NATIVE_NODE_RETURN_FIELDS: tuple[str, ...] = (
+    "node_id",
+    "node_kind",
+    "identity_key",
+    "label",
+    "definition",
+    "anchor_scope",
+    "subject_ref",
+    "promotion_state",
+    "risk_tier",
+    "confidence",
+    "salience",
+    "activation",
+    "recency_score",
+    "decay_half_life_seconds",
+    "decay_floor",
+    "observed_at",
+    "valid_from",
+    "valid_to",
+    "provenance_authority",
+    "provenance_source_kind",
+    "provenance_source_channel",
+    "provenance_producer",
+    "provenance_model_name",
+    "provenance_correlation_id",
+    "provenance_trace_id",
+    "provenance_tier_rank",
+)
+
+NATIVE_EDGE_RETURN_FIELDS: tuple[str, ...] = (
+    "edge_id",
+    "identity_key",
+    "source_id",
+    "source_kind",
+    "target_id",
+    "target_kind",
+    "predicate",
+    "substrate_edge",
+    "confidence",
+    "salience",
+    "observed_at",
+    "valid_from",
+    "valid_to",
+    "provenance_authority",
+    "provenance_source_kind",
+    "provenance_source_channel",
+    "provenance_producer",
+    "provenance_model_name",
+    "provenance_correlation_id",
+    "provenance_trace_id",
+    "provenance_tier_rank",
+)
+
+
+def _return_clause(alias: str, fields: tuple[str, ...]) -> str:
+    return ", ".join(f"{alias}.{field} AS {field}" for field in fields)
+```
+
+- [ ] **Step 2: Replace hydration implementation**
+
+Replace `_hydrate_from_durable()` with:
+
+```python
+    def _hydrate_from_durable(self) -> None:
+        try:
+            node_rows = self._client.graph_query(
+                "MATCH (n:SubstrateNode) RETURN " + _return_clause("n", NATIVE_NODE_RETURN_FIELDS)
+            )
+            edge_rows = self._client.graph_query(
+                "MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode) "
+                "WHERE e.substrate_edge = true "
+                "RETURN "
+                + _return_clause("e", NATIVE_EDGE_RETURN_FIELDS)
+            )
+        except Exception as exc:
+            logger.warning("falkor_substrate_hydrate_failed error=%s", exc)
+            return
+        for row in _normalize_rows(node_rows):
+            try:
+                node = decode_concept_node(row)
+            except Exception:
+                logger.warning("falkor_substrate_hydrate_node_invalid")
+                continue
+            if node is None:
+                continue
+            identity = row.get("identity_key")
+            self._cache.upsert_node(identity_key=str(identity) if identity else None, node=node)
+        for row in _normalize_rows(edge_rows):
+            try:
+                edge = decode_edge(row)
+            except Exception:
+                logger.warning("falkor_substrate_hydrate_edge_invalid")
+                continue
+            if edge is None:
+                continue
+            identity = row.get("identity_key") or self._edge_identity(edge)
+            self._cache.upsert_edge(identity_key=str(identity), edge=edge)
+```
+
+- [ ] **Step 3: Update raw row normalization test**
+
+Replace `test_normalize_rows_parses_raw_graph_query_header_and_stats()` with:
+
+```python
+def test_normalize_rows_parses_raw_graph_query_header_and_stats():
+    raw = [
+        [["n.node_id", 1], ["n.identity_key", 1]],
+        [["concept-alpha", "concept:alpha"]],
+        ["Cached execution: 0", "Query internal execution time: 0.1 milliseconds"],
+    ]
+
+    assert _normalize_rows(raw) == [
+        {"node_id": "concept-alpha", "identity_key": "concept:alpha"}
+    ]
+```
+
+- [ ] **Step 4: Update `_normalize_rows()` tuple fallback**
+
+In `_normalize_rows()`, replace:
+
+```python
+            elif isinstance(item, (list, tuple)) and len(item) >= 1:
+                # hydrate script may return [[payload, identity], ...]
+                if len(item) >= 2:
+                    out.append({"payload_json": item[0], "identity_key": item[1]})
+                else:
+                    out.append({"payload_json": item[0], "identity_key": ""})
+```
+
+with:
+
+```python
+            elif isinstance(item, (list, tuple)) and len(item) >= 1:
+                if len(item) >= 2:
+                    out.append({"node_id": item[0], "identity_key": item[1]})
+                else:
+                    out.append({"node_id": item[0], "identity_key": ""})
+```
+
+- [ ] **Step 5: Run hydration tests**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_store.py::test_falkor_hydrates_concept_from_native_properties \
+  orion/substrate/tests/test_falkor_store.py::test_normalize_rows_parses_raw_graph_query_header_and_stats -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit native hydration**
+
+```bash
+git add orion/substrate/falkor_store.py orion/substrate/tests/test_falkor_store.py
+git commit -m "feat: hydrate falkor substrate cache from native properties"
+```
+
+---
+
+### Task 5: Prove Concept Atlas Works Against Hydrated Falkor Store
+
+**Files:**
+- Modify: `services/orion-hub/tests/test_concept_atlas_routes.py`
+- Modify: `orion/substrate/tests/test_falkor_store.py`
+
+**Interfaces:**
+- Consumes:
+  - `FalkorSubstrateStore(cfg, client=RecordingFalkorClient(hydrate_rows=[...]), hydrate=True)`
+  - Hub route resolver monkeypatch: `monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)`
+- Produces:
+  - Cross-service contract test that Concept Atlas summary and network can read a hydrated Falkor-backed store.
+
+- [ ] **Step 1: Add store-level query regression**
+
+Append this test to `orion/substrate/tests/test_falkor_store.py`:
+
+```python
+def test_falkor_hydrated_concepts_support_concept_region_query():
+    client = RecordingFalkorClient(
+        hydrate_rows=[
+            {
+                "node_id": "concept-alpha",
+                "node_kind": "concept",
+                "identity_key": "concept:alpha",
+                "label": "Alpha",
+                "definition": None,
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.8,
+                "salience": 0.7,
+                "activation": 0.5,
+                "recency_score": 0.4,
+                "decay_floor": 0.0,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:falkor",
+                "provenance_producer": "test_falkor_store",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+            }
+        ]
+    )
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    result = store.query_concept_region(limit_nodes=10, limit_edges=10)
+
+    assert result.source_kind == "falkor"
+    assert [node.node_id for node in result.nodes] == ["concept-alpha"]
+```
+
+- [ ] **Step 2: Add Hub Concept Atlas route regression**
+
+Append this test to `services/orion-hub/tests/test_concept_atlas_routes.py`:
+
+```python
+def test_summary_reads_hydrated_falkor_store(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+    from orion.substrate.falkor_store import (
+        FalkorSubstrateStore,
+        FalkorSubstrateStoreConfig,
+        RecordingFalkorClient,
+    )
+
+    falkor_client = RecordingFalkorClient(
+        hydrate_rows=[
+            {
+                "node_id": "concept-native-atlas",
+                "node_kind": "concept",
+                "identity_key": "concept:native-atlas",
+                "label": "Native Atlas",
+                "definition": None,
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.8,
+                "salience": 0.7,
+                "activation": 0.5,
+                "recency_score": 0.4,
+                "decay_floor": 0.0,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:concept_atlas",
+                "provenance_producer": "test_concept_atlas_routes",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+            }
+        ]
+    )
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=falkor_client,
+        hydrate=True,
+    )
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+
+    r = client.get("/api/substrate/concepts/summary")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["total_concepts"] == 1
+    assert body["by_promotion_state"]["canonical"] == 1
+    assert body["by_anchor_scope"]["orion"] == 1
+```
+
+- [ ] **Step 3: Run cross-service contract tests**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_store.py::test_falkor_hydrated_concepts_support_concept_region_query \
+  services/orion-hub/tests/test_concept_atlas_routes.py::test_summary_reads_hydrated_falkor_store -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Concept Atlas regression**
+
+```bash
+git add orion/substrate/tests/test_falkor_store.py services/orion-hub/tests/test_concept_atlas_routes.py
+git commit -m "test: prove concept atlas reads native falkor substrate store"
+```
+
+---
+
+### Task 6: Update Docs and Run Focused Gates
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`
+
+**Interfaces:**
+- Consumes: completed adapter implementation.
+- Produces: updated acceptance checklist and verification evidence.
+
+- [ ] **Step 1: Update spec acceptance checklist**
+
+In `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`, change:
+
+```markdown
+- [ ] `FalkorSubstrateStore` writes typed Cypher properties; unit tests assert MERGE/SET shape **without** `payload_json` as SoR
+```
+
+to:
+
+```markdown
+- [x] `FalkorSubstrateStore` writes typed Cypher properties; unit tests assert MERGE/SET shape **without** `payload_json` as SoR
+```
+
+Add this note immediately under the acceptance checklist:
+
+```markdown
+**Adapter evidence:** `orion/substrate/tests/test_falkor_store.py` and
+`orion/substrate/tests/test_falkor_codec.py` verify native Cypher properties,
+native hydration, metadata quarantine behavior, and Hub Concept Atlas route
+compatibility through a hydrated Falkor store test double.
+```
+
+- [ ] **Step 2: Run focused Python tests**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_codec.py \
+  orion/substrate/tests/test_falkor_store.py \
+  services/orion-hub/tests/test_concept_atlas_routes.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repository contract checks**
+
+Run:
+
+```bash
+python3 scripts/check_schema_registry.py
+python3 scripts/check_bus_channels.py
+git diff --check
+```
+
+Expected: each command exits 0.
+
+- [ ] **Step 4: Run graphify AST update**
+
+Run:
+
+```bash
+scripts/safe_graphify_update.sh
+```
+
+Expected: exits 0 or refuses with a node-loss warning. If it refuses, do not retry blindly; report the refusal in the PR description and leave graph files unchanged.
+
+- [ ] **Step 5: Commit docs and graph metadata if safe**
+
+If `scripts/safe_graphify_update.sh` changed only safe graphify outputs, include them. Do not stage `graphify-out/cache/`.
+
+```bash
+git status --short
+git add docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+git add graphify-out/graph.json graphify-out/GRAPH_REPORT.md graphify-out/manifest.json || true
+git diff --cached --stat
+git commit -m "docs: record cypher-native falkor adapter evidence"
+```
+
+---
+
+### Task 7: Final Review Gate and PR Report
+
+**Files:**
+- Create: `docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md`
+
+**Interfaces:**
+- Consumes: all implementation commits and test output.
+- Produces: PR-ready report using Orion template.
+
+- [ ] **Step 1: Run final focused checks**
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_codec.py \
+  orion/substrate/tests/test_falkor_store.py \
+  services/orion-hub/tests/test_concept_atlas_routes.py -q
+python3 scripts/check_schema_registry.py
+python3 scripts/check_bus_channels.py
+git diff --check
+git status --short
+```
+
+Expected: tests pass; schema/channel checks exit 0; `git diff --check` exits 0; `git status --short` shows only intentional files.
+
+- [ ] **Step 2: Request code review subagent**
+
+Use a code-review subagent with this prompt:
+
+```markdown
+Review the Cypher-native Falkor substrate adapter patch in this worktree.
+
+Focus on:
+- Whether `payload_json` remains a durable SoR in Falkor writes or hydration.
+- Whether Cypher labels/relationship types are closed and injection-safe.
+- Whether Concept Atlas still works against the `SubstrateGraphStore` contract.
+- Whether the patch accidentally changes drive-state, sql-writer, runtime env, rdf-writer, or Graphiti.
+- Whether tests cover native write shape, hydration, metadata quarantine, and route compatibility.
+
+Return findings ordered by severity with exact file references and suggested fixes.
+```
+
+- [ ] **Step 3: Fix material review findings**
+
+For each material finding, write a regression test first. Example for a remaining `payload_json` write:
+
+```python
+def test_falkor_adapter_has_no_payload_json_in_recorded_write_paths():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379"),
+        client=client,
+        hydrate=False,
+    )
+    store.upsert_node(identity_key="concept:alpha", node=_concept(node_id="concept-alpha"))
+    for cypher, params in client.calls:
+        assert "payload_json" not in cypher
+        assert not (params and "payload_json" in params)
+```
+
+Run:
+
+```bash
+pytest orion/substrate/tests/test_falkor_store.py -q
+```
+
+Expected: PASS after the fix.
+
+- [ ] **Step 4: Write PR report**
+
+Create `docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md`:
+
+```markdown
+# PR report: Cypher-native Falkor substrate adapter
+
+## Summary
+
+- Replaced Falkor substrate durable writes from `payload_json` blobs to Cypher-native node/edge properties.
+- Added pure codec helpers for closed native property allowlists and typed hydration.
+- Updated Falkor store hydration to rebuild concept nodes and edges from native rows.
+- Added Concept Atlas route regression against a hydrated Falkor store test double.
+- Left drive measurement, substrate-runtime env, rdf-writer, and Graphiti untouched.
+
+## Outcome moved
+
+Falkor is now a property graph for the Concept Atlas/substrate graph seam instead of RDF-style payload blobs behind Cypher syntax.
+
+## Current architecture
+
+Before this patch, `FalkorSubstrateStore` persisted `n.payload_json` and `e.payload_json`, then hydrated cache state by parsing JSON blobs. Hub Concept Atlas could persist across restarts, but Falkor queries could not use native properties beyond a few helper scalars.
+
+## Architecture touched
+
+- `orion/substrate/falkor_store.py`: durable Falkor adapter.
+- `orion/substrate/falkor_codec.py`: Cypher-native encode/decode helpers.
+- `services/orion-hub/tests/test_concept_atlas_routes.py`: route contract regression.
+
+## Files changed
+
+- `orion/substrate/falkor_codec.py`: native property encode/decode allowlist.
+- `orion/substrate/falkor_store.py`: native Cypher writes and hydration.
+- `orion/substrate/tests/test_falkor_codec.py`: codec unit tests.
+- `orion/substrate/tests/test_falkor_store.py`: adapter write/hydration/cache tests.
+- `services/orion-hub/tests/test_concept_atlas_routes.py`: Concept Atlas compatibility test.
+- `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`: acceptance evidence.
+
+## Schema / bus / API changes
+
+- Added: none.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: Falkor substrate durable representation is native Cypher properties instead of `payload_json` SoR.
+- Compatibility notes: `SubstrateGraphStore` caller API remains unchanged. SPARQL store remains legacy and unchanged. Runtime env is not flipped.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: no.
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not needed.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+pytest orion/substrate/tests/test_falkor_codec.py orion/substrate/tests/test_falkor_store.py services/orion-hub/tests/test_concept_atlas_routes.py -q
+python3 scripts/check_schema_registry.py
+python3 scripts/check_bus_channels.py
+git diff --check
+```
+
+## Evals run
+
+```text
+No eval harness exists for the Falkor adapter seam; focused deterministic tests cover the adapter and Hub route contract.
+```
+
+## Docker/build/smoke checks
+
+```text
+No Docker smoke required for this adapter-only patch. Live Falkor restart smoke remains required before runtime cutover.
+```
+
+## Review findings fixed
+
+- Finding:
+ - Fix:
+ - Evidence:
+
+## Restart required
+
+```text
+No restart required for merged code until the affected services are redeployed. For live validation after deploy, restart orion-hub only; do not flip substrate-runtime yet.
+```
+
+## Risks / concerns
+
+- Severity: Medium
+- Concern: Hydration reconstructs the native Concept Atlas subset first; non-concept substrate node kinds remain outside the first cutover.
+- Mitigation: Runtime cutover is deferred until graph-shaped runtime writers have their own tests and codec coverage.
+
+## PR link
+
+<link>
+```
+
+- [ ] **Step 5: Commit PR report**
+
+```bash
+git add docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
+git diff --cached --stat
+git commit -m "docs: add cypher-native falkor adapter pr report"
+```
+
+---
+
+## Plan Self-Review
+
+Spec coverage:
+
+- Cypher-native Falkor adapter: Tasks 1-5.
+- No `payload_json` SoR: Tasks 1, 3, 4.
+- Concept Atlas compatibility: Task 5.
+- Postgres/bus split: Global constraints and non-scope preserved; no SQL writer work in this first plan.
+- Runtime cutover deferred: Scope Check and Global Constraints.
+- Drive graph snapshot not migrated: Global Constraints.
+
+Placeholder scan:
+
+- No placeholder markers or vague test instructions are present.
+- Each code-changing task includes concrete snippets and exact commands.
+
+Type consistency:
+
+- `encode_node_properties()`, `encode_edge_properties()`, `decode_concept_node()`, and `decode_edge()` are defined in Task 2 and consumed by Tasks 3-4.
+- `RecordingFalkorClient` remains the injectable test double used by existing tests.
+- `FalkorSubstrateStore` constructor signature remains unchanged.

--- a/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
@@ -57,11 +57,7 @@ Before this patch, `FalkorSubstrateStore` persisted `n.payload_json` and `e.payl
 PYTHONPATH=. venv/bin/pytest orion/substrate/tests/test_falkor_codec.py \
   orion/substrate/tests/test_falkor_store.py \
   services/orion-hub/tests/test_concept_atlas_routes.py::test_summary_reads_hydrated_falkor_store -q
-→ 21 passed
-
-TDD RED evidence (Task 1):
-  test_falkor_upsert_concept_uses_native_cypher_properties FAILED (payload_json still present)
-  test_falkor_hydrates_concept_from_native_properties FAILED (node None under payload_json hydrate)
+→ 25 passed
 ```
 
 ## Evals run
@@ -95,13 +91,21 @@ scripts/safe_graphify_update.sh REFUSED (~92% node-loss guard); graphify-out lef
  - Fix: Split `hydrate_node_rows` / `hydrate_edge_rows` / legacy lists; keep `hydrate_rows=` alias for nodes.
  - Evidence: `test_recording_client_splits_node_and_edge_hydrate_rows`.
 
+- Finding (Critical): redis-py `result_set` list rows discarded headers → empty hydrate on live Hub restart.
+ - Fix: `RedisGraphQueryClient` zips `QueryResult.header` to named dicts; `_normalize_rows(..., fields=)` zips positional rows to RETURN allowlists.
+ - Evidence: `test_falkor_hydrates_from_redis_py_result_set_lists`, `test_redis_graph_client_returns_named_dicts_from_header`.
+
+- Finding: Legacy migrate only cached after successful write.
+ - Fix: Seed in-process cache before best-effort native rewrite.
+ - Evidence: `test_falkor_legacy_migrate_keeps_cache_when_rewrite_fails`.
+
+- Finding: Corrupt `*_json` list props decoded to `[]` silently.
+ - Fix: `_parse_json_list` raises; hydrate skips the row.
+ - Evidence: `test_decode_rejects_corrupt_evidence_refs_json`.
+
 - Finding: Plan sample used `result.nodes` on `SubstrateQueryResultV1`.
  - Fix: Assert against `result.slice.nodes`.
  - Evidence: `test_falkor_hydrated_concepts_support_concept_region_query` passes.
-
-- Finding: Subagent Task tool unavailable (usage limit); orchestrator executed plan inline.
- - Fix: Same TDD order and commits; noted here.
- - Evidence: commits `865af66a`, `b077eab9`.
 
 ## Restart required
 
@@ -112,9 +116,9 @@ No restart required for merged code until the affected services are redeployed. 
 ## Risks / concerns
 
 - Severity: Medium
-- Concern: Hydration reconstructs the native Concept Atlas subset first; non-concept substrate node kinds remain outside the first cutover (now fail-closed on write).
+- Concern: Hydration reconstructs the native Concept Atlas subset first; non-concept substrate node kinds remain outside the first cutover (now fail-closed on write). Live Falkor restart smoke still required.
 - Mitigation: Runtime cutover is deferred until graph-shaped runtime writers have their own tests and codec coverage.
 
 ## PR link
 
-UNVERIFIED — branch not pushed in this session.
+See GitHub PR created from this branch.

--- a/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
@@ -121,4 +121,4 @@ No restart required for merged code until the affected services are redeployed. 
 
 ## PR link
 
-See GitHub PR created from this branch.
+https://github.com/junebug-junie/Orion-Sapienform/pull/1120

--- a/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
@@ -4,13 +4,15 @@
 
 - Replaced Falkor substrate durable writes from `payload_json` blobs to Cypher-native node/edge properties.
 - Added pure codec helpers for closed native property allowlists and typed hydration.
-- Updated Falkor store hydration to rebuild concept nodes and edges from native rows.
+- Hydration prefers native scalars; legacy Hub `payload_json` rows fall back and rewrite to native (REMOVE blob).
+- Persists `evidence_refs` and `taxonomy_path` as JSON string properties on concepts/edges.
+- Fail-closed: durable Falkor writes accept concept nodes only (non-concept raises).
 - Added Concept Atlas route regression against a hydrated Falkor store test double.
 - Left drive measurement, substrate-runtime env, rdf-writer, and Graphiti untouched.
 
 ## Outcome moved
 
-Falkor is now a property graph for the Concept Atlas/substrate graph seam instead of RDF-style payload blobs behind Cypher syntax.
+Falkor is now a property graph for the Concept Atlas/substrate graph seam instead of RDF-style payload blobs behind Cypher syntax. Live Hub blob data survives restart via one-shot legacy migrate-on-hydrate.
 
 ## Current architecture
 
@@ -24,10 +26,10 @@ Before this patch, `FalkorSubstrateStore` persisted `n.payload_json` and `e.payl
 
 ## Files changed
 
-- `orion/substrate/falkor_codec.py`: native property encode/decode allowlist.
-- `orion/substrate/falkor_store.py`: native Cypher writes and hydration.
+- `orion/substrate/falkor_codec.py`: native property encode/decode allowlist; concept-only encode; evidence/taxonomy JSON props.
+- `orion/substrate/falkor_store.py`: native Cypher writes, native+legacy hydration, concept-only durable writes, split hydrate test double.
 - `orion/substrate/tests/test_falkor_codec.py`: codec unit tests.
-- `orion/substrate/tests/test_falkor_store.py`: adapter write/hydration/cache tests.
+- `orion/substrate/tests/test_falkor_store.py`: adapter write/hydration/migration/cache tests.
 - `services/orion-hub/tests/test_concept_atlas_routes.py`: Concept Atlas compatibility test.
 - `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`: acceptance evidence.
 - `docs/superpowers/plans/2026-07-16-cypher-native-falkor-substrate-adapter.md`: implementation plan (committed earlier).
@@ -37,8 +39,8 @@ Before this patch, `FalkorSubstrateStore` persisted `n.payload_json` and `e.payl
 - Added: none.
 - Removed: none.
 - Renamed: none.
-- Behavior changed: Falkor substrate durable representation is native Cypher properties instead of `payload_json` SoR.
-- Compatibility notes: `SubstrateGraphStore` caller API remains unchanged. SPARQL store remains legacy and unchanged. Runtime env is not flipped. Hydration reconstructs concept nodes first; non-concept kinds remain out of this cutover.
+- Behavior changed: Falkor substrate durable representation is native Cypher properties instead of `payload_json` SoR. Legacy blobs migrate on hydrate. Non-concept durable upserts raise.
+- Compatibility notes: `SubstrateGraphStore` caller API remains unchanged for concept paths. Callers writing non-concept nodes to Falkor must catch `ValueError` or use another backend. SPARQL store remains legacy and unchanged. Runtime env is not flipped.
 
 ## Env/config changes
 
@@ -54,8 +56,8 @@ Before this patch, `FalkorSubstrateStore` persisted `n.payload_json` and `e.payl
 ```text
 PYTHONPATH=. venv/bin/pytest orion/substrate/tests/test_falkor_codec.py \
   orion/substrate/tests/test_falkor_store.py \
-  services/orion-hub/tests/test_concept_atlas_routes.py -q
-→ 31 passed (focused adapter + Concept Atlas suite)
+  services/orion-hub/tests/test_concept_atlas_routes.py::test_summary_reads_hydrated_falkor_store -q
+→ 21 passed
 
 TDD RED evidence (Task 1):
   test_falkor_upsert_concept_uses_native_cypher_properties FAILED (payload_json still present)
@@ -77,6 +79,22 @@ scripts/safe_graphify_update.sh REFUSED (~92% node-loss guard); graphify-out lef
 
 ## Review findings fixed
 
+- Finding: Live Hub Falkor data still uses blob `payload_json`; native-only hydrate would empty Concept Atlas after restart.
+ - Fix: Hydrate legacy `payload_json` rows, rewrite via native upsert, `REMOVE n.payload_json` / `REMOVE e.payload_json`.
+ - Evidence: `test_falkor_hydrates_legacy_payload_json_and_rewrites_native` passes.
+
+- Finding: Non-concept kinds could be written but only concepts hydrate → silent loss.
+ - Fix: `upsert_node` and `encode_node_properties` fail closed for non-concept.
+ - Evidence: `test_falkor_rejects_non_concept_durable_write`, `test_encode_node_properties_rejects_non_concept`.
+
+- Finding: `evidence_refs` and `taxonomy_path` not persisted.
+ - Fix: Durable `evidence_refs_json` / `taxonomy_path_json` encode/decode.
+ - Evidence: `test_encode_preserves_evidence_refs_and_taxonomy_path_round_trip`.
+
+- Finding: `RecordingFalkorClient` reused one `hydrate_rows` list for node and edge queries.
+ - Fix: Split `hydrate_node_rows` / `hydrate_edge_rows` / legacy lists; keep `hydrate_rows=` alias for nodes.
+ - Evidence: `test_recording_client_splits_node_and_edge_hydrate_rows`.
+
 - Finding: Plan sample used `result.nodes` on `SubstrateQueryResultV1`.
  - Fix: Assert against `result.slice.nodes`.
  - Evidence: `test_falkor_hydrated_concepts_support_concept_region_query` passes.
@@ -94,7 +112,7 @@ No restart required for merged code until the affected services are redeployed. 
 ## Risks / concerns
 
 - Severity: Medium
-- Concern: Hydration reconstructs the native Concept Atlas subset first; non-concept substrate node kinds remain outside the first cutover.
+- Concern: Hydration reconstructs the native Concept Atlas subset first; non-concept substrate node kinds remain outside the first cutover (now fail-closed on write).
 - Mitigation: Runtime cutover is deferred until graph-shaped runtime writers have their own tests and codec coverage.
 
 ## PR link

--- a/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md
@@ -1,0 +1,102 @@
+# PR report: Cypher-native Falkor substrate adapter
+
+## Summary
+
+- Replaced Falkor substrate durable writes from `payload_json` blobs to Cypher-native node/edge properties.
+- Added pure codec helpers for closed native property allowlists and typed hydration.
+- Updated Falkor store hydration to rebuild concept nodes and edges from native rows.
+- Added Concept Atlas route regression against a hydrated Falkor store test double.
+- Left drive measurement, substrate-runtime env, rdf-writer, and Graphiti untouched.
+
+## Outcome moved
+
+Falkor is now a property graph for the Concept Atlas/substrate graph seam instead of RDF-style payload blobs behind Cypher syntax.
+
+## Current architecture
+
+Before this patch, `FalkorSubstrateStore` persisted `n.payload_json` and `e.payload_json`, then hydrated cache state by parsing JSON blobs. Hub Concept Atlas could persist across restarts, but Falkor queries could not use native properties beyond a few helper scalars.
+
+## Architecture touched
+
+- `orion/substrate/falkor_store.py`: durable Falkor adapter.
+- `orion/substrate/falkor_codec.py`: Cypher-native encode/decode helpers.
+- `services/orion-hub/tests/test_concept_atlas_routes.py`: route contract regression.
+
+## Files changed
+
+- `orion/substrate/falkor_codec.py`: native property encode/decode allowlist.
+- `orion/substrate/falkor_store.py`: native Cypher writes and hydration.
+- `orion/substrate/tests/test_falkor_codec.py`: codec unit tests.
+- `orion/substrate/tests/test_falkor_store.py`: adapter write/hydration/cache tests.
+- `services/orion-hub/tests/test_concept_atlas_routes.py`: Concept Atlas compatibility test.
+- `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`: acceptance evidence.
+- `docs/superpowers/plans/2026-07-16-cypher-native-falkor-substrate-adapter.md`: implementation plan (committed earlier).
+
+## Schema / bus / API changes
+
+- Added: none.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: Falkor substrate durable representation is native Cypher properties instead of `payload_json` SoR.
+- Compatibility notes: `SubstrateGraphStore` caller API remains unchanged. SPARQL store remains legacy and unchanged. Runtime env is not flipped. Hydration reconstructs concept nodes first; non-concept kinds remain out of this cutover.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: no.
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not needed.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+PYTHONPATH=. venv/bin/pytest orion/substrate/tests/test_falkor_codec.py \
+  orion/substrate/tests/test_falkor_store.py \
+  services/orion-hub/tests/test_concept_atlas_routes.py -q
+→ 31 passed (focused adapter + Concept Atlas suite)
+
+TDD RED evidence (Task 1):
+  test_falkor_upsert_concept_uses_native_cypher_properties FAILED (payload_json still present)
+  test_falkor_hydrates_concept_from_native_properties FAILED (node None under payload_json hydrate)
+```
+
+## Evals run
+
+```text
+No eval harness exists for the Falkor adapter seam; focused deterministic tests cover the adapter and Hub route contract.
+```
+
+## Docker/build/smoke checks
+
+```text
+No Docker smoke required for this adapter-only patch. Live Falkor restart smoke remains required before runtime cutover.
+scripts/safe_graphify_update.sh REFUSED (~92% node-loss guard); graphify-out left unchanged.
+```
+
+## Review findings fixed
+
+- Finding: Plan sample used `result.nodes` on `SubstrateQueryResultV1`.
+ - Fix: Assert against `result.slice.nodes`.
+ - Evidence: `test_falkor_hydrated_concepts_support_concept_region_query` passes.
+
+- Finding: Subagent Task tool unavailable (usage limit); orchestrator executed plan inline.
+ - Fix: Same TDD order and commits; noted here.
+ - Evidence: commits `865af66a`, `b077eab9`.
+
+## Restart required
+
+```text
+No restart required for merged code until the affected services are redeployed. For live validation after deploy, restart orion-hub only; do not flip substrate-runtime yet.
+```
+
+## Risks / concerns
+
+- Severity: Medium
+- Concern: Hydration reconstructs the native Concept Atlas subset first; non-concept substrate node kinds remain outside the first cutover.
+- Mitigation: Runtime cutover is deferred until graph-shaped runtime writers have their own tests and codec coverage.
+
+## PR link
+
+UNVERIFIED — branch not pushed in this session.

--- a/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+++ b/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
@@ -1,0 +1,267 @@
+# Cypher-native substrate + Postgres-via-bus split — design spec
+
+**Date:** 2026-07-16
+**Status:** PROPOSAL — agreed direction after Falkor wedge (#1099 / #1105); not yet implemented
+**Mode:** Proposal (touches cognitive-graph persistence + drive measurement SoR; AGENTS.md §0A)
+**Related:**
+- `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md` (router / Falkor wedge; this doc **supersedes** its “migrate drive_state into Falkor” implication)
+- `docs/superpowers/pr-reports/2026-07-15-drive-audit-graph-path-kill-pr.md` (Postgres SoR precedent for drives)
+- `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md` (Concept Atlas consumer)
+- `orion/substrate/falkor_store.py` (current Falkor adapter — still `payload_json` SoR)
+
+---
+
+## Arsonist summary
+
+The Falkor wedge proved the engine and Hub Concept Atlas durability. It did **not** redesign the data model. Live Falkor writes still store opaque `payload_json` — RDF `payloadJson` with Cypher syntax. That is a lift-and-shift, not a property graph.
+
+Next work must:
+
+1. **Redesign graph-shaped substrate for Cypher-native storage** (typed labels, relationship types, scalar properties; no JSON blob as SoR).
+2. **Keep measurement / time-series / latest-row state in Postgres**, written via **bus → `orion-sql-writer`**, never HTTP into sql-writer.
+3. **Split substrate-runtime workloads by shape**, not migrate “the whole service” onto Falkor.
+
+Drive measurement (pressures, activations, dominant drive, summary, tension kinds) is Postgres SoR. Chat stance must move off the transitional graph snapshot node toward the same measurement rail Mind already uses (`drive_audits` / bus-fed SQL). Graph gets a drive hook only if a named neighborhood/activation consumer ships in the same patch — default: none.
+
+---
+
+## Core question
+
+How does Orion finish the Falkor cutover without recreating SPARQL-shaped blobs in Cypher, while putting relational drive/measurement state on the bus→Postgres rail the mesh already trusts?
+
+---
+
+## Ground truth (verified 2026-07-16 / conversation)
+
+| Claim | Evidence |
+|---|---|
+| Hub Concept Atlas is on Falkor | `services/orion-hub/.env_example`: `SUBSTRATE_STORE_BACKEND=falkor`; live-verified in Falkor routing spec |
+| Falkor adapter SoR is still `payload_json` | `orion/substrate/falkor_store.py` MERGE/SET `n.payload_json` |
+| SPARQL store uses the same blob pattern | `orion/substrate/graphdb_store.py` `orion:payloadJson` |
+| Substrate-runtime still SPARQL | `services/orion-substrate-runtime/.env`: `SUBSTRATE_STORE_BACKEND=sparql` |
+| Drive audits are Postgres-only via bus | kill PR; `orion:memory:drives:audit` → sql-writer → `drive_audits` |
+| Mind already reads drive measurement from Postgres | `fetch_drive_state_facet_for_mind` / thought facet → `drive_audits` |
+| Chat stance still reads graph snapshot nodes | `chat_stance.py` `_project_autonomy_from_beliefs` filters `snapshot_source == "drive_state"` |
+| Runtime materializes drive into substrate graph | `BiometricsSubstrateWorker._materialize_drive_state_to_substrate` |
+| Drive state already has a bus channel | `orion:memory:drives:state` / `DriveStateV1` |
+| sql-writer is bus-native | README: durable consumer of subscribe channels; no producer HTTP contract |
+
+---
+
+## Hard constraints (agreed)
+
+1. **No SPARQL smoosh into Falkor.** Retire `payload_json` / `payloadJson` as the durable schema for new and migrated graph writes.
+2. **Cypher-native model** for graph-shaped work: labels, relationship types, closed scalar property allowlists, queryable without JSON parse.
+3. **Postgres where sane** for measurement, history, receipts, projections, latest-row reads.
+4. **Bus → `orion-sql-writer` for those Postgres writes.** No direct HTTPS/API writes to sql-writer from producers. Existing runtime reducer tables that already use the service’s own Postgres store stay as-is until a separate redesign; **new** measurement durability must not invent Hub→sql-writer HTTP.
+5. **Split by workload shape**, not by service name.
+
+---
+
+## What is graph-shaped vs Postgres-sane
+
+### Falkor / Cypher-native (keep / redesign)
+
+| Workload | Why graph |
+|---|---|
+| Concept nodes + typed edges (`supports` / `contradicts` / `refines` / `co_occurs_with` / …) | Relation traversal, Concept Atlas network, contradiction/hotspot regions |
+| Activation / salience neighborhood queries | Focal slice, dynamics seeding across related nodes |
+| Prediction-error / surprise as **node scalars that participate in propagation** | Only if dynamics/attention consumers read them as graph signals |
+
+### Postgres via bus → sql-writer (keep / move)
+
+| Workload | Why Postgres |
+|---|---|
+| Drive audits (`memory.drives.audit.v1`) | Already done |
+| Drive **measurement / latest state** for stance/Mind | Latest-row + history; Mind already on `drive_audits` |
+| Grammar receipts / projection tables (existing) | Already reducer → Postgres in substrate-runtime (own DSN today) |
+| Brain-frame **samples as telemetry/history** (if persisted for replay) | Time-series samples, not edge traversal |
+
+### Explicit non-destinations
+
+- Do **not** put drive snapshot SoR on Falkor.
+- Do **not** migrate generic `orion-rdf-writer` kinds in this effort.
+- Do **not** merge Graphiti Entity schema with ConceptNode.
+- Do **not** dual-SoR drive state permanently (Postgres + graph snapshot).
+
+---
+
+## Cypher-native substrate model (normative)
+
+### Rejected pattern
+
+```text
+(:SubstrateNode {node_id, payload_json})   # opaque SoR — FORBIDDEN for new design
+```
+
+### Target pattern
+
+```text
+(:Concept {
+  node_id, identity_key?,
+  label, promotion_state, risk_tier?,
+  anchor_scope, subject_ref?,
+  salience, activation?, recency?,
+  embedding_ref?, evidence_ref?
+})
+  -[:CONTRADICTS {edge_id, identity_key?, salience}]-> (:Concept)
+```
+
+Rules:
+
+1. **Closed property allowlists** per label / relationship type (Pydantic / schema; `extra="forbid"`). Reuse doctrine from Falkor routing property guard.
+2. **Relationship type = predicate** (already validated closed `SubstrateEdgePredicateV1`).
+3. **Scalars only** on the graph; large text / embeddings / raw evidence stay in Postgres or vector host behind refs.
+4. **`metadata` quarantine** remains size-capped and audited; unknown keys rejected. Promote to first-class Cypher properties only with a second consumer.
+5. **Optional `schema_version` + `updated_at`** on nodes for migration/hydration — not a blob dump.
+6. **Reads that need full typed `ConceptNodeV1`** may reconstruct from Cypher properties + optional Postgres blob **by ref**; Cypher properties remain authoritative for graph queries.
+7. **Hydration / cold start** loads typed properties into the in-process cache; do not require `payload_json` to exist.
+
+### Adapter ownership
+
+- `orion/substrate/falkor_store.py` becomes Cypher-native writer/reader.
+- `SubstrateGraphStore` API stays the producer-facing contract (nodes/edges), not N-Triples and not raw Cypher in callers.
+- SPARQL/`payloadJson` path remains legacy until runtime cutover; no new features target it.
+
+---
+
+## Drive measurement: Postgres SoR + consumer migration
+
+### Decision (agreed): option A
+
+**Postgres is SoR for drive measurement.** Graph does not carry a full drive snapshot node as SoR.
+
+### Write path
+
+```text
+DriveEngine
+  → bus: orion:memory:drives:state  (DriveStateV1)
+  → bus: orion:memory:drives:audit  (DriveAuditV1)  [already → sql-writer]
+        ↓
+orion-sql-writer
+        ↓
+Postgres (extend drive_audits and/or add latest-drive projection table —
+           exact table shape in implementation plan; prefer reuse of drive_audits
+           if latest-row semantics already cover stance needs)
+```
+
+Constraints:
+
+- Producers publish bus envelopes only.
+- sql-writer remains the durable SQL consumer.
+- No `httpx` / Hub proxy POST to sql-writer for this seam.
+
+### Read path (target)
+
+| Consumer | Today | Target |
+|---|---|---|
+| Mind / thought `drive_state_compact` | Postgres `drive_audits` | unchanged |
+| Chat stance `chat_drive_state` | Substrate graph `state_snapshot` / `drive_state` | Postgres (same measurement rail as Mind), fail-open |
+| Runtime `_materialize_drive_state_to_substrate` | Upserts graph nodes | **Stop** as SoR writer; delete or gate off once stance reads Postgres |
+
+### Optional graph hook (default off)
+
+A thin Falkor hook (e.g. `drive_ref` / dominant-drive scalar on an existing cognitive node, or a typed edge into a concept region) is allowed **only when**:
+
+- a named consumer needs it for neighborhood/activation, and
+- producer + consumer + test ship in the **same** changeset.
+
+Otherwise: no drive nodes on Falkor.
+
+### Dual-run
+
+Short dual (graph snapshot + Postgres) is allowed only as a **migration ladder with exit criteria**, not as architecture. Prefer flip chat stance read to Postgres first, then delete graph materialization.
+
+---
+
+## Substrate-runtime cutover (after Cypher-native adapter)
+
+Do **not** flip `SUBSTRATE_STORE_BACKEND=falkor` on runtime while SoR is still `payload_json`.
+
+Order:
+
+1. **Cypher-native Falkor adapter** + Hub Concept Atlas still green (restart durability, network query).
+2. **Drive measurement:** stance → Postgres; stop graph drive snapshot SoR writes.
+3. **Runtime graph-shaped writers** (dynamics, prediction-error scalars, attention-related substrate nodes that are truly graph) → Cypher-native Falkor, preferably via `routed` (primary falkor, shadow sparql) briefly, then shadow off.
+4. **Measure Fuseki `/update` drop**; attribute remaining traffic.
+5. Later (separate): deprecate `orion:kg:edge:ingest.v1` → rdf-writer.
+
+Postgres reducer loops inside runtime (biometrics / execution / transport / chat / route projections) are **out of scope** for Falkor migration. They already use Postgres. Whether those should eventually publish via bus→sql-writer instead of the service-local DSN is a **separate** proposal — not required for this design.
+
+---
+
+## Relationship to Falkor routing doctrine
+
+| Topic | 2026-07-16 routing spec | This spec |
+|---|---|---|
+| Engine | Falkor + Postgres + temp RDF | unchanged |
+| Concept Atlas | Falkor primary | Falkor **Cypher-native** (fix blob SoR) |
+| `substrate.drive_state` → Falkor | Listed as target | **Superseded:** Postgres via bus; not Falkor SoR |
+| Router / dual-run ladder | Keep for graph workloads | Keep; do not use to justify drive dual-SoR forever |
+| Property cathedral rules | Keep | Keep; apply to Cypher properties |
+
+---
+
+## Risks
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| High | Chat stance regression when leaving graph snapshot | Mirror Mind’s bounded Postgres fetch; fail-open; regression tests on `_project_autonomy_from_beliefs` + live smoke |
+| High | Cypher redesign breaks Concept Atlas mid-flight | Adapter feature flag / dual property write during Hub-only canary; restart hydration test |
+| Medium | Someone “temporarily” keeps `payload_json` forever | Acceptance: graph queries filter on native properties without parsing JSON; tests assert no `payload_json` SoR writes |
+| Medium | Direct SQL from a new producer, skipping bus | Review checklist + channel registry; sql-writer route map is the only durable write door for this seam |
+| Low | Temptation to put brain-frame telemetry in Falkor | Brain-frame history → Postgres if persisted; live sample may read graph snapshot without copying history into Cypher |
+
+---
+
+## Non-goals
+
+- Full Fuseki decommission in this patch series
+- Generic rdf-writer → Falkor migration
+- Graphiti + substrate schema unification
+- Rewriting all substrate-runtime reducers onto bus→sql-writer
+- SPARQL compatibility layer inside Falkor
+- Drive-audit graph revival
+
+---
+
+## Acceptance checks
+
+- [ ] Spec reviewed by Juniper
+- [ ] Implementation plan exists (Cypher-native adapter first; drive SoR second; runtime graph writers third)
+- [ ] `FalkorSubstrateStore` writes typed Cypher properties; unit tests assert MERGE/SET shape **without** `payload_json` as SoR
+- [ ] Concept Atlas Hub summary/network survives restart against real Falkor after redesign
+- [ ] Chat stance drive projection reads Postgres measurement rail (bus-fed); graph drive snapshot materialization off or deleted
+- [ ] No new producer path calls sql-writer over HTTP for drive measurement
+- [ ] Runtime SPARQL cutover (if included in same plan series) uses Cypher-native adapter, not blob port
+- [ ] Fuseki update-rate attribution after runtime graph cutover (graph-shaped writers only)
+
+---
+
+## Recommended next patch
+
+1. Implementation plan: **Cypher-native `FalkorSubstrateStore`** (replace `payload_json` SoR; Hub Concept Atlas regression).
+2. Implementation plan: **chat stance → Postgres drive measurement**; stop `_materialize_drive_state_to_substrate` as SoR (extend sql-writer / `drive_audits` only if latest-row gaps exist; bus only).
+3. Implementation plan: **substrate-runtime graph writers → Falkor Cypher-native** (`routed` then primary-only).
+
+Do not start with “flip runtime env to falkor” on the blob adapter.
+
+---
+
+## Open questions (narrowed)
+
+1. **Latest-drive table shape:** Reuse `drive_audits` latest-row semantics for stance, or add an explicit `drive_state_latest` projection written by sql-writer from `orion:memory:drives:state`? *(Recommendation: prefer `drive_audits` if fields suffice; add a thin latest table only if state vs audit cadence/fields diverge.)*
+2. **Blob retention during Cypher migration:** Keep `payload_json` as a deprecated shadow property for one canary window, or hard cut? *(Recommendation: hard cut in adapter tests; optional one-release dual-write only if Hub live risk demands it, with kill date.)*
+
+---
+
+## Appendix — philosophy checklist (why this split)
+
+| Mesh rule | Application here |
+|---|---|
+| Event substrate first | Drive measurement via bus events, not service-local graph invent |
+| Runtime truth / no empty shell | Stance must read a real Postgres row Mind already trusts |
+| Edges meaning / properties measurements | Concepts+relations → Cypher; drive pressures → SQL columns |
+| No property without consumer | No Falkor drive node without a neighborhood consumer |
+| Wrong-tool precedent | Drive audit RDF kill → do not recreate on Falkor |
+| Thin seams | Adapter redesign + consumer flip + runtime graph cutover as separate patches |

--- a/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+++ b/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
@@ -229,7 +229,12 @@ Postgres reducer loops inside runtime (biometrics / execution / transport / chat
 
 - [ ] Spec reviewed by Juniper
 - [ ] Implementation plan exists (Cypher-native adapter first; drive SoR second; runtime graph writers third)
-- [ ] `FalkorSubstrateStore` writes typed Cypher properties; unit tests assert MERGE/SET shape **without** `payload_json` as SoR
+- [x] `FalkorSubstrateStore` writes typed Cypher properties; unit tests assert MERGE/SET shape **without** `payload_json` as SoR
+
+**Adapter evidence:** `orion/substrate/tests/test_falkor_store.py` and
+`orion/substrate/tests/test_falkor_codec.py` verify native Cypher properties,
+native hydration, metadata quarantine behavior, and Hub Concept Atlas route
+compatibility through a hydrated Falkor store test double.
 - [ ] Concept Atlas Hub summary/network survives restart against real Falkor after redesign
 - [ ] Chat stance drive projection reads Postgres measurement rail (bus-fed); graph drive snapshot materialization off or deleted
 - [ ] No new producer path calls sql-writer over HTTP for drive measurement

--- a/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+++ b/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
@@ -1,13 +1,13 @@
 # Cypher-native substrate + Postgres-via-bus split — design spec
 
 **Date:** 2026-07-16
-**Status:** PROPOSAL — agreed direction after Falkor wedge (#1099 / #1105); not yet implemented
+**Status:** IN PROGRESS — Cypher-native Falkor adapter shipped in this branch; drive Postgres SoR + runtime cutover remain follow-ons
 **Mode:** Proposal (touches cognitive-graph persistence + drive measurement SoR; AGENTS.md §0A)
 **Related:**
 - `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md` (router / Falkor wedge; this doc **supersedes** its “migrate drive_state into Falkor” implication)
 - `docs/superpowers/pr-reports/2026-07-15-drive-audit-graph-path-kill-pr.md` (Postgres SoR precedent for drives)
 - `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md` (Concept Atlas consumer)
-- `orion/substrate/falkor_store.py` (current Falkor adapter — still `payload_json` SoR)
+- `orion/substrate/falkor_store.py` (Cypher-native Concept/edge adapter; legacy `payload_json` migrate-on-hydrate)
 
 ---
 
@@ -36,7 +36,7 @@ How does Orion finish the Falkor cutover without recreating SPARQL-shaped blobs 
 | Claim | Evidence |
 |---|---|
 | Hub Concept Atlas is on Falkor | `services/orion-hub/.env_example`: `SUBSTRATE_STORE_BACKEND=falkor`; live-verified in Falkor routing spec |
-| Falkor adapter SoR is still `payload_json` | `orion/substrate/falkor_store.py` MERGE/SET `n.payload_json` |
+| Falkor adapter Concept/edge SoR is Cypher-native (legacy blob migrate-on-hydrate) | `orion/substrate/falkor_store.py` MERGE/SET native props + `REMOVE n.payload_json`; tests in `test_falkor_store.py` |
 | SPARQL store uses the same blob pattern | `orion/substrate/graphdb_store.py` `orion:payloadJson` |
 | Substrate-runtime still SPARQL | `services/orion-substrate-runtime/.env`: `SUBSTRATE_STORE_BACKEND=sparql` |
 | Drive audits are Postgres-only via bus | kill PR; `orion:memory:drives:audit` → sql-writer → `drive_audits` |
@@ -176,7 +176,7 @@ Short dual (graph snapshot + Postgres) is allowed only as a **migration ladder w
 
 ## Substrate-runtime cutover (after Cypher-native adapter)
 
-Do **not** flip `SUBSTRATE_STORE_BACKEND=falkor` on runtime while SoR is still `payload_json`.
+Do **not** flip `SUBSTRATE_STORE_BACKEND=falkor` on runtime until runtime writers also use the Cypher-native concept contract (Hub Concept Atlas path is already native).
 
 Order:
 

--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -2,10 +2,14 @@
 
 This module is intentionally pure: no Redis client, no store cache, no graph
 queries. It owns the durable property allowlist used by FalkorSubstrateStore.
+
+Durable Falkor support is intentionally Concept + SubstrateEdge first. Other
+node kinds must not be silently persisted as incomplete native rows.
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
@@ -44,6 +48,22 @@ def _dt(value: datetime | None) -> str | None:
     return value.isoformat() if value is not None else None
 
 
+def _json_list(values: list[Any] | None) -> str:
+    return json.dumps(list(values or []), ensure_ascii=False, sort_keys=True)
+
+
+def _parse_json_list(raw: Any) -> list[Any]:
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return list(raw)
+    try:
+        parsed = json.loads(str(raw))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return []
+    return list(parsed) if isinstance(parsed, list) else []
+
+
 def _common_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
     activation = node.signals.activation
     provenance = node.provenance
@@ -73,14 +93,19 @@ def _common_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None)
         "provenance_correlation_id": provenance.correlation_id,
         "provenance_trace_id": provenance.trace_id,
         "provenance_tier_rank": provenance.tier_rank,
+        "evidence_refs_json": _json_list(provenance.evidence_refs),
     }
 
 
 def encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
+    if node.node_kind != "concept":
+        raise ValueError(
+            f"falkor durable path supports concept nodes only; got node_kind={node.node_kind!r}"
+        )
     props = _common_node_properties(node, identity_key)
-    if node.node_kind == "concept":
-        props["label"] = getattr(node, "label")
-        props["definition"] = getattr(node, "definition", None)
+    props["label"] = getattr(node, "label")
+    props["definition"] = getattr(node, "definition", None)
+    props["taxonomy_path_json"] = _json_list(getattr(node, "taxonomy_path", None))
     return props
 
 
@@ -109,6 +134,7 @@ def encode_edge_properties(edge: SubstrateEdgeV1, identity_key: str) -> dict[str
         "provenance_correlation_id": provenance.correlation_id,
         "provenance_trace_id": provenance.trace_id,
         "provenance_tier_rank": provenance.tier_rank,
+        "evidence_refs_json": _json_list(provenance.evidence_refs),
     }
 
 
@@ -129,7 +155,7 @@ def _provenance_from_row(row: Mapping[str, Any]) -> SubstrateProvenanceV1:
         model_name=row.get("provenance_model_name"),
         correlation_id=row.get("provenance_correlation_id"),
         trace_id=row.get("provenance_trace_id"),
-        evidence_refs=[],
+        evidence_refs=[str(item) for item in _parse_json_list(row.get("evidence_refs_json"))],
         tier_rank=row.get("provenance_tier_rank"),
     )
 
@@ -154,6 +180,7 @@ def decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None:
         node_id=str(row["node_id"]),
         label=str(row["label"]),
         definition=row.get("definition"),
+        taxonomy_path=[str(item) for item in _parse_json_list(row.get("taxonomy_path_json"))],
         anchor_scope=row["anchor_scope"],
         subject_ref=row.get("subject_ref"),
         promotion_state=row.get("promotion_state") or "proposed",

--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -1,0 +1,187 @@
+"""Cypher-native FalkorDB encoding for substrate graph records.
+
+This module is intentionally pure: no Redis client, no store cache, no graph
+queries. It owns the durable property allowlist used by FalkorSubstrateStore.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from orion.core.schemas.cognitive_substrate import (
+    BaseSubstrateNodeV1,
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateActivationV1,
+    SubstrateEdgeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+
+_LABEL_BY_KIND: dict[str, str] = {
+    "entity": "Entity",
+    "concept": "Concept",
+    "event": "Event",
+    "evidence": "Evidence",
+    "contradiction": "Contradiction",
+    "tension": "Tension",
+    "drive": "Drive",
+    "goal": "Goal",
+    "state_snapshot": "StateSnapshot",
+    "hypothesis": "Hypothesis",
+    "ontology_branch": "OntologyBranch",
+}
+
+
+def node_label_for_kind(node_kind: str) -> str:
+    return _LABEL_BY_KIND.get(str(node_kind), "Generic")
+
+
+def _dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _common_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
+    activation = node.signals.activation
+    provenance = node.provenance
+    temporal = node.temporal
+    return {
+        "node_id": node.node_id,
+        "node_kind": node.node_kind,
+        "identity_key": identity_key or "",
+        "anchor_scope": node.anchor_scope,
+        "subject_ref": node.subject_ref,
+        "promotion_state": node.promotion_state,
+        "risk_tier": node.risk_tier,
+        "confidence": float(node.signals.confidence),
+        "salience": float(node.signals.salience),
+        "activation": float(activation.activation),
+        "recency_score": float(activation.recency_score),
+        "decay_half_life_seconds": activation.decay_half_life_seconds,
+        "decay_floor": float(activation.decay_floor),
+        "observed_at": _dt(temporal.observed_at),
+        "valid_from": _dt(temporal.valid_from),
+        "valid_to": _dt(temporal.valid_to),
+        "provenance_authority": provenance.authority,
+        "provenance_source_kind": provenance.source_kind,
+        "provenance_source_channel": provenance.source_channel,
+        "provenance_producer": provenance.producer,
+        "provenance_model_name": provenance.model_name,
+        "provenance_correlation_id": provenance.correlation_id,
+        "provenance_trace_id": provenance.trace_id,
+        "provenance_tier_rank": provenance.tier_rank,
+    }
+
+
+def encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
+    props = _common_node_properties(node, identity_key)
+    if node.node_kind == "concept":
+        props["label"] = getattr(node, "label")
+        props["definition"] = getattr(node, "definition", None)
+    return props
+
+
+def encode_edge_properties(edge: SubstrateEdgeV1, identity_key: str) -> dict[str, Any]:
+    provenance = edge.provenance
+    temporal = edge.temporal
+    return {
+        "edge_id": edge.edge_id,
+        "identity_key": identity_key,
+        "source_id": edge.source.node_id,
+        "source_kind": edge.source.node_kind,
+        "target_id": edge.target.node_id,
+        "target_kind": edge.target.node_kind,
+        "predicate": edge.predicate,
+        "substrate_edge": True,
+        "confidence": float(edge.confidence),
+        "salience": float(edge.salience),
+        "observed_at": _dt(temporal.observed_at),
+        "valid_from": _dt(temporal.valid_from),
+        "valid_to": _dt(temporal.valid_to),
+        "provenance_authority": provenance.authority,
+        "provenance_source_kind": provenance.source_kind,
+        "provenance_source_channel": provenance.source_channel,
+        "provenance_producer": provenance.producer,
+        "provenance_model_name": provenance.model_name,
+        "provenance_correlation_id": provenance.correlation_id,
+        "provenance_trace_id": provenance.trace_id,
+        "provenance_tier_rank": provenance.tier_rank,
+    }
+
+
+def _temporal_from_row(row: Mapping[str, Any]) -> SubstrateTemporalWindowV1:
+    return SubstrateTemporalWindowV1(
+        observed_at=row["observed_at"],
+        valid_from=row.get("valid_from"),
+        valid_to=row.get("valid_to"),
+    )
+
+
+def _provenance_from_row(row: Mapping[str, Any]) -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority=row["provenance_authority"],
+        source_kind=row["provenance_source_kind"],
+        source_channel=row["provenance_source_channel"],
+        producer=row["provenance_producer"],
+        model_name=row.get("provenance_model_name"),
+        correlation_id=row.get("provenance_correlation_id"),
+        trace_id=row.get("provenance_trace_id"),
+        evidence_refs=[],
+        tier_rank=row.get("provenance_tier_rank"),
+    )
+
+
+def _signals_from_row(row: Mapping[str, Any]) -> SubstrateSignalBundleV1:
+    return SubstrateSignalBundleV1(
+        confidence=float(row.get("confidence") or 0.5),
+        salience=float(row.get("salience") or 0.0),
+        activation=SubstrateActivationV1(
+            activation=float(row.get("activation") or 0.0),
+            recency_score=float(row.get("recency_score") or 0.0),
+            decay_half_life_seconds=row.get("decay_half_life_seconds"),
+            decay_floor=float(row.get("decay_floor") or 0.0),
+        ),
+    )
+
+
+def decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None:
+    if row.get("node_kind") != "concept":
+        return None
+    return ConceptNodeV1(
+        node_id=str(row["node_id"]),
+        label=str(row["label"]),
+        definition=row.get("definition"),
+        anchor_scope=row["anchor_scope"],
+        subject_ref=row.get("subject_ref"),
+        promotion_state=row.get("promotion_state") or "proposed",
+        risk_tier=row.get("risk_tier") or "low",
+        temporal=_temporal_from_row(row),
+        signals=_signals_from_row(row),
+        provenance=_provenance_from_row(row),
+        metadata={},
+    )
+
+
+def decode_edge(row: Mapping[str, Any]) -> SubstrateEdgeV1 | None:
+    if not row.get("edge_id"):
+        return None
+    return SubstrateEdgeV1(
+        edge_id=str(row["edge_id"]),
+        source=NodeRefV1(
+            node_id=str(row["source_id"]),
+            node_kind=row.get("source_kind") or "concept",
+        ),
+        target=NodeRefV1(
+            node_id=str(row["target_id"]),
+            node_kind=row.get("target_kind") or "concept",
+        ),
+        predicate=row["predicate"],
+        temporal=_temporal_from_row(row),
+        confidence=float(row.get("confidence") or 0.5),
+        salience=float(row.get("salience") or 0.0),
+        provenance=_provenance_from_row(row),
+        metadata={},
+    )

--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -52,16 +52,18 @@ def _json_list(values: list[Any] | None) -> str:
     return json.dumps(list(values or []), ensure_ascii=False, sort_keys=True)
 
 
-def _parse_json_list(raw: Any) -> list[Any]:
+def _parse_json_list(raw: Any, *, field: str = "json_list") -> list[Any]:
     if raw is None or raw == "":
         return []
     if isinstance(raw, list):
         return list(raw)
     try:
         parsed = json.loads(str(raw))
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return []
-    return list(parsed) if isinstance(parsed, list) else []
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid {field}: {exc}") from exc
+    if not isinstance(parsed, list):
+        raise ValueError(f"invalid {field}: expected JSON list")
+    return list(parsed)
 
 
 def _common_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
@@ -155,7 +157,7 @@ def _provenance_from_row(row: Mapping[str, Any]) -> SubstrateProvenanceV1:
         model_name=row.get("provenance_model_name"),
         correlation_id=row.get("provenance_correlation_id"),
         trace_id=row.get("provenance_trace_id"),
-        evidence_refs=[str(item) for item in _parse_json_list(row.get("evidence_refs_json"))],
+        evidence_refs=[str(item) for item in _parse_json_list(row.get("evidence_refs_json"), field="evidence_refs_json")],
         tier_rank=row.get("provenance_tier_rank"),
     )
 
@@ -180,7 +182,7 @@ def decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None:
         node_id=str(row["node_id"]),
         label=str(row["label"]),
         definition=row.get("definition"),
-        taxonomy_path=[str(item) for item in _parse_json_list(row.get("taxonomy_path_json"))],
+        taxonomy_path=[str(item) for item in _parse_json_list(row.get("taxonomy_path_json"), field="taxonomy_path_json")],
         anchor_scope=row["anchor_scope"],
         subject_ref=row.get("subject_ref"),
         promotion_state=row.get("promotion_state") or "proposed",

--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -2,8 +2,12 @@
 
 Queries and reads are served from the in-process cache (same shape as a warm
 GraphDBSubstrateStore). Durable writes go through an injectable sync client so
-unit tests never need a live FalkorDB. Cold-start hydration is best-effort via
-MATCH … RETURN native scalar properties when the client can answer.
+unit tests never need a live FalkorDB.
+
+Durable support is Concept + SubstrateEdge first. Cold-start hydration prefers
+native scalar properties and falls back to legacy ``payload_json`` rows,
+rewriting them to native properties (and removing the blob) on successful
+concept/edge decode.
 """
 
 from __future__ import annotations
@@ -14,7 +18,13 @@ from dataclasses import dataclass, replace
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
-from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
+from pydantic import TypeAdapter
+
+from orion.core.schemas.cognitive_substrate import (
+    BaseSubstrateNodeV1,
+    SubstrateEdgeV1,
+    SubstrateNodeV1,
+)
 from orion.graph.property_guard import sanitize_metadata
 from orion.substrate.falkor_codec import (
     decode_concept_node,
@@ -31,6 +41,8 @@ from orion.substrate.store import (
 )
 
 logger = logging.getLogger("orion.substrate.falkor_store")
+
+NODE_ADAPTER = TypeAdapter(SubstrateNodeV1)
 
 
 class FalkorGraphClient(Protocol):
@@ -49,6 +61,7 @@ NATIVE_NODE_RETURN_FIELDS: tuple[str, ...] = (
     "identity_key",
     "label",
     "definition",
+    "taxonomy_path_json",
     "anchor_scope",
     "subject_ref",
     "promotion_state",
@@ -70,6 +83,7 @@ NATIVE_NODE_RETURN_FIELDS: tuple[str, ...] = (
     "provenance_correlation_id",
     "provenance_trace_id",
     "provenance_tier_rank",
+    "evidence_refs_json",
 )
 
 NATIVE_EDGE_RETURN_FIELDS: tuple[str, ...] = (
@@ -94,6 +108,7 @@ NATIVE_EDGE_RETURN_FIELDS: tuple[str, ...] = (
     "provenance_correlation_id",
     "provenance_trace_id",
     "provenance_tier_rank",
+    "evidence_refs_json",
 )
 
 
@@ -109,14 +124,34 @@ def _set_assignments(alias: str, params: dict[str, Any], *, skip: set[str]) -> s
 class RecordingFalkorClient:
     """Test double that records Cypher and optionally returns scripted rows."""
 
-    def __init__(self, *, hydrate_rows: list[dict[str, Any]] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        hydrate_node_rows: list[dict[str, Any]] | None = None,
+        hydrate_edge_rows: list[dict[str, Any]] | None = None,
+        hydrate_legacy_node_rows: list[dict[str, Any]] | None = None,
+        hydrate_legacy_edge_rows: list[dict[str, Any]] | None = None,
+        hydrate_rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        # hydrate_rows is a compatibility alias for hydrate_node_rows.
+        if hydrate_rows is not None and hydrate_node_rows is None:
+            hydrate_node_rows = hydrate_rows
         self.calls: list[tuple[str, dict[str, Any] | None]] = []
-        self._hydrate_rows = list(hydrate_rows or [])
+        self._hydrate_node_rows = list(hydrate_node_rows or [])
+        self._hydrate_edge_rows = list(hydrate_edge_rows or [])
+        self._hydrate_legacy_node_rows = list(hydrate_legacy_node_rows or [])
+        self._hydrate_legacy_edge_rows = list(hydrate_legacy_edge_rows or [])
 
     def graph_query(self, cypher: str, params: dict[str, Any] | None = None) -> Any:
         self.calls.append((cypher, params))
-        if "RETURN n.node_id AS node_id" in cypher or "RETURN e.edge_id AS edge_id" in cypher:
-            return self._hydrate_rows
+        if "WHERE n.payload_json IS NOT NULL" in cypher:
+            return self._hydrate_legacy_node_rows
+        if "WHERE e.payload_json IS NOT NULL" in cypher:
+            return self._hydrate_legacy_edge_rows
+        if "RETURN n.node_id AS node_id" in cypher:
+            return self._hydrate_node_rows
+        if "RETURN e.edge_id AS edge_id" in cypher:
+            return self._hydrate_edge_rows
         return []
 
 
@@ -149,7 +184,11 @@ def _with_sanitized_metadata(model: Any) -> Any:
 
 
 class FalkorSubstrateStore:
-    """SubstrateGraphStore with Falkor write-through and in-memory read cache."""
+    """SubstrateGraphStore with Falkor write-through and in-memory read cache.
+
+    Durable persistence is Concept + SubstrateEdge only. Non-concept node
+    upserts raise ``ValueError`` rather than writing incomplete native rows.
+    """
 
     def __init__(
         self,
@@ -177,9 +216,18 @@ class FalkorSubstrateStore:
                 "WHERE e.substrate_edge = true "
                 "RETURN " + _return_clause("e", NATIVE_EDGE_RETURN_FIELDS)
             )
+            legacy_node_rows = self._client.graph_query(
+                "MATCH (n:SubstrateNode) WHERE n.payload_json IS NOT NULL "
+                "RETURN n.payload_json AS payload_json, n.identity_key AS identity_key"
+            )
+            legacy_edge_rows = self._client.graph_query(
+                "MATCH ()-[e]->() WHERE e.payload_json IS NOT NULL "
+                "RETURN e.payload_json AS payload_json, e.identity_key AS identity_key"
+            )
         except Exception as exc:
             logger.warning("falkor_substrate_hydrate_failed error=%s", exc)
             return
+
         for row in _normalize_rows(node_rows):
             try:
                 node = decode_concept_node(row)
@@ -190,6 +238,7 @@ class FalkorSubstrateStore:
                 continue
             identity = row.get("identity_key")
             self._cache.upsert_node(identity_key=str(identity) if identity else None, node=node)
+
         for row in _normalize_rows(edge_rows):
             try:
                 edge = decode_edge(row)
@@ -200,6 +249,68 @@ class FalkorSubstrateStore:
                 continue
             identity = row.get("identity_key") or self._edge_identity(edge)
             self._cache.upsert_edge(identity_key=str(identity), edge=edge)
+
+        self._migrate_legacy_payload_nodes(_normalize_rows(legacy_node_rows))
+        self._migrate_legacy_payload_edges(_normalize_rows(legacy_edge_rows))
+
+    def _migrate_legacy_payload_nodes(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            payload = row.get("payload_json")
+            if not payload:
+                continue
+            try:
+                node = NODE_ADAPTER.validate_json(payload)
+            except Exception:
+                logger.warning("falkor_substrate_legacy_node_invalid")
+                continue
+            if getattr(node, "node_kind", None) != "concept":
+                logger.warning(
+                    "falkor_substrate_legacy_node_skipped node_kind=%s node_id=%s",
+                    getattr(node, "node_kind", None),
+                    getattr(node, "node_id", None),
+                )
+                continue
+            identity = row.get("identity_key")
+            identity_key = str(identity) if identity else None
+            try:
+                # Rewrite to native properties and REMOVE payload_json.
+                self.upsert_node(identity_key=identity_key, node=node)
+                logger.info(
+                    "falkor_substrate_legacy_node_migrated node_id=%s identity_key=%s",
+                    node.node_id,
+                    identity_key or "",
+                )
+            except Exception as exc:
+                logger.warning(
+                    "falkor_substrate_legacy_node_migrate_failed node_id=%s error=%s",
+                    getattr(node, "node_id", None),
+                    exc,
+                )
+
+    def _migrate_legacy_payload_edges(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            payload = row.get("payload_json")
+            if not payload:
+                continue
+            try:
+                edge = SubstrateEdgeV1.model_validate_json(payload)
+            except Exception:
+                logger.warning("falkor_substrate_legacy_edge_invalid")
+                continue
+            identity = row.get("identity_key") or self._edge_identity(edge)
+            try:
+                self.upsert_edge(identity_key=str(identity), edge=edge)
+                logger.info(
+                    "falkor_substrate_legacy_edge_migrated edge_id=%s identity_key=%s",
+                    edge.edge_id,
+                    identity,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "falkor_substrate_legacy_edge_migrate_failed edge_id=%s error=%s",
+                    edge.edge_id,
+                    exc,
+                )
 
     @staticmethod
     def _edge_identity(edge: SubstrateEdgeV1) -> str:
@@ -218,11 +329,20 @@ class FalkorSubstrateStore:
         return self._cache.get_edge_id_by_identity(identity_key)
 
     def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
+        if getattr(node, "node_kind", None) != "concept":
+            raise ValueError(
+                "FalkorSubstrateStore durable writes support concept nodes only; "
+                f"got node_kind={getattr(node, 'node_kind', None)!r}"
+            )
         node = _with_sanitized_metadata(node)
         params = encode_node_properties(node, identity_key)
         label = node_label_for_kind(str(node.node_kind))
         assignments = _set_assignments("n", params, skip={"node_id"})
-        cypher = f"MERGE (n:SubstrateNode:{label} {{node_id: $node_id}}) SET {assignments}"
+        cypher = (
+            f"MERGE (n:SubstrateNode:{label} {{node_id: $node_id}}) "
+            f"SET {assignments} "
+            "REMOVE n.payload_json"
+        )
         try:
             self._client.graph_query(cypher, params)
         except Exception as exc:
@@ -239,7 +359,8 @@ class FalkorSubstrateStore:
             "MERGE (source:SubstrateNode {node_id: $source_id}) "
             "MERGE (target:SubstrateNode {node_id: $target_id}) "
             f"MERGE (source)-[e:`{relationship_type}` {{edge_id: $edge_id}}]->(target) "
-            f"SET {assignments}"
+            f"SET {assignments} "
+            "REMOVE e.payload_json"
         )
         try:
             self._client.graph_query(cypher, params)

--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -173,7 +173,48 @@ class RedisGraphQueryClient:
 
     def graph_query(self, cypher: str, params: dict[str, Any] | None = None) -> Any:
         result = self._graph.query(cypher, params=params)
-        return result.result_set
+        # redis-py exposes list-shaped result_set rows and keeps column names on
+        # QueryResult.header as [type, name] pairs. Zip to dicts so hydrate can
+        # address fields by name (native multi-column and legacy 2-column alike).
+        return _rows_from_query_result(getattr(result, "header", None), result.result_set)
+
+
+def _header_field_names(header: Any) -> list[str]:
+    names: list[str] = []
+    if not header:
+        return names
+    for column in header:
+        if isinstance(column, (list, tuple)) and len(column) >= 2:
+            left, right = column[0], column[1]
+            # redis-py QueryResult: [column_type:int, column_name:str]
+            # some raw wire fixtures: [column_name:str, column_type:int]
+            if isinstance(left, int) or (isinstance(left, str) and str(left).isdigit()):
+                names.append(str(right).split(".")[-1])
+            elif isinstance(right, int) or (isinstance(right, str) and str(right).isdigit()):
+                names.append(str(left).split(".")[-1])
+            else:
+                names.append(str(right).split(".")[-1])
+        elif isinstance(column, (list, tuple)) and column:
+            names.append(str(column[0]).split(".")[-1])
+        else:
+            names.append(str(column).split(".")[-1])
+    return names
+
+
+def _rows_from_query_result(header: Any, result_set: Any) -> list[dict[str, Any]]:
+    if result_set is None:
+        return []
+    names = _header_field_names(header)
+    out: list[dict[str, Any]] = []
+    for record in result_set:
+        if isinstance(record, dict):
+            out.append(record)
+        elif isinstance(record, (list, tuple)):
+            if names and len(names) == len(record):
+                out.append(dict(zip(names, record)))
+            else:
+                out.append({"_positional": list(record)})
+    return out
 
 
 def _with_sanitized_metadata(model: Any) -> Any:
@@ -228,7 +269,7 @@ class FalkorSubstrateStore:
             logger.warning("falkor_substrate_hydrate_failed error=%s", exc)
             return
 
-        for row in _normalize_rows(node_rows):
+        for row in _normalize_rows(node_rows, fields=NATIVE_NODE_RETURN_FIELDS):
             try:
                 node = decode_concept_node(row)
             except Exception:
@@ -239,7 +280,7 @@ class FalkorSubstrateStore:
             identity = row.get("identity_key")
             self._cache.upsert_node(identity_key=str(identity) if identity else None, node=node)
 
-        for row in _normalize_rows(edge_rows):
+        for row in _normalize_rows(edge_rows, fields=NATIVE_EDGE_RETURN_FIELDS):
             try:
                 edge = decode_edge(row)
             except Exception:
@@ -250,8 +291,12 @@ class FalkorSubstrateStore:
             identity = row.get("identity_key") or self._edge_identity(edge)
             self._cache.upsert_edge(identity_key=str(identity), edge=edge)
 
-        self._migrate_legacy_payload_nodes(_normalize_rows(legacy_node_rows))
-        self._migrate_legacy_payload_edges(_normalize_rows(legacy_edge_rows))
+        self._migrate_legacy_payload_nodes(
+            _normalize_rows(legacy_node_rows, fields=("payload_json", "identity_key"))
+        )
+        self._migrate_legacy_payload_edges(
+            _normalize_rows(legacy_edge_rows, fields=("payload_json", "identity_key"))
+        )
 
     def _migrate_legacy_payload_nodes(self, rows: list[dict[str, Any]]) -> None:
         for row in rows:
@@ -272,6 +317,8 @@ class FalkorSubstrateStore:
                 continue
             identity = row.get("identity_key")
             identity_key = str(identity) if identity else None
+            # Seed cache first so a transient rewrite failure cannot empty Atlas.
+            self._cache.upsert_node(identity_key=identity_key, node=node)
             try:
                 # Rewrite to native properties and REMOVE payload_json.
                 self.upsert_node(identity_key=identity_key, node=node)
@@ -298,6 +345,7 @@ class FalkorSubstrateStore:
                 logger.warning("falkor_substrate_legacy_edge_invalid")
                 continue
             identity = row.get("identity_key") or self._edge_identity(edge)
+            self._cache.upsert_edge(identity_key=str(identity), edge=edge)
             try:
                 self.upsert_edge(identity_key=str(identity), edge=edge)
                 logger.info(
@@ -444,7 +492,9 @@ def _retag_source(result: SubstrateQueryResultV1, source_kind: str) -> Substrate
     return replace(result, source_kind=source_kind)
 
 
-def _normalize_rows(raw: Any) -> list[dict[str, Any]]:
+def _normalize_rows(
+    raw: Any, *, fields: tuple[str, ...] | list[str] | None = None
+) -> list[dict[str, Any]]:
     if raw is None:
         return []
     if isinstance(raw, list):
@@ -458,20 +508,35 @@ def _normalize_rows(raw: Any) -> list[dict[str, Any]]:
             and raw[0]
             and all(isinstance(column, (list, tuple)) for column in raw[0])
         ):
-            names = [str(column[0]).split(".")[-1] for column in raw[0]]
+            names = _header_field_names(raw[0])
             return [
                 dict(zip(names, record))
                 for record in raw[1]
-                if isinstance(record, (list, tuple))
+                if isinstance(record, (list, tuple)) and len(record) == len(names)
             ]
+        field_names = list(fields) if fields else []
         out: list[dict[str, Any]] = []
         for item in raw:
             if isinstance(item, dict):
+                if "_positional" in item and field_names:
+                    values = item.get("_positional")
+                    if isinstance(values, list) and len(values) == len(field_names):
+                        out.append(dict(zip(field_names, values)))
+                        continue
                 out.append(item)
-            elif isinstance(item, (list, tuple)) and len(item) >= 1:
-                if len(item) >= 2:
+            elif isinstance(item, (list, tuple)):
+                if field_names and len(item) == len(field_names):
+                    out.append(dict(zip(field_names, item)))
+                elif field_names:
+                    logger.warning(
+                        "falkor_substrate_normalize_row_width_mismatch expected=%s got=%s",
+                        len(field_names),
+                        len(item),
+                    )
+                elif len(item) >= 2:
+                    # Legacy two-column fallback only when caller omitted fields.
                     out.append({"node_id": item[0], "identity_key": item[1]})
-                else:
+                elif item:
                     out.append({"node_id": item[0], "identity_key": ""})
         return out
     return []

--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -1,24 +1,28 @@
-"""FalkorDB-backed SubstrateGraphStore (write-through cache + payload_json).
+"""FalkorDB-backed SubstrateGraphStore (write-through cache + Cypher-native properties).
 
 Queries and reads are served from the in-process cache (same shape as a warm
 GraphDBSubstrateStore). Durable writes go through an injectable sync client so
 unit tests never need a live FalkorDB. Cold-start hydration is best-effort via
-MATCH … RETURN payload_json when the client can answer.
+MATCH … RETURN native scalar properties when the client can answer.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
-from pydantic import TypeAdapter
-
-from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1, SubstrateNodeV1
+from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
 from orion.graph.property_guard import sanitize_metadata
+from orion.substrate.falkor_codec import (
+    decode_concept_node,
+    decode_edge,
+    encode_edge_properties,
+    encode_node_properties,
+    node_label_for_kind,
+)
 from orion.substrate.store import (
     InMemorySubstrateGraphStore,
     MaterializedSubstrateGraphState,
@@ -27,8 +31,6 @@ from orion.substrate.store import (
 )
 
 logger = logging.getLogger("orion.substrate.falkor_store")
-
-NODE_ADAPTER = TypeAdapter(SubstrateNodeV1)
 
 
 class FalkorGraphClient(Protocol):
@@ -41,6 +43,69 @@ class FalkorSubstrateStoreConfig:
     graph_name: str = "orion_substrate"
 
 
+NATIVE_NODE_RETURN_FIELDS: tuple[str, ...] = (
+    "node_id",
+    "node_kind",
+    "identity_key",
+    "label",
+    "definition",
+    "anchor_scope",
+    "subject_ref",
+    "promotion_state",
+    "risk_tier",
+    "confidence",
+    "salience",
+    "activation",
+    "recency_score",
+    "decay_half_life_seconds",
+    "decay_floor",
+    "observed_at",
+    "valid_from",
+    "valid_to",
+    "provenance_authority",
+    "provenance_source_kind",
+    "provenance_source_channel",
+    "provenance_producer",
+    "provenance_model_name",
+    "provenance_correlation_id",
+    "provenance_trace_id",
+    "provenance_tier_rank",
+)
+
+NATIVE_EDGE_RETURN_FIELDS: tuple[str, ...] = (
+    "edge_id",
+    "identity_key",
+    "source_id",
+    "source_kind",
+    "target_id",
+    "target_kind",
+    "predicate",
+    "substrate_edge",
+    "confidence",
+    "salience",
+    "observed_at",
+    "valid_from",
+    "valid_to",
+    "provenance_authority",
+    "provenance_source_kind",
+    "provenance_source_channel",
+    "provenance_producer",
+    "provenance_model_name",
+    "provenance_correlation_id",
+    "provenance_trace_id",
+    "provenance_tier_rank",
+)
+
+
+def _return_clause(alias: str, fields: tuple[str, ...]) -> str:
+    return ", ".join(f"{alias}.{field} AS {field}" for field in fields)
+
+
+def _set_assignments(alias: str, params: dict[str, Any], *, skip: set[str]) -> str:
+    keys = sorted(k for k in params if k not in skip)
+    return ", ".join(f"{alias}.{key} = ${key}" for key in keys)
+
+
 class RecordingFalkorClient:
     """Test double that records Cypher and optionally returns scripted rows."""
 
@@ -50,7 +115,7 @@ class RecordingFalkorClient:
 
     def graph_query(self, cypher: str, params: dict[str, Any] | None = None) -> Any:
         self.calls.append((cypher, params))
-        if "RETURN n.payload_json" in cypher or "RETURN e.payload_json" in cypher:
+        if "RETURN n.node_id AS node_id" in cypher or "RETURN e.edge_id AS edge_id" in cypher:
             return self._hydrate_rows
         return []
 
@@ -105,34 +170,33 @@ class FalkorSubstrateStore:
     def _hydrate_from_durable(self) -> None:
         try:
             node_rows = self._client.graph_query(
-                "MATCH (n:SubstrateNode) RETURN n.payload_json AS payload_json, n.identity_key AS identity_key"
+                "MATCH (n:SubstrateNode) RETURN " + _return_clause("n", NATIVE_NODE_RETURN_FIELDS)
             )
             edge_rows = self._client.graph_query(
-                "MATCH ()-[e]->() WHERE e.substrate_edge = true "
-                "RETURN e.payload_json AS payload_json, e.identity_key AS identity_key"
+                "MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode) "
+                "WHERE e.substrate_edge = true "
+                "RETURN " + _return_clause("e", NATIVE_EDGE_RETURN_FIELDS)
             )
         except Exception as exc:
             logger.warning("falkor_substrate_hydrate_failed error=%s", exc)
             return
         for row in _normalize_rows(node_rows):
-            payload = row.get("payload_json")
-            if not payload:
-                continue
             try:
-                node = NODE_ADAPTER.validate_json(payload)
+                node = decode_concept_node(row)
             except Exception:
                 logger.warning("falkor_substrate_hydrate_node_invalid")
+                continue
+            if node is None:
                 continue
             identity = row.get("identity_key")
             self._cache.upsert_node(identity_key=str(identity) if identity else None, node=node)
         for row in _normalize_rows(edge_rows):
-            payload = row.get("payload_json")
-            if not payload:
-                continue
             try:
-                edge = SubstrateEdgeV1.model_validate_json(payload)
+                edge = decode_edge(row)
             except Exception:
                 logger.warning("falkor_substrate_hydrate_edge_invalid")
+                continue
+            if edge is None:
                 continue
             identity = row.get("identity_key") or self._edge_identity(edge)
             self._cache.upsert_edge(identity_key=str(identity), edge=edge)
@@ -155,19 +219,10 @@ class FalkorSubstrateStore:
 
     def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
         node = _with_sanitized_metadata(node)
-        payload_json = json.dumps(node.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
-        params = {
-            "node_id": node.node_id,
-            "node_kind": node.node_kind,
-            "payload_json": payload_json,
-            "identity_key": identity_key or "",
-            "salience": float(node.signals.salience),
-        }
-        cypher = (
-            "MERGE (n:SubstrateNode {node_id: $node_id}) "
-            "SET n.node_kind = $node_kind, n.payload_json = $payload_json, "
-            "n.identity_key = $identity_key, n.salience = $salience"
-        )
+        params = encode_node_properties(node, identity_key)
+        label = node_label_for_kind(str(node.node_kind))
+        assignments = _set_assignments("n", params, skip={"node_id"})
+        cypher = f"MERGE (n:SubstrateNode:{label} {{node_id: $node_id}}) SET {assignments}"
         try:
             self._client.graph_query(cypher, params)
         except Exception as exc:
@@ -177,27 +232,15 @@ class FalkorSubstrateStore:
 
     def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None:
         edge = _with_sanitized_metadata(edge)
-        payload_json = json.dumps(edge.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
-        params = {
-            "edge_id": edge.edge_id,
-            "payload_json": payload_json,
-            "identity_key": identity_key,
-            "source_id": edge.source.node_id,
-            "target_id": edge.target.node_id,
-            "salience": float(edge.salience),
-        }
-        # SubstrateEdgeV1 validates predicate against a closed Literal, so it
-        # is safe to use as the relationship type (Cypher cannot parameterize
-        # relationship types).
+        params = encode_edge_properties(edge, identity_key)
         relationship_type = edge.predicate
+        assignments = _set_assignments("e", params, skip={"edge_id", "source_id", "target_id"})
         cypher = (
             "MERGE (source:SubstrateNode {node_id: $source_id}) "
             "MERGE (target:SubstrateNode {node_id: $target_id}) "
             f"MERGE (source)-[e:`{relationship_type}` {{edge_id: $edge_id}}]->(target) "
-            "SET e.payload_json = $payload_json, e.identity_key = $identity_key, "
-            "e.substrate_edge = true, e.predicate = $predicate, e.salience = $salience"
+            f"SET {assignments}"
         )
-        params["predicate"] = relationship_type
         try:
             self._client.graph_query(cypher, params)
         except Exception as exc:
@@ -214,19 +257,25 @@ class FalkorSubstrateStore:
             self._result_source_kind,
         )
 
-    def query_hotspot_region(self, *, min_salience: float = 0.6, limit_nodes: int = 32, limit_edges: int = 64) -> SubstrateQueryResultV1:
+    def query_hotspot_region(
+        self, *, min_salience: float = 0.6, limit_nodes: int = 32, limit_edges: int = 64
+    ) -> SubstrateQueryResultV1:
         result = self._cache.query_hotspot_region(
             min_salience=min_salience, limit_nodes=limit_nodes, limit_edges=limit_edges
         )
         return _retag_source(result, self._result_source_kind)
 
-    def query_contradiction_region(self, *, limit_nodes: int = 32, limit_edges: int = 64) -> SubstrateQueryResultV1:
+    def query_contradiction_region(
+        self, *, limit_nodes: int = 32, limit_edges: int = 64
+    ) -> SubstrateQueryResultV1:
         return _retag_source(
             self._cache.query_contradiction_region(limit_nodes=limit_nodes, limit_edges=limit_edges),
             self._result_source_kind,
         )
 
-    def query_concept_region(self, *, limit_nodes: int = 32, limit_edges: int = 64) -> SubstrateQueryResultV1:
+    def query_concept_region(
+        self, *, limit_nodes: int = 32, limit_edges: int = 64
+    ) -> SubstrateQueryResultV1:
         return _retag_source(
             self._cache.query_concept_region(limit_nodes=limit_nodes, limit_edges=limit_edges),
             self._result_source_kind,
@@ -299,11 +348,10 @@ def _normalize_rows(raw: Any) -> list[dict[str, Any]]:
             if isinstance(item, dict):
                 out.append(item)
             elif isinstance(item, (list, tuple)) and len(item) >= 1:
-                # hydrate script may return [[payload, identity], ...]
                 if len(item) >= 2:
-                    out.append({"payload_json": item[0], "identity_key": item[1]})
+                    out.append({"node_id": item[0], "identity_key": item[1]})
                 else:
-                    out.append({"payload_json": item[0], "identity_key": ""})
+                    out.append({"node_id": item[0], "identity_key": ""})
         return out
     return []
 

--- a/orion/substrate/tests/test_falkor_codec.py
+++ b/orion/substrate/tests/test_falkor_codec.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from orion.core.schemas.cognitive_substrate import (
     ConceptNodeV1,
+    DriveNodeV1,
     NodeRefV1,
     SubstrateActivationV1,
     SubstrateEdgeV1,
@@ -20,13 +23,15 @@ from orion.substrate.falkor_codec import (
 )
 
 
-def _provenance() -> SubstrateProvenanceV1:
-    return SubstrateProvenanceV1(
+def _provenance(**kwargs) -> SubstrateProvenanceV1:
+    base = dict(
         authority="local_inferred",
         source_kind="test",
         source_channel="test:falkor_codec",
         producer="test_falkor_codec",
     )
+    base.update(kwargs)
+    return SubstrateProvenanceV1(**base)
 
 
 def _temporal() -> SubstrateTemporalWindowV1:
@@ -38,10 +43,11 @@ def _concept() -> ConceptNodeV1:
         node_id="concept-alpha",
         label="Alpha",
         definition="A test concept",
+        taxonomy_path=["root", "branch"],
         anchor_scope="orion",
         promotion_state="canonical",
         temporal=_temporal(),
-        provenance=_provenance(),
+        provenance=_provenance(evidence_refs=["ev:1", "ev:2"]),
         signals=SubstrateSignalBundleV1(
             confidence=0.8,
             salience=0.7,
@@ -91,9 +97,32 @@ def test_encode_concept_node_properties_are_native_scalars_without_payload_json(
         "provenance_correlation_id": None,
         "provenance_trace_id": None,
         "provenance_tier_rank": None,
+        "evidence_refs_json": '["ev:1", "ev:2"]',
         "label": "Alpha",
         "definition": "A test concept",
+        "taxonomy_path_json": '["root", "branch"]',
     }
+
+
+def test_encode_preserves_evidence_refs_and_taxonomy_path_round_trip():
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+    node = decode_concept_node(row)
+
+    assert node is not None
+    assert node.provenance.evidence_refs == ["ev:1", "ev:2"]
+    assert node.taxonomy_path == ["root", "branch"]
+
+
+def test_encode_node_properties_rejects_non_concept():
+    drive = DriveNodeV1(
+        node_id="drive-curiosity",
+        drive_kind="curiosity",
+        anchor_scope="orion",
+        temporal=_temporal(),
+        provenance=_provenance(),
+    )
+    with pytest.raises(ValueError, match="concept nodes only"):
+        encode_node_properties(drive, identity_key="drive:curiosity")
 
 
 def test_decode_concept_node_reconstructs_minimal_typed_model():
@@ -122,7 +151,7 @@ def test_encode_edge_properties_are_native_scalars_without_payload_json():
         temporal=_temporal(),
         confidence=0.9,
         salience=0.4,
-        provenance=_provenance(),
+        provenance=_provenance(evidence_refs=["edge-ev:1"]),
         metadata={"ignored": "not durable SoR"},
     )
 
@@ -137,6 +166,7 @@ def test_encode_edge_properties_are_native_scalars_without_payload_json():
     assert props["identity_key"] == "edge:alpha-beta"
     assert props["confidence"] == 0.9
     assert props["salience"] == 0.4
+    assert props["evidence_refs_json"] == '["edge-ev:1"]'
 
 
 def test_decode_edge_reconstructs_typed_edge():
@@ -148,7 +178,7 @@ def test_decode_edge_reconstructs_typed_edge():
         temporal=_temporal(),
         confidence=0.9,
         salience=0.4,
-        provenance=_provenance(),
+        provenance=_provenance(evidence_refs=["edge-ev:1"]),
     )
     row = encode_edge_properties(edge, identity_key="edge:alpha-beta")
 
@@ -161,3 +191,4 @@ def test_decode_edge_reconstructs_typed_edge():
     assert decoded.predicate == "contradicts"
     assert decoded.confidence == 0.9
     assert decoded.salience == 0.4
+    assert decoded.provenance.evidence_refs == ["edge-ev:1"]

--- a/orion/substrate/tests/test_falkor_codec.py
+++ b/orion/substrate/tests/test_falkor_codec.py
@@ -169,6 +169,14 @@ def test_encode_edge_properties_are_native_scalars_without_payload_json():
     assert props["evidence_refs_json"] == '["edge-ev:1"]'
 
 
+def test_decode_rejects_corrupt_evidence_refs_json():
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+    row["evidence_refs_json"] = "{not-json"
+
+    with pytest.raises(ValueError, match="evidence_refs_json"):
+        decode_concept_node(row)
+
+
 def test_decode_edge_reconstructs_typed_edge():
     edge = SubstrateEdgeV1(
         edge_id="edge-alpha-beta",

--- a/orion/substrate/tests/test_falkor_codec.py
+++ b/orion/substrate/tests/test_falkor_codec.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    NodeRefV1,
+    SubstrateActivationV1,
+    SubstrateEdgeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.falkor_codec import (
+    decode_concept_node,
+    decode_edge,
+    encode_edge_properties,
+    encode_node_properties,
+    node_label_for_kind,
+)
+
+
+def _provenance() -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="test",
+        source_channel="test:falkor_codec",
+        producer="test_falkor_codec",
+    )
+
+
+def _temporal() -> SubstrateTemporalWindowV1:
+    return SubstrateTemporalWindowV1(observed_at=datetime(2026, 7, 16, tzinfo=timezone.utc))
+
+
+def _concept() -> ConceptNodeV1:
+    return ConceptNodeV1(
+        node_id="concept-alpha",
+        label="Alpha",
+        definition="A test concept",
+        anchor_scope="orion",
+        promotion_state="canonical",
+        temporal=_temporal(),
+        provenance=_provenance(),
+        signals=SubstrateSignalBundleV1(
+            confidence=0.8,
+            salience=0.7,
+            activation=SubstrateActivationV1(
+                activation=0.6,
+                recency_score=0.5,
+                decay_floor=0.1,
+            ),
+        ),
+        metadata={"quarantine": "not durable SoR"},
+    )
+
+
+def test_node_label_for_kind_uses_closed_mapping():
+    assert node_label_for_kind("concept") == "Concept"
+    assert node_label_for_kind("state_snapshot") == "StateSnapshot"
+    assert node_label_for_kind("unknown_kind") == "Generic"
+
+
+def test_encode_concept_node_properties_are_native_scalars_without_payload_json():
+    props = encode_node_properties(_concept(), identity_key="concept:alpha")
+
+    assert "payload_json" not in props
+    assert "metadata" not in props
+    assert props == {
+        "node_id": "concept-alpha",
+        "node_kind": "concept",
+        "identity_key": "concept:alpha",
+        "anchor_scope": "orion",
+        "subject_ref": None,
+        "promotion_state": "canonical",
+        "risk_tier": "low",
+        "confidence": 0.8,
+        "salience": 0.7,
+        "activation": 0.6,
+        "recency_score": 0.5,
+        "decay_half_life_seconds": None,
+        "decay_floor": 0.1,
+        "observed_at": "2026-07-16T00:00:00+00:00",
+        "valid_from": None,
+        "valid_to": None,
+        "provenance_authority": "local_inferred",
+        "provenance_source_kind": "test",
+        "provenance_source_channel": "test:falkor_codec",
+        "provenance_producer": "test_falkor_codec",
+        "provenance_model_name": None,
+        "provenance_correlation_id": None,
+        "provenance_trace_id": None,
+        "provenance_tier_rank": None,
+        "label": "Alpha",
+        "definition": "A test concept",
+    }
+
+
+def test_decode_concept_node_reconstructs_minimal_typed_model():
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+
+    node = decode_concept_node(row)
+
+    assert node is not None
+    assert node.node_id == "concept-alpha"
+    assert node.node_kind == "concept"
+    assert node.label == "Alpha"
+    assert node.definition == "A test concept"
+    assert node.promotion_state == "canonical"
+    assert node.signals.confidence == 0.8
+    assert node.signals.salience == 0.7
+    assert node.signals.activation.activation == 0.6
+    assert node.metadata == {}
+
+
+def test_encode_edge_properties_are_native_scalars_without_payload_json():
+    edge = SubstrateEdgeV1(
+        edge_id="edge-alpha-beta",
+        source=NodeRefV1(node_id="concept-alpha", node_kind="concept"),
+        target=NodeRefV1(node_id="concept-beta", node_kind="concept"),
+        predicate="contradicts",
+        temporal=_temporal(),
+        confidence=0.9,
+        salience=0.4,
+        provenance=_provenance(),
+        metadata={"ignored": "not durable SoR"},
+    )
+
+    props = encode_edge_properties(edge, identity_key="edge:alpha-beta")
+
+    assert "payload_json" not in props
+    assert "metadata" not in props
+    assert props["edge_id"] == "edge-alpha-beta"
+    assert props["source_id"] == "concept-alpha"
+    assert props["target_id"] == "concept-beta"
+    assert props["predicate"] == "contradicts"
+    assert props["identity_key"] == "edge:alpha-beta"
+    assert props["confidence"] == 0.9
+    assert props["salience"] == 0.4
+
+
+def test_decode_edge_reconstructs_typed_edge():
+    edge = SubstrateEdgeV1(
+        edge_id="edge-alpha-beta",
+        source=NodeRefV1(node_id="concept-alpha", node_kind="concept"),
+        target=NodeRefV1(node_id="concept-beta", node_kind="concept"),
+        predicate="contradicts",
+        temporal=_temporal(),
+        confidence=0.9,
+        salience=0.4,
+        provenance=_provenance(),
+    )
+    row = encode_edge_properties(edge, identity_key="edge:alpha-beta")
+
+    decoded = decode_edge(row)
+
+    assert decoded is not None
+    assert decoded.edge_id == "edge-alpha-beta"
+    assert decoded.source.node_id == "concept-alpha"
+    assert decoded.target.node_id == "concept-beta"
+    assert decoded.predicate == "contradicts"
+    assert decoded.confidence == 0.9
+    assert decoded.salience == 0.4

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -178,7 +178,8 @@ def test_falkor_edge_is_persisted_as_typed_relationship():
 
     cypher, params = client.calls[-1]
     assert "MERGE (source)-[e:`supports`" in cypher
-    assert "e.substrate_edge = true" in cypher
+    assert "payload_json" not in cypher
+    assert "e.substrate_edge = $substrate_edge" in cypher
     assert params is not None
     assert params["source_id"] == "sub-node-a"
     assert params["target_id"] == "sub-node-b"
@@ -234,11 +235,56 @@ def test_redis_graph_client_uses_redis_py_parameter_header():
 
 def test_normalize_rows_parses_raw_graph_query_header_and_stats():
     raw = [
-        [["n.payload_json", 1], ["n.identity_key", 1]],
-        [["{\"node_id\":\"sub-node-a\"}", "id-a"]],
+        [["n.node_id", 1], ["n.identity_key", 1]],
+        [["concept-alpha", "concept:alpha"]],
         ["Cached execution: 0", "Query internal execution time: 0.1 milliseconds"],
     ]
 
     assert _normalize_rows(raw) == [
-        {"payload_json": "{\"node_id\":\"sub-node-a\"}", "identity_key": "id-a"}
+        {"node_id": "concept-alpha", "identity_key": "concept:alpha"}
     ]
+
+
+def test_falkor_hydrated_concepts_support_concept_region_query():
+    client = RecordingFalkorClient(
+        hydrate_rows=[
+            {
+                "node_id": "concept-alpha",
+                "node_kind": "concept",
+                "identity_key": "concept:alpha",
+                "label": "Alpha",
+                "definition": None,
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.8,
+                "salience": 0.7,
+                "activation": 0.5,
+                "recency_score": 0.4,
+                "decay_floor": 0.0,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:falkor",
+                "provenance_producer": "test_falkor_store",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+            }
+        ]
+    )
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    result = store.query_concept_region(limit_nodes=10, limit_edges=10)
+
+    assert result.source_kind == "falkor"
+    assert [node.node_id for node in result.slice.nodes] == ["concept-alpha"]

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -53,6 +53,91 @@ def test_falkor_upsert_round_trip_via_cache():
     assert any("MERGE (n:SubstrateNode" in cypher for cypher, _ in client.calls)
 
 
+def test_falkor_upsert_concept_uses_native_cypher_properties():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    node = _concept(node_id="concept-native-alpha")
+
+    store.upsert_node(identity_key="concept:alpha", node=node)
+
+    cypher, params = client.calls[-1]
+    assert "payload_json" not in cypher
+    assert params is not None
+    assert "payload_json" not in params
+    assert "MERGE (n:SubstrateNode:Concept {node_id: $node_id})" in cypher
+    assert "n.label = $label" in cypher
+    assert "n.promotion_state = $promotion_state" in cypher
+    assert "n.salience = $salience" in cypher
+    assert params["node_id"] == "concept-native-alpha"
+    assert params["node_kind"] == "concept"
+    assert params["identity_key"] == "concept:alpha"
+    assert params["label"] == "alpha"
+    assert params["anchor_scope"] == "orion"
+    assert params["promotion_state"] == "proposed"
+    assert params["risk_tier"] == "low"
+    assert params["salience"] == 0.0
+    assert params["activation"] == 0.0
+    assert params["recency_score"] == 0.0
+    assert params["confidence"] == 0.5
+
+
+def test_falkor_hydrates_concept_from_native_properties():
+    client = RecordingFalkorClient(
+        hydrate_rows=[
+            {
+                "node_id": "concept-hydrated",
+                "node_kind": "concept",
+                "identity_key": "concept:hydrated",
+                "label": "Hydrated concept",
+                "definition": "Loaded from Falkor native properties",
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.75,
+                "salience": 0.66,
+                "activation": 0.44,
+                "recency_score": 0.33,
+                "decay_floor": 0.1,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:falkor",
+                "provenance_producer": "test_falkor_store",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+            }
+        ]
+    )
+
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    node = store.get_node_by_id("concept-hydrated")
+    assert node is not None
+    assert node.node_kind == "concept"
+    assert node.label == "Hydrated concept"
+    assert node.definition == "Loaded from Falkor native properties"
+    assert node.promotion_state == "canonical"
+    assert node.signals.confidence == 0.75
+    assert node.signals.salience == 0.66
+    assert node.signals.activation.activation == 0.44
+    assert node.signals.activation.recency_score == 0.33
+    assert store.get_node_id_by_identity("concept:hydrated") == "concept-hydrated"
+
+
 def test_falkor_sanitizes_metadata_cathedral():
     client = RecordingFalkorClient()
     store = FalkorSubstrateStore(

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -326,9 +326,10 @@ def test_build_substrate_store_falkor_missing_uri(monkeypatch):
     assert isinstance(store, InMemorySubstrateGraphStore)
 
 
-def test_redis_graph_client_uses_redis_py_parameter_header():
+def test_redis_graph_client_returns_named_dicts_from_header():
     class _Result:
-        result_set = [["payload", "identity"]]
+        header = [[1, "node_id"], [1, "identity_key"]]
+        result_set = [["concept-alpha", "concept:alpha"]]
 
     class _Graph:
         def __init__(self):
@@ -344,7 +345,7 @@ def test_redis_graph_client_uses_redis_py_parameter_header():
 
     result = client.graph_query("RETURN $node_id", {"node_id": "sub-node-a"})
 
-    assert result == [["payload", "identity"]]
+    assert result == [{"node_id": "concept-alpha", "identity_key": "concept:alpha"}]
     assert graph.calls == [("RETURN $node_id", {"node_id": "sub-node-a"})]
 
 
@@ -358,6 +359,171 @@ def test_normalize_rows_parses_raw_graph_query_header_and_stats():
     assert _normalize_rows(raw) == [
         {"node_id": "concept-alpha", "identity_key": "concept:alpha"}
     ]
+
+
+def test_normalize_rows_zips_redis_py_list_rows_to_native_fields():
+    from orion.substrate.falkor_store import NATIVE_NODE_RETURN_FIELDS
+
+    values = []
+    for field in NATIVE_NODE_RETURN_FIELDS:
+        if field == "node_id":
+            values.append("concept-list")
+        elif field == "node_kind":
+            values.append("concept")
+        elif field == "identity_key":
+            values.append("concept:list")
+        elif field == "label":
+            values.append("List Row")
+        elif field == "definition":
+            values.append("From redis-py lists")
+        elif field == "taxonomy_path_json":
+            values.append('["list"]')
+        elif field == "anchor_scope":
+            values.append("orion")
+        elif field == "promotion_state":
+            values.append("canonical")
+        elif field == "risk_tier":
+            values.append("low")
+        elif field in {"confidence", "salience", "activation", "recency_score", "decay_floor"}:
+            values.append(0.5)
+        elif field == "observed_at":
+            values.append("2026-07-16T00:00:00+00:00")
+        elif field == "provenance_authority":
+            values.append("local_inferred")
+        elif field == "provenance_source_kind":
+            values.append("test")
+        elif field == "provenance_source_channel":
+            values.append("test:list")
+        elif field == "provenance_producer":
+            values.append("test_falkor_store")
+        elif field == "evidence_refs_json":
+            values.append('["ev:list"]')
+        else:
+            values.append(None)
+
+    rows = _normalize_rows([values], fields=NATIVE_NODE_RETURN_FIELDS)
+    assert rows[0]["node_id"] == "concept-list"
+    assert rows[0]["label"] == "List Row"
+    assert rows[0]["evidence_refs_json"] == '["ev:list"]'
+
+
+def test_falkor_hydrates_from_redis_py_result_set_lists():
+    from orion.substrate.falkor_store import NATIVE_NODE_RETURN_FIELDS
+
+    values = []
+    for field in NATIVE_NODE_RETURN_FIELDS:
+        defaults = {
+            "node_id": "concept-redis-py",
+            "node_kind": "concept",
+            "identity_key": "concept:redis-py",
+            "label": "Redis Py",
+            "definition": "list hydrate",
+            "taxonomy_path_json": '["r"]',
+            "anchor_scope": "orion",
+            "promotion_state": "canonical",
+            "risk_tier": "low",
+            "confidence": 0.8,
+            "salience": 0.7,
+            "activation": 0.5,
+            "recency_score": 0.4,
+            "decay_floor": 0.0,
+            "observed_at": "2026-07-16T00:00:00+00:00",
+            "provenance_authority": "local_inferred",
+            "provenance_source_kind": "test",
+            "provenance_source_channel": "test:redis-py",
+            "provenance_producer": "test_falkor_store",
+            "evidence_refs_json": '["ev:r"]',
+        }
+        values.append(defaults.get(field))
+
+    legacy = ConceptNodeV1(
+        node_id="concept-legacy-list",
+        label="Legacy list",
+        taxonomy_path=["legacy"],
+        anchor_scope="orion",
+        promotion_state="canonical",
+        temporal=SubstrateTemporalWindowV1(
+            observed_at=datetime(2026, 7, 16, tzinfo=timezone.utc)
+        ),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="test:legacy-list",
+            producer="test_falkor_store",
+            evidence_refs=["ev:legacy-list"],
+        ),
+    )
+
+    class ListRowClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict | None]] = []
+
+        def graph_query(self, cypher: str, params: dict | None = None):
+            self.calls.append((cypher, params))
+            if "WHERE n.payload_json IS NOT NULL" in cypher:
+                return [[legacy.model_dump_json(), "concept:legacy-list"]]
+            if "WHERE e.payload_json IS NOT NULL" in cypher:
+                return []
+            if "RETURN n.node_id AS node_id" in cypher:
+                return [values]
+            if "RETURN e.edge_id AS edge_id" in cypher:
+                return []
+            return []
+
+    client = ListRowClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    native = store.get_node_by_id("concept-redis-py")
+    assert native is not None
+    assert native.label == "Redis Py"
+    assert native.provenance.evidence_refs == ["ev:r"]
+
+    migrated = store.get_node_by_id("concept-legacy-list")
+    assert migrated is not None
+    assert migrated.label == "Legacy list"
+    assert any("MERGE (n:SubstrateNode" in c for c, _ in client.calls)
+
+
+def test_falkor_legacy_migrate_keeps_cache_when_rewrite_fails():
+    legacy = ConceptNodeV1(
+        node_id="concept-cache-seed",
+        label="Cache seed",
+        anchor_scope="orion",
+        temporal=SubstrateTemporalWindowV1(
+            observed_at=datetime(2026, 7, 16, tzinfo=timezone.utc)
+        ),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="test:cache-seed",
+            producer="test_falkor_store",
+        ),
+    )
+
+    class FailRewriteClient(RecordingFalkorClient):
+        def graph_query(self, cypher: str, params: dict | None = None):
+            if "MERGE (n:SubstrateNode" in cypher:
+                raise RuntimeError("falkor unavailable")
+            return super().graph_query(cypher, params)
+
+    client = FailRewriteClient(
+        hydrate_legacy_node_rows=[
+            {"payload_json": legacy.model_dump_json(), "identity_key": "concept:cache-seed"}
+        ]
+    )
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    node = store.get_node_by_id("concept-cache-seed")
+    assert node is not None
+    assert node.label == "Cache seed"
 
 
 def test_falkor_hydrated_concepts_support_concept_region_query():

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from orion.core.schemas.cognitive_substrate import (
     ConceptNodeV1,
+    DriveNodeV1,
     NodeRefV1,
     SubstrateEdgeV1,
     SubstrateProvenanceV1,
@@ -24,6 +27,7 @@ def _concept(*, node_id: str = "sub-node-a", metadata: dict | None = None) -> Co
     return ConceptNodeV1(
         node_id=node_id,
         label="alpha",
+        taxonomy_path=["root"],
         anchor_scope="orion",
         temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
         provenance=SubstrateProvenanceV1(
@@ -31,10 +35,19 @@ def _concept(*, node_id: str = "sub-node-a", metadata: dict | None = None) -> Co
             source_kind="test",
             source_channel="test",
             producer="test_falkor_store",
-            evidence_refs=[],
+            evidence_refs=["ev:store"],
         ),
         metadata=metadata or {},
     )
+
+
+def _assert_no_payload_json_sor(cypher: str, params: dict | None) -> None:
+    assert "$payload_json" not in cypher
+    assert "payload_json =" not in cypher.replace("REMOVE n.payload_json", "").replace(
+        "REMOVE e.payload_json", ""
+    )
+    assert params is not None
+    assert "payload_json" not in params
 
 
 def test_falkor_upsert_round_trip_via_cache():
@@ -65,13 +78,14 @@ def test_falkor_upsert_concept_uses_native_cypher_properties():
     store.upsert_node(identity_key="concept:alpha", node=node)
 
     cypher, params = client.calls[-1]
-    assert "payload_json" not in cypher
-    assert params is not None
-    assert "payload_json" not in params
+    _assert_no_payload_json_sor(cypher, params)
+    assert "REMOVE n.payload_json" in cypher
     assert "MERGE (n:SubstrateNode:Concept {node_id: $node_id})" in cypher
     assert "n.label = $label" in cypher
     assert "n.promotion_state = $promotion_state" in cypher
     assert "n.salience = $salience" in cypher
+    assert "n.evidence_refs_json = $evidence_refs_json" in cypher
+    assert "n.taxonomy_path_json = $taxonomy_path_json" in cypher
     assert params["node_id"] == "concept-native-alpha"
     assert params["node_kind"] == "concept"
     assert params["identity_key"] == "concept:alpha"
@@ -83,17 +97,46 @@ def test_falkor_upsert_concept_uses_native_cypher_properties():
     assert params["activation"] == 0.0
     assert params["recency_score"] == 0.0
     assert params["confidence"] == 0.5
+    assert params["evidence_refs_json"] == '["ev:store"]'
+    assert params["taxonomy_path_json"] == '["root"]'
+
+
+def test_falkor_rejects_non_concept_durable_write():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    drive = DriveNodeV1(
+        node_id="drive-curiosity",
+        drive_kind="curiosity",
+        anchor_scope="orion",
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="test",
+            producer="test_falkor_store",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="concept nodes only"):
+        store.upsert_node(identity_key="drive:curiosity", node=drive)
+
+    assert client.calls == []
 
 
 def test_falkor_hydrates_concept_from_native_properties():
     client = RecordingFalkorClient(
-        hydrate_rows=[
+        hydrate_node_rows=[
             {
                 "node_id": "concept-hydrated",
                 "node_kind": "concept",
                 "identity_key": "concept:hydrated",
                 "label": "Hydrated concept",
                 "definition": "Loaded from Falkor native properties",
+                "taxonomy_path_json": '["atlas"]',
                 "anchor_scope": "orion",
                 "subject_ref": None,
                 "promotion_state": "canonical",
@@ -115,6 +158,7 @@ def test_falkor_hydrates_concept_from_native_properties():
                 "provenance_correlation_id": None,
                 "provenance_trace_id": None,
                 "provenance_tier_rank": None,
+                "evidence_refs_json": '["ev:hydrate"]',
             }
         ]
     )
@@ -130,12 +174,83 @@ def test_falkor_hydrates_concept_from_native_properties():
     assert node.node_kind == "concept"
     assert node.label == "Hydrated concept"
     assert node.definition == "Loaded from Falkor native properties"
+    assert node.taxonomy_path == ["atlas"]
     assert node.promotion_state == "canonical"
     assert node.signals.confidence == 0.75
     assert node.signals.salience == 0.66
     assert node.signals.activation.activation == 0.44
     assert node.signals.activation.recency_score == 0.33
+    assert node.provenance.evidence_refs == ["ev:hydrate"]
     assert store.get_node_id_by_identity("concept:hydrated") == "concept-hydrated"
+
+
+def test_falkor_hydrates_legacy_payload_json_and_rewrites_native():
+    legacy_node = ConceptNodeV1(
+        node_id="concept-legacy",
+        label="Legacy concept",
+        definition="From blob SoR",
+        taxonomy_path=["legacy"],
+        anchor_scope="orion",
+        promotion_state="canonical",
+        temporal=SubstrateTemporalWindowV1(
+            observed_at=datetime(2026, 7, 16, tzinfo=timezone.utc)
+        ),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="test:legacy",
+            producer="test_falkor_store",
+            evidence_refs=["ev:legacy"],
+        ),
+    )
+    client = RecordingFalkorClient(
+        hydrate_legacy_node_rows=[
+            {
+                "payload_json": legacy_node.model_dump_json(),
+                "identity_key": "concept:legacy",
+            }
+        ]
+    )
+
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    node = store.get_node_by_id("concept-legacy")
+    assert node is not None
+    assert node.label == "Legacy concept"
+    assert node.taxonomy_path == ["legacy"]
+    assert node.provenance.evidence_refs == ["ev:legacy"]
+    assert store.get_node_id_by_identity("concept:legacy") == "concept-legacy"
+
+    write_calls = [(c, p) for c, p in client.calls if "MERGE (n:SubstrateNode" in c]
+    assert write_calls, "expected native rewrite after legacy hydrate"
+    cypher, params = write_calls[-1]
+    _assert_no_payload_json_sor(cypher, params)
+    assert "REMOVE n.payload_json" in cypher
+    assert params["label"] == "Legacy concept"
+    assert params["evidence_refs_json"] == '["ev:legacy"]'
+
+
+def test_recording_client_splits_node_and_edge_hydrate_rows():
+    client = RecordingFalkorClient(
+        hydrate_node_rows=[{"node_id": "n1", "node_kind": "concept"}],
+        hydrate_edge_rows=[{"edge_id": "e1", "predicate": "supports"}],
+    )
+
+    node_rows = client.graph_query(
+        "MATCH (n:SubstrateNode) RETURN n.node_id AS node_id, n.node_kind AS node_kind"
+    )
+    edge_rows = client.graph_query(
+        "MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode) "
+        "WHERE e.substrate_edge = true "
+        "RETURN e.edge_id AS edge_id"
+    )
+
+    assert node_rows == [{"node_id": "n1", "node_kind": "concept"}]
+    assert edge_rows == [{"edge_id": "e1", "predicate": "supports"}]
 
 
 def test_falkor_sanitizes_metadata_cathedral():
@@ -178,9 +293,9 @@ def test_falkor_edge_is_persisted_as_typed_relationship():
 
     cypher, params = client.calls[-1]
     assert "MERGE (source)-[e:`supports`" in cypher
-    assert "payload_json" not in cypher
+    _assert_no_payload_json_sor(cypher, params)
+    assert "REMOVE e.payload_json" in cypher
     assert "e.substrate_edge = $substrate_edge" in cypher
-    assert params is not None
     assert params["source_id"] == "sub-node-a"
     assert params["target_id"] == "sub-node-b"
 
@@ -247,13 +362,14 @@ def test_normalize_rows_parses_raw_graph_query_header_and_stats():
 
 def test_falkor_hydrated_concepts_support_concept_region_query():
     client = RecordingFalkorClient(
-        hydrate_rows=[
+        hydrate_node_rows=[
             {
                 "node_id": "concept-alpha",
                 "node_kind": "concept",
                 "identity_key": "concept:alpha",
                 "label": "Alpha",
                 "definition": None,
+                "taxonomy_path_json": "[]",
                 "anchor_scope": "orion",
                 "subject_ref": None,
                 "promotion_state": "canonical",
@@ -275,6 +391,7 @@ def test_falkor_hydrated_concepts_support_concept_region_query():
                 "provenance_correlation_id": None,
                 "provenance_trace_id": None,
                 "provenance_tier_rank": None,
+                "evidence_refs_json": "[]",
             }
         ]
     )

--- a/services/orion-hub/tests/test_concept_atlas_routes.py
+++ b/services/orion-hub/tests/test_concept_atlas_routes.py
@@ -367,3 +367,60 @@ def test_app_js_pings_activate_and_deactivate_for_concept_atlas() -> None:
     assert "conceptAtlasPanelFrame" in app_js_text
     assert "OrionConceptAtlas.activate" in app_js_text
     assert "OrionConceptAtlas.deactivate" in app_js_text
+
+
+def test_summary_reads_hydrated_falkor_store(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes
+    from orion.substrate.falkor_store import (
+        FalkorSubstrateStore,
+        FalkorSubstrateStoreConfig,
+        RecordingFalkorClient,
+    )
+
+    falkor_client = RecordingFalkorClient(
+        hydrate_rows=[
+            {
+                "node_id": "concept-native-atlas",
+                "node_kind": "concept",
+                "identity_key": "concept:native-atlas",
+                "label": "Native Atlas",
+                "definition": None,
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.8,
+                "salience": 0.7,
+                "activation": 0.5,
+                "recency_score": 0.4,
+                "decay_floor": 0.0,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:concept_atlas",
+                "provenance_producer": "test_concept_atlas_routes",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+            }
+        ]
+    )
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=falkor_client,
+        hydrate=True,
+    )
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+
+    r = client.get("/api/substrate/concepts/summary")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["total_concepts"] == 1
+    assert body["by_promotion_state"]["canonical"] == 1
+    assert body["by_anchor_scope"]["orion"] == 1


### PR DESCRIPTION
## Summary

- Replace Falkor substrate durable `payload_json` SoR with Cypher-native Concept/edge properties.
- Hydrate from native scalars; migrate legacy Hub blobs on hydrate (`REMOVE` after rewrite).
- Zip redis-py `QueryResult.header` + list `result_set` rows so live Hub restart cannot empty Concept Atlas.
- Persist `evidence_refs` / `taxonomy_path`; fail-closed non-concept durable writes.
- Spec/plan/PR report for the Postgres-via-bus split follow-ons (not in this cutover).

## Test plan

- [x] `PYTHONPATH=. pytest orion/substrate/tests/test_falkor_codec.py orion/substrate/tests/test_falkor_store.py services/orion-hub/tests/test_concept_atlas_routes.py::test_summary_reads_hydrated_falkor_store -q` → 25 passed
- [ ] After deploy: restart `orion-hub` against live Falkor; confirm Concept Atlas `/api/substrate/concepts/summary` survives cold hydrate (legacy blob + native)
- [ ] Do **not** flip `orion-substrate-runtime` to Falkor in this PR

## Notes

Full PR report: `docs/superpowers/pr-reports/2026-07-16-cypher-native-falkor-substrate-adapter-pr.md`


Made with [Cursor](https://cursor.com)