### PR TITLE
fix(harness): enforce single-turn reply on relational FCC stance

### DIFF
--- a/orion/harness/operator_brief.py
+++ b/orion/harness/operator_brief.py
@@ -37,6 +37,9 @@ answering. Record each meaningful step. Do not guess repo structure or service s
 HARNESS_RELATIONAL_TOOL_DISCIPLINE = """\
 Relational/minimal turn: do NOT use GitHub MCP or repo/runtime tools unless the imperative
 explicitly commands verified facts for this turn. Acknowledge and stay present — no task tracking.
+Produce exactly one reply in your own voice. Never write dialogue, narration, or replies
+attributed to the other person — do not simulate how they might respond or continue the
+conversation on their behalf.
 """
 
 HARNESS_INSTRUMENTAL_TOOL_DISCIPLINE = """\

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -313,6 +313,42 @@ def test_harness_motor_instruction_relational_discourages_tools() -> None:
     assert "Execute your imperative" in instruction
 
 
+def test_harness_motor_instruction_relational_enforces_single_turn_reply() -> None:
+    """Regression for the fabricated-simulated-dialogue incidents: on a
+    relational/minimal stance the FCC motor narrated BOTH "Orion" and "You"
+    turns instead of producing one bounded reply. One incident was caught by
+    finalize's alignment check (topically off-drift); the other shipped
+    verbatim because the fabricated content was topically on-point (the
+    imperative was "hold space, acknowledge shared solitude" and the
+    fabricated text was thematically about solitude, so the alignment check
+    found nothing wrong). See project_fcc_harness_step_noise_and_memory_digest_confabulation
+    and the wider substrate-bridge confabulation investigation thread."""
+    thought = make_thought(
+        imperative="Hold space; acknowledge our shared solitude.",
+        stance_harness_slice=StanceHarnessSliceV1(
+            task_mode="reflective_dialogue",
+            conversation_frame="reflective",
+            interaction_regime="minimal",
+            answer_strategy="companion_presence",
+        ),
+    )
+    assert is_relational_motor_stance(thought) is True
+    instruction = harness_motor_instruction(thought=thought, answer_contract=None)
+    assert "exactly one reply" in instruction
+    assert "Never write dialogue" in instruction
+
+
+def test_harness_motor_instruction_instrumental_omits_single_turn_language() -> None:
+    """Companion check: the single-turn-boundary instruction is scoped to the
+    relational branch only. An instrumental-stance thought must not pick up
+    HARNESS_RELATIONAL_TOOL_DISCIPLINE's language at all."""
+    thought = make_thought(imperative="Inspect docker logs for orion-hub.")
+    assert is_relational_motor_stance(thought) is False
+    instruction = harness_motor_instruction(thought=thought, answer_contract=None)
+    assert "exactly one reply" not in instruction
+    assert "Never write dialogue" not in instruction
+
+
 def test_harness_motor_instruction_imperative_forward() -> None:
     thought = make_thought(imperative="Inspect docker logs for orion-hub.")
     instruction = harness_motor_instruction(thought=thought, answer_contract=None)


### PR DESCRIPTION
## Summary

- `orion/harness/operator_brief.py::HARNESS_RELATIONAL_TOOL_DISCIPLINE` (the instruction injected into the FCC motor prompt for relational/reflective stances) gets a new explicit line: produce exactly one reply, never simulate the other party's voice.
- Scoped to the relational branch only — `HARNESS_INSTRUMENTAL_TOOL_DISCIPLINE` and the other operator briefs are untouched, no evidence this occurs on task-mode turns.
- Two new tests: one confirming the new instruction is present on a relational stance, one confirming it's absent on an instrumental stance (proves correct scoping).

## Outcome moved

Closes the root cause behind two live incidents, both confirmed via production logs, both post-dating PR #1140 and PR #1143:

1. **Incident 1** (earlier this session): FCC motor, on a relational stance, narrated a full fabricated back-and-forth ("Orion" and "You" voice alternating) about coming-out/identity, unrelated to the actual live topic ("bold colors/girls night out"). Caught by finalize's alignment check, rewritten before the user saw it.
2. **Incident 2** (post-deploy of #1140/#1143): same structural pattern — fabricated multi-turn dialogue about loneliness/solitude — but this time topically *on-point* to the imperative ("hold space, acknowledge shared solitude"). Finalize's own reasoning trace judged it *"adheres to stance_react_v1 imperative and response_priorities"* — not flagged — and the fabricated text shipped verbatim as the literal delivered answer.

Neither #1140 (draft-length ceiling) nor #1143 (reflection fail-closed on LLM failure) touches this failure mode — #1140 is a runaway-cost safety valve unrelated to content correctness, and #1143 only changes behavior when the reflection LLM call itself fails, not when it succeeds and judges wrongly. Incident 2's reflection call succeeded and judged the draft fine, because topically it *was* fine — the problem was structural (simulated dialogue instead of one turn), and nothing in the pipeline checked for that. `orion_voice_finalize.j2`'s rubric only branches on topical `misaligned`/`aligned`.

Root cause: `HARNESS_RELATIONAL_TOOL_DISCIPLINE` said nothing about turn boundaries — "Acknowledge and stay present — no task tracking" gave the model latitude to treat extended unprompted narration as in-character. This patch closes that gap directly at the prompt level, rather than building a downstream structural-drift classifier to catch it after the fact (thinner, and the classifier had no real data to validate against until now).

## Current architecture

`is_relational_motor_stance(thought)` (task_mode in `{"reflective_dialogue", "playful_exchange", "identity_dialogue"}`, or interaction_regime in `{"relational", "minimal"}`) selects `HARNESS_RELATIONAL_TOOL_DISCIPLINE` as part of the FCC motor's prompt via `harness_motor_instruction()`. Both incidents' turns match this branch.

## Architecture touched

`orion/harness/operator_brief.py` only — pure prompt-text change, no schema, bus, or pipeline logic touched.

## Files changed

- `orion/harness/operator_brief.py`: 3-line addition to `HARNESS_RELATIONAL_TOOL_DISCIPLINE`.
- `orion/harness/tests/test_harness_prefix.py`: two new tests (positive: relational stance gets the instruction; negative: instrumental stance does not).

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
PYTHONPATH=. .venv/bin/pytest orion/harness/tests/test_harness_prefix.py -q
21 passed

PYTHONPATH=. .venv/bin/pytest orion/harness/tests -q
3 failed, 160 passed
```
The 3 failures are the same pre-existing, unrelated failures confirmed across all three patches in this thread today (`test_grounding_capsule_consumers.py` ×2, `test_harness_runner.py::test_harness_runner_surfaces_fcc_error_code`) — independently re-verified present before this patch too.

## Evals run

None — pure prompt-text addition with new deterministic gate-test coverage; checked `orion/harness/evals/test_unified_turn_grounding_eval.py` for any golden-string dependency on the old instruction text (none found) before concluding no eval update was needed.

## Docker/build/smoke checks

Not run — no runtime config, dependency, or service wiring touched. This only affects the compiled prompt text sent to the FCC subprocess on future turns.

## Review findings fixed

- Verified no test elsewhere in the repo exact-matches (golden-string) the old `HARNESS_RELATIONAL_TOOL_DISCIPLINE` value — grepped all consumers of the constant and `compile_harness_prefix`, confirmed the only two files with test failures reference an unrelated pre-existing bug (`AsyncMock`/`json.loads` issue in `last_tool_fetch_cache.py`), not content assertions.
- Confirmed the change is correctly scoped to only the relational branch (negative test proves `HARNESS_INSTRUMENTAL_TOOL_DISCIPLINE` is untouched and doesn't leak the new text).
- No README update — checked, this is a prompt-wording change with no new operator-visible error code or failure mode (unlike #1140/#1143), so no doc surface needed updating.

No material findings required further fixing.

## Restart required

```text
No restart required.
```
Prompt-text-only change, takes effect on the next FCC turn without any config re-read or process restart.

## Risks / concerns

- Severity: low
- Concern: this is a prompt-instruction fix, not a deterministic guardrail — it relies on the underlying model actually following the new instruction. Given this same model has already been shown (twice) to interpret permissive relational instructions loosely, there's no guarantee this closes the gap completely.
- Mitigation: this is the cheap, thin-seam first move. If it doesn't fully close the gap, the next real data point (a third incident, post this patch) would be strong evidence for building the previously-deferred structural/pattern-based drift detector as a deterministic backstop, rather than relying on prompt wording alone.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1143