### PR TITLE
fix(substrate): promote dynamics scalars to native Falkor properties, prove runtime writers work

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-17-cypher-native-runtime-graph-writers-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-cypher-native-runtime-graph-writers-pr.md
@@ -78,6 +78,11 @@ No eval harness exists for the Falkor adapter / substrate-runtime dynamics seam;
 
 ```text
 No Docker smoke run. No runtime/config/dependency/port changes in this patch. Live Falkor restart smoke against a real Hub deployment remains required before any live cutover decision (tracked as an open acceptance check in the design spec, unchanged by this patch).
+
+scripts/safe_graphify_update.sh REFUSED (~92% node-loss guard, the known 2026-07-14
+destructive-update failure mode) and auto-restored graph.json/manifest.json; left
+graphify-out unchanged rather than re-running or trusting the raw `graphify update`
+output.
 ```
 
 ## Review findings fixed

--- a/docs/superpowers/pr-reports/2026-07-17-cypher-native-runtime-graph-writers-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-cypher-native-runtime-graph-writers-pr.md
@@ -110,4 +110,4 @@ an operator deliberately flips those flags.
 
 ## PR link
 
-<link — to be filled in after `gh pr create`>
+https://github.com/junebug-junie/Orion-Sapienform/pull/1145

--- a/docs/superpowers/pr-reports/2026-07-17-cypher-native-runtime-graph-writers-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-cypher-native-runtime-graph-writers-pr.md
@@ -1,0 +1,108 @@
+# PR report: substrate-runtime graph writers proven against Cypher-native Falkor adapter
+
+## Summary
+
+- Promoted 5 dynamics-engine metadata keys (`dynamic_pressure`, `dynamic_pressure_reason`, `dormant`, `dormancy_updated_at`, `prediction_error`) from `BaseSubstrateNodeV1.metadata` to native Cypher scalar properties on concept nodes in `orion/substrate/falkor_codec.py` / `falkor_store.py`.
+- Closed a restart-durability gap: `FalkorSubstrateStore`'s cold-start hydration always produced `metadata={}`, so a process restart against a Falkor-backed store would silently reset all `SubstrateDynamicsEngine`/`attention_broadcast` state — masked today only because the in-process cache serves reads while the process stays up.
+- Found and fixed a second, related bug during review: `services/orion-substrate-runtime/app/worker.py::_write_prediction_error_node` builds a fresh `ConceptNodeV1` on every call and writes it under a fixed, reused `node_id` (its own documented "re-writes collapse" behavior) — once the codec always includes the 5 dynamics keys in every upsert's `SET` clause, a repeat prediction-error event durably clobbered the dynamics engine's already-computed `dynamic_pressure`/`dormant` state back to defaults. Fixed by carrying forward dynamics-engine-owned metadata from any existing node before overwriting.
+- Added integration tests proving `SubstrateDynamicsEngine.tick()` and the runtime worker's `_write_prediction_error_node` / `_dynamics_tick` work correctly against a Falkor-primary `RoutedSubstrateGraphStore`, at both the library level and the service level — closing the design spec's "runtime SPARQL cutover uses Cypher-native adapter, not blob port" acceptance check.
+- Updated `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`'s acceptance checklist and status line with this evidence.
+- Left `services/orion-substrate-runtime/.env_example`/`.env`/`docker-compose.yml` untouched — no defaults flipped, no live cutover performed in this patch.
+
+## Outcome moved
+
+The Cypher-native Falkor adapter (PR #1120) is now proven, with tests, to correctly carry the specific graph-shaped signals (`prediction_error`, `dynamic_pressure`, dormancy) that `orion-substrate-runtime`'s dynamics tick and attention broadcast already depend on — including across a simulated process restart. Before this patch, cutting runtime over to Falkor would have silently reset all dynamics state on every restart, and separately, on every repeat prediction-error event even without a restart. Both gaps are closed at the code level; the live env cutover itself remains a deliberately separate, later decision.
+
+## Current architecture
+
+`orion/substrate/falkor_codec.py`'s `encode_node_properties()`/`decode_concept_node()` handled only the common `BaseSubstrateNodeV1` scalar fields (confidence, salience, activation, provenance, etc.) plus concept-specific `label`/`definition`/`taxonomy_path`/`evidence_refs`. Anything in the free-form `metadata` dict — including the fields `SubstrateDynamicsEngine` and `attention_broadcast` actually read and write — was dropped on every durable write and every cold-start hydration. `services/orion-substrate-runtime/app/worker.py`'s `_dynamics_tick()` and `_write_prediction_error_node()` already exercise this path today against SPARQL (where the same issue does not apply, since that store's persistence model differs), gated off by default behind `SUBSTRATE_DYNAMICS_TICK_ENABLED` / `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES`.
+
+## Architecture touched
+
+- `orion/substrate/falkor_codec.py`: closed 5-key metadata-promotion allowlist, `DYNAMICS_METADATA_KEYS`/`DYNAMICS_ENGINE_OWNED_METADATA_KEYS` constants, tolerant float coercion.
+- `orion/substrate/falkor_store.py`: `NATIVE_NODE_RETURN_FIELDS` carries the 5 new columns through cold-start hydration's Cypher `RETURN` clause.
+- `services/orion-substrate-runtime/app/worker.py`: `_write_prediction_error_node` carries forward dynamics-engine-owned metadata before overwriting a node under its fixed `node_id`.
+
+## Files changed
+
+- `orion/substrate/falkor_codec.py`: 5-key native property promotion (encode/decode), `_safe_float()` tolerant coercion, `DYNAMICS_METADATA_KEYS`/`DYNAMICS_ENGINE_OWNED_METADATA_KEYS`.
+- `orion/substrate/falkor_store.py`: `NATIVE_NODE_RETURN_FIELDS` extended for cold-start hydration.
+- `orion/substrate/tests/test_falkor_codec.py`: encode/decode/round-trip/no-dynamics-defaults tests for the 5 promoted keys.
+- `orion/substrate/tests/test_falkor_store.py`: upsert-sets-native-properties + hydrate-into-metadata tests.
+- `orion/substrate/tests/test_dynamics_falkor_routed.py` (new): library-level integration proof, including a simulated-process-restart round trip through native Cypher properties.
+- `services/orion-substrate-runtime/app/worker.py`: `_write_prediction_error_node` preserves dynamics-engine-owned metadata across rewrites.
+- `services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py` (new): worker-level proof for `_write_prediction_error_node`, `_dynamics_tick`, and env-wiring (`build_substrate_store_from_env` → Falkor-primary routed store), plus the rewrite-preserves-state regression.
+- `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md`: acceptance evidence + status update.
+
+## Schema / bus / API changes
+
+- Added: none (no new bus channels, no new schema registry entries).
+- Removed: none.
+- Renamed: none.
+- Behavior changed: Falkor durable writes for concept nodes now include 5 additional native Cypher scalar properties (`dynamic_pressure`, `dynamic_pressure_reason`, `dormant`, `dormancy_updated_at`, `prediction_error`); previously these were silently dropped. `_write_prediction_error_node`'s repeat-write behavior now preserves prior dynamics state instead of resetting it.
+- Compatibility notes: Purely additive to the Falkor Cypher schema — no existing property renamed or removed. SPARQL store, non-concept node kinds, edges, and drive/goal/tension/contradiction handling are untouched.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: no (verified existing Falkor/routed documentation in `services/orion-substrate-runtime/.env_example` already matches the code; no staleness found).
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not needed (no env template change).
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+PYTHONPATH=.:services/orion-substrate-runtime /tmp/orion-test-venv/bin/python3 -m pytest \
+  services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py \
+  services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py \
+  services/orion-substrate-runtime/tests/test_worker_dynamics_tick.py \
+  orion/substrate/tests/ -q
+→ 346 passed
+
+git diff --check → clean
+```
+
+`scripts/check_schema_registry.py` / `scripts/check_bus_channels.py` referenced in the standard gate list do not exist in this repo (closest matches are `check_activation_saturation.py`, `check_single_consumer_channels.py`, neither applicable — no bus/schema change in this patch).
+
+Note: the broader `services/orion-substrate-runtime/tests/` suite has 12 pre-existing failures / 9 pre-existing errors unrelated to this patch (confirmed identical against the branch's pre-patch state) — an `app.models` package-ambiguity issue between `orion-substrate-runtime`'s own `app` package and `orion-sql-writer`'s `app.models` when both are on `PYTHONPATH` together, and other pre-existing environment/fixture gaps. Not touched or worsened by this patch.
+
+## Evals run
+
+```text
+No eval harness exists for the Falkor adapter / substrate-runtime dynamics seam; focused deterministic tests cover the codec, adapter, and worker-level integration.
+```
+
+## Docker/build/smoke checks
+
+```text
+No Docker smoke run. No runtime/config/dependency/port changes in this patch. Live Falkor restart smoke against a real Hub deployment remains required before any live cutover decision (tracked as an open acceptance check in the design spec, unchanged by this patch).
+```
+
+## Review findings fixed
+
+- Finding (High): `_write_prediction_error_node`'s documented "re-writes collapse" behavior (fixed `node_id`, fresh `ConceptNodeV1` per call) durably clobbered `SubstrateDynamicsEngine.tick()`'s already-computed `dynamic_pressure`/`dormant` state back to defaults on every repeat prediction-error event, once the codec started always including those keys in the upsert's `SET` clause.
+  - Fix: `_write_prediction_error_node` now best-effort looks up the existing node by `node_id` and carries forward `DYNAMICS_ENGINE_OWNED_METADATA_KEYS` before constructing the new node; lookup failure stays fail-open (some store test doubles only implement `upsert_node`).
+  - Evidence: `test_write_prediction_error_node_preserves_dynamics_state_on_rewrite` in `services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py`; reviewer reproduced the bug live against the real code path before landing the fix.
+
+## Restart required
+
+```text
+No restart required. This patch changes library/adapter code and adds tests only;
+no service is currently configured to use SUBSTRATE_STORE_BACKEND=falkor/routed,
+SUBSTRATE_WRITE_PREDICTION_ERROR_NODES, or SUBSTRATE_DYNAMICS_TICK_ENABLED by
+default, so no running orion-substrate-runtime instance's behavior changes until
+an operator deliberately flips those flags.
+```
+
+## Risks / concerns
+
+- Severity: Medium
+- Concern: Live cutover of `orion-substrate-runtime` to `SUBSTRATE_STORE_BACKEND=routed`/`falkor` still requires a real-Redis restart smoke (Concept Atlas survives restart check from the Slice 1 acceptance list is Hub-specific; an equivalent runtime-specific smoke has not been run against a live FalkorDB instance) before that flag flip should happen. This patch proves correctness against a scripted test double, not a live server.
+- Severity: Low
+- Concern: `bool(metadata.get("dormant", False))` would coerce a non-bool truthy string (e.g. `"false"`) to `True`; not reachable today since the only real producer (`dynamics.py`) always writes real Python bools, but worth remembering if a future producer writes this key from a different serialization path.
+
+## PR link
+
+<link — to be filled in after `gh pr create`>

--- a/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+++ b/docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
@@ -1,7 +1,7 @@
 # Cypher-native substrate + Postgres-via-bus split — design spec
 
 **Date:** 2026-07-16
-**Status:** IN PROGRESS — Cypher-native Falkor adapter shipped in this branch; drive Postgres SoR + runtime cutover remain follow-ons
+**Status:** IN PROGRESS — Cypher-native Falkor adapter shipped (PR #1120); runtime graph-writer path (item 3) proven via routed-store integration tests, env cutover not yet flipped; drive Postgres SoR (item 2) remains a follow-on
 **Mode:** Proposal (touches cognitive-graph persistence + drive measurement SoR; AGENTS.md §0A)
 **Related:**
 - `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md` (router / Falkor wedge; this doc **supersedes** its “migrate drive_state into Falkor” implication)
@@ -238,8 +238,31 @@ compatibility through a hydrated Falkor store test double.
 - [ ] Concept Atlas Hub summary/network survives restart against real Falkor after redesign
 - [x] Chat stance drive projection reads Postgres measurement rail (bus-fed); graph drive snapshot materialization off or deleted
 - [x] No new producer path calls sql-writer over HTTP for drive measurement
-- [ ] Runtime SPARQL cutover (if included in same plan series) uses Cypher-native adapter, not blob port
+- [x] Runtime graph-shaped writers (`_write_prediction_error_node`, `_dynamics_tick`) proven to work against the Cypher-native Falkor adapter via `RoutedSubstrateGraphStore`, not a blob port — env still off by default, live cutover not yet flipped
 - [ ] Fuseki update-rate attribution after runtime graph cutover (graph-shaped writers only)
+
+**Runtime graph-writer evidence (2026-07-17):** Proving this surfaced a real gap:
+`SubstrateDynamicsEngine.tick()` and `attention_broadcast._node_salience()` — both
+already-shipped consumers — read/write `dynamic_pressure`, `dynamic_pressure_reason`,
+`dormant`, `dormancy_updated_at`, and `prediction_error` inside `BaseSubstrateNodeV1
+.metadata`, but the Cypher-native codec dropped `metadata` entirely on durable writes
+(`decode_concept_node()` always produced `metadata={}`). Masked in-process by the
+Falkor store's read cache, this would have silently reset all dynamics/dormancy/
+prediction-error state on every restart once runtime cut over to Falkor. Fixed by
+promoting exactly these 5 keys to native Cypher scalar properties on concept nodes
+(`orion/substrate/falkor_codec.py`), per this spec's own "promote to first-class
+Cypher properties only with a second consumer" rule. A second bug — repeat
+`_write_prediction_error_node` calls under the same fixed `node_id` (the intended
+"re-writes collapse" path) durably clobbering the dynamics engine's already-computed
+state back to defaults — was found and fixed the same way (carry forward
+dynamics-engine-owned keys before overwriting). Proof: `orion/substrate/tests/
+test_dynamics_falkor_routed.py` (library-level, includes a simulated-restart round
+trip through native properties) and `services/orion-substrate-runtime/tests/
+test_worker_falkor_routed_store.py` (worker-level, against a Falkor-primary
+`RoutedSubstrateGraphStore`). `SUBSTRATE_STORE_BACKEND`/`SUBSTRATE_WRITE_PREDICTION
+_ERROR_NODES`/`SUBSTRATE_DYNAMICS_TICK_ENABLED` remain off by default — actually
+flipping runtime to `routed`/`falkor` live is a separate, later decision requiring a
+live Redis smoke (Concept Atlas restart check above), not made in this patch.
 
 ---
 

--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -108,7 +108,41 @@ def encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) 
     props["label"] = getattr(node, "label")
     props["definition"] = getattr(node, "definition", None)
     props["taxonomy_path_json"] = _json_list(getattr(node, "taxonomy_path", None))
+    props.update(_dynamics_properties_from_metadata(node.metadata))
     return props
+
+
+# Closed allowlist of dynamics-engine metadata keys promoted to native Cypher
+# scalar properties (concept nodes only). These are the only metadata keys two
+# already-shipped consumers (SubstrateDynamicsEngine.tick() and
+# attention_broadcast._node_salience()) actually read/write; see
+# docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+# item 3's "promote to first-class Cypher properties only with a second
+# consumer" escape hatch. Do NOT add a generic metadata-dump path here.
+def _safe_float(value: Any, *, default: float | None) -> float | None:
+    """Tolerant numeric coercion matching the `.get(key) or default` pattern
+    every current consumer of these keys already uses (attention_broadcast.py's
+    `_f()`, dynamics.py, pressure.py). A corrupted/non-numeric metadata value
+    must not abort the whole encode call -- and by extension must not abort
+    SubstrateDynamicsEngine.tick()'s per-node loop -- just for one bad node.
+    """
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dynamics_properties_from_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    meta = metadata or {}
+    return {
+        "dynamic_pressure": _safe_float(meta.get("dynamic_pressure"), default=0.0),
+        "dynamic_pressure_reason": meta.get("dynamic_pressure_reason"),
+        "dormant": bool(meta.get("dormant", False)),
+        "dormancy_updated_at": meta.get("dormancy_updated_at"),
+        "prediction_error": _safe_float(meta.get("prediction_error"), default=None),
+    }
 
 
 def encode_edge_properties(edge: SubstrateEdgeV1, identity_key: str) -> dict[str, Any]:
@@ -175,6 +209,35 @@ def _signals_from_row(row: Mapping[str, Any]) -> SubstrateSignalBundleV1:
     )
 
 
+def _dynamics_metadata_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    # dynamic_pressure/dormant always come back as a real scalar -- dynamics.py
+    # and pressure.py already tolerate a present-but-default value via
+    # `.get(key) or default`/`.get(key, False)`, so there is no ambiguity in
+    # always including them. prediction_error/dynamic_pressure_reason/
+    # dormancy_updated_at are omitted entirely when absent so this codec keeps
+    # "no prediction error yet" (key absent) distinguishable from "computed
+    # prediction error of exactly 0" (key present, value 0.0) at the storage
+    # layer -- even though today's readers of prediction_error (pressure.py,
+    # attention_broadcast.py) still read it via `.get(key) or 0.0` and so do
+    # not yet observe the difference themselves. This preserves headroom for
+    # a future consumer that does need the distinction, per the closed
+    # 5-key allowlist this codec owns.
+    metadata: dict[str, Any] = {
+        "dynamic_pressure": _safe_float(row.get("dynamic_pressure"), default=0.0),
+        "dormant": bool(row.get("dormant") or False),
+    }
+    reason = row.get("dynamic_pressure_reason")
+    if reason is not None:
+        metadata["dynamic_pressure_reason"] = reason
+    dormancy_updated_at = row.get("dormancy_updated_at")
+    if dormancy_updated_at is not None:
+        metadata["dormancy_updated_at"] = dormancy_updated_at
+    prediction_error = _safe_float(row.get("prediction_error"), default=None)
+    if prediction_error is not None:
+        metadata["prediction_error"] = prediction_error
+    return metadata
+
+
 def decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None:
     if row.get("node_kind") != "concept":
         return None
@@ -190,7 +253,7 @@ def decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None:
         temporal=_temporal_from_row(row),
         signals=_signals_from_row(row),
         provenance=_provenance_from_row(row),
-        metadata={},
+        metadata=_dynamics_metadata_from_row(row),
     )
 
 

--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -119,6 +119,29 @@ def encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) 
 # docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
 # item 3's "promote to first-class Cypher properties only with a second
 # consumer" escape hatch. Do NOT add a generic metadata-dump path here.
+DYNAMICS_METADATA_KEYS: tuple[str, ...] = (
+    "dynamic_pressure",
+    "dynamic_pressure_reason",
+    "dormant",
+    "dormancy_updated_at",
+    "prediction_error",
+)
+
+# Subset of DYNAMICS_METADATA_KEYS owned by SubstrateDynamicsEngine.tick()
+# rather than by whichever writer is upserting this call -- any caller that
+# upserts a concept node via a freshly-constructed model (not one round-tripped
+# from the store) must carry these forward from the pre-existing node or its
+# own upsert_node() call will durably reset dynamics.py's computed pressure/
+# dormancy state back to defaults. See
+# services/orion-substrate-runtime/app/worker.py::_write_prediction_error_node.
+DYNAMICS_ENGINE_OWNED_METADATA_KEYS: tuple[str, ...] = (
+    "dynamic_pressure",
+    "dynamic_pressure_reason",
+    "dormant",
+    "dormancy_updated_at",
+)
+
+
 def _safe_float(value: Any, *, default: float | None) -> float | None:
     """Tolerant numeric coercion matching the `.get(key) or default` pattern
     every current consumer of these keys already uses (attention_broadcast.py's

--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -84,6 +84,11 @@ NATIVE_NODE_RETURN_FIELDS: tuple[str, ...] = (
     "provenance_trace_id",
     "provenance_tier_rank",
     "evidence_refs_json",
+    "dynamic_pressure",
+    "dynamic_pressure_reason",
+    "dormant",
+    "dormancy_updated_at",
+    "prediction_error",
 )
 
 NATIVE_EDGE_RETURN_FIELDS: tuple[str, ...] = (

--- a/orion/substrate/tests/test_dynamics_falkor_routed.py
+++ b/orion/substrate/tests/test_dynamics_falkor_routed.py
@@ -1,0 +1,181 @@
+"""Integration proof that SubstrateDynamicsEngine works end-to-end against a
+Falkor-backed store reached through the production routing layer
+(RoutedSubstrateGraphStore), not just InMemorySubstrateGraphStore.
+
+This is the acceptance check the design spec calls for: "Runtime SPARQL
+cutover ... uses Cypher-native adapter, not blob port." It also closes the
+restart-durability gap this patch exists to fix -- before promoting
+dynamic_pressure/dormant/prediction_error to native Cypher properties,
+FalkorSubstrateStore's cold-start hydration (`decode_concept_node`) always
+produced `metadata={}`, so a process restart would silently reset all
+dynamics state even though the in-process cache made it look fine while the
+process stayed up.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from orion.substrate.dynamics import SubstrateDynamicsEngine
+from orion.substrate.falkor_store import (
+    FalkorSubstrateStore,
+    FalkorSubstrateStoreConfig,
+    RecordingFalkorClient,
+)
+from orion.substrate.routed_store import RoutedSubstrateGraphStore
+
+_NOW = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _prediction_error_row(
+    *,
+    node_id: str = "concept-pe-alpha",
+    observed_at: str,
+    dynamic_pressure: float = 0.0,
+    dynamic_pressure_reason: str | None = None,
+    dormant: bool = False,
+    dormancy_updated_at: str | None = None,
+    prediction_error: float = 0.7,
+    activation: float = 0.1,
+    recency_score: float = 0.1,
+) -> dict:
+    """A native-property Falkor row for a concept node carrying a standing
+    prediction_error and (optionally) prior dynamics state -- shaped exactly
+    like what FalkorSubstrateStore's cold-start hydration query would return
+    (NATIVE_NODE_RETURN_FIELDS), so it can be fed straight into
+    RecordingFalkorClient(hydrate_node_rows=[...]).
+    """
+    return {
+        "node_id": node_id,
+        "node_kind": "concept",
+        "identity_key": f"concept:{node_id}",
+        "label": "Prediction error concept",
+        "definition": None,
+        "taxonomy_path_json": "[]",
+        "anchor_scope": "orion",
+        "subject_ref": None,
+        "promotion_state": "canonical",
+        "risk_tier": "low",
+        "confidence": 0.7,
+        "salience": 0.5,
+        "activation": activation,
+        "recency_score": recency_score,
+        "decay_half_life_seconds": None,
+        "decay_floor": 0.0,
+        "observed_at": observed_at,
+        "valid_from": None,
+        "valid_to": None,
+        "provenance_authority": "local_inferred",
+        "provenance_source_kind": "test",
+        "provenance_source_channel": "test:dynamics_falkor_routed",
+        "provenance_producer": "test_dynamics_falkor_routed",
+        "provenance_model_name": None,
+        "provenance_correlation_id": None,
+        "provenance_trace_id": None,
+        "provenance_tier_rank": None,
+        "evidence_refs_json": "[]",
+        "dynamic_pressure": dynamic_pressure,
+        "dynamic_pressure_reason": dynamic_pressure_reason,
+        "dormant": dormant,
+        "dormancy_updated_at": dormancy_updated_at,
+        "prediction_error": prediction_error,
+    }
+
+
+def test_tick_seeds_pressure_from_prediction_error_through_routed_falkor_store():
+    observed_at = (_NOW - timedelta(seconds=60)).isoformat()
+    row = _prediction_error_row(observed_at=observed_at)
+    client = RecordingFalkorClient(hydrate_node_rows=[row])
+    falkor_store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+    routed = RoutedSubstrateGraphStore(primary=falkor_store, shadow=None)
+    engine = SubstrateDynamicsEngine(store=routed)
+
+    result = engine.tick(now=_NOW)
+
+    assert result.pressure_updates, "expected standing prediction_error to seed dynamic_pressure"
+    update = result.pressure_updates[0]
+    assert update.new_pressure > 0.0
+
+    node = routed.get_node_by_id(row["node_id"])
+    assert node is not None
+    assert node.metadata.get("dynamic_pressure") == pytest.approx(round(update.new_pressure, 6))
+
+    write_calls = [(c, p) for c, p in client.calls if "MERGE (n:SubstrateNode" in c]
+    assert write_calls, "expected dynamics tick to durably persist the pressure update"
+    cypher, params = write_calls[-1]
+    assert "n.dynamic_pressure = $dynamic_pressure" in cypher
+    assert "payload_json" not in cypher.replace("REMOVE n.payload_json", "")
+    assert params is not None
+    assert "payload_json" not in params
+    assert params["dynamic_pressure"] == pytest.approx(round(update.new_pressure, 6))
+
+
+def test_dynamic_pressure_persists_through_native_properties_across_process_restart():
+    """The restart-durability proof: rebuild a *fresh* FalkorSubstrateStore
+    from the client's durably-written row between tick 1 and tick 2 (simulating
+    a process restart re-hydrating from durable Falkor rows), and confirm
+    tick 2 reads tick 1's dynamic_pressure as its prev_pressure -- proving the
+    round trip through native Cypher properties (not the in-process cache) is
+    what actually carries dynamics state across a restart.
+
+    RecordingFalkorClient does not auto-persist writes into its own
+    hydrate_node_rows (graph_query() only records calls and replays whatever
+    rows were passed in at construction -- see FalkorSubstrateStore's
+    `_hydrate_from_durable`/RecordingFalkorClient.graph_query), so this test
+    manually feeds tick 1's actual upsert params back into a new client's
+    hydrate rows to script that restart.
+    """
+    observed_at = (_NOW - timedelta(seconds=60)).isoformat()
+    row = _prediction_error_row(observed_at=observed_at)
+    client = RecordingFalkorClient(hydrate_node_rows=[row])
+    falkor_store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+    routed = RoutedSubstrateGraphStore(primary=falkor_store, shadow=None)
+    engine = SubstrateDynamicsEngine(store=routed)
+
+    tick1 = engine.tick(now=_NOW)
+    assert tick1.pressure_updates
+    tick1_pressure = round(tick1.pressure_updates[0].new_pressure, 6)
+
+    write_calls = [(c, p) for c, p in client.calls if "MERGE (n:SubstrateNode" in c]
+    assert write_calls
+    _, durable_params = write_calls[-1]
+    assert durable_params["dynamic_pressure"] == pytest.approx(tick1_pressure)
+
+    # "Process restart": a brand-new client/store/routed-store/engine, hydrated
+    # only from the row tick 1 actually wrote durably -- no shared in-process
+    # cache with the first store at all.
+    restart_client = RecordingFalkorClient(hydrate_node_rows=[durable_params])
+    restarted_falkor_store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=restart_client,
+        hydrate=True,
+    )
+    restarted_routed = RoutedSubstrateGraphStore(primary=restarted_falkor_store, shadow=None)
+
+    rehydrated_node = restarted_routed.get_node_by_id(row["node_id"])
+    assert rehydrated_node is not None
+    assert rehydrated_node.metadata.get("dynamic_pressure") == pytest.approx(tick1_pressure)
+
+    restarted_engine = SubstrateDynamicsEngine(store=restarted_routed)
+    tick2 = restarted_engine.tick(now=_NOW + timedelta(seconds=30))
+
+    assert tick2.pressure_updates, "expected further decay to still register as a pressure update"
+    update2 = tick2.pressure_updates[0]
+    # This is the crux of the restart-durability proof: tick 2's prev_pressure
+    # (read from node.metadata.get("dynamic_pressure") at the top of tick())
+    # equals tick 1's durably-written value -- not 0.0, which is what it would
+    # be if decode_concept_node() still produced metadata={} on every hydrate.
+    assert update2.previous_pressure == pytest.approx(tick1_pressure)
+    # Further decay since tick 1 means tick 2's freshly recomputed pressure is
+    # slightly lower, not a reset back to a fresh seed.
+    assert update2.new_pressure < update2.previous_pressure

--- a/orion/substrate/tests/test_falkor_codec.py
+++ b/orion/substrate/tests/test_falkor_codec.py
@@ -101,6 +101,11 @@ def test_encode_concept_node_properties_are_native_scalars_without_payload_json(
         "label": "Alpha",
         "definition": "A test concept",
         "taxonomy_path_json": '["root", "branch"]',
+        "dynamic_pressure": 0.0,
+        "dynamic_pressure_reason": None,
+        "dormant": False,
+        "dormancy_updated_at": None,
+        "prediction_error": None,
     }
 
 
@@ -139,7 +144,12 @@ def test_decode_concept_node_reconstructs_minimal_typed_model():
     assert node.signals.confidence == 0.8
     assert node.signals.salience == 0.7
     assert node.signals.activation.activation == 0.6
-    assert node.metadata == {}
+    # dynamic_pressure/dormant always come back as real scalars (0.0/False
+    # defaults); dynamics.py/pressure.py already tolerate these via
+    # `.get(key) or default`, so this is not an empty-metadata regression --
+    # see test_concept_with_no_dynamics_metadata_encodes_and_decodes_with_sane_defaults
+    # for the full defaults contract.
+    assert node.metadata == {"dynamic_pressure": 0.0, "dormant": False}
 
 
 def test_encode_edge_properties_are_native_scalars_without_payload_json():
@@ -175,6 +185,84 @@ def test_decode_rejects_corrupt_evidence_refs_json():
 
     with pytest.raises(ValueError, match="evidence_refs_json"):
         decode_concept_node(row)
+
+
+def _concept_with_dynamics_metadata() -> ConceptNodeV1:
+    base = _concept()
+    return base.model_copy(
+        update={
+            "metadata": {
+                "dynamic_pressure": 0.42,
+                "dynamic_pressure_reason": "prediction_error_seed",
+                "dormant": True,
+                "dormancy_updated_at": "2026-07-17T00:00:00+00:00",
+                "prediction_error": 0.8,
+            }
+        }
+    )
+
+
+def test_encode_promotes_dynamics_metadata_keys_to_native_scalars():
+    props = encode_node_properties(_concept_with_dynamics_metadata(), identity_key="concept:alpha")
+
+    assert "metadata" not in props
+    assert "payload_json" not in props
+    assert props["dynamic_pressure"] == 0.42
+    assert props["dynamic_pressure_reason"] == "prediction_error_seed"
+    assert props["dormant"] is True
+    assert props["dormancy_updated_at"] == "2026-07-17T00:00:00+00:00"
+    assert props["prediction_error"] == 0.8
+
+
+def test_decode_reconstructs_dynamics_metadata_from_row():
+    row = encode_node_properties(_concept_with_dynamics_metadata(), identity_key="concept:alpha")
+
+    node = decode_concept_node(row)
+
+    assert node is not None
+    assert node.metadata.get("dynamic_pressure") == 0.42
+    assert node.metadata.get("dynamic_pressure_reason") == "prediction_error_seed"
+    assert node.metadata.get("dormant") is True
+    assert node.metadata.get("dormancy_updated_at") == "2026-07-17T00:00:00+00:00"
+    assert node.metadata.get("prediction_error") == 0.8
+
+
+def test_dynamics_metadata_round_trips_through_encode_decode():
+    original = _concept_with_dynamics_metadata()
+
+    decoded = decode_concept_node(encode_node_properties(original, identity_key="concept:alpha"))
+
+    assert decoded is not None
+    for key in (
+        "dynamic_pressure",
+        "dynamic_pressure_reason",
+        "dormant",
+        "dormancy_updated_at",
+        "prediction_error",
+    ):
+        assert decoded.metadata.get(key) == original.metadata.get(key)
+
+
+def test_concept_with_no_dynamics_metadata_encodes_and_decodes_with_sane_defaults():
+    node = _concept()  # metadata has no dynamics keys at all -- the common case
+    row = encode_node_properties(node, identity_key="concept:alpha")
+
+    assert row["dynamic_pressure"] == 0.0
+    assert row["dynamic_pressure_reason"] is None
+    assert row["dormant"] is False
+    assert row["dormancy_updated_at"] is None
+    assert row["prediction_error"] is None
+
+    decoded = decode_concept_node(row)
+    assert decoded is not None
+
+    # Mirror the exact accessor patterns dynamics.py/pressure.py/attention_broadcast.py
+    # use in production -- no KeyError, no None-vs-0.0 confusion.
+    assert float(decoded.metadata.get("dynamic_pressure") or 0.0) == 0.0
+    assert bool(decoded.metadata.get("dormant", False)) is False
+    assert decoded.metadata.get("dynamic_pressure_reason") is None
+    assert float(decoded.metadata.get("prediction_error") or 0.0) == 0.0
+    assert decoded.metadata.get("dormancy_updated_at") is None
 
 
 def test_decode_edge_reconstructs_typed_edge():

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -101,6 +101,95 @@ def test_falkor_upsert_concept_uses_native_cypher_properties():
     assert params["taxonomy_path_json"] == '["root"]'
 
 
+def test_falkor_upsert_concept_sets_native_dynamics_properties():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    node = _concept(
+        node_id="concept-dynamics-alpha",
+        metadata={
+            "dynamic_pressure": 0.42,
+            "dynamic_pressure_reason": "prediction_error_seed",
+            "dormant": True,
+            "dormancy_updated_at": "2026-07-17T00:00:00+00:00",
+            "prediction_error": 0.8,
+        },
+    )
+
+    store.upsert_node(identity_key="concept:dynamics-alpha", node=node)
+
+    cypher, params = client.calls[-1]
+    assert "n.dynamic_pressure = $dynamic_pressure" in cypher
+    assert "n.dynamic_pressure_reason = $dynamic_pressure_reason" in cypher
+    assert "n.dormant = $dormant" in cypher
+    assert "n.dormancy_updated_at = $dormancy_updated_at" in cypher
+    assert "n.prediction_error = $prediction_error" in cypher
+    assert params["dynamic_pressure"] == 0.42
+    assert params["dynamic_pressure_reason"] == "prediction_error_seed"
+    assert params["dormant"] is True
+    assert params["dormancy_updated_at"] == "2026-07-17T00:00:00+00:00"
+    assert params["prediction_error"] == 0.8
+
+
+def test_falkor_hydrates_dynamics_properties_into_metadata():
+    client = RecordingFalkorClient(
+        hydrate_node_rows=[
+            {
+                "node_id": "concept-dynamics-hydrated",
+                "node_kind": "concept",
+                "identity_key": "concept:dynamics-hydrated",
+                "label": "Hydrated dynamics concept",
+                "definition": None,
+                "taxonomy_path_json": "[]",
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.75,
+                "salience": 0.66,
+                "activation": 0.44,
+                "recency_score": 0.33,
+                "decay_floor": 0.1,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:falkor",
+                "provenance_producer": "test_falkor_store",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+                "evidence_refs_json": "[]",
+                "dynamic_pressure": 0.55,
+                "dynamic_pressure_reason": "drive_seed",
+                "dormant": True,
+                "dormancy_updated_at": "2026-07-17T01:00:00+00:00",
+                "prediction_error": 0.9,
+            }
+        ]
+    )
+
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    node = store.get_node_by_id("concept-dynamics-hydrated")
+    assert node is not None
+    assert node.metadata.get("dynamic_pressure") == 0.55
+    assert node.metadata.get("dynamic_pressure_reason") == "drive_seed"
+    assert node.metadata.get("dormant") is True
+    assert node.metadata.get("dormancy_updated_at") == "2026-07-17T01:00:00+00:00"
+    assert node.metadata.get("prediction_error") == 0.9
+
+
 def test_falkor_rejects_non_concept_durable_write():
     client = RecordingFalkorClient()
     store = FalkorSubstrateStore(

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -696,6 +696,17 @@ class BiometricsSubstrateWorker:
         enabled it writes a single node under a fixed identity_key so re-writes
         collapse (no unbounded node growth), letting the dynamics engine seed
         pressure from ``metadata['prediction_error']``.
+
+        This builds a fresh ``ConceptNodeV1`` on every call rather than
+        round-tripping the existing one, so any dynamics-engine-owned metadata
+        already durably set on this same ``node_id`` (``dynamic_pressure``,
+        ``dynamic_pressure_reason``, ``dormant``, ``dormancy_updated_at`` --
+        now native Cypher properties, see falkor_codec.py) must be carried
+        forward explicitly. Without this, a repeat prediction-error event for
+        the same fixed node_id -- the documented, intended "re-writes collapse"
+        path -- would durably clobber SubstrateDynamicsEngine.tick()'s computed
+        state back to 0.0/False on every re-write, since encode_node_properties()
+        now always includes those keys in the upsert's SET clause.
         """
         if not _prediction_error_nodes_enabled():
             return
@@ -718,8 +729,26 @@ class BiometricsSubstrateWorker:
                 SubstrateSignalBundleV1,
             )
             from orion.substrate.adapters._common import make_temporal
+            from orion.substrate.falkor_codec import DYNAMICS_ENGINE_OWNED_METADATA_KEYS
 
             salience = max(0.0, min(1.0, error))
+            metadata: dict[str, Any] = {
+                "source_kind": "substrate_prediction_error",
+                "prediction_error": round(salience, 6),
+                "reducer_key": reducer_key,
+            }
+            # Best-effort: not every injected store double implements
+            # get_node_by_id (e.g. unit-test fakes that only cover
+            # upsert_node), and a lookup failure must not block the write
+            # itself -- this stays fail-open like the rest of this method.
+            try:
+                existing = store.get_node_by_id(node_id)
+            except Exception:
+                existing = None
+            if existing is not None:
+                for key in DYNAMICS_ENGINE_OWNED_METADATA_KEYS:
+                    if key in existing.metadata:
+                        metadata[key] = existing.metadata[key]
             node = ConceptNodeV1(
                 node_id=node_id,
                 anchor_scope="orion",
@@ -734,11 +763,7 @@ class BiometricsSubstrateWorker:
                     tier_rank=2,
                 ),
                 signals=SubstrateSignalBundleV1(confidence=1.0, salience=salience),
-                metadata={
-                    "source_kind": "substrate_prediction_error",
-                    "prediction_error": round(salience, 6),
-                    "reducer_key": reducer_key,
-                },
+                metadata=metadata,
             )
             store.upsert_node(
                 identity_key=f"substrate_prediction_error|{node_id}",

--- a/services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py
+++ b/services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py
@@ -1,0 +1,247 @@
+"""Service-level proof: the worker's real graph writers work against a
+Falkor-primary RoutedSubstrateGraphStore, not just the fakes/mocks used by
+test_worker_prediction_error_node.py / test_worker_dynamics_tick.py.
+
+Design spec: docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+item 3 -- "substrate-runtime graph writers -> Falkor Cypher-native (routed
+then primary-only) -- after adapter is proven live." This file is that proof
+at the worker level, mirroring the library-level pattern already established
+in orion/substrate/tests/test_dynamics_falkor_routed.py.
+
+None of this flips any default -- SUBSTRATE_WRITE_PREDICTION_ERROR_NODES,
+SUBSTRATE_DYNAMICS_TICK_ENABLED, and SUBSTRATE_STORE_BACKEND=routed all stay
+off/unset in .env_example and .env; these tests set them only in-process via
+monkeypatch.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SUBSTRATE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SUBSTRATE_ROOT))
+
+from app.worker import BiometricsSubstrateWorker, _PREDICTION_ERROR_NODE_FLAG
+
+from orion.substrate.falkor_store import (
+    FalkorSubstrateStore,
+    FalkorSubstrateStoreConfig,
+    RecordingFalkorClient,
+)
+from orion.substrate.routed_store import RoutedSubstrateGraphStore
+
+_NOW = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_worker_with_store(store) -> BiometricsSubstrateWorker:
+    """Mirrors test_worker_prediction_error_node.py's ``_make_worker`` helper:
+    build the worker without running __init__, then set the cached store
+    directly on ``_substrate_graph_store`` so ``_get_substrate_graph_store``
+    reuses it instead of calling ``build_substrate_store_from_env``."""
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._substrate_graph_store = store
+    return worker
+
+
+def _make_falkor_routed_store(*, hydrate_node_rows: list[dict] | None = None) -> tuple[
+    RoutedSubstrateGraphStore, RecordingFalkorClient
+]:
+    client = RecordingFalkorClient(hydrate_node_rows=hydrate_node_rows or [])
+    falkor_store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=bool(hydrate_node_rows),
+    )
+    routed = RoutedSubstrateGraphStore(primary=falkor_store, shadow=None)
+    return routed, client
+
+
+def _prediction_error_row(
+    *,
+    node_id: str = "concept-pe-alpha",
+    observed_at: str,
+    dynamic_pressure: float = 0.0,
+    dynamic_pressure_reason: str | None = None,
+    dormant: bool = False,
+    dormancy_updated_at: str | None = None,
+    prediction_error: float = 0.7,
+    activation: float = 0.1,
+    recency_score: float = 0.1,
+) -> dict:
+    """A native-property Falkor row for a concept node carrying a standing
+    prediction_error -- shaped exactly like FalkorSubstrateStore's cold-start
+    hydration query result (NATIVE_NODE_RETURN_FIELDS), so it can be fed
+    straight into RecordingFalkorClient(hydrate_node_rows=[...]).
+
+    Inlined rather than imported from orion.substrate.tests.test_dynamics_falkor_routed
+    -- a cross-package test-file import is unusual in this repo's test layout,
+    and this fixture is small enough that duplicating it here is cheaper than
+    the coupling.
+    """
+    return {
+        "node_id": node_id,
+        "node_kind": "concept",
+        "identity_key": f"concept:{node_id}",
+        "label": "Prediction error concept",
+        "definition": None,
+        "taxonomy_path_json": "[]",
+        "anchor_scope": "orion",
+        "subject_ref": None,
+        "promotion_state": "canonical",
+        "risk_tier": "low",
+        "confidence": 0.7,
+        "salience": 0.5,
+        "activation": activation,
+        "recency_score": recency_score,
+        "decay_half_life_seconds": None,
+        "decay_floor": 0.0,
+        "observed_at": observed_at,
+        "valid_from": None,
+        "valid_to": None,
+        "provenance_authority": "local_inferred",
+        "provenance_source_kind": "test",
+        "provenance_source_channel": "test:worker_falkor_routed_store",
+        "provenance_producer": "test_worker_falkor_routed_store",
+        "provenance_model_name": None,
+        "provenance_correlation_id": None,
+        "provenance_trace_id": None,
+        "provenance_tier_rank": None,
+        "evidence_refs_json": "[]",
+        "dynamic_pressure": dynamic_pressure,
+        "dynamic_pressure_reason": dynamic_pressure_reason,
+        "dormant": dormant,
+        "dormancy_updated_at": dormancy_updated_at,
+        "prediction_error": prediction_error,
+    }
+
+
+def _write_calls(client: RecordingFalkorClient) -> list[tuple[str, dict]]:
+    return [(c, p) for c, p in client.calls if "MERGE (n:SubstrateNode" in c]
+
+
+# ---------------------------------------------------------------------------
+# 1. _write_prediction_error_node against a Falkor-primary routed store.
+# ---------------------------------------------------------------------------
+
+
+def test_write_prediction_error_node_against_falkor_routed_store(monkeypatch) -> None:
+    monkeypatch.setenv(_PREDICTION_ERROR_NODE_FLAG, "true")
+    routed, client = _make_falkor_routed_store()
+    worker = _make_worker_with_store(routed)
+
+    node_id = "node:substrate.execution"
+    error = 0.6
+    reducer_key = "execution_trajectory"
+
+    # No exception raised.
+    worker._write_prediction_error_node(
+        node_id=node_id,
+        error=error,
+        now=_NOW,
+        reducer_key=reducer_key,
+    )
+
+    write_calls = _write_calls(client)
+    assert write_calls, "expected the worker's upsert to durably write via Falkor"
+    cypher, params = write_calls[-1]
+    assert "n.prediction_error = $prediction_error" in cypher
+    assert "payload_json" not in cypher.replace("REMOVE n.payload_json", "")
+    assert params is not None
+    assert "payload_json" not in params
+
+    node = routed.get_node_by_id(node_id)
+    assert node is not None
+    salience = max(0.0, min(1.0, error))
+    expected_prediction_error = round(salience, 6)
+    assert node.metadata.get("prediction_error") == pytest.approx(expected_prediction_error)
+    assert params["prediction_error"] == pytest.approx(expected_prediction_error)
+
+
+# ---------------------------------------------------------------------------
+# 2. _dynamics_tick end-to-end against the same Falkor-primary routed store.
+# ---------------------------------------------------------------------------
+
+
+def _make_worker_for_dynamics_tick(monkeypatch, store) -> BiometricsSubstrateWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused/unused")
+    monkeypatch.setenv("SUBSTRATE_DYNAMICS_TICK_ENABLED", "true")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._settings = settings_mod.get_settings()
+    worker._substrate_graph_store = store
+    return worker
+
+
+def test_dynamics_tick_against_falkor_routed_store(monkeypatch) -> None:
+    # _dynamics_tick hardcodes datetime.now(timezone.utc) internally (no `now`
+    # kwarg like SubstrateDynamicsEngine.tick() itself takes), so anchor the
+    # seed row's observed_at to real wall-clock time rather than a fixed
+    # constant -- avoids needing to freeze/monkeypatch datetime just to keep
+    # the prediction-error decay window (see prediction_error_pressure in
+    # orion/substrate/pressure.py) from aging the seed out before the tick runs.
+    real_now = datetime.now(timezone.utc)
+    observed_at = (real_now - timedelta(seconds=60)).isoformat()
+    row = _prediction_error_row(observed_at=observed_at)
+    routed, client = _make_falkor_routed_store(hydrate_node_rows=[row])
+    worker = _make_worker_for_dynamics_tick(monkeypatch, routed)
+
+    seed_node = routed.get_node_by_id(row["node_id"])
+    assert seed_node is not None
+    seed_pressure = seed_node.metadata.get("dynamic_pressure")
+
+    # No exception raised.
+    worker._dynamics_tick()
+
+    updated_node = routed.get_node_by_id(row["node_id"])
+    assert updated_node is not None
+    new_pressure = updated_node.metadata.get("dynamic_pressure")
+    assert new_pressure != seed_pressure, "expected the tick to actually seed pressure, not no-op"
+    assert new_pressure > 0.0
+
+    write_calls = _write_calls(client)
+    assert write_calls, "expected the dynamics tick to durably persist the pressure update"
+    cypher, params = write_calls[-1]
+    assert "n.dynamic_pressure = $dynamic_pressure" in cypher
+    assert "payload_json" not in cypher.replace("REMOVE n.payload_json", "")
+    assert params is not None
+    assert "payload_json" not in params
+    assert params["dynamic_pressure"] == pytest.approx(new_pressure)
+
+
+# ---------------------------------------------------------------------------
+# 3. build_substrate_store_from_env() wires a Falkor-backed routed store from
+#    the runtime's own documented env var names (no live Redis required).
+# ---------------------------------------------------------------------------
+
+
+def test_build_substrate_store_from_env_wires_falkor_routed_store(monkeypatch) -> None:
+    # Point FALKORDB_URI at a closed local port so RedisGraphQueryClient's
+    # connection attempt fails fast (ECONNREFUSED, no real network/DNS hop)
+    # instead of hanging -- confirmed empirically: connecting to a closed
+    # port on localhost returns immediately (< 2ms), well under any test
+    # timeout. FalkorSubstrateStore._hydrate_from_durable() wraps the whole
+    # hydrate call in try/except Exception and only logs a warning on
+    # failure, so construction still succeeds with an empty cache.
+    monkeypatch.setenv("SUBSTRATE_STORE_BACKEND", "routed")
+    monkeypatch.setenv("SUBSTRATE_STORE_PRIMARY", "falkor")
+    monkeypatch.setenv("SUBSTRATE_STORE_SHADOW", "")
+    monkeypatch.setenv("FALKORDB_URI", "redis://127.0.0.1:1")
+    monkeypatch.setenv("FALKORDB_SUBSTRATE_GRAPH", "orion_substrate_test")
+
+    from orion.substrate.graphdb_store import build_substrate_store_from_env
+
+    store = build_substrate_store_from_env()
+
+    assert isinstance(store, RoutedSubstrateGraphStore)
+    assert isinstance(store._primary, FalkorSubstrateStore)

--- a/services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py
+++ b/services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py
@@ -165,6 +165,55 @@ def test_write_prediction_error_node_against_falkor_routed_store(monkeypatch) ->
     assert params["prediction_error"] == pytest.approx(expected_prediction_error)
 
 
+def test_write_prediction_error_node_preserves_dynamics_state_on_rewrite(monkeypatch) -> None:
+    """Regression test: _write_prediction_error_node's docstring says it "writes
+    a single node under a fixed identity_key so re-writes collapse" -- i.e. the
+    same node_id is upserted repeatedly (see worker.py's _execution_tick /
+    _transport_tick callers, both using a fixed node_id every cycle). Now that
+    falkor_codec.py always includes dynamic_pressure/dormant/etc in every
+    upsert's SET clause, a naive re-write that doesn't carry forward the
+    dynamics engine's already-computed state would durably reset it to
+    0.0/False on every single re-write -- defeating the very durability this
+    branch exists to add.
+    """
+    from orion.substrate.dynamics import SubstrateDynamicsEngine
+
+    monkeypatch.setenv(_PREDICTION_ERROR_NODE_FLAG, "true")
+    routed, client = _make_falkor_routed_store()
+    worker = _make_worker_with_store(routed)
+
+    node_id = "node:substrate.execution"
+
+    worker._write_prediction_error_node(
+        node_id=node_id, error=0.7, now=_NOW, reducer_key="execution_trajectory"
+    )
+
+    engine = SubstrateDynamicsEngine(store=routed)
+    tick_result = engine.tick(now=_NOW)
+    assert tick_result.pressure_updates, "expected the standing prediction_error to seed pressure"
+
+    node_after_tick = routed.get_node_by_id(node_id)
+    assert node_after_tick is not None
+    dynamic_pressure_after_tick = node_after_tick.metadata.get("dynamic_pressure")
+    assert dynamic_pressure_after_tick, "expected dynamics.tick() to have set a non-zero dynamic_pressure"
+
+    # Same fixed node_id re-written by a fresh prediction-error event.
+    worker._write_prediction_error_node(
+        node_id=node_id, error=0.65, now=_NOW, reducer_key="execution_trajectory"
+    )
+
+    node_after_rewrite = routed.get_node_by_id(node_id)
+    assert node_after_rewrite is not None
+    assert node_after_rewrite.metadata.get("dynamic_pressure") == pytest.approx(
+        dynamic_pressure_after_tick
+    ), "dynamics-engine-owned dynamic_pressure must survive an unrelated prediction-error rewrite"
+    assert node_after_rewrite.metadata.get("dynamic_pressure_reason") == node_after_tick.metadata.get(
+        "dynamic_pressure_reason"
+    )
+    # The writer's own field still updates to the new value.
+    assert node_after_rewrite.metadata.get("prediction_error") == pytest.approx(round(0.65, 6))
+
+
 # ---------------------------------------------------------------------------
 # 2. _dynamics_tick end-to-end against the same Falkor-primary routed store.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Promotes 5 dynamics-engine metadata keys (`dynamic_pressure`, `dynamic_pressure_reason`, `dormant`, `dormancy_updated_at`, `prediction_error`) from `BaseSubstrateNodeV1.metadata` to native Cypher scalar properties on concept nodes (`orion/substrate/falkor_codec.py`/`falkor_store.py`), per the design spec's "promote to first-class Cypher properties only with a second consumer" rule -- `SubstrateDynamicsEngine` and `attention_broadcast` are both already-shipped consumers of these keys.
- Closes a restart-durability gap: cold-start hydration always produced `metadata={}`, so a Falkor-backed process restart would have silently reset all dynamics/dormancy/prediction-error state.
- Review found and fixed a second bug: repeat `_write_prediction_error_node` calls under the same fixed `node_id` (documented "re-writes collapse" behavior) durably clobbered the dynamics engine's already-computed state back to defaults, once the codec always writes those keys.
- Adds library-level (`orion/substrate/tests/test_dynamics_falkor_routed.py`) and service-level (`services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py`) integration tests proving the runtime's real graph writers work against a Falkor-primary `RoutedSubstrateGraphStore`, including a simulated-process-restart round trip.
- Updates `docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md` acceptance checklist with this evidence.
- No env defaults flipped, no live cutover performed -- `SUBSTRATE_STORE_BACKEND=falkor/routed` remains off by default.

Full report: `docs/superpowers/pr-reports/2026-07-17-cypher-native-runtime-graph-writers-pr.md`

## Test plan

- [x] `orion/substrate/tests/` -- 334 passed
- [x] `services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py` + `test_worker_prediction_error_node.py` + `test_worker_dynamics_tick.py` -- 12 passed
- [x] `git diff --check` clean
- [x] Code review subagent run; 1 High finding fixed (rewrite-clobbers-state bug)
- [ ] Live Falkor restart smoke against a real Hub deployment (separate, tracked in design spec -- not required for this patch since no env default changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)