### PR TITLE
docs: surface drive/field decay-mismatch bug history to future agents automatically

### DIFF
--- a/orion/spark/concept_induction/CLAUDE.md
+++ b/orion/spark/concept_induction/CLAUDE.md
@@ -1,0 +1,30 @@
+# orion/spark/concept_induction — read before touching drive/tension math
+
+This directory (`drives.py`, `tensions.py`, `bus_worker.py`) has had the **same class of bug
+found and fixed independently multiple times** because the write-up wasn't checked first. Before
+changing `DriveEngine.update()`, `extract_tensions_from_self_state()`, or `_update_drive_pressures`:
+
+**Read `orion/autonomy/drives_and_autonomy_retrospective.md` first — §5b through §5e
+specifically.** It has the exact mechanisms, the live evidence, and what's already fixed vs.
+still open. Don't re-derive it from scratch; that's exactly what already happened three times.
+
+Known, load-bearing facts as of 2026-07-17 (verify against the retrospective before assuming
+these are still current):
+
+- `DriveEngine.update()`'s live path (`leaky_math_enabled=True`) applies tension impacts
+  **sequentially per event**, not summed-then-clamped — a sum-then-clamp design let a fold batch
+  collapse multiple drives to an identical value (fixed PR #1148, §5d). If you're changing this
+  aggregation again, know why the sequential design exists before reverting to a sum.
+- `_update_drive_pressures` (`bus_worker.py`) only writes the persisted integrator once per
+  `_DRIVE_FOLD_INTERVAL_SEC=900s` (O2, PR #1126) — every bus event still gets a live decay-only
+  read. If two drives ever end up sharing an identical persisted pressure, nothing here detects
+  or breaks that tie automatically; it self-heals only when a differentiating tension happens to
+  land (§5e — this took ~10.5h once, not instant).
+- The six-drive taxonomy (`coherence, continuity, capability, relational, predictive, autonomy`)
+  has no independently-derived rationale — it came from an external design chat. See
+  `docs/superpowers/specs/2026-07-11-drive-taxonomy-conceptual-audit-design.md` before assuming
+  it's settled.
+
+This directory shares the exact same bug *class* — a decay mechanism whose injection cadence
+isn't reconciled against its own decay rate — with `services/orion-field-digester`. If you're
+debugging a saturation/oscillation/collapse symptom here, check that service's `CLAUDE.md` too.

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -814,6 +814,12 @@ class ConceptWorker:
         getting a fresh drive_state every event -- only the WRITE side is
         throttled, not the READ side. Returns (pressures, activations, folded).
 
+        See this directory's CLAUDE.md and orion/autonomy/drives_and_autonomy_
+        retrospective.md sec5b-sec5e before changing this function or DriveEngine's
+        aggregation math -- if two drives ever end up sharing an identical persisted
+        pressure, this function does not detect or break that tie; it only self-heals
+        once a differentiating tension happens to land (took ~10.5h once, see sec5e).
+
         Note: the pressure component of goal-proposal priority scoring
         (GoalProposalEngine._priority) can lag up to _DRIVE_FOLD_INTERVAL_SEC
         behind a freshly-dominant drive's own tick -- accepted, documented

--- a/orion/spark/concept_induction/drives.py
+++ b/orion/spark/concept_induction/drives.py
@@ -1,3 +1,8 @@
+"""Read orion/autonomy/drives_and_autonomy_retrospective.md (sec5b-sec5e) and this
+directory's CLAUDE.md before changing DriveEngine.update()'s aggregation math -- the
+sum-then-clamp-once collapse bug this module used to have was found and re-derived
+independently more than once because that write-up wasn't checked first."""
+
 from __future__ import annotations
 
 import math

--- a/services/orion-field-digester/CLAUDE.md
+++ b/services/orion-field-digester/CLAUDE.md
@@ -1,0 +1,26 @@
+# services/orion-field-digester — read before touching decay/perturbation math
+
+This service (`app/digestion/decay.py`, `app/digestion/perturbation.py`) has had the **same
+class of bug found and fixed independently multiple times** because the write-up wasn't checked
+first. Before changing `apply_decay()` or `apply_perturbations()`:
+
+**Read this service's own `README.md`, section "Decay vs. injection-interval mismatch", and
+`orion/autonomy/drives_and_autonomy_retrospective.md` §5b/§5c.** They have the exact mechanism,
+the live evidence, and what's already fixed. Don't re-derive it from scratch.
+
+Known, load-bearing facts as of 2026-07-17 (verify against the README before assuming these are
+still current):
+
+- `apply_decay()` no longer decays a `NODE_DECAY_CHANNELS` channel unconditionally every
+  `RECEIPT_POLL_INTERVAL_SEC=2s` tick — it holds the value flat while within
+  `FIELD_DECAY_STALENESS_THRESHOLD_SEC` (default 90s) of its last real write
+  (`FieldStateV1.node_vector_updated_at`, fixed PR #1144). If a channel is written directly to
+  `node_vectors` **outside** `apply_perturbations()` (as `worker.py`'s `field_coherence_warning`
+  and `suppression.py`'s `staleness` reset both do), it must also record a
+  `node_vector_updated_at` stamp or it silently falls back to the old unconditional-decay
+  behavior for that one channel — this has already been missed once by review.
+- This is the mirror-image bug to `orion/spark/concept_induction`'s `DriveEngine.update()`: same
+  root cause (decay/injection-cadence mismatch), opposite symptom (this one produces a
+  sawtooth from decay being *too fast* relative to injection; the other produces a
+  clamp-collapse from decay being *too slow*). If you're debugging a saturation, oscillation, or
+  collapse symptom anywhere in the drive/field pipeline, check both `CLAUDE.md`s, not just one.

--- a/services/orion-field-digester/app/digestion/decay.py
+++ b/services/orion-field-digester/app/digestion/decay.py
@@ -1,3 +1,8 @@
+"""Read this service's README ("Decay vs. injection-interval mismatch") and this
+directory's CLAUDE.md before changing apply_decay() -- the unconditional-per-tick-decay
+sawtooth bug this module used to have was found and re-derived independently more than
+once because that write-up wasn't checked first."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone

--- a/services/orion-field-digester/app/digestion/perturbation.py
+++ b/services/orion-field-digester/app/digestion/perturbation.py
@@ -1,3 +1,6 @@
+"""Tightly coupled to app/digestion/decay.py -- read that module's docstring and this
+directory's CLAUDE.md before changing how node_vector_updated_at gets written here."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary

Root-cause fix for a meta-problem, not a code bug: the same decay/injection-cadence-mismatch bug class was independently rediscovered multiple times (twice in orion-field-digester, once in DriveEngine) across today's investigation, despite `orion/autonomy/drives_and_autonomy_retrospective.md` already documenting it in detail. The doc existed; nothing pointed an agent at it before they started digging.

- New `orion/spark/concept_induction/CLAUDE.md` and `services/orion-field-digester/CLAUDE.md` — directory-scoped, load automatically for any agent working there (unlike a README that has to be found), pointing at the retrospective and naming the known-fixed mechanisms so the next agent doesn't re-derive them from scratch.
- Short pointer comments added directly in the hot files (`drives.py`, `decay.py`, `perturbation.py`, `bus_worker.py`'s `_update_drive_pressures`) as a second layer — even if CLAUDE.md loading is ever bypassed, reading the file surfaces it.
- Registered via `graphify save-result`/`graphify reflect` so this repo's mandatory graphify-query-before-touching-source hook surfaces it too (host-local only, not committed — matches existing `graphify-out/.gitignore` scoping).

No behavior change — docstrings/comments only.

## Test plan

- [x] `ast.parse` on all 3 edited Python files (docstring-before-`__future__ import` positioning is a real Python constraint, verified not violated)
- [x] `pytest orion/spark/concept_induction/tests -q` — 168 passed
- [x] `pytest services/orion-field-digester/tests -q` — 100 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)