### PR TITLE
feat(hub): live decay scheduler for concept activation (Gap 3)

### DIFF
--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -418,6 +418,11 @@ SUBSTRATE_REVIEW_TELEMETRY_SQL_DB_PATH=
 # Seeds the 3 golden concepts (Orion, Juniper, relationship) into SUBSTRATE_SEMANTIC_STORE
 # at startup -- see orion/substrate/seed.py. Idempotent, safe to leave enabled.
 SUBSTRATE_CONCEPT_SEED_ENABLED=true
+# Applies half-life activation decay to every concept-kind node on a fixed
+# interval -- see api_routes.py::decay_concept_activations(). Idempotent, safe
+# to leave enabled.
+SUBSTRATE_DECAY_SCHEDULER_ENABLED=true
+SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC=120
 SUBSTRATE_AUTONOMY_ENABLED=true
 SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED=true
 SUBSTRATE_AUTONOMY_APPLY_ENABLED=true

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -511,6 +511,14 @@ class Settings(BaseSettings):
     # (see main.py's startup_event) since SUBSTRATE_STORE_BACKEND=sparql (this
     # service's own default) makes the underlying writes blocking HTTP calls to Fuseki.
     SUBSTRATE_CONCEPT_SEED_ENABLED: bool = Field(default=True, alias="SUBSTRATE_CONCEPT_SEED_ENABLED")
+    # Applies half-life activation decay to every concept-kind node in
+    # SUBSTRATE_SEMANTIC_STORE on a fixed interval -- see
+    # api_routes.py::decay_concept_activations(). Runs in a background thread
+    # (see main.py's startup_event) for the same reason the concept-seed step
+    # does: SUBSTRATE_STORE_BACKEND=sparql (this service's own default) makes
+    # the underlying writes blocking HTTP calls to Fuseki.
+    SUBSTRATE_DECAY_SCHEDULER_ENABLED: bool = Field(default=True, alias="SUBSTRATE_DECAY_SCHEDULER_ENABLED")
+    SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC: float = Field(default=120.0, alias="SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC")
     SUBSTRATE_AUTONOMY_ENABLED: bool = Field(default=False, alias="SUBSTRATE_AUTONOMY_ENABLED")
     SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED: bool = Field(default=True, alias="SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED")
     SUBSTRATE_AUTONOMY_APPLY_ENABLED: bool = Field(default=False, alias="SUBSTRATE_AUTONOMY_APPLY_ENABLED")

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -119,6 +119,7 @@ from orion.core.schemas.substrate_mutation import (
     RecallShadowEvalRunV1,
     RecallStrategyProfileV1,
 )
+from orion.core.activation_decay import decay_activation
 from orion.substrate import build_substrate_policy_store_from_env, build_substrate_store_from_env
 from orion.substrate.consolidation import GraphConsolidationEvaluator
 from orion.substrate.policy_comparison import SubstratePolicyComparisonService
@@ -249,6 +250,124 @@ def seed_golden_concepts_at_startup() -> int:
     except Exception as exc:  # pragma: no cover - defensive, mirrors other startup steps
         logger.warning("substrate_concept_seed_failed error=%s", exc)
         return 0
+
+
+def decay_concept_activations(elapsed_seconds: Optional[float] = None) -> dict[str, Any]:
+    """Apply half-life activation decay to every concept-kind node in
+    SUBSTRATE_SEMANTIC_STORE, in place (re-upserted with only
+    signals.activation.activation changed).
+
+    This is the live writer that ``SubstrateActivationV1.activation`` has
+    lacked -- see the honesty note in ``concept_atlas_routes.py``'s
+    ``_at_risk_concepts``. Reuses the same validated decay helper
+    (``orion.core.activation_decay.decay_activation``).
+
+    ``elapsed_seconds``, when given, is applied uniformly to every node as
+    the decay window (the caller -- the periodic scheduler in ``main.py`` --
+    passes the actual wall-clock time since its previous tick). This is the
+    correct mode for a function called repeatedly on a fixed cadence:
+    exponential decay is memoryless, so decaying an already-decayed
+    ``current`` value by the true inter-tick interval on every call is
+    equivalent to decaying once by the total elapsed time.
+
+    When ``elapsed_seconds`` is omitted (``None``), falls back to computing
+    elapsed time from ``node.temporal.observed_at`` per node -- a one-shot
+    decay against the node's full age, useful for an ad-hoc/manual
+    invocation. This mode must NOT be used by a loop that calls this
+    function repeatedly without also advancing ``observed_at`` between
+    calls: since ``observed_at`` carries real "last touched" semantics read
+    by other consumers (recency scoring in ``orion/substrate/dynamics.py``,
+    sustained-surprise pressure in ``orion/substrate/pressure.py``, reconcile
+    merge-max in ``orion/substrate/reconcile.py``), this function
+    deliberately never mutates it -- so reusing this fallback mode on every
+    scheduler tick would keep re-decaying from the same, ever-growing
+    elapsed-since-creation window on top of an already-shrunk ``current``,
+    collapsing activation to ``decay_floor`` within roughly one configured
+    half-life regardless of the half-life value. That failure mode is why
+    the scheduler always passes ``elapsed_seconds`` explicitly.
+
+    Real identity key, not node_id, mirroring the sibling in-memory tick loop
+    (``orion/substrate/dynamics.py::SubstrateDynamicsEngine.tick``) --
+    ``upsert_node``'s ``identity_key`` is the store's domain-dedup key (e.g.
+    ``concept|<scope>|<subject>|seed`` from ``orion/substrate/seed.py``), not
+    the same string as ``node_id``. Passing ``node_id`` as the identity key
+    would silently overwrite each node's real identity record on backends
+    where that property is a single-valued overwrite (e.g. FalkorDB),
+    breaking later identity-based lookups/dedup after the next cache
+    rehydrate. Reverse-mapped here from ``snapshot.node_identity_index``
+    (identity -> node_id) exactly as ``dynamics.py``'s ``identity_by_node_id``
+    does; unknown identity degrades to ``None`` (the safe "no identity index
+    entry" convention already used elsewhere, e.g. ``graphdb_store.py``).
+
+    Never raises -- a single malformed/missing-timestamp node is skipped
+    (counted in ``skipped``), not fatal to the rest of the pass or to the
+    caller.
+
+    Returns a summary dict: ``{"decayed": int, "skipped": int, "errors": int,
+    "total_concepts": int}``. ``decayed`` counts nodes successfully
+    re-upserted with a recomputed activation value.
+    """
+    summary: dict[str, Any] = {
+        "decayed": 0,
+        "skipped": 0,
+        "errors": 0,
+        "total_concepts": 0,
+    }
+    try:
+        snapshot = SUBSTRATE_SEMANTIC_STORE.snapshot()
+    except Exception as exc:
+        logger.warning("substrate_concept_decay_snapshot_failed error=%s", exc)
+        summary["errors"] += 1
+        return summary
+
+    concept_nodes = [n for n in snapshot.nodes.values() if getattr(n, "node_kind", None) == "concept"]
+    summary["total_concepts"] = len(concept_nodes)
+    if not concept_nodes:
+        return summary
+
+    identity_by_node_id = {node_id: identity for identity, node_id in snapshot.node_identity_index.items()}
+
+    now = datetime.now(timezone.utc)
+    for node in concept_nodes:
+        try:
+            activation_signal = node.signals.activation
+            observed_at = node.temporal.observed_at
+        except AttributeError:
+            summary["skipped"] += 1
+            continue
+        if activation_signal is None or observed_at is None:
+            summary["skipped"] += 1
+            continue
+
+        try:
+            if elapsed_seconds is not None:
+                node_elapsed_seconds = max(0.0, float(elapsed_seconds))
+            else:
+                if observed_at.tzinfo is None:
+                    observed_at = observed_at.replace(tzinfo=timezone.utc)
+                node_elapsed_seconds = max(0.0, (now - observed_at).total_seconds())
+
+            prev_activation = activation_signal.activation
+            new_activation = decay_activation(
+                current=prev_activation,
+                elapsed_seconds=node_elapsed_seconds,
+                half_life_seconds=activation_signal.decay_half_life_seconds,
+                floor=activation_signal.decay_floor,
+            )
+
+            updated_signal = activation_signal.model_copy(update={"activation": new_activation})
+            updated_signals = node.signals.model_copy(update={"activation": updated_signal})
+            updated_node = node.model_copy(update={"signals": updated_signals})
+
+            SUBSTRATE_SEMANTIC_STORE.upsert_node(
+                identity_key=identity_by_node_id.get(node.node_id), node=updated_node
+            )
+            summary["decayed"] += 1
+        except Exception as exc:
+            logger.warning("substrate_concept_decay_node_failed node_id=%s error=%s", getattr(node, "node_id", "?"), exc)
+            summary["errors"] += 1
+
+    return summary
 
 
 SUBSTRATE_POLICY_STORE = build_substrate_policy_store_from_env()

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import asyncio
+import time
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -267,6 +268,7 @@ embodiment_outcome_cache: Optional[EmbodimentOutcomeCache] = None
 presence_state: Optional["PresenceState"] = None
 presence_context_store: Optional["PresenceContextStore"] = None
 substrate_autonomy_task: Optional[asyncio.Task] = None
+substrate_decay_task: Optional[asyncio.Task] = None
 
 
 class PresenceState:
@@ -339,7 +341,7 @@ async def startup_event():
     Initializes all shared services at application startup.
     OrionBus + Clients + UI template.
     """
-    global bus, rpc_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, presence_state, presence_context_store, substrate_autonomy_task
+    global bus, rpc_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, presence_state, presence_context_store, substrate_autonomy_task, substrate_decay_task
 
     # ------------------------------------------------------------
     # Orion Bus Initialization
@@ -505,6 +507,46 @@ async def startup_event():
     else:
         logger.info("substrate_autonomy_scheduler_disabled reason=env_disabled")
 
+    if settings.SUBSTRATE_DECAY_SCHEDULER_ENABLED:
+        decay_interval_sec = max(1.0, float(settings.SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC))
+
+        async def _run_substrate_decay_scheduler() -> None:
+            # Tracks true wall-clock time between ticks (not just decay_interval_sec)
+            # so a slow to_thread call or scheduling jitter doesn't desync the decay
+            # window from what actually elapsed -- see decay_concept_activations()'s
+            # docstring for why passing an explicit, per-tick elapsed_seconds (rather
+            # than falling back to its node.temporal.observed_at-based one-shot mode)
+            # is required for a function called repeatedly on a loop.
+            last_tick_monotonic = time.monotonic()
+            while True:
+                await asyncio.sleep(decay_interval_sec)
+                now_monotonic = time.monotonic()
+                tick_elapsed_sec = now_monotonic - last_tick_monotonic
+                last_tick_monotonic = now_monotonic
+                try:
+                    summary = await asyncio.to_thread(
+                        api_routes_runtime.decay_concept_activations,
+                        elapsed_seconds=tick_elapsed_sec,
+                    )
+                    logger.info(
+                        "substrate_decay_scheduler_tick decayed=%s skipped=%s errors=%s total_concepts=%s elapsed_sec=%.1f",
+                        summary.get("decayed"),
+                        summary.get("skipped"),
+                        summary.get("errors"),
+                        summary.get("total_concepts"),
+                        tick_elapsed_sec,
+                    )
+                except Exception as exc:  # advisory runtime loop; never crash service startup
+                    logger.warning("substrate_decay_scheduler_error error=%s", exc)
+
+        substrate_decay_task = asyncio.create_task(
+            _run_substrate_decay_scheduler(),
+            name="hub-substrate-decay-scheduler",
+        )
+        logger.info("substrate_decay_scheduler_enabled interval_sec=%s", decay_interval_sec)
+    else:
+        logger.info("substrate_decay_scheduler_disabled reason=env_disabled")
+
 
     # ------------------------------------------------------------
     # Validate UI HTML Template (served fresh from disk on each GET /)
@@ -564,7 +606,7 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
-    global bus, rpc_bus, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, substrate_autonomy_task
+    global bus, rpc_bus, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, substrate_autonomy_task, substrate_decay_task
     pool = getattr(app.state, "memory_pg_pool", None)
     if pool is not None:
         try:
@@ -580,6 +622,13 @@ async def shutdown_event() -> None:
         except asyncio.CancelledError:
             pass
         substrate_autonomy_task = None
+    if substrate_decay_task is not None:
+        substrate_decay_task.cancel()
+        try:
+            await substrate_decay_task
+        except asyncio.CancelledError:
+            pass
+        substrate_decay_task = None
     if biometrics_cache is not None:
         await biometrics_cache.stop()
     if notification_cache is not None:

--- a/services/orion-hub/tests/test_substrate_concept_decay_scheduler.py
+++ b/services/orion-hub/tests/test_substrate_concept_decay_scheduler.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import os
+import sys
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+os.environ.setdefault("CHANNEL_VOICE_TRANSCRIPT", "orion:voice:transcript")
+os.environ.setdefault("CHANNEL_VOICE_LLM", "orion:voice:llm")
+os.environ.setdefault("CHANNEL_VOICE_TTS", "orion:voice:tts")
+os.environ.setdefault("CHANNEL_COLLAPSE_INTAKE", "orion:collapse:intake")
+os.environ.setdefault("CHANNEL_COLLAPSE_TRIAGE", "orion:collapse:triage")
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+hub_scripts_pkg = HUB_ROOT / "scripts" / "__init__.py"
+if (
+    "scripts" not in sys.modules
+    or not str(getattr(sys.modules.get("scripts"), "__file__", "")).startswith(str(HUB_ROOT))
+):
+    spec = importlib.util.spec_from_file_location(
+        "scripts",
+        str(hub_scripts_pkg),
+        submodule_search_locations=[str(HUB_ROOT / "scripts")],
+    )
+    if spec is not None and spec.loader is not None:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["scripts"] = module
+        spec.loader.exec_module(module)
+
+from scripts import api_routes  # noqa: E402
+
+from orion.core.schemas.cognitive_substrate import (  # noqa: E402
+    ConceptNodeV1,
+    EntityNodeV1,
+    SubstrateActivationV1,
+    SubstrateSignalBundleV1,
+)
+from orion.substrate.adapters._common import make_provenance, make_temporal  # noqa: E402
+from orion.substrate.store import InMemorySubstrateGraphStore  # noqa: E402
+
+
+def _make_concept_node(
+    *,
+    node_id: str,
+    activation: float,
+    decay_half_life_seconds: int | None,
+    decay_floor: float,
+    observed_at: datetime,
+) -> ConceptNodeV1:
+    return ConceptNodeV1(
+        node_id=node_id,
+        anchor_scope="world",
+        label=f"concept-{node_id}",
+        temporal=make_temporal(observed_at=observed_at),
+        signals=SubstrateSignalBundleV1(
+            activation=SubstrateActivationV1(
+                activation=activation,
+                recency_score=0.5,
+                decay_half_life_seconds=decay_half_life_seconds,
+                decay_floor=decay_floor,
+            )
+        ),
+        provenance=make_provenance(
+            source_kind="test.fixture",
+            source_channel="test:substrate:decay",
+            producer="test_substrate_concept_decay_scheduler",
+        ),
+    )
+
+
+def test_decay_concept_activations_decays_old_node_toward_floor(monkeypatch) -> None:
+    fresh_store = InMemorySubstrateGraphStore()
+    old_observed_at = datetime.now(timezone.utc) - timedelta(hours=6)
+    node = _make_concept_node(
+        node_id="concept-old",
+        activation=1.0,
+        decay_half_life_seconds=3600,  # 1 hour half-life, 6 hours elapsed -> heavy decay
+        decay_floor=0.1,
+        observed_at=old_observed_at,
+    )
+    fresh_store.upsert_node(identity_key=node.node_id, node=node)
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", fresh_store)
+
+    summary = api_routes.decay_concept_activations()
+
+    assert summary == {"decayed": 1, "skipped": 0, "errors": 0, "total_concepts": 1}
+    updated = fresh_store.get_node_by_id("concept-old")
+    assert updated is not None
+    new_activation = updated.signals.activation.activation
+    assert new_activation < 1.0
+    # 6 hours / 1 hour half-life = 6 half-lives -> well below the original value,
+    # but never below the floor.
+    assert new_activation < 0.2
+    assert new_activation >= 0.1
+
+
+def test_decay_concept_activations_barely_moves_recent_node(monkeypatch) -> None:
+    fresh_store = InMemorySubstrateGraphStore()
+    recent_observed_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    node = _make_concept_node(
+        node_id="concept-recent",
+        activation=0.8,
+        decay_half_life_seconds=3600,
+        decay_floor=0.0,
+        observed_at=recent_observed_at,
+    )
+    fresh_store.upsert_node(identity_key=node.node_id, node=node)
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", fresh_store)
+
+    summary = api_routes.decay_concept_activations()
+
+    assert summary == {"decayed": 1, "skipped": 0, "errors": 0, "total_concepts": 1}
+    updated = fresh_store.get_node_by_id("concept-recent")
+    assert updated is not None
+    new_activation = updated.signals.activation.activation
+    # Barely any time has passed -- activation should be close to the original.
+    assert abs(new_activation - 0.8) < 0.01
+
+
+def test_decay_concept_activations_only_touches_activation_field(monkeypatch) -> None:
+    fresh_store = InMemorySubstrateGraphStore()
+    node = _make_concept_node(
+        node_id="concept-preserve",
+        activation=0.9,
+        decay_half_life_seconds=60,
+        decay_floor=0.0,
+        observed_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    node = node.model_copy(update={"promotion_state": "canonical", "metadata": {"foo": "bar"}})
+    fresh_store.upsert_node(identity_key=node.node_id, node=node)
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", fresh_store)
+
+    api_routes.decay_concept_activations()
+
+    updated = fresh_store.get_node_by_id("concept-preserve")
+    assert updated is not None
+    assert updated.promotion_state == "canonical"
+    assert updated.metadata == {"foo": "bar"}
+    assert updated.label == "concept-concept-preserve"
+    # Only the activation value changed -- recency_score/decay_half_life_seconds/decay_floor untouched.
+    assert updated.signals.activation.recency_score == 0.5
+    assert updated.signals.activation.decay_half_life_seconds == 60
+    assert updated.signals.activation.decay_floor == 0.0
+
+
+def test_decay_concept_activations_skips_malformed_node_without_crashing(monkeypatch) -> None:
+    fresh_store = InMemorySubstrateGraphStore()
+    good_node = _make_concept_node(
+        node_id="concept-good",
+        activation=0.7,
+        decay_half_life_seconds=3600,
+        decay_floor=0.0,
+        observed_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+    )
+    fresh_store.upsert_node(identity_key=good_node.node_id, node=good_node)
+
+    # A non-concept node (entity) must not be touched or counted -- _concept_nodes-style
+    # filtering by node_kind == "concept" should exclude it entirely.
+    entity_node = EntityNodeV1(
+        node_id="entity-1",
+        anchor_scope="world",
+        label="not-a-concept",
+        temporal=make_temporal(observed_at=datetime.now(timezone.utc)),
+        provenance=make_provenance(
+            source_kind="test.fixture",
+            source_channel="test:substrate:decay",
+            producer="test_substrate_concept_decay_scheduler",
+        ),
+    )
+    fresh_store.upsert_node(identity_key=entity_node.node_id, node=entity_node)
+
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", fresh_store)
+
+    summary = api_routes.decay_concept_activations()
+
+    assert summary["total_concepts"] == 1
+    assert summary["decayed"] == 1
+    assert summary["skipped"] == 0
+    assert summary["errors"] == 0
+    # Entity node is untouched (not even inspected as a concept).
+    entity_after = fresh_store.get_node_by_id("entity-1")
+    assert entity_after is not None
+    assert entity_after.label == "not-a-concept"
+
+
+def test_decay_concept_activations_skips_malformed_activation_without_crashing(monkeypatch) -> None:
+    """A concept node whose signals/temporal bundle is missing/malformed must be
+    skipped (counted in ``skipped``), not crash the rest of the pass."""
+
+    class _FakeSignals:
+        # No `.activation` attribute at all -- simulates a malformed bundle.
+        pass
+
+    class _MalformedConceptNode:
+        node_id = "concept-malformed"
+        node_kind = "concept"
+        signals = _FakeSignals()
+        temporal = None
+
+    fresh_store = InMemorySubstrateGraphStore()
+    good_node = _make_concept_node(
+        node_id="concept-good-2",
+        activation=0.6,
+        decay_half_life_seconds=3600,
+        decay_floor=0.0,
+        observed_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+    )
+    fresh_store.upsert_node(identity_key=good_node.node_id, node=good_node)
+    # Bypass pydantic validation entirely by writing directly into the store's
+    # internal node dict -- this is the only way to construct a genuinely
+    # malformed node, since ConceptNodeV1 itself would reject one.
+    fresh_store._nodes[_MalformedConceptNode.node_id] = _MalformedConceptNode()
+
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", fresh_store)
+
+    summary = api_routes.decay_concept_activations()
+
+    assert summary["total_concepts"] == 2
+    assert summary["decayed"] == 1
+    assert summary["skipped"] == 1
+    assert summary["errors"] == 0
+    # The good node was still processed correctly despite the malformed sibling.
+    updated_good = fresh_store.get_node_by_id("concept-good-2")
+    assert updated_good.signals.activation.activation < 0.6
+
+
+def test_decay_concept_activations_snapshot_failure_never_raises(monkeypatch) -> None:
+    class _BoomStore:
+        def snapshot(self):
+            raise RuntimeError("store is unreachable")
+
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", _BoomStore())
+
+    summary = api_routes.decay_concept_activations()
+
+    assert summary["decayed"] == 0
+    assert summary["errors"] == 1
+    assert summary["total_concepts"] == 0
+
+
+def test_decay_concept_activations_empty_store_returns_clean_zero_summary(monkeypatch) -> None:
+    fresh_store = InMemorySubstrateGraphStore()
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", fresh_store)
+
+    summary = api_routes.decay_concept_activations()
+
+    assert summary == {"decayed": 0, "skipped": 0, "errors": 0, "total_concepts": 0}
+
+
+def test_decay_concept_activations_repeated_ticks_match_single_equivalent_call(monkeypatch) -> None:
+    """Regression for the compounding-decay bug: calling decay_concept_activations
+    N times with elapsed_seconds=tick (as the scheduler does every real tick) must
+    land on the same activation as a single call with elapsed_seconds=N*tick --
+    NOT the far-more-collapsed value you get from re-deriving elapsed from
+    observed_at on every call without ever advancing the reference point."""
+    half_life = 3600
+    floor = 0.1
+    start_activation = 1.0
+    tick_seconds = 120.0
+    ticks = 30  # 30 * 120s = 3600s = exactly one half-life
+
+    repeated_store = InMemorySubstrateGraphStore()
+    node = _make_concept_node(
+        node_id="concept-repeated",
+        activation=start_activation,
+        decay_half_life_seconds=half_life,
+        decay_floor=floor,
+        observed_at=datetime.now(timezone.utc),
+    )
+    repeated_store.upsert_node(identity_key=node.node_id, node=node)
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", repeated_store)
+
+    for _ in range(ticks):
+        api_routes.decay_concept_activations(elapsed_seconds=tick_seconds)
+
+    repeated_result = repeated_store.get_node_by_id("concept-repeated").signals.activation.activation
+
+    single_call_store = InMemorySubstrateGraphStore()
+    single_call_store.upsert_node(
+        identity_key=node.node_id,
+        node=_make_concept_node(
+            node_id="concept-repeated",
+            activation=start_activation,
+            decay_half_life_seconds=half_life,
+            decay_floor=floor,
+            observed_at=datetime.now(timezone.utc),
+        ),
+    )
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", single_call_store)
+
+    api_routes.decay_concept_activations(elapsed_seconds=ticks * tick_seconds)
+    single_call_result = single_call_store.get_node_by_id("concept-repeated").signals.activation.activation
+
+    assert abs(repeated_result - single_call_result) < 1e-9
+    # decay_activation() is max(floor, current * 0.5**(elapsed/half_life)) -- after
+    # exactly one half-life that's max(0.1, 1.0 * 0.5) == 0.5, not collapsed near floor.
+    expected = max(floor, start_activation * 0.5)
+    assert abs(repeated_result - expected) < 1e-6


### PR DESCRIPTION
## Summary

- Adds `decay_concept_activations()` to `services/orion-hub/scripts/api_routes.py` -- applies `orion.core.activation_decay.decay_activation()` (half-life decay) to every concept-kind node in `SUBSTRATE_SEMANTIC_STORE`, re-upserting only `signals.activation.activation`.
- Adds a background scheduler task (`substrate_decay_task`) in `main.py`, gated by `SUBSTRATE_DECAY_SCHEDULER_ENABLED` (default `true`), ticking every `SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC` (default 120s) -- mirrors the existing `substrate_autonomy_task` pattern exactly: `asyncio.to_thread` offload, cancel-on-shutdown, never-crash-startup.
- Fixes a real compounding-decay bug found during code review (see below) by having the scheduler track true wall-clock elapsed time via `time.monotonic()` and pass it explicitly, instead of the function re-deriving elapsed time from `node.temporal.observed_at` on every call.
- New test file `test_substrate_concept_decay_scheduler.py`, 8 tests including a regression test proving repeated ticks compose correctly.

## Outcome moved

`SubstrateActivationV1.activation` was a schema field with no live writer -- concepts never actually decayed regardless of how stale they got. This is that writer, live on a fixed cadence.

## Current architecture

Concept nodes carry `signals.activation.activation` (float, 0-1), `decay_half_life_seconds`, and `decay_floor`, all read by `orion/substrate/relation_classification.py`'s Option C strategy and Concept Atlas's `_at_risk_concepts` staleness view -- but nothing ever wrote a decayed value back. `orion/substrate/dynamics.py::SubstrateDynamicsEngine.tick` has similar decay math but is gated off by default (`SUBSTRATE_DYNAMICS_TICK_ENABLED=false`) and re-seeds from a live baseline each tick, which incidentally avoids the compounding failure mode this PR had to fix explicitly.

## Architecture touched

`services/orion-hub` only: `scripts/api_routes.py`, `scripts/main.py`, `app/settings.py`, `.env_example`.

## Files changed

- `services/orion-hub/scripts/api_routes.py`: new `decay_concept_activations(elapsed_seconds=None)` function.
- `services/orion-hub/scripts/main.py`: new `substrate_decay_task` background scheduler in `startup_event()`, matching cancellation in `shutdown_event()`.
- `services/orion-hub/app/settings.py`: two new settings fields.
- `services/orion-hub/.env_example`: two new env keys.
- `services/orion-hub/tests/test_substrate_concept_decay_scheduler.py`: new, 8 tests.

## Schema / bus / API changes

- Added: none (no schema field added -- see "bug found" below for why).
- Removed: none.
- Renamed: none.
- Behavior changed: concept node `activation` values now decay live on a schedule instead of staying frozen.
- Compatibility notes: `decay_half_life_seconds` defaults to `None` on every current producer path (seed.py, adapters, reconcile.py) -- until some producer sets a real half-life, this scheduler runs every 120s, re-upserts every concept node's activation *unchanged* (a no-op decay-wise, per `decay_activation()`'s `if not half_life_seconds` clamp-only branch), and logs `decayed=N`. Flagging this per CLAUDE.md's "no empty-shell cognition" rule: the writer is live and correct, but nothing feeds it a real half-life yet.

## Env/config changes

- Added keys: `SUBSTRATE_DECAY_SCHEDULER_ENABLED=true`, `SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC=120`.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes.
- local `.env` synced: yes (`services/orion-hub/.env` updated directly in the shared checkout in the same session).
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH=. .venv/bin/python -m pytest services/orion-hub/tests/test_substrate_concept_decay_scheduler.py -q
8 passed

PYTHONPATH=. .venv/bin/python -m pytest services/orion-hub/tests/test_substrate_concept_seed_startup.py services/orion-hub/tests/test_substrate_concept_decay_scheduler.py services/orion-hub/tests/test_substrate_mutation_scheduler_runtime.py services/orion-hub/tests/test_concept_atlas_routes.py services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py orion/substrate/tests -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
382 passed
```

(`test_refit_salience_stub.py` excluded from the combined run only -- it collection-errors under a `scripts` package-name collision when collected alongside `services/orion-hub/tests/*`, a pre-existing pytest rootdir quirk unrelated to this change; it passes on its own: `pytest orion/substrate/tests/test_refit_salience_stub.py -q` -> `2 passed`.)

## Evals run

No eval harness exists for `services/orion-hub`; not adding one for this seam (a background decay tick is exercised correctly by the unit tests above, including the compounding-composition regression test).

## Docker/build/smoke checks

Not run -- no Docker environment available in this session. `main.py`'s FastAPI app was confirmed to import and construct successfully via `test_concept_atlas_routes.py` (builds the real app object, including both new `startup_event`/`shutdown_event` globals and the decorator registration).

## Review findings fixed

- Finding: Repeated scheduler ticks compound decay to near-zero far faster than the configured half-life -- `decay_concept_activations()` derived `elapsed_seconds` from `node.temporal.observed_at` on every call, but never advanced that timestamp, so each tick re-decayed an already-shrunk `activation` value against an ever-growing elapsed-since-creation window. Verified numerically by the reviewer: at exactly one configured half-life of wall-clock time, activation had collapsed to ~0.000022 instead of the intended 0.5.
  - Fix: gave `decay_concept_activations()` an explicit `elapsed_seconds` parameter; the scheduler now tracks true wall-clock time between ticks via `time.monotonic()` and passes it directly (exponential decay is memoryless, so N ticks of the true inter-tick interval compose exactly to one call for the total elapsed time). `observed_at` is never mutated (it carries real "last touched" semantics read by `dynamics.py` recency scoring, `pressure.py` sustained-surprise detection, and `reconcile.py`'s merge-max -- overwriting it to `now` on every tick would have silently broken all three). The no-arg fallback (elapsed from `observed_at`) is kept only for one-shot/manual invocation.
  - Evidence: new regression test `test_decay_concept_activations_repeated_ticks_match_single_equivalent_call` -- asserts 30 ticks of 120s land within `1e-9` of a single 3600s call, and within `1e-6` of the analytically-expected `max(floor, start * 0.5)` after exactly one half-life. 8/8 tests pass post-fix.
- Finding: `.env_example` changed but local `.env` was not synced.
  - Fix: `services/orion-hub/.env` updated directly in the same session.
  - Evidence: `grep SUBSTRATE_DECAY_SCHEDULER services/orion-hub/.env` -> both keys present.
- Finding (informational, not fixed -- documented instead): decay math is currently a no-op against live data since no producer sets `decay_half_life_seconds`.
  - Fix: none -- this is expected given current producer state, called out explicitly above per CLAUDE.md's "runtime truth beats config truth" rule rather than silently shipped as if fully live.
  - Evidence: grepped every producer path (`seed.py`, adapters, `reconcile.py`); only test fixtures set the field.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build orion-hub
```

## Risks / concerns

- Severity: low
- Concern: decay is currently a no-op against real data (no producer sets `decay_half_life_seconds` yet) -- the scheduler runs, logs, and re-upserts unchanged values every 120s.
- Mitigation: this is expected and documented; a follow-up should wire a real half-life-setting producer (likely alongside Gap 5's autonomous topic-foundry ingestion, since that's the main organic-concept producer path).

## PR link

(populated after creation)