### PR TITLE
feat(hub): autonomous scheduled topic-foundry training + concept ingestion (Gap 5)

### DIFF
--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -423,6 +423,16 @@ SUBSTRATE_CONCEPT_SEED_ENABLED=true
 # to leave enabled.
 SUBSTRATE_DECAY_SCHEDULER_ENABLED=true
 SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC=120
+# Autonomous topic-foundry training + concept ingestion (Gap 5). Each tick:
+# ensure a well-known dataset+model exist (idempotent get-or-create by name),
+# trigger a training run for a rolling SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS-day
+# window, then ingest whatever the latest COMPLETED run currently is. Real
+# compute cost (trains a clustering model) -- defaults to DISABLED, unlike
+# the decay scheduler above; operator must opt in explicitly.
+SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED=false
+SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_INTERVAL_SEC=86400
+SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS=30
+SUBSTRATE_TOPIC_FOUNDRY_EMBEDDING_URL=http://orion-athena-vector-host:8320/embedding
 SUBSTRATE_AUTONOMY_ENABLED=true
 SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED=true
 SUBSTRATE_AUTONOMY_APPLY_ENABLED=true

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -401,6 +401,72 @@ for what the surface means to an operator, and
 [docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md](../../docs/superpowers/specs/2026-07-16-hub-drives-analytics-design.md)
 for the full design.
 
+### 5.5 Concept Atlas: golden concepts, decay, typed relations, autonomous ingestion
+
+**What it is:** the concept-graph-pipeline design's live substrate. A shared FalkorDB-backed
+concept graph (`SUBSTRATE_STORE_BACKEND=falkor`, graph `orion_substrate` — same instance
+`orion-cortex-exec` and `orion-recall` read from) seeded with three golden concepts (Orion,
+Juniper, the Orion↔Juniper relationship, see `orion/substrate/seed.py`) plus concepts that
+grow organically from real conversation via topic-foundry clustering
+(`orion/substrate/adapters/topic_foundry.py`). Inspect it live at the **Concept Atlas** Hub
+tab (`GET /concept-atlas`, backed by `GET /api/substrate/concepts/summary` and `.../network`).
+
+**Pipeline stages, each independently gated by its own env flag:**
+
+| Stage | Where | Flag (default) |
+|---|---|---|
+| Seed golden concepts at startup | `api_routes.py::seed_golden_concepts_at_startup()` | `SUBSTRATE_CONCEPT_SEED_ENABLED` (`true`) |
+| Live activation decay | `api_routes.py::decay_concept_activations()`, ticked by `main.py`'s `substrate_decay_task` | `SUBSTRATE_DECAY_SCHEDULER_ENABLED` (`true`), interval `SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC` (`120`) |
+| Manual topic-foundry ingestion | `POST /api/substrate/concepts/ingest-topic-foundry` (`concept_atlas_routes.py`) | operator-triggered, no flag |
+| Typed relation classification (supports/contradicts/refines) | `concept_atlas_routes.py::_classify_typed_concept_relations()`, called from the ingestion route above | runs automatically as part of ingestion, capped at `_RELATION_CLASSIFICATION_PAIR_CAP=10` pairs/call — see `services/orion-hub/scripts/concept_relation_classifier.py` for the real LLM classifier |
+| Autonomous scheduled training + ingestion | `main.py`'s `substrate_topic_foundry_scheduler_task`, calling `concept_atlas_routes.py::trigger_topic_foundry_training_run()` then the ingestion route above | `SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED` (**`false`** — real compute cost, opt-in), interval `SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_INTERVAL_SEC` (`86400`), window `SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS` (`30`) |
+
+**Surfaced into live cognition two ways**, not as permanent context bloat — only when
+salient:
+
+- `orion-cortex-exec`'s always-on chat-stance producer lane reads golden/relationship
+  concepts via `orion/substrate/relational/adapters/concept_induction_ctx.py` (repointed at
+  this store in PR #1128 — it previously read a dead spaCy pipeline that never returned
+  anything).
+- `orion-recall`'s purposeful-phase belief lane reads a turn-scoped neighborhood via the
+  `concept_region` collector (see `services/orion-recall/README.md` § 15, PR #1133) — a
+  cheap label-substring match against the current turn's text, empty when nothing matches.
+
+**Decay math, if you're debugging why an activation value looks wrong:**
+`decay_concept_activations()` takes an explicit `elapsed_seconds` parameter from its caller
+(the scheduler passes true wall-clock time since the previous tick, tracked via
+`time.monotonic()`) rather than deriving elapsed time from `node.temporal.observed_at`
+internally — the latter is only a documented one-shot fallback for ad-hoc/manual invocation.
+A function called repeatedly on a loop that re-derives elapsed time from a never-advancing
+`observed_at` on every call compounds: each tick re-decays an already-shrunk value against
+an ever-growing elapsed-since-creation window, collapsing activation to `decay_floor` within
+roughly one configured half-life regardless of the half-life value (a real bug caught in
+review during PR #1131 — see that PR's description for the numeric trace).
+
+**Autonomous scheduler window math, if debugging why a training run didn't fire:**
+`trigger_topic_foundry_training_run()` floors its rolling window's `end_at` to a UTC day
+boundary before computing `start_at` from it — NOT `datetime.now()` verbatim. This is load-
+bearing: topic-foundry's own `POST /runs/train` dedups by a `spec_hash` computed over the
+exact `start_at`/`end_at` it receives, so a microsecond-unique window on every tick would
+mean the dedup never fires and every tick trains a brand-new HDBSCAN model from scratch
+regardless of interval (also a real bug caught in review, PR #1136). Practically: repeated
+ticks within the same UTC day resolve to the same already-queued/running/complete run;
+you'll see a new training run at most once per day at the default interval.
+
+**Restart required after enabling the autonomous scheduler:** none beyond the normal Hub
+restart — the flag defaults off, so turning it on is a deliberate `.env` edit + restart, not
+a silent behavior change on an existing deploy.
+
+```bash
+scripts/safe_docker_build.sh orion-hub up -d --build
+```
+
+See also: PRs #1128 (stance repoint), #1131 (decay scheduler), #1132 (relation classifier),
+#1133 (recall wiring), #1136 (autonomous scheduler) for the full review history including
+every bug caught and fixed before each shipped, and
+[docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md](../../docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md)
+for the original design.
+
 ---
 
 ## 🚀 Running Hub

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -519,6 +519,44 @@ class Settings(BaseSettings):
     # the underlying writes blocking HTTP calls to Fuseki.
     SUBSTRATE_DECAY_SCHEDULER_ENABLED: bool = Field(default=True, alias="SUBSTRATE_DECAY_SCHEDULER_ENABLED")
     SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC: float = Field(default=120.0, alias="SUBSTRATE_DECAY_SCHEDULER_INTERVAL_SEC")
+    # Autonomous topic-foundry training + concept ingestion (Gap 5 of the
+    # concept-graph-pipeline design). Each tick: (1) ensure a well-known
+    # dataset+model exist on topic-foundry (idempotent get-or-create by name,
+    # see concept_atlas_routes.py::_ensure_topic_foundry_dataset_and_model),
+    # (2) trigger a training run for a rolling window, floored to a UTC day
+    # boundary (NOT datetime.now() verbatim) so every tick within the same
+    # day computes an identical (start_at, end_at) pair -- this is what lets
+    # topic-foundry's own spec_hash dedup (services/orion-topic-foundry/app/
+    # routers/runs.py::train_run_endpoint) return the existing run as a cheap
+    # no-op instead of retraining; without the day-flooring, spec_hash would
+    # differ on literally every tick and this would train a brand-new HDBSCAN
+    # model every single tick regardless of interval, (3) ingest whatever the
+    # latest COMPLETED run currently is via the existing
+    # concept_atlas_ingest_topic_foundry() route logic -- this may lag the
+    # run just triggered by one or more ticks/days since training is
+    # genuinely async on topic-foundry's side; that is expected, not a bug.
+    # Defaults to DISABLED, unlike the decay scheduler above: this is a
+    # real-compute-cost, autonomy-touching background job (training a
+    # clustering model), not a cheap idempotent decay pass -- operator must
+    # opt in explicitly. Known limitation (not fixed here): nothing checks
+    # whether a previously-triggered run is still queued/running before a
+    # later tick fires again -- day-flooring covers the default 24h interval
+    # exactly (one tick per day -> one unique window per day), but a shorter
+    # custom interval combined with training slower than that interval could
+    # still pile up concurrent runs on topic-foundry's side.
+    SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED: bool = Field(
+        default=False, alias="SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED"
+    )
+    SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_INTERVAL_SEC: float = Field(
+        default=86400.0, alias="SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_INTERVAL_SEC"
+    )
+    SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS: int = Field(
+        default=30, alias="SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS"
+    )
+    SUBSTRATE_TOPIC_FOUNDRY_EMBEDDING_URL: str = Field(
+        default="http://orion-athena-vector-host:8320/embedding",
+        alias="SUBSTRATE_TOPIC_FOUNDRY_EMBEDDING_URL",
+    )
     SUBSTRATE_AUTONOMY_ENABLED: bool = Field(default=False, alias="SUBSTRATE_AUTONOMY_ENABLED")
     SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED: bool = Field(default=True, alias="SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED")
     SUBSTRATE_AUTONOMY_APPLY_ENABLED: bool = Field(default=False, alias="SUBSTRATE_AUTONOMY_APPLY_ENABLED")

--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -20,13 +20,22 @@ to an honest "unavailable" response instead of fabricating data or raising a
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from .settings import settings
-from .topic_foundry_client import TopicFoundryClientError, fetch_run_topics_and_keywords
+from .topic_foundry_client import (
+    TopicFoundryClientError,
+    create_dataset,
+    create_model,
+    fetch_run_topics_and_keywords,
+    list_datasets,
+    list_models,
+    trigger_training_run,
+)
 
 logger = logging.getLogger("orion-hub.concept_atlas")
 
@@ -60,6 +69,150 @@ _AT_RISK_MARGIN = 0.05
 # manual, operator-triggered route (not a hot path), but an unbounded or
 # high cap could still make one ingest call take minutes.
 _RELATION_CLASSIFICATION_PAIR_CAP = 10
+
+# Well-known, fixed names for the scheduler's own topic-foundry dataset/model
+# (Gap 5). Idempotent get-or-create by name -- see
+# _ensure_topic_foundry_dataset_and_model -- so the scheduler survives Hub
+# restarts and topic-foundry redeploys without losing track of "its"
+# dataset/model. Same source-table/columns/windowing/model-spec shape as
+# services/orion-topic-foundry/scripts/smoke_topic_foundry_train_and_poll.sh's
+# defaults (the only other place this pipeline has been exercised end-to-end
+# against real chat history).
+_TOPIC_FOUNDRY_DATASET_NAME = "orion-hub-autonomous-dataset"
+_TOPIC_FOUNDRY_MODEL_NAME = "orion-hub-autonomous"
+_TOPIC_FOUNDRY_MODEL_VERSION = "v1"
+_TOPIC_FOUNDRY_SOURCE_TABLE = "chat_history_log"
+_TOPIC_FOUNDRY_ID_COLUMN = "correlation_id"
+_TOPIC_FOUNDRY_TIME_COLUMN = "created_at"
+_TOPIC_FOUNDRY_TEXT_COLUMNS = ["prompt", "response"]
+
+
+def _ensure_topic_foundry_dataset_and_model(base_url: str) -> Optional[tuple[str, str]]:
+    """Idempotent get-or-create for the scheduler's dataset+model, by name.
+
+    Returns ``(dataset_id, model_id)``, or ``None`` on any failure -- never
+    raises. Safe to call on every scheduler tick: after the first tick
+    creates both, every later tick finds them by name and reuses the same
+    ids.
+    """
+    try:
+        datasets = list_datasets(base_url)
+        dataset = next((d for d in datasets if d.get("name") == _TOPIC_FOUNDRY_DATASET_NAME), None)
+        if dataset is None:
+            dataset = create_dataset(
+                base_url,
+                {
+                    "name": _TOPIC_FOUNDRY_DATASET_NAME,
+                    "source_table": _TOPIC_FOUNDRY_SOURCE_TABLE,
+                    "id_column": _TOPIC_FOUNDRY_ID_COLUMN,
+                    "time_column": _TOPIC_FOUNDRY_TIME_COLUMN,
+                    "text_columns": _TOPIC_FOUNDRY_TEXT_COLUMNS,
+                    "timezone": "UTC",
+                },
+            )
+        dataset_id = str(dataset["dataset_id"])
+
+        models = list_models(base_url)
+        model = next((m for m in models if m.get("name") == _TOPIC_FOUNDRY_MODEL_NAME), None)
+        if model is None:
+            model = create_model(
+                base_url,
+                {
+                    "name": _TOPIC_FOUNDRY_MODEL_NAME,
+                    "version": _TOPIC_FOUNDRY_MODEL_VERSION,
+                    "stage": "development",
+                    "dataset_id": dataset_id,
+                    "model_spec": {
+                        "algorithm": "hdbscan",
+                        "embedding_source_url": str(settings.SUBSTRATE_TOPIC_FOUNDRY_EMBEDDING_URL),
+                        "min_cluster_size": 15,
+                        "metric": "euclidean",
+                        "params": {},
+                    },
+                    "windowing_spec": {
+                        "block_mode": "turn_pairs",
+                        "include_roles": ["user", "assistant"],
+                        "time_gap_seconds": 900,
+                        "max_window_seconds": 7200,
+                        "min_blocks_per_segment": 1,
+                        "max_chars": 6000,
+                    },
+                    "metadata": {},
+                },
+            )
+        model_id = str(model["model_id"])
+        return dataset_id, model_id
+    except Exception as exc:
+        logger.warning("topic_foundry_dataset_model_ensure_failed error=%s", exc)
+        return None
+
+
+def trigger_topic_foundry_training_run() -> dict[str, Any]:
+    """Scheduler entry point (Gap 5): ensure the scheduler's dataset/model
+    exist, then trigger a training run for a rolling
+    ``SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS``-day window ending now.
+
+    Fire-and-forget from this function's perspective -- training runs as a
+    background task on topic-foundry's side (see
+    ``services/orion-topic-foundry/app/routers/runs.py::train_run_endpoint``);
+    this function returns as soon as the run is queued (or immediately, if
+    topic-foundry's own ``spec_hash`` dedup finds an identical run already
+    exists). Ingesting the run's results once it completes is a separate
+    step -- see ``concept_atlas_ingest_topic_foundry()`` -- deliberately not
+    called from here, since the two are wired as two independent steps of
+    the same scheduler tick in ``main.py``, not a blocking call chain.
+
+    Never raises. Returns a summary dict, always including ``"triggered":
+    bool``.
+    """
+    base_url = str(getattr(settings, "TOPIC_FOUNDRY_BASE_URL", "") or "").strip()
+    if not base_url:
+        return {"triggered": False, "reason": "topic_foundry_base_url_not_configured"}
+
+    ids = _ensure_topic_foundry_dataset_and_model(base_url)
+    if ids is None:
+        return {"triggered": False, "reason": "dataset_or_model_resolution_failed"}
+    dataset_id, model_id = ids
+
+    window_days = max(1, int(getattr(settings, "SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS", 30)))
+    # Floor to a day boundary (UTC midnight), NOT datetime.now(timezone.utc)
+    # verbatim. topic-foundry's own train-trigger route dedups by a spec_hash
+    # computed over the exact start_at/end_at it receives (see
+    # services/orion-topic-foundry/app/routers/runs.py::train_run_endpoint
+    # and app/services/spec_hash.py) -- with microsecond-precision "now" on
+    # every call, spec_hash would differ on literally every tick, so the
+    # dedup this scheduler's safety argument depends on (re-triggering an
+    # unchanged window is a cheap no-op) would never actually fire, and every
+    # single tick would kick off a brand-new HDBSCAN training run regardless
+    # of interval. Flooring to a day boundary means every tick within the
+    # same UTC day computes the identical (start_at, end_at) pair, so
+    # repeated ticks within a day correctly resolve to topic-foundry's
+    # existing queued/running/complete run instead of enqueueing a duplicate.
+    end_at = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    start_at = end_at - timedelta(days=window_days)
+
+    try:
+        run = trigger_training_run(
+            base_url,
+            model_id=model_id,
+            dataset_id=dataset_id,
+            start_at=start_at.isoformat(),
+            end_at=end_at.isoformat(),
+        )
+        return {
+            "triggered": True,
+            "run_id": run.get("run_id"),
+            "status": run.get("status"),
+            "dataset_id": dataset_id,
+            "model_id": model_id,
+            "window_days": window_days,
+        }
+    except TopicFoundryClientError as exc:
+        logger.warning("topic_foundry_train_trigger_failed error=%s", exc)
+        return {"triggered": False, "reason": "train_trigger_failed", "error": str(exc)}
+    except Exception as exc:  # pragma: no cover - defensive, never let a client bug crash the scheduler
+        logger.warning("topic_foundry_train_trigger_unexpected_error error=%s", exc)
+        return {"triggered": False, "reason": "unexpected_error", "error": str(exc)}
 
 
 def _get_substrate_store() -> Any:
@@ -463,11 +616,18 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
     and writes the resulting concept/evidence nodes and edges into the shared
     ``SUBSTRATE_SEMANTIC_STORE``.
 
-    This is a manual trigger only -- not wired into Hub's startup event or any
-    scheduler, mirroring ``/api/substrate/review-runtime/debug-run``'s shape
-    (operator-triggered multi-step pipeline, not an automatic background job).
-    Every failure mode below degrades to an honest, non-500 response rather
-    than fabricating a success result.
+    Reachable two ways: as this HTTP route (an operator-triggered manual
+    call, mirroring ``/api/substrate/review-runtime/debug-run``'s shape), and
+    -- as of Gap 5 -- as a plain function call from ``main.py``'s
+    ``_run_substrate_topic_foundry_scheduler`` background task (gated by
+    ``SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED``, default off), which calls
+    this once per scheduler tick after triggering a training run. Both call
+    paths are safe: this function is a plain zero-argument sync ``def`` with
+    no FastAPI dependency injection, so direct invocation behaves identically
+    to going through the route. Every failure mode below degrades to an
+    honest, non-500-shaped response rather than fabricating a success result
+    (the scheduler path logs the same dict's fields rather than checking an
+    HTTP status).
 
     Scoping note: ``segment_topic_map`` is passed as empty in this first cut,
     so no ``co_occurs_with`` co-occurrence edges are produced yet -- only

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -25,6 +25,7 @@ from scripts.memory_consolidation_draft_routes import router as memory_consolida
 from scripts.proposal_review_routes import router as proposal_review_router
 from scripts.concept_atlas_routes import router as concept_atlas_router
 import scripts.api_routes as api_routes_runtime
+import scripts.concept_atlas_routes as concept_atlas_routes_runtime
 from scripts.websocket_handler import websocket_endpoint
 from scripts.service_logs_ws import service_logs_websocket_endpoint
 from scripts.biometrics_cache import BiometricsCache
@@ -269,6 +270,7 @@ presence_state: Optional["PresenceState"] = None
 presence_context_store: Optional["PresenceContextStore"] = None
 substrate_autonomy_task: Optional[asyncio.Task] = None
 substrate_decay_task: Optional[asyncio.Task] = None
+substrate_topic_foundry_scheduler_task: Optional[asyncio.Task] = None
 
 
 class PresenceState:
@@ -341,7 +343,7 @@ async def startup_event():
     Initializes all shared services at application startup.
     OrionBus + Clients + UI template.
     """
-    global bus, rpc_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, presence_state, presence_context_store, substrate_autonomy_task, substrate_decay_task
+    global bus, rpc_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, presence_state, presence_context_store, substrate_autonomy_task, substrate_decay_task, substrate_topic_foundry_scheduler_task
 
     # ------------------------------------------------------------
     # Orion Bus Initialization
@@ -547,6 +549,64 @@ async def startup_event():
     else:
         logger.info("substrate_decay_scheduler_disabled reason=env_disabled")
 
+    if settings.SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED:
+        topic_foundry_interval_sec = max(
+            1.0, float(settings.SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_INTERVAL_SEC)
+        )
+
+        async def _run_substrate_topic_foundry_scheduler() -> None:
+            # Two independent steps per tick, not a blocking call chain: (1)
+            # trigger a training run for the current rolling window (async on
+            # topic-foundry's own side -- this returns as soon as the run is
+            # queued, or immediately if spec_hash dedup finds an identical
+            # run already exists), (2) ingest whatever the latest COMPLETED
+            # run currently is. Step 2 may ingest a run from a PREVIOUS tick
+            # (training takes real time), or find nothing new -- both are
+            # expected, not errors. See
+            # trigger_topic_foundry_training_run()'s docstring.
+            while True:
+                await asyncio.sleep(topic_foundry_interval_sec)
+                try:
+                    trigger_summary = await asyncio.to_thread(
+                        concept_atlas_routes_runtime.trigger_topic_foundry_training_run
+                    )
+                    logger.info(
+                        "substrate_topic_foundry_scheduler_trigger_tick triggered=%s run_id=%s status=%s reason=%s",
+                        trigger_summary.get("triggered"),
+                        trigger_summary.get("run_id"),
+                        trigger_summary.get("status"),
+                        trigger_summary.get("reason"),
+                    )
+                except Exception as exc:  # advisory runtime loop; never crash service startup
+                    logger.warning("substrate_topic_foundry_scheduler_trigger_error error=%s", exc)
+
+                try:
+                    ingest_summary = await asyncio.to_thread(
+                        concept_atlas_routes_runtime.concept_atlas_ingest_topic_foundry
+                    )
+                    logger.info(
+                        "substrate_topic_foundry_scheduler_ingest_tick available=%s run_id=%s concepts_written=%s edges_written=%s typed_edges_written=%s",
+                        ingest_summary.get("available"),
+                        ingest_summary.get("run_id"),
+                        ingest_summary.get("concepts_written"),
+                        ingest_summary.get("edges_written"),
+                        ingest_summary.get("typed_edges_written"),
+                    )
+                except Exception as exc:  # advisory runtime loop; never crash service startup
+                    logger.warning("substrate_topic_foundry_scheduler_ingest_error error=%s", exc)
+
+        substrate_topic_foundry_scheduler_task = asyncio.create_task(
+            _run_substrate_topic_foundry_scheduler(),
+            name="hub-substrate-topic-foundry-scheduler",
+        )
+        logger.info(
+            "substrate_topic_foundry_scheduler_enabled interval_sec=%s window_days=%s",
+            topic_foundry_interval_sec,
+            settings.SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS,
+        )
+    else:
+        logger.info("substrate_topic_foundry_scheduler_disabled reason=env_disabled")
+
 
     # ------------------------------------------------------------
     # Validate UI HTML Template (served fresh from disk on each GET /)
@@ -606,7 +666,7 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
-    global bus, rpc_bus, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, substrate_autonomy_task, substrate_decay_task
+    global bus, rpc_bus, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, substrate_autonomy_task, substrate_decay_task, substrate_topic_foundry_scheduler_task
     pool = getattr(app.state, "memory_pg_pool", None)
     if pool is not None:
         try:
@@ -629,6 +689,13 @@ async def shutdown_event() -> None:
         except asyncio.CancelledError:
             pass
         substrate_decay_task = None
+    if substrate_topic_foundry_scheduler_task is not None:
+        substrate_topic_foundry_scheduler_task.cancel()
+        try:
+            await substrate_topic_foundry_scheduler_task
+        except asyncio.CancelledError:
+            pass
+        substrate_topic_foundry_scheduler_task = None
     if biometrics_cache is not None:
         await biometrics_cache.stop()
     if notification_cache is not None:

--- a/services/orion-hub/scripts/topic_foundry_client.py
+++ b/services/orion-hub/scripts/topic_foundry_client.py
@@ -138,6 +138,124 @@ def fetch_keywords_for_topic(
     return [str(k) for k in keywords if isinstance(k, (str, int, float))]
 
 
+def list_datasets(base_url: str, *, timeout: float = DEFAULT_TIMEOUT_SEC) -> list[dict[str, Any]]:
+    """Return every ``DatasetSpec`` dict topic-foundry currently has.
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure.
+    An empty list (no datasets yet) is not an error.
+    """
+    url = f"{base_url.rstrip('/')}/datasets"
+    try:
+        resp = requests.get(url, timeout=timeout)
+        resp.raise_for_status()
+        payload = resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_datasets_request_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_datasets_invalid_json: {exc}") from exc
+
+    datasets = payload.get("datasets") if isinstance(payload, dict) else None
+    if datasets is None:
+        raise TopicFoundryClientError("topic_foundry_datasets_malformed_response")
+    return [d for d in datasets if isinstance(d, dict)]
+
+
+def list_models(base_url: str, *, timeout: float = DEFAULT_TIMEOUT_SEC) -> list[dict[str, Any]]:
+    """Return every ``ModelSummary`` dict topic-foundry currently has.
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure.
+    An empty list (no models yet) is not an error.
+    """
+    url = f"{base_url.rstrip('/')}/models"
+    try:
+        resp = requests.get(url, timeout=timeout)
+        resp.raise_for_status()
+        payload = resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_models_request_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_models_invalid_json: {exc}") from exc
+
+    models = payload.get("models") if isinstance(payload, dict) else None
+    if models is None:
+        raise TopicFoundryClientError("topic_foundry_models_malformed_response")
+    return [m for m in models if isinstance(m, dict)]
+
+
+def create_dataset(
+    base_url: str, payload: dict[str, Any], *, timeout: float = DEFAULT_TIMEOUT_SEC
+) -> dict[str, Any]:
+    """Create a topic-foundry dataset (``DatasetCreateRequest`` shape).
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure.
+    Returns the raw ``DatasetCreateResponse`` dict (``dataset_id``, ``created_at``).
+    """
+    url = f"{base_url.rstrip('/')}/datasets"
+    try:
+        resp = requests.post(url, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_create_dataset_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_create_dataset_invalid_json: {exc}") from exc
+
+
+def create_model(
+    base_url: str, payload: dict[str, Any], *, timeout: float = DEFAULT_TIMEOUT_SEC
+) -> dict[str, Any]:
+    """Create a topic-foundry model (``ModelCreateRequest`` shape).
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure.
+    Returns the raw ``ModelCreateResponse`` dict (``model_id``, ``created_at``).
+    """
+    url = f"{base_url.rstrip('/')}/models"
+    try:
+        resp = requests.post(url, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_create_model_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_create_model_invalid_json: {exc}") from exc
+
+
+def trigger_training_run(
+    base_url: str,
+    *,
+    model_id: str,
+    dataset_id: str,
+    start_at: str,
+    end_at: str,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+) -> dict[str, Any]:
+    """``POST /runs/train`` (``RunTrainRequest`` shape) -- starts training as a
+    background task on topic-foundry's side and returns immediately with
+    ``{"run_id": ..., "status": "queued"}`` (or an existing run's id/status
+    if topic-foundry's own ``spec_hash`` dedup finds an identical
+    dataset+model+window run already exists -- see
+    ``services/orion-topic-foundry/app/routers/runs.py::train_run_endpoint``,
+    not duplicated here).
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure.
+    """
+    url = f"{base_url.rstrip('/')}/runs/train"
+    payload = {
+        "model_id": model_id,
+        "dataset_id": dataset_id,
+        "start_at": start_at,
+        "end_at": end_at,
+    }
+    try:
+        resp = requests.post(url, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_train_trigger_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_train_trigger_invalid_json: {exc}") from exc
+
+
 def fetch_run_topics_and_keywords(
     base_url: str,
     *,

--- a/services/orion-hub/tests/test_topic_foundry_scheduler.py
+++ b/services/orion-hub/tests/test_topic_foundry_scheduler.py
@@ -1,0 +1,370 @@
+"""Tests for the autonomous topic-foundry training + ingestion scheduler
+(Gap 5 of the concept-graph-pipeline design).
+
+Covers the new client functions in
+``services/orion-hub/scripts/topic_foundry_client.py``
+(``list_datasets``/``list_models``/``create_dataset``/``create_model``/
+``trigger_training_run``) and the scheduler entry points in
+``services/orion-hub/scripts/concept_atlas_routes.py``
+(``_ensure_topic_foundry_dataset_and_model``/
+``trigger_topic_foundry_training_run``). All HTTP calls are mocked at the
+``requests.get``/``requests.post`` boundary inside ``scripts.topic_foundry_client``
+-- no real topic-foundry service, no network.
+
+The actual `main.py` scheduler loop (the ``asyncio.create_task`` wiring) is
+intentionally not unit-tested here, mirroring the established convention for
+the sibling decay scheduler (PR #1131): the loop itself is a thin
+sleep-then-call wrapper with no independently testable logic; what matters
+is that the two functions it calls (tested here) behave correctly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+for key, value in {
+    "CHANNEL_VOICE_TRANSCRIPT": "orion:voice:transcript",
+    "CHANNEL_VOICE_LLM": "orion:voice:llm",
+    "CHANNEL_VOICE_TTS": "orion:voice:tts",
+    "CHANNEL_COLLAPSE_INTAKE": "orion:collapse:intake",
+    "CHANNEL_COLLAPSE_TRIAGE": "orion:collapse:triage",
+}.items():
+    os.environ.setdefault(key, value)
+
+FAKE_BASE_URL = "http://fake-topic-foundry:8615"
+FAKE_DATASET_ID = "33333333-3333-3333-3333-333333333333"
+FAKE_MODEL_ID = "22222222-2222-2222-2222-222222222222"
+FAKE_RUN_ID = "11111111-1111-1111-1111-111111111111"
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"status {self.status_code}")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _clean_import_path():
+    _ensure_hub_scripts_import_path()
+    yield
+
+
+# --- topic_foundry_client.py: list/create dataset/model, trigger run -------
+
+
+def test_list_datasets_returns_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url, params=None, timeout=None):
+        assert url == f"{FAKE_BASE_URL}/datasets"
+        return _FakeResponse(200, {"datasets": [{"dataset_id": FAKE_DATASET_ID, "name": "d"}]})
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    result = tfc.list_datasets(FAKE_BASE_URL)
+    assert result == [{"dataset_id": FAKE_DATASET_ID, "name": "d"}]
+
+
+def test_list_datasets_malformed_response_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    monkeypatch.setattr(tfc.requests, "get", lambda *a, **k: _FakeResponse(200, {"not_datasets": []}))
+    with pytest.raises(tfc.TopicFoundryClientError):
+        tfc.list_datasets(FAKE_BASE_URL)
+
+
+def test_list_models_returns_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url, params=None, timeout=None):
+        assert url == f"{FAKE_BASE_URL}/models"
+        return _FakeResponse(200, {"models": [{"model_id": FAKE_MODEL_ID, "name": "m"}]})
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    result = tfc.list_models(FAKE_BASE_URL)
+    assert result == [{"model_id": FAKE_MODEL_ID, "name": "m"}]
+
+
+def test_create_dataset_posts_payload_and_returns_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    posted = {}
+
+    def fake_post(url, json=None, timeout=None):
+        posted["url"] = url
+        posted["json"] = json
+        return _FakeResponse(200, {"dataset_id": FAKE_DATASET_ID, "created_at": "2026-07-17T00:00:00Z"})
+
+    monkeypatch.setattr(tfc.requests, "post", fake_post)
+    result = tfc.create_dataset(FAKE_BASE_URL, {"name": "d"})
+    assert posted["url"] == f"{FAKE_BASE_URL}/datasets"
+    assert posted["json"] == {"name": "d"}
+    assert result["dataset_id"] == FAKE_DATASET_ID
+
+
+def test_create_model_posts_payload_and_returns_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_post(url, json=None, timeout=None):
+        assert url == f"{FAKE_BASE_URL}/models"
+        return _FakeResponse(200, {"model_id": FAKE_MODEL_ID, "created_at": "2026-07-17T00:00:00Z"})
+
+    monkeypatch.setattr(tfc.requests, "post", fake_post)
+    result = tfc.create_model(FAKE_BASE_URL, {"name": "m"})
+    assert result["model_id"] == FAKE_MODEL_ID
+
+
+def test_trigger_training_run_posts_run_train_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    posted = {}
+
+    def fake_post(url, json=None, timeout=None):
+        posted["url"] = url
+        posted["json"] = json
+        return _FakeResponse(200, {"run_id": FAKE_RUN_ID, "status": "queued"})
+
+    monkeypatch.setattr(tfc.requests, "post", fake_post)
+    result = tfc.trigger_training_run(
+        FAKE_BASE_URL,
+        model_id=FAKE_MODEL_ID,
+        dataset_id=FAKE_DATASET_ID,
+        start_at="2026-06-17T00:00:00+00:00",
+        end_at="2026-07-17T00:00:00+00:00",
+    )
+    assert posted["url"] == f"{FAKE_BASE_URL}/runs/train"
+    assert posted["json"] == {
+        "model_id": FAKE_MODEL_ID,
+        "dataset_id": FAKE_DATASET_ID,
+        "start_at": "2026-06-17T00:00:00+00:00",
+        "end_at": "2026-07-17T00:00:00+00:00",
+    }
+    assert result == {"run_id": FAKE_RUN_ID, "status": "queued"}
+
+
+def test_trigger_training_run_connection_error_raises_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_post(url, json=None, timeout=None):
+        raise requests.exceptions.ConnectionError("refused")
+
+    monkeypatch.setattr(tfc.requests, "post", fake_post)
+    with pytest.raises(tfc.TopicFoundryClientError):
+        tfc.trigger_training_run(
+            FAKE_BASE_URL, model_id=FAKE_MODEL_ID, dataset_id=FAKE_DATASET_ID, start_at="x", end_at="y"
+        )
+
+
+# --- concept_atlas_routes.py: dataset/model ensure + trigger entry point ---
+
+
+def test_ensure_dataset_and_model_finds_existing_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes as car
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url, params=None, timeout=None):
+        if url.endswith("/datasets"):
+            return _FakeResponse(
+                200, {"datasets": [{"dataset_id": FAKE_DATASET_ID, "name": car._TOPIC_FOUNDRY_DATASET_NAME}]}
+            )
+        if url.endswith("/models"):
+            return _FakeResponse(
+                200, {"models": [{"model_id": FAKE_MODEL_ID, "name": car._TOPIC_FOUNDRY_MODEL_NAME}]}
+            )
+        raise AssertionError(f"unexpected GET {url}")
+
+    create_calls = []
+
+    def fake_post(url, json=None, timeout=None):
+        create_calls.append(url)
+        raise AssertionError("should not create when an existing dataset/model is found")
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    monkeypatch.setattr(tfc.requests, "post", fake_post)
+
+    result = car._ensure_topic_foundry_dataset_and_model(FAKE_BASE_URL)
+    assert result == (FAKE_DATASET_ID, FAKE_MODEL_ID)
+    assert create_calls == []
+
+
+def test_ensure_dataset_and_model_creates_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes as car
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url, params=None, timeout=None):
+        if url.endswith("/datasets"):
+            return _FakeResponse(200, {"datasets": []})
+        if url.endswith("/models"):
+            return _FakeResponse(200, {"models": []})
+        raise AssertionError(f"unexpected GET {url}")
+
+    create_calls = []
+
+    def fake_post(url, json=None, timeout=None):
+        create_calls.append(url)
+        if url.endswith("/datasets"):
+            assert json["name"] == car._TOPIC_FOUNDRY_DATASET_NAME
+            return _FakeResponse(200, {"dataset_id": FAKE_DATASET_ID, "created_at": "2026-07-17T00:00:00Z"})
+        if url.endswith("/models"):
+            assert json["name"] == car._TOPIC_FOUNDRY_MODEL_NAME
+            assert json["dataset_id"] == FAKE_DATASET_ID
+            return _FakeResponse(200, {"model_id": FAKE_MODEL_ID, "created_at": "2026-07-17T00:00:00Z"})
+        raise AssertionError(f"unexpected POST {url}")
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    monkeypatch.setattr(tfc.requests, "post", fake_post)
+
+    result = car._ensure_topic_foundry_dataset_and_model(FAKE_BASE_URL)
+    assert result == (FAKE_DATASET_ID, FAKE_MODEL_ID)
+    assert set(create_calls) == {f"{FAKE_BASE_URL}/datasets", f"{FAKE_BASE_URL}/models"}
+
+
+def test_ensure_dataset_and_model_degrades_to_none_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes as car
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url, params=None, timeout=None):
+        raise requests.exceptions.ConnectionError("refused")
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    assert car._ensure_topic_foundry_dataset_and_model(FAKE_BASE_URL) is None
+
+
+def test_trigger_topic_foundry_training_run_no_base_url_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes as car
+
+    monkeypatch.setattr(car.settings, "TOPIC_FOUNDRY_BASE_URL", "")
+    result = car.trigger_topic_foundry_training_run()
+    assert result == {"triggered": False, "reason": "topic_foundry_base_url_not_configured"}
+
+
+def test_trigger_topic_foundry_training_run_dataset_model_resolution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import concept_atlas_routes as car
+
+    monkeypatch.setattr(car.settings, "TOPIC_FOUNDRY_BASE_URL", FAKE_BASE_URL)
+    monkeypatch.setattr(car, "_ensure_topic_foundry_dataset_and_model", lambda base_url: None)
+    result = car.trigger_topic_foundry_training_run()
+    assert result == {"triggered": False, "reason": "dataset_or_model_resolution_failed"}
+
+
+def test_trigger_topic_foundry_training_run_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes as car
+
+    monkeypatch.setattr(car.settings, "TOPIC_FOUNDRY_BASE_URL", FAKE_BASE_URL)
+    monkeypatch.setattr(car.settings, "SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS", 30)
+    monkeypatch.setattr(
+        car, "_ensure_topic_foundry_dataset_and_model", lambda base_url: (FAKE_DATASET_ID, FAKE_MODEL_ID)
+    )
+
+    trigger_calls = []
+
+    def fake_trigger_training_run(base_url, *, model_id, dataset_id, start_at, end_at, timeout=None):
+        trigger_calls.append((base_url, model_id, dataset_id, start_at, end_at))
+        return {"run_id": FAKE_RUN_ID, "status": "queued"}
+
+    monkeypatch.setattr(car, "trigger_training_run", fake_trigger_training_run)
+
+    result = car.trigger_topic_foundry_training_run()
+    assert result["triggered"] is True
+    assert result["run_id"] == FAKE_RUN_ID
+    assert result["status"] == "queued"
+    assert result["dataset_id"] == FAKE_DATASET_ID
+    assert result["model_id"] == FAKE_MODEL_ID
+    assert result["window_days"] == 30
+    assert len(trigger_calls) == 1
+    assert trigger_calls[0][0] == FAKE_BASE_URL
+    assert trigger_calls[0][1] == FAKE_MODEL_ID
+    assert trigger_calls[0][2] == FAKE_DATASET_ID
+
+
+def test_trigger_topic_foundry_training_run_windows_are_day_floored_and_repeatable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the spec_hash-dedup-never-fires bug caught in review:
+    start_at/end_at must be floored to a UTC day boundary, NOT
+    datetime.now(timezone.utc) verbatim -- otherwise every tick computes a
+    microsecond-unique window, topic-foundry's spec_hash dedup (keyed on the
+    exact start_at/end_at it receives) never matches a prior run, and every
+    single tick trains a brand-new HDBSCAN model regardless of interval.
+    Two calls within the same UTC day must produce byte-identical
+    start_at/end_at strings."""
+    from scripts import concept_atlas_routes as car
+
+    monkeypatch.setattr(car.settings, "TOPIC_FOUNDRY_BASE_URL", FAKE_BASE_URL)
+    monkeypatch.setattr(car.settings, "SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS", 30)
+    monkeypatch.setattr(
+        car, "_ensure_topic_foundry_dataset_and_model", lambda base_url: (FAKE_DATASET_ID, FAKE_MODEL_ID)
+    )
+
+    windows_seen = []
+
+    def fake_trigger_training_run(base_url, *, model_id, dataset_id, start_at, end_at, timeout=None):
+        windows_seen.append((start_at, end_at))
+        return {"run_id": FAKE_RUN_ID, "status": "queued"}
+
+    monkeypatch.setattr(car, "trigger_training_run", fake_trigger_training_run)
+
+    car.trigger_topic_foundry_training_run()
+    car.trigger_topic_foundry_training_run()
+
+    assert len(windows_seen) == 2
+    assert windows_seen[0] == windows_seen[1]
+
+    start_at_str, end_at_str = windows_seen[0]
+    end_at = datetime.fromisoformat(end_at_str)
+    start_at = datetime.fromisoformat(start_at_str)
+    assert end_at.hour == 0 and end_at.minute == 0 and end_at.second == 0 and end_at.microsecond == 0
+    assert start_at == end_at - timedelta(days=30)
+
+
+def test_trigger_topic_foundry_training_run_client_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import concept_atlas_routes as car
+    from scripts.topic_foundry_client import TopicFoundryClientError
+
+    monkeypatch.setattr(car.settings, "TOPIC_FOUNDRY_BASE_URL", FAKE_BASE_URL)
+    monkeypatch.setattr(
+        car, "_ensure_topic_foundry_dataset_and_model", lambda base_url: (FAKE_DATASET_ID, FAKE_MODEL_ID)
+    )
+
+    def fake_trigger_training_run(base_url, *, model_id, dataset_id, start_at, end_at, timeout=None):
+        raise TopicFoundryClientError("boom")
+
+    monkeypatch.setattr(car, "trigger_training_run", fake_trigger_training_run)
+
+    result = car.trigger_topic_foundry_training_run()
+    assert result["triggered"] is False
+    assert result["reason"] == "train_trigger_failed"


### PR DESCRIPTION
## Summary

- Adds a background scheduler that periodically trains topic-foundry on recent chat history and ingests the results into the substrate concept graph -- Gap 5 of the concept-graph-pipeline design, the last of the 5 originally-identified gaps.
- Each tick: (1) idempotent get-or-create of a well-known dataset+model on topic-foundry, (2) trigger a training run for a rolling day-floored window, (3) ingest whatever the latest completed run currently is (reusing the existing manual `concept_atlas_ingest_topic_foundry()` route logic directly).
- Defaults to **disabled** (`SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED=false`) -- unlike the sibling decay scheduler (PR #1131), this is a real-compute-cost job (trains an HDBSCAN clustering model); operator must opt in.
- A critical resource-cost bug (spec_hash dedup never actually firing, meaning every tick would train a brand-new model regardless of interval) was caught in code review and fixed before shipping.

## Outcome moved

The concept graph's organic growth (golden concepts seeded, LLM-typed relations classified, activation decayed, surfaced into live chat) previously required a human to manually trigger topic-foundry training + ingestion every time (as done for Gap 4). This closes that loop autonomously.

## Current architecture

`concept_atlas_ingest_topic_foundry()` already existed as a manual, operator-triggered HTTP route that fetches topic-foundry's *latest completed* run and materializes it. Nothing existed to actually *trigger* a new training run, or to do either on a schedule.

## Architecture touched

`services/orion-hub` only (plus read-only calls against `services/orion-topic-foundry`'s existing HTTP API -- no changes to that service).

## Files changed

- `services/orion-hub/scripts/topic_foundry_client.py`: 5 new functions -- `list_datasets`/`list_models`/`create_dataset`/`create_model`/`trigger_training_run`.
- `services/orion-hub/scripts/concept_atlas_routes.py`: `_ensure_topic_foundry_dataset_and_model()` (idempotent get-or-create by name) and `trigger_topic_foundry_training_run()` (scheduler entry point); also a docstring fix on `concept_atlas_ingest_topic_foundry()` (see Review findings).
- `services/orion-hub/scripts/main.py`: new `substrate_topic_foundry_scheduler_task`, mirroring `substrate_decay_task`'s lifecycle pattern exactly.
- `services/orion-hub/app/settings.py`: 4 new fields.
- `services/orion-hub/.env_example` / local `.env`: synced.
- `services/orion-hub/tests/test_topic_foundry_scheduler.py` (new, 15 tests).

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: `concept_atlas_ingest_topic_foundry()` is now also called on a schedule, not only manually via HTTP (confirmed safe -- plain zero-arg sync function, no FastAPI dependency injection).
- Compatibility notes: none.

## Env/config changes

- Added keys: `SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED=false`, `SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_INTERVAL_SEC=86400`, `SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS=30`, `SUBSTRATE_TOPIC_FOUNDRY_EMBEDDING_URL=http://orion-athena-vector-host:8320/embedding`.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes.
- local `.env` synced: yes.
- `docker-compose.yml` updated: not needed -- confirmed `services/orion-hub/docker-compose.yml` uses `env_file: [{path: .env}]`, so new pydantic-Settings-driven vars load automatically (unlike `orion-recall`'s Gap 1b, which needed an explicit compose fix for exactly this reason).
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH=. .venv/bin/python -m pytest services/orion-hub/tests/test_topic_foundry_scheduler.py -q
15 passed

PYTHONPATH=. .venv/bin/python -m pytest services/orion-hub/tests/test_topic_foundry_scheduler.py services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py services/orion-hub/tests/test_concept_atlas_routes.py services/orion-hub/tests/test_substrate_concept_seed_startup.py services/orion-hub/tests/test_substrate_concept_decay_scheduler.py services/orion-hub/tests/test_substrate_mutation_scheduler_runtime.py services/orion-hub/tests/test_concept_relation_classifier.py orion/substrate/tests -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
413 passed
```

(`test_refit_salience_stub.py` excluded from the combined run only -- pre-existing pytest rootdir `scripts`-package-name collision, unrelated; passes standalone.)

## Evals run

No eval harness exists for this seam. The scheduler's real-world effect (does it actually grow the concept graph with useful organic concepts over time) is best evaluated live once enabled, not via synthetic fixtures -- flagged as a follow-up once this ships and gets turned on deliberately.

## Docker/build/smoke checks

Not run -- no Docker environment available in this session. `main.py`'s FastAPI app confirmed to import/construct successfully via `test_concept_atlas_routes.py` (part of the 413-test sweep above).

## Review findings fixed

- Finding (CRITICAL): `trigger_topic_foundry_training_run()` originally computed `start_at`/`end_at` as `datetime.now(timezone.utc)` verbatim (microsecond precision) on every tick. topic-foundry's own `POST /runs/train` dedups via a `spec_hash` computed over the exact `start_at`/`end_at` it receives -- with a microsecond-unique window every call, `spec_hash` differs every single tick, so the dedup this scheduler's safety argument explicitly depended on ("re-triggering an unchanged window is a cheap no-op that returns the existing run") never actually fires. Every tick would have trained a brand-new HDBSCAN clustering model from scratch, forever, regardless of the configured interval -- a real, unbounded compute-cost bug, not theoretical.
  - Fix: floor `end_at` to a UTC day boundary (`.replace(hour=0, minute=0, second=0, microsecond=0)`) before computing `start_at` from it, so every tick within the same UTC day computes an identical window and correctly resolves to topic-foundry's existing run instead of enqueueing a duplicate.
  - Evidence: new regression test `test_trigger_topic_foundry_training_run_windows_are_day_floored_and_repeatable` -- two calls produce byte-identical `start_at`/`end_at` strings; `end_at` has zeroed hour/minute/second/microsecond.
- Finding: `concept_atlas_ingest_topic_foundry()`'s docstring still said "This is a manual trigger only -- not wired into Hub's startup event or any scheduler" -- no longer true as of this PR (the scheduler now calls it directly every tick).
  - Fix: docstring updated to describe both call paths and confirm direct-invocation safety.
  - Evidence: `concept_atlas_routes.py`'s updated docstring.
- Finding (verified, not a bug): calling `concept_atlas_ingest_topic_foundry()` directly as a plain function from the scheduler (rather than via HTTP) is safe -- confirmed it's a zero-argument sync `def` with no FastAPI `Depends()`/`Request`/`BackgroundTasks` injection, and its only shared-state touch (`_get_substrate_store()`) reads a module-level global identically regardless of call path.
- Finding (documented, not fixed -- out of scope): nothing checks whether a previously-triggered run is still queued/running before a later tick fires again. Day-flooring covers the default 24h interval exactly (one tick per day → one unique window per day, so a still-running prior-day run and a newly-triggered one can't collide via spec_hash), but a much shorter custom interval combined with slower-than-interval training could still pile up concurrent runs on topic-foundry's side.
- Finding (documented, not fixed -- out of scope): `orion/substrate/reconcile.py::merge_node` has no cap on accumulating `evidence_refs` across genuinely different runs over time (repeated ingestion of the SAME run is confirmed idempotent via deterministic node/evidence ids, so this only applies across distinct runs). Day-flooring bounds growth to ~1 new run/day rather than ~1/tick, but an uncapped-growth follow-up (matching this repo's prior `evidence_event_ids`/evidence-refs caps in other subsystems) is worth tracking separately.
- Finding (documented, not fixed -- out of scope, low severity): `topic_foundry_datasets` has no `UNIQUE` constraint on `name` (unlike `topic_foundry_models`, which has `UNIQUE(name, version)`), so a genuinely concurrent list-then-create race (e.g. Hub restart overlap) could create two dataset rows with the same name. Low practical impact -- `list_datasets()` orders by `created_at DESC` so resolution is consistently the newest row, and duplicate rows share identical training-relevant fields. Would need a topic-foundry-side migration to fully close, out of scope for this Hub-side patch.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build hub-app
```

## Risks / concerns

- Severity: medium
- Concern: this is the first genuinely autonomous, real-compute-cost background job in the concept-graph pipeline (trains a clustering model on real chat history on a schedule).
- Mitigation: defaults to disabled; day-flooring bounds cost to at most one real training run per UTC day at the default interval; every failure mode degrades to a logged no-op, never crashes Hub startup.
- Severity: low
- Concern: `evidence_refs` growth on `merge_node` is uncapped across distinct runs (see Review findings).
- Mitigation: bounded to ~1 run/day by day-flooring; flagged as a separate follow-up rather than expanding this patch's scope into a shared substrate-wide function.

## PR link

(populated after creation)