### PR TITLE
fix(fcc-motor): hard draft-length ceiling as runaway-cost circuit breaker

### DIFF
--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -593,7 +593,15 @@ async def run_fcc_turn(
                 }
                 context_nudge_sent = True
 
-            if budget_chars >= ceiling_chars:
+            # A "result" event is the CLI's own authoritative signal that the
+            # turn already completed -- never kill on it. Without this guard,
+            # a legitimately long-but-successful answer can get its own
+            # already-generated result payload counted against the ceiling
+            # (measure_step_payload_chars has no result-specific branch, so
+            # it falls back to json.dumps(raw), re-measuring text already
+            # counted via the preceding assistant deltas) and lose the
+            # completed answer to a false-positive runaway-draft error.
+            if str(parsed.get("type") or "") != "result" and budget_chars >= ceiling_chars:
                 proc.kill()
                 yield {
                     "type": "error",

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -593,6 +593,20 @@ async def run_fcc_turn(
                 }
                 context_nudge_sent = True
 
+            if budget_chars >= ceiling_chars:
+                proc.kill()
+                yield {
+                    "type": "error",
+                    "error": (
+                        f"fcc draft exceeded context ceiling ({budget_chars} >= "
+                        f"{ceiling_chars} chars) without completing the turn"
+                    ),
+                    "error_code": "fcc_draft_length_ceiling_exceeded",
+                    "steps_seen": steps_seen,
+                    "llm_response": accumulated or None,
+                }
+                return
+
             text, sid, _dur = extract_final_from_stream_event(parsed, accumulated=accumulated)
             if text:
                 accumulated = text

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -204,6 +204,62 @@ async def test_run_fcc_turn_normal_turn_unaffected_by_draft_length_ceiling(
 
 
 @pytest.mark.asyncio
+async def test_run_fcc_turn_does_not_kill_on_terminal_result_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A "result" event is the CLI's own signal the turn already finished --
+
+    it must never be treated as ceiling-exceeding runaway, even though
+    measure_step_payload_chars has no result-specific branch and falls back
+    to json.dumps(raw) for it (re-measuring text already counted via the
+    preceding assistant deltas, which alone can push budget_chars over a
+    tight ceiling on the very event that completes the turn). Regression
+    test for a review finding on this same patch: before the fix, this
+    scenario killed an already-finished process and discarded its answer as
+    fcc_draft_length_ceiling_exceeded instead of yielding it.
+    """
+    monkeypatch.setenv("HARNESS_FCC_MAX_CONTEXT_TOKENS", "30")
+    monkeypatch.setenv("ORION_FCC_CHARS_PER_TOKEN", "1")
+    # ceiling_chars = 30; prompt "hi" (2 chars) + assistant delta (17 chars)
+    # = budget_chars 19, still under ceiling. The result event's own
+    # json.dumps(raw) fallback size (well over 11 chars of headroom, since
+    # it restates the answer text plus JSON structure/session_id) is what
+    # used to push budget_chars over 30 on the completing event.
+    proc = _FakeProc(
+        [
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"0123456789012345"}]}}',
+            '{"type":"result","result":"0123456789012345","session_id":"s1"}',
+        ],
+    )
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(motor, "_preflight_fcc_server", lambda *a, **k: None)
+    monkeypatch.setattr(motor, "load_fcc_env", _fake_fcc_env)
+    monkeypatch.setattr(motor, "_maybe_render_mcp_config", lambda **k: None)
+
+    events = []
+    async for ev in motor.run_fcc_turn(
+        prompt="hi",
+        fcc_model_label="MODEL_HAIKU",
+        correlation_id="corr-draft-ceiling-result-guard",
+        workspace="/tmp",
+        fcc_server_url="http://127.0.0.1:8082",
+        auth_token="tok",
+        claude_bin="claude",
+        timeout_sec=30.0,
+    ):
+        events.append(ev)
+
+    assert all(ev["type"] != "error" for ev in events)
+    assert events[-1]["type"] == "final"
+    assert events[-1]["llm_response"] == "0123456789012345"
+    assert proc.killed is False
+
+
+@pytest.mark.asyncio
 async def test_run_fcc_turn_whole_turn_timeout_wins_near_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -114,6 +114,96 @@ async def test_run_fcc_turn_fails_fast_on_stalled_stream(
 
 
 @pytest.mark.asyncio
+async def test_run_fcc_turn_fails_fast_on_draft_length_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A draft that keeps streaming text without ever finishing the turn must be
+
+    killed once accumulated chars cross the context ceiling, instead of being
+    allowed to run away (live incident: an FCC draft narrated a fabricated
+    multi-turn dialogue instead of stopping after one bounded reply — it
+    completed and was caught downstream by finalize, but a worse case could
+    burn far more compute before finishing). This mirrors the existing
+    stream-stall-timeout safety valve above, but caps total draft size rather
+    than per-line silence.
+    """
+    monkeypatch.setenv("HARNESS_FCC_MAX_CONTEXT_TOKENS", "20")
+    monkeypatch.setenv("ORION_FCC_CHARS_PER_TOKEN", "1")
+    # ceiling_chars = 20 * 1 = 20
+
+    proc = _FakeProc(
+        [
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"0123456789"}]}}',
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"9876543210"}]}}',
+        ],
+    )
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(motor, "_preflight_fcc_server", lambda *a, **k: None)
+    monkeypatch.setattr(motor, "load_fcc_env", _fake_fcc_env)
+    monkeypatch.setattr(motor, "_maybe_render_mcp_config", lambda **k: None)
+
+    events = []
+    async for ev in motor.run_fcc_turn(
+        prompt="hi",
+        fcc_model_label="MODEL_HAIKU",
+        correlation_id="corr-draft-ceiling",
+        workspace="/tmp",
+        fcc_server_url="http://127.0.0.1:8082",
+        auth_token="tok",
+        claude_bin="claude",
+        timeout_sec=30.0,
+    ):
+        events.append(ev)
+
+    assert events[-1]["type"] == "error"
+    assert events[-1]["error_code"] == "fcc_draft_length_ceiling_exceeded"
+    assert proc.killed is True
+
+
+@pytest.mark.asyncio
+async def test_run_fcc_turn_normal_turn_unaffected_by_draft_length_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A normal, well-under-budget turn must not trip the new hard ceiling."""
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
+        return _FakeProc(
+            [
+                '{"type":"assistant","message":{"content":[{"type":"text","text":"Hi there."}]}}',
+                '{"type":"result","result":"Hi there.","session_id":"s1"}',
+            ],
+        )
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(motor, "_preflight_fcc_server", lambda *a, **k: None)
+    monkeypatch.setattr(motor, "load_fcc_env", _fake_fcc_env)
+    monkeypatch.setattr(motor, "_maybe_render_mcp_config", lambda **k: None)
+    monkeypatch.delenv("HARNESS_FCC_MAX_CONTEXT_TOKENS", raising=False)
+    monkeypatch.delenv("ORION_FCC_CHARS_PER_TOKEN", raising=False)
+
+    events = []
+    async for ev in motor.run_fcc_turn(
+        prompt="hello",
+        fcc_model_label="MODEL_HAIKU",
+        correlation_id="corr-draft-ceiling-ok",
+        workspace="/tmp",
+        fcc_server_url="http://127.0.0.1:8082",
+        auth_token="tok",
+        claude_bin="claude",
+        timeout_sec=30.0,
+    ):
+        events.append(ev)
+
+    assert [ev["type"] for ev in events] == ["step", "step", "final"]
+    assert all(ev["type"] != "error" for ev in events)
+    assert all(ev.get("error_code") != "fcc_draft_length_ceiling_exceeded" for ev in events)
+
+
+@pytest.mark.asyncio
 async def test_run_fcc_turn_whole_turn_timeout_wins_near_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds a generous hard ceiling on FCC draft generation size (`orion/harness/fcc_motor.py::run_fcc_turn`), reusing the existing `budget_chars`/`ceiling_chars` context-budget accounting already computed for the soft context-pressure nudge.
- When `budget_chars >= ceiling_chars` on a non-terminal event, kills the subprocess and yields a structured `fcc_draft_length_ceiling_exceeded` error, mirroring the existing `fcc_stream_stalled` kill/yield/return shape exactly.
- Deliberately excludes the CLI's terminal `"result"` event from the kill check (see Review findings below) — a `result` event means the turn already finished, so nothing should be killed on it regardless of size.

## Outcome moved

Closes an open gap flagged (and deliberately left unfixed) in the 2026-07-12 stall-timeout PR: `services/orion-llm-gateway/app/anthropic_passthrough.py` still has no `max_tokens`/stop-sequence governor, and there was no hard cap anywhere on total draft size — only a stall-timeout that fires on silence, not on a model that keeps producing output. Live incident motivating this: an FCC draft narrated a fabricated multi-turn dialogue instead of stopping after one bounded reply. It completed and was caught downstream by finalize's alignment check that time, but nothing stopped a worse case from burning far more compute/latency before finishing.

This is deliberately scoped as a **worst-case circuit breaker only**, not a fix for the confabulation pattern itself. The ceiling is generous by design — it must never fire on a normal turn or on drift comparable to the observed incident, since both `orion/harness/finalize.py` and a separate downstream reverie-trigger pipeline (design spec, PR #1135) need the full draft text when one exists. Pattern-based drift detection and gateway-level stop-sequences are explicitly out of scope pending real volume data — see `project_fcc_draft_confabulation_guard_spec` memory record for the fuller open-questions context this patch was scoped out of.

## Current architecture

`run_fcc_turn()`'s main loop already tracked `budget_chars` (seeded from `len(prompt)`, incremented every step via `measure_step_payload_chars`) against `ceiling_chars` (`max_context_chars()`) purely to decide when to send a one-time soft "context pressure" nudge to the model. There was no hard consequence at any threshold — a turn could keep streaming indefinitely as long as it didn't hit the (silence-based) stall timeout or the (wall-clock) turn timeout.

## Architecture touched

`orion/harness/fcc_motor.py` only. No schema, bus, or service-boundary changes — this is a pure control-flow addition inside an existing function, using accounting that already existed.

## Files changed

- `orion/harness/fcc_motor.py`: new hard-ceiling kill check in `run_fcc_turn()`'s main loop, with a `result`-event exclusion guard added after review.
- `orion/harness/tests/test_fcc_motor_mcp.py`: three new tests — ceiling-trips-on-runaway-assistant-deltas, normal-turn-unaffected, and a regression test for the result-event false-positive found in review.

## Schema / bus / API changes

None. New `error_code` value (`fcc_draft_length_ceiling_exceeded`) follows the existing generic `error_code` consumption pattern in `orion/harness/runner.py` — no schema enum, no new registry entry needed (verified: `grounding_status` is a plain `str` field, not a closed `Literal`).

## Env/config changes

None. Reuses `HARNESS_FCC_MAX_CONTEXT_TOKENS` / `ORION_FCC_CHARS_PER_TOKEN` exactly as they already existed for the soft-nudge mechanism — no new env keys, no `.env_example` changes, no sync needed.

## Tests run

```
PYTHONPATH=. .venv/bin/pytest orion/harness/tests/test_fcc_motor_mcp.py -q
28 passed in 1.1s

PYTHONPATH=. .venv/bin/pytest orion/harness/tests -q
3 failed, 158 passed
```
The 3 failures (`test_grounding_capsule_consumers.py::test_stance_react_prompt_renders_identity_when_present`, `::test_stance_react_prompt_renders_without_identity`, `test_harness_runner.py::test_harness_runner_surfaces_fcc_error_code`) are pre-existing on `main` — independently verified by checking out the pre-patch commit (`113fa70e`) and reproducing identically, unrelated to this change (an `AsyncMock`/`json.loads` issue in `last_tool_fetch_cache.py`).

The result-event regression test was verified to actually fail without the fix (isolated via `git stash` of just the fix commit, confirmed `AssertionError` on `all(ev["type"] != "error" ...)`, then restored) — not a tautological test.

## Evals run

None — this is deterministic, gate-test-shaped control-flow behavior (a numeric threshold check), not a quality/behavior question an eval harness would cover. `orion/harness/evals/` covers a different concern (introspection/grounding quality).

## Docker/build/smoke checks

Not run — no runtime config, dependency, port, health check, worker, or compose wiring touched. Pure in-process control flow inside an existing async generator.

## Review findings fixed

- Finding: the ceiling check could fire on the terminal `"result"` event, killing an already-finished process and discarding a successfully-completed answer as a false-positive `fcc_draft_length_ceiling_exceeded` error. Root cause: `measure_step_payload_chars` has no `"result"`-specific branch, so it falls back to `json.dumps(raw)`, re-measuring text already counted via the preceding assistant deltas — independently found by 4 parallel review angles (line-by-line scan, removed-behavior audit, cross-file tracer, and a combined cleanup/altitude pass that live-verified the double-counting with a synthetic 5000-char example).
  - Fix: excluded `"result"`-type events from the kill check entirely — a result event is the CLI's own authoritative signal the turn already completed, so nothing should ever be killed on it.
  - Evidence: new regression test `test_run_fcc_turn_does_not_kill_on_terminal_result_event`, confirmed to fail pre-fix and pass post-fix via isolated `git stash` testing.
- Minor findings noted but not blocking, left as-is: (1) `budget_chars` seeding from `len(prompt)` is existing, intentional behavior of the pre-existing soft-nudge mechanism this patch reuses, not a new bug — the error message could be worded more precisely but this is cosmetic; (2) a suggestion to reuse `context_risk_level()`/`step["context_obs"]["risk"]` instead of a fresh inline comparison to avoid future threshold-formula drift — reasonable but deferred, not a correctness issue; (3) the observation that confabulated-but-under-ceiling content still reaches finalize is explicitly the intended design (finalize and the reverie-trigger pipeline both need the full draft text), not a gap.

## Restart required

```text
No restart required.
```
This only affects future harness turns' generation-time behavior — no config read at boot, no service restart needed.

## Risks / concerns

- Severity: low
- Concern: the ceiling is a single global threshold reusing `max_context_chars()` directly; if a future turn legitimately needs a context window close to that ceiling for reasons unrelated to runaway drafting (e.g. very large tool-fetch results folded into context), it could trip unexpectedly.
- Mitigation: by design this only fires when a turn's cumulative draft content approaches the model's own configured context ceiling — at that point the CLI's own auto-compact should already have engaged if behaving normally, so hitting this ceiling is itself informative (worth investigating, not just retrying blindly). Not blocking for this patch; flagged for awareness if it fires more than expected.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1139