### PR TITLE
feat(substrate,hub): wire real LLM classifier into typed concept relations (Gap 2)

### DIFF
--- a/orion/substrate/relation_classification.py
+++ b/orion/substrate/relation_classification.py
@@ -50,6 +50,7 @@ not propagated.
 
 from __future__ import annotations
 
+import hashlib
 import math
 from datetime import datetime, timezone
 from typing import Callable, Literal, Optional
@@ -325,7 +326,30 @@ def classify_relation(
         return None
 
     try:
+        # Deterministic edge_id (derived from the (source, predicate, target)
+        # identity triple), not the model's uuid4 default_factory -- a caller
+        # that re-classifies the same pair on a later pass (co-occurrence
+        # count only grows, so the same pair keeps clearing the threshold)
+        # must land on the SAME edge_id so store.upsert_edge()'s
+        # self._edges[edge.edge_id] = edge (in-memory) and Falkor's
+        # `MERGE ... {edge_id: $edge_id}` (durable) both overwrite the prior
+        # judgment in place instead of accumulating an unbounded duplicate
+        # relationship per repeat call. A uuid4 edge_id here was the root
+        # cause of exactly that: every call built a schema-valid but
+        # brand-new edge_id, so identity-keyed upsert_edge only ever
+        # repointed its identity index while the previous edge_id's row/
+        # relationship stayed behind, orphaned but still visible in
+        # snapshot(). (If a later call for the same pair yields a *different*
+        # predicate, this still produces a distinct edge_id per predicate --
+        # both edges persist rather than the older one being retracted. That
+        # residual case needs store-level identity retraction to close
+        # fully; deliberately not solved here to keep this fix to the
+        # non-determinism defect, not a broader edge-lifecycle change.)
+        edge_id = "sub-edge-" + hashlib.sha1(
+            f"{node_a.node_id}|{predicate}|{node_b.node_id}".encode("utf-8")
+        ).hexdigest()[:24]
         return SubstrateEdgeV1(
+            edge_id=edge_id,
             source=NodeRefV1(node_id=node_a.node_id, node_kind=node_a.node_kind),
             target=NodeRefV1(node_id=node_b.node_id, node_kind=node_b.node_kind),
             predicate=predicate,

--- a/orion/substrate/tests/test_relation_classification.py
+++ b/orion/substrate/tests/test_relation_classification.py
@@ -303,6 +303,34 @@ def test_classify_relation_calls_classifier_only_when_worth_it() -> None:
     assert calls == [("concept-a", "concept-b", above_edge.edge_id)]
 
 
+def test_classify_relation_produces_deterministic_edge_id_for_same_pair() -> None:
+    """Regression: classify_relation() must return the same edge_id for the
+    same (source, predicate, target) triple across separate calls -- a caller
+    that re-classifies the same pair on a later pass (co-occurrence count
+    only grows) must land on an identity-stable edge_id so store.upsert_edge()
+    overwrites the prior judgment in place instead of accumulating an
+    unbounded duplicate edge per repeat call. Before this fix, edge_id used
+    the model's uuid4 default_factory, which produced a fresh id every call."""
+    node_a = _concept(node_id="concept-a", label="a")
+    node_b = _concept(node_id="concept-b", label="b")
+
+    def fake_classifier(a, b, e):
+        return "supports"
+
+    edge = _edge(co_occurrence_count=DEFAULT_COUNT_THRESHOLD)
+    first = classify_relation(node_a, node_b, edge, classifier=fake_classifier)
+    second = classify_relation(node_a, node_b, edge, classifier=fake_classifier)
+
+    assert first is not None and second is not None
+    assert first.edge_id == second.edge_id
+
+    def fake_classifier_contradicts(a, b, e):
+        return "contradicts"
+
+    different_predicate = classify_relation(node_a, node_b, edge, classifier=fake_classifier_contradicts)
+    assert different_predicate.edge_id != first.edge_id
+
+
 def test_classify_relation_none_result_produces_no_edge() -> None:
     node_a = _concept(node_id="concept-a", label="a")
     node_b = _concept(node_id="concept-b", label="b")

--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -50,6 +50,17 @@ _VALID_ANCHOR_SCOPES = {"orion", "juniper", "relationship", "world", "session"}
 # comment in ``_at_risk_concepts`` below.
 _AT_RISK_MARGIN = 0.05
 
+# Max co_occurs_with pairs classified for a typed relationship (supports/
+# contradicts/refines) per ingestion call. Each classified pair costs one
+# bounded LLM RPC (see concept_relation_classifier.py), so this directly
+# bounds the added route latency: worst case (every RPC timing out at
+# HUB_LLM_GATEWAY_TIMEOUT_SEC, default 5s) is roughly
+# _RELATION_CLASSIFICATION_PAIR_CAP * 5s of extra route time. Picked at the
+# low end of the task's suggested 10-20 range for that reason -- this is a
+# manual, operator-triggered route (not a hot path), but an unbounded or
+# high cap could still make one ingest call take minutes.
+_RELATION_CLASSIFICATION_PAIR_CAP = 10
+
 
 def _get_substrate_store() -> Any:
     """Best-effort resolution of the shared substrate store, never raises.
@@ -119,6 +130,110 @@ def _concept_nodes(store: Any) -> list[Any]:
         logger.warning("concept_atlas_snapshot_failed error=%s", exc)
         return []
     return [n for n in snapshot.nodes.values() if getattr(n, "node_kind", None) == "concept"]
+
+
+def _typed_relation_classification_candidates(store: Any) -> tuple[dict[str, Any], list[Any]]:
+    """Current concept nodes (by node_id) and not-yet-classified ``co_occurs_with``
+    edges between them, read fresh from the store's snapshot. Returns ``({}, [])``
+    on any store failure -- never raises.
+
+    Excludes any ``co_occurs_with`` edge that already produced a typed edge in
+    a prior pass -- ``classify_relation()`` stamps the typed edge's
+    ``metadata["source_edge_id"]`` with the ``co_occurs_with`` edge's own
+    ``edge_id`` (``orion/substrate/relation_classification.py``), so that
+    marker is how "already classified" is recognized here. Without this
+    filter, every ingestion call would re-spend its entire
+    ``_RELATION_CLASSIFICATION_PAIR_CAP``-pair budget reclassifying pairs it
+    already has an answer for (co-occurrence count only grows, so a
+    qualifying pair keeps qualifying forever), permanently starving any
+    candidate pair beyond the cap once the corpus grows past it. A pair whose
+    prior judgment was "none" (no typed edge written) is deliberately NOT
+    excluded -- its co-occurrence evidence keeps strengthening over time, so
+    retrying it on a later pass is a reasonable, cheap use of a cap slot.
+    """
+    try:
+        snapshot = store.snapshot()
+    except Exception as exc:
+        logger.warning("concept_atlas_relation_classification_snapshot_failed error=%s", exc)
+        return {}, []
+    concept_nodes = {
+        n.node_id: n for n in snapshot.nodes.values() if getattr(n, "node_kind", None) == "concept"
+    }
+    already_classified_source_edge_ids = {
+        e.metadata.get("source_edge_id")
+        for e in snapshot.edges.values()
+        if isinstance(e.metadata, dict) and e.metadata.get("source_edge_id")
+    }
+    co_occurs_edges = [
+        e
+        for e in snapshot.edges.values()
+        if e.predicate == "co_occurs_with"
+        and e.source.node_id in concept_nodes
+        and e.target.node_id in concept_nodes
+        and e.edge_id not in already_classified_source_edge_ids
+    ]
+    return concept_nodes, co_occurs_edges
+
+
+def _classify_typed_concept_relations(store: Any) -> int:
+    """Post-ingestion step (Phase 4 of the concept-graph-pipeline design):
+    for ``co_occurs_with`` edges among current concept nodes that clear the
+    ``count`` worth-classifying threshold
+    (``orion.substrate.relation_classification.is_worth_classifying``,
+    capped at ``_RELATION_CLASSIFICATION_PAIR_CAP`` pairs), ask a real LLM
+    classifier whether the pair is a typed ``supports``/``contradicts``/
+    ``refines`` relationship, and write any resulting typed edge into the
+    same store.
+
+    Additive best-effort enrichment, not required for the route's core
+    success -- returns ``0`` (an honest count, not an error) on any failure
+    or when nothing was worth classifying. Never raises past this function.
+    """
+    from orion.substrate.relation_classification import classify_relation, is_worth_classifying
+
+    from .concept_relation_classifier import build_llm_relation_classifier
+
+    try:
+        concept_nodes, co_occurs_edges = _typed_relation_classification_candidates(store)
+        if not co_occurs_edges:
+            return 0
+
+        candidate_pairs: list[tuple[Any, Any, Any]] = []
+        for edge in co_occurs_edges:
+            node_a = concept_nodes.get(edge.source.node_id)
+            node_b = concept_nodes.get(edge.target.node_id)
+            if node_a is None or node_b is None:
+                continue
+            # "count" strategy: the simplest baseline, matches the design
+            # spec's called-out safe default. pmi/activation strategies exist
+            # in relation_classification.py but wiring all three behind a
+            # live flag is out of scope for this patch.
+            if not is_worth_classifying(node_a, node_b, edge, strategy="count"):
+                continue
+            candidate_pairs.append((node_a, node_b, edge))
+            if len(candidate_pairs) >= _RELATION_CLASSIFICATION_PAIR_CAP:
+                break
+
+        if not candidate_pairs:
+            return 0
+
+        classifier = build_llm_relation_classifier(candidate_pairs, settings=settings)
+
+        typed_edges_written = 0
+        for node_a, node_b, edge in candidate_pairs:
+            new_edge = classify_relation(node_a, node_b, edge, classifier=classifier, strategy="count")
+            if new_edge is None:
+                continue
+            try:
+                identity_key = f"{new_edge.source.node_id}|{new_edge.predicate}|{new_edge.target.node_id}"
+                store.upsert_edge(identity_key=identity_key, edge=new_edge)
+                typed_edges_written += 1
+            except Exception as exc:
+                logger.warning("concept_atlas_typed_edge_write_failed error=%s", exc)
+        return typed_edges_written
+    except Exception as exc:  # pragma: no cover - defensive, mirrors this module's degrade-never-500 convention
+        logger.warning("concept_atlas_relation_classification_failed error=%s", exc)
+        return 0
 
 
 def _at_risk_concepts(concept_nodes: list[Any]) -> tuple[list[dict[str, Any]], Optional[str]]:
@@ -446,6 +561,21 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             edges_written=counting_store.edges_written,
         )
 
+    # Post-ingestion typed-relation classification (Phase 4 wiring): scans the
+    # store (not counting_store -- this must not inflate edges_written above,
+    # which reports only the materializer's own co_occurs_with/supports
+    # writes) for co_occurs_with edges worth an LLM classification call and
+    # writes any resulting typed edge directly. Best-effort, capped, never
+    # raises -- see _classify_typed_concept_relations for the honest-0 vs
+    # error distinction. Adds real latency: up to
+    # _RELATION_CLASSIFICATION_PAIR_CAP sequential bounded LLM RPCs (see
+    # concept_relation_classifier.py's module docstring and the cap comment
+    # above) -- acceptable here since this route is a manual, operator-
+    # triggered trigger, not a hot path, and the route already runs as a sync
+    # def in FastAPI's threadpool (see this function's own docstring), so the
+    # added synchronous LLM round trips do not block the event loop.
+    typed_edges_written = _classify_typed_concept_relations(store)
+
     # Same counter owns success and failure accounting. Counts are successful
     # upserts (including merges), not unique durable nodes after merge.
     return {
@@ -456,6 +586,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
         "evidence_nodes_written": counting_store.evidence_nodes_written,
         "edges_written": counting_store.edges_written,
         "co_occurrence_edges_skipped": "segment_topic_map not supplied in this ingestion route (empty by design)",
+        "typed_edges_written": typed_edges_written,
     }
 
 

--- a/services/orion-hub/scripts/concept_relation_classifier.py
+++ b/services/orion-hub/scripts/concept_relation_classifier.py
@@ -1,0 +1,283 @@
+"""Real LLM classifier for typed concept-relation edges (Phase 4 wiring).
+
+Fills the injection seam left open by
+``orion.substrate.relation_classification.classify_relation()`` (the
+``RelationClassifier`` callable): given two co-occurring ``ConceptNodeV1``
+nodes and the ``SubstrateEdgeV1`` connecting them, ask an LLM whether one
+``supports``/``contradicts``/``refines`` the other, or ``None`` if the
+relationship is not confidently one of those three.
+
+Mechanism chosen: a direct, bounded, structured-output bus RPC to the LLM
+gateway (``settings.CHANNEL_LLM_INTAKE``) -- the same shape already proven by
+``orion/memory/crystallization/concept_relation.py::resolve_concept_relation()``
+(same-shaped judgment: two candidates in, one of a small set of typed
+relations or "none" out, never raises) and by this service's own existing
+bus-RPC client convention (``pre_turn_appraisal_client.py``,
+``thought_client.py``: a small class/function wrapping
+``OrionBusAsync.rpc_request()`` directly against a bus channel). This is
+deliberately NOT ``CortexGatewayClient.chat()``
+(``services/orion-hub/scripts/bus_clients/cortex_client.py``): that sends a
+``CortexChatRequest`` through the full cortex-orch cognition pipeline
+(self-state, drives, memory recall, session context) -- the wrong weight
+class for a bounded per-pair classification call, and reusing it here would
+mean constructing a full chat request just to get a one-word structured
+answer. The direct-RPC path requires no new plumbing: Hub already imports
+``OrionBusAsync``/``bus_schemas`` and calls ``bus.rpc_request()`` directly in
+multiple existing files.
+
+``RelationClassifier`` is a plain **synchronous** 3-arg callable --
+``classify_relation()`` calls it directly, not awaited (see
+``orion/substrate/relation_classification.py``). The actual LLM judgment is
+an async bus RPC, so ``build_llm_relation_classifier()`` below runs one
+bounded async batch up front (a single ``asyncio.run()`` call, one shared bus
+connection, sequential RPCs across the caller's already-capped pair list) and
+returns a synchronous closure that reads from the precomputed result dict.
+This avoids spinning up a fresh event loop + bus connection per pair, and
+avoids the impossible alternative of reusing one ``OrionBusAsync`` connection
+across multiple independent ``asyncio.run()`` calls (its Redis connection is
+bound to the event loop it was created on).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Literal, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ChatRequestPayload, LLMMessage, ServiceRef
+from orion.core.llm_json import parse_json_object
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateEdgePredicateV1,
+    SubstrateEdgeV1,
+)
+from orion.substrate.relation_classification import RelationClassifier
+
+logger = logging.getLogger("hub.concept_relation_classifier")
+
+RelationPair = tuple[ConceptNodeV1, ConceptNodeV1, SubstrateEdgeV1]
+
+_SUMMARY_TRUNC_CHARS = 300
+# "quick" mirrors services/orion-memory-consolidation's classify lane default use
+# (small/fast route, not the full reasoning "metacog"/"brain" routes) -- this is a
+# bounded per-pair structured judgment, not a conversational turn.
+_DEFAULT_ROUTE = "quick"
+_DEFAULT_MAX_TOKENS = 40
+
+
+class _RelationJudgment(BaseModel):
+    """Local to this seam -- not a bus-published event, no registry entry needed
+    (same precedent as ``ConceptRelationDecision`` in
+    ``orion/memory/crystallization/concept_relation.py``).
+
+    ``extra="ignore"``, not ``"forbid"``: small instruct models frequently add a
+    stray field (e.g. "reasoning") to structured output despite prompt
+    instructions to emit only the bare object -- same rationale as
+    ``ConceptRelationDecision``.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    predicate: Literal["supports", "contradicts", "refines", "none"] = "none"
+
+
+def _truncate(text: str, *, limit: int) -> str:
+    s = (text or "").strip()
+    if len(s) <= limit:
+        return s
+    return s[: limit - 3] + "..."
+
+
+def _node_block(label: str, node: ConceptNodeV1) -> str:
+    definition = _truncate(node.definition or "", limit=_SUMMARY_TRUNC_CHARS)
+    line = f"{label}: {node.label}"
+    if definition:
+        line += f"\n  definition: {definition}"
+    return line
+
+
+def _build_relation_prompt(
+    node_a: ConceptNodeV1, node_b: ConceptNodeV1, edge: SubstrateEdgeV1
+) -> str:
+    co_occurrence = None
+    if isinstance(edge.metadata, dict):
+        co_occurrence = edge.metadata.get("co_occurrence_count")
+    evidence_line = f"co-occurrence count: {co_occurrence}\n" if co_occurrence is not None else ""
+
+    return (
+        "Judge the relationship between CONCEPT A and CONCEPT B below, which have "
+        "been observed co-occurring in the same conversational context.\n\n"
+        f"{_node_block('CONCEPT A', node_a)}\n"
+        f"{_node_block('CONCEPT B', node_b)}\n"
+        f"{evidence_line}\n"
+        "Choose exactly one relation, judged from A's perspective toward B:\n"
+        '  "supports"    = A provides evidence for, reinforces, or is consistent with B\n'
+        '  "contradicts" = A conflicts with or undermines B\n'
+        '  "refines"     = A is a more precise/updated/narrower version of B\n'
+        '  "none"        = none of the above with real confidence; default when unsure\n\n'
+        "Respond with ONLY a single JSON object, no prose, no markdown fences, shaped "
+        "exactly like:\n"
+        '{"predicate": "supports"|"contradicts"|"refines"|"none"}\n'
+    )
+
+
+async def _classify_pair_async(
+    bus: OrionBusAsync,
+    node_a: ConceptNodeV1,
+    node_b: ConceptNodeV1,
+    edge: SubstrateEdgeV1,
+    *,
+    settings: Any,
+    timeout_sec: float,
+    route: str,
+) -> Optional[SubstrateEdgePredicateV1]:
+    """One bounded, structured-output LLM call over an already-connected ``bus``.
+
+    NEVER raises -- degrades to ``None`` on any failure (RPC timeout, decode
+    failure, malformed/unparseable JSON, schema-invalid predicate, "none").
+    """
+    try:
+        prompt = _build_relation_prompt(node_a, node_b, edge)
+        rpc_corr = str(uuid4())
+        gateway_service_name = str(getattr(settings, "LLM_GATEWAY_SERVICE_NAME", "LLMGatewayService"))
+        reply_channel = f"orion:exec:result:{gateway_service_name}:{rpc_corr}"
+        payload = ChatRequestPayload(
+            messages=[LLMMessage(role="user", content=prompt)],
+            route=route,
+            options={
+                "return_logprobs": False,
+                "max_tokens": _DEFAULT_MAX_TOKENS,
+                "llm_route": route,
+                "purpose": "classify",
+                "skip_spark_candidate_publish": True,
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        )
+        env = BaseEnvelope(
+            kind="llm.chat.request",
+            source=ServiceRef(
+                name=settings.SERVICE_NAME,
+                version=settings.SERVICE_VERSION,
+                node=settings.NODE_NAME,
+            ),
+            correlation_id=rpc_corr,
+            reply_to=reply_channel,
+            payload=payload.model_dump(mode="json"),
+        )
+        msg = await bus.rpc_request(
+            settings.CHANNEL_LLM_INTAKE,
+            env,
+            reply_channel=reply_channel,
+            timeout_sec=timeout_sec,
+        )
+        decoded = bus.codec.decode(msg.get("data"))
+        if not decoded.ok:
+            raise RuntimeError(decoded.error)
+        content = str(
+            decoded.envelope.payload.get("content") or decoded.envelope.payload.get("text") or ""
+        )
+        # Models sometimes wrap the JSON object in prose or markdown fences despite
+        # instructions -- reuse the shared, already-battle-tested LLM JSON extraction
+        # (handles ```json fences, trailing commas, Python True/False/None literals)
+        # instead of a narrower hand-rolled parse.
+        obj = parse_json_object(content)
+        judgment = _RelationJudgment.model_validate(obj)
+        if judgment.predicate == "none":
+            return None
+        return judgment.predicate  # type: ignore[return-value]
+    except Exception as exc:
+        logger.warning(
+            "concept_relation_classify_pair_failed source=%s target=%s error=%s",
+            node_a.node_id,
+            node_b.node_id,
+            exc,
+        )
+        return None
+
+
+async def _classify_pairs_batch_async(
+    pairs: list[RelationPair],
+    *,
+    settings: Any,
+    timeout_sec: float,
+    route: str,
+) -> dict[str, Optional[SubstrateEdgePredicateV1]]:
+    """One shared bus connection for the whole capped batch, sequential RPCs.
+
+    NEVER raises -- a connect failure degrades every pair in the batch to
+    ``None`` rather than propagating.
+    """
+    results: dict[str, Optional[SubstrateEdgePredicateV1]] = {}
+    bus = OrionBusAsync(str(settings.ORION_BUS_URL))
+    try:
+        await bus.connect()
+    except Exception as exc:
+        logger.warning("concept_relation_classify_bus_connect_failed error=%s", exc)
+        return {edge.edge_id: None for _, _, edge in pairs}
+    try:
+        for node_a, node_b, edge in pairs:
+            results[edge.edge_id] = await _classify_pair_async(
+                bus,
+                node_a,
+                node_b,
+                edge,
+                settings=settings,
+                timeout_sec=timeout_sec,
+                route=route,
+            )
+    finally:
+        try:
+            await bus.close()
+        except Exception:
+            pass
+    return results
+
+
+def build_llm_relation_classifier(
+    pairs: list[RelationPair],
+    *,
+    settings: Any,
+    timeout_sec: Optional[float] = None,
+    route: Optional[str] = None,
+) -> RelationClassifier:
+    """Runs one bounded async batch of LLM classification calls up front, then
+    returns a plain synchronous ``RelationClassifier`` closure over the
+    precomputed results -- matching the sync-callable contract
+    ``classify_relation()`` requires (it calls the injected classifier
+    directly, not awaited).
+
+    Callers are expected to have already capped ``pairs`` to a small bound
+    (the ingestion route caps it before calling this) -- this function does
+    not itself impose a limit, since the cap is a caller policy decision
+    (how many pairs are worth the added route latency), not a classifier
+    concern.
+
+    NEVER raises -- any batch-level failure (bus connect, event loop) degrades
+    every pair to ``None`` so the caller's per-pair ``classify_relation()``
+    loop proceeds with "no typed edge for this pair" rather than failing the
+    whole ingestion run.
+    """
+    resolved_timeout = float(
+        timeout_sec if timeout_sec is not None else getattr(settings, "HUB_LLM_GATEWAY_TIMEOUT_SEC", 5.0)
+    )
+    resolved_route = str(route or _DEFAULT_ROUTE)
+    try:
+        judgments = asyncio.run(
+            _classify_pairs_batch_async(
+                pairs, settings=settings, timeout_sec=resolved_timeout, route=resolved_route
+            )
+        )
+    except Exception as exc:
+        logger.warning("concept_relation_classify_batch_failed error=%s", exc)
+        judgments = {edge.edge_id: None for _, _, edge in pairs}
+
+    def _classifier(
+        node_a: ConceptNodeV1, node_b: ConceptNodeV1, edge: SubstrateEdgeV1
+    ) -> Optional[SubstrateEdgePredicateV1]:
+        return judgments.get(edge.edge_id)
+
+    return _classifier

--- a/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
+++ b/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
@@ -639,3 +639,228 @@ def test_client_no_completed_run_raises_client_error(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(tfc.requests, "get", fake_get)
     with pytest.raises(tfc.TopicFoundryClientError):
         tfc.fetch_run_topics_and_keywords(FAKE_BASE_URL)
+
+
+# --- post-ingestion typed-relation classification step -----------------------
+#
+# Covers the additive post-ingestion step added to
+# concept_atlas_ingest_topic_foundry(): for co_occurs_with edges among current
+# concept nodes that clear the "count" worth-classifying threshold
+# (orion.substrate.relation_classification.is_worth_classifying), call the
+# injected classifier and write any resulting typed edge. The real LLM
+# classifier (scripts/concept_relation_classifier.py) is never invoked here --
+# build_llm_relation_classifier is monkeypatched to a fake so these tests stay
+# fast, deterministic, and network-free.
+
+
+def _seed_relation_pair_nodes_and_edges(store: Any) -> dict[str, str]:
+    """Pre-seed the store with three concept nodes and two co_occurs_with
+    edges: one crossing the default count threshold (5), one below it.
+    Returns the seeded node ids so tests can assert against them.
+    """
+    from orion.core.schemas.cognitive_substrate import ConceptNodeV1, NodeRefV1, SubstrateEdgeV1
+    from orion.substrate.adapters._common import make_provenance, make_temporal
+
+    def _node(node_id: str, label: str) -> ConceptNodeV1:
+        return ConceptNodeV1(
+            node_id=node_id,
+            anchor_scope="world",
+            label=label,
+            temporal=make_temporal(observed_at=None),
+            provenance=make_provenance(source_kind="test", source_channel="test", producer="test"),
+        )
+
+    def _co_occurs_edge(source_id: str, target_id: str, *, count: int) -> SubstrateEdgeV1:
+        return SubstrateEdgeV1(
+            source=NodeRefV1(node_id=source_id, node_kind="concept"),
+            target=NodeRefV1(node_id=target_id, node_kind="concept"),
+            predicate="co_occurs_with",
+            temporal=make_temporal(observed_at=None),
+            provenance=make_provenance(source_kind="test", source_channel="test", producer="test"),
+            metadata={"co_occurrence_count": count},
+        )
+
+    node_a = _node("sub-node-seed-a", "seed concept a")
+    node_b = _node("sub-node-seed-b", "seed concept b")
+    node_c = _node("sub-node-seed-c", "seed concept c")
+    store.upsert_node(identity_key=None, node=node_a)
+    store.upsert_node(identity_key=None, node=node_b)
+    store.upsert_node(identity_key=None, node=node_c)
+
+    # Default DEFAULT_COUNT_THRESHOLD is 5 (relation_classification.py) -- 10
+    # clears it, 2 does not.
+    edge_ab = _co_occurs_edge(node_a.node_id, node_b.node_id, count=10)
+    edge_bc = _co_occurs_edge(node_b.node_id, node_c.node_id, count=2)
+    store.upsert_edge(identity_key="seed-ab", edge=edge_ab)
+    store.upsert_edge(identity_key="seed-bc", edge=edge_bc)
+
+    return {
+        "node_a": node_a.node_id,
+        "node_b": node_b.node_id,
+        "node_c": node_c.node_id,
+        "edge_ab": edge_ab.edge_id,
+        "edge_bc": edge_bc.edge_id,
+    }
+
+
+def _patch_fake_relation_classifier(monkeypatch: pytest.MonkeyPatch, *, predicate: Optional[str]):
+    """Monkeypatch build_llm_relation_classifier so no real LLM/bus call ever
+    happens. Returns the list of (source_id, target_id, edge_id) tuples the
+    fake classifier was actually invoked with, for call-count assertions.
+    """
+    from scripts import concept_relation_classifier as crc
+
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_build_llm_relation_classifier(pairs, *, settings, timeout_sec=None, route=None):
+        def _classifier(node_a, node_b, edge):
+            calls.append((node_a.node_id, node_b.node_id, edge.edge_id))
+            return predicate
+
+        return _classifier
+
+    monkeypatch.setattr(crc, "build_llm_relation_classifier", fake_build_llm_relation_classifier)
+    return calls
+
+
+def test_ingest_classifies_only_pairs_crossing_count_threshold(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    seeded = _seed_relation_pair_nodes_and_edges(store)
+    calls = _patch_fake_relation_classifier(monkeypatch, predicate="supports")
+
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+
+    # Only the A-B pair (count=10) clears the default threshold of 5; B-C
+    # (count=2) must never reach the classifier.
+    assert len(calls) == 1
+    assert calls[0][0] == seeded["node_a"]
+    assert calls[0][1] == seeded["node_b"]
+    assert calls[0][2] == seeded["edge_ab"]
+
+    assert body["typed_edges_written"] == 1
+
+    # classify_relation() stamps metadata["source_edge_id"] with the
+    # co_occurs_with edge it classified (relation_classification.py) -- use
+    # that as the unique marker for "the typed edge our new step wrote",
+    # since the normal ingest fixture also produces unrelated evidence-
+    # >concept "supports" edges from the materializer itself.
+    snapshot = store.snapshot()
+    typed_edges = [
+        e
+        for e in snapshot.edges.values()
+        if e.predicate == "supports" and e.metadata.get("source_edge_id") == seeded["edge_ab"]
+    ]
+    assert len(typed_edges) == 1
+    assert typed_edges[0].source.node_id == seeded["node_a"]
+    assert typed_edges[0].target.node_id == seeded["node_b"]
+
+
+def test_ingest_classifier_none_result_writes_no_typed_edge(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A classifier that returns None (no confident relation) must not
+    produce a typed edge, but must still be honestly reported as 0, not an
+    error."""
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    seeded = _seed_relation_pair_nodes_and_edges(store)
+    calls = _patch_fake_relation_classifier(monkeypatch, predicate=None)
+
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+
+    assert len(calls) == 1  # still invoked for the qualifying pair
+    assert body["typed_edges_written"] == 0
+
+    snapshot = store.snapshot()
+    typed_edges = [
+        e for e in snapshot.edges.values() if e.metadata.get("source_edge_id") == seeded["edge_ab"]
+    ]
+    assert typed_edges == []
+
+
+def test_ingest_no_co_occurs_edges_reports_zero_typed_edges_without_classifier_call(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The normal ingest fixture never produces co_occurs_with edges
+    (segment_topic_map is empty by design) -- the classifier must never be
+    invoked, and typed_edges_written must be an honest 0, not omitted."""
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    calls = _patch_fake_relation_classifier(monkeypatch, predicate="supports")
+
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["typed_edges_written"] == 0
+    assert calls == []
+
+
+def test_ingest_second_call_does_not_duplicate_or_reclassify_already_typed_pair(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: calling the ingest route twice against the same store must
+    not (a) write a second, duplicate typed edge for a pair already classified,
+    or (b) spend another classifier call on it. Before the deterministic
+    edge_id fix (relation_classification.py) and the already-classified
+    filter (_typed_relation_classification_candidates), every call re-built a
+    fresh-uuid edge_id for the same pair (accumulating unbounded duplicates in
+    the store) and re-spent the LLM budget reclassifying pairs it already had
+    an answer for."""
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    seeded = _seed_relation_pair_nodes_and_edges(store)
+    calls = _patch_fake_relation_classifier(monkeypatch, predicate="supports")
+
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal())
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r1 = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r1.status_code == 200
+    assert r1.json()["typed_edges_written"] == 1
+    assert len(calls) == 1
+
+    r2 = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r2.status_code == 200
+    # Second call must not reclassify the already-typed A-B pair.
+    assert r2.json()["typed_edges_written"] == 0
+    assert len(calls) == 1  # classifier not invoked again
+
+    snapshot = store.snapshot()
+    typed_edges = [
+        e
+        for e in snapshot.edges.values()
+        if e.predicate == "supports" and e.metadata.get("source_edge_id") == seeded["edge_ab"]
+    ]
+    # Exactly one typed edge for this pair -- not two.
+    assert len(typed_edges) == 1

--- a/services/orion-hub/tests/test_concept_relation_classifier.py
+++ b/services/orion-hub/tests/test_concept_relation_classifier.py
@@ -1,0 +1,316 @@
+"""Tests for the real LLM classifier wired into
+``orion.substrate.relation_classification``'s ``RelationClassifier`` seam.
+
+Covers ``services/orion-hub/scripts/concept_relation_classifier.py``. All bus
+I/O is faked at the ``OrionBusAsync`` boundary -- no real LLM gateway, no
+network, no event loop left dangling. Every test is fast and deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_import_path()
+
+from orion.core.schemas.cognitive_substrate import ConceptNodeV1, NodeRefV1, SubstrateEdgeV1  # noqa: E402
+from orion.substrate.adapters._common import make_provenance, make_temporal  # noqa: E402
+
+from scripts import concept_relation_classifier as crc  # noqa: E402
+
+
+def _fake_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        ORION_BUS_URL="redis://fake:6379/0",
+        SERVICE_NAME="hub",
+        SERVICE_VERSION="0.0.0-test",
+        NODE_NAME="test-node",
+        CHANNEL_LLM_INTAKE="orion:exec:request:LLMGatewayService",
+        LLM_GATEWAY_SERVICE_NAME="LLMGatewayService",
+        HUB_LLM_GATEWAY_TIMEOUT_SEC=5.0,
+    )
+
+
+def _concept_node(node_id: str, *, label: str, definition: str = "") -> ConceptNodeV1:
+    return ConceptNodeV1(
+        node_id=node_id,
+        anchor_scope="world",
+        label=label,
+        definition=definition or None,
+        temporal=make_temporal(observed_at=None),
+        provenance=make_provenance(source_kind="test", source_channel="test", producer="test"),
+    )
+
+
+def _edge(source_id: str, target_id: str, *, co_occurrence_count: int = 10) -> SubstrateEdgeV1:
+    return SubstrateEdgeV1(
+        source=NodeRefV1(node_id=source_id, node_kind="concept"),
+        target=NodeRefV1(node_id=target_id, node_kind="concept"),
+        predicate="co_occurs_with",
+        temporal=make_temporal(observed_at=None),
+        provenance=make_provenance(source_kind="test", source_channel="test", producer="test"),
+        metadata={"co_occurrence_count": co_occurrence_count},
+    )
+
+
+class _FakeDecoded:
+    def __init__(self, *, ok: bool, payload: Optional[dict] = None, error: Optional[str] = None):
+        self.ok = ok
+        self.error = error
+        self.envelope = SimpleNamespace(payload=payload or {})
+
+
+class _FakeCodec:
+    def __init__(self, decode_fn):
+        self._decode_fn = decode_fn
+
+    def decode(self, data):
+        return self._decode_fn(data)
+
+
+class _FakeBus:
+    """Stand-in for OrionBusAsync -- no network, fully scripted responses."""
+
+    def __init__(self, url: str, *, rpc_fn=None, connect_error: Optional[Exception] = None, decode_fn=None):
+        self.url = url
+        self._rpc_fn = rpc_fn
+        self._connect_error = connect_error
+        self.codec = _FakeCodec(decode_fn or (lambda data: _FakeDecoded(ok=True, payload=data)))
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        if self._connect_error is not None:
+            raise self._connect_error
+        self.connected = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def rpc_request(self, channel, envelope, *, reply_channel, timeout_sec):
+        return await self._rpc_fn(channel, envelope, reply_channel=reply_channel, timeout_sec=timeout_sec)
+
+
+def _install_fake_bus(monkeypatch: pytest.MonkeyPatch, *, rpc_fn=None, connect_error=None, decode_fn=None) -> None:
+    def _factory(url: str, *_, **__):
+        return _FakeBus(url, rpc_fn=rpc_fn, connect_error=connect_error, decode_fn=decode_fn)
+
+    monkeypatch.setattr(crc, "OrionBusAsync", _factory)
+
+
+def _content_msg(content: str) -> dict:
+    return {"data": {"content": content}}
+
+
+def _decode_content_passthrough(data: dict) -> _FakeDecoded:
+    return _FakeDecoded(ok=True, payload={"content": data["content"]})
+
+
+# --- clear supports / contradicts cases -------------------------------------
+
+
+def test_classify_pair_supports_case_returns_predicate(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        return _content_msg(json.dumps({"predicate": "supports"}))
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="continuity")
+    node_b = _concept_node("sub-node-b", label="memory persistence")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    result = classifier(node_a, node_b, edge)
+    assert result == "supports"
+
+
+def test_classify_pair_contradicts_case_returns_predicate(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        return _content_msg(json.dumps({"predicate": "contradicts"}))
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="fixed identity")
+    node_b = _concept_node("sub-node-b", label="fluid self-model")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    result = classifier(node_a, node_b, edge)
+    assert result == "contradicts"
+
+
+def test_classify_pair_refines_case_returns_predicate(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        return _content_msg(json.dumps({"predicate": "refines"}))
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="narrow definition")
+    node_b = _concept_node("sub-node-b", label="broad definition")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    result = classifier(node_a, node_b, edge)
+    assert result == "refines"
+
+
+# --- ambiguous / unparseable degrades to None --------------------------------
+
+
+def test_classify_pair_explicit_none_predicate_degrades_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        return _content_msg(json.dumps({"predicate": "none"}))
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="weather")
+    node_b = _concept_node("sub-node-b", label="unrelated topic")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    assert classifier(node_a, node_b, edge) is None
+
+
+def test_classify_pair_unparseable_response_degrades_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        # Prose, no JSON object at all.
+        return _content_msg("I think these concepts are related somehow.")
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="a")
+    node_b = _concept_node("sub-node-b", label="b")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    assert classifier(node_a, node_b, edge) is None
+
+
+def test_classify_pair_invalid_predicate_value_degrades_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        # Valid JSON, but "predicate" is not one of the allowed literals.
+        return _content_msg(json.dumps({"predicate": "banana"}))
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="a")
+    node_b = _concept_node("sub-node-b", label="b")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    assert classifier(node_a, node_b, edge) is None
+
+
+def test_classify_pair_decode_failure_degrades_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        return {"data": {}}
+
+    def decode_fn(data):
+        return _FakeDecoded(ok=False, error="bad codec frame")
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=decode_fn)
+
+    node_a = _concept_node("sub-node-a", label="a")
+    node_b = _concept_node("sub-node-b", label="b")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    assert classifier(node_a, node_b, edge) is None
+
+
+# --- timeout / exception from the LLM call degrades to None, never raises ---
+
+
+def test_classify_pair_rpc_timeout_degrades_to_none_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        raise TimeoutError("RPC timeout waiting on reply channel")
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="a")
+    node_b = _concept_node("sub-node-b", label="b")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    assert classifier(node_a, node_b, edge) is None
+
+
+def test_classify_pair_rpc_exception_degrades_to_none_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        raise RuntimeError("connection reset")
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="a")
+    node_b = _concept_node("sub-node-b", label="b")
+    edge = _edge(node_a.node_id, node_b.node_id)
+
+    classifier = crc.build_llm_relation_classifier([(node_a, node_b, edge)], settings=_fake_settings())
+    assert classifier(node_a, node_b, edge) is None
+
+
+def test_classify_batch_bus_connect_failure_degrades_all_pairs_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_bus(monkeypatch, connect_error=RuntimeError("redis unreachable"))
+
+    node_a = _concept_node("sub-node-a", label="a")
+    node_b = _concept_node("sub-node-b", label="b")
+    node_c = _concept_node("sub-node-c", label="c")
+    edge_ab = _edge(node_a.node_id, node_b.node_id)
+    edge_bc = _edge(node_b.node_id, node_c.node_id)
+
+    classifier = crc.build_llm_relation_classifier(
+        [(node_a, node_b, edge_ab), (node_b, node_c, edge_bc)], settings=_fake_settings()
+    )
+    assert classifier(node_a, node_b, edge_ab) is None
+    assert classifier(node_b, node_c, edge_bc) is None
+
+
+# --- batch behavior: multiple pairs, one shared connection -------------------
+
+
+def test_classify_batch_multiple_pairs_get_distinct_judgments(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def rpc_fn(channel, envelope, *, reply_channel, timeout_sec):
+        calls.append(envelope.correlation_id)
+        # Alternate response based on call order so each pair gets a distinct judgment.
+        if len(calls) == 1:
+            return _content_msg(json.dumps({"predicate": "supports"}))
+        return _content_msg(json.dumps({"predicate": "none"}))
+
+    _install_fake_bus(monkeypatch, rpc_fn=rpc_fn, decode_fn=_decode_content_passthrough)
+
+    node_a = _concept_node("sub-node-a", label="a")
+    node_b = _concept_node("sub-node-b", label="b")
+    node_c = _concept_node("sub-node-c", label="c")
+    edge_ab = _edge(node_a.node_id, node_b.node_id)
+    edge_bc = _edge(node_b.node_id, node_c.node_id)
+
+    classifier = crc.build_llm_relation_classifier(
+        [(node_a, node_b, edge_ab), (node_b, node_c, edge_bc)], settings=_fake_settings()
+    )
+    assert classifier(node_a, node_b, edge_ab) == "supports"
+    assert classifier(node_b, node_c, edge_bc) is None
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary

- Wires a real LLM classifier into `orion/substrate/relation_classification.py`'s existing `RelationClassifier` injection seam (Phase 4 of the concept-graph-pipeline design) -- typed `supports`/`contradicts`/`refines` edges between co-occurring concepts are now real, LLM-judged relationships, not just raw co-occurrence counts.
- New `services/orion-hub/scripts/concept_relation_classifier.py`: bounded, direct bus-RPC classifier (never raises, degrades to `None` per pair on any failure).
- New post-ingestion step in `concept_atlas_ingest_topic_foundry()`: classifies up to 10 qualifying pairs per call, writes typed edges back to the store, reports `typed_edges_written`.
- Fixes a real duplicate-edge bug (found in code review) at the root: `classify_relation()` now derives a deterministic `edge_id`, and the ingestion route now skips already-classified pairs.

## Outcome moved

Typed concept relationships (supports/contradicts/refines) go from "schema exists, nothing produces them" to a live, LLM-backed writer on the existing manual ingestion route.

## Current architecture

`orion/substrate/relation_classification.py` already had `is_worth_classifying()` (three threshold strategies) and `classify_relation()` (the shape of the classification step), deliberately built with no LLM call -- a caller was supposed to inject a real `RelationClassifier`. Nothing did.

## Architecture touched

`orion/substrate/relation_classification.py` (root-cause edge_id fix only -- decision logic itself unchanged) and `services/orion-hub` (new classifier module + ingestion route wiring).

## Files changed

- `orion/substrate/relation_classification.py`: `classify_relation()` now builds a deterministic `edge_id` from the `(source, predicate, target)` identity triple instead of the model's `uuid4` default.
- `orion/substrate/tests/test_relation_classification.py`: regression test for the above.
- `services/orion-hub/scripts/concept_relation_classifier.py` (new): the real classifier.
- `services/orion-hub/scripts/concept_atlas_routes.py`: post-ingestion classification step, wired into the existing ingest route; excludes already-classified pairs from the candidate list.
- `services/orion-hub/tests/test_concept_relation_classifier.py` (new): 12 tests, all bus I/O faked.
- `services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py`: 4 new tests (3 for the classification step, 1 regression test for the duplicate-edge fix).

## Schema / bus / API changes

- Added: none (no new schema fields, no new bus channels -- reuses `settings.CHANNEL_LLM_INTAKE`, already registered).
- Removed: none.
- Renamed: none.
- Behavior changed: `classify_relation()`'s output `edge_id` is now deterministic per `(source, predicate, target)` rather than random per call -- this is a behavior change to a function that had zero real callers before this PR, so no compatibility break for anything live.
- Compatibility notes: `POST /api/substrate/concepts/ingest-topic-foundry`'s response gained a `typed_edges_written` field (additive).

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: not applicable (no new keys).
- local `.env` synced: not applicable.
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH=. .venv/bin/python -m pytest orion/substrate/tests/test_relation_classification.py services/orion-hub/tests/test_concept_relation_classifier.py services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py -q
55 passed

PYTHONPATH=. .venv/bin/python -m pytest orion/substrate/tests services/orion-hub/tests/test_concept_relation_classifier.py services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py services/orion-hub/tests/test_concept_atlas_routes.py services/orion-hub/tests/test_substrate_concept_seed_startup.py -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
371 passed
```

(`test_refit_salience_stub.py` excluded from the combined run only -- pre-existing pytest rootdir `scripts`-package-name collision when collected alongside `services/orion-hub/tests/*`, unrelated to this change; passes standalone.)

## Evals run

No eval harness exists for this seam. Not adding one -- the classifier's judgment quality is a genuine open question best evaluated against real conversation-derived concept pairs once Gap 5 (autonomous scheduled ingestion) is producing a steady stream of candidates, not synthetic test fixtures.

## Docker/build/smoke checks

Not run -- no Docker environment available in this session. `main.py`'s FastAPI app (which mounts `concept_atlas_routes.py`'s router) was confirmed to import and construct successfully via `test_concept_atlas_routes.py`.

## Review findings fixed

- Finding: Repeated ingestion runs accumulate unbounded duplicate typed edges for the same concept pair, in both the in-memory and durable (FalkorDB) store -- `classify_relation()`'s `SubstrateEdgeV1` used the model's `uuid4` default_factory for `edge_id`, so every call for the same pair built a schema-valid but brand-new `edge_id`. `store.upsert_edge()`'s identity-keyed upsert only repoints its identity index (`InMemorySubstrateGraphStore`) or MERGEs on `{edge_id: $edge_id}` (`FalkorSubstrateStore`) -- neither dedupes on the logical `(source, predicate, target)` identity, so each repeat classification of a qualifying pair (co-occurrence count only grows, so it keeps qualifying) left the prior edge_id's row/relationship behind, orphaned but still visible in `snapshot()`, or created a genuinely new durable relationship in FalkorDB. This was exactly the precondition `orion/spark/concept_induction/falkor_materialization.py`'s own comments already flagged as unresolved.
  - Fix: `classify_relation()` now derives `edge_id` deterministically via `sha1(f"{source}|{predicate}|{target}")`, so a repeat call for the same pair+judgment lands on the identical `edge_id` and both backends' upsert overwrites in place. (Residual case, documented in code: if a later call for the same pair yields a *different* predicate, that's still a distinct `edge_id` -- both edges persist rather than the older one being retracted. Full retraction semantics need store-level identity-based edge lifecycle work, out of scope here.)
  - Evidence: new test `test_classify_relation_produces_deterministic_edge_id_for_same_pair` -- same-pair/same-predicate calls produce identical `edge_id`; same-pair/different-predicate calls produce a different one.
- Finding: No "already classified" check -- every ingestion call re-spends its entire pair-cap budget reclassifying pairs it already has an answer for, permanently starving new candidates once the corpus grows past the cap.
  - Fix: `_typed_relation_classification_candidates()` now excludes any `co_occurs_with` edge whose `edge_id` already appears as a typed edge's `metadata["source_edge_id"]` marker. A pair whose prior judgment was `"none"` is deliberately not excluded (its evidence keeps strengthening over time -- worth a retry, not a permanent skip).
  - Evidence: new test `test_ingest_second_call_does_not_duplicate_or_reclassify_already_typed_pair` -- second ingestion call against the same store reports `typed_edges_written == 0`, classifier invoked 0 additional times, exactly one typed edge exists for the pair (not two).
- Finding (verified, not a bug): `asyncio.run()` inside `build_llm_relation_classifier`, called from a sync FastAPI route -- confirmed safe, since `concept_atlas_ingest_topic_foundry` is a plain sync `def` and FastAPI dispatches sync routes via a threadpool worker with no already-running event loop.
- Finding (verified, not a bug): LLM gateway response payload shape (`.get("content")`/`.get("text")` fallback) -- confirmed the real gateway's `ChatResultPayload` always normalizes to `content`, matching an identical fallback pattern already used by `memory_graph_structured_output.py`.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build orion-hub
```

## Risks / concerns

- Severity: low
- Concern: if a pair's classified predicate genuinely flips between runs (e.g. "supports" then later "contradicts" as evidence accumulates), both typed edges persist rather than the stale one being retracted.
- Mitigation: documented in code as a deliberately out-of-scope residual case; full fix needs store-level identity-based edge retraction, a broader change affecting all edge producers, not just this seam.
- Severity: low
- Concern: no eval harness for classifier judgment quality yet.
- Mitigation: deferred until Gap 5 (autonomous ingestion) is producing a steady stream of real candidate pairs to evaluate against.

## PR link

(populated after creation)