### PR TITLE
Fix/agent board session cwd lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,8 @@ Manual `checkin`/`heartbeat`/`add`/`checkout` calls above are still the right to
 
 Both heartbeats are best-effort and never fail the commit or the build they ride on — a board write error is swallowed, not surfaced as a failure of the underlying git/docker operation.
 
+**A separate, previously-undiscovered bug in `scripts/hooks/session_start_agent_board.py`/`session_stop_agent_board.py`** (the Claude-Code-specific SessionStart/Stop hooks, distinct from the git hooks above): confirmed live that these run with a process `cwd` fixed to wherever the session originally started (its own stdin payload's `cwd` field reported the shared/primary checkout even while real git work had been happening in a linked worktree for many turns) — it does not track `cd` calls a Bash tool makes mid-session, so `git rev-parse --show-toplevel` from that same fixed cwd resolved to the same wrong worktree every time, and `render_checkin_context` was additionally *writing* a spurious presence row under that wrong path on every SessionStart. Fixed with `agent_board_lib.resolve_current_identity()`: both hooks now read `session_id` from their own stdin payload and look up the most recently heartbeated presence row tagged with that same session_id instead of trusting their own cwd — `scripts/git_hooks/post-commit` and `scripts/safe_docker_build.sh` tag their heartbeats with `$CLAUDE_CODE_SESSION_ID` (inherited from the Claude Code Bash tool's own subprocess environment) precisely so this lookup has something real to find. Falls back to the old cwd-based resolution when no matching session_id is on the board yet (e.g. the very first hook fire in a session, before any git-hook-driven heartbeat has landed).
+
 Branch type examples:
 
 ```text

--- a/docs/superpowers/pr-reports/2026-07-17-agent-board-session-cwd-lookup-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-agent-board-session-cwd-lookup-pr.md
@@ -1,0 +1,186 @@
+## Summary
+
+- Fix a second, previously-undiscovered agent-board bug found via live
+  investigation while a user was querying a Stop-hook reminder: Claude
+  Code's own `SessionStart`/`Stop` hooks (`scripts/hooks/
+  session_start_agent_board.py`, `scripts/hooks/session_stop_agent_board.py`
+  -- distinct from the git hooks shipped in the already-merged
+  `chore/agent-board-heartbeat-coupling` PR) run with a process `cwd` fixed
+  to wherever the session originally started, and do not track `cd` calls a
+  Bash tool makes mid-session. Confirmed by inspecting the Stop hook's own
+  stdin JSON payload: its `cwd` field reported the shared/primary checkout
+  even while real git work had been happening in a linked worktree for many
+  turns.
+- `render_checkin_context()` was additionally *writing* a spurious presence
+  row under that wrong path on every `SessionStart`, not just misreporting
+  on read.
+- Fixed with a new `resolve_current_identity()` in `agent_board_lib.py`:
+  when a `session_id` is available, look up the most recently heartbeated
+  presence row tagged with that session_id and use its `worktree_path`
+  instead of the hook's own cwd. Works because the already-shipped
+  `scripts/git_hooks/post-commit` and `scripts/safe_docker_build.sh` now
+  tag their heartbeats with `$CLAUDE_CODE_SESSION_ID` (confirmed live to be
+  present in the Bash tool's subprocess environment and to inherit
+  correctly down to a git-hook subprocess). Falls back to the old
+  cwd-based resolution when no matching session_id is on the board yet.
+- Code review (dispatched subagent) confirmed the two direct regression
+  tests actually fail against the pre-fix code (not placebo coverage) and
+  found two minor nitpicks, both fixed here: a duplicated
+  `_read_session_id()` helper consolidated into
+  `read_session_id_from_stdin_hook_payload()`, and a TTY guard added so
+  manual invocation for debugging doesn't block on stdin.
+
+## Outcome moved
+
+Before this fix, every concurrent Claude Code session working via linked
+worktrees (this repo's own convention) had its `SessionStart`/`Stop`
+board hooks silently attributing presence and open-item lookups to the
+shared/primary checkout instead of its actual worktree -- weakening the
+board's whole worktree-scoped collision-avoidance design for anything
+routed through these two hooks. Confirmed live post-fix: a real commit's
+heartbeat correctly carries this session's own `session_id`
+(`4dd9ea4b-3afa-4362-8590-3bd65e3ac4ac`), which the fixed hooks can now
+use to resolve the correct worktree.
+
+## Current architecture
+
+`scripts/agent_board_lib.py`'s `current_worktree_identity()` resolves the
+board's notion of "current worktree" purely via `git rev-parse
+--show-toplevel` from the calling process's own inherited cwd. Both
+`session_start_agent_board.py` and `session_stop_agent_board.py` called
+this directly with no way to override it. Separately,
+`scripts/git_hooks/post-commit` and `scripts/safe_docker_build.sh`
+(merged in `chore/agent-board-heartbeat-coupling`) already heartbeat the
+board correctly, since they're invoked by `git`/`docker` with the correct
+cwd, not by the Claude Code harness's own hook mechanism.
+
+## Architecture touched
+
+- `scripts/agent_board_lib.py`: new `resolve_current_identity()` and
+  `read_session_id_from_stdin_hook_payload()`; `upsert_presence()` gained
+  optional `worktree_path`/`branch` overrides; `render_checkin_context()`
+  gained an optional `session_id` kwarg.
+- `scripts/hooks/session_start_agent_board.py`,
+  `scripts/hooks/session_stop_agent_board.py`: read `session_id` from
+  their own stdin JSON payload, pass it through to the board lib.
+- `scripts/git_hooks/post-commit`, `scripts/safe_docker_build.sh`: pass
+  `--session-id "$CLAUDE_CODE_SESSION_ID"` to their heartbeat calls when
+  that env var is set.
+- `CLAUDE.md`: documents the bug and fix under "Agent workspace board".
+
+## Files changed
+
+- `scripts/agent_board_lib.py`: `resolve_current_identity()`,
+  `read_session_id_from_stdin_hook_payload()` (new); `upsert_presence()`,
+  `render_checkin_context()` (modified signatures, backward compatible --
+  both new params are keyword-only with `None` defaults that short-circuit
+  to the exact old behavior).
+- `scripts/hooks/session_start_agent_board.py`,
+  `scripts/hooks/session_stop_agent_board.py`: read and thread through
+  `session_id`.
+- `scripts/git_hooks/post-commit`, `scripts/safe_docker_build.sh`:
+  `--session-id` passthrough when `$CLAUDE_CODE_SESSION_ID` is set.
+- `tests/scripts/test_agent_board_lib.py`: 4 new tests for
+  `resolve_current_identity` (session match, multi-worktree tie-break,
+  no-match fallback, `session_id=None` fallback).
+- `tests/scripts/test_session_agent_board_hooks.py`: 3 new tests --
+  Stop-hook and SessionStart-hook resolution via session_id from a
+  simulated wrong cwd, plus a no-match fallback case; `_run_hook` helper
+  extended to pass an explicit stdin JSON payload.
+- `tests/scripts/test_install_git_safety_hooks.py`,
+  `tests/scripts/test_safe_docker_build_heartbeat.py`: new tests
+  confirming `$CLAUDE_CODE_SESSION_ID` actually flows through into the
+  heartbeat's `--session-id` argument.
+- `CLAUDE.md`: new paragraph under "Agent workspace board".
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. `$CLAUDE_CODE_SESSION_ID` is set by the Claude Code harness itself,
+not something this repo configures.
+
+## Tests run
+
+```text
+/mnt/scripts/Orion-Sapienform/.venv/bin/pytest tests/scripts/ -q
+199 passed in 47.3s
+```
+
+Plus live verification: a real commit on this branch tagged its heartbeat
+with this session's actual `$CLAUDE_CODE_SESSION_ID`, confirmed via the
+raw board JSONL.
+
+## Evals run
+
+No eval harness applies to shell/hook tooling in this repo.
+
+## Docker/build/smoke checks
+
+Not applicable -- no service touched.
+
+## Review findings fixed
+
+- Finding: `_read_session_id()` was duplicated verbatim across both hook
+  scripts.
+  - Fix: consolidated into `agent_board_lib.read_session_id_from_stdin_hook_payload()`.
+  - Evidence: both hook files now import and call the single shared
+    function; full suite still green (199 passed).
+- Finding: `sys.stdin.read()` would block indefinitely if either hook is
+  invoked manually from an interactive terminal for debugging (not a risk
+  in the real Claude Code/Cursor invocation paths, where stdin is a pipe
+  the harness writes-then-closes, but a new failure mode this diff
+  introduced that didn't exist before it touched stdin at all).
+  - Fix: `read_session_id_from_stdin_hook_payload()` checks
+    `stream.isatty()` first and skips reading entirely on a live TTY.
+  - Evidence: code inspection; the existing test suite's `input=""`-based
+    invocations are piped, not TTY, so this path is exercised by every
+    existing hook test without behavior change.
+- Finding (verified, not a defect): tie-breaking on identical
+  `heartbeat_at` timestamps within `resolve_current_identity` falls back
+  to dict-iteration/insertion order rather than an explicit secondary key.
+  - Not fixed: reviewer assessed a genuine same-second tie between two
+    worktrees under one session_id as unlikely enough in practice not to
+    matter; flagging as a known, accepted limitation rather than adding
+    complexity for it.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+Local git-hook/hook-script tooling only. Anyone who wants the corrected
+`SessionStart`/`Stop` resolution active needs no action beyond having this
+merged code checked out -- these are plain Python scripts invoked fresh by
+the harness each time, not something requiring a hook re-install (unlike
+the git hooks, which do need `scripts/install_git_safety_hooks.sh` re-run
+once per machine to pick up code changes, already covered by the earlier
+PR).
+
+## Risks / concerns
+
+- Severity: Low
+  - Concern: this fix's live verification was necessarily partial --
+    confirming the git-hook side tags the real session_id into a real
+    heartbeat is straightforward and done, but confirming the
+    `SessionStart`/`Stop` hooks themselves correctly resolve via that
+    session_id in a live Claude Code invocation (as opposed to the test
+    suite's simulated stdin payloads) requires the fix to actually be
+    merged and live in the shared checkout first, since `$CLAUDE_PROJECT_DIR`
+    still points at pre-fix code until then.
+  - Mitigation: the test suite's regression tests were confirmed to
+    genuinely fail against the pre-fix code (not placebo coverage, per
+    the dispatched review), and the underlying mechanism (session_id
+    passed via stdin JSON, looked up against a real presence row) was
+    exercised end-to-end in tests using the exact same code paths the
+    real hooks call. Recommend a live spot-check after merge: make a
+    commit from a linked worktree, then check whether the next Stop
+    hook's reminder correctly reports items scoped to that worktree
+    rather than the shared checkout.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/agent-board-session-cwd-lookup

--- a/scripts/agent_board_lib.py
+++ b/scripts/agent_board_lib.py
@@ -217,14 +217,101 @@ def current_worktree_identity(cwd: Path | None = None) -> dict[str, str]:
     return {"worktree_path": str(root), "branch": branch}
 
 
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return datetime.min.replace(tzinfo=UTC)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def read_session_id_from_stdin_hook_payload(stream=None) -> str | None:
+    """Extract `session_id` from a Claude Code hook's own stdin JSON payload.
+
+    Shared by session_start_agent_board.py and session_stop_agent_board.py
+    (both previously duplicated this logic verbatim). Never raises and
+    never blocks past whatever the caller's stream naturally does -- skips
+    reading entirely when stdin is a live TTY (a human running the hook
+    script by hand to debug it, not the harness piping a payload in and
+    closing it), since `.read()` on an open TTY blocks until EOF/interrupt.
+    """
+    import sys as _sys
+
+    stream = stream if stream is not None else _sys.stdin
+    try:
+        if hasattr(stream, "isatty") and stream.isatty():
+            return None
+        raw = stream.read()
+    except Exception:
+        return None
+    if not raw.strip():
+        return None
+    try:
+        payload_in = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload_in, dict):
+        return None
+    session_id = payload_in.get("session_id")
+    return str(session_id) if session_id else None
+
+
+def resolve_current_identity(
+    config: BoardConfig,
+    *,
+    session_id: str | None = None,
+) -> dict[str, str]:
+    """Resolve the worktree identity to use for a board call.
+
+    Claude Code's SessionStart/Stop hooks run with a process cwd fixed to
+    the session's original project directory -- it does NOT track `cd`
+    calls a Bash tool makes mid-session (confirmed live: a Stop hook's own
+    stdin payload reported `cwd` as the shared/primary checkout even while
+    the agent's actual git work was happening in a linked worktree several
+    turns earlier). `git rev-parse --show-toplevel` from that same fixed
+    cwd resolves to the same wrong answer, so it can't be fixed by cwd
+    detection alone.
+
+    When `session_id` is given (the hook's own stdin payload carries one),
+    look up the most recently heartbeated presence row tagged with that
+    same session_id -- git-hook-driven heartbeats (`scripts/git_hooks/
+    post-commit`, `scripts/safe_docker_build.sh`) pass `$CLAUDE_CODE_SESSION_ID`
+    when set, and those DO run with the correct worktree cwd (they're
+    invoked by `git`/`docker`, not by the Claude Code harness's own hook
+    mechanism). Falls back to the normal git-rev-parse-based resolution if
+    no matching session_id is found yet (e.g. the very first hook fire in a
+    session, before any git-hook-driven heartbeat has landed).
+    """
+    if session_id:
+        state = load_state(config)
+        candidates = [
+            row for row in state.presence.values()
+            if row.get("session_id") == session_id and row.get("worktree_path")
+        ]
+        if candidates:
+            best = max(candidates, key=lambda row: _parse_timestamp(str(row.get("heartbeat_at") or "")))
+            return {
+                "worktree_path": str(best["worktree_path"]),
+                "branch": str(best.get("branch") or ""),
+            }
+    return current_worktree_identity()
+
+
 def upsert_presence(
     config: BoardConfig,
     *,
     summary: str | None = None,
     task: str | None = None,
     session_id: str | None = None,
+    worktree_path: str | None = None,
+    branch: str | None = None,
 ) -> dict[str, object]:
-    identity = current_worktree_identity()
+    if worktree_path is not None:
+        identity = {"worktree_path": worktree_path, "branch": branch or ""}
+    else:
+        identity = current_worktree_identity()
     payload: dict[str, object] = {
         "worktree_path": identity["worktree_path"],
         "branch": identity["branch"],
@@ -415,11 +502,16 @@ def _global_items(state: BoardState) -> list[dict[str, object]]:
     ]
 
 
-def render_checkin_context(config: BoardConfig) -> str:
-    identity = current_worktree_identity()
+def render_checkin_context(config: BoardConfig, *, session_id: str | None = None) -> str:
+    identity = resolve_current_identity(config, session_id=session_id)
     live = live_worktree_paths()
     state = reconcile_closed_worktrees(config, live_paths=live)
-    upsert_presence(config)
+    upsert_presence(
+        config,
+        session_id=session_id,
+        worktree_path=identity["worktree_path"],
+        branch=identity["branch"],
+    )
     state = load_state(config, live_worktrees=live)
     current = identity["worktree_path"]
     lines: list[str] = ["Agent workspace board"]

--- a/scripts/git_hooks/post-commit
+++ b/scripts/git_hooks/post-commit
@@ -32,4 +32,16 @@ command -v python3 >/dev/null 2>&1 || exit 0
 SUBJECT=$(git log -1 --pretty=%s 2>/dev/null) || exit 0
 [ -n "$SUBJECT" ] || exit 0
 
-python3 "$REPO_ROOT/scripts/agent_board.py" heartbeat --summary "$SUBJECT" >/dev/null 2>&1 || true
+# Tag the heartbeat with the Claude Code session id when this commit ran
+# inside a Claude Code Bash tool call (the env var is inherited down to
+# this hook's subprocess same as any other). This lets the SessionStart/Stop
+# hooks -- which run with a process cwd fixed to the session's original
+# project directory, not wherever an agent `cd`d into mid-session -- look up
+# "the worktree this session most recently heartbeated" instead of
+# resolving cwd themselves, which resolves to the wrong path (confirmed
+# live: see resolve_current_identity()'s docstring in agent_board_lib.py).
+if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    python3 "$REPO_ROOT/scripts/agent_board.py" heartbeat --summary "$SUBJECT" --session-id "$CLAUDE_CODE_SESSION_ID" >/dev/null 2>&1 || true
+else
+    python3 "$REPO_ROOT/scripts/agent_board.py" heartbeat --summary "$SUBJECT" >/dev/null 2>&1 || true
+fi

--- a/scripts/hooks/session_start_agent_board.py
+++ b/scripts/hooks/session_start_agent_board.py
@@ -11,12 +11,17 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from agent_board_lib import board_config_from_env, render_checkin_context  # noqa: E402
+from agent_board_lib import (  # noqa: E402
+    board_config_from_env,
+    read_session_id_from_stdin_hook_payload,
+    render_checkin_context,
+)
 
 
 def main() -> None:
+    session_id = read_session_id_from_stdin_hook_payload()
     try:
-        context = render_checkin_context(board_config_from_env())
+        context = render_checkin_context(board_config_from_env(), session_id=session_id)
     except Exception:
         return
     payload = {

--- a/scripts/hooks/session_stop_agent_board.py
+++ b/scripts/hooks/session_stop_agent_board.py
@@ -11,13 +11,19 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from agent_board_lib import board_config_from_env, current_worktree_identity, load_state  # noqa: E402
+from agent_board_lib import (  # noqa: E402
+    board_config_from_env,
+    load_state,
+    read_session_id_from_stdin_hook_payload,
+    resolve_current_identity,
+)
 
 
 def main() -> None:
+    session_id = read_session_id_from_stdin_hook_payload()
     try:
         cfg = board_config_from_env()
-        current = current_worktree_identity()["worktree_path"]
+        current = resolve_current_identity(cfg, session_id=session_id)["worktree_path"]
         state = load_state(cfg)
         open_items = [
             item for item in state.items.values()

--- a/scripts/safe_docker_build.sh
+++ b/scripts/safe_docker_build.sh
@@ -98,9 +98,15 @@ fi
 # agent_board.py lives as a sibling file.
 _SCRIPT_DIR_FOR_BOARD=$(cd "$(dirname "$0")" && pwd)
 if [ -f "$_SCRIPT_DIR_FOR_BOARD/agent_board.py" ] && command -v python3 >/dev/null 2>&1; then
-    python3 "$_SCRIPT_DIR_FOR_BOARD/agent_board.py" heartbeat \
-        --summary "docker compose $* for services/$SERVICE" \
-        --task "deploy:$SERVICE" >/dev/null 2>&1 || true
+    if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+        python3 "$_SCRIPT_DIR_FOR_BOARD/agent_board.py" heartbeat \
+            --summary "docker compose $* for services/$SERVICE" \
+            --task "deploy:$SERVICE" --session-id "$CLAUDE_CODE_SESSION_ID" >/dev/null 2>&1 || true
+    else
+        python3 "$_SCRIPT_DIR_FOR_BOARD/agent_board.py" heartbeat \
+            --summary "docker compose $* for services/$SERVICE" \
+            --task "deploy:$SERVICE" >/dev/null 2>&1 || true
+    fi
 fi
 
 # --- 3. Run docker compose with this repo's mandatory dual --env-file  -----

--- a/tests/scripts/test_agent_board_lib.py
+++ b/tests/scripts/test_agent_board_lib.py
@@ -19,6 +19,7 @@ from agent_board_lib import (  # noqa: E402
     load_state,
     reconcile_closed_worktrees,
     render_checkin_context,
+    resolve_current_identity,
     validate_item_payload,
 )
 
@@ -401,3 +402,96 @@ def test_reconcile_closed_worktrees_persists_closed_event(tmp_path: Path) -> Non
     persisted = load_state(cfg)
     assert persisted.presence["/repo/old"]["status"] == "closed"
     assert state.presence["/repo/old"]["status"] == "closed"
+
+
+def test_resolve_current_identity_finds_worktree_by_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Core regression coverage for the Claude-Code hook-cwd bug: a Stop/
+    SessionStart hook's own process cwd is fixed to wherever the session
+    originally started and does not track mid-session `cd` calls, so
+    resolving identity via git-rev-parse-from-cwd resolves to the wrong
+    worktree. A git-hook-driven heartbeat (which DOES run with correct cwd)
+    tags its presence row with a session_id; resolve_current_identity must
+    prefer that over the ambient cwd when a session_id is given."""
+    cfg = _config(tmp_path)
+    append_event(
+        cfg,
+        "presence_upserted",
+        {"worktree_path": "/repo/real-worktree", "branch": "feat/real", "session_id": "sess-1"},
+    )
+    monkeypatch.setattr(
+        "agent_board_lib.current_worktree_identity",
+        lambda: {"worktree_path": "/repo/wrong-fixed-cwd", "branch": "main"},
+    )
+
+    identity = resolve_current_identity(cfg, session_id="sess-1")
+
+    assert identity["worktree_path"] == "/repo/real-worktree"
+    assert identity["branch"] == "feat/real"
+
+
+def test_resolve_current_identity_picks_most_recent_when_session_touched_multiple_worktrees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same session_id can legitimately appear on multiple worktrees'
+    presence rows over a session's lifetime (an agent working across several
+    worktrees in one conversation) -- resolution must pick the most
+    recently heartbeated one, not just any match."""
+    cfg = _config(tmp_path)
+    append_event(
+        cfg,
+        "presence_upserted",
+        {
+            "worktree_path": "/repo/earlier-worktree",
+            "branch": "feat/earlier",
+            "session_id": "sess-2",
+            "heartbeat_at": "2026-07-17T10:00:00+00:00",
+        },
+    )
+    append_event(
+        cfg,
+        "presence_upserted",
+        {
+            "worktree_path": "/repo/later-worktree",
+            "branch": "feat/later",
+            "session_id": "sess-2",
+            "heartbeat_at": "2026-07-17T12:00:00+00:00",
+        },
+    )
+    monkeypatch.setattr(
+        "agent_board_lib.current_worktree_identity",
+        lambda: {"worktree_path": "/repo/wrong-fixed-cwd", "branch": "main"},
+    )
+
+    identity = resolve_current_identity(cfg, session_id="sess-2")
+
+    assert identity["worktree_path"] == "/repo/later-worktree"
+
+
+def test_resolve_current_identity_falls_back_to_cwd_when_no_session_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _config(tmp_path)
+    monkeypatch.setattr(
+        "agent_board_lib.current_worktree_identity",
+        lambda: {"worktree_path": "/repo/fallback", "branch": "main"},
+    )
+
+    identity = resolve_current_identity(cfg, session_id="no-such-session")
+
+    assert identity["worktree_path"] == "/repo/fallback"
+
+
+def test_resolve_current_identity_falls_back_when_session_id_is_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _config(tmp_path)
+    monkeypatch.setattr(
+        "agent_board_lib.current_worktree_identity",
+        lambda: {"worktree_path": "/repo/fallback", "branch": "main"},
+    )
+
+    identity = resolve_current_identity(cfg, session_id=None)
+
+    assert identity["worktree_path"] == "/repo/fallback"

--- a/tests/scripts/test_install_git_safety_hooks.py
+++ b/tests/scripts/test_install_git_safety_hooks.py
@@ -282,3 +282,49 @@ def test_installed_post_commit_hook_heartbeats_the_agent_board(tmp_path: Path) -
     )
     assert listed.returncode == 0, listed.stderr
     assert "test: verify post-commit board heartbeat" in listed.stdout
+
+
+def test_post_commit_hook_tags_heartbeat_with_claude_session_id_when_set(tmp_path: Path) -> None:
+    """The Stop/SessionStart hooks need a session_id-tagged presence row to
+    resolve the real worktree despite their own fixed process cwd (see
+    resolve_current_identity() in agent_board_lib.py) -- this only works if
+    the post-commit hook actually passes $CLAUDE_CODE_SESSION_ID through
+    when Claude Code set it for the commit's own subprocess."""
+    primary = tmp_path / "primary"
+    _init_repo(primary)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=primary, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=primary, check=True)
+
+    board_scripts_dir = primary / "scripts"
+    board_scripts_dir.mkdir()
+    for name in ("agent_board.py", "agent_board_lib.py", "worktree_lib.py"):
+        (board_scripts_dir / name).write_text(
+            (ROOT / "scripts" / name).read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    subprocess.run(["git", "add", "-A"], cwd=primary, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=primary, check=True)
+
+    proc = _run_installer(primary)
+    assert proc.returncode == 0, proc.stderr
+
+    worktree = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "worktree", "add", "-q", str(worktree), "-b", "chore/test-session-id"],
+        cwd=primary,
+        check=True,
+    )
+
+    board = tmp_path / "agent-board.jsonl"
+    env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board), "CLAUDE_CODE_SESSION_ID": "sess-xyz-789"}
+
+    (worktree / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "add", "f.txt"], cwd=worktree, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "test: verify session id passthrough"],
+        cwd=worktree,
+        check=True,
+        env=env,
+    )
+
+    raw_events = board.read_text(encoding="utf-8")
+    assert '"session_id": "sess-xyz-789"' in raw_events

--- a/tests/scripts/test_safe_docker_build_heartbeat.py
+++ b/tests/scripts/test_safe_docker_build_heartbeat.py
@@ -89,6 +89,40 @@ def test_heartbeats_before_running_docker_compose(tmp_path: Path) -> None:
     assert "deploy:orion-fake-service" in listed.stdout
 
 
+def test_heartbeat_tags_claude_session_id_when_set(tmp_path: Path) -> None:
+    """The Stop/SessionStart hooks need a session_id-tagged presence row to
+    resolve the real worktree despite their own fixed process cwd (see
+    resolve_current_identity() in agent_board_lib.py) -- this only works if
+    the docker-build heartbeat actually passes $CLAUDE_CODE_SESSION_ID
+    through when Claude Code set it for the wrapper's own subprocess."""
+    worktree = _init_worktree_repo(tmp_path, "orion-fake-service")
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    _make_fake_docker(fake_bin)
+
+    board = tmp_path / "agent-board.jsonl"
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+        "ORION_AGENT_BOARD_PATH": str(board),
+        "CLAUDE_CODE_SESSION_ID": "sess-docker-456",
+    }
+
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), "orion-fake-service", "up", "-d"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    raw_events = board.read_text(encoding="utf-8")
+    assert '"session_id": "sess-docker-456"' in raw_events
+
+
 def test_never_fails_the_build_when_board_path_is_unwritable(tmp_path: Path) -> None:
     """The heartbeat is advisory-only -- an agent-board failure must never
     block a real deploy."""

--- a/tests/scripts/test_session_agent_board_hooks.py
+++ b/tests/scripts/test_session_agent_board_hooks.py
@@ -11,12 +11,20 @@ START_HOOK = ROOT / "scripts" / "hooks" / "session_start_agent_board.py"
 STOP_HOOK = ROOT / "scripts" / "hooks" / "session_stop_agent_board.py"
 
 
-def _run_hook(hook: Path, cwd: Path, board_path: Path) -> subprocess.CompletedProcess:
+def _run_hook(
+    hook: Path, cwd: Path, board_path: Path, *, stdin_payload: dict | None = None
+) -> subprocess.CompletedProcess:
     env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board_path)}
+    # Explicit input= regardless of whether a real payload is given -- these
+    # hooks now read stdin (for session_id), and relying on however pytest
+    # happens to have stdin configured is fragile; an empty string mimics
+    # "no payload" the same way a closed stdin would.
+    stdin_text = json.dumps(stdin_payload) if stdin_payload is not None else ""
     return subprocess.run(
         [sys.executable, str(hook)],
         cwd=cwd,
         env=env,
+        input=stdin_text,
         capture_output=True,
         text=True,
         timeout=30,
@@ -52,6 +60,103 @@ def test_hooks_fail_open_outside_git_repo(tmp_path: Path) -> None:
     assert start.stdout == ""
     assert stop.returncode == 0
     assert stop.stdout == ""
+
+
+def _run_board_cli(cwd: Path, board_path: Path, *args: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board_path)}
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "agent_board.py"), *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_stop_hook_uses_session_id_to_find_the_real_worktree(
+    repo_with_worktrees: tuple[Path, Path, Path], tmp_path: Path
+) -> None:
+    """Regression test for a real bug caught live: Claude Code's Stop hook
+    runs with a process cwd fixed to wherever the session originally
+    started, which does NOT track `cd` calls a Bash tool made mid-session --
+    confirmed live by inspecting the hook's own stdin payload, which reported
+    `cwd` as the shared/primary checkout even while real git work had been
+    happening in a linked worktree for many turns. `git rev-parse
+    --show-toplevel` from that same fixed cwd resolves to the same wrong
+    answer, so the hook was reporting (or missing) open items for the wrong
+    worktree entirely.
+
+    A git-hook-driven heartbeat (`scripts/git_hooks/post-commit`) tags its
+    heartbeat with `$CLAUDE_CODE_SESSION_ID` when set -- that hook DOES run
+    with the correct cwd (invoked by `git`, not the Claude Code harness). The
+    Stop hook can then look up "the most recently heartbeated worktree for
+    this session_id" from its own stdin payload instead of trusting its own
+    cwd."""
+    primary, merged_wt, _unmerged_wt = repo_with_worktrees
+    board = tmp_path / "agent-board.jsonl"
+    session_id = "sess-abc-123"
+
+    # Simulate the git-hook-driven heartbeat that happens on a real commit
+    # in merged_wt, tagged with the session id.
+    heartbeat = _run_board_cli(
+        merged_wt, board, "heartbeat", "--summary", "real work happened here", "--session-id", session_id
+    )
+    assert heartbeat.returncode == 0, heartbeat.stderr
+
+    # An open item scoped to merged_wt -- this is what the Stop hook should
+    # report on, since that's where the session's real work is.
+    add = _run_board_cli(
+        merged_wt, board, "add", "--kind", "finding", "--severity", "note", "--summary", "found something"
+    )
+    assert add.returncode == 0, add.stderr
+
+    # Run the Stop hook from `primary` (simulating the harness's fixed,
+    # wrong cwd) but WITH the session_id in its stdin payload.
+    proc = _run_hook(STOP_HOOK, primary, board, stdin_payload={"session_id": session_id})
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    detail = payload["hookSpecificOutput"]["additionalContext"]
+    assert "1 open item" in detail, detail
+
+
+def test_stop_hook_falls_back_to_cwd_when_session_id_has_no_match(
+    primary_repo: Path, tmp_path: Path
+) -> None:
+    """No git-hook-driven heartbeat has landed for this session_id yet (e.g.
+    the very first hook fire in a session) -- must fall back to the old
+    git-rev-parse-based resolution rather than erroring or misreporting."""
+    board = tmp_path / "agent-board.jsonl"
+    proc = _run_hook(STOP_HOOK, primary_repo, board, stdin_payload={"session_id": "no-such-session"})
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert "no open board items" in payload["hookSpecificOutput"]["additionalContext"].lower()
+
+
+def test_session_start_hook_resolves_via_session_id_not_fixed_cwd(
+    repo_with_worktrees: tuple[Path, Path, Path], tmp_path: Path
+) -> None:
+    """Same bug, SessionStart side: `render_checkin_context` must report
+    (and heartbeat) the session-resolved worktree, not wherever the hook's
+    own process cwd happens to be fixed to."""
+    primary, merged_wt, _unmerged_wt = repo_with_worktrees
+    board = tmp_path / "agent-board.jsonl"
+    session_id = "sess-def-456"
+
+    heartbeat = _run_board_cli(
+        merged_wt, board, "heartbeat", "--summary", "prior work", "--session-id", session_id
+    )
+    assert heartbeat.returncode == 0, heartbeat.stderr
+    add = _run_board_cli(
+        merged_wt, board, "add", "--kind", "followup", "--severity", "note", "--summary", "remember to check X"
+    )
+    assert add.returncode == 0, add.stderr
+
+    proc = _run_hook(START_HOOK, primary, board, stdin_payload={"session_id": session_id})
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert "remember to check X" in context
 
 
 def test_cursor_hooks_file_calls_agent_board_scripts() -> None:


### PR DESCRIPTION
## Summary

- Fix a second, previously-undiscovered agent-board bug found via live
  investigation while a user was querying a Stop-hook reminder: Claude
  Code's own `SessionStart`/`Stop` hooks (`scripts/hooks/
  session_start_agent_board.py`, `scripts/hooks/session_stop_agent_board.py`
  -- distinct from the git hooks shipped in the already-merged
  `chore/agent-board-heartbeat-coupling` PR) run with a process `cwd` fixed
  to wherever the session originally started, and do not track `cd` calls a
  Bash tool makes mid-session. Confirmed by inspecting the Stop hook's own
  stdin JSON payload: its `cwd` field reported the shared/primary checkout
  even while real git work had been happening in a linked worktree for many
  turns.
- `render_checkin_context()` was additionally *writing* a spurious presence
  row under that wrong path on every `SessionStart`, not just misreporting
  on read.
- Fixed with a new `resolve_current_identity()` in `agent_board_lib.py`:
  when a `session_id` is available, look up the most recently heartbeated
  presence row tagged with that session_id and use its `worktree_path`
  instead of the hook's own cwd. Works because the already-shipped
  `scripts/git_hooks/post-commit` and `scripts/safe_docker_build.sh` now
  tag their heartbeats with `$CLAUDE_CODE_SESSION_ID` (confirmed live to be
  present in the Bash tool's subprocess environment and to inherit
  correctly down to a git-hook subprocess). Falls back to the old
  cwd-based resolution when no matching session_id is on the board yet.
- Code review (dispatched subagent) confirmed the two direct regression
  tests actually fail against the pre-fix code (not placebo coverage) and
  found two minor nitpicks, both fixed here: a duplicated
  `_read_session_id()` helper consolidated into
  `read_session_id_from_stdin_hook_payload()`, and a TTY guard added so
  manual invocation for debugging doesn't block on stdin.

## Outcome moved

Before this fix, every concurrent Claude Code session working via linked
worktrees (this repo's own convention) had its `SessionStart`/`Stop`
board hooks silently attributing presence and open-item lookups to the
shared/primary checkout instead of its actual worktree -- weakening the
board's whole worktree-scoped collision-avoidance design for anything
routed through these two hooks. Confirmed live post-fix: a real commit's
heartbeat correctly carries this session's own `session_id`
(`4dd9ea4b-3afa-4362-8590-3bd65e3ac4ac`), which the fixed hooks can now
use to resolve the correct worktree.

## Current architecture

`scripts/agent_board_lib.py`'s `current_worktree_identity()` resolves the
board's notion of "current worktree" purely via `git rev-parse
--show-toplevel` from the calling process's own inherited cwd. Both
`session_start_agent_board.py` and `session_stop_agent_board.py` called
this directly with no way to override it. Separately,
`scripts/git_hooks/post-commit` and `scripts/safe_docker_build.sh`
(merged in `chore/agent-board-heartbeat-coupling`) already heartbeat the
board correctly, since they're invoked by `git`/`docker` with the correct
cwd, not by the Claude Code harness's own hook mechanism.

## Architecture touched

- `scripts/agent_board_lib.py`: new `resolve_current_identity()` and
  `read_session_id_from_stdin_hook_payload()`; `upsert_presence()` gained
  optional `worktree_path`/`branch` overrides; `render_checkin_context()`
  gained an optional `session_id` kwarg.
- `scripts/hooks/session_start_agent_board.py`,
  `scripts/hooks/session_stop_agent_board.py`: read `session_id` from
  their own stdin JSON payload, pass it through to the board lib.
- `scripts/git_hooks/post-commit`, `scripts/safe_docker_build.sh`: pass
  `--session-id "$CLAUDE_CODE_SESSION_ID"` to their heartbeat calls when
  that env var is set.
- `CLAUDE.md`: documents the bug and fix under "Agent workspace board".

## Files changed

- `scripts/agent_board_lib.py`: `resolve_current_identity()`,
  `read_session_id_from_stdin_hook_payload()` (new); `upsert_presence()`,
  `render_checkin_context()` (modified signatures, backward compatible --
  both new params are keyword-only with `None` defaults that short-circuit
  to the exact old behavior).
- `scripts/hooks/session_start_agent_board.py`,
  `scripts/hooks/session_stop_agent_board.py`: read and thread through
  `session_id`.
- `scripts/git_hooks/post-commit`, `scripts/safe_docker_build.sh`:
  `--session-id` passthrough when `$CLAUDE_CODE_SESSION_ID` is set.
- `tests/scripts/test_agent_board_lib.py`: 4 new tests for
  `resolve_current_identity` (session match, multi-worktree tie-break,
  no-match fallback, `session_id=None` fallback).
- `tests/scripts/test_session_agent_board_hooks.py`: 3 new tests --
  Stop-hook and SessionStart-hook resolution via session_id from a
  simulated wrong cwd, plus a no-match fallback case; `_run_hook` helper
  extended to pass an explicit stdin JSON payload.
- `tests/scripts/test_install_git_safety_hooks.py`,
  `tests/scripts/test_safe_docker_build_heartbeat.py`: new tests
  confirming `$CLAUDE_CODE_SESSION_ID` actually flows through into the
  heartbeat's `--session-id` argument.
- `CLAUDE.md`: new paragraph under "Agent workspace board".

## Schema / bus / API changes

None.

## Env/config changes

None. `$CLAUDE_CODE_SESSION_ID` is set by the Claude Code harness itself,
not something this repo configures.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/pytest tests/scripts/ -q
199 passed in 47.3s
```

Plus live verification: a real commit on this branch tagged its heartbeat
with this session's actual `$CLAUDE_CODE_SESSION_ID`, confirmed via the
raw board JSONL.

## Evals run

No eval harness applies to shell/hook tooling in this repo.

## Docker/build/smoke checks

Not applicable -- no service touched.

## Review findings fixed

- Finding: `_read_session_id()` was duplicated verbatim across both hook
  scripts.
  - Fix: consolidated into `agent_board_lib.read_session_id_from_stdin_hook_payload()`.
  - Evidence: both hook files now import and call the single shared
    function; full suite still green (199 passed).
- Finding: `sys.stdin.read()` would block indefinitely if either hook is
  invoked manually from an interactive terminal for debugging (not a risk
  in the real Claude Code/Cursor invocation paths, where stdin is a pipe
  the harness writes-then-closes, but a new failure mode this diff
  introduced that didn't exist before it touched stdin at all).
  - Fix: `read_session_id_from_stdin_hook_payload()` checks
    `stream.isatty()` first and skips reading entirely on a live TTY.
  - Evidence: code inspection; the existing test suite's `input=""`-based
    invocations are piped, not TTY, so this path is exercised by every
    existing hook test without behavior change.
- Finding (verified, not a defect): tie-breaking on identical
  `heartbeat_at` timestamps within `resolve_current_identity` falls back
  to dict-iteration/insertion order rather than an explicit secondary key.
  - Not fixed: reviewer assessed a genuine same-second tie between two
    worktrees under one session_id as unlikely enough in practice not to
    matter; flagging as a known, accepted limitation rather than adding
    complexity for it.

## Restart required

```text
No restart required.
```

Local git-hook/hook-script tooling only. Anyone who wants the corrected
`SessionStart`/`Stop` resolution active needs no action beyond having this
merged code checked out -- these are plain Python scripts invoked fresh by
the harness each time, not something requiring a hook re-install (unlike
the git hooks, which do need `scripts/install_git_safety_hooks.sh` re-run
once per machine to pick up code changes, already covered by the earlier
PR).

## Risks / concerns

- Severity: Low
  - Concern: this fix's live verification was necessarily partial --
    confirming the git-hook side tags the real session_id into a real
    heartbeat is straightforward and done, but confirming the
    `SessionStart`/`Stop` hooks themselves correctly resolve via that
    session_id in a live Claude Code invocation (as opposed to the test
    suite's simulated stdin payloads) requires the fix to actually be
    merged and live in the shared checkout first, since `$CLAUDE_PROJECT_DIR`
    still points at pre-fix code until then.
  - Mitigation: the test suite's regression tests were confirmed to
    genuinely fail against the pre-fix code (not placebo coverage, per
    the dispatched review), and the underlying mechanism (session_id
    passed via stdin JSON, looked up against a real presence row) was
    exercised end-to-end in tests using the exact same code paths the
    real hooks call. Recommend a live spot-check after merge: make a
    commit from a linked worktree, then check whether the next Stop
    hook's reminder correctly reports items scoped to that worktree
    rather than the shared checkout.
