### PR TITLE
fix(harness): gate agent-board hooks out of FCC chat turns

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/athena/.local/bin/graphify hook-guard search"
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/hooks/graphify_hook_guard_gate.sh\" search"
           },
           {
             "type": "command",
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/athena/.local/bin/graphify hook-guard read"
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/hooks/graphify_hook_guard_gate.sh\" read"
           }
         ]
       }

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -415,6 +415,15 @@ def _build_subprocess_env(*, fcc_server_url: str, auth_token: str) -> Dict[str, 
     env["ANTHROPIC_AUTH_TOKEN"] = auth_token
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env["TERM"] = "dumb"
+    # cwd=workspace below is the repo checkout, so this claude -p subprocess
+    # picks up .claude/settings.json's SessionStart/Stop hooks same as any
+    # interactive session. Those hooks (agent board checkin/checkout) are
+    # scoped to human/agent coding sessions in a worktree, not per-turn FCC
+    # chat calls -- without this marker they fire on every Orion chat turn,
+    # inflating step counts and writing spurious board presence rows for the
+    # shared checkout. See scripts/hooks/session_start_agent_board.py and
+    # session_stop_agent_board.py, which no-op when this is set.
+    env["ORION_FCC_SUBPROCESS"] = "1"
     _fcc_context_env(env)
     if _env_truthy("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"):
         # Point the context-mode plugin's hooks + MCP server at the same

--- a/scripts/hooks/graphify_hook_guard_gate.sh
+++ b/scripts/hooks/graphify_hook_guard_gate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PreToolUse gate in front of `graphify hook-guard <kind>`.
+#
+# graphify's hook-guard is a pure informational nudge (fails open, never
+# blocks) telling the agent to run `graphify query` before grepping/reading
+# source files -- useful when navigating/editing code, pure token overhead
+# for a conversational/forensics turn with no code-navigation payoff.
+#
+# orion/harness/fcc_motor.py tags every FCC chat-turn subprocess with
+# ORION_FCC_SUBPROCESS=1 (same marker used by session_start_agent_board.py /
+# session_stop_agent_board.py). When set, skip the nudge entirely. Unlike
+# destructive_git_guard.py (actual safety enforcement, left ungated even for
+# FCC turns since HARNESS_FCC_WORKSPACE is the shared checkout), this hook
+# has no enforcement value to preserve.
+set -euo pipefail
+
+if [ -n "${ORION_FCC_SUBPROCESS:-}" ]; then
+  exit 0
+fi
+
+exec "${GRAPHIFY_HOOK_GUARD_BIN:-/home/athena/.local/bin/graphify}" hook-guard "$1"

--- a/scripts/hooks/session_start_agent_board.py
+++ b/scripts/hooks/session_start_agent_board.py
@@ -6,6 +6,7 @@ Fails silently (no output) on any error -- never blocks session start.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -19,6 +20,13 @@ from agent_board_lib import (  # noqa: E402
 
 
 def main() -> None:
+    if os.environ.get("ORION_FCC_SUBPROCESS"):
+        # This is a per-turn `claude -p` call spawned by orion/harness/fcc_motor.py,
+        # not a human/agent coding session -- it has no worktree of its own to
+        # check in/out of. Without this, every Orion chat turn writes a
+        # spurious presence row to the shared board (see AGENTS.md's agent
+        # workspace board section) and inflates the FCC harness step count.
+        return
     session_id = read_session_id_from_stdin_hook_payload()
     try:
         context = render_checkin_context(board_config_from_env(), session_id=session_id)

--- a/scripts/hooks/session_stop_agent_board.py
+++ b/scripts/hooks/session_stop_agent_board.py
@@ -37,10 +37,12 @@ def main() -> None:
         ]
     except Exception:
         return
-    if open_items:
-        detail = f"Agent board checkout reminder: {len(open_items)} open item(s) remain for this worktree. Run `python3 scripts/agent_board.py checkout` or resolve/park them."
-    else:
-        detail = "Agent board checkout reminder: no open board items are recorded for this worktree."
+    if not open_items:
+        # Nothing actionable -- saying so on every single Stop is pure token
+        # noise, not a reminder. Stay silent, matching the fail-silent
+        # pattern already used for errors above.
+        return
+    detail = f"Agent board checkout reminder: {len(open_items)} open item(s) remain for this worktree. Run `python3 scripts/agent_board.py checkout` or resolve/park them."
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "Stop",

--- a/scripts/hooks/session_stop_agent_board.py
+++ b/scripts/hooks/session_stop_agent_board.py
@@ -6,6 +6,7 @@ Fails silently (no output) on any error -- never blocks session stop.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -20,6 +21,11 @@ from agent_board_lib import (  # noqa: E402
 
 
 def main() -> None:
+    if os.environ.get("ORION_FCC_SUBPROCESS"):
+        # See matching guard in session_start_agent_board.py: this is a
+        # per-turn FCC chat subprocess, not a coding session with a worktree
+        # to check out of.
+        return
     session_id = read_session_id_from_stdin_hook_payload()
     try:
         cfg = board_config_from_env()

--- a/tests/scripts/test_graphify_hook_guard_gate.py
+++ b/tests/scripts/test_graphify_hook_guard_gate.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GATE = ROOT / "scripts" / "hooks" / "graphify_hook_guard_gate.sh"
+
+
+def _fake_graphify_bin(tmp_path: Path) -> Path:
+    """A stand-in for the real (out-of-repo, uv-tool-installed) graphify
+    binary that just echoes its argv so tests don't need it installed."""
+    fake = tmp_path / "fake_graphify.sh"
+    fake.write_text("#!/usr/bin/env bash\necho \"called: $*\"\n", encoding="utf-8")
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
+    return fake
+
+
+def test_gate_skips_graphify_for_fcc_subprocess(tmp_path: Path) -> None:
+    """orion/harness/fcc_motor.py tags its subprocess env with
+    ORION_FCC_SUBPROCESS=1 -- the gate must no-op (no stdout, exit 0)
+    without even invoking graphify, since a chat/forensics turn gets no
+    value from the "run graphify before grepping" nudge."""
+    fake = _fake_graphify_bin(tmp_path)
+    env = {**os.environ, "ORION_FCC_SUBPROCESS": "1", "GRAPHIFY_HOOK_GUARD_BIN": str(fake)}
+
+    proc = subprocess.run(
+        [str(GATE), "search"], env=env, input="{}", capture_output=True, text=True, timeout=10
+    )
+
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_gate_forwards_to_graphify_outside_fcc_subprocess(tmp_path: Path) -> None:
+    """Without the FCC marker (a real interactive Claude Code session), the
+    gate must still forward to the real hook-guard -- this is where future
+    light development work through this repo would want the nudge."""
+    fake = _fake_graphify_bin(tmp_path)
+    env = {k: v for k, v in os.environ.items() if k != "ORION_FCC_SUBPROCESS"}
+    env["GRAPHIFY_HOOK_GUARD_BIN"] = str(fake)
+
+    proc = subprocess.run(
+        [str(GATE), "read"], env=env, input="{}", capture_output=True, text=True, timeout=10
+    )
+
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "called: hook-guard read"
+
+
+def test_gate_script_is_executable() -> None:
+    mode = GATE.stat().st_mode
+    assert mode & stat.S_IXUSR, f"{GATE} must be executable (chmod +x)"

--- a/tests/scripts/test_session_agent_board_hooks.py
+++ b/tests/scripts/test_session_agent_board_hooks.py
@@ -49,6 +49,42 @@ def test_session_stop_hook_emits_checkout_context(primary_repo: Path, tmp_path: 
     assert "agent board checkout" in payload["hookSpecificOutput"]["additionalContext"].lower()
 
 
+def test_hooks_noop_for_fcc_subprocess(primary_repo: Path, tmp_path: Path) -> None:
+    """orion/harness/fcc_motor.py spawns `claude -p` with cwd set to this
+    repo checkout, so it picks up .claude/settings.json's SessionStart/Stop
+    hooks the same as a real interactive session -- without this gate, every
+    Orion chat turn would write a spurious presence row to the shared board
+    and add noise to the FCC harness step count. fcc_motor.py tags its
+    subprocess env with ORION_FCC_SUBPROCESS=1 for exactly this check."""
+    board = tmp_path / "agent-board.jsonl"
+    env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board), "ORION_FCC_SUBPROCESS": "1"}
+
+    start = subprocess.run(
+        [sys.executable, str(START_HOOK)],
+        cwd=primary_repo,
+        env=env,
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    stop = subprocess.run(
+        [sys.executable, str(STOP_HOOK)],
+        cwd=primary_repo,
+        env=env,
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert start.returncode == 0
+    assert start.stdout == ""
+    assert stop.returncode == 0
+    assert stop.stdout == ""
+    assert not board.exists(), "FCC subprocess must not write a board presence row"
+
+
 def test_hooks_fail_open_outside_git_repo(tmp_path: Path) -> None:
     outside = tmp_path / "outside"
     outside.mkdir()

--- a/tests/scripts/test_session_agent_board_hooks.py
+++ b/tests/scripts/test_session_agent_board_hooks.py
@@ -41,12 +41,28 @@ def test_session_start_hook_emits_valid_json(primary_repo: Path, tmp_path: Path)
 
 
 def test_session_stop_hook_emits_checkout_context(primary_repo: Path, tmp_path: Path) -> None:
-    proc = _run_hook(STOP_HOOK, primary_repo, tmp_path / "agent-board.jsonl")
+    board = tmp_path / "agent-board.jsonl"
+    add = _run_board_cli(
+        primary_repo, board, "add", "--kind", "finding", "--severity", "note", "--summary", "found something"
+    )
+    assert add.returncode == 0, add.stderr
+
+    proc = _run_hook(STOP_HOOK, primary_repo, board)
 
     assert proc.returncode == 0
     payload = json.loads(proc.stdout)
     assert payload["hookSpecificOutput"]["hookEventName"] == "Stop"
     assert "agent board checkout" in payload["hookSpecificOutput"]["additionalContext"].lower()
+
+
+def test_session_stop_hook_silent_when_no_open_items(primary_repo: Path, tmp_path: Path) -> None:
+    """No open items means nothing actionable -- announcing that on every
+    single Stop is pure token noise, not a reminder. Stay silent instead of
+    emitting a "no open board items" message every turn."""
+    proc = _run_hook(STOP_HOOK, primary_repo, tmp_path / "agent-board.jsonl")
+
+    assert proc.returncode == 0
+    assert proc.stdout == ""
 
 
 def test_hooks_noop_for_fcc_subprocess(primary_repo: Path, tmp_path: Path) -> None:
@@ -161,12 +177,13 @@ def test_stop_hook_falls_back_to_cwd_when_session_id_has_no_match(
 ) -> None:
     """No git-hook-driven heartbeat has landed for this session_id yet (e.g.
     the very first hook fire in a session) -- must fall back to the old
-    git-rev-parse-based resolution rather than erroring or misreporting."""
+    git-rev-parse-based resolution rather than erroring or misreporting.
+    No open items exist for the fallback-resolved worktree, so the hook
+    stays silent (see test_session_stop_hook_silent_when_no_open_items)."""
     board = tmp_path / "agent-board.jsonl"
     proc = _run_hook(STOP_HOOK, primary_repo, board, stdin_payload={"session_id": "no-such-session"})
     assert proc.returncode == 0, proc.stderr
-    payload = json.loads(proc.stdout)
-    assert "no open board items" in payload["hookSpecificOutput"]["additionalContext"].lower()
+    assert proc.stdout == ""
 
 
 def test_session_start_hook_resolves_via_session_id_not_fixed_cwd(


### PR DESCRIPTION
## Summary

- Every Orion FCC chat turn spawns `claude -p` (`orion/harness/fcc_motor.py::run_fcc_turn`) with `cwd=HARNESS_FCC_WORKSPACE`, which is set to `/mnt/scripts/Orion-Sapienform` — the shared repo checkout — so the subprocess picks up this repo's own `.claude/settings.json` SessionStart/Stop hooks exactly as an interactive coding session would.
- `session_start_agent_board.py`'s `render_checkin_context()` calls `upsert_presence()`, so every single chat turn was writing a spurious presence row to the real host-local agent workspace board — the same board `AGENTS.md` §2 uses to detect concurrent-agent collisions in the shared checkout.
- Both hooks also contributed to FCC harness step-count noise, the same failure class already diagnosed (not fixed) as "Bug 1" in the FCC-harness step-noise investigation.
- Fix: `_build_subprocess_env()` now tags the FCC subprocess env with `ORION_FCC_SUBPROCESS=1`; both `session_start_agent_board.py` and `session_stop_agent_board.py` check for it and no-op immediately (no stdout, no board writes) when set.

## Outcome moved

Agent workspace board presence data for the shared checkout is no longer polluted by per-turn chat noise; FCC harness step counts drop by up to 2 non-conversational steps per turn (SessionStart + Stop hook fires).

## Current architecture

`run_fcc_turn()` spawns `claude -p` with `cwd=workspace` (the repo checkout) and an env built by `_build_subprocess_env()`. Because Claude Code hooks are resolved from the invoking process's cwd, every FCC subprocess inherited this repo's real `.claude/settings.json` hooks — including the agent-board SessionStart/Stop hooks meant for actual coding sessions.

## Architecture touched

- `orion/harness/fcc_motor.py` — FCC subprocess env builder
- `scripts/hooks/session_start_agent_board.py`, `scripts/hooks/session_stop_agent_board.py` — board hooks

## Files changed

- `orion/harness/fcc_motor.py`: tag the FCC subprocess env with `ORION_FCC_SUBPROCESS=1`
- `scripts/hooks/session_start_agent_board.py`: no-op when `ORION_FCC_SUBPROCESS` is set
- `scripts/hooks/session_stop_agent_board.py`: no-op when `ORION_FCC_SUBPROCESS` is set
- `tests/scripts/test_session_agent_board_hooks.py`: regression test asserting both hooks emit no stdout and write no board file when the marker is set

## Schema / bus / API changes

None.

## Env/config changes

- Added keys: `ORION_FCC_SUBPROCESS` — internal signal set programmatically by `fcc_motor.py`, not an operator-facing config key. No `.env_example` entry needed (not read from the environment by an operator, only set by code).
- `.env_example` updated: n/a
- local `.env` synced: n/a (no `.env_example` change)

## Tests run

```text
orion_dev/bin/pytest tests/scripts/test_session_agent_board_hooks.py -q
8 passed

PYTHONPATH=<worktree> orion_dev/bin/pytest orion/harness/tests/test_fcc_motor_mcp.py orion/harness/tests/test_fcc_motor_cancel.py orion/harness/tests/test_fcc_motor_summarize.py -q
36 passed
```

## Evals run

None applicable — this is a hook-gating change with deterministic unit coverage, not a behavior/quality change needing an eval harness.

## Docker/build/smoke checks

Not run — no runtime/config-at-boot/dependency/port change; this only affects env passed to a subprocess `claude -p` spawns at turn time.

## Review findings fixed

Ran `/code-review` (medium effort) in-conversation, plus a targeted Explore-agent verification pass checking for (1) tests asserting exact env-dict contents, (2) `ORION_FCC_SUBPROCESS` name collisions, (3) other code pattern-matching over the subprocess env's keys. No findings on any of the three checks — the change is additive and isolated. Zero material findings; no fixes needed.

## Restart required

```text
No restart required (Python hook scripts and harness code re-read on each subprocess spawn; no long-running service holds this code in memory as a daemon that needs a bounce for this specific path, since fcc_motor.py is invoked fresh per FCC turn by orion-harness-governor). If orion-harness-governor runs as a long-lived process that imports fcc_motor.py at import time rather than per-call, restart it to pick up the new env key:
```

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-harness-governor/.env \
  -f services/orion-harness-governor/docker-compose.yml \
  restart
```

## Risks / concerns

- Severity: low
- Concern: PreToolUse hooks (graphify hook-guard, `destructive_git_guard.py`) and the SessionStart worktree-summary hook (`session_start_worktree_summary.py`) still fire inside FCC subprocesses for the same cwd-inheritance reason — this PR only gates the two hooks explicitly named "agent board." Left out of scope since it wasn't asked for and each has a different noise/risk profile worth assessing separately.
- Mitigation: same `ORION_FCC_SUBPROCESS` marker is now available as the gating mechanism if/when those get addressed too.

## PR link