### PR TITLE
fix(rdf-writer): stop writing cognition.trace/metacog.trace to Fuseki

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-17-rdf-writer-cognition-metacog-fuseki-kill-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-rdf-writer-cognition-metacog-fuseki-kill-pr.md
@@ -1,0 +1,107 @@
+# PR report: stop writing cognition.trace / metacog.trace to Fuseki
+
+## Summary
+
+- Live investigation this session found `orion-rdf-writer` still committing ~750 real writes/6h to Fuseki for exactly two channels: `orion:metacog:trace` and `orion:cognition:trace`.
+- Both are already durably persisted in Postgres via `orion-sql-writer`: `orion_metacognitive_trace` (already triple-written to sql-writer, vector-writer, and rdf-writer — confirmed via live logs) and `cognition_traces` (confirmed via direct Postgres query: 61,079 live rows, most recent ~1 minute old at check time). `channels.yaml` simply never declared `orion-sql-writer` as a consumer of `orion:cognition:trace` — a stale registry entry, not a missing migration.
+- Consumer audit (done before any producer change, per the split-design doctrine's "producer + consumer + test in the same changeset" rule): confirmed the only other Fuseki reader of these two graphs, `orion-graph-compression`'s episodic federator, is already fail-open by construction and degrades correctly when these 2 of 9 federated graphs go quiet. No other real consumer exists — `orion-recall`'s graph-URI dict entries for both are dead, unreferenced constants.
+- Removed both channels from `orion-rdf-writer`'s subscribe list, removed their dispatch branches and handler functions, fixed `channels.yaml`'s registry (added `orion-sql-writer` as a real consumer of `orion:cognition:trace`; dropped `orion-rdf-writer` from both).
+- Code review caught and fixed a real env-parity gap: `CHANNEL_COGNITION_TRACE_PUB` was left dangling in `.env_example`/`docker-compose.yml` after the `Settings` field was removed.
+
+## Outcome moved
+
+`orion-rdf-writer` no longer writes redundant copies of cognition/metacognitive trace data to Fuseki — both already have a real, live, non-degrading durable home in Postgres. This is the second concrete "wrong-tool precedent" cleanup in the same arc as the drive-audit RDF kill (2026-07-15) and the Falkor substrate-runtime cutover (PR #1145/#1153, same session).
+
+## Current architecture
+
+Before this patch, `orion-rdf-writer` subscribed to `orion:metacog:trace` and `orion:cognition:trace`, built RDF triples for each (`_handle_metacognitive_trace`, `_handle_cognition_trace` in `rdf_builder.py`), and committed them to Fuseki graphs `orion:metacog`/`orion:cognition`. `orion-sql-writer` was *also* independently subscribed to both channels already, with real SQLAlchemy models and live data — making the RDF copy pure redundancy with no consumer that needed it (verified via a consumer audit, not assumed).
+
+## Architecture touched
+
+- `services/orion-rdf-writer/app/settings.py`: subscribe list, removed field.
+- `services/orion-rdf-writer/app/rdf_builder.py`: dispatch + handler removal.
+- `services/orion-rdf-writer/.env_example` / `docker-compose.yml`: dangling key cleanup (review finding).
+- `orion/bus/channels.yaml`: registry accuracy for both channels.
+
+## Files changed
+
+- `services/orion-rdf-writer/app/settings.py`: removed `"orion:metacog:trace"` and `CHANNEL_COGNITION_TRACE_PUB` from `get_all_subscribe_channels()`; removed the now-unused `CHANNEL_COGNITION_TRACE_PUB` field; added an explanatory comment mirroring the existing `CHANNEL_MEMORY_DRIVES_AUDIT` precedent.
+- `services/orion-rdf-writer/app/rdf_builder.py`: removed the `cognition.trace`/`metacognitive.trace.v1` dispatch branches, the `_handle_cognition_trace`/`_handle_metacognitive_trace` functions, and their now-unused schema imports.
+- `services/orion-rdf-writer/.env_example`, `services/orion-rdf-writer/docker-compose.yml`: removed dangling `CHANNEL_COGNITION_TRACE_PUB` (review finding).
+- `orion/bus/channels.yaml`: `orion:metacog:trace` drops `orion-rdf-writer` as a consumer; `orion:cognition:trace` gains `orion-sql-writer` (registry accuracy — it was already a real consumer) and never listed `orion-rdf-writer`.
+- `services/orion-rdf-writer/tests/test_autonomy_materialization.py`: two new channel-not-subscribed regression tests (mirroring the existing drive-audit precedent test in the same file) and two new quiet-no-op dispatch tests.
+- `services/orion-rdf-writer/tests/test_service_rdf_store_integration.py`: removed both kinds from the parametrized "writes for kind" test (that test fully mocks the builder, so this is cosmetic — real per-kind behavior is covered unmocked in `test_autonomy_materialization.py` instead; mirrors that `memory.drives.audit.v1` was never in this list either).
+
+## Schema / bus / API changes
+
+- Added: `orion-sql-writer` declared as a consumer of `orion:cognition:trace` in `channels.yaml` (registry accuracy — it was already consuming it in code).
+- Removed: `orion-rdf-writer` as a consumer of `orion:metacog:trace` and (never-declared, now explicitly absent) `orion:cognition:trace`. `CHANNEL_COGNITION_TRACE_PUB` field removed from `orion-rdf-writer`'s `Settings` (unrelated same-named fields in `orion-spark-introspector`, `orion-equilibrium-service`, `orion-cortex-exec` are untouched — each owns its own independent field).
+- Renamed: none.
+- Behavior changed: `orion-rdf-writer` no longer writes `orion:cognition`/`orion:metacog` Fuseki graphs. `orion-graph-compression`'s episodic region summaries stop incorporating cognition/metacog content going forward (a deliberate, understood narrowing — that federator already degrades gracefully for graphs with no new triples; not touched in this patch).
+- Compatibility notes: no schema changes. Postgres tables (`cognition_traces`, `orion_metacognitive_trace`) already existed and are untouched.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: `CHANNEL_COGNITION_TRACE_PUB` from `services/orion-rdf-writer/.env_example`, `docker-compose.yml`, and the local `.env` (synced by hand in the primary checkout, not left as an operator TODO).
+- Renamed keys: none.
+- `.env_example` updated: yes (key removed, comment added explaining why, mirroring the `CHANNEL_MEMORY_DRIVES_AUDIT` precedent already in the same file).
+- local `.env` synced: yes, directly edited `services/orion-rdf-writer/.env` in the primary checkout to remove the same key. `scripts/sync_local_env_from_example.py` run afterward — clean, no divergence reported for `orion-rdf-writer`.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+ORION_BUS_URL=redis://127.0.0.1:6379/0 PYTHONPATH=.:services/orion-rdf-writer \
+  /tmp/orion-test-venv/bin/python3 -m pytest services/orion-rdf-writer/tests -q
+→ 41 passed
+
+git diff --check → clean
+python3 scripts/sync_local_env_from_example.py → clean, no orion-rdf-writer divergence
+scripts/check_service_env_compose_parity.py orion-rdf-writer → same pre-existing
+  17-key gap (unrelated keys: PROJECT, NET, Fuseki JVM tuning, etc.) before and
+  after this patch; no new gap introduced
+```
+
+`scripts/check_schema_registry.py` / `scripts/check_bus_channels.py` referenced in the standard gate list do not exist in this repo. `orion/bus/channels.yaml` was validated by direct YAML parse (262 entries parse cleanly) and manual review of both edited entries.
+
+## Evals run
+
+```text
+No eval harness exists for rdf-writer's channel dispatch; focused deterministic
+tests cover subscription list and dispatch behavior.
+```
+
+## Docker/build/smoke checks
+
+```text
+No Docker rebuild/restart performed for this PR — code change only, no live
+service currently depends on this behavior changing until orion-rdf-writer is
+rebuilt and restarted from this branch.
+```
+
+## Review findings fixed
+
+- Finding (should-fix): `CHANNEL_COGNITION_TRACE_PUB` left dangling in `.env_example`/`docker-compose.yml` after the `Settings` field was removed — dead, misleading operator-facing config (harmless at runtime due to `extra="ignore"`, but a real env-parity gap per CLAUDE.md §7).
+  - Fix: removed from both files with an explanatory comment; verified via `check_service_env_compose_parity.py` that no new parity gap was introduced.
+  - Evidence: commit `fad4801d`.
+
+Reviewer also confirmed: no dangling references to removed symbols anywhere in the repo, `channels.yaml`'s consumer lists are internally consistent for both channels, the new tests exercise real (unmocked) dispatch behavior rather than being tautological, `orion-sql-writer`'s consumption of both channels is confirmed live in code (not stale/aspirational), and unsubscribing introduces no other side effect (nothing depends on `orion:rdf:confirm`/`orion:rdf:error` firing for these two kinds specifically).
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-rdf-writer/.env \
+  -f services/orion-rdf-writer/docker-compose.yml up -d --build
+```
+
+Not required for correctness before merge (no other service depends on this behavior changing), but needed to actually stop the live redundant Fuseki writes this session observed.
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: `orion-graph-compression`'s episodic region summaries will stop incorporating cognition/metacog trace content going forward (2 of its 9 federated graphs go quiet). Already assessed as a deliberate, understood, non-breaking scope narrowing — that federator is fail-open by construction and was not modified in this patch.
+
+## PR link
+
+<link — to be filled in after `gh pr create`>

--- a/docs/superpowers/pr-reports/2026-07-17-rdf-writer-cognition-metacog-fuseki-kill-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-rdf-writer-cognition-metacog-fuseki-kill-pr.md
@@ -104,4 +104,4 @@ Not required for correctness before merge (no other service depends on this beha
 
 ## PR link
 
-<link — to be filled in after `gh pr create`>
+https://github.com/junebug-junie/Orion-Sapienform/pull/1155

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -708,7 +708,10 @@ channels:
     kind: "event"
     schema_id: "MetacognitiveTraceV1"
     producer_services: ["orion-cortex-exec", "orion-hub"]
-    consumer_services: ["orion-sql-writer", "orion-vector-writer", "orion-rdf-writer"]
+    # orion-rdf-writer removed 2026-07-17: pure redundancy with orion-sql-writer's
+    # `orion_metacognitive_trace` table (already the real durable copy) with no
+    # real Fuseki-side reader (see split-design spec).
+    consumer_services: ["orion-sql-writer", "orion-vector-writer"]
     stability: "experimental"
     since: "2026-03-29"
 
@@ -1540,7 +1543,12 @@ channels:
     kind: "event"
     schema_id: "CognitionTracePayload"
     producer_services: ["orion-cortex-exec"]
-    consumer_services: ["orion-spark-introspector", "orion-landing-pad", "orion-bus-tap"]
+    # orion-sql-writer added 2026-07-17: was already a real, live consumer
+    # (durably persists to Postgres `cognition_traces`, confirmed 61k+ live
+    # rows) but had never been declared here -- registry accuracy fix, not a
+    # new wire-up. orion-rdf-writer intentionally NOT a consumer: the RDF copy
+    # was pure redundancy with no real reader (see split-design spec).
+    consumer_services: ["orion-spark-introspector", "orion-landing-pad", "orion-bus-tap", "orion-sql-writer"]
     stability: "experimental"
     since: "2026-01-10"
 

--- a/services/orion-rdf-writer/.env_example
+++ b/services/orion-rdf-writer/.env_example
@@ -28,12 +28,15 @@ CHANNEL_EVENTS_TAGGED_CHAT=orion:tags:chat:enriched
 CHANNEL_CORE_EVENTS=orion:core:events
 CHANNEL_WORKER_RDF=orion:rdf:worker
 CORTEX_LOG_CHANNEL=orion:cortex:telemetry
-CHANNEL_COGNITION_TRACE_PUB=orion:cognition:trace
 CHANNEL_CHAT_HISTORY_TURN=orion:chat:history:turn
 CHANNEL_CHAT_HISTORY_LOG=orion:chat:history:log
 CHANNEL_MEMORY_IDENTITY_SNAPSHOT=orion:memory:identity:snapshot
 # CHANNEL_MEMORY_DRIVES_AUDIT removed 2026-07-15: drive audits are Postgres-only
 # (`drive_audits` via orion-sql-writer); rdf-writer no longer subscribes or handles the kind.
+# CHANNEL_COGNITION_TRACE_PUB and orion:metacog:trace removed 2026-07-17: both
+# cognition.trace and metacognitive.trace.v1 are Postgres-only via orion-sql-writer
+# (`cognition_traces`, `orion_metacognitive_trace`); rdf-writer no longer subscribes
+# or handles either kind.
 CHANNEL_MEMORY_GOALS_PROPOSED=orion:memory:goals:proposed
 CHANNEL_WORLD_PULSE_GRAPH=orion:world_pulse:graph:upsert
 

--- a/services/orion-rdf-writer/app/rdf_builder.py
+++ b/services/orion-rdf-writer/app/rdf_builder.py
@@ -14,8 +14,6 @@ from orion.schemas.collapse_mirror import CollapseMirrorEntry
 from orion.schemas.telemetry.meta_tags import MetaTagsPayload
 from orion.schemas.rdf import RdfWriteRequest, RdfBuildRequest
 from orion.schemas.social_chat import SocialRoomTurnStoredV1
-from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
-from orion.schemas.metacognitive_trace import MetacognitiveTraceV1
 from orion.schemas.world_pulse import GraphDeltaPlanV1
 
 from app.autonomy import build_autonomy_triples
@@ -154,17 +152,10 @@ def build_triples_from_envelope(env_kind: str, payload: Any) -> Tuple[Optional[s
         elif env_kind in ("memory.identity.snapshot.v1", "memory.goals.proposed.v1"):
             return build_autonomy_triples(env_kind, payload)
 
-        # 6. Cognition Trace
-        elif env_kind == "cognition.trace":
-            if isinstance(payload, dict):
-                trace = CognitionTracePayload.model_validate(payload)
-            else:
-                trace = payload
-            return _handle_cognition_trace(g, trace)
-
-        elif env_kind == "metacognitive.trace.v1":
-            trace = MetacognitiveTraceV1.model_validate(payload if isinstance(payload, dict) else payload.model_dump())
-            return _handle_metacognitive_trace(g, trace)
+        # 6. Cognition Trace / Metacognitive Trace deliberately absent (2026-07-17):
+        # both are Postgres-only via orion-sql-writer (cognition_traces,
+        # orion_metacognitive_trace) — the RDF copy was pure redundancy with no
+        # real reader. Do not re-add without a real consumer.
 
         # 7. Core Events (Legacy Fallback or "targets": ["rdf"])
         elif env_kind == "orion.event" or "targets" in str(payload):
@@ -248,56 +239,6 @@ def _handle_cortex_build(g: Graph, args: Any) -> Tuple[str, str]:
     return g.serialize(format="nt"), "orion:cognition"
 
 
-def _handle_cognition_trace(g: Graph, trace: CognitionTracePayload) -> Tuple[str, str]:
-    """
-    Builds a connectable graph for a CognitionTrace.
-    """
-    run_uri = ORION[f"run_{trace.correlation_id}"]
-
-    # Run Metadata
-    g.add((run_uri, RDF.type, ORION.CognitionRun))
-    g.add((run_uri, ORION.correlationId, Literal(str(trace.correlation_id), datatype=XSD.string)))
-    g.add((run_uri, ORION.mode, Literal(trace.mode, datatype=XSD.string)))
-    g.add((run_uri, ORION.verb, Literal(trace.verb, datatype=XSD.string)))
-    g.add((run_uri, ORION.timestamp, Literal(trace.timestamp, datatype=XSD.double)))
-    g.add((run_uri, ORION.sourceService, Literal(trace.source_service, datatype=XSD.string)))
-
-    # final_text omitted: full text lives in Postgres; IRI is the join key
-
-    # Steps
-    prev_step_uri = None
-
-    for i, step in enumerate(trace.steps):
-        step_uri = ORION[f"step_{trace.correlation_id}_{i}"]
-        g.add((step_uri, RDF.type, ORION.CognitionStep))
-        g.add((step_uri, ORION.stepIndex, Literal(i, datatype=XSD.integer)))
-        g.add((step_uri, ORION.stepName, Literal(step.step_name)))
-        g.add((step_uri, ORION.stepVerb, Literal(step.verb_name)))
-        g.add((step_uri, ORION.status, Literal(step.status)))
-
-        # Link to Run
-        g.add((run_uri, ORION.hasStep, step_uri))
-
-        # Sequence
-        if prev_step_uri:
-            g.add((prev_step_uri, ORION.nextStep, step_uri))
-            g.add((step_uri, ORION.prevStep, prev_step_uri))
-        prev_step_uri = step_uri
-
-        # thought/reasoning text omitted: full text lives in Postgres; IRI is the join key
-
-        # Used Services/Tools
-        # We don't have explicit 'tools used' in StepExecutionResult other than artifacts?
-        # Assuming artifacts might contain refs
-        if step.artifacts:
-            for key, val in step.artifacts.items():
-                # Naive check for IDs
-                if isinstance(val, str) and (val.startswith("http") or val.startswith("uuid:")):
-                     g.add((step_uri, ORION.hasEvidenceRef, Literal(val)))
-
-    return g.serialize(format="nt"), "orion:cognition"
-
-
 def _handle_social_room_turn(g: Graph, payload: dict[str, Any]) -> Tuple[str, str]:
     turn = SocialRoomTurnStoredV1.model_validate(payload)
     turn_uri = URIRef(f"http://conjourney.net/orion/socialTurn/{_sanitize_fragment(turn.turn_id)}")
@@ -327,33 +268,6 @@ def _handle_social_room_turn(g: Graph, payload: dict[str, Any]) -> Tuple[str, st
         g.add((turn_uri, ORION.supportedByEvidence, evidence_uri))
     attach_provenance(g, turn_uri, turn.source)
     return g.serialize(format="nt"), "orion:chat:social"
-
-
-def _handle_metacognitive_trace(g: Graph, trace: MetacognitiveTraceV1) -> Tuple[str, str]:
-    trace_uri = ORION[f"trace_{_sanitize_fragment(trace.trace_id)}"]
-    turn_ref = _sanitize_fragment(trace.message_id or trace.correlation_id)
-    turn_uri = ORION[f"turn_{turn_ref}"]
-
-    g.add((trace_uri, RDF.type, ORION.CognitiveTrace))
-    role_map = {
-        "reasoning": ORION.ReasoningTrace,
-        "planning": ORION.PlanTrace,
-        "reflection": ORION.ReflectionTrace,
-        "self_check": ORION.SelfCritique,
-        "critique": ORION.SelfCritique,
-    }
-    g.add((trace_uri, RDF.type, role_map.get(trace.trace_role, ORION.CognitiveTrace)))
-    g.add((trace_uri, ORION.traceOfTurn, turn_uri))
-    g.add((trace_uri, ORION.generatedByModel, Literal(trace.model, datatype=XSD.string)))
-    g.add((trace_uri, ORION.traceStage, Literal(trace.trace_stage, datatype=XSD.string)))
-    g.add((trace_uri, ORION.traceRole, Literal(trace.trace_role, datatype=XSD.string)))
-    # traceText omitted: full text lives in Postgres; IRI is the join key
-    g.add((trace_uri, ORION.correlationId, Literal(trace.correlation_id, datatype=XSD.string)))
-    if trace.session_id:
-        g.add((trace_uri, ORION.sessionId, Literal(trace.session_id, datatype=XSD.string)))
-    if trace.token_count is not None:
-        g.add((trace_uri, ORION.tokenCount, Literal(trace.token_count, datatype=XSD.integer)))
-    return g.serialize(format="nt"), "orion:metacog"
 
 
 # === Chat History ===

--- a/services/orion-rdf-writer/app/settings.py
+++ b/services/orion-rdf-writer/app/settings.py
@@ -52,12 +52,15 @@ class Settings(BaseSettings):
     CHANNEL_EVENTS_TAGGED_CHAT: str = Field(default="orion:tags:chat:enriched", env="CHANNEL_EVENTS_TAGGED_CHAT")
     CHANNEL_CORE_EVENTS: str = Field(default="orion:core:events", env="CHANNEL_CORE_EVENTS")
     CHANNEL_WORKER_RDF: str = Field(default="orion:rdf:worker", env="CHANNEL_WORKER_RDF")
-    CHANNEL_COGNITION_TRACE_PUB: str = Field(default="orion:cognition:trace", env="CHANNEL_COGNITION_TRACE_PUB")
     CHANNEL_CHAT_HISTORY_TURN: str = Field(default="orion:chat:history:turn", env="CHANNEL_CHAT_HISTORY_TURN")
     CHANNEL_CHAT_HISTORY_LOG: str = Field(default="orion:chat:history:log", env="CHANNEL_CHAT_HISTORY_LOG")
     CHANNEL_MEMORY_IDENTITY_SNAPSHOT: str = Field(default="orion:memory:identity:snapshot", env="CHANNEL_MEMORY_IDENTITY_SNAPSHOT")
     # orion:memory:drives:audit deliberately not subscribed: drive audits are
     # Postgres-only (`drive_audits` via orion-sql-writer) as of 2026-07-15.
+    # orion:cognition:trace and orion:metacog:trace deliberately not subscribed
+    # (as of 2026-07-17): both are Postgres-only via orion-sql-writer
+    # (`cognition_traces`, `orion_metacognitive_trace`) — the RDF copy was pure
+    # redundancy with no real reader.
     CHANNEL_MEMORY_GOALS_PROPOSED: str = Field(default="orion:memory:goals:proposed", env="CHANNEL_MEMORY_GOALS_PROPOSED")
 
     # === PUBLISH CHANNELS ===
@@ -97,12 +100,10 @@ class Settings(BaseSettings):
             self.CHANNEL_CORE_EVENTS,
             self.CHANNEL_WORKER_RDF,
             self.CORTEX_LOG_CHANNEL,
-            self.CHANNEL_COGNITION_TRACE_PUB,
             self.CHANNEL_CHAT_HISTORY_TURN,
             self.CHANNEL_CHAT_HISTORY_LOG,
             self.CHANNEL_MEMORY_IDENTITY_SNAPSHOT,
             self.CHANNEL_MEMORY_GOALS_PROPOSED,
-            "orion:metacog:trace",
             self.CHANNEL_WORLD_PULSE_GRAPH,
         ]
         seen = set()

--- a/services/orion-rdf-writer/docker-compose.yml
+++ b/services/orion-rdf-writer/docker-compose.yml
@@ -42,11 +42,12 @@ services:
       # Worker intake for Cortex (RPC)
       - CHANNEL_WORKER_RDF=${CHANNEL_WORKER_RDF}
       - CORTEX_LOG_CHANNEL=${CORTEX_LOG_CHANNEL}
-      - CHANNEL_COGNITION_TRACE_PUB=${CHANNEL_COGNITION_TRACE_PUB}
       - CHANNEL_CHAT_HISTORY_TURN=${CHANNEL_CHAT_HISTORY_TURN}
       - CHANNEL_CHAT_HISTORY_LOG=${CHANNEL_CHAT_HISTORY_LOG}
       - CHANNEL_MEMORY_IDENTITY_SNAPSHOT=${CHANNEL_MEMORY_IDENTITY_SNAPSHOT}
       # CHANNEL_MEMORY_DRIVES_AUDIT removed 2026-07-15: drive audits are Postgres-only (orion-sql-writer).
+      # CHANNEL_COGNITION_TRACE_PUB and orion:metacog:trace removed 2026-07-17: both
+      # cognition.trace and metacognitive.trace.v1 are Postgres-only (orion-sql-writer).
       - CHANNEL_MEMORY_GOALS_PROPOSED=${CHANNEL_MEMORY_GOALS_PROPOSED}
       - CHANNEL_WORLD_PULSE_GRAPH=${CHANNEL_WORLD_PULSE_GRAPH}
 

--- a/services/orion-rdf-writer/tests/test_autonomy_materialization.py
+++ b/services/orion-rdf-writer/tests/test_autonomy_materialization.py
@@ -153,6 +153,32 @@ def test_drives_audit_channel_not_in_default_subscriptions():
     assert "orion:memory:drives:audit" not in channels
 
 
+def test_cognition_and_metacog_trace_channels_not_in_default_subscriptions():
+    """rdf-writer must not subscribe to orion:cognition:trace or orion:metacog:trace
+    by default (2026-07-17): both are Postgres-only via orion-sql-writer
+    (cognition_traces, orion_metacognitive_trace) -- the RDF copy was pure
+    redundancy with no real reader."""
+    channels = settings_mod.Settings(ORION_BUS_URL="redis://example.test/0").get_all_subscribe_channels()
+    assert "orion:cognition:trace" not in channels
+    assert "orion:metacog:trace" not in channels
+
+
+def test_cognition_trace_dispatch_is_quiet_no_op():
+    """The rdf_builder dispatch must treat cognition.trace as unknown (quiet no-op)."""
+    nt, graph_name = build_triples_from_envelope("cognition.trace", {"correlation_id": "corr-1"})
+    assert nt is None
+    assert graph_name is None
+
+
+def test_metacognitive_trace_dispatch_is_quiet_no_op():
+    """The rdf_builder dispatch must treat metacognitive.trace.v1 as unknown (quiet no-op)."""
+    nt, graph_name = build_triples_from_envelope(
+        "metacognitive.trace.v1", {"trace_id": "trace-1", "correlation_id": "corr-1"}
+    )
+    assert nt is None
+    assert graph_name is None
+
+
 def test_goal_materialization_writes_proposal_status_and_base():
     payload = {
         "artifact_id": "goal-new",

--- a/services/orion-rdf-writer/tests/test_service_rdf_store_integration.py
+++ b/services/orion-rdf-writer/tests/test_service_rdf_store_integration.py
@@ -67,8 +67,6 @@ def svc_sync(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     [
         "chat.history",
         "chat.history.message.v1",
-        "cognition.trace",
-        "metacognitive.trace.v1",
         "tags.enriched",
         "collapse.mirror.entry",
         "rdf.write.request",


### PR DESCRIPTION
## Summary

- Live investigation found `orion-rdf-writer` still committing ~750 real writes/6h to Fuseki for `orion:metacog:trace` and `orion:cognition:trace` -- both already durably persisted in Postgres via `orion-sql-writer` (`orion_metacognitive_trace`, `cognition_traces` -- the latter confirmed live with 61k+ rows). The Fuseki copies were pure redundancy.
- Consumer audit done *before* touching the producer: the only other Fuseki reader of these two graphs (`orion-graph-compression`'s episodic federator) is already fail-open and degrades correctly when these 2 of 9 federated graphs go quiet -- no real consumer left unaddressed.
- Removed both channels from `orion-rdf-writer`'s subscribe list + dispatch, fixed `orion/bus/channels.yaml`'s registry (it never declared `orion-sql-writer` as a consumer of `orion:cognition:trace`, despite it already being one in code).
- Review caught and fixed a real env-parity gap: a dangling `CHANNEL_COGNITION_TRACE_PUB` left in `.env_example`/`docker-compose.yml` after the settings field was removed.

Full report: `docs/superpowers/pr-reports/2026-07-17-rdf-writer-cognition-metacog-fuseki-kill-pr.md`

## Test plan

- [x] `services/orion-rdf-writer/tests` -- 41 passed (4 new regression tests)
- [x] `git diff --check` clean
- [x] Code review subagent run; 1 should-fix finding (dangling env key) fixed
- [x] `scripts/check_service_env_compose_parity.py orion-rdf-writer` -- no new gap
- [x] `scripts/sync_local_env_from_example.py` -- clean, local `.env` synced by hand
- [x] Consumer audit performed before producer change (no orphaned reader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)