### PR TITLE
feat(recall): wire concept_region collector into purposeful-recall pipeline (Gap 1b)

### DIFF
--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -41,6 +41,17 @@ RECALL_CONTINUITY_RENDER_BUDGET=96
 RECALL_ACTIVE_PACKET_ENABLED=true
 # Minimum dynamics.activation for crystallizations in active_packet (matches recall_eligibility)
 ACTIVATION_RECALL_FLOOR=0.08
+# Turn-scoped concept-region collector (app/collectors/concept_region.py) -- see
+# app/substrate_store.py's field comment in settings.py for what this reads from.
+RECALL_CONCEPT_REGION_ENABLED=true
+# Substrate graph store backend for the concept-region collector -- shared FalkorDB
+# instance + graph name also used by orion-cortex-exec and orion-hub
+# (FALKORDB_SUBSTRATE_GRAPH=orion_substrate). See orion/substrate/graphdb_store.py's
+# build_substrate_store_from_env() -- read directly from the environment, not via
+# this service's own Settings class, so no matching pydantic field is needed.
+SUBSTRATE_STORE_BACKEND=falkor
+FALKORDB_URI=redis://orion-athena-falkordb:6379
+FALKORDB_SUBSTRATE_GRAPH=orion_substrate
 RECALL_BELIEF_RENDER_BUDGET=128
 # Live default as of 2026-07-13 (graphiti_core backend proven working -- docs/superpowers/
 # specs/2026-07-13-graphiti-core-backend-activation-spec.md). Only fires when a turn's

--- a/services/orion-recall/README.md
+++ b/services/orion-recall/README.md
@@ -769,3 +769,37 @@ Note this only affects *scoring* (a continuous, soft decay) — it does not give
 ### Compose env-var defaults hardened (fixed 2026-07-14)
 
 `docker-compose.yml`'s `environment:` list (added by the compose-parity PR, #1021) crash-looped this service in production: `RECALL_SKIP_MAX_NOVELTY`, `RECALL_SKIP_SHIFT_NOVELTY_FLOOR`, `RECALL_CONTINUITY_SQL_MINUTES`, `RECALL_CONTINUITY_RENDER_BUDGET`, `RECALL_BELIEF_RENDER_BUDGET`, and `RECALL_CRYSTALLIZATION_VECTOR_COLLECTION` were missing from live `.env` and had no `${VAR:-default}` fallback, so compose substituted empty strings and pydantic Settings validation failed on every boot (`float_parsing`/`int_parsing` errors). Fixed live by syncing the missing keys into `.env` (`python scripts/sync_local_env_from_example.py --all-keys orion-recall`) and, in this changeset, adding compose-level `:-default` fallbacks matching `.env_example` so a missing `.env` key can't crash the service again — see `services/orion-recall/tests/test_docker_compose_numeric_defaults.py`. `RECALL_GRAPHITI_IN_CHAT`/`RECALL_GRAPHITI_ADAPTER_URL` remain deliberately unguarded (see the comment above them in `docker-compose.yml`) — they're `NEVER_SYNC_KEYS`-protected and a duplicated default here would drift from `.env_example` over time.
+
+## 15) Concept-region collector (substrate concept graph in belief-lane recall)
+
+`app/collectors/concept_region.py::fetch_concept_region_fragment()` is a PCR collector
+alongside `active_packet`, wired into `process_recall`'s purposeful phase in `app/worker.py`.
+It matches the current turn's text against concept labels already materialized in the
+shared substrate graph (golden Orion/Juniper/relationship concepts seeded by `orion-hub`,
+plus organically-grown topic-foundry concepts) and, on a match, returns a bounded
+neighborhood fragment scoped to that turn. Matching is deliberately dumb — case-insensitive
+label substring match, no embedding/LLM call — and it never does a store read at all if the
+turn text matches nothing.
+
+**Env vars:**
+
+| Var | Default | Meaning |
+|---|---|---|
+| `RECALL_CONCEPT_REGION_ENABLED` | `true` | Master on/off switch for this collector. |
+| `SUBSTRATE_STORE_BACKEND` | `falkor` | Which substrate store backend `app/substrate_store.py::get_substrate_store()` builds (shared with `orion-cortex-exec`/`orion-hub`, same `FalkorDB` instance/graph). |
+| `FALKORDB_URI` | `redis://orion-athena-falkordb:6379` | Bridge-network Docker DNS — this service runs in bridge mode, **not** Hub's host-mode `127.0.0.1:6380` convention. |
+| `FALKORDB_SUBSTRATE_GRAPH` | `orion_substrate` | Graph name inside FalkorDB. |
+
+**Verify it's live:** trigger a purposeful-phase turn whose text mentions a known concept
+label (e.g. a golden concept's name), then check `decision.recall_debug["pcr"]["backend_plan"]`
+includes `concept_region`, and look for a `source: "concept_region"` candidate/item. If the
+substrate store failed to construct (bad `FALKORDB_URI`, FalkorDB unreachable), the collector
+degrades to `[]` silently — check Hub's own Concept Atlas tab or `orion-hub` logs for
+`recall_substrate_store_init_failed` first.
+
+**Known limitation:** `FalkorSubstrateStore` hydrates its snapshot once at process start and
+never refreshes — concepts added by `orion-hub`'s topic-foundry scheduler after this service's
+first `concept_region` call are invisible here until `orion-recall` restarts. Not specific to
+this collector (shared `orion/substrate/falkor_store.py` behavior), but this is the first
+continuously-changing-data consumer of the store in this service, so it's the first place the
+limitation is actually load-bearing. See PR #1133.

--- a/services/orion-recall/app/fusion.py
+++ b/services/orion-recall/app/fusion.py
@@ -685,11 +685,12 @@ def render_continuity_bundle(
 
 _BELIEF_SOURCE_ORDER = {
     "active_packet": 0,
-    "cards": 1,
-    "rdf": 2,
-    "rdf_chat": 3,
-    "memory_graph_sparql": 4,
-    "graphiti": 5,
+    "concept_region": 1,
+    "cards": 2,
+    "rdf": 3,
+    "rdf_chat": 4,
+    "memory_graph_sparql": 5,
+    "graphiti": 6,
 }
 
 

--- a/services/orion-recall/app/pcr_collectors.py
+++ b/services/orion-recall/app/pcr_collectors.py
@@ -5,11 +5,11 @@ from typing import Any
 from orion.schemas.recall_pcr import RetrievalIntentV1
 
 _COLLECTOR_PLANS: dict[str, dict[str, bool]] = {
-    "relational": {"cards": True, "rdf": True, "rdf_chat": True, "active_packet": True},
-    "semantic": {"cards": True, "rdf": True, "rdf_chat": True, "active_packet": True},
-    "procedural": {"cards": True, "active_packet": True},
-    "open_loop": {"cards": True, "rdf_chat": True, "active_packet": True},
-    "contradiction": {"cards": True, "rdf": True, "active_packet": True, "graphiti": True},
+    "relational": {"cards": True, "rdf": True, "rdf_chat": True, "active_packet": True, "concept_region": True},
+    "semantic": {"cards": True, "rdf": True, "rdf_chat": True, "active_packet": True, "concept_region": True},
+    "procedural": {"cards": True, "active_packet": True, "concept_region": True},
+    "open_loop": {"cards": True, "rdf_chat": True, "active_packet": True, "concept_region": True},
+    "contradiction": {"cards": True, "rdf": True, "active_packet": True, "graphiti": True, "concept_region": True},
 }
 
 

--- a/services/orion-recall/app/settings.py
+++ b/services/orion-recall/app/settings.py
@@ -222,6 +222,17 @@ class Settings(BaseSettings):
     RECALL_ACTIVE_PACKET_ENABLED: bool = Field(
         default=True, validation_alias=AliasChoices("RECALL_ACTIVE_PACKET_ENABLED")
     )
+    # Turn-scoped concept-region collector (services/orion-recall/app/collectors/
+    # concept_region.py) -- cheap, self-gating label-substring match against the
+    # substrate concept graph (golden Orion/Juniper/relationship concepts +
+    # organically-grown topic-foundry concepts, see orion/substrate/seed.py and
+    # orion/substrate/adapters/topic_foundry.py). Reads via
+    # app/substrate_store.py's lazily-initialized store handle (env-driven
+    # backend selection: SUBSTRATE_STORE_BACKEND/FALKORDB_URI/
+    # FALKORDB_SUBSTRATE_GRAPH below), never raises.
+    RECALL_CONCEPT_REGION_ENABLED: bool = Field(
+        default=True, validation_alias=AliasChoices("RECALL_CONCEPT_REGION_ENABLED")
+    )
     RECALL_BELIEF_RENDER_BUDGET: int = Field(
         default=128, validation_alias=AliasChoices("RECALL_BELIEF_RENDER_BUDGET")
     )

--- a/services/orion-recall/app/substrate_store.py
+++ b/services/orion-recall/app/substrate_store.py
@@ -1,0 +1,45 @@
+"""Lazily-initialized process-level substrate graph store for orion-recall.
+
+Mirrors the singleton-caching pattern in
+``orion/substrate/relational/adapters/concept_induction_ctx.py::_get_store``
+-- same never-raise-on-init-failure contract, same env-driven backend
+selection (``build_substrate_store_from_env``). A dedicated singleton lives
+here rather than importing cortex-exec's or Hub's store instance: each
+service builds its own store handle against the same shared FALKORDB_URI
+backend (see ``.env_example``), there is no cross-service store object to
+share, and importing across service boundaries is against this repo's
+service-isolation convention (see CLAUDE.md section 5).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from orion.substrate import build_substrate_store_from_env
+from orion.substrate.store import SubstrateGraphStore
+
+logger = logging.getLogger(__name__)
+
+_STORE: Optional[SubstrateGraphStore] = None
+
+
+def get_substrate_store() -> Optional[SubstrateGraphStore]:
+    """Return (or lazily initialise) the process-level substrate store.
+
+    Never raises: a construction failure is logged and the caller degrades
+    to ``None`` (collectors reading from a ``None`` store return empty,
+    never raise -- see ``collectors/concept_region.py``).
+    """
+
+    global _STORE
+    if _STORE is None:
+        try:
+            _STORE = build_substrate_store_from_env()
+        except Exception as exc:
+            logger.debug("recall_substrate_store_init_failed error=%s", exc)
+            return None
+    return _STORE
+
+
+__all__ = ["get_substrate_store"]

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -26,6 +26,8 @@ try:
     from .fusion import fuse_candidates, pcr_fuse_belief_candidates, render_continuity_bundle
     from .pcr_collectors import apply_collector_plan, collectors_for_intent
     from .collectors.active_packet import fetch_active_packet_fragments
+    from .collectors.concept_region import fetch_concept_region_fragment
+    from .substrate_store import get_substrate_store
     from .profiles import get_profile
     from .settings import settings
     from .source_policy import build_vector_policy
@@ -54,6 +56,8 @@ except ImportError as _e:  # pragma: no cover - fallback for runtime pathing
         from app.fusion import fuse_candidates, pcr_fuse_belief_candidates, render_continuity_bundle  # type: ignore
         from app.pcr_collectors import apply_collector_plan, collectors_for_intent  # type: ignore
         from app.collectors.active_packet import fetch_active_packet_fragments  # type: ignore
+        from app.collectors.concept_region import fetch_concept_region_fragment  # type: ignore
+        from app.substrate_store import get_substrate_store  # type: ignore
         from app.profiles import get_profile  # type: ignore
         from app.settings import settings  # type: ignore
         from app.source_policy import build_vector_policy  # type: ignore
@@ -1598,6 +1602,27 @@ async def process_recall(
                 backend_counts_total["active_packet"] = len(ap_frags)
             except Exception as exc:
                 logger.debug("active_packet collector skipped: %s", exc)
+
+        if pcr_backend_plan.get("concept_region") and settings.RECALL_CONCEPT_REGION_ENABLED:
+            try:
+                # Both get_substrate_store() (first-call hydration: FalkorDB
+                # issues several synchronous GRAPH.QUERY network calls with
+                # no client-side timeout, see FalkorSubstrateStore.__init__)
+                # and fetch_concept_region_fragment's store read are blocking
+                # -- both must run inside the offloaded thread, not just the
+                # fragment fetch. asyncio.to_thread only defers execution of
+                # the callable it's given; any argument expression (like a
+                # bare get_substrate_store() call) is still evaluated
+                # up front on the calling coroutine, i.e. still on this
+                # shared event loop. The lambda below defers both calls into
+                # the thread.
+                cr_frags = await asyncio.to_thread(
+                    lambda: fetch_concept_region_fragment(q, store=get_substrate_store())
+                )
+                candidates.extend(cr_frags)
+                backend_counts_total["concept_region"] = len(cr_frags)
+            except Exception as exc:
+                logger.debug("concept_region collector skipped: %s", exc)
 
     latency_ms = int((time.time() - t0) * 1000)
     fuse_started = time.time()

--- a/services/orion-recall/docker-compose.yml
+++ b/services/orion-recall/docker-compose.yml
@@ -47,6 +47,18 @@ services:
       - RECALL_CONTINUITY_RENDER_BUDGET=${RECALL_CONTINUITY_RENDER_BUDGET:-96}
       - RECALL_ACTIVE_PACKET_ENABLED=${RECALL_ACTIVE_PACKET_ENABLED:-true}
       - ACTIVATION_RECALL_FLOOR=${ACTIVATION_RECALL_FLOOR:-0.08}
+      - RECALL_CONCEPT_REGION_ENABLED=${RECALL_CONCEPT_REGION_ENABLED:-true}
+      # SUBSTRATE_STORE_BACKEND/FALKORDB_URI/FALKORDB_SUBSTRATE_GRAPH are read directly
+      # from the process environment by orion/substrate/graphdb_store.py's
+      # build_substrate_store_from_env() (no matching pydantic Settings field in this
+      # service) -- this service has no env_file: directive, so without these three
+      # entries here they never reach the container's real OS environment regardless
+      # of what .env/.env_example say, and the concept_region collector silently
+      # degrades to an empty in-memory store forever. Same shared FalkorDB
+      # instance/graph as orion-cortex-exec and orion-hub.
+      - SUBSTRATE_STORE_BACKEND=${SUBSTRATE_STORE_BACKEND:-falkor}
+      - FALKORDB_URI=${FALKORDB_URI}
+      - FALKORDB_SUBSTRATE_GRAPH=${FALKORDB_SUBSTRATE_GRAPH:-orion_substrate}
       - RECALL_BELIEF_RENDER_BUDGET=${RECALL_BELIEF_RENDER_BUDGET:-128}
       # No compose-level default on these two: they are NEVER_SYNC_KEYS-protected in
       # scripts/sync_local_env_from_example.py (must be set by hand in .env) and their

--- a/services/orion-recall/tests/test_concept_region_wiring.py
+++ b/services/orion-recall/tests/test_concept_region_wiring.py
@@ -1,0 +1,175 @@
+"""Tests for concept_region collector wiring into the live purposeful-recall
+turn pipeline (Gap 1b of the concept-graph-pipeline design).
+
+`services/orion-recall/tests/test_concept_region_collector.py` already covers
+`fetch_concept_region_fragment()` in isolation against a real store. This file
+covers the wiring itself: `worker.process_recall()` invoking the collector at
+the right point, respecting `RECALL_CONCEPT_REGION_ENABLED` /
+`pcr_backend_plan`, degrading gracefully on collector failure, and the
+`get_substrate_store()` singleton's never-raise contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_RECALL_ROOT = _REPO / "services" / "orion-recall"
+if str(_RECALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RECALL_ROOT))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from app import worker
+from app.profiles import get_profile
+from app.substrate_store import get_substrate_store
+from orion.core.contracts.recall import MemoryBundleStatsV1, MemoryBundleV1, RecallQueryV1
+
+
+def _base_worker_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(worker.settings, "RECALL_PCR_ENABLED", True)
+    monkeypatch.setattr(worker.settings, "RECALL_ACTIVE_PACKET_ENABLED", False)
+    monkeypatch.setattr(worker.settings, "RECALL_BELIEF_RENDER_BUDGET", 128)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_SQL_CHAT", False)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_SQL_TIMELINE", False)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_RDF", False)
+    monkeypatch.setattr(worker.settings, "RECALL_INTENT_ROUTING_ENABLED", False)
+
+
+def _wire_common_mocks(monkeypatch: pytest.MonkeyPatch, *, belief_fuse_called: list) -> None:
+    belief_profile = get_profile("chat.belief.semantic.v1")
+    monkeypatch.setattr(worker, "get_profile", lambda _name: dict(belief_profile))
+
+    async def _anchor(**kwargs):
+        return [], {}
+
+    def _mock_fuse(**kwargs):
+        return MemoryBundleV1(rendered="fuse", stats=MemoryBundleStatsV1()), []
+
+    def _mock_belief_fuse(**kwargs):
+        belief_fuse_called.append(kwargs)
+        return MemoryBundleV1(rendered="belief ok", stats=MemoryBundleStatsV1()), []
+
+    monkeypatch.setattr(worker, "_fetch_anchor_candidates", _anchor)
+    monkeypatch.setattr(worker, "_query_backends", AsyncMock(return_value=([], {})))
+    monkeypatch.setattr(worker, "fuse_candidates", _mock_fuse)
+    monkeypatch.setattr(worker, "pcr_fuse_belief_candidates", _mock_belief_fuse)
+
+
+def _purposeful_query() -> RecallQueryV1:
+    return RecallQueryV1(
+        fragment="tell me about continuity and self-modeling",
+        profile="chat.belief.semantic.v1",
+        recall_phase="purposeful",
+        retrieval_intent="semantic",
+        task_hints={"rule_id": "topic_shift"},
+        session_id="sess-concept-region",
+    )
+
+
+def test_worker_invokes_concept_region_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _base_worker_settings(monkeypatch)
+    monkeypatch.setattr(worker.settings, "RECALL_CONCEPT_REGION_ENABLED", True)
+
+    belief_fuse_called: list = []
+    _wire_common_mocks(monkeypatch, belief_fuse_called=belief_fuse_called)
+
+    concept_region_called: list = []
+
+    def _mock_concept_region(query, *, store):
+        concept_region_called.append((query, store))
+        return [{"id": "cr-1", "source": "concept_region", "snippet": "Orion: continuity", "score": 0.7}]
+
+    monkeypatch.setattr(worker, "fetch_concept_region_fragment", _mock_concept_region)
+    monkeypatch.setattr(worker, "get_substrate_store", lambda: "fake-store-handle")
+
+    bundle, decision = asyncio.run(worker.process_recall(_purposeful_query(), corr_id="corr-cr-1", diagnostic=True))
+
+    assert concept_region_called
+    assert concept_region_called[0][1] == "fake-store-handle"
+    assert belief_fuse_called
+    passed_candidates = belief_fuse_called[0]["candidates"]
+    assert any(c.get("source") == "concept_region" for c in passed_candidates)
+    assert bundle.rendered == "belief ok"
+    assert decision.recall_debug["pcr"]["backend_plan"]
+    assert "concept_region" in decision.recall_debug["pcr"]["backend_plan"]
+
+
+def test_worker_skips_concept_region_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _base_worker_settings(monkeypatch)
+    monkeypatch.setattr(worker.settings, "RECALL_CONCEPT_REGION_ENABLED", False)
+
+    belief_fuse_called: list = []
+    _wire_common_mocks(monkeypatch, belief_fuse_called=belief_fuse_called)
+
+    concept_region_called: list = []
+
+    def _mock_concept_region(query, *, store):
+        concept_region_called.append((query, store))
+        return [{"id": "cr-1", "source": "concept_region", "snippet": "should not appear", "score": 0.7}]
+
+    monkeypatch.setattr(worker, "fetch_concept_region_fragment", _mock_concept_region)
+
+    asyncio.run(worker.process_recall(_purposeful_query(), corr_id="corr-cr-2", diagnostic=True))
+
+    assert concept_region_called == []
+
+
+def test_worker_concept_region_failure_degrades_gracefully(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A collector-level exception must not crash the turn -- the route must
+    still render a bundle, just without concept_region's fragments."""
+    _base_worker_settings(monkeypatch)
+    monkeypatch.setattr(worker.settings, "RECALL_CONCEPT_REGION_ENABLED", True)
+
+    belief_fuse_called: list = []
+    _wire_common_mocks(monkeypatch, belief_fuse_called=belief_fuse_called)
+
+    def _raising_concept_region(query, *, store):
+        raise RuntimeError("store unreachable")
+
+    monkeypatch.setattr(worker, "fetch_concept_region_fragment", _raising_concept_region)
+    monkeypatch.setattr(worker, "get_substrate_store", lambda: None)
+
+    bundle, decision = asyncio.run(worker.process_recall(_purposeful_query(), corr_id="corr-cr-3", diagnostic=True))
+
+    assert bundle.rendered == "belief ok"
+    passed_candidates = belief_fuse_called[0]["candidates"]
+    assert not any(c.get("source") == "concept_region" for c in passed_candidates)
+
+
+def test_get_substrate_store_never_raises_on_init_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.substrate_store as substrate_store_mod
+
+    monkeypatch.setattr(substrate_store_mod, "_STORE", None)
+
+    def _boom():
+        raise RuntimeError("backend unreachable")
+
+    monkeypatch.setattr(substrate_store_mod, "build_substrate_store_from_env", _boom)
+
+    assert substrate_store_mod.get_substrate_store() is None
+
+
+def test_get_substrate_store_caches_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.substrate_store as substrate_store_mod
+
+    monkeypatch.setattr(substrate_store_mod, "_STORE", None)
+
+    calls: list[int] = []
+
+    def _fake_build():
+        calls.append(1)
+        return object()
+
+    monkeypatch.setattr(substrate_store_mod, "build_substrate_store_from_env", _fake_build)
+
+    first = get_substrate_store()
+    second = substrate_store_mod.get_substrate_store()
+
+    assert first is second
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary

- Wires the already-built, already-isolation-tested `concept_region` collector into `orion-recall`'s live purposeful-recall turn pipeline -- Gap 1b of the concept-graph-pipeline design.
- Golden Orion/Juniper/relationship concepts and organically-grown topic-foundry concepts can now surface into real chat turns via `orion-recall`'s belief lane, complementing `orion-cortex-exec`'s stance lane (Gap 1a, PR #1128, merged).
- New `app/substrate_store.py`: lazy process-level store singleton, mirroring `orion/substrate/relational/adapters/concept_induction_ctx.py::_get_store`'s never-raise contract.
- Two real bugs caught in code review and fixed before shipping: a missing `docker-compose.yml` env forward (feature would have been dead-on-arrival in the real container) and an event-loop-blocking store construction call.

## Outcome moved

`fetch_concept_region_fragment()` (built, tested in isolation, explicitly documented as "wiring out of scope" in its own module docstring) is now a live collector in `process_recall`'s purposeful phase.

## Current architecture

`orion-recall`'s purposeful-phase PCR pipeline already had an `active_packet` collector wired the same way (`pcr_backend_plan` gate + settings flag + `candidates.extend()` + `backend_counts_total` bookkeeping). `concept_region.py` existed with an identical fragment shape (`id`/`source`/`snippet`/`text`/`score`/`tags`) but no caller.

## Architecture touched

`services/orion-recall` only.

## Files changed

- `app/substrate_store.py` (new): lazy singleton, `get_substrate_store()`.
- `app/worker.py`: new gated block in `process_recall`, mirroring `active_packet`'s wiring shape exactly.
- `app/pcr_collectors.py`: `"concept_region": True` added to all 5 intent plans.
- `app/fusion.py`: `"concept_region"` added to `_BELIEF_SOURCE_ORDER`.
- `app/settings.py`: new `RECALL_CONCEPT_REGION_ENABLED` flag (default `true`).
- `.env_example` / `docker-compose.yml`: new env keys (see below).
- `tests/test_concept_region_wiring.py` (new, 6 tests).

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: purposeful-phase recall turns can now include `concept_region`-sourced candidates in the belief-lane render.
- Compatibility notes: none -- purely additive collector, degrades to no-op on any failure.

## Env/config changes

- Added keys: `RECALL_CONCEPT_REGION_ENABLED=true`, `SUBSTRATE_STORE_BACKEND=falkor`, `FALKORDB_URI=redis://orion-athena-falkordb:6379`, `FALKORDB_SUBSTRATE_GRAPH=orion_substrate` (same shared FalkorDB instance/graph as `orion-cortex-exec`/`orion-hub`).
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes.
- local `.env` synced: yes (`services/orion-recall/.env` updated directly in the same session).
- `docker-compose.yml` updated: yes -- see Review findings below, this was originally missed and caught in review.
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH=. .venv/bin/python -m pytest services/orion-recall/tests/test_concept_region_wiring.py services/orion-recall/tests/test_concept_region_collector.py -q
19 passed

PYTHONPATH=. .venv/bin/python -m pytest services/orion-recall/tests/ -q
120 passed, 3 failed
```

The 3 failures (`test_process_recall_active_turn_exclusion.py::test_process_recall_excludes_active_turn_candidates`, `test_recall_policy_harness.py::test_process_recall_diagnostic_contains_gating_suppression_and_selection`, `test_recall_vector_amputation.py::test_worker_and_recall_v2_import_without_vector_adapter`) are confirmed present on unmodified `main` too (a `lane` kwarg mismatch and an unrelated import issue) -- pre-existing, unrelated to this diff.

## Evals run

No eval harness exists for `orion-recall`. Not adding one for this seam.

## Docker/build/smoke checks

`docker compose ... config` not run (no Docker environment available in this session). YAML validity of the updated `docker-compose.yml` confirmed via `python3 -c "import yaml; yaml.safe_load(open(...))"`.

## Review findings fixed

- Finding: `docker-compose.yml` never forwarded the new env vars -- this service has no `env_file:` directive (unlike `orion-cortex-exec`), so every settings-driven var must be enumerated by hand in the compose file's `environment:` block. `SUBSTRATE_STORE_BACKEND`/`FALKORDB_URI`/`FALKORDB_SUBSTRATE_GRAPH` are read directly from the process environment by `build_substrate_store_from_env()` (no matching pydantic field), so without compose entries they never reach the container's real OS environment regardless of `.env`/`.env_example` -- `build_substrate_store_from_env()` would see an empty backend string and silently fall back to an empty `InMemorySubstrateGraphStore`, making the collector return `[]` on every production turn forever. Invisible to every test since all of them monkeypatch `get_substrate_store` directly.
  - Fix: added all four keys to `docker-compose.yml`'s `environment:` block.
  - Evidence: `grep -n "RECALL_CONCEPT_REGION_ENABLED\|SUBSTRATE_STORE_BACKEND\|FALKORDB" services/orion-recall/docker-compose.yml` now matches.
- Finding: `get_substrate_store()` was evaluated as a bare argument expression to `asyncio.to_thread(fetch_concept_region_fragment, q, store=get_substrate_store())` -- Python evaluates call arguments before `to_thread` runs, so the store's first-call hydration (FalkorDB: several synchronous `GRAPH.QUERY` network calls with no client-side timeout) would execute directly on `process_recall`'s calling coroutine, blocking the shared event loop for every other in-flight recall turn.
  - Fix: wrapped both calls in a lambda so `asyncio.to_thread` defers both into the offloaded thread.
  - Evidence: `app/worker.py`'s updated block; all 120 tests still pass post-fix.
- Finding (documented, not fixed -- out of scope): `FalkorSubstrateStore` hydrates its snapshot once at construction and never refreshes; the process-level singleton means topic-foundry concepts added after orion-recall's first `concept_region` call are invisible until restart.
  - Fix: none in this patch.
  - Evidence: called out explicitly below as a known limitation.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml \
  up -d --build orion-recall
```

## Risks / concerns

- Severity: low
- Concern: `FalkorSubstrateStore`'s snapshot never refreshes after first hydration -- new concepts invisible to `concept_region` until `orion-recall` restarts.
- Mitigation: not a regression this diff introduces (shared `falkor_store.py` limitation), but flagged as a real follow-up since this is the first continuously-changing-data consumer of the store in this service. Follow-up: TTL/refresh mechanism mirroring `GraphDBSubstrateStore`'s `SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC`, or accept restart-cadence freshness for now.
- Severity: low
- Concern: `_BELIEF_SOURCE_ORDER` rank only affects display order among survivors after `fuse_candidates`'s composite-score-driven budget truncation, not actual selection priority (pre-existing behavior, not introduced by this diff).
- Mitigation: none needed -- `concept_region` and `active_packet` share the same default backend weight (0.5), so they compete on equal footing by score.

## PR link

(populated after creation)