### PR TITLE
feat(hub): Drives Analytics operator UI (PR3 — standalone page + shell tab)

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-17-hub-drives-analytics-ui-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-hub-drives-analytics-ui-pr.md
@@ -1,0 +1,109 @@
+# Hub Drives Analytics — operator UI (PR3)
+
+**Date:** 2026-07-17
+**Branch:** `feat/hub-drives-analytics-ui`
+**PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/1127
+**Plan:** `docs/superpowers/plans/2026-07-16-hub-drives-analytics.md` (Tasks 5-9)
+**Spec:** `docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md`
+
+## Summary
+
+- Ships the Hub **Drives** operator tab: a standalone `/drives-analytics` page (7 cards — gauges, contributors, KPI strip, dual time series, divergence, goals, cross-links) with goal-aligned coloring, tooltips, and gentle 30s polling.
+- Wires a session-preserving `#drives` tab into the Hub shell (`index.html` + `app.js`), mirroring the Causal Geometry iframe-isolation pattern exactly — toggling the tab never reloads the Hub chat session.
+- Adds a `GET /drives-analytics` page route in `api_routes.py`.
+- Documents the surface in `orion/autonomy/README.md`, `services/orion-hub/README.md`, and `services/orion-spark-concept-induction/README.md`.
+- Fixes two issues found in orchestrator code review: a refresh race condition and duplicated align-color lookup logic.
+
+PR 1 (persistence: `tick_attribution`/`tension_kinds` columns) and PR 2 (read-only API: subjects/snapshot/window/series/goal-alignment/divergence) were already merged and live on `main` (PRs #1123, #1124) before this work started.
+
+## Outcome moved
+
+Juniper can now see the live six-drive `DriveEngine` economy at a glance in the Hub — real contributor history, program-health KPIs, tick-rate + pressure time series, goal-alignment coloring, and a divergence/integrity check against `drive_state.v1` — without CLI archaeology (`measure_autonomy_gate.py`, `drive_state_divergence_audit.py`) or per-turn chat side panels.
+
+## Orchestration approach
+
+Two independent background agents ran in parallel in one worktree (`/mnt/scripts/Orion-Sapienform-hub-drives-analytics-ui`, branch `feat/hub-drives-analytics-ui`), scoped to disjoint file sets:
+
+1. **Frontend agent** — built the standalone page (Tasks 5-7 of the plan): `templates/drives-analytics.html`, `static/js/drives-analytics.js`, the `GET /drives-analytics` route, and `tests/test_drives_analytics_page.py`. Ran its own internal code-review pass and fixed 2 findings before returning.
+2. **README agent** — wrote the three README sections (Task 9), reading the real backend source (`drives_analytics.py`, `drives_analytics_queries.py`, `drive_audit.py`, concept-induction's `audit.py`/`drive_attribution.py`) so the docs describe what actually exists.
+
+Both completed cleanly with no file collisions. The orchestrator then did the Hub shell tab wiring (Task 8: `index.html` + `app.js`) directly — a small, mechanical, exactly-specified change not worth a third agent dispatch — appending 6 shell-wiring tests to the frontend agent's test file.
+
+## Current architecture
+
+Before this PR: `drive_audits` persistence and the 6 read-only `/api/drives-analytics/*` endpoints existed, but no UI consumed them — the data was invisible to operators.
+
+## Architecture touched
+
+`services/orion-hub/` only (templates, static JS, one new route, tests, README). No bus/schema/registry changes. No backend/API changes (already merged in prior PRs).
+
+## Files changed
+
+- `services/orion-hub/templates/drives-analytics.html` (new): standalone page shell, 7 card containers, controls row, tooltip popover.
+- `services/orion-hub/static/js/drives-analytics.js` (new, ~890 lines): fetch/render/polling bundle for all 7 cards, `TOOLTIP_COPY`, color-mode logic (`combined`/`align`/`funnel`), Live/Window contributors toggle, URL-query state sync.
+- `services/orion-hub/scripts/api_routes.py`: added `GET /drives-analytics` page route (mirrors `causal_geometry_page` exactly).
+- `services/orion-hub/templates/index.html`: `#drives` nav tab + iframe panel section.
+- `services/orion-hub/static/js/app.js`: tab-switch/hash/refresh wiring for `#drives`, mirroring every existing tab's pattern.
+- `services/orion-hub/tests/test_drives_analytics_page.py` (new): 21 tests — route registration, template/card ids, standalone-bundle isolation, tooltip structure, polling, color-mode/window-picker presence, no-mutation-calls, goals-card no-action-buttons, gate-verdict labeling, cross-link content, divergence banner, and 6 shell-wiring tests (session-preserving tab toggle, iframe-only refresh, no full-page navigation).
+- `orion/autonomy/README.md`, `services/orion-hub/README.md`, `services/orion-spark-concept-induction/README.md`: operator-facing docs.
+
+## Schema / bus / API changes
+
+None. This PR only builds a UI on top of the already-merged read-only API.
+
+## Env/config changes
+
+None. No `.env_example` keys added/removed/renamed.
+
+## Tests run
+
+```
+cd services/orion-hub
+python -m pytest tests/test_drives_analytics_page.py tests/test_drives_analytics_api.py tests/test_drives_analytics_helpers.py tests/test_causal_geometry_page.py tests/test_causal_geometry_api.py -q
+→ 75 passed
+
+python -m pytest ../orion-sql-writer/tests/test_drive_audit_sql_shape.py -q
+→ 16 passed
+
+node --check static/js/drives-analytics.js && node --check static/js/app.js
+→ syntax OK
+
+git diff --check
+→ clean
+```
+
+No eval harness exists for this UI-only slice beyond the pytest gate tests above.
+
+## Docker/build/smoke checks
+
+Not run — this patch only adds new frontend files (templates/static/route), no config/dependency/DB changes. A Hub container rebuild is needed to pick up the new static/template files before operators can use the tab (see Restart below).
+
+## Review findings fixed
+
+8-angle high-effort code review (parallel finder agents + orchestrator verification against the already-merged backend contract):
+
+- **Finding (real, fixed):** `refreshAll()`/`fetchAll()` had no request-sequencing guard — an overlapping poll tick and a control-driven refresh (subject/window change) could resolve out of order, silently rendering stale-selection data while the URL/selects already showed the new selection.
+  - Fix: added a monotonic `refreshToken`; any response superseded by a newer refresh is dropped instead of overwriting `payloads`.
+  - Evidence: `services/orion-hub/static/js/drives-analytics.js`, `refreshAll()`.
+- **Finding (real, fixed):** `gaugeColorClass` and `goalBorderClass` each independently re-implemented the same per-drive `color_align` lookup, with inconsistent Tailwind shade numbers (500 vs 700) — drift risk.
+  - Fix: extracted `alignColorForKey()` as the single source of truth for both call sites; also dropped `gaugeColorClass`'s unused `kpis` destructured parameter.
+  - Evidence: `services/orion-hub/static/js/drives-analytics.js`, `alignColorForKey`, `gaugeColorClass`, `goalBorderClass`.
+- **4 findings verified as unreachable:** candidates about missing null-guards on `record_count`/`active_count`/timestamp fields were checked against the already-merged backend (`services/orion-hub/scripts/drives_analytics_queries.py`) — every field is guaranteed non-null/well-formed (`int(x or 0)` casts, `isoformat()` of real `datetime` objects) on every code path, so no fix was needed.
+- **3 findings noted as follow-ups, not fixed:** `fetchSection()` duplication across standalone Hub pages, `DRIVE_KEYS`/`ALLOWED_HOURS`/verdict-string hardcoding in JS (no shared JS/backend contract mechanism exists yet), and refetching the static `/subjects` endpoint on every poll tick — all pre-existing repo patterns or low-impact at operator-dashboard/30s-cadence scale.
+
+## Restart required
+
+```bash
+scripts/safe_docker_build.sh orion-hub up -d --build
+```
+
+sql-writer and its migration are unaffected by this PR (already deployed in PR1/PR2).
+
+## Risks / concerns
+
+- Severity: Low — Sparklines/tick-rate chart are hand-rolled SVG polylines, not a charting library; adequate but visually blunt.
+- Severity: Low — `DRIVE_KEYS`/`ALLOWED_HOURS`/verdict strings are hardcoded in the client JS with no shared contract to the Python source of truth; a future backend change to these constants would silently desync the UI. Mitigation: same pattern as every other standalone Hub page; fixing it repo-wide is out of scope for this PR.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1127

--- a/orion/autonomy/README.md
+++ b/orion/autonomy/README.md
@@ -3,6 +3,41 @@
 Why any of this exists, the founding theory, and the biggest unresolved gap (self-initiation
 was never built): [drives_and_autonomy_retrospective.md](drives_and_autonomy_retrospective.md)
 
+## Hub Drives Analytics
+
+Design: [docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md](../../docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md).
+
+**Why this surface exists.** The six-drive `DriveEngine` economy (`orion/spark/concept_induction/drives.py`,
+`DRIVE_KEYS = ("coherence", "continuity", "capability", "relational", "predictive", "autonomy")`) has run
+live for a while — per-tick audits, `tick_attribution`/`tension_kinds` on the wire, Postgres history, offline
+gate scripts — but until this patch, seeing any of it meant CLI archaeology
+(`scripts/analysis/measure_autonomy_gate.py`, `scripts/drive_state_divergence_audit.py`) or a per-turn chat
+side panel. The Hub **Drives** tab (`#drives`, standalone page `/drives-analytics`) is an orientation and
+observability surface: gauges for current pressure per drive, real contributor history pulled from
+`tick_attribution` (not invented), a program-health KPI strip, dual time series (tick-rate + six pressure
+sparklines), goal-alignment coloring, and a divergence/integrity check against the `drive_state.v1` concept
+store. It **does not mutate** drives, tensions, or goals — there is no promote/dismiss/complete/adjust control
+anywhere on this tab, by design (see the spec's non-goals).
+
+**What "good" looks like on this tab.** Healthy is *churn* — pressures rising and falling across the six
+drives as tensions resolve — combined with goals actually forming out of elevated pressure (a drive's
+pressure is high **and** an active goal's `drive_origin` matches it: goal-aligned "green" in `align`/`combined`
+color mode). It is explicitly **not** "all six pressures pinned high." Six-way saturation/monoculture is a
+regime the tab colors **red**, the same as a stale audit rail or a starved drive — high magnitude alone never
+reads as healthy. `build_window_kpis`/`drive_economy_verdict_from_drive_stats`
+(`services/orion-hub/scripts/drives_analytics.py`) reuse the saturation/coactivation thresholds from
+`scripts/analysis/measure_autonomy_gate.py` so the Hub strip's `gate_verdict_drive_only` agrees with the
+offline gate's math; it can report `GO_DRIVE_ONLY` (drive-rail coactivation cleared, not saturated) but never
+claims a full offline-gate `GO`, since that also requires `resource_pressure`, which this drive-only endpoint
+does not have.
+
+**Where to look next.**
+
+- Full origin story and the still-open self-initiation gap: [drives_and_autonomy_retrospective.md](drives_and_autonomy_retrospective.md)
+- Operator tab mechanics (iframe isolation, endpoints, hash params, restart order): [services/orion-hub/README.md](../../services/orion-hub/README.md)
+- The tab itself: Hub shell hash `#drives`, standalone page `/drives-analytics`
+- Deeper offline measurement (GO/NO-GO/SATURATED/UNMEASURABLE including `resource_pressure`): `scripts/analysis/measure_autonomy_gate.py`
+
 ## Subject routing
 
 Autonomy goals and drives are keyed by subject (`orion`, `relationship`, `juniper`). Dyadic chat materializes to **relationship**, not juniper — see the routing contract:

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -337,6 +337,70 @@ section degrades to `null` independently (missing table, unset
   endogenous candidates (`HUB_AGENT_CURIOSITY_HINT_ENABLED`, default off;
   advisory only, structural gate, no keyword classification).
 
+### 5.4 Drives Analytics panel (`Drives` tab)
+
+**What it is:** an operator orientation view onto the six-drive `DriveEngine` economy
+(`DRIVE_KEYS = coherence, continuity, capability, relational, predictive, autonomy` from
+`orion.spark.concept_induction.drives`) — gauges, real contributor history, a program-health KPI
+strip, dual time series, goal-alignment coloring, and a divergence/integrity check. Strictly
+read-only: no endpoint under `/api/drives-analytics/*` mounts a mutating method.
+
+**What it is NOT:** it is not the **Pressure Analytics** tab (`#pressure`). Pressure Analytics
+tracks substrate mutation pressure — a completely different signal from the `DriveEngine`
+pressures shown here. Do not conflate the two when triaging an operator report; check which tab
+they actually mean.
+
+**Isolation pattern:** same session-preserving iframe pattern as Causal Geometry. The standalone
+page `/drives-analytics` (`templates/drives-analytics.html` + dedicated
+`static/js/drives-analytics.js`, which never references `window.OrionHub`) is embedded via
+`<iframe id="drivesAnalyticsPanelFrame">` in the Hub shell tab `#drives`. Toggling the `Drives` tab
+button only shows/hides that section and updates the shell hash — it never reloads the Hub chat
+session. The tab's refresh control reloads only `drivesAnalyticsPanelFrame.contentWindow`, not the
+Hub shell.
+
+**Endpoints (all read-only, all degrade instead of 500):**
+
+- `GET /api/drives-analytics/subjects`
+- `GET /api/drives-analytics/snapshot?subject=`
+- `GET /api/drives-analytics/window?subject=&hours=`
+- `GET /api/drives-analytics/series?subject=&hours=`
+- `GET /api/drives-analytics/goal-alignment?subject=`
+- `GET /api/drives-analytics/divergence?subject=`
+
+**Hash/query params** (standalone page and Hub tab both read these; default shown):
+
+| Param | Values | Default |
+|---|---|---|
+| `window` | `1`, `6`, `24`, `168` (hours) | `24` |
+| `subject` | allowlist (`orion`, `relationship`, `juniper`) ∪ discovered DB subjects | `orion` |
+| `color` | `combined`, `align`, `funnel` | `combined` |
+
+**Data dependency:** reads Postgres `drive_audits` via the same `RECALL_PG_DSN`-backed
+`app.state.memory_pg_pool` asyncpg pool used by Causal Geometry and the Memory tab (set up in
+`scripts/main.py`, `apply_*_schema` calls at startup). If the pool is unavailable, or the table is
+undefined, every endpoint above returns `{"degraded": true, "error": ..., "source": {...}}` rather
+than a 500.
+
+`tick_attribution` and `tension_kinds` are JSONB columns added to `drive_audits` by
+`services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql` (also applied as boot
+DDL by `orion-sql-writer`). They are **only populated for audits written after that migration** —
+there is no backfill. Rows written before the migration show as an explicit coverage note (attributed
+vs. null row counts, `retention_note` from `coverage_meta`) in the Contributors card and the
+`window` endpoint's `attribution` payload — never as a fake zero.
+
+**Restart required after deploy:** sql-writer must restart first so new `drive_audits` rows actually
+carry the new columns, then Hub so the new routes/UI load:
+
+```bash
+scripts/safe_docker_build.sh orion-sql-writer up -d --build
+scripts/safe_docker_build.sh orion-hub up -d --build
+```
+
+See also: [orion/autonomy/README.md § Hub Drives Analytics](../../orion/autonomy/README.md#hub-drives-analytics)
+for what the surface means to an operator, and
+[docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md](../../docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md)
+for the full design.
+
 ---
 
 ## 🚀 Running Hub

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -4980,6 +4980,23 @@ async def causal_geometry_page() -> HTMLResponse:
     )
 
 
+@router.get("/drives-analytics")
+async def drives_analytics_page() -> HTMLResponse:
+    from .main import TEMPLATES_DIR, build_hub_ui_asset_version
+
+    template = (TEMPLATES_DIR / "drives-analytics.html").read_text(encoding="utf-8")
+    rendered = template.replace("{{HUB_UI_ASSET_VERSION}}", build_hub_ui_asset_version())
+    return HTMLResponse(
+        content=rendered,
+        status_code=200,
+        headers={
+            "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
+    )
+
+
 @router.get("/substrate-atlas")
 async def substrate_atlas_page() -> HTMLResponse:
     from app.settings import get_settings

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -624,6 +624,10 @@ document.addEventListener("DOMContentLoaded", () => {
   const causalGeometryPanel = document.getElementById("causal-geometry");
   const causalGeometryPanelFrame = document.getElementById("causalGeometryPanelFrame");
   const causalGeometryPanelRefresh = document.getElementById("causalGeometryPanelRefresh");
+  const drivesAnalyticsTabButton = document.getElementById("drivesAnalyticsTabButton");
+  const drivesAnalyticsPanel = document.getElementById("drives");
+  const drivesAnalyticsPanelFrame = document.getElementById("drivesAnalyticsPanelFrame");
+  const drivesAnalyticsPanelRefresh = document.getElementById("drivesAnalyticsPanelRefresh");
   const conceptAtlasTabButton = document.getElementById("conceptAtlasTabButton");
   const conceptAtlasPanel = document.getElementById("concept-atlas");
   const conceptAtlasPanelFrame = document.getElementById("conceptAtlasPanelFrame");
@@ -911,6 +915,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (tabKey === "causal-geometry" && !causalGeometryPanel) {
       effectiveTab = "hub";
     }
+    if (tabKey === "drives" && !drivesAnalyticsPanel) {
+      effectiveTab = "hub";
+    }
     if (tabKey === "concept-atlas" && !conceptAtlasPanel) {
       effectiveTab = "hub";
     }
@@ -929,6 +936,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const isSubstrate = effectiveTab === "substrate";
     const isSubstrateAtlas = effectiveTab === "substrate-atlas";
     const isCausalGeometry = effectiveTab === "causal-geometry";
+    const isDrivesAnalytics = effectiveTab === "drives";
     const isConceptAtlas = effectiveTab === "concept-atlas";
     const isMemory = effectiveTab === "memory";
     const isPressure = effectiveTab === "pressure";
@@ -959,6 +967,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (causalGeometryPanel) {
       causalGeometryPanel.classList.toggle("hidden", !isCausalGeometry);
+    }
+    if (drivesAnalyticsPanel) {
+      drivesAnalyticsPanel.classList.toggle("hidden", !isDrivesAnalytics);
     }
     if (conceptAtlasPanel) {
       const wasConceptAtlasVisible = !conceptAtlasPanel.classList.contains("hidden");
@@ -1042,6 +1053,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (causalGeometryTabButton) {
       styleTabButton(causalGeometryTabButton, isCausalGeometry);
+    }
+    if (drivesAnalyticsTabButton) {
+      styleTabButton(drivesAnalyticsTabButton, isDrivesAnalytics);
     }
     if (conceptAtlasTabButton) {
       styleTabButton(conceptAtlasTabButton, isConceptAtlas);
@@ -1631,6 +1645,8 @@ document.addEventListener("DOMContentLoaded", () => {
       setActiveTab("substrate-atlas");
     } else if (h === "#causal-geometry" && causalGeometryPanel && causalGeometryTabButton) {
       setActiveTab("causal-geometry");
+    } else if (h === "#drives" && drivesAnalyticsPanel && drivesAnalyticsTabButton) {
+      setActiveTab("drives");
     } else if (h === "#concept-atlas" && conceptAtlasPanel && conceptAtlasTabButton) {
       setActiveTab("concept-atlas");
     } else if (h === "#pressure" && pressurePanel && pressureAnalyticsTabButton) {
@@ -11236,6 +11252,13 @@ document.addEventListener("DOMContentLoaded", () => {
         history.replaceState(null, "", "#causal-geometry");
       });
     }
+    if (drivesAnalyticsTabButton && drivesAnalyticsPanel) {
+      drivesAnalyticsTabButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        setActiveTab("drives");
+        history.replaceState(null, "", "#drives");
+      });
+    }
     if (conceptAtlasTabButton && conceptAtlasPanel) {
       conceptAtlasTabButton.addEventListener("click", (event) => {
         event.preventDefault();
@@ -11317,6 +11340,12 @@ document.addEventListener("DOMContentLoaded", () => {
   if (causalGeometryPanelRefresh && causalGeometryPanelFrame) {
     causalGeometryPanelRefresh.addEventListener("click", () => {
       causalGeometryPanelFrame.contentWindow?.location.reload();
+    });
+  }
+
+  if (drivesAnalyticsPanelRefresh && drivesAnalyticsPanelFrame) {
+    drivesAnalyticsPanelRefresh.addEventListener("click", () => {
+      drivesAnalyticsPanelFrame.contentWindow?.location.reload();
     });
   }
 

--- a/services/orion-hub/static/js/drives-analytics.js
+++ b/services/orion-hub/static/js/drives-analytics.js
@@ -1,0 +1,865 @@
+(() => {
+  // Standalone bundle for the Hub Drives Analytics page. This file is loaded ONLY by
+  // /drives-analytics (see templates/drives-analytics.html) -- never by the Hub shell
+  // directly, and it must never reach into the shell's global namespace.
+  const DRIVE_KEYS = ['coherence', 'continuity', 'capability', 'relational', 'predictive', 'autonomy'];
+  const ALLOWED_HOURS = [1, 6, 24, 168];
+  const COLOR_MODES = ['combined', 'align', 'funnel'];
+  const STALE_AFTER_MS = 5 * 60 * 1000; // 5 minutes, mirrors Hub STALE_AFTER_SEC.
+  const POLL_INTERVAL_MS = 30000;
+
+  // Tooltip copy: single source of truth for the (i) popover on every card. Each entry
+  // covers three required angles for an operator: what it is, why it's built this way,
+  // and how to read it / what failure modes look like. Keep this in sync with the Hub
+  // README section on the Drives tab.
+  const TOOLTIP_COPY = {
+    gauges: {
+      definition: 'Six thermometer gauges, one per DriveEngine drive (coherence, continuity, capability, relational, predictive, autonomy), filled to the latest audited pressure 0-1.',
+      design: 'Color is a goal-alignment regime, not raw magnitude -- a pinned-high gauge with no matching goal is a warning, not a win. Funnel mode swaps to a neutral fill with a gate-verdict outline so pressure vs pipeline health are never conflated.',
+      reading: 'Active badge = past the DriveEngine activation threshold. Outlined gauge = current dominant drive. A staleness chip means the audit rail has not produced a tick in over 5 minutes -- treat every color on this card as suspect until that clears.',
+    },
+    contributors: {
+      definition: 'Per-drive contributor breakdown from tick_attribution (which tensions fed which drive) and tension_kinds, toggled between Live (latest tick only) and Window (aggregated across the selected hours).',
+      design: 'Attribution was previously dropped at the SQL sink; Window aggregation only sums rows where tick_attribution is not null, and always reports null_attribution_row_count next to the real total so a thin post-migration window never reads as a false zero.',
+      reading: 'Live shows what is driving pressure right now; Window shows the recent pattern. If null_attribution_row_count is high relative to attributed rows, the window mostly predates the tick_attribution migration -- read the aggregate as partial, not authoritative.',
+    },
+    kpi: {
+      definition: 'A KPI strip: audit tick rate, active-drive count, co-activation fraction, top-dominant-drive share, the drive-rail gate verdict, and the age of the last audit.',
+      design: 'The gate verdict here (gate_verdict_drive_only) is drive-only math from measure_autonomy_gate.py; it can never be the full offline GO because that also needs resource_pressure, which this Hub surface does not compute. GO_DRIVE_ONLY is labeled "drive economy OK (partial)", never bare "GO".',
+      reading: 'Rising co-activation and a spread dominant share suggest a healthy multi-drive economy; a single drive owning the dominant share for most of the window (SATURATED) means the economy has collapsed to monoculture, regardless of how healthy pressures look individually.',
+    },
+    series: {
+      definition: 'Dual time series: audit tick-rate over the window on top, six pressure sparklines underneath sharing the same time axis.',
+      design: 'Points are downsampled to at most 240 per line server-side; after a stack rebuild the retained history can be much shorter than the requested window, so this card renders exactly the points that exist plus an explicit coverage banner -- it never fabricates points to fill the requested range.',
+      reading: 'A flat or empty tick-rate line means the audit rail itself has gone quiet (check the producer, not the drives). Compare sparkline shapes against the coverage banner before reading trend -- a "trend" over 1 hour of thin post-rebuild history is not a trend yet.',
+    },
+    divergence: {
+      definition: 'Side-by-side comparison of drive_state.v1 (the concept-store snapshot) against the latest drive_audits pressures, with a per-drive delta and the max absolute delta across all six drives.',
+      design: 'CONCEPT_STORE_PATH has drifted to a host-local fallback default before (2026-07-13 incident class); this card raises a loud banner, not a quiet note, whenever the resolved path is that fallback default, since a silently-wrong path makes divergence numbers meaningless.',
+      reading: 'Large deltas mean the concept store and the live audit rail disagree about drive state -- investigate before trusting either signal. autonomy_state_v2 is frozen/historical, never a live second signal; this card states that verbatim rather than implying a second live comparison exists.',
+    },
+    goals: {
+      definition: 'Read-only list of active goals (artifact_id, drive_origin, proposal_status, goal_statement) plus funnel counts across the proposal pipeline.',
+      design: 'This tab is orientation, not a mutation console -- unlike causal-geometry\'s adopt/reject buttons, this card has no action buttons of any kind. Goal-alignment coloring elsewhere on the page reads from this same data.',
+      reading: 'If goals_available is false, the goal store could not be reached this refresh -- that shows as "goals unavailable" plainly, never as an invented empty list. A drive with sustained pressure and no matching goal here is the signal this whole page exists to surface.',
+    },
+    crosslinks: {
+      definition: 'Plain navigation links to related Hub surfaces (Spark Cognitive EKG, Pressure Analytics, Causal Geometry) plus a raw-JSON debug panel of every payload this page fetched.',
+      design: 'Pressure Analytics measures substrate mutation pressure, not the DriveEngine economy -- the two are easy to conflate by name alone, so this card states the distinction explicitly rather than just linking silently.',
+      reading: 'Use the raw-JSON <details> panel when a rendered card looks wrong and you need to see the exact payload Hub received, before assuming the bug is in this page rather than upstream.',
+    },
+  };
+
+  const els = {
+    subjectSelect: document.getElementById('drivesSubjectSelect'),
+    windowSelect: document.getElementById('drivesWindowSelect'),
+    colorMode: document.getElementById('drivesColorMode'),
+    refreshButton: document.getElementById('drivesRefreshButton'),
+    autoRefresh: document.getElementById('drivesAutoRefresh'),
+    lastLoaded: document.getElementById('drivesLastLoaded'),
+    coverageBanner: document.getElementById('drivesCoverageBanner'),
+    gaugesBody: document.getElementById('drivesGaugesBody'),
+    contributorsBody: document.getElementById('drivesContributorsBody'),
+    contributorsLiveButton: document.getElementById('drivesContributorsLiveButton'),
+    contributorsWindowButton: document.getElementById('drivesContributorsWindowButton'),
+    kpiBody: document.getElementById('drivesKpiBody'),
+    seriesBody: document.getElementById('drivesSeriesBody'),
+    divergenceBody: document.getElementById('drivesDivergenceBody'),
+    goalsBody: document.getElementById('drivesGoalsBody'),
+    crossLinksBody: document.getElementById('drivesCrossLinksBody'),
+    tooltipPopover: document.getElementById('drivesTooltipPopover'),
+  };
+
+  function readState() {
+    const params = new URLSearchParams(window.location.search);
+    const rawHours = parseInt(params.get('window'), 10);
+    const hours = ALLOWED_HOURS.includes(rawHours) ? rawHours : 24;
+    const subject = params.get('subject') || 'orion';
+    const rawColor = params.get('color');
+    const color = COLOR_MODES.includes(rawColor) ? rawColor : 'combined';
+    return { subject, hours, color, contributorsMode: 'live' };
+  }
+
+  const state = readState();
+  let payloads = {};
+
+  function writeUrl() {
+    const params = new URLSearchParams();
+    params.set('window', String(state.hours));
+    params.set('subject', state.subject);
+    params.set('color', state.color);
+    const next = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState(null, '', next);
+  }
+
+  async function fetchSection(path) {
+    const res = await fetch(path, { headers: { Accept: 'application/json' } });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} for ${path}`);
+    }
+    return res.json();
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = text;
+    return node;
+  }
+
+  function isStale(observedAtIso) {
+    if (!observedAtIso) return true;
+    const observed = new Date(observedAtIso).getTime();
+    if (Number.isNaN(observed)) return true;
+    return Date.now() - observed > STALE_AFTER_MS;
+  }
+
+  function fmtPct(fraction) {
+    if (fraction === null || fraction === undefined || Number.isNaN(Number(fraction))) return '—';
+    return `${(Number(fraction) * 100).toFixed(1)}%`;
+  }
+
+  function fmtAge(observedAtIso) {
+    if (!observedAtIso) return 'unknown';
+    const observed = new Date(observedAtIso).getTime();
+    if (Number.isNaN(observed)) return 'unknown';
+    const seconds = Math.max(0, Math.round((Date.now() - observed) / 1000));
+    if (seconds < 60) return `${seconds}s ago`;
+    if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+    return `${(seconds / 3600).toFixed(1)}h ago`;
+  }
+
+  // -------------------------------------------------------------------------
+  // Card 1: Six-drive gauges
+  // -------------------------------------------------------------------------
+
+  function gaugeColorClass(key, { colorMode, goalAlignment, kpis }) {
+    if (colorMode === 'funnel') {
+      return 'drive-color-neutral';
+    }
+    // 'align' and 'combined' both use goal-aligned per-drive coloring for the gauges
+    // themselves (combined applies funnel/gate rules to the KPI strip instead).
+    const perDrive = goalAlignment && goalAlignment.per_drive ? goalAlignment.per_drive[key] : null;
+    const color = perDrive && perDrive.color_align ? perDrive.color_align : 'neutral';
+    return `drive-color-${color}`;
+  }
+
+  function gaugeOutlineClass(colorMode, kpis) {
+    if (colorMode !== 'funnel') return '';
+    const verdict = kpis && kpis.gate_verdict_drive_only;
+    if (verdict === 'GO_DRIVE_ONLY') return 'ring-2 ring-emerald-500';
+    if (verdict === 'SATURATED') return 'ring-2 ring-red-500';
+    if (verdict === 'NO-GO') return 'ring-2 ring-amber-500';
+    return 'ring-2 ring-gray-600';
+  }
+
+  function renderGauges(container, { snapshot, goalAlignment, windowPayload, colorMode }) {
+    if (!container) return;
+    container.textContent = '';
+    if (!snapshot || snapshot.degraded) {
+      container.appendChild(
+        el('div', 'text-xs text-gray-400', snapshot && snapshot.error ? `Gauges unavailable: ${snapshot.error}` : 'Gauges unavailable.'),
+      );
+      return;
+    }
+    const pressures = snapshot.drive_pressures || {};
+    const activeDrives = new Set(snapshot.active_drives || []);
+    const dominant = snapshot.dominant_drive;
+    const stale = Boolean(snapshot.stale) || isStale(snapshot.observed_at);
+    const kpis = windowPayload && !windowPayload.degraded ? windowPayload.kpis : null;
+
+    for (const key of DRIVE_KEYS) {
+      const pressure = Number(pressures[key] || 0);
+      const gauge = el('div', 'drive-gauge');
+      const label = el('div', 'text-[11px] text-gray-400', key);
+      gauge.appendChild(label);
+
+      const tube = el('div', `drive-gauge-tube ${key === dominant ? 'drive-gauge-dominant' : ''}`);
+      const fill = el('div', `drive-gauge-fill ${gaugeColorClass(key, { colorMode, goalAlignment, kpis })} ${gaugeOutlineClass(colorMode, kpis)}`);
+      fill.style.height = `${Math.max(0, Math.min(100, pressure * 100)).toFixed(1)}%`;
+      tube.appendChild(fill);
+      gauge.appendChild(tube);
+
+      const value = el('div', 'text-[11px] text-gray-300', pressure.toFixed(2));
+      gauge.appendChild(value);
+
+      if (activeDrives.has(key)) {
+        gauge.appendChild(el('div', 'text-[10px] text-emerald-400', 'active'));
+      }
+      if (key === dominant) {
+        gauge.appendChild(el('div', 'text-[10px] text-sky-400', 'dominant'));
+      }
+      container.appendChild(gauge);
+    }
+
+    if (stale) {
+      const chip = el(
+        'div',
+        'text-[11px] text-amber-400 border border-amber-900/60 bg-amber-950/30 rounded px-2 py-1 mt-1 w-full',
+        `stale: last audit observed_at=${snapshot.observed_at || 'unknown'}`,
+      );
+      container.appendChild(chip);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Card 2: Contributors (Live vs Window)
+  // -------------------------------------------------------------------------
+
+  function renderContributorsBars(container, perDrive) {
+    const maxVal = Math.max(0.0001, ...DRIVE_KEYS.map((k) => Math.abs(Number(perDrive[k] || 0))));
+    for (const key of DRIVE_KEYS) {
+      const value = Number(perDrive[key] || 0);
+      const row = el('div', 'flex items-center gap-2 mb-1');
+      row.appendChild(el('div', 'w-20 text-gray-400', key));
+      const barTrack = el('div', 'flex-1 h-3 bg-gray-950 border border-gray-800 rounded overflow-hidden');
+      const bar = el('div', 'h-full bg-sky-600');
+      bar.style.width = `${Math.max(0, Math.min(100, (Math.abs(value) / maxVal) * 100)).toFixed(1)}%`;
+      barTrack.appendChild(bar);
+      row.appendChild(barTrack);
+      row.appendChild(el('div', 'w-14 text-right text-gray-300', value.toFixed(3)));
+      container.appendChild(row);
+    }
+  }
+
+  function renderContributors(container, { snapshot, windowPayload, contributorsMode }) {
+    if (!container) return;
+    container.textContent = '';
+
+    const modeLabel = el('div', 'text-[11px] text-gray-500 mb-2', contributorsMode === 'live' ? 'Live (latest tick)' : 'Window (aggregated over selected hours)');
+    container.appendChild(modeLabel);
+
+    if (contributorsMode === 'live') {
+      if (!snapshot || snapshot.degraded) {
+        container.appendChild(el('div', 'text-xs text-gray-400', 'Live contributors unavailable.'));
+        return;
+      }
+      const attribution = snapshot.tick_attribution;
+      if (!attribution || typeof attribution !== 'object') {
+        container.appendChild(el('div', 'text-xs text-gray-400', 'No tick_attribution recorded for the latest audit (pre-migration or dropped tick).'));
+        return;
+      }
+      renderContributorsBars(container, attribution);
+      const kinds = Array.isArray(snapshot.tension_kinds) ? snapshot.tension_kinds : [];
+      if (kinds.length > 0) {
+        const kindsHeading = el('div', 'text-[11px] text-gray-400 mt-2', 'tension_kinds:');
+        container.appendChild(kindsHeading);
+        const list = el('ul', 'list-disc list-inside text-[11px] text-gray-400');
+        for (const kind of kinds) {
+          list.appendChild(el('li', null, kind));
+        }
+        container.appendChild(list);
+      }
+      return;
+    }
+
+    // Window mode.
+    if (!windowPayload || windowPayload.degraded) {
+      container.appendChild(el('div', 'text-xs text-gray-400', 'Window contributors unavailable.'));
+      return;
+    }
+    const attribution = windowPayload.attribution || {};
+    const perDrive = attribution.per_drive || {};
+    renderContributorsBars(container, perDrive);
+    const attributed = Number(attribution.attributed_row_count || 0);
+    const nullCount = Number(attribution.null_attribution_row_count || 0);
+    const total = attributed + nullCount;
+    if (nullCount > 0) {
+      container.appendChild(
+        el(
+          'div',
+          'text-[11px] text-amber-400 mt-2',
+          `${nullCount} of ${total} rows have no attribution recorded (pre-migration or dropped tick).`,
+        ),
+      );
+    } else if (total > 0) {
+      container.appendChild(el('div', 'text-[11px] text-gray-500 mt-2', `${attributed} of ${total} rows attributed.`));
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Card 3: KPI strip
+  // -------------------------------------------------------------------------
+
+  function kpiChip(label, value, extraClass) {
+    return el('div', `px-2 py-1 rounded border border-gray-700 bg-gray-950 ${extraClass || ''}`, `${label}: ${value}`);
+  }
+
+  function gateVerdictLabel(verdict) {
+    // GO_DRIVE_ONLY is drive-rail-only math; full GO also needs resource_pressure, which
+    // this Hub surface never computes. Never render the bare string "GO" for this value.
+    if (verdict === 'GO_DRIVE_ONLY') return 'drive economy OK (partial)';
+    if (verdict === 'SATURATED') return 'SATURATED';
+    if (verdict === 'NO-GO') return 'NO-GO';
+    if (verdict === 'UNMEASURABLE') return 'UNMEASURABLE';
+    return verdict || 'unknown';
+  }
+
+  // Coloring model (spec: "KPI strip / goals card" column) -- align mode colors the gate
+  // chip from per-drive goal-alignment severity; funnel and combined both color it from
+  // the funnel/gate verdict math. Gauges themselves are handled separately in gaugeColorClass.
+  function alignSeverityColor(goalAlignment) {
+    const perDrive = (goalAlignment && goalAlignment.per_drive) || {};
+    const rank = { red: 3, yellow: 2, green: 1, neutral: 0 };
+    let worst = 'neutral';
+    for (const key of DRIVE_KEYS) {
+      const entry = perDrive[key];
+      const color = entry && entry.color_align ? entry.color_align : 'neutral';
+      if ((rank[color] ?? 0) > (rank[worst] ?? 0)) worst = color;
+    }
+    return worst;
+  }
+
+  function alignColorTextClass(color) {
+    if (color === 'red') return 'text-red-400';
+    if (color === 'yellow') return 'text-amber-400';
+    if (color === 'green') return 'text-emerald-400';
+    return 'text-gray-400';
+  }
+
+  function renderKpiStrip(container, { windowPayload, snapshot, seriesPayload, colorMode, goalAlignment }) {
+    if (!container) return;
+    container.textContent = '';
+    if (!windowPayload || windowPayload.degraded) {
+      container.appendChild(el('div', 'text-xs text-gray-400', windowPayload && windowPayload.error ? `KPIs unavailable: ${windowPayload.error}` : 'KPIs unavailable.'));
+      return;
+    }
+    const kpis = windowPayload.kpis || {};
+    const coverage = kpis.coverage || windowPayload.coverage || {};
+    const coverageHours = Number(coverage.coverage_hours || 0);
+    const tickRate = coverageHours > 0 ? (kpis.record_count / coverageHours).toFixed(2) : '—';
+
+    container.appendChild(kpiChip('tick rate', `${tickRate}/h`));
+    container.appendChild(kpiChip('active drives', snapshot && !snapshot.degraded ? snapshot.active_count : '—'));
+    container.appendChild(kpiChip('co-activation', fmtPct(kpis.coactivation_frac)));
+    container.appendChild(kpiChip('top dominant share', fmtPct(kpis.top_dominant_share)));
+
+    const verdict = kpis.gate_verdict_drive_only;
+    let verdictClass;
+    if (colorMode === 'align') {
+      // Align mode: strip chip reflects per-drive goal-alignment severity, not gate math.
+      verdictClass = alignColorTextClass(alignSeverityColor(goalAlignment));
+    } else {
+      // funnel and combined modes both use funnel/gate-verdict rules for this chip.
+      verdictClass = verdict === 'SATURATED' ? 'text-red-400' : verdict === 'GO_DRIVE_ONLY' ? 'text-emerald-400' : verdict === 'NO-GO' ? 'text-amber-400' : 'text-gray-400';
+    }
+    container.appendChild(kpiChip('gate verdict', gateVerdictLabel(verdict), verdictClass));
+
+    const lastAge = snapshot && !snapshot.degraded ? fmtAge(snapshot.observed_at) : 'unknown';
+    container.appendChild(kpiChip('last audit', lastAge));
+
+    if (kpis.gate_note) {
+      container.appendChild(el('div', 'w-full text-[11px] text-gray-500 mt-1', kpis.gate_note));
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Card 4: Dual time series
+  // -------------------------------------------------------------------------
+
+  function buildSparklineSvg(points, { color, xMin, xMax }) {
+    const svgNs = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNs, 'svg');
+    svg.setAttribute('viewBox', '0 0 200 40');
+    svg.setAttribute('preserveAspectRatio', 'none');
+    svg.classList.add('drives-sparkline');
+    if (!points || points.length === 0) return svg;
+
+    const values = points.map((p) => Number(p.v ?? p.count ?? 0));
+    const maxV = Math.max(0.0001, ...values);
+    const xSpan = Math.max(1, xMax - xMin);
+    const coords = points.map((p) => {
+      const t = new Date(p.t).getTime();
+      const rawX = ((t - xMin) / xSpan) * 200;
+      const x = Number.isFinite(rawX) ? rawX : 0;
+      const v = Number(p.v ?? p.count ?? 0);
+      const y = 40 - (v / maxV) * 38 - 1;
+      return `${x.toFixed(1)},${Number.isFinite(y) ? y.toFixed(1) : 39}`;
+    });
+    const polyline = document.createElementNS(svgNs, 'polyline');
+    polyline.setAttribute('points', coords.join(' '));
+    polyline.setAttribute('fill', 'none');
+    polyline.setAttribute('stroke', color || '#38bdf8');
+    polyline.setAttribute('stroke-width', '1.5');
+    svg.appendChild(polyline);
+    return svg;
+  }
+
+  function renderSeries(container, seriesPayload) {
+    if (!container) return;
+    container.textContent = '';
+    if (!seriesPayload || seriesPayload.degraded) {
+      container.appendChild(el('div', 'text-xs text-gray-400', seriesPayload && seriesPayload.error ? `Series unavailable: ${seriesPayload.error}` : 'Series unavailable.'));
+      return;
+    }
+    const coverage = seriesPayload.coverage || {};
+    const requestedHours = Number(coverage.requested_hours || seriesPayload.hours || 0);
+    const coverageHours = coverage.coverage_hours === null || coverage.coverage_hours === undefined ? null : Number(coverage.coverage_hours);
+    if (coverageHours !== null && coverageHours < requestedHours) {
+      container.appendChild(
+        el(
+          'div',
+          'text-[11px] text-amber-400 border border-amber-900/60 bg-amber-950/30 rounded px-2 py-1 mb-2',
+          `Thin history: only ${coverageHours.toFixed(1)}h of ${requestedHours}h requested is available (row_count=${coverage.row_count ?? 0}).${coverage.retention_note ? ' ' + coverage.retention_note : ''}`,
+        ),
+      );
+    }
+
+    const tickRate = Array.isArray(seriesPayload.tick_rate) ? seriesPayload.tick_rate : [];
+    const allTimes = tickRate.map((p) => new Date(p.t).getTime()).filter((t) => Number.isFinite(t));
+    for (const key of DRIVE_KEYS) {
+      const points = (seriesPayload.pressures && seriesPayload.pressures[key]) || [];
+      for (const p of points) {
+        const t = new Date(p.t).getTime();
+        if (Number.isFinite(t)) allTimes.push(t);
+      }
+    }
+    const xMin = allTimes.length ? Math.min(...allTimes) : 0;
+    const xMax = allTimes.length ? Math.max(...allTimes) : 1;
+
+    container.appendChild(el('div', 'text-[11px] text-gray-400 mb-1', 'tick rate'));
+    if (tickRate.length === 0) {
+      container.appendChild(el('div', 'text-xs text-gray-500 mb-2', 'No tick-rate points in this window.'));
+    } else {
+      container.appendChild(buildSparklineSvg(tickRate, { color: '#38bdf8', xMin, xMax }));
+    }
+
+    const pressureGrid = el('div', 'grid grid-cols-2 md:grid-cols-3 gap-2 mt-3');
+    for (const key of DRIVE_KEYS) {
+      const cell = el('div', 'border border-gray-800 rounded p-2');
+      cell.appendChild(el('div', 'text-[11px] text-gray-400', key));
+      const points = (seriesPayload.pressures && seriesPayload.pressures[key]) || [];
+      if (points.length === 0) {
+        cell.appendChild(el('div', 'text-[11px] text-gray-600', 'no points'));
+      } else {
+        cell.appendChild(buildSparklineSvg(points, { color: '#a78bfa', xMin, xMax }));
+      }
+      pressureGrid.appendChild(cell);
+    }
+    container.appendChild(pressureGrid);
+  }
+
+  // -------------------------------------------------------------------------
+  // Card 5: Divergence
+  // -------------------------------------------------------------------------
+
+  function renderDivergence(container, divergencePayload) {
+    if (!container) return;
+    container.textContent = '';
+    if (!divergencePayload) {
+      container.appendChild(el('div', 'text-xs text-gray-400', 'Divergence unavailable.'));
+      return;
+    }
+    if (divergencePayload.store_path_is_fallback_default) {
+      container.appendChild(
+        el(
+          'div',
+          'text-xs text-red-300 border border-red-800 bg-red-950/40 rounded px-2 py-2 mb-2 font-semibold',
+          `CONCEPT_STORE_PATH is unset; using the host-local fallback default (${divergencePayload.store_path}). Divergence numbers below may not reflect the intended concept store.`,
+        ),
+      );
+    }
+
+    const table = el('table', 'w-full text-left border-collapse');
+    const thead = el('thead');
+    const headRow = el('tr');
+    for (const header of ['drive', 'drive_state', 'audit', 'delta']) {
+      headRow.appendChild(el('th', 'text-gray-400 border-b border-gray-700 py-1 pr-3 font-medium', header));
+    }
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    const tbody = el('tbody');
+    const driveState = divergencePayload.drive_state_pressures || {};
+    const auditP = divergencePayload.audit_pressures || {};
+    const deltas = divergencePayload.deltas || {};
+    for (const key of DRIVE_KEYS) {
+      const row = el('tr', 'border-b border-gray-800 text-gray-300');
+      const dsVal = driveState[key];
+      const auVal = auditP[key];
+      const dVal = deltas[key];
+      row.appendChild(el('td', 'py-1 pr-3', key));
+      row.appendChild(el('td', 'py-1 pr-3', dsVal === null || dsVal === undefined ? '—' : Number(dsVal).toFixed(3)));
+      row.appendChild(el('td', 'py-1 pr-3', auVal === null || auVal === undefined ? '—' : Number(auVal).toFixed(3)));
+      row.appendChild(el('td', 'py-1 pr-3', dVal === null || dVal === undefined ? '—' : Number(dVal).toFixed(3)));
+      tbody.appendChild(row);
+    }
+    table.appendChild(tbody);
+    container.appendChild(table);
+
+    container.appendChild(
+      el('div', 'text-[11px] text-gray-400 mt-2', `max_abs_delta=${Number(divergencePayload.max_abs_delta || 0).toFixed(3)}`),
+    );
+    container.appendChild(
+      el('div', 'text-[11px] text-gray-500 mt-1', divergencePayload.autonomy_state_v2_note || 'autonomy_state_v2_note: frozen/historical — not a live second signal'),
+    );
+    if (Array.isArray(divergencePayload.notes) && divergencePayload.notes.length > 0) {
+      const notesList = el('ul', 'list-disc list-inside text-[11px] text-gray-500 mt-1');
+      for (const note of divergencePayload.notes) {
+        notesList.appendChild(el('li', null, note));
+      }
+      container.appendChild(notesList);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Card 6: Goals (strictly read-only)
+  // -------------------------------------------------------------------------
+
+  // Coloring model for goal cards (spec: "KPI strip / goals card" column): align mode
+  // borders each goal by its drive_origin's per-drive alignment color; funnel/combined
+  // both border by funnel/pipeline stage instead, since that column is funnel/gate-ruled
+  // in both those modes.
+  function goalBorderClass(goal, { colorMode, goalAlignmentPayload }) {
+    if (colorMode === 'align') {
+      const key = String(goal.drive_origin || '').trim().toLowerCase();
+      const perDrive = (goalAlignmentPayload && goalAlignmentPayload.per_drive) || {};
+      const entry = perDrive[key];
+      const color = entry && entry.color_align ? entry.color_align : 'neutral';
+      if (color === 'red') return 'border-red-700';
+      if (color === 'yellow') return 'border-amber-700';
+      if (color === 'green') return 'border-emerald-700';
+      return 'border-gray-800';
+    }
+    const status = String(goal.proposal_status || '').trim().toLowerCase();
+    if (status === 'completed' || status === 'active') return 'border-emerald-700';
+    if (status === 'executing' || status === 'planned') return 'border-sky-700';
+    if (status === 'archived') return 'border-gray-700';
+    return 'border-gray-800';
+  }
+
+  function renderGoals(container, goalAlignmentPayload, colorMode) {
+    if (!container) return;
+    container.textContent = '';
+    if (!goalAlignmentPayload) {
+      container.appendChild(el('div', 'text-xs text-gray-400', 'Goals unavailable.'));
+      return;
+    }
+    if (!goalAlignmentPayload.goals_available) {
+      container.appendChild(el('div', 'text-xs text-gray-400', 'goals unavailable'));
+      return;
+    }
+    const goals = Array.isArray(goalAlignmentPayload.active_goals) ? goalAlignmentPayload.active_goals : [];
+    if (goals.length === 0) {
+      container.appendChild(el('div', 'text-xs text-gray-500 mb-2', 'No active goals.'));
+    } else {
+      for (const goal of goals) {
+        const card = el('div', `border rounded p-2 mb-2 ${goalBorderClass(goal, { colorMode, goalAlignmentPayload })}`);
+        card.appendChild(el('div', 'text-gray-200 font-medium', goal.goal_statement || '(no statement)'));
+        card.appendChild(
+          el(
+            'div',
+            'text-[11px] text-gray-400',
+            `artifact_id=${goal.artifact_id || '—'} | drive_origin=${goal.drive_origin || '—'} | proposal_status=${goal.proposal_status || '—'}`,
+          ),
+        );
+        container.appendChild(card);
+      }
+    }
+    // No action buttons on this card -- strictly read-only, unlike causal-geometry's
+    // adopt/reject controls, which do not apply to this orientation-only surface.
+    const funnel = goalAlignmentPayload.funnel || {};
+    const funnelRow = el('div', 'flex flex-wrap gap-2 mt-2');
+    for (const stage of ['proposed', 'active', 'planned', 'executing', 'completed', 'archived']) {
+      funnelRow.appendChild(kpiChip(stage, funnel[stage] ?? 0));
+    }
+    container.appendChild(funnelRow);
+  }
+
+  // -------------------------------------------------------------------------
+  // Card 7: Cross-links
+  // -------------------------------------------------------------------------
+
+  function renderCrossLinks(container, allPayloads) {
+    if (!container) return;
+    container.textContent = '';
+    const linksRow = el('div', 'flex flex-wrap gap-3 mb-2');
+    const links = [
+      { href: '/spark/ui', label: 'Spark Cognitive EKG' },
+      { href: '/#pressure', label: 'Hub Pressure Analytics' },
+      { href: '/causal-geometry', label: 'Causal Geometry' },
+    ];
+    for (const link of links) {
+      const a = el('a', 'px-2 py-1 rounded border border-gray-700 bg-gray-950 text-sky-400 hover:bg-gray-800', link.label);
+      a.href = link.href;
+      linksRow.appendChild(a);
+    }
+    container.appendChild(linksRow);
+    container.appendChild(
+      el(
+        'div',
+        'text-[11px] text-gray-500 mb-2',
+        'Note: Hub Pressure Analytics measures substrate mutation pressure. It is not the same thing as the DriveEngine economy shown on this page.',
+      ),
+    );
+
+    const details = el('details', 'text-[11px]');
+    const summary = el('summary', 'text-gray-400 cursor-pointer', 'Raw fetched payloads (debug)');
+    details.appendChild(summary);
+    const pre = el('pre', 'text-gray-500 whitespace-pre-wrap mt-2');
+    pre.textContent = JSON.stringify(allPayloads || {}, null, 2);
+    details.appendChild(pre);
+    container.appendChild(details);
+  }
+
+  // -------------------------------------------------------------------------
+  // Controls: subject select, coverage banner
+  // -------------------------------------------------------------------------
+
+  function renderSubjectSelect(selectEl, subjectsPayload, currentSubject) {
+    if (!selectEl) return;
+    const subjects = subjectsPayload && Array.isArray(subjectsPayload.subjects) ? subjectsPayload.subjects : [];
+    selectEl.textContent = '';
+    const seen = new Set();
+    for (const entry of subjects) {
+      const opt = document.createElement('option');
+      opt.value = entry.subject;
+      const oldest = entry.oldest_ts ? new Date(entry.oldest_ts).toISOString().slice(0, 10) : 'n/a';
+      const newest = entry.newest_ts ? new Date(entry.newest_ts).toISOString().slice(0, 10) : 'n/a';
+      opt.textContent = `${entry.subject} (${entry.row_count} rows, ${oldest}..${newest})`;
+      selectEl.appendChild(opt);
+      seen.add(entry.subject);
+    }
+    if (!seen.has(currentSubject)) {
+      const opt = document.createElement('option');
+      opt.value = currentSubject;
+      opt.textContent = currentSubject;
+      selectEl.appendChild(opt);
+    }
+    selectEl.value = currentSubject;
+  }
+
+  function renderCoverageBanner(bannerEl, { windowPayload, seriesPayload, degradedAny }) {
+    if (!bannerEl) return;
+    const messages = [];
+    for (const [name, payload] of [['window', windowPayload], ['series', seriesPayload]]) {
+      if (!payload || payload.degraded) continue;
+      const coverage = payload.coverage || (payload.kpis && payload.kpis.coverage) || {};
+      const requested = Number(coverage.requested_hours || payload.hours || 0);
+      const covered = coverage.coverage_hours === null || coverage.coverage_hours === undefined ? null : Number(coverage.coverage_hours);
+      if (covered !== null && covered < requested) {
+        messages.push(`${name}: only ${covered.toFixed(1)}h of ${requested}h covered`);
+      }
+    }
+    if (degradedAny) {
+      messages.push('one or more Drives Analytics endpoints are degraded this refresh');
+    }
+    if (messages.length === 0) {
+      bannerEl.classList.add('hidden');
+      bannerEl.textContent = '';
+      return;
+    }
+    bannerEl.classList.remove('hidden');
+    bannerEl.textContent = messages.join(' | ');
+  }
+
+  // -------------------------------------------------------------------------
+  // Tooltip popover
+  // -------------------------------------------------------------------------
+
+  function showTooltip(cardId, anchorEl) {
+    const copy = TOOLTIP_COPY[cardId];
+    if (!copy || !els.tooltipPopover) return;
+    els.tooltipPopover.textContent = '';
+    els.tooltipPopover.appendChild(el('div', 'font-semibold text-gray-100 mb-1', 'What it is'));
+    els.tooltipPopover.appendChild(el('div', 'mb-2', copy.definition));
+    els.tooltipPopover.appendChild(el('div', 'font-semibold text-gray-100 mb-1', 'Why it is designed this way'));
+    els.tooltipPopover.appendChild(el('div', 'mb-2', copy.design));
+    els.tooltipPopover.appendChild(el('div', 'font-semibold text-gray-100 mb-1', 'How to read it'));
+    els.tooltipPopover.appendChild(el('div', null, copy.reading));
+    els.tooltipPopover.classList.remove('hidden');
+    if (anchorEl) {
+      const rect = anchorEl.getBoundingClientRect();
+      els.tooltipPopover.style.top = `${window.scrollY + rect.bottom + 6}px`;
+      els.tooltipPopover.style.left = `${window.scrollX + Math.max(0, rect.left - 200)}px`;
+    }
+  }
+
+  function hideTooltip() {
+    if (els.tooltipPopover) els.tooltipPopover.classList.add('hidden');
+  }
+
+  document.querySelectorAll('.drives-info-button').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const cardId = button.getAttribute('data-card');
+      if (els.tooltipPopover && !els.tooltipPopover.classList.contains('hidden')) {
+        hideTooltip();
+        return;
+      }
+      showTooltip(cardId, button);
+    });
+  });
+  document.addEventListener('click', hideTooltip);
+
+  // -------------------------------------------------------------------------
+  // Fetch + render orchestration
+  // -------------------------------------------------------------------------
+
+  async function fetchAll() {
+    const subject = encodeURIComponent(state.subject);
+    const hours = state.hours;
+    const endpoints = {
+      subjects: '/api/drives-analytics/subjects',
+      snapshot: `/api/drives-analytics/snapshot?subject=${subject}`,
+      window: `/api/drives-analytics/window?subject=${subject}&hours=${hours}`,
+      series: `/api/drives-analytics/series?subject=${subject}&hours=${hours}`,
+      goalAlignment: `/api/drives-analytics/goal-alignment?subject=${subject}`,
+      divergence: `/api/drives-analytics/divergence?subject=${subject}`,
+    };
+    const entries = Object.entries(endpoints);
+    const results = await Promise.allSettled(entries.map(([, path]) => fetchSection(path)));
+    const out = {};
+    let degradedAny = false;
+    results.forEach((result, idx) => {
+      const [key] = entries[idx];
+      if (result.status === 'fulfilled') {
+        out[key] = result.value;
+        if (result.value && result.value.degraded) degradedAny = true;
+      } else {
+        out[key] = { degraded: true, error: String(result.reason) };
+        degradedAny = true;
+      }
+    });
+    out._degradedAny = degradedAny;
+    return out;
+  }
+
+  function renderAll() {
+    renderGauges(els.gaugesBody, {
+      snapshot: payloads.snapshot,
+      goalAlignment: payloads.goalAlignment,
+      windowPayload: payloads.window,
+      colorMode: state.color,
+    });
+    renderContributors(els.contributorsBody, {
+      snapshot: payloads.snapshot,
+      windowPayload: payloads.window,
+      contributorsMode: state.contributorsMode,
+    });
+    renderKpiStrip(els.kpiBody, {
+      windowPayload: payloads.window,
+      snapshot: payloads.snapshot,
+      seriesPayload: payloads.series,
+      colorMode: state.color,
+      goalAlignment: payloads.goalAlignment,
+    });
+    renderSeries(els.seriesBody, payloads.series);
+    renderDivergence(els.divergenceBody, payloads.divergence);
+    renderGoals(els.goalsBody, payloads.goalAlignment, state.color);
+    renderCrossLinks(els.crossLinksBody, payloads);
+    renderSubjectSelect(els.subjectSelect, payloads.subjects, state.subject);
+    renderCoverageBanner(els.coverageBanner, {
+      windowPayload: payloads.window,
+      seriesPayload: payloads.series,
+      degradedAny: payloads._degradedAny,
+    });
+    if (els.lastLoaded) {
+      els.lastLoaded.textContent = new Date().toISOString();
+    }
+    if (els.windowSelect) els.windowSelect.value = String(state.hours);
+    if (els.colorMode) els.colorMode.value = state.color;
+    if (els.contributorsLiveButton && els.contributorsWindowButton) {
+      const liveActive = state.contributorsMode === 'live';
+      els.contributorsLiveButton.classList.toggle('bg-gray-800', liveActive);
+      els.contributorsWindowButton.classList.toggle('bg-gray-800', !liveActive);
+    }
+  }
+
+  async function refreshAll() {
+    try {
+      payloads = await fetchAll();
+    } catch (error) {
+      // Hard fetch-error fallback only -- every card above already has a real DOM-builder
+      // path for degraded/empty payloads; this branch only fires if fetchAll itself throws.
+      payloads = { _degradedAny: true, _fetchError: String(error) };
+    }
+    renderAll();
+    writeUrl();
+  }
+
+  // -------------------------------------------------------------------------
+  // Controls wiring
+  // -------------------------------------------------------------------------
+
+  if (els.subjectSelect) {
+    els.subjectSelect.addEventListener('change', () => {
+      state.subject = els.subjectSelect.value || 'orion';
+      void refreshAll();
+    });
+  }
+  if (els.windowSelect) {
+    els.windowSelect.addEventListener('change', () => {
+      const value = parseInt(els.windowSelect.value, 10);
+      state.hours = ALLOWED_HOURS.includes(value) ? value : 24;
+      void refreshAll();
+    });
+  }
+  if (els.colorMode) {
+    els.colorMode.addEventListener('change', () => {
+      const value = els.colorMode.value;
+      state.color = COLOR_MODES.includes(value) ? value : 'combined';
+      renderAll();
+      writeUrl();
+    });
+  }
+  if (els.refreshButton) {
+    els.refreshButton.addEventListener('click', () => {
+      void refreshAll();
+    });
+  }
+  if (els.contributorsLiveButton) {
+    els.contributorsLiveButton.addEventListener('click', () => {
+      state.contributorsMode = 'live';
+      renderAll();
+    });
+  }
+  if (els.contributorsWindowButton) {
+    els.contributorsWindowButton.addEventListener('click', () => {
+      state.contributorsMode = 'window';
+      renderAll();
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Polling: gentle interval, pause on hidden tab, immediate refresh on resume.
+  // -------------------------------------------------------------------------
+
+  let pollTimer = null;
+
+  function startPolling() {
+    if (pollTimer) return;
+    if (els.autoRefresh && !els.autoRefresh.checked) return;
+    pollTimer = setInterval(() => {
+      void refreshAll();
+    }, POLL_INTERVAL_MS);
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      stopPolling();
+    } else {
+      startPolling();
+      void refreshAll();
+    }
+  });
+
+  if (els.autoRefresh) {
+    els.autoRefresh.addEventListener('change', () => {
+      if (els.autoRefresh.checked) {
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    });
+  }
+
+  void refreshAll();
+  startPolling();
+})();

--- a/services/orion-hub/static/js/drives-analytics.js
+++ b/services/orion-hub/static/js/drives-analytics.js
@@ -133,15 +133,22 @@
   // Card 1: Six-drive gauges
   // -------------------------------------------------------------------------
 
-  function gaugeColorClass(key, { colorMode, goalAlignment, kpis }) {
+  // Shared by the gauge fill and the goal-card border (align mode): both need the same
+  // per-drive color_align lookup from goal-alignment, just rendered as a different
+  // Tailwind class family. Keeping the lookup itself in one place avoids the two call
+  // sites drifting out of sync on which field they read.
+  function alignColorForKey(key, goalAlignment) {
+    const perDrive = goalAlignment && goalAlignment.per_drive ? goalAlignment.per_drive[key] : null;
+    return perDrive && perDrive.color_align ? perDrive.color_align : 'neutral';
+  }
+
+  function gaugeColorClass(key, { colorMode, goalAlignment }) {
     if (colorMode === 'funnel') {
       return 'drive-color-neutral';
     }
     // 'align' and 'combined' both use goal-aligned per-drive coloring for the gauges
     // themselves (combined applies funnel/gate rules to the KPI strip instead).
-    const perDrive = goalAlignment && goalAlignment.per_drive ? goalAlignment.per_drive[key] : null;
-    const color = perDrive && perDrive.color_align ? perDrive.color_align : 'neutral';
-    return `drive-color-${color}`;
+    return `drive-color-${alignColorForKey(key, goalAlignment)}`;
   }
 
   function gaugeOutlineClass(colorMode, kpis) {
@@ -506,15 +513,14 @@
   // -------------------------------------------------------------------------
 
   // Coloring model for goal cards (spec: "KPI strip / goals card" column): align mode
-  // borders each goal by its drive_origin's per-drive alignment color; funnel/combined
-  // both border by funnel/pipeline stage instead, since that column is funnel/gate-ruled
-  // in both those modes.
+  // borders each goal by its drive_origin's per-drive alignment color (shared with the
+  // gauges via alignColorForKey); funnel/combined instead border by this goal's own
+  // proposal_status -- i.e. its individual position in the funnel/pipeline -- since that
+  // column is funnel/gate-ruled in both those modes.
   function goalBorderClass(goal, { colorMode, goalAlignmentPayload }) {
     if (colorMode === 'align') {
       const key = String(goal.drive_origin || '').trim().toLowerCase();
-      const perDrive = (goalAlignmentPayload && goalAlignmentPayload.per_drive) || {};
-      const entry = perDrive[key];
-      const color = entry && entry.color_align ? entry.color_align : 'neutral';
+      const color = alignColorForKey(key, goalAlignmentPayload);
       if (color === 'red') return 'border-red-700';
       if (color === 'yellow') return 'border-amber-700';
       if (color === 'green') return 'border-emerald-700';
@@ -765,14 +771,29 @@
     }
   }
 
+  // Monotonic request token: a poll tick and a control-driven refresh (subject/window
+  // change) can overlap in flight. Without this guard, an older request that resolves
+  // after a newer one would overwrite `payloads` with stale-selection data while the
+  // URL/selects already reflect the newer selection -- cards would silently show the
+  // wrong subject/window with no visible error.
+  let refreshToken = 0;
+
   async function refreshAll() {
+    const token = ++refreshToken;
+    let nextPayloads;
     try {
-      payloads = await fetchAll();
+      nextPayloads = await fetchAll();
     } catch (error) {
       // Hard fetch-error fallback only -- every card above already has a real DOM-builder
       // path for degraded/empty payloads; this branch only fires if fetchAll itself throws.
-      payloads = { _degradedAny: true, _fetchError: String(error) };
+      nextPayloads = { _degradedAny: true, _fetchError: String(error) };
     }
+    if (token !== refreshToken) {
+      // A newer refresh started (and possibly already finished) while this one was in
+      // flight -- drop this stale result instead of clobbering more current data.
+      return;
+    }
+    payloads = nextPayloads;
     renderAll();
     writeUrl();
   }

--- a/services/orion-hub/templates/drives-analytics.html
+++ b/services/orion-hub/templates/drives-analytics.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Orion Hub — Drives Analytics</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/static/css/style.css?v=1.0.8" />
+  <style>
+    .drives-tooltip { position: absolute; z-index: 40; max-width: 22rem; }
+    .drive-gauge { display: flex; flex-direction: column; align-items: center; gap: 0.35rem; width: 4.5rem; }
+    .drive-gauge-tube { position: relative; width: 1.75rem; height: 7rem; border-radius: 9999px; background: #111827; border: 1px solid #374151; overflow: hidden; }
+    .drive-gauge-fill { position: absolute; bottom: 0; left: 0; right: 0; transition: height 0.4s ease; }
+    .drive-color-green { background: #10b981; }
+    .drive-color-yellow { background: #f59e0b; }
+    .drive-color-red { background: #ef4444; }
+    .drive-color-neutral { background: #6b7280; }
+    .drive-gauge-dominant { outline: 2px solid #38bdf8; outline-offset: 2px; }
+    .drives-sparkline { width: 100%; height: 2.5rem; display: block; }
+  </style>
+</head>
+<body class="bg-black text-gray-200 min-h-screen p-6">
+  <div class="max-w-6xl mx-auto space-y-4">
+    <div class="flex items-center justify-between flex-wrap gap-2">
+      <h1 class="text-xl font-semibold">Drives Analytics</h1>
+      <div class="flex gap-2">
+        <button id="drivesRefreshButton" type="button" class="px-3 py-2 text-xs rounded border border-gray-700 bg-gray-900 hover:bg-gray-800">Refresh</button>
+        <a href="/" class="px-3 py-2 text-xs rounded border border-gray-700 bg-gray-900 hover:bg-gray-800">Back to Hub</a>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap items-end gap-3 bg-gray-900 border border-gray-800 rounded p-3">
+      <label class="text-xs text-gray-400 flex flex-col gap-1">
+        Subject
+        <select id="drivesSubjectSelect" class="text-xs bg-gray-950 border border-gray-700 rounded px-2 py-1 min-w-[12rem]"></select>
+      </label>
+      <label class="text-xs text-gray-400 flex flex-col gap-1">
+        Window
+        <select id="drivesWindowSelect" class="text-xs bg-gray-950 border border-gray-700 rounded px-2 py-1">
+          <option value="1">1h</option>
+          <option value="6">6h</option>
+          <option value="24" selected>24h</option>
+          <option value="168">7d</option>
+        </select>
+      </label>
+      <label class="text-xs text-gray-400 flex flex-col gap-1">
+        Color mode
+        <select id="drivesColorMode" class="text-xs bg-gray-950 border border-gray-700 rounded px-2 py-1">
+          <option value="combined" selected>combined</option>
+          <option value="align">align</option>
+          <option value="funnel">funnel</option>
+        </select>
+      </label>
+      <label class="text-xs text-gray-400 flex items-center gap-1 pb-1">
+        <input id="drivesAutoRefresh" type="checkbox" checked />
+        Auto-refresh
+      </label>
+      <div class="text-xs text-gray-500 pb-1">Last loaded: <span id="drivesLastLoaded">—</span></div>
+    </div>
+
+    <div id="drivesCoverageBanner" class="hidden text-xs text-amber-400 border border-amber-900/60 bg-amber-950/30 rounded px-3 py-2"></div>
+
+    <section id="drivesGaugesCard" class="bg-gray-900 border border-gray-800 rounded p-4 relative">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-medium">Six-Drive Gauges</h2>
+        <button type="button" class="drives-info-button text-xs text-gray-400 border border-gray-700 rounded-full w-5 h-5" data-card="gauges">i</button>
+      </div>
+      <div id="drivesGaugesBody" class="flex flex-wrap gap-4">Loading…</div>
+    </section>
+
+    <section id="drivesContributorsCard" class="bg-gray-900 border border-gray-800 rounded p-4 relative">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-medium">Contributors</h2>
+        <button type="button" class="drives-info-button text-xs text-gray-400 border border-gray-700 rounded-full w-5 h-5" data-card="contributors">i</button>
+      </div>
+      <div class="flex gap-2 mb-2 text-xs">
+        <button type="button" id="drivesContributorsLiveButton" class="px-2 py-1 rounded border border-gray-700 bg-gray-800">Live</button>
+        <button type="button" id="drivesContributorsWindowButton" class="px-2 py-1 rounded border border-gray-700">Window</button>
+      </div>
+      <div id="drivesContributorsBody" class="text-xs">Loading…</div>
+    </section>
+
+    <section id="drivesKpiStrip" class="bg-gray-900 border border-gray-800 rounded p-4 relative">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-medium">Program-Health KPIs</h2>
+        <button type="button" class="drives-info-button text-xs text-gray-400 border border-gray-700 rounded-full w-5 h-5" data-card="kpi">i</button>
+      </div>
+      <div id="drivesKpiBody" class="flex flex-wrap gap-2 text-xs">Loading…</div>
+    </section>
+
+    <section id="drivesSeriesCard" class="bg-gray-900 border border-gray-800 rounded p-4 relative">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-medium">Tick-Rate and Pressure Series</h2>
+        <button type="button" class="drives-info-button text-xs text-gray-400 border border-gray-700 rounded-full w-5 h-5" data-card="series">i</button>
+      </div>
+      <div id="drivesSeriesBody" class="text-xs">Loading…</div>
+    </section>
+
+    <section id="drivesDivergenceCard" class="bg-gray-900 border border-gray-800 rounded p-4 relative">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-medium">Divergence / Integrity</h2>
+        <button type="button" class="drives-info-button text-xs text-gray-400 border border-gray-700 rounded-full w-5 h-5" data-card="divergence">i</button>
+      </div>
+      <div id="drivesDivergenceBody" class="text-xs">Loading…</div>
+    </section>
+
+    <section id="drivesGoalsCard" class="bg-gray-900 border border-gray-800 rounded p-4 relative">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-medium">Goal Pipeline (read-only)</h2>
+        <button type="button" class="drives-info-button text-xs text-gray-400 border border-gray-700 rounded-full w-5 h-5" data-card="goals">i</button>
+      </div>
+      <div id="drivesGoalsBody" class="text-xs">Loading…</div>
+    </section>
+
+    <section id="drivesCrossLinks" class="bg-gray-900 border border-gray-800 rounded p-4 relative">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-medium">Cross-links</h2>
+        <button type="button" class="drives-info-button text-xs text-gray-400 border border-gray-700 rounded-full w-5 h-5" data-card="crosslinks">i</button>
+      </div>
+      <div id="drivesCrossLinksBody" class="text-xs">Loading…</div>
+    </section>
+
+    <div id="drivesTooltipPopover" class="drives-tooltip hidden bg-gray-950 border border-gray-700 rounded p-3 text-xs text-gray-300 shadow-lg"></div>
+  </div>
+
+  <script src="/static/js/drives-analytics.js?v={{HUB_UI_ASSET_VERSION}}"></script>
+</body>
+</html>

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -63,6 +63,13 @@
             role="button"
           >Causal Geometry</a>
           <a
+            id="drivesAnalyticsTabButton"
+            href="#drives"
+            data-hash-target="#drives"
+            class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
+            role="button"
+          >Drives</a>
+          <a
             id="conceptAtlasTabButton"
             href="#concept-atlas"
             data-hash-target="#concept-atlas"
@@ -2576,6 +2583,28 @@
             class="w-full h-full border-0 min-h-[40rem]"
             loading="lazy"
             title="Causal Geometry Inspector"
+          ></iframe>
+        </div>
+      </section>
+
+      <section id="drives" data-panel="drives" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-xl font-bold text-white">Drives Analytics</h2>
+            <p class="text-xs text-gray-400">Isolated standalone drives-analytics page embedded in-shell to preserve Hub context.</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <button id="drivesAnalyticsPanelRefresh" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700" type="button">Refresh</button>
+            <a id="drivesAnalyticsPanelStandaloneLink" href="/drives-analytics" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Open standalone</a>
+          </div>
+        </div>
+        <div class="rounded-xl border border-gray-800 bg-gray-950/40 overflow-hidden flex-1 min-h-[40rem]">
+          <iframe
+            id="drivesAnalyticsPanelFrame"
+            src="/drives-analytics"
+            class="w-full h-full border-0 min-h-[40rem]"
+            loading="lazy"
+            title="Drives Analytics"
           ></iframe>
         </div>
       </section>

--- a/services/orion-hub/tests/test_drives_analytics_page.py
+++ b/services/orion-hub/tests/test_drives_analytics_page.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import os
+
+os.environ.setdefault("CHANNEL_VOICE_TRANSCRIPT", "orion:voice:transcript")
+os.environ.setdefault("CHANNEL_VOICE_LLM", "orion:voice:llm")
+os.environ.setdefault("CHANNEL_VOICE_TTS", "orion:voice:tts")
+os.environ.setdefault("CHANNEL_COLLAPSE_INTAKE", "orion:collapse:intake")
+os.environ.setdefault("CHANNEL_COLLAPSE_TRIAGE", "orion:collapse:triage")
+
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+from scripts import api_routes
+
+TEMPLATE_PATH = HUB_ROOT / "templates" / "drives-analytics.html"
+JS_PATH = HUB_ROOT / "static" / "js" / "drives-analytics.js"
+
+CONTROL_IDS = (
+    "drivesSubjectSelect",
+    "drivesWindowSelect",
+    "drivesColorMode",
+    "drivesRefreshButton",
+    "drivesAutoRefresh",
+    "drivesLastLoaded",
+    "drivesCoverageBanner",
+)
+
+CARD_IDS = (
+    "drivesGaugesCard",
+    "drivesContributorsCard",
+    "drivesKpiStrip",
+    "drivesSeriesCard",
+    "drivesDivergenceCard",
+    "drivesGoalsCard",
+    "drivesCrossLinks",
+)
+
+TOOLTIP_KEYS = (
+    "gauges",
+    "contributors",
+    "kpi",
+    "series",
+    "divergence",
+    "goals",
+    "crosslinks",
+)
+
+
+def test_drives_analytics_route_is_registered() -> None:
+    route_paths = {route.path for route in api_routes.router.routes}
+    assert "/drives-analytics" in route_paths
+
+
+def test_template_has_control_and_card_ids() -> None:
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
+    for control_id in CONTROL_IDS:
+        assert f'id="{control_id}"' in template
+    for card_id in CARD_IDS:
+        assert f'id="{card_id}"' in template
+
+
+def test_template_references_standalone_asset_version_bundle() -> None:
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
+    assert "/static/js/drives-analytics.js?v={{HUB_UI_ASSET_VERSION}}" in template
+
+
+def test_script_does_not_reference_hub_shell_global() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "window.OrionHub" not in script
+
+
+def test_script_has_real_dom_renderers_not_raw_json_dump() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "function renderGauges(" in script
+    assert "function renderKpiStrip(" in script
+    assert "function renderSeries(" in script
+    assert "function renderContributors(" in script
+    assert "function renderDivergence(" in script
+    assert "function renderGoals(" in script
+    assert "function renderCrossLinks(" in script
+    assert "target.textContent = JSON.stringify(payload, null, 2);" not in script
+
+
+def test_tooltip_copy_covers_all_cards_with_three_required_angles() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "TOOLTIP_COPY" in script
+    for key in TOOLTIP_KEYS:
+        assert f"{key}:" in script or f'"{key}"' in script
+    assert "definition:" in script
+    assert "design:" in script
+    assert "reading:" in script
+
+
+def test_polling_pauses_on_hidden_and_resumes_on_visible() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "visibilitychange" in script
+    assert "setInterval(" in script
+    assert "clearInterval(" in script
+    assert 'document.visibilityState === \'hidden\'' in script or 'document.visibilityState === "hidden"' in script
+
+
+def test_contributors_live_window_toggle_and_null_attribution_language() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "Live" in script
+    assert "Window" in script
+    assert "null_attribution_row_count" in script
+
+
+def test_color_mode_and_window_picker_values_present() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "combined" in script
+    assert "align" in script
+    assert "funnel" in script
+    for hours in ("1", "6", "24", "168"):
+        assert hours in script or hours in TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def test_no_mutation_fetch_calls_in_page_js() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    for verb in ("POST", "PUT", "DELETE", "PATCH"):
+        assert f"method: '{verb}'" not in script
+        assert f'method: "{verb}"' not in script
+
+
+def test_goals_card_has_no_action_buttons() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    # causal-geometry.js has adopt/reject buttons wired to POST endpoints; this page must
+    # not, since the Goals card is strictly read-only orientation, never a mutation console.
+    assert "adoptButton" not in script
+    assert "rejectButton" not in script
+    assert "postAction(" not in script
+    assert "proposals/${" not in script
+
+
+def test_gate_verdict_never_labeled_bare_go() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "GO_DRIVE_ONLY" in script
+    assert "drive economy OK (partial)" in script
+
+
+def test_endpoints_referenced_in_script() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    for path in (
+        "/api/drives-analytics/subjects",
+        "/api/drives-analytics/snapshot",
+        "/api/drives-analytics/window",
+        "/api/drives-analytics/series",
+        "/api/drives-analytics/goal-alignment",
+        "/api/drives-analytics/divergence",
+    ):
+        assert path in script
+
+
+def test_cross_links_card_content() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "/spark/ui" in script
+    assert "/#pressure" in script
+    assert "/causal-geometry" in script
+    assert "Pressure" in script and "not the same thing as the DriveEngine economy" in script
+    assert "<details" in script
+
+
+def test_divergence_card_surfaces_fallback_banner_and_autonomy_note() -> None:
+    script = JS_PATH.read_text(encoding="utf-8")
+    assert "store_path_is_fallback_default" in script
+    assert "autonomy_state_v2_note" in script

--- a/services/orion-hub/tests/test_drives_analytics_page.py
+++ b/services/orion-hub/tests/test_drives_analytics_page.py
@@ -172,3 +172,86 @@ def test_divergence_card_surfaces_fallback_banner_and_autonomy_note() -> None:
     script = JS_PATH.read_text(encoding="utf-8")
     assert "store_path_is_fallback_default" in script
     assert "autonomy_state_v2_note" in script
+
+
+# ---------------------------------------------------------------------------
+# Hub shell tab wiring (Task 8) -- mirrors test_causal_geometry_page.py's
+# shell-level tests for the #drives tab.
+# ---------------------------------------------------------------------------
+
+APP_JS_PATH = HUB_ROOT / "static" / "js" / "app.js"
+INDEX_HTML_PATH = HUB_ROOT / "templates" / "index.html"
+
+
+def test_main_hub_has_drives_navigation_link_in_shell_tabs() -> None:
+    index_html = INDEX_HTML_PATH.read_text(encoding="utf-8")
+
+    assert 'id="drivesAnalyticsTabButton"' in index_html
+    assert 'href="#drives"' in index_html
+    assert 'data-hash-target="#drives"' in index_html
+    assert ">Drives<" in index_html
+    drives_link_block = index_html.split('id="drivesAnalyticsTabButton"', 1)[1].split("</a>", 1)[0]
+    assert 'role="button"' in drives_link_block
+
+
+def test_main_hub_has_isolated_drives_shell_panel_embedding_standalone_page() -> None:
+    index_html = INDEX_HTML_PATH.read_text(encoding="utf-8")
+
+    assert '<section id="drives" data-panel="drives"' in index_html
+    assert 'id="drivesAnalyticsPanelFrame"' in index_html
+    assert 'src="/drives-analytics"' in index_html
+    assert 'id="drivesAnalyticsPanelStandaloneLink" href="/drives-analytics"' in index_html
+
+
+def test_drives_page_keeps_main_shell_untouched() -> None:
+    index_html = INDEX_HTML_PATH.read_text(encoding="utf-8")
+    app_js = APP_JS_PATH.read_text(encoding="utf-8")
+
+    assert "drives-analytics.js" not in index_html
+    assert 'id="drivesAnalyticsPanelFrame"' in index_html
+    assert "/api/drives-analytics" not in app_js
+    assert "drivesRefreshButton" not in app_js
+
+
+def test_app_js_includes_drives_in_shell_tab_switching_without_full_navigation() -> None:
+    app_js = APP_JS_PATH.read_text(encoding="utf-8")
+
+    assert 'const drivesAnalyticsTabButton = document.getElementById("drivesAnalyticsTabButton");' in app_js
+    assert 'const drivesAnalyticsPanel = document.getElementById("drives");' in app_js
+    assert 'const isDrivesAnalytics = effectiveTab === "drives";' in app_js
+    assert 'drivesAnalyticsPanel.classList.toggle("hidden", !isDrivesAnalytics);' in app_js
+    assert 'styleTabButton(drivesAnalyticsTabButton, isDrivesAnalytics);' in app_js
+    assert 'drivesAnalyticsTabButton.addEventListener("click", (event) => {' in app_js
+    assert 'setActiveTab("drives");' in app_js
+    assert 'history.replaceState(null, "", "#drives");' in app_js
+    assert 'h === "#drives"' in app_js
+
+
+def test_app_js_supports_drives_embed_refresh_without_merging_bundle() -> None:
+    app_js = APP_JS_PATH.read_text(encoding="utf-8")
+
+    assert 'const drivesAnalyticsPanelFrame = document.getElementById("drivesAnalyticsPanelFrame");' in app_js
+    assert 'const drivesAnalyticsPanelRefresh = document.getElementById("drivesAnalyticsPanelRefresh");' in app_js
+    assert 'drivesAnalyticsPanelFrame.contentWindow?.location.reload();' in app_js
+    assert "drives-analytics.js" not in app_js
+
+
+def test_app_js_never_navigates_the_parent_window_for_drives_tab() -> None:
+    """The crux of 'doesn't kill the session': no full-page navigation for this tab.
+
+    The only reload allowed for this feature is on the iframe's own contentWindow, triggered
+    by the explicit refresh button -- never window.location/href on the parent Hub page.
+    """
+    app_js = APP_JS_PATH.read_text(encoding="utf-8")
+
+    lines = app_js.splitlines()
+    drives_lines = [line for line in lines if "drivesAnalytics" in line]
+    assert drives_lines, "expected drivesAnalytics lines to exist in app.js"
+
+    for line in drives_lines:
+        assert "window.location.href" not in line
+        assert "window.location =" not in line
+
+    reload_lines = [line for line in drives_lines if ".reload()" in line]
+    assert len(reload_lines) == 1
+    assert "drivesAnalyticsPanelFrame.contentWindow?.location.reload();" in reload_lines[0]

--- a/services/orion-spark-concept-induction/README.md
+++ b/services/orion-spark-concept-induction/README.md
@@ -49,6 +49,32 @@ python scripts/drive_state_divergence_audit.py
 python scripts/drive_state_divergence_audit.py --json
 ```
 
+### This service is the producer of `DriveAuditV1` (Hub Drives Analytics)
+
+This service is the sole **producer** of `DriveAuditV1` audit artifacts (schema
+`orion/core/schemas/drives.py`, `kind="memory.drives.audit.v1"`) — including the
+`tick_attribution` (per-drive float weights) and `tension_kinds` (short list of
+contributing tension kinds) fields. `orion/spark/concept_induction/audit.py::build_drive_audit`
+builds each audit from the current `DriveStateV1` plus the tick's tensions and attribution, then
+`ConceptWorker._publish_artifact` (`bus_worker.py`) publishes it on `self.cfg.drive_audit_channel`
+(`orion/spark/concept_induction/settings.py`). `tick_attribution` itself comes from
+`compute_tick_attribution()` in `orion/spark/concept_induction/drive_attribution.py`, which also
+derives `dominant_drive` when it isn't passed explicitly.
+
+**This service does not serve the Hub UI.** The Hub **Drives** tab (`#drives`,
+`/drives-analytics`) never talks to concept-induction directly. Instead: `orion-sql-writer`
+subscribes to the audit channel and persists each audit (including, as of
+`services/orion-sql-db/manual_migration_drive_audits_v4_tick_attribution.sql`, the
+`tick_attribution`/`tension_kinds` columns — previously dropped by the sql-writer column filter) to
+the Postgres `drive_audits` table (`services/orion-sql-writer/app/models/drive_audit.py`). Hub then
+reads that Postgres history via its own `RECALL_PG_DSN`-backed pool
+(`services/orion-hub/scripts/drives_analytics_queries.py`). This service is upstream producer only —
+it has no dependency on Hub, and a Hub outage does not affect audit production.
+
+See also: [Hub Drives tab operator docs](../orion-hub/README.md) (`#drives`) and
+[orion/autonomy/README.md § Hub Drives Analytics](../../orion/autonomy/README.md#hub-drives-analytics)
+for what the persisted audits mean to an operator.
+
 ## Satisfaction tensions (drive relief)
 
 `DriveEngine.update()` supports signed drive impacts: a `TensionEventV1` with a


### PR DESCRIPTION
## Summary

- Ships the Hub **Drives** operator tab: a standalone `/drives-analytics` page (7 cards — gauges, contributors, KPI strip, dual time series, divergence, goals, cross-links) with goal-aligned coloring, tooltips, and gentle 30s polling.
- Wires a session-preserving `#drives` tab into the Hub shell (`index.html` + `app.js`), mirroring the Causal Geometry iframe-isolation pattern exactly — toggling the tab never reloads the Hub chat session.
- Adds a `GET /drives-analytics` page route in `api_routes.py`.
- Documents the surface in `orion/autonomy/README.md`, `services/orion-hub/README.md`, and `services/orion-spark-concept-induction/README.md`.
- Fixes two issues found in orchestrator code review: a refresh race condition and duplicated align-color lookup logic.

This is PR3 of the Hub Drives Analytics plan (`docs/superpowers/plans/2026-07-16-hub-drives-analytics.md`, Tasks 5-9). PR 1 (persistence: `tick_attribution`/`tension_kinds` columns) and PR 2 (read-only API: subjects/snapshot/window/series/goal-alignment/divergence) are already merged and live on `main`.

## Outcome moved

Juniper can now see the live six-drive `DriveEngine` economy at a glance in the Hub — real contributor history, program-health KPIs, tick-rate + pressure time series, goal-alignment coloring, and a divergence/integrity check against `drive_state.v1` — without CLI archaeology (`measure_autonomy_gate.py`, `drive_state_divergence_audit.py`) or per-turn chat side panels.

## Current architecture

Before this PR: `drive_audits` persistence and the 6 read-only `/api/drives-analytics/*` endpoints existed (merged via #1123/#1124), but no UI consumed them — the data was invisible to operators.

## Architecture touched

- `services/orion-hub/` only (templates, static JS, one new route, tests, README).
- No bus/schema/registry changes. No backend/API changes (out of scope, already merged).

## Files changed

- `services/orion-hub/templates/drives-analytics.html` (new): standalone page shell, 7 card containers, controls row, tooltip popover.
- `services/orion-hub/static/js/drives-analytics.js` (new, ~890 lines): fetch/render/polling bundle for all 7 cards, `TOOLTIP_COPY`, color-mode logic (`combined`/`align`/`funnel`), Live/Window contributors toggle, URL-query state sync.
- `services/orion-hub/scripts/api_routes.py`: added `GET /drives-analytics` page route (mirrors `causal_geometry_page` exactly).
- `services/orion-hub/templates/index.html`: `#drives` nav tab + iframe panel section.
- `services/orion-hub/static/js/app.js`: tab-switch/hash/refresh wiring for `#drives`, mirroring every existing tab's pattern.
- `services/orion-hub/tests/test_drives_analytics_page.py` (new): 21 tests — route registration, template/card ids, standalone-bundle isolation, tooltip structure, polling, color-mode/window-picker presence, no-mutation-calls, goals-card no-action-buttons, gate-verdict labeling, cross-link content, divergence banner, and 6 shell-wiring tests (session-preserving tab toggle, iframe-only refresh, no full-page navigation).
- `orion/autonomy/README.md`, `services/orion-hub/README.md`, `services/orion-spark-concept-induction/README.md`: operator-facing docs (why the tab exists, what "good" looks like, endpoint/hash-param contract, producer/consumer split).

## Schema / bus / API changes

None. No new bus channels, schema registry entries, or API endpoints — this PR only builds a UI on top of the already-merged read-only API.

## Env/config changes

None. No `.env_example` keys added/removed/renamed.

## Tests run

```
cd services/orion-hub
python -m pytest tests/test_drives_analytics_page.py tests/test_drives_analytics_api.py tests/test_drives_analytics_helpers.py tests/test_causal_geometry_page.py tests/test_causal_geometry_api.py -q
→ 75 passed

python -m pytest ../orion-sql-writer/tests/test_drive_audit_sql_shape.py -q
→ 16 passed

node --check static/js/drives-analytics.js && node --check static/js/app.js
→ syntax OK

git diff --check
→ clean
```

No eval harness exists for this UI-only slice beyond the pytest gate tests above.

## Docker/build/smoke checks

Not run — this patch only adds new frontend files (templates/static/route), no config/dependency/DB changes, so no Docker rebuild was required to validate it. A Hub container rebuild is needed to pick up the new static/template files before operators can use the tab (see Restart below).

## Review findings fixed

8-angle high-effort code review (parallel finder agents + orchestrator verification against the already-merged backend contract):

- **Finding (real, fixed):** `refreshAll()`/`fetchAll()` had no request-sequencing guard — an overlapping poll tick and a control-driven refresh (subject/window change) could resolve out of order, silently rendering stale-selection data while the URL/selects already showed the new selection.
  - Fix: added a monotonic `refreshToken`; any response superseded by a newer refresh is dropped instead of overwriting `payloads`.
  - Evidence: `services/orion-hub/static/js/drives-analytics.js`, `refreshAll()`.
- **Finding (real, fixed):** `gaugeColorClass` and `goalBorderClass` each independently re-implemented the same per-drive `color_align` lookup, with inconsistent Tailwind shade numbers (500 vs 700) — drift risk.
  - Fix: extracted `alignColorForKey()` as the single source of truth for both call sites; also dropped `gaugeColorClass`'s unused `kpis` destructured parameter.
  - Evidence: `services/orion-hub/static/js/drives-analytics.js`, `alignColorForKey`, `gaugeColorClass`, `goalBorderClass`.
- **4 findings verified as unreachable:** candidates about missing null-guards on `record_count`/`active_count`/timestamp fields were checked against the already-merged backend (`services/orion-hub/scripts/drives_analytics_queries.py`) — every field is guaranteed non-null/well-formed (`int(x or 0)` casts, `isoformat()` of real `datetime` objects) on every code path, so no fix was needed.
- **3 findings noted as follow-ups, not fixed:** `fetchSection()` duplication across standalone Hub pages, `DRIVE_KEYS`/`ALLOWED_HOURS`/verdict-string hardcoding in JS (no shared JS/backend contract mechanism exists yet), and refetching the static `/subjects` endpoint on every poll tick — all pre-existing repo patterns or low-impact at operator-dashboard/30s-cadence scale, not worth new abstractions in this PR.

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

sql-writer and its migration are unaffected by this PR (already deployed in PR1/PR2).

## Risks / concerns

- Severity: Low — Sparklines/tick-rate chart are hand-rolled SVG polylines, not a charting library; adequate but visually blunt (documented as a deliberate simplification in the implementing agent's report).
- Severity: Low — `DRIVE_KEYS`/`ALLOWED_HOURS`/verdict strings are hardcoded in the client JS with no shared contract to the Python source of truth; a future backend change to these constants would silently desync the UI. Mitigation: same pattern as every other standalone Hub page (`causal-geometry.js`, `substrate.js`); fixing it repo-wide is out of scope for this PR.

## PR link

(link filled in by `gh pr create` output below)