### PR TITLE
fix(harness): fail closed on reflect LLM failure, not aligned

### DIFF
--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -387,7 +387,7 @@ async def run_finalize_reflection(
                 imperative=thought.imperative,
                 tone=thought.tone,
                 strain_refs=list(thought.strain_refs),
-                alignment_verdict="aligned",
+                alignment_verdict="misaligned",
                 alignment_notes=[f"reflect_llm_failed: {_excerpt(str(exc), max_len=200)}"],
                 strain_unresolved=False,
                 reflection_source="degraded_llm_failure_fallback",

--- a/orion/harness/tests/test_finalize_reflect_llm_fallback.py
+++ b/orion/harness/tests/test_finalize_reflect_llm_fallback.py
@@ -10,6 +10,10 @@ from orion.harness.tests.fixtures import make_appraisal, make_repair_overlay, ma
 
 @pytest.mark.asyncio
 async def test_reflect_llm_failure_uses_degraded_reflection_when_quick_lane_blocked() -> None:
+    """Degraded fallback must fail closed: reflect LLM failure is not proof the
+    draft is aligned, so the fallback verdict is "misaligned" (not "aligned").
+    This forces the downstream voice-finalize pass (5c) to materially revise
+    the draft instead of shipping it through unreviewed."""
     thought = make_thought(repair_pressure_level=0.9)
     appraisal = make_appraisal(surprise_level=0.5)
 
@@ -27,4 +31,4 @@ async def test_reflect_llm_failure_uses_degraded_reflection_when_quick_lane_bloc
 
     assert quick_skipped is False
     assert reflection.reflection_source == "degraded_llm_failure_fallback"
-    assert reflection.alignment_verdict == "aligned"
+    assert reflection.alignment_verdict == "misaligned"

--- a/services/orion-harness-governor/README.md
+++ b/services/orion-harness-governor/README.md
@@ -103,6 +103,14 @@ Claude Code only writes a `stream-json` line once a step fully completes — wit
 
 This does not fix a runaway upstream generation (e.g. a local model that never emits a stop token) — that failure mode lives in the model-serving stack outside this repo. It bounds how long a turn can be stuck waiting on one before the operator gets a diagnosable, fast failure instead of a silent hang.
 
+### Draft length ceiling
+
+`orion/harness/fcc_motor.py::run_fcc_turn` kills the fcc subprocess with `error_code=fcc_draft_length_ceiling_exceeded` if the accumulated draft size reaches the model's context ceiling (`max_context_chars()` in `orion/fcc/context_budget.py` — `HARNESS_FCC_MAX_CONTEXT_TOKENS` tokens times `ORION_FCC_CHARS_PER_TOKEN`, 65536 × 4 chars by default). The ceiling is deliberately generous: it never fires on normal turns, and it explicitly skips the terminal `"result"` stream event (the CLI's own signal that a turn already finished), so a legitimately long-but-completed answer can't get its own already-generated payload double-counted into a false-positive kill. It only fires on true runaway generation.
+
+### Reflection fail-closed fallback
+
+If the 5b reflect LLM call itself fails (`run_finalize_reflection` in `orion/harness/finalize.py`) and the deterministic quick-lane gate is also blocked, the degraded fallback verdict is `alignment_verdict="misaligned"` (`reflection_source="degraded_llm_failure_fallback"`) — not `"aligned"`. Reflection failing is not evidence the draft is fine, so the fallback fails closed instead of open. The 5c voice-finalize pass always runs regardless of verdict, but a `"misaligned"` verdict is the documented signal (in `orion_voice_finalize.j2`) to materially revise the draft rather than pass it through unreviewed. This does not fix why 5b failed — check `alignment_notes` on the verdict artifact (`reflect_llm_failed: <exception excerpt>`) for that.
+
 ### Required secrets
 
 Mount host `~/.fcc` (already wired in compose). In `~/.fcc/.env` (or path from `HARNESS_FCC_ENV_PATH`):


### PR DESCRIPTION
## Summary

- `run_finalize_reflection()`'s degraded fallback — the branch that runs when the 5b reflect LLM call itself raises an exception (timeout, provider error, malformed response) and the deterministic quick-lane retry is also blocked — hardcoded `alignment_verdict="aligned"` regardless of the draft's actual content.
- Changed to `alignment_verdict="misaligned"`. This activates `orion_voice_finalize.j2`'s already-existing, already-tested instruction ("materially revise the draft — do not paste unchanged or ship confabulated specifics") instead of the "refine voice, preserve content" instruction meant for genuinely-judged-fine drafts.
- Quick lane (`maybe_quick_lane_verdict`) is untouched — explicitly out of scope per Juniper ("i dont care about quick lane for chat, it is a debug mode").
- Documents this and the already-shipped PR #1140 draft-length ceiling in `services/orion-harness-governor/README.md` — neither was previously documented there.

## Outcome moved

Closes a structural fail-open gap found while investigating whether finalize's alignment check is reliable (follow-on to PR #1140 / the FCC draft confabulation guard spec, see `project_fcc_draft_confabulation_guard_spec` memory record). The original incident motivating this whole thread only got caught because the reflection LLM call happened to succeed. Before this patch, if that same call had simply failed (timeout, provider hiccup, malformed JSON) instead of succeeding, the identical bad draft would have shipped through 5c voice-finalize on the strength of an exception, unreviewed — the fallback assumed "reflection failed" meant "draft is probably fine," which has no logical basis.

Considered and rejected `alignment_verdict="uncertain"` first: checked `orion_voice_finalize.j2` and found it has zero defined behavior for that value (only `misaligned`/`aligned` have explicit instructions), so `"uncertain"` would just leave the voice-finalize LLM to improvise on an undefined case — worse than useless for hardening purposes. `"misaligned"` reuses real, tested behavior with zero prompt-template changes.

## Current architecture

`run_finalize_reflection()` had two paths that hardcoded `"aligned"` independent of draft content: the quick-lane bypass (skips the LLM call when substrate signals are calm — out of scope here) and this degraded fallback (runs when the LLM call itself fails). Both defaulted to the same optimistic value.

## Architecture touched

`orion/harness/finalize.py` only, plus its test coverage and one service README. No schema, bus, or new-file changes — `FinalizeReflectionV1.alignment_verdict` is already `Literal["aligned", "misaligned", "uncertain"]` (`orion/schemas/harness_finalize.py:64`), `"misaligned"` was already a valid, exercised value elsewhere.

## Files changed

- `orion/harness/finalize.py`: one-line fallback value change.
- `orion/harness/tests/test_finalize_reflect_llm_fallback.py`: updated the one existing assertion that was testing (and thus locking in) the old "aligned" fallback behavior — now asserts `"misaligned"`, with a docstring explaining why.
- `services/orion-harness-governor/README.md`: two new subsections ("Draft length ceiling", "Reflection fail-closed fallback") between the existing "Stream stall detection" section and "Required secrets", matching that section's style.

## Schema / bus / API changes

None — no new enum values, no registry changes. `"misaligned"` already existed and is already handled downstream (`_voice_finalize_changed()`, `emit_turn_outcome_molecule()`'s `surprise_resolved` computation) — this patch just makes the degraded-fallback path route into already-correct existing logic instead of bypassing it.

## Env/config changes

None.

## Tests run

```
PYTHONPATH=. .venv/bin/pytest orion/harness/tests/test_finalize_reflect_llm_fallback.py -v
1 passed

PYTHONPATH=. .venv/bin/pytest orion/harness/tests -q
3 failed, 158 passed
```
The 3 failures are the same pre-existing, unrelated failures confirmed against `main` in PR #1140's review (`test_grounding_capsule_consumers.py` ×2, `test_harness_runner.py::test_harness_runner_surfaces_fcc_error_code`) — independently re-confirmed present before this patch too, not introduced by it.

## Evals run

None — single-value fallback change with existing test coverage updated in place; no quality/behavior question an eval harness would newly cover.

## Docker/build/smoke checks

Not run — no runtime config, dependency, or service wiring touched.

## Review findings fixed

Traced downstream blast radius directly (both by me and independently by the implementing agent's own review pass) before shipping:
- `emit_turn_outcome_molecule()`'s `surprise_resolved` computation already required `alignment_verdict == "aligned"` — now correctly evaluates `False` for this path, which is the intended effect (a turn where reflection failed should not be recorded as "surprise resolved").
- `_voice_finalize_changed()` already special-cases `"misaligned"` to force `finalize_changed=True` regardless of whether 5c's text differs byte-for-byte from the draft — pre-existing logic, this patch just routes a new path into it. Noted as a minor pre-existing quirk, not a defect, not blocking.
- Grepped for other consumers of `reflection_source == "degraded_llm_failure_fallback"` — only the schema `Literal` definition and this one construction site reference it; no hidden coupling elsewhere assumed a stale "aligned" pairing.
- Confirmed the quick-lane branch (separate `FinalizeReflectionV1` construction earlier in the same function) was correctly left untouched — verified by reading the full function, not just the diff, since the two branches look similar enough to confuse.

No material findings required further fixing beyond what's already reflected in the diff.

## Restart required

```text
No restart required.
```
Behavior-only change in a function called per-turn; no config read at boot.

## Risks / concerns

- Severity: low (nit)
- Concern: `finalize_changed` will report `True` on this degraded-fallback path even if 5c's revision happens to be textually identical to the draft.
- Mitigation: this is pre-existing `_voice_finalize_changed()` behavior already applied to every other `"misaligned"` verdict — not something this patch introduces or should change unilaterally. Flagging for awareness only.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1142