### PR TITLE
fix(substrate): allow evidence nodes through Falkor durable write gate

### DIFF
--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -3,8 +3,8 @@
 This module is intentionally pure: no Redis client, no store cache, no graph
 queries. It owns the durable property allowlist used by FalkorSubstrateStore.
 
-Durable Falkor support is intentionally Concept + SubstrateEdge first. Other
-node kinds must not be silently persisted as incomplete native rows.
+Durable Falkor support is intentionally Concept + Evidence + SubstrateEdge.
+Other node kinds must not be silently persisted as incomplete native rows.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from typing import Any
 from orion.core.schemas.cognitive_substrate import (
     BaseSubstrateNodeV1,
     ConceptNodeV1,
+    EvidenceNodeV1,
     NodeRefV1,
     SubstrateActivationV1,
     SubstrateEdgeV1,
@@ -100,15 +101,20 @@ def _common_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None)
 
 
 def encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) -> dict[str, Any]:
-    if node.node_kind != "concept":
+    if node.node_kind not in ("concept", "evidence"):
         raise ValueError(
-            f"falkor durable path supports concept nodes only; got node_kind={node.node_kind!r}"
+            "falkor durable path supports concept and evidence nodes only; "
+            f"got node_kind={node.node_kind!r}"
         )
     props = _common_node_properties(node, identity_key)
-    props["label"] = getattr(node, "label")
-    props["definition"] = getattr(node, "definition", None)
-    props["taxonomy_path_json"] = _json_list(getattr(node, "taxonomy_path", None))
-    props.update(_dynamics_properties_from_metadata(node.metadata))
+    if node.node_kind == "concept":
+        props["label"] = getattr(node, "label")
+        props["definition"] = getattr(node, "definition", None)
+        props["taxonomy_path_json"] = _json_list(getattr(node, "taxonomy_path", None))
+        props.update(_dynamics_properties_from_metadata(node.metadata))
+    else:
+        props["evidence_type"] = getattr(node, "evidence_type")
+        props["content_ref"] = getattr(node, "content_ref")
     return props
 
 
@@ -278,6 +284,31 @@ def decode_concept_node(row: Mapping[str, Any]) -> ConceptNodeV1 | None:
         provenance=_provenance_from_row(row),
         metadata=_dynamics_metadata_from_row(row),
     )
+
+
+def decode_evidence_node(row: Mapping[str, Any]) -> EvidenceNodeV1 | None:
+    if row.get("node_kind") != "evidence":
+        return None
+    return EvidenceNodeV1(
+        node_id=str(row["node_id"]),
+        evidence_type=str(row["evidence_type"]),
+        content_ref=str(row["content_ref"]),
+        anchor_scope=row["anchor_scope"],
+        subject_ref=row.get("subject_ref"),
+        promotion_state=row.get("promotion_state") or "proposed",
+        risk_tier=row.get("risk_tier") or "low",
+        temporal=_temporal_from_row(row),
+        signals=_signals_from_row(row),
+        provenance=_provenance_from_row(row),
+        metadata={},
+    )
+
+
+def decode_node(row: Mapping[str, Any]) -> BaseSubstrateNodeV1 | None:
+    node = decode_concept_node(row)
+    if node is not None:
+        return node
+    return decode_evidence_node(row)
 
 
 def decode_edge(row: Mapping[str, Any]) -> SubstrateEdgeV1 | None:

--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -4,10 +4,10 @@ Queries and reads are served from the in-process cache (same shape as a warm
 GraphDBSubstrateStore). Durable writes go through an injectable sync client so
 unit tests never need a live FalkorDB.
 
-Durable support is Concept + SubstrateEdge first. Cold-start hydration prefers
-native scalar properties and falls back to legacy ``payload_json`` rows,
-rewriting them to native properties (and removing the blob) on successful
-concept/edge decode.
+Durable support is Concept + Evidence + SubstrateEdge. Cold-start hydration
+prefers native scalar properties and falls back to legacy ``payload_json``
+rows, rewriting them to native properties (and removing the blob) on
+successful concept/edge decode.
 """
 
 from __future__ import annotations
@@ -27,8 +27,8 @@ from orion.core.schemas.cognitive_substrate import (
 )
 from orion.graph.property_guard import sanitize_metadata
 from orion.substrate.falkor_codec import (
-    decode_concept_node,
     decode_edge,
+    decode_node,
     encode_edge_properties,
     encode_node_properties,
     node_label_for_kind,
@@ -62,6 +62,8 @@ NATIVE_NODE_RETURN_FIELDS: tuple[str, ...] = (
     "label",
     "definition",
     "taxonomy_path_json",
+    "evidence_type",
+    "content_ref",
     "anchor_scope",
     "subject_ref",
     "promotion_state",
@@ -232,8 +234,9 @@ def _with_sanitized_metadata(model: Any) -> Any:
 class FalkorSubstrateStore:
     """SubstrateGraphStore with Falkor write-through and in-memory read cache.
 
-    Durable persistence is Concept + SubstrateEdge only. Non-concept node
-    upserts raise ``ValueError`` rather than writing incomplete native rows.
+    Durable persistence is Concept + Evidence + SubstrateEdge only. Node
+    upserts for any other node kind raise ``ValueError`` rather than writing
+    incomplete native rows.
     """
 
     def __init__(
@@ -276,7 +279,7 @@ class FalkorSubstrateStore:
 
         for row in _normalize_rows(node_rows, fields=NATIVE_NODE_RETURN_FIELDS):
             try:
-                node = decode_concept_node(row)
+                node = decode_node(row)
             except Exception:
                 logger.warning("falkor_substrate_hydrate_node_invalid")
                 continue
@@ -382,9 +385,9 @@ class FalkorSubstrateStore:
         return self._cache.get_edge_id_by_identity(identity_key)
 
     def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
-        if getattr(node, "node_kind", None) != "concept":
+        if getattr(node, "node_kind", None) not in ("concept", "evidence"):
             raise ValueError(
-                "FalkorSubstrateStore durable writes support concept nodes only; "
+                "FalkorSubstrateStore durable writes support concept and evidence nodes only; "
                 f"got node_kind={getattr(node, 'node_kind', None)!r}"
             )
         node = _with_sanitized_metadata(node)

--- a/orion/substrate/tests/test_falkor_codec.py
+++ b/orion/substrate/tests/test_falkor_codec.py
@@ -7,6 +7,7 @@ import pytest
 from orion.core.schemas.cognitive_substrate import (
     ConceptNodeV1,
     DriveNodeV1,
+    EvidenceNodeV1,
     NodeRefV1,
     SubstrateActivationV1,
     SubstrateEdgeV1,
@@ -17,6 +18,8 @@ from orion.core.schemas.cognitive_substrate import (
 from orion.substrate.falkor_codec import (
     decode_concept_node,
     decode_edge,
+    decode_evidence_node,
+    decode_node,
     encode_edge_properties,
     encode_node_properties,
     node_label_for_kind,
@@ -44,6 +47,28 @@ def _concept() -> ConceptNodeV1:
         label="Alpha",
         definition="A test concept",
         taxonomy_path=["root", "branch"],
+        anchor_scope="orion",
+        promotion_state="canonical",
+        temporal=_temporal(),
+        provenance=_provenance(evidence_refs=["ev:1", "ev:2"]),
+        signals=SubstrateSignalBundleV1(
+            confidence=0.8,
+            salience=0.7,
+            activation=SubstrateActivationV1(
+                activation=0.6,
+                recency_score=0.5,
+                decay_floor=0.1,
+            ),
+        ),
+        metadata={"quarantine": "not durable SoR"},
+    )
+
+
+def _evidence() -> EvidenceNodeV1:
+    return EvidenceNodeV1(
+        node_id="evidence-alpha",
+        evidence_type="chat_turn",
+        content_ref="ev-content-ref-1",
         anchor_scope="orion",
         promotion_state="canonical",
         temporal=_temporal(),
@@ -126,7 +151,7 @@ def test_encode_node_properties_rejects_non_concept():
         temporal=_temporal(),
         provenance=_provenance(),
     )
-    with pytest.raises(ValueError, match="concept nodes only"):
+    with pytest.raises(ValueError, match="concept and evidence nodes only"):
         encode_node_properties(drive, identity_key="drive:curiosity")
 
 
@@ -150,6 +175,73 @@ def test_decode_concept_node_reconstructs_minimal_typed_model():
     # see test_concept_with_no_dynamics_metadata_encodes_and_decodes_with_sane_defaults
     # for the full defaults contract.
     assert node.metadata == {"dynamic_pressure": 0.0, "dormant": False}
+
+
+def test_encode_evidence_node_properties_are_native_scalars():
+    props = encode_node_properties(_evidence(), identity_key="evidence:alpha")
+
+    assert "payload_json" not in props
+    assert "metadata" not in props
+    assert "label" not in props
+    assert "definition" not in props
+    assert "taxonomy_path_json" not in props
+    assert props == {
+        "node_id": "evidence-alpha",
+        "node_kind": "evidence",
+        "identity_key": "evidence:alpha",
+        "anchor_scope": "orion",
+        "subject_ref": None,
+        "promotion_state": "canonical",
+        "risk_tier": "low",
+        "confidence": 0.8,
+        "salience": 0.7,
+        "activation": 0.6,
+        "recency_score": 0.5,
+        "decay_half_life_seconds": None,
+        "decay_floor": 0.1,
+        "observed_at": "2026-07-16T00:00:00+00:00",
+        "valid_from": None,
+        "valid_to": None,
+        "provenance_authority": "local_inferred",
+        "provenance_source_kind": "test",
+        "provenance_source_channel": "test:falkor_codec",
+        "provenance_producer": "test_falkor_codec",
+        "provenance_model_name": None,
+        "provenance_correlation_id": None,
+        "provenance_trace_id": None,
+        "provenance_tier_rank": None,
+        "evidence_refs_json": '["ev:1", "ev:2"]',
+        "evidence_type": "chat_turn",
+        "content_ref": "ev-content-ref-1",
+    }
+
+
+def test_decode_evidence_node_reconstructs_minimal_typed_model():
+    row = encode_node_properties(_evidence(), identity_key="evidence:alpha")
+
+    node = decode_evidence_node(row)
+
+    assert node is not None
+    assert node.node_id == "evidence-alpha"
+    assert node.node_kind == "evidence"
+    assert node.evidence_type == "chat_turn"
+    assert node.content_ref == "ev-content-ref-1"
+    assert node.provenance.evidence_refs == ["ev:1", "ev:2"]
+
+
+def test_decode_node_dispatches_to_concept_or_evidence():
+    concept_row = encode_node_properties(_concept(), identity_key="concept:alpha")
+    evidence_row = encode_node_properties(_evidence(), identity_key="evidence:alpha")
+
+    concept_result = decode_node(concept_row)
+    evidence_result = decode_node(evidence_row)
+
+    assert isinstance(concept_result, ConceptNodeV1)
+    assert isinstance(evidence_result, EvidenceNodeV1)
+
+    unrelated_row = dict(concept_row)
+    unrelated_row["node_kind"] = "drive"
+    assert decode_node(unrelated_row) is None
 
 
 def test_encode_edge_properties_are_native_scalars_without_payload_json():

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -7,6 +7,7 @@ import pytest
 from orion.core.schemas.cognitive_substrate import (
     ConceptNodeV1,
     DriveNodeV1,
+    EvidenceNodeV1,
     NodeRefV1,
     SubstrateEdgeV1,
     SubstrateProvenanceV1,
@@ -28,6 +29,24 @@ def _concept(*, node_id: str = "sub-node-a", metadata: dict | None = None) -> Co
         node_id=node_id,
         label="alpha",
         taxonomy_path=["root"],
+        anchor_scope="orion",
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="test",
+            producer="test_falkor_store",
+            evidence_refs=["ev:store"],
+        ),
+        metadata=metadata or {},
+    )
+
+
+def _evidence(*, node_id: str = "evidence-node-a", metadata: dict | None = None) -> EvidenceNodeV1:
+    return EvidenceNodeV1(
+        node_id=node_id,
+        evidence_type="chat_turn",
+        content_ref="ev-content-ref-store",
         anchor_scope="orion",
         temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
         provenance=SubstrateProvenanceV1(
@@ -210,10 +229,123 @@ def test_falkor_rejects_non_concept_durable_write():
         ),
     )
 
-    with pytest.raises(ValueError, match="concept nodes only"):
+    with pytest.raises(ValueError, match="concept and evidence nodes only"):
         store.upsert_node(identity_key="drive:curiosity", node=drive)
 
     assert client.calls == []
+
+
+def test_falkor_upsert_evidence_uses_native_cypher_properties():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    node = _evidence(node_id="evidence-native-alpha")
+
+    store.upsert_node(identity_key="evidence:alpha", node=node)
+
+    cypher, params = client.calls[-1]
+    _assert_no_payload_json_sor(cypher, params)
+    assert "REMOVE n.payload_json" in cypher
+    assert "MERGE (n:SubstrateNode:Evidence {node_id: $node_id})" in cypher
+    assert "n.evidence_type = $evidence_type" in cypher
+    assert "n.content_ref = $content_ref" in cypher
+    assert params["node_id"] == "evidence-native-alpha"
+    assert params["node_kind"] == "evidence"
+    assert params["identity_key"] == "evidence:alpha"
+    assert params["evidence_type"] == "chat_turn"
+    assert params["content_ref"] == "ev-content-ref-store"
+    assert "label" not in params
+    assert "definition" not in params
+    assert "taxonomy_path_json" not in params
+
+
+def test_falkor_hydrates_concept_and_evidence_from_mixed_native_rows():
+    client = RecordingFalkorClient(
+        hydrate_node_rows=[
+            {
+                "node_id": "concept-mixed",
+                "node_kind": "concept",
+                "identity_key": "concept:mixed",
+                "label": "Mixed concept",
+                "definition": None,
+                "taxonomy_path_json": "[]",
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "canonical",
+                "risk_tier": "low",
+                "confidence": 0.7,
+                "salience": 0.6,
+                "activation": 0.5,
+                "recency_score": 0.4,
+                "decay_floor": 0.0,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:falkor",
+                "provenance_producer": "test_falkor_store",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+                "evidence_refs_json": "[]",
+            },
+            {
+                "node_id": "evidence-mixed",
+                "node_kind": "evidence",
+                "identity_key": "evidence:mixed",
+                "evidence_type": "chat_turn",
+                "content_ref": "ev-content-ref-mixed",
+                "anchor_scope": "orion",
+                "subject_ref": None,
+                "promotion_state": "proposed",
+                "risk_tier": "low",
+                "confidence": 0.65,
+                "salience": 0.55,
+                "activation": 0.45,
+                "recency_score": 0.35,
+                "decay_floor": 0.0,
+                "decay_half_life_seconds": None,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "valid_from": None,
+                "valid_to": None,
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:falkor",
+                "provenance_producer": "test_falkor_store",
+                "provenance_model_name": None,
+                "provenance_correlation_id": None,
+                "provenance_trace_id": None,
+                "provenance_tier_rank": None,
+                "evidence_refs_json": '["ev:mixed"]',
+            },
+        ]
+    )
+
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    concept_node = store.get_node_by_id("concept-mixed")
+    assert concept_node is not None
+    assert concept_node.node_kind == "concept"
+    assert concept_node.label == "Mixed concept"
+    assert store.get_node_id_by_identity("concept:mixed") == "concept-mixed"
+
+    evidence_node = store.get_node_by_id("evidence-mixed")
+    assert evidence_node is not None
+    assert evidence_node.node_kind == "evidence"
+    assert evidence_node.evidence_type == "chat_turn"
+    assert evidence_node.content_ref == "ev-content-ref-mixed"
+    assert evidence_node.provenance.evidence_refs == ["ev:mixed"]
+    assert store.get_node_id_by_identity("evidence:mixed") == "evidence-mixed"
 
 
 def test_falkor_hydrates_concept_from_native_properties():


### PR DESCRIPTION
## Summary

Confirmed live: `POST /api/substrate/concepts/ingest-topic-foundry` was failing on the very first evidence node of every real ingestion run, blocking the entire topic-foundry concept pipeline (both the manual route and the autonomous scheduler enabled in PR #1139). Root cause: `FalkorSubstrateStore.upsert_node()`/`falkor_codec.encode_node_properties()` hard-rejected any `node_kind != "concept"` — a deliberate, documented first-cut scoping decision from PR #1120 ("Runtime cutover is deferred until graph-shaped runtime writers have their own tests and codec coverage"). `orion/substrate/adapters/topic_foundry.py::map_topic_foundry_run_to_substrate()` produces one `EvidenceNodeV1` per real topic alongside each `ConceptNodeV1`, and `materializer.py::apply_record()` writes every node in a record unconditionally with no kind filtering — so the first evidence node aborted the whole write.

This closes that gap the same way PR #1145 closed it for dynamics scalars: extends the codec/store node-kind gate to accept `concept` + `evidence` (nothing else — `drive`/`contradiction`/`tension`/etc. still raise, unchanged).

## Outcome moved

Topic-foundry ingestion can now actually complete a full write (concepts + evidence + edges) against the live Falkor backend instead of aborting on the first evidence node.

## Current architecture

`_LABEL_BY_KIND` (Cypher-label mapping) and `SubstrateIdentityResolver.canonical_node_key()` (identity-key resolution) already had full `"evidence"` support before this diff — only the write/read gate itself was the blocker.

## Files changed

- `orion/substrate/falkor_codec.py`: `encode_node_properties()` branches per-kind (concept gets `label`/`definition`/`taxonomy_path_json`/dynamics fields, evidence gets `evidence_type`/`content_ref`), sharing `_common_node_properties()`. New `decode_evidence_node()` mirrors `decode_concept_node()`. New `decode_node()` dispatcher tries concept then evidence.
- `orion/substrate/falkor_store.py`: `NATIVE_NODE_RETURN_FIELDS` gains `evidence_type`/`content_ref` (harmless `NULL` on concept rows). `upsert_node()`'s guard now accepts `("concept", "evidence")`. `_hydrate_from_durable()` uses the new `decode_node()` dispatcher so evidence nodes survive cold-start hydration too.
- `orion/substrate/tests/test_falkor_codec.py` / `test_falkor_store.py`: new fixtures/tests for evidence encode/decode round-trip, dispatcher branching (concept/evidence/neither), real Cypher-string assertions for the upsert path (`MERGE (n:SubstrateNode:Evidence {node_id: $node_id})`), and a mixed concept+evidence cold-start hydration round trip.

No changes to `materializer.py`, `adapters/topic_foundry.py`, or `concept_atlas_routes.py` — the bug was entirely in the codec/store gate.

## Schema / bus / API changes

- Added: none (no new schema fields — `EvidenceNodeV1` already existed).
- Removed: none.
- Renamed: none.
- Behavior changed: `FalkorSubstrateStore.upsert_node()` now accepts evidence nodes instead of raising.
- Compatibility notes: node kinds other than `concept`/`evidence` (`drive`, `contradiction`, `tension`, ...) still raise `ValueError`, unchanged — this is a narrow gate-widening, not a general cutover.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. .venv/bin/python -m pytest orion/substrate/tests -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
337 passed

PYTHONPATH=. .venv/bin/python -m pytest services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py services/orion-hub/tests/test_concept_atlas_routes.py services/orion-hub/tests/test_topic_foundry_scheduler.py -q
58 passed
```

(`test_refit_salience_stub.py` excluded from the combined run only — pre-existing pytest rootdir collision, unrelated.)

`orion/substrate/tests/test_dynamics_falkor_routed.py` (PR #1145's dynamics-scalar test) passes unmodified — confirms the concept-node dynamics path is untouched by this patch.

## Evals run

No eval harness exists for this seam.

## Docker/build/smoke checks

Not run in this session — this fix was built and reviewed in an isolated worktree without a live FalkorDB. **Live verification is the natural next step**: the bug was originally found by hitting the running Hub instance's ingest route directly and observing the real failure; the same manual trigger should be re-run post-deploy to confirm the fix closes the loop for real (this PR's own tests use `RecordingFalkorClient`, a test double — they prove the codec/store contract is now correct, not that the live container is fixed until redeployed and re-tested).

## Review findings fixed

None — code review (dispatched via the code-review skill in a subagent) found no material issues. It specifically checked and ruled out: whether `EvidenceNodeV1.metadata` gets silently dropped (confirmed matches the pre-existing concept-node pattern, and no live consumer reads it back — the two real callers either don't set it or set only re-derivable values), whether the `decode_node()` dispatch order could misclassify a row (confirmed both decoders gate strictly on an exact `node_kind` match, no overlap risk), whether evidence-node identity-key resolution is safe (confirmed `reconcile.py`'s `evidence|...` namespace prefix already existed and doesn't collide with `concept|...`), and whether the topic-foundry `supports` edge (evidence → concept) resolves correctly now that evidence nodes are real graph nodes (confirmed `materializer.py::apply_record()` always processes all nodes before any edges).

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

## Risks / concerns

- Severity: low
- Concern: this hasn't been verified against a live FalkorDB yet (isolated worktree, no real backend available).
- Mitigation: recommend re-running the manual ingest trigger (`POST /api/substrate/concepts/ingest-topic-foundry`) against the live Hub instance post-deploy — this is exactly the check that found the original bug, so it's the right verification to repeat.

## PR link

(populated after creation)