### PR TITLE
Rate-normalize the drive integrator (O2)

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-17-drive-cadence-fold-o2-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-drive-cadence-fold-o2-pr.md
@@ -1,0 +1,261 @@
+# PR report: rate-normalize the drive integrator (O2)
+
+Branch: `feat/drive-cadence-fold-o2`
+Series: follows `docs/superpowers/pr-reports/2026-07-16-drive-economy-desaturation-o1-o4-pr.md`
+(O1+O4) and `docs/superpowers/pr-reports/2026-07-17-drive-predictive-reground-o3-pr.md`
+(O3, PR #1114, merged). This is O2 -- the last of the two named follow-ups
+from that diagnosis, and the last piece of the drive-economy desaturation
+sequence (O1/O3/O4 already merged).
+
+## Summary
+
+- `DriveEngine.update()` (`orion/spark/concept_induction/drives.py`, untouched
+  by this patch) was called once per raw bus event (~13/min, ~4.6s apart) from
+  `orion/spark/concept_induction/bus_worker.py`. With `decay_tau_sec=1800.0`,
+  decay between consecutive calls is negligible (~0.3%) -- repeated
+  same-direction impulses converge pressure toward 1.0 within seconds
+  regardless of tau (verified concretely during O3's review: a repeated
+  impulse of ~0.5 pins pressure above 0.95 within ~5 ticks, ~23 seconds).
+  This is the event-rate/decay mismatch mechanism behind the cpu/gpu_pressure
+  saturation bugs (PRs #1108-1111), reproduced by any repeated same-direction
+  impulse at bus cadence.
+- New `ConceptWorker._update_drive_pressures(subject, tensions, now)` method
+  splits read from write: every bus event still gets a fresh drive-pressure
+  snapshot (a decay-only projection, `tensions=[]`, on non-fold ticks -- so
+  goal proposal, dossier, identity snapshot, and the publish itself all keep
+  getting a live `drive_state` every event, unchanged from before), but NEW
+  tension impulses are buffered per-subject in memory and only actually
+  applied + persisted to the integrator at most once per
+  `_DRIVE_FOLD_INTERVAL_SEC` (900.0s, a first-pass calibration -- see the
+  interval-math table in this report's history, not a new env key, same
+  convention as O3's/O4's own threshold constants).
+- Both existing call sites (`_handle_signal_drive_tick`, `handle_envelope`)
+  refactored to call the shared method instead of inlining load/update/save.
+- `DriveEngine` itself is completely unchanged -- this is purely a call-site
+  cadence fix in the stateful caller, not a change to the integrator math.
+  Every tension is still individually published to the bus exactly as
+  before, on every event, regardless of fold status -- only whether it gets
+  folded into the *persisted pressure* is throttled.
+
+## Outcome moved
+
+This closes the drive-economy desaturation diagnosis started 2026-07-15/16.
+O1 fixed dominance-attribution poisoning; O3 gave `predictive` its first
+primary tension source; O2 fixes the remaining pressure-pinning mechanism
+(event-rate vs decay-rate mismatch) both of them shared. Expect
+`measure_autonomy_gate.py`'s SATURATED verdict (added in O4) to clear for
+honest reasons post-deploy, and `drive_audits` to show real, differentiated
+per-drive variance instead of pinned-near-1.0 pressures -- this is the
+post-deploy re-measurement this whole series has been building toward.
+
+## Current architecture
+
+`handle_envelope` and `_handle_signal_drive_tick` each independently loaded
+`prior_drive_state`, computed `previous_ts`, called
+`DriveEngine.update(tensions=<this event's tensions>, ...)`, and immediately
+persisted the result via `store.save_drive_state(...)` -- once per raw bus
+event, with no cadence awareness.
+
+## Architecture touched
+
+`orion/spark/concept_induction/bus_worker.py` only. No changes to
+`DriveEngine`/`drives.py`, `store.py`, `ConceptSettings`, schema registry,
+bus channels, or env.
+
+## Files changed
+
+- `orion/spark/concept_induction/bus_worker.py`:
+  - New module constants `_DRIVE_FOLD_INTERVAL_SEC = 900.0` and
+    `_MAX_PENDING_DRIVE_TENSIONS = 500` (see Review findings below for the
+    latter).
+  - `ConceptWorker.__init__`: two new in-memory per-subject dicts,
+    `self._pending_drive_tensions` and `self._last_drive_fold_at`.
+  - New `ConceptWorker._update_drive_pressures()` method.
+  - `_handle_signal_drive_tick` and `handle_envelope`: both refactored to
+    call the new method instead of inlining load/update/save.
+  - `_log_drive_pressure_probe`'s docstring corrected (see Review findings).
+- `orion/spark/concept_induction/tests/test_drive_pressure_fold.py`: new
+  file, 5 tests (cold-start always folds, in-interval call neither folds nor
+  persists, post-interval call folds everything buffered since the last real
+  fold, a 30-tick steady-state saturation-prevention regression, and a
+  buffer-overflow-caps-and-drops-oldest test added during review).
+
+## Schema / bus / API changes
+
+None. `TensionEventV1` publishing is unaffected -- every tension is still
+published to the bus on every event; only persistence-into-the-integrator
+cadence changed.
+
+## Env/config changes
+
+None. Both new thresholds are plain module-level constants, not env keys,
+matching this patch series' established convention (O3's `0.30`/`0.05`
+thresholds, O4's `SATURATION_*` constants).
+
+## Tests run
+
+```text
+cd /mnt/scripts/Orion-Sapienform-drive-cadence-fold-o2
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/spark/concept_induction/tests -q
+165 passed, 20 warnings in 12.57s
+```
+
+(164 before the review-driven overflow-cap addition, 165 after.)
+
+## Evals run
+
+No eval harness exists for this surface (tracked as issue #1066, same gap
+noted in O1/O3/O4). The post-deploy live re-measurement below is the
+behavioral check.
+
+## Docker/build/smoke checks
+
+Not run -- pure Python call-cadence change in an already-running consumer
+path (`ConceptWorker`), no config/dependency/port/compose changes. Restart of
+`orion-spark-concept-induction` picks this up.
+
+## Review findings fixed
+
+Full 8-angle `/code-review medium` pass (3 correctness angles, 3 cleanup
+angles, altitude, conventions; 1-vote verify where needed).
+
+- **Fixed (efficiency, real gap): unbounded pending-tension buffer.**
+  `_pending_drive_tensions[subject]` had only a time-based bound (900s), no
+  numeric cap -- each buffered `TensionEventV1` carries a full
+  `ArtifactProvenance`, and this repo has an established convention of
+  capping exactly this class of collection (`evidence_event_ids <= 200` in
+  the pressure reducer and execution merge, cited precedent from prior
+  fixes). Added `_MAX_PENDING_DRIVE_TENSIONS = 500`, drop-oldest-first on
+  overflow (same "keep most recent" convention as `_prune_window`'s window
+  trimming), with a `drive_pressure_fold_buffer_overflow` warning log so an
+  overflow is observable, not silent. New regression test
+  (`test_pending_buffer_caps_and_drops_oldest`) confirms the cap and the
+  drop-oldest ordering.
+- **Fixed (simplification, real): duplicate `DriveEngine.update()` calls.**
+  The original fold/non-fold branches each called `self.drive_engine.update()`
+  with nearly-identical arguments (differing only in `tensions=`). Collapsed
+  to `tensions_to_apply = pending if should_fold else []` computed once, a
+  single `update()` call, branching only on the persist/clear/log side --
+  removes the duplication-drift risk the reviewer flagged. No behavior
+  change (165/165 still passing after the refactor).
+- **Fixed (cosmetic, cross-file trace): stale `_log_drive_pressure_probe`
+  docstring.** Claimed to log "right after every `save_drive_state`," but
+  post-O2 it's called on every event including non-fold ticks where
+  `save_drive_state` is not invoked. Docstring corrected to point readers at
+  the `drive_pressure_fold folded=` log line for that distinction, and to
+  flag that the original `AutonomyStateV2` comparison this probe was built
+  for is itself historical (V2 retired 2026-07-16, independent of this
+  patch).
+- **Checked and cleared: `goals.py` priority-scoring pressure lag.**
+  `GoalProposalEngine._priority` weights `drive_state.pressures.get(drive_origin)`
+  at 0.7 and a same-tick tension-magnitude term at 0.3. On non-fold ticks,
+  the 0.7-weighted pressure term is a decay-only projection that doesn't yet
+  reflect this tick's own new tension (buffered, not applied) -- up to 900s
+  of lag on that one term specifically. This is an accepted, documented
+  consequence of the fix (`dominant_drive` and the tension-weight term both
+  still react immediately every tick; only the persisted-pressure component
+  is throttled) -- not a bug, and not fixed, because "fold on every
+  goal-proposal-relevant tick" would defeat the entire point of this patch.
+  Documented directly in `_update_drive_pressures`'s docstring so it's not
+  lost.
+- **Checked and cleared: `scripts/drive_state_divergence_audit.py` /
+  `services/orion-hub/scripts/drives_analytics_queries.py` reading a
+  less-frequently-updated value.** The divergence-audit script's own
+  docstring already documents that its `AutonomyStateV2` comparison side is
+  "frozen/historical" (V2 retired 2026-07-16) -- it was already a
+  point-in-time snapshot against a static baseline, not a live trend tool,
+  so `DriveEngine`'s side updating at most every 900s doesn't introduce new
+  noise; if anything it makes back-to-back script reruns more stable, not
+  less. The Hub analytics panel showing a value that's honestly stale by up
+  to 900s (vs. a value that updates every event but is pinned near 1.0, the
+  actual pre-fix state) is a strict improvement, not a regression.
+- **Checked and cleared: in-memory-only buffer lost on worker restart.**
+  `_pending_drive_tensions` has no persistence -- a restart mid-fold-window
+  silently drops buffered-but-unfolded tensions (their pressure effect
+  vanishes for that window; the raw `TensionEventV1`s are still published to
+  the bus first, so the audit trail is intact). This is the identical
+  restart-loses-state risk profile every other in-memory per-subject buffer
+  in this same file already carries (`self.window`, `self.last_run`,
+  `self.recent_event_seen`) -- not a new class of fragility introduced by
+  this patch, and adding persistence for this one buffer while the others
+  stay in-memory would be an inconsistent, out-of-scope special case.
+- **Checked and cleared (verified via trace, not assumed): no
+  race/aliasing/mutable-default bugs.** `_update_drive_pressures` is a plain
+  sync method with no `await` inside it, so no interleaving is possible
+  between the two call sites even though they can share the same subject
+  (`"orion"`). The `fold_tensions = pending` / `self._pending_drive_tensions[subject]
+  = []` sequence rebinds the dict key to a *new* list object; the local
+  variable retains the old reference, already consumed by
+  `drive_engine.update()` before the reassignment -- no aliasing bug,
+  confirmed by the passing `test_third_call_after_interval_folds_all_buffered_tensions_together`.
+- **Checked and cleared: `previous_ts` tz-naive-guard asymmetry.** The old
+  `handle_envelope` inline block lacked the `tzinfo is None` guard that
+  `_handle_signal_drive_tick`'s inline block had; the new shared method now
+  applies the guard uniformly. Confirmed this is a strict improvement, not a
+  behavior change in practice -- `save_drive_state` always serializes from a
+  tz-aware `datetime.now(timezone.utc)`, so the guard was already dead code
+  on the `handle_envelope` path either way.
+- **Checked and cleared (altitude): right layer, right generality.**
+  `DriveEngine` is deliberately kept a pure, externally-stated function (no
+  internal clock, no subject-awareness) -- it's directly instantiated by
+  `orion/autonomy/evals/run_homeostatic_drives_eval.py` for deterministic
+  math testing, and pushing cadence state into it would contaminate that
+  determinism while duplicating the per-subject-dict pattern `ConceptWorker`
+  already owns. Confirmed `bus_worker.py` is the *only* production caller of
+  `DriveEngine.update()` in the repo, so a generic reusable "cadence-gated
+  integrator" primitive would be premature abstraction against a population
+  of one. Confirmed this fix is orthogonal to (not a second special case
+  stacked on) the earlier `leaky_math_enabled` fix -- that one fixed the
+  decay function's *shape* (removed the ~0.731 fixed point); this one fixes
+  *call frequency vs. tau*.
+- **Checked and cleared (reuse): no existing "buffer + fold" primitive
+  duplicated.** `TensionRateLimiter` is a sliding-window drop-over-cap
+  limiter (discards excess, never queues) -- a genuinely different contract
+  from accumulate-and-flush-later. `DeviationGate` has no cadence concept.
+  `endogenous_origination.py`'s `cooldown_sec` gate is structurally closest
+  but is suppress-and-discard, not accumulate-and-flush. No existing
+  primitive does what `_update_drive_pressures` needed; it's a legitimately
+  new, correctly-scoped mechanism.
+- **Checked and cleared (conventions): no CLAUDE.md violation.** Real test
+  coverage attached to the new mechanism (including an explicit regression
+  test for the saturation bug this patch fixes, per section 11's "every bug
+  fix ships with a regression test that would have caught the bug"), a
+  documented tunable constant rather than a bare magic number, no env/schema
+  surface touched, minimal thin-seam patch riding the existing
+  `DriveEngine.update()` call sites.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: LOW. Concern: `_DRIVE_FOLD_INTERVAL_SEC=900.0` is a first-pass
+  calibration with no live pressure-distribution data to validate against
+  (same honesty standard as every other threshold in this series). Interval
+  math worked out during design: `p* = impulse / (1 - decay*(1-impulse))`
+  with `decay = exp(-interval/1800)` -- at 900s, decay≈0.607, giving
+  p*≈0.63 for a representative ~0.4 folded impulse (right at the 0.62
+  activation threshold). Mitigation: plain module constant, trivially
+  tunable; post-deploy re-measurement against `drive_audits` (same command
+  used to verify O1/O3/O4) is the real check.
+- Severity: LOW. Concern: if the *folded* impulse itself gets clamped near
+  1.0 (many co-firing tensions summed within the 900s window before the
+  `_clamp_signed([-1,1])` ceiling in `DriveEngine.update()`), decay stops
+  mattering and pressure still approaches 1.0 regardless of interval choice.
+  Cannot be ruled out without live data on how many co-firing, same-drive
+  tensions typically land within one 900s window. Mitigation: same
+  post-deploy re-measurement; if this manifests, the next lever is the fold
+  interval itself, already isolated to one named constant.
+- Severity: LOW. Concern (documented, not fixed): goal-proposal priority
+  scoring's pressure term can lag a freshly-dominant drive by up to 900s.
+  Mitigation: `dominant_drive` and the tension-weight term react
+  immediately; only 70% of one scoring formula's inputs are throttled, and
+  that's the intended trade this whole patch makes.
+
+## PR link
+
+(filled after push)

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -72,6 +72,28 @@ from .wp_stream_consumer import WorldPulseStreamConsumer, utcnow
 
 logger = logging.getLogger("orion.spark.concept.worker")
 
+# O2 (event-rate/decay mismatch fix): DriveEngine.update() is called once per
+# raw bus event (~13/min), but decay_tau_sec=1800.0 means decay between
+# consecutive calls is negligible (~0.3%) -- repeated same-direction impulses
+# converge pressure toward 1.0 within seconds regardless of tau, reproducing
+# the cpu/gpu_pressure saturation bugs (PRs #1108-1111) from a different
+# mechanism. This throttles how often NEW impulses get folded into the
+# persisted integrator (see _update_drive_pressures) while every event still
+# gets a fresh decay-only projection for display/audit/goal-proposal. 900s is
+# a first-pass calibration (matches the SATURATED-verdict math worked out
+# during the O3 review), trivially tunable, deliberately not a new env key
+# (same convention as O3's/O4's own threshold constants).
+_DRIVE_FOLD_INTERVAL_SEC = 900.0
+
+# Cap on tensions buffered between folds, matching this repo's established
+# collection-cap convention (e.g. evidence_event_ids <= 200 in the pressure
+# reducer and execution merge). At real production rates this cap should
+# never be reached (900s of buffering, not unbounded time), but each
+# TensionEventV1 carries a full ArtifactProvenance -- bound it defensively
+# rather than trust the time window alone. Drops oldest-first on overflow
+# (same "keep most recent" convention as _prune_window's window trimming).
+_MAX_PENDING_DRIVE_TENSIONS = 500
+
 
 @dataclass
 class ConceptInductionTrigger:
@@ -187,6 +209,12 @@ class ConceptWorker:
             service_ref=service_ref,
         )
         self.window: Dict[str, List[WindowEvent]] = {s: [] for s in cfg.subjects}
+        # O2 drive-pressure fold buffers. Plain {} (not pre-keyed by cfg.subjects
+        # like self.window): the homeostatic rail's subject is always the
+        # hardcoded string "orion", which may or may not be pre-listed in
+        # cfg.subjects, so _update_drive_pressures uses .setdefault()/.get().
+        self._pending_drive_tensions: Dict[str, List[TensionEventV1]] = {}
+        self._last_drive_fold_at: Dict[str, datetime] = {}
         self.inflight_subjects: Set[str] = set()
         self.recent_event_seen: Dict[str, datetime] = {}
         self.trigger_decisions: List[dict] = []
@@ -609,13 +637,16 @@ class ConceptWorker:
         return True
 
     def _log_drive_pressure_probe(self, subject: str, pressures: dict) -> None:
-        """Measurement-only (Phase 4, 2026-07-12): log `DriveEngine`'s pressure
-        vector right after every `save_drive_state` so it can be compared
-        offline against `AutonomyStateV2`'s independently-computed pressures
-        (logged from `chat_stance._run_autonomy_reducer`) by grepping both
-        services' logs and correlating on `subject` + nearby timestamp. Never
-        raises: a logging failure here must not break the drive-update rail,
-        which runs on live bus traffic.
+        """Measurement-only (Phase 4, 2026-07-12; historical -- the original
+        AutonomyStateV2 comparison this was built for was retired 2026-07-16).
+        Logs `DriveEngine`'s pressure vector on every event, called from
+        `_update_drive_pressures`'s caller regardless of whether that call
+        actually folded (persisted) or just returned a decay-only projection
+        (see `_DRIVE_FOLD_INTERVAL_SEC`, O2) -- do not assume every logged
+        line here corresponds to a `save_drive_state` write; check the
+        `drive_pressure_fold folded=` log line from the same call for that.
+        Never raises: a logging failure here must not break the drive-update
+        rail, which runs on live bus traffic.
         """
         try:
             logger.info(
@@ -771,6 +802,76 @@ class ConceptWorker:
         except Exception:
             return None
 
+    def _update_drive_pressures(
+        self, subject: str, tensions: List[TensionEventV1], now: datetime,
+    ) -> tuple[Dict[str, float], Dict[str, bool], bool]:
+        """O2: apply new tension impulses to the persisted drive-pressure
+        integrator at most once per _DRIVE_FOLD_INTERVAL_SEC, folding everything
+        buffered since the last fold in one DriveEngine.update() call. Every
+        call still returns a live pressure/activation snapshot (a decay-only
+        projection on non-fold ticks, tensions=[] so no impulse is applied) so
+        every caller (goal proposal, dossier, identity snapshot, publish) keeps
+        getting a fresh drive_state every event -- only the WRITE side is
+        throttled, not the READ side. Returns (pressures, activations, folded).
+
+        Note: the pressure component of goal-proposal priority scoring
+        (GoalProposalEngine._priority) can lag up to _DRIVE_FOLD_INTERVAL_SEC
+        behind a freshly-dominant drive's own tick -- accepted, documented
+        consequence of this fix (dominant_drive/tension_weight still react
+        immediately; only the persisted pressure integrator is throttled),
+        not a bug."""
+        prior = self.store.load_drive_state(subject)
+        previous_ts: Optional[datetime] = None
+        if isinstance(prior.get("updated_at"), str):
+            try:
+                previous_ts = datetime.fromisoformat(prior["updated_at"])
+                if previous_ts.tzinfo is None:
+                    previous_ts = previous_ts.replace(tzinfo=timezone.utc)
+            except ValueError:
+                previous_ts = None
+
+        pending = self._pending_drive_tensions.setdefault(subject, [])
+        pending.extend(tensions)
+        if len(pending) > _MAX_PENDING_DRIVE_TENSIONS:
+            dropped = len(pending) - _MAX_PENDING_DRIVE_TENSIONS
+            del pending[:dropped]
+            logger.warning(
+                "drive_pressure_fold_buffer_overflow subject=%s dropped=%d cap=%d",
+                subject, dropped, _MAX_PENDING_DRIVE_TENSIONS,
+            )
+
+        last_fold_at = self._last_drive_fold_at.get(subject)
+        should_fold = (
+            last_fold_at is None
+            or (now - last_fold_at).total_seconds() >= _DRIVE_FOLD_INTERVAL_SEC
+        )
+        tensions_to_apply = pending if should_fold else []
+
+        pressures, activations = self.drive_engine.update(
+            previous_pressures=prior.get("pressures"),
+            previous_activations=prior.get("activations"),
+            tensions=tensions_to_apply,
+            now=now,
+            previous_ts=previous_ts,
+        )
+
+        if should_fold:
+            self.store.save_drive_state(
+                subject, pressures=pressures, activations=activations, updated_at=now
+            )
+            self._pending_drive_tensions[subject] = []
+            self._last_drive_fold_at[subject] = now
+            logger.info(
+                "drive_pressure_fold subject=%s folded=True tensions_folded=%d",
+                subject, len(tensions_to_apply),
+            )
+        else:
+            logger.info(
+                "drive_pressure_fold subject=%s folded=False pending_buffered=%d",
+                subject, len(pending),
+            )
+        return pressures, activations, should_fold
+
     async def _handle_signal_drive_tick(
         self, env: BaseEnvelope, intake_channel: str, source: str
     ) -> None:
@@ -818,26 +919,7 @@ class ConceptWorker:
             for tension in tensions:
                 await self._publish_tension_event(tension, env.correlation_id)
 
-            prior = self.store.load_drive_state(subject)
-            previous_ts: Optional[datetime] = None
-            if isinstance(prior.get("updated_at"), str):
-                try:
-                    previous_ts = datetime.fromisoformat(prior["updated_at"])
-                    if previous_ts.tzinfo is None:
-                        previous_ts = previous_ts.replace(tzinfo=timezone.utc)
-                except ValueError:
-                    previous_ts = None
-
-            pressures, activations = self.drive_engine.update(
-                previous_pressures=prior.get("pressures"),
-                previous_activations=prior.get("activations"),
-                tensions=tensions,
-                now=now,
-                previous_ts=previous_ts,
-            )
-            self.store.save_drive_state(
-                subject, pressures=pressures, activations=activations, updated_at=now
-            )
+            pressures, activations, _folded = self._update_drive_pressures(subject, tensions, now)
             self._log_drive_pressure_probe(subject, pressures)
 
             trace_id = extract_trace_id(env)
@@ -956,22 +1038,8 @@ class ConceptWorker:
 
         all_spark_tensions = spark_tensions + metabolism_tensions
 
-        prior_drive_state = self.store.load_drive_state(subject)
-        previous_ts = None
-        if isinstance(prior_drive_state.get("updated_at"), str):
-            try:
-                previous_ts = datetime.fromisoformat(prior_drive_state["updated_at"])
-            except ValueError:
-                previous_ts = None
         now = datetime.now(timezone.utc)
-        pressures, activations = self.drive_engine.update(
-            previous_pressures=prior_drive_state.get("pressures"),
-            previous_activations=prior_drive_state.get("activations"),
-            tensions=all_spark_tensions,
-            now=now,
-            previous_ts=previous_ts,
-        )
-        self.store.save_drive_state(subject, pressures=pressures, activations=activations, updated_at=now)
+        pressures, activations, _folded = self._update_drive_pressures(subject, all_spark_tensions, now)
         self._log_drive_pressure_probe(subject, pressures)
 
         pressure_tensions = derive_pressure_competition_tensions(

--- a/orion/spark/concept_induction/tests/test_drive_pressure_fold.py
+++ b/orion/spark/concept_induction/tests/test_drive_pressure_fold.py
@@ -1,0 +1,195 @@
+"""O2 (event-rate/decay mismatch fix): DriveEngine.update() is called once per
+raw bus event (~13/min, ~4.6s apart), but decay_tau_sec=1800.0 means decay
+between consecutive calls is negligible (~0.3%) -- repeated same-direction
+impulses converge pressure toward 1.0 within seconds regardless of tau,
+reproducing the cpu/gpu_pressure saturation bugs (PRs #1108-1111) from a
+different mechanism (see docs/superpowers/pr-reports/2026-07-16-drive-economy-
+desaturation-o1-o4-pr.md and orion/autonomy/drives_and_autonomy_retrospective.md
+Section 5a).
+
+These tests exercise ConceptWorker._update_drive_pressures directly: the new
+seam that throttles how often NEW tension impulses get folded into the
+persisted drive-pressure integrator (at most once per _DRIVE_FOLD_INTERVAL_SEC
+== 900.0s) while every event still gets a fresh decay-only projection for
+display/audit/goal-proposal.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from orion.core.schemas.drives import TensionEventV1
+from orion.spark.concept_induction.bus_worker import (
+    _MAX_PENDING_DRIVE_TENSIONS,
+    ConceptWorker,
+)
+from orion.spark.concept_induction.drives import DriveEngine, DriveMathConfig
+from orion.spark.concept_induction.settings import ConceptSettings
+
+NOW = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _tension(drive: str, magnitude: float, *, artifact_id: str = "t-test") -> TensionEventV1:
+    return TensionEventV1(
+        artifact_id=artifact_id,
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        kind="tension.test.v1",
+        magnitude=magnitude,
+        drive_impacts={drive: 1.0},
+        provenance={"intake_channel": "test:drive-fold"},
+    )
+
+
+def _worker(tmp_path) -> ConceptWorker:
+    return ConceptWorker(
+        ConceptSettings(orion_bus_enabled=False, store_path=str(tmp_path / "state.json"))
+    )
+
+
+def test_first_ever_call_always_folds(tmp_path) -> None:
+    """No prior fold timestamp recorded for the subject -- there's nothing to
+    wait for, so the very first tick always folds and persists."""
+    worker = _worker(tmp_path)
+    tension = _tension("coherence", magnitude=0.5)
+
+    pressures, activations, folded = worker._update_drive_pressures("orion", [tension], NOW)
+
+    assert folded is True
+    # The impulse was actually applied, not just decay from a zero baseline.
+    assert pressures["coherence"] > 0.0
+
+    persisted = worker.store.load_drive_state("orion")
+    assert persisted.get("updated_at") == NOW.isoformat()
+    assert persisted.get("pressures", {}).get("coherence") == pressures["coherence"]
+
+
+def test_second_call_within_fold_interval_does_not_fold_or_persist(tmp_path) -> None:
+    """A second call arriving well within _DRIVE_FOLD_INTERVAL_SEC (900s) of the
+    first fold must NOT apply its tension to the persisted integrator, and must
+    NOT touch the store -- it only returns a decay-only projection."""
+    worker = _worker(tmp_path)
+    tension1 = _tension("coherence", magnitude=0.5, artifact_id="t-1")
+    worker._update_drive_pressures("orion", [tension1], NOW)
+    persisted_after_call1 = worker.store.load_drive_state("orion")
+
+    now2 = NOW + timedelta(seconds=60)
+    tension2 = _tension("coherence", magnitude=0.9, artifact_id="t-2")
+    pressures2, activations2, folded2 = worker._update_drive_pressures("orion", [tension2], now2)
+
+    assert folded2 is False
+
+    # Expected: pure wall-clock decay of call 1's persisted pressure, computed
+    # independently via a fresh DriveEngine with tensions=[] (no impulse) --
+    # NOT influenced by tension2 at all, since it was buffered, not applied.
+    expected_engine = DriveEngine(DriveMathConfig())
+    expected_pressures, expected_activations = expected_engine.update(
+        previous_pressures=persisted_after_call1["pressures"],
+        previous_activations=persisted_after_call1["activations"],
+        tensions=[],
+        now=now2,
+        previous_ts=NOW,
+    )
+    assert pressures2 == expected_pressures
+    assert activations2 == expected_activations
+
+    # The store must be untouched by call 2 -- still shows call 1's timestamp.
+    persisted_after_call2 = worker.store.load_drive_state("orion")
+    assert persisted_after_call2.get("updated_at") == NOW.isoformat()
+    assert persisted_after_call2 == persisted_after_call1
+
+
+def test_third_call_after_interval_folds_all_buffered_tensions_together(tmp_path) -> None:
+    """Once _DRIVE_FOLD_INTERVAL_SEC has elapsed since the last fold, the next
+    call folds EVERYTHING buffered since then (the skipped call 2's tension
+    plus this call's own new tension) into a single DriveEngine.update() --
+    not two separate applications."""
+    worker = _worker(tmp_path)
+    tension1 = _tension("coherence", magnitude=0.5, artifact_id="t-1")
+    worker._update_drive_pressures("orion", [tension1], NOW)
+    persisted_after_call1 = worker.store.load_drive_state("orion")
+
+    now2 = NOW + timedelta(seconds=60)
+    tension2 = _tension("coherence", magnitude=0.9, artifact_id="t-2")
+    worker._update_drive_pressures("orion", [tension2], now2)  # buffered, not folded
+
+    now3 = NOW + timedelta(seconds=901)  # past the 900s interval from the call-1 fold
+    tension3 = _tension("coherence", magnitude=0.3, artifact_id="t-3")
+    pressures3, activations3, folded3 = worker._update_drive_pressures("orion", [tension3], now3)
+
+    assert folded3 is True
+
+    # Expected: one single DriveEngine.update() call starting from call 1's
+    # persisted state, applying BOTH tension2 and tension3 together.
+    expected_engine = DriveEngine(DriveMathConfig())
+    expected_pressures, expected_activations = expected_engine.update(
+        previous_pressures=persisted_after_call1["pressures"],
+        previous_activations=persisted_after_call1["activations"],
+        tensions=[tension2, tension3],
+        now=now3,
+        previous_ts=NOW,
+    )
+    assert pressures3 == expected_pressures
+    assert activations3 == expected_activations
+
+    persisted_after_call3 = worker.store.load_drive_state("orion")
+    assert persisted_after_call3.get("updated_at") == now3.isoformat()
+
+
+def test_saturation_prevention_regression(tmp_path) -> None:
+    """The actual point of O2: this is the test that would have caught the
+    original per-event saturation problem. OLD (unthrottled) behavior for a
+    repeated impulse of this exact shape (drive_impacts={"predictive": 1.0},
+    magnitude=0.5, applied on every single DriveEngine.update() call) pins
+    pressure above 0.95 within ~5 ticks / ~23 seconds (verified during the O3
+    review). NEW (fold-gated) behavior must NOT do that.
+
+    This simulates the STEADY-STATE bus cadence (~13 events/min, ~4.6s apart)
+    that follows an already-recent fold, by seeding _last_drive_fold_at
+    directly rather than letting the loop's own first call trigger a
+    cold-start fold (that cold-start path is exercised separately by
+    test_first_ever_call_always_folds above) -- none of these 30 calls should
+    cross the 900s fold boundary, so every one of them must be a pure
+    decay-only projection with no impulse applied.
+    """
+    worker = _worker(tmp_path)
+    worker._last_drive_fold_at["orion"] = NOW - timedelta(seconds=1)
+
+    now = NOW
+    pressures: dict = {}
+    for _ in range(30):
+        tension = _tension("predictive", magnitude=0.5)
+        pressures, _activations, folded = worker._update_drive_pressures("orion", [tension], now)
+        assert folded is False  # steady-state: none of these 30 calls cross 900s
+        now = now + timedelta(seconds=4.6)
+
+    # ~138.6s of ~4.6s-cadence impulses, none folded -> pressure stays at the
+    # decayed baseline (0, since nothing has ever been folded in) instead of
+    # climbing toward 1.0 the way the old unthrottled per-event call would.
+    assert pressures["predictive"] < 0.1
+
+
+def test_pending_buffer_caps_and_drops_oldest(tmp_path) -> None:
+    """Review finding: the pending buffer had no size cap, only a time-based
+    fold gate -- a subject that never crosses a fold boundary could buffer an
+    unbounded number of tensions (each carrying a full ArtifactProvenance).
+    _MAX_PENDING_DRIVE_TENSIONS bounds it, dropping the oldest entries first
+    (same "keep most recent" convention as _prune_window)."""
+    worker = _worker(tmp_path)
+    # Seed a recent fold so none of the following calls cross the 900s gate.
+    worker._last_drive_fold_at["orion"] = NOW
+
+    overflow_count = _MAX_PENDING_DRIVE_TENSIONS + 10
+    for i in range(overflow_count):
+        tension = _tension("coherence", magnitude=0.1, artifact_id=f"t-{i}")
+        _, _, folded = worker._update_drive_pressures(
+            "orion", [tension], NOW + timedelta(seconds=i)
+        )
+        assert folded is False
+
+    pending = worker._pending_drive_tensions["orion"]
+    assert len(pending) == _MAX_PENDING_DRIVE_TENSIONS
+    # Oldest entries (t-0 .. t-9) were dropped; the most recent survive.
+    kept_ids = {t.artifact_id for t in pending}
+    assert "t-0" not in kept_ids
+    assert f"t-{overflow_count - 1}" in kept_ids


### PR DESCRIPTION
## Summary

- `DriveEngine.update()` was called once per raw bus event (~13/min, ~4.6s apart), but `decay_tau_sec=1800.0` means decay between consecutive calls is negligible (~0.3%) -- repeated same-direction impulses converge pressure toward 1.0 within seconds regardless of tau. This is the event-rate/decay mismatch behind the cpu/gpu_pressure saturation bugs (PRs #1108-1111), and the last unfixed half of the drive-economy desaturation diagnosis (O1/O3/O4 already merged, see #1114 and `docs/superpowers/pr-reports/2026-07-16-drive-economy-desaturation-o1-o4-pr.md`).
- New `ConceptWorker._update_drive_pressures()` splits read from write: every bus event still gets a fresh drive-pressure snapshot (decay-only projection on non-fold ticks -- goal proposal, dossier, identity snapshot, and publish all keep getting a live `drive_state` every event, unchanged from before), but new tension impulses are buffered per-subject in memory and only actually folded into the persisted integrator at most once per 900 seconds.
- `DriveEngine` itself is completely untouched -- this is purely a call-cadence fix in the stateful caller (`bus_worker.py`), not a change to the integrator math. Every tension is still individually published to the bus on every event, unchanged; only whether it gets folded into persisted pressure is throttled.

## Outcome moved

Closes the drive-economy desaturation diagnosis started 2026-07-15/16. Expect `measure_autonomy_gate.py`'s SATURATED verdict to clear for honest reasons post-deploy, and `drive_audits` to show real, differentiated per-drive variance instead of pinned-near-1.0 pressures.

## Files changed

- `orion/spark/concept_induction/bus_worker.py`: new `_DRIVE_FOLD_INTERVAL_SEC=900.0` / `_MAX_PENDING_DRIVE_TENSIONS=500` constants, new `_pending_drive_tensions`/`_last_drive_fold_at` per-subject state, new `_update_drive_pressures()` method, both existing call sites refactored to use it.
- `orion/spark/concept_induction/tests/test_drive_pressure_fold.py`: new file, 5 tests -- cold-start always folds, in-interval call neither folds nor persists, post-interval call folds everything buffered together, a 30-tick steady-state saturation-prevention regression test, and a buffer-overflow-caps-and-drops-oldest test.

## Tests run

```
165 passed, 20 warnings in 12.57s
```

## Review findings fixed

Full 8-angle \`/code-review medium\` pass. Fixed: an unbounded pending-tension buffer (capped at 500, drop-oldest, matching this repo's established \`evidence_event_ids<=200\` convention) and a duplicate \`DriveEngine.update()\` call (collapsed to one). Traced and confirmed as accepted, documented, non-bug consequences of the design: goal-proposal priority-scoring lag (up to 900s on one 0.7-weighted term), divergence-audit-script staleness (its AutonomyStateV2 comparison side is already frozen/historical, so this doesn't add new noise), and in-memory-buffer-loss-on-restart (same risk profile every other per-subject buffer in this file already has). Full writeup: \`docs/superpowers/pr-reports/2026-07-17-drive-cadence-fold-o2-pr.md\`.

## Restart required

\`\`\`bash
docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
\`\`\`

## Risks / concerns

- LOW: 900s fold interval is a first-pass calibration (math worked out in the PR report), needs post-deploy re-measurement against live `drive_audits`.
- LOW: if a folded impulse itself clamps near 1.0 (many co-firing same-drive tensions within one 900s window), decay stops mattering regardless of interval -- can't rule out without live data.