### PR TITLE
fix(hub): wire real segment_topic_map so co_occurs_with edges actually exist

### DIFF
--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -32,6 +32,7 @@ from .topic_foundry_client import (
     create_dataset,
     create_model,
     fetch_run_topics_and_keywords,
+    fetch_segments_for_run,
     list_datasets,
     list_models,
     trigger_training_run,
@@ -85,6 +86,34 @@ _TOPIC_FOUNDRY_SOURCE_TABLE = "chat_history_log"
 _TOPIC_FOUNDRY_ID_COLUMN = "correlation_id"
 _TOPIC_FOUNDRY_TIME_COLUMN = "created_at"
 _TOPIC_FOUNDRY_TEXT_COLUMNS = ["prompt", "response"]
+
+# HDBSCAN's noise/outlier bucket (topic-foundry side). Never a real topic --
+# same convention as orion/substrate/adapters/topic_foundry.py's own
+# OUTLIER_TOPIC_ID, not imported from there since this module deliberately
+# has no import-time dependency on the adapter (it's only imported lazily
+# inside concept_atlas_ingest_topic_foundry()).
+_OUTLIER_TOPIC_ID = -1
+
+
+def _day_bucket_from_timestamp(value: Any) -> Optional[str]:
+    """Parse a topic-foundry segment's ``start_at`` (a plain string over the
+    wire, typically ISO-8601, e.g. ``"2026-07-15T10:23:00Z"`` or
+    ``"...+00:00"``) into a UTC-day bucket key (``"2026-07-15"``).
+
+    Used as the ``segment_topic_map`` grouping key -- ``SegmentRecord`` has
+    no direct session/conversation id, so day-bucketing is the best
+    available real proxy for "same conversation window." Never raises --
+    any unparseable value degrades to ``None`` (caller skips it).
+    """
+    if not value:
+        return None
+    try:
+        text = str(value)
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return datetime.fromisoformat(text).date().isoformat()
+    except (TypeError, ValueError):
+        return None
 
 
 def _ensure_topic_foundry_dataset_and_model(base_url: str) -> Optional[tuple[str, str]]:
@@ -629,10 +658,20 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
     (the scheduler path logs the same dict's fields rather than checking an
     HTTP status).
 
-    Scoping note: ``segment_topic_map`` is passed as empty in this first cut,
-    so no ``co_occurs_with`` co-occurrence edges are produced yet -- only
-    concept nodes (+ backing evidence nodes/edges) per real topic. See the PR
-    report for why this was scoped out rather than attempted.
+    ``segment_topic_map`` (the co-occurrence input -- see
+    ``map_topic_foundry_run_to_substrate``'s docstring) is built here from a
+    real ``GET /segments`` fetch, grouped by UTC-day bucket of each
+    segment's ``start_at``. ``SegmentRecord`` carries no direct session/
+    conversation id -- day-bucketing is the best available real (not
+    fabricated) proxy for "same conversation window" without inventing new
+    schema. This is what feeds real candidate pairs to
+    ``_classify_typed_concept_relations`` below (which only ever looks at
+    ``co_occurs_with`` edges): before this, that classifier had zero real
+    input and never fired in production despite being fully wired (PR
+    #1132). A segments-fetch failure degrades to an empty
+    ``segment_topic_map`` (no ``co_occurs_with`` edges produced for this
+    call) rather than aborting the route -- concept/evidence node ingestion
+    below is independent of it.
     """
     store = _get_substrate_store()
     if store is None:
@@ -669,6 +708,38 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
     topics = fetched["topics"]
     keywords_by_topic = fetched["keywords_by_topic"]
 
+    segment_topic_map: dict[str, list[int]] = {}
+    segments_fetched = 0
+    try:
+        segments = fetch_segments_for_run(base_url, run_id)
+        segments_fetched = len(segments)
+        for seg in segments:
+            topic_id = seg.get("topic_id")
+            start_at = seg.get("start_at")
+            if topic_id is None or start_at is None:
+                continue
+            try:
+                topic_id_int = int(topic_id)
+            except (TypeError, ValueError):
+                continue
+            if topic_id_int == _OUTLIER_TOPIC_ID:
+                continue
+            day_bucket = _day_bucket_from_timestamp(start_at)
+            if day_bucket is None:
+                continue
+            segment_topic_map.setdefault(day_bucket, []).append(topic_id_int)
+    except TopicFoundryClientError as exc:
+        logger.warning(
+            "concept_atlas_ingest_topic_foundry_segments_fetch_failed run_id=%s error=%s", run_id, exc
+        )
+        # Degrade to empty segment_topic_map -- co_occurs_with edges just
+        # won't be produced for this ingestion call; concept/evidence node
+        # ingestion below proceeds normally regardless.
+    except Exception as exc:  # pragma: no cover - defensive, never let a client bug abort the route
+        logger.warning(
+            "concept_atlas_ingest_topic_foundry_segments_unexpected_error run_id=%s error=%s", run_id, exc
+        )
+
     try:
         from orion.substrate.adapters.topic_foundry import map_topic_foundry_run_to_substrate
 
@@ -676,7 +747,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             run_id=run_id,
             topics=topics,
             keywords_by_topic=keywords_by_topic,
-            segment_topic_map={},
+            segment_topic_map=segment_topic_map,
         )
     except Exception as exc:  # pragma: no cover - the adapter itself never raises, but don't trust across the boundary
         logger.warning("concept_atlas_ingest_topic_foundry_adapter_failed run_id=%s error=%s", run_id, exc)
@@ -745,7 +816,8 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
         "concepts_written": counting_store.concepts_written,
         "evidence_nodes_written": counting_store.evidence_nodes_written,
         "edges_written": counting_store.edges_written,
-        "co_occurrence_edges_skipped": "segment_topic_map not supplied in this ingestion route (empty by design)",
+        "segments_fetched": segments_fetched,
+        "segment_topic_map_buckets": len(segment_topic_map),
         "typed_edges_written": typed_edges_written,
     }
 

--- a/services/orion-hub/scripts/topic_foundry_client.py
+++ b/services/orion-hub/scripts/topic_foundry_client.py
@@ -256,6 +256,65 @@ def trigger_training_run(
         raise TopicFoundryClientError(f"topic_foundry_train_trigger_invalid_json: {exc}") from exc
 
 
+def fetch_segments_for_run(
+    base_url: str,
+    run_id: str,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    limit: int = 1000,
+) -> list[dict[str, Any]]:
+    """Return the raw ``SegmentRecord`` dicts for ``run_id`` (``GET /segments``,
+    ``format=wrapped`` for the paginated ``SegmentListPage`` shape,
+    ``include_bounds=True`` so each item carries ``start_at``/``end_at``).
+
+    Raises ``TopicFoundryClientError`` on any network/HTTP/parse failure or a
+    response missing the expected ``items`` list. An empty ``items`` list (a
+    real run with zero segments) is not an error -- returns ``[]``.
+
+    ``limit`` is capped by the API itself at 1000 (``ge=1, le=1000`` on
+    ``GET /segments``); this function's own default matches that ceiling
+    since the caller (segment_topic_map construction) wants the whole run's
+    segments, not a page. No pagination loop -- a run with more than 1000
+    segments silently only gets co-occurrence built from the first 1000
+    (API's default `sort_by=created_at, sort_dir=desc`, a near-arbitrary
+    subset for same-run segments). Logs a warning (not silent) when the
+    response's own `total` exceeds what was fetched, so this is at least
+    visible in logs even though nothing here backfills the rest via
+    pagination.
+    """
+    url = f"{base_url.rstrip('/')}/segments"
+    try:
+        resp = requests.get(
+            url,
+            params={"run_id": run_id, "format": "wrapped", "include_bounds": True, "limit": limit},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_segments_request_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_segments_invalid_json: {exc}") from exc
+
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if items is None:
+        raise TopicFoundryClientError("topic_foundry_segments_malformed_response")
+    result = [item for item in items if isinstance(item, dict)]
+
+    total = payload.get("total") if isinstance(payload, dict) else None
+    if isinstance(total, int) and total > len(result):
+        logger.warning(
+            "topic_foundry_segments_truncated run_id=%s fetched=%s total=%s limit=%s -- "
+            "segment_topic_map co-occurrence will only reflect the fetched subset",
+            run_id,
+            len(result),
+            total,
+            limit,
+        )
+
+    return result
+
+
 def fetch_run_topics_and_keywords(
     base_url: str,
     *,

--- a/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
+++ b/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
@@ -151,7 +151,18 @@ def _keywords_payload(topic_id: int) -> dict[str, Any]:
     return {"topic_id": topic_id, "keywords": fixtures.get(topic_id, [])}
 
 
-def _make_fake_get(*, topics_payload: dict[str, Any], run_id: str = FAKE_RUN_ID, unreachable: bool = False):
+def _segments_payload_empty(run_id: str = FAKE_RUN_ID) -> dict[str, Any]:
+    return {"run_id": run_id, "items": [], "limit": 1000, "offset": 0, "total": 0}
+
+
+def _make_fake_get(
+    *,
+    topics_payload: dict[str, Any],
+    run_id: str = FAKE_RUN_ID,
+    unreachable: bool = False,
+    segments_payload: Optional[dict[str, Any]] = None,
+    segments_unreachable: bool = False,
+):
     calls: list[tuple[str, Optional[dict[str, Any]]]] = []
 
     def fake_get(url: str, params: Optional[dict[str, Any]] = None, timeout: Optional[float] = None):
@@ -165,6 +176,10 @@ def _make_fake_get(*, topics_payload: dict[str, Any], run_id: str = FAKE_RUN_ID,
         if "/topics/" in url and url.endswith("/keywords"):
             topic_id = int(url.rsplit("/", 2)[1])
             return _FakeResponse(200, _keywords_payload(topic_id))
+        if url.endswith("/segments"):
+            if segments_unreachable:
+                raise requests.exceptions.ConnectionError("connection refused")
+            return _FakeResponse(200, segments_payload if segments_payload is not None else _segments_payload_empty(run_id))
         raise AssertionError(f"unexpected URL in fake_get: {url}")
 
     return fake_get, calls
@@ -213,7 +228,9 @@ def test_ingest_normal_run_writes_concepts_excludes_outlier_and_below_floor(
     # is below the adapter's default min_doc_count floor of 3.
     assert body["concepts_written"] == 2
     assert body["evidence_nodes_written"] == 2
-    assert body["edges_written"] == 2  # supports edges only; no co_occurs_with (empty segment_topic_map)
+    assert body["edges_written"] == 2  # supports edges only; no co_occurs_with (no segments fixture -> empty map)
+    assert body["segments_fetched"] == 0
+    assert body["segment_topic_map_buckets"] == 0
 
     snapshot = store.snapshot()
     concept_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "concept"]
@@ -864,3 +881,167 @@ def test_ingest_second_call_does_not_duplicate_or_reclassify_already_typed_pair(
     ]
     # Exactly one typed edge for this pair -- not two.
     assert len(typed_edges) == 1
+
+
+# --- segment_topic_map construction (co_occurs_with edges from real segments) ---
+#
+# Regression coverage for the bug found via live verification: the ingest route
+# used to always pass segment_topic_map={} to map_topic_foundry_run_to_substrate(),
+# so co_occurs_with edges were never produced, so _classify_typed_concept_relations
+# (above) never had any real candidate pairs to classify -- despite being fully
+# wired and tested against synthetic fixtures. Confirmed live: the running
+# FalkorDB substrate graph had zero co_occurs_with edges despite real ingestion
+# having run. Fixed by fetching GET /segments and grouping by UTC-day bucket of
+# each segment's start_at (SegmentRecord has no direct session/conversation id).
+
+
+def _segments_payload_same_day(run_id: str = FAKE_RUN_ID) -> dict[str, Any]:
+    # Two segments for topic 0 and two for topic 1, all on 2026-07-15 (same UTC
+    # day bucket) -- topics 0 and 1 co-occurring in that bucket should produce a
+    # co_occurs_with edge between them. A third segment for topic -1 (outlier)
+    # and a fourth with no start_at must both be excluded from the map entirely.
+    return {
+        "run_id": run_id,
+        "items": [
+            {"segment_id": "seg-0a", "topic_id": 0, "start_at": "2026-07-15T09:00:00Z"},
+            {"segment_id": "seg-1a", "topic_id": 1, "start_at": "2026-07-15T14:30:00+00:00"},
+            {"segment_id": "seg-outlier", "topic_id": -1, "start_at": "2026-07-15T10:00:00Z"},
+            {"segment_id": "seg-no-ts", "topic_id": 0, "start_at": None},
+        ],
+        "limit": 1000,
+        "offset": 0,
+        "total": 4,
+    }
+
+
+def test_ingest_builds_segment_topic_map_and_produces_co_occurs_with_edges(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, calls = _make_fake_get(
+        topics_payload=_topics_payload_normal(),
+        segments_payload=_segments_payload_same_day(),
+    )
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+
+    segments_call_urls = [url for url, _params in calls if url.endswith("/segments")]
+    assert len(segments_call_urls) == 1
+
+    snapshot = store.snapshot()
+    co_occurs_edges = [e for e in snapshot.edges.values() if e.predicate == "co_occurs_with"]
+    assert len(co_occurs_edges) == 1
+    edge = co_occurs_edges[0]
+    node_ids = {edge.source.node_id, edge.target.node_id}
+    assert node_ids == {
+        f"sub-concept-topicfoundry-{FAKE_RUN_ID}-0",
+        f"sub-concept-topicfoundry-{FAKE_RUN_ID}-1",
+    }
+    # edges_written in the response counts the co_occurs_with edge too (plus
+    # the 2 supports edges from the normal-topics fixture).
+    assert body["edges_written"] == 3
+    assert body["segments_fetched"] == 4  # includes the excluded outlier + no-timestamp segments
+    assert body["segment_topic_map_buckets"] == 1  # all real segments land in the same UTC day
+
+
+def test_ingest_segments_fetch_failure_still_ingests_concepts(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A segments-fetch failure must degrade to an empty segment_topic_map, not
+    abort the route -- concept/evidence ingestion is independent of it."""
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal(), segments_unreachable=True)
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["concepts_written"] == 2  # unaffected by the segments failure
+    assert body["edges_written"] == 2  # supports edges only; no co_occurs_with
+    assert body["segments_fetched"] == 0
+    assert body["segment_topic_map_buckets"] == 0
+
+    snapshot = store.snapshot()
+    co_occurs_edges = [e for e in snapshot.edges.values() if e.predicate == "co_occurs_with"]
+    assert co_occurs_edges == []
+
+
+def test_ingest_co_occurs_with_edge_clears_classification_threshold(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prove the fix actually unblocks _classify_typed_concept_relations, not
+    just that a co_occurs_with edge exists: a single ingestion call with enough
+    same-day segment overlap must produce an edge whose co_occurrence_count
+    clears orion.substrate.relation_classification's DEFAULT_COUNT_THRESHOLD (5),
+    and is_worth_classifying() must say yes for it."""
+    from orion.substrate.relation_classification import is_worth_classifying
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+
+    # 6 distinct day-buckets, each with one segment for topic 0 and one for
+    # topic 1 -- 6 co-occurrences of the (0, 1) pair, clearing threshold=5.
+    items = []
+    for day in range(15, 21):  # 2026-07-15 .. 2026-07-20
+        items.append({"segment_id": f"seg-0-{day}", "topic_id": 0, "start_at": f"2026-07-{day}T09:00:00Z"})
+        items.append({"segment_id": f"seg-1-{day}", "topic_id": 1, "start_at": f"2026-07-{day}T14:00:00Z"})
+    segments_payload = {"run_id": FAKE_RUN_ID, "items": items, "limit": 1000, "offset": 0, "total": len(items)}
+
+    fake_get, _calls = _make_fake_get(topics_payload=_topics_payload_normal(), segments_payload=segments_payload)
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+
+    snapshot = store.snapshot()
+    co_occurs_edges = [e for e in snapshot.edges.values() if e.predicate == "co_occurs_with"]
+    assert len(co_occurs_edges) == 1
+    edge = co_occurs_edges[0]
+    assert edge.metadata.get("co_occurrence_count") == 6
+
+    concept_nodes = {n.node_id: n for n in snapshot.nodes.values() if n.node_kind == "concept"}
+    node_a = concept_nodes[edge.source.node_id]
+    node_b = concept_nodes[edge.target.node_id]
+    assert is_worth_classifying(node_a, node_b, edge, strategy="count") is True
+
+
+# --- _day_bucket_from_timestamp -----------------------------------------------
+
+
+def test_day_bucket_from_timestamp_parses_z_suffixed_iso() -> None:
+    from scripts.concept_atlas_routes import _day_bucket_from_timestamp
+
+    assert _day_bucket_from_timestamp("2026-07-15T10:23:00Z") == "2026-07-15"
+
+
+def test_day_bucket_from_timestamp_parses_offset_iso() -> None:
+    from scripts.concept_atlas_routes import _day_bucket_from_timestamp
+
+    assert _day_bucket_from_timestamp("2026-07-15T10:23:00+00:00") == "2026-07-15"
+
+
+def test_day_bucket_from_timestamp_garbage_returns_none() -> None:
+    from scripts.concept_atlas_routes import _day_bucket_from_timestamp
+
+    assert _day_bucket_from_timestamp("not-a-timestamp") is None
+
+
+def test_day_bucket_from_timestamp_none_returns_none() -> None:
+    from scripts.concept_atlas_routes import _day_bucket_from_timestamp
+
+    assert _day_bucket_from_timestamp(None) is None

--- a/services/orion-hub/tests/test_topic_foundry_scheduler.py
+++ b/services/orion-hub/tests/test_topic_foundry_scheduler.py
@@ -117,6 +117,63 @@ def test_list_models_returns_items(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result == [{"model_id": FAKE_MODEL_ID, "name": "m"}]
 
 
+def test_fetch_segments_for_run_returns_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResponse(
+            200,
+            {
+                "run_id": FAKE_RUN_ID,
+                "items": [{"segment_id": "s1", "topic_id": 0, "start_at": "2026-07-15T10:00:00Z"}],
+                "limit": 1000,
+                "offset": 0,
+                "total": 1,
+            },
+        )
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    result = tfc.fetch_segments_for_run(FAKE_BASE_URL, FAKE_RUN_ID)
+    assert captured["url"] == f"{FAKE_BASE_URL}/segments"
+    assert captured["params"]["run_id"] == FAKE_RUN_ID
+    assert captured["params"]["format"] == "wrapped"
+    assert captured["params"]["include_bounds"] is True
+    assert result == [{"segment_id": "s1", "topic_id": 0, "start_at": "2026-07-15T10:00:00Z"}]
+
+
+def test_fetch_segments_for_run_malformed_response_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    monkeypatch.setattr(tfc.requests, "get", lambda *a, **k: _FakeResponse(200, {"not_items": []}))
+    with pytest.raises(tfc.TopicFoundryClientError):
+        tfc.fetch_segments_for_run(FAKE_BASE_URL, FAKE_RUN_ID)
+
+
+def test_fetch_segments_for_run_logs_warning_when_total_exceeds_fetched(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Regression for silent truncation at the 1000-segment fetch ceiling: when
+    the response's own total exceeds what was actually fetched, this must be
+    logged (not silently dropped) even though no pagination loop backfills it."""
+    from scripts import topic_foundry_client as tfc
+
+    monkeypatch.setattr(
+        tfc.requests,
+        "get",
+        lambda *a, **k: _FakeResponse(
+            200, {"run_id": FAKE_RUN_ID, "items": [{"segment_id": "s1"}], "limit": 1, "offset": 0, "total": 5}
+        ),
+    )
+    with caplog.at_level("WARNING", logger="orion-hub.topic_foundry_client"):
+        result = tfc.fetch_segments_for_run(FAKE_BASE_URL, FAKE_RUN_ID)
+    assert len(result) == 1
+    assert any("topic_foundry_segments_truncated" in rec.message for rec in caplog.records)
+
+
 def test_create_dataset_posts_payload_and_returns_response(monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import topic_foundry_client as tfc
 


### PR DESCRIPTION
## Summary

Confirmed live via direct FalkorDB query: the concept-graph pipeline's LLM relation classifier (`_classify_typed_concept_relations`, PR #1132, already merged) has **never fired in production**. Root cause: it only ever looks at `co_occurs_with` edges as candidates, but `concept_atlas_ingest_topic_foundry()` always called `map_topic_foundry_run_to_substrate(..., segment_topic_map={})` — always empty — so those edges were never produced by real ingestion. Zero existed in the live graph despite real ingestion having run (40 real concept nodes present, only `supports`/`associated_with` edges from unrelated paths).

Fixes it by fetching real segments from topic-foundry and building a real `segment_topic_map`, grouped by UTC-day bucket of each segment's `start_at` (the closest available real, non-fabricated proxy for "same conversation window" — `SegmentRecord` has no direct session/conversation id field).

## Outcome moved

`_classify_typed_concept_relations()` now has real candidate pairs to work with on every ingestion call (manual route or Gap 5's scheduler tick) instead of zero, forever.

## Files changed

- `services/orion-hub/scripts/topic_foundry_client.py`: new `fetch_segments_for_run()`.
- `services/orion-hub/scripts/concept_atlas_routes.py`: new `_day_bucket_from_timestamp()` helper, segment-fetch + day-bucketing wiring in `concept_atlas_ingest_topic_foundry()`, docstring update, and a fix for a stale/misleading response field (see Review findings).
- `services/orion-hub/tests/test_topic_foundry_scheduler.py`: 3 new tests.
- `services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py`: `_make_fake_get` extended (all 17 pre-existing tests in this file still pass unmodified against the new default-empty-segments behavior), 4 new tests + field assertions added to 2 existing ones.

## Schema / bus / API changes

- Added: none.
- Removed: `POST /api/substrate/concepts/ingest-topic-foundry`'s response field `co_occurrence_edges_skipped` (a hardcoded string that became actively false the moment this fix landed — see Review findings).
- Renamed: none.
- Behavior changed: the same route now produces real `co_occurs_with` edges; response gains `segments_fetched`/`segment_topic_map_buckets` fields.
- Compatibility notes: any UI/consumer reading `co_occurrence_edges_skipped` needs to switch to the new fields — grepped, nothing in this repo currently reads it besides the one line that produced it.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. .venv/bin/python -m pytest services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py services/orion-hub/tests/test_topic_foundry_scheduler.py services/orion-hub/tests/test_concept_atlas_routes.py -q
58 passed

PYTHONPATH=. .venv/bin/python -m pytest orion/substrate/tests services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py services/orion-hub/tests/test_topic_foundry_scheduler.py services/orion-hub/tests/test_concept_atlas_routes.py services/orion-hub/tests/test_concept_relation_classifier.py -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
393 passed
```

(`test_refit_salience_stub.py` excluded from the combined run only — pre-existing pytest rootdir `scripts`-package-name collision, unrelated; passes standalone.)

## Evals run

No eval harness exists for this seam. Real-world effect (does the classifier now produce meaningful typed relations against real conversation data) is best evaluated live post-deploy, not synthetic fixtures.

## Docker/build/smoke checks

Not run — no Docker environment available in this session. Live verification that motivated this fix was done via `docker exec orion-athena-falkordb redis-cli GRAPH.QUERY orion_substrate ...` against the actually-running containers (Hub/cortex-exec/recall all confirmed up, no store-init errors, golden concepts present with `promotion_state: canonical`) — that's what surfaced the zero-`co_occurs_with`-edges finding in the first place.

## Review findings fixed

- Finding (HIGH): `co_occurrence_edges_skipped: "segment_topic_map not supplied in this ingestion route (empty by design)"` was a hardcoded response field that this exact patch falsifies — an operator hitting the route to verify the fix (the same kind of check that found this bug) would see the route actively telling them co-occurrence is still skipped by design, even while real `co_occurs_with` edges are being written in the same response.
  - Fix: removed the field, replaced with real counts (`segments_fetched`, `segment_topic_map_buckets`).
  - Evidence: `grep -rn "co_occurrence_edges_skipped" services/orion-hub/` now finds nothing; new/updated tests assert the real fields instead.
- Finding (SHOULD FIX): `fetch_segments_for_run` fetches at most 1000 segments with no pagination loop and silently discarded the response's own `total` count, so a run with >1000 real segments would silently only get co-occurrence built from an arbitrary subset (API defaults to `sort_by=created_at DESC`, a near-arbitrary tiebreak for same-run segments) with zero signal anywhere.
  - Fix: log a warning when `total > len(items)`, so truncation is at least visible in logs even without a pagination backfill.
  - Evidence: new test `test_fetch_segments_for_run_logs_warning_when_total_exceeds_fetched`.
- Finding (verified, documented, not fixed — pre-existing, out of scope): `orion/substrate/adapters/topic_foundry.py`'s `_build()` truncates a day-bucket with more than `MAX_TOPICS_PER_SEGMENT=20` distinct topics to the 20 numerically-lowest `topic_id`s, not the most frequent/salient ones. This logic predates this diff and is untouched by it, but this diff makes it reachable with real data for the first time (previously `segment_topic_map` was always empty, so this branch never ran in production). Worth a follow-up ticket; not touched here since it's already correct/tested code whose only bug was that its caller never gave it real data — which is exactly what this patch fixes.
- Finding (verified, not a bug): the adapter's own combinatorial caps (`MAX_SEGMENTS_FOR_COOCCURRENCE=5000`, `MAX_TOPICS_PER_SEGMENT=20`, `MAX_COOCCURRENCE_EDGES=2000`) still correctly bound worst-case work against day-bucketed input — distinct day-buckets are inherently capped at ≤1000 by the segments fetch limit, well under 5000.
- Finding (verified, not a bug): the new sequential `/segments` HTTP call doesn't change this route's existing threadpool-blocking-is-fine reasoning (already established for its pre-existing sequential LLM RPCs in the same route).

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

## Risks / concerns

- Severity: low
- Concern: silent truncation at 1000 segments for very large runs (now logged, not fixed via pagination).
- Mitigation: logged warning is enough signal for now; pagination loop is a reasonable follow-up if this proves to matter in practice (default 30-day window is unlikely to exceed 1000 segments for most conversation volumes).
- Severity: low
- Concern: day-bucketing is a coarser co-occurrence proxy than a real session/conversation id would be (two unrelated topics discussed at different times of the same day would be treated as co-occurring).
- Mitigation: this is the best available real signal without inventing new schema on `SegmentRecord`; documented explicitly in code rather than silently accepted.

## PR link

(populated after creation)