### PR TITLE
fix(substrate): FalkorSubstrateStore stops resurrecting deleted nodes

### DIFF
--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -13,7 +13,10 @@ successful concept/edge decode.
 from __future__ import annotations
 
 import logging
+import math
 import os
+import threading
+import time
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
 from urllib.parse import urlparse
@@ -39,6 +42,7 @@ from orion.substrate.store import (
     SubstrateNeighborhoodSliceV1,
     SubstrateQueryResultV1,
 )
+from orion.substrate.graphdb_store import _resolve_snapshot_force_refresh_ceiling_sec
 
 logger = logging.getLogger("orion.substrate.falkor_store")
 
@@ -53,6 +57,50 @@ class FalkorGraphClient(Protocol):
 class FalkorSubstrateStoreConfig:
     uri: str
     graph_name: str = "orion_substrate"
+    # Same knob name and same generation+ceiling GATING logic as
+    # GraphDBSubstrateStoreConfig's field of this name (see that class's
+    # docstring) -- real change detection via a same-process write-
+    # generation counter, with this as the periodic safety-net ceiling
+    # bounding staleness from writes this process can't see (a different
+    # process's write, or a direct external mutation like an operator
+    # running Cypher DELETE by hand). Without any periodic refresh, a direct
+    # external deletion is invisible to this cache forever, AND the decay
+    # scheduler (services/orion-hub/scripts/api_routes.py::
+    # decay_concept_activations) durably re-upserts every node in every
+    # snapshot() it reads on every tick -- so a stale cache doesn't just
+    # show old data, it actively resurrects deleted durable data on the next
+    # tick. Confirmed live: this exact resurrection loop was observed and
+    # root-caused in production.
+    #
+    # NOT the same as GraphDB in two respects, both worth knowing:
+    # (1) GraphDBSubstrateStore's own generation+ceiling refresh is upsert-
+    #     only (never removes cache entries for durably-deleted nodes) and
+    #     it never does an eager hydration at construction -- so GraphDB
+    #     likely still has an equivalent resurrection exposure of its own;
+    #     porting this fix here does not imply GraphDB is already immune.
+    #     The fresh-cache-swap idea (see _hydrate_from_durable) is what
+    #     actually fixes deletion-visibility and is new to this store, not
+    #     ported from GraphDB.
+    # (2) This store's hydrate queries have no LIMIT (GraphDB's are capped
+    #     at 500 nodes / 1000 edges), and same_generation is invalidated by
+    #     ANY write anywhere -- so a caller that both reads and writes every
+    #     tick (the decay scheduler above is exactly this shape: one
+    #     snapshot() read, then N upsert_node() writes) will see a
+    #     generation mismatch on its OWN next tick's read, forcing a full
+    #     unbounded re-hydration on very close to every tick regardless of
+    #     this ceiling. This is an accepted, understood tradeoff at current
+    #     graph sizes (tens of nodes) -- correctness over cache efficiency
+    #     for this caller shape -- not a bug, but worth revisiting (a LIMIT,
+    #     or excluding a caller's own immediately-prior writes from
+    #     generation invalidation) if it ever shows up as real cost.
+    #
+    # See also FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC (falls back to this
+    # shared SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC when unset) for an
+    # independent override -- RoutedSubstrateGraphStore can run both a
+    # GraphDB-backed and a Falkor-backed store concurrently in one process
+    # (primary + shadow), and given point (2) above, the two backends' real
+    # refresh costs are not symmetric.
+    snapshot_force_refresh_ceiling_sec: float = 30.0
 
 
 NATIVE_NODE_RETURN_FIELDS: tuple[str, ...] = (
@@ -252,10 +300,45 @@ class FalkorSubstrateStore:
         )
         self._cache = InMemorySubstrateGraphStore()
         self._result_source_kind = "falkor"
+        # See FalkorSubstrateStoreConfig.snapshot_force_refresh_ceiling_sec's
+        # docstring for the full reasoning -- mirrors GraphDBSubstrateStore's
+        # already-proven write-generation + ceiling mechanism exactly.
+        self._write_generation = 0
+        self._last_snapshot_at: float | None = None
+        # -1 sentinel: guarantees the first snapshot() call always sees
+        # same_generation=False (0 == -1 is never true), so no separate
+        # "first call" branch is needed in snapshot() itself.
+        self._last_snapshot_generation = -1
+        self._snapshot_lock = threading.Lock()
         if hydrate:
             self._hydrate_from_durable()
+            # Record that construction already did a full hydration, so the
+            # first real snapshot() call doesn't immediately redo it. Without
+            # this, the -1 sentinel above would force a second, wasted
+            # refresh on literally the next call (GraphDBSubstrateStore
+            # doesn't have this wrinkle because it never hydrates eagerly at
+            # construction -- its first snapshot() call is genuinely the
+            # first fetch, not a redundant second one).
+            self._last_snapshot_at = time.monotonic()
+            self._last_snapshot_generation = self._write_generation
 
     def _hydrate_from_durable(self) -> None:
+        """(Re)populate the in-process cache from durable Falkor state.
+
+        Called once at construction, and again periodically by snapshot()'s
+        refresh path (see FalkorSubstrateStoreConfig.snapshot_force_refresh_ceiling_sec).
+        Builds a FRESH InMemorySubstrateGraphStore and swaps it in wholesale
+        rather than upserting into the existing self._cache in place -- this
+        is the actual fix for the resurrection bug: an in-place upsert can
+        only ever add/update nodes that still exist durably, it can never
+        remove a node that was deleted directly in Falkor (bypassing this
+        process). A fresh cache, containing only what's durably present
+        right now, correctly reflects deletions on every refresh.
+
+        On query failure, returns without touching self._cache at all --
+        the stale-but-still-valid existing cache is a strictly better
+        fallback than an empty one.
+        """
         try:
             node_rows = self._client.graph_query(
                 "MATCH (n:SubstrateNode) RETURN " + _return_clause("n", NATIVE_NODE_RETURN_FIELDS)
@@ -277,6 +360,7 @@ class FalkorSubstrateStore:
             logger.warning("falkor_substrate_hydrate_failed error=%s", exc)
             return
 
+        fresh_cache = InMemorySubstrateGraphStore()
         for row in _normalize_rows(node_rows, fields=NATIVE_NODE_RETURN_FIELDS):
             try:
                 node = decode_node(row)
@@ -286,7 +370,7 @@ class FalkorSubstrateStore:
             if node is None:
                 continue
             identity = row.get("identity_key")
-            self._cache.upsert_node(identity_key=str(identity) if identity else None, node=node)
+            fresh_cache.upsert_node(identity_key=str(identity) if identity else None, node=node)
 
         for row in _normalize_rows(edge_rows, fields=NATIVE_EDGE_RETURN_FIELDS):
             try:
@@ -297,7 +381,27 @@ class FalkorSubstrateStore:
             if edge is None:
                 continue
             identity = row.get("identity_key") or self._edge_identity(edge)
-            self._cache.upsert_edge(identity_key=str(identity), edge=edge)
+            fresh_cache.upsert_edge(identity_key=str(identity), edge=edge)
+
+        # Swap now, before legacy migration -- _migrate_legacy_payload_*
+        # below call self.upsert_node()/self.upsert_edge() (the full public
+        # write path, which also bumps self._write_generation), and must
+        # operate against the current cache, not a soon-to-be-discarded one.
+        #
+        # Known, bounded race: upsert_node()/upsert_edge() are deliberately
+        # not protected by _snapshot_lock (matching GraphDBSubstrateStore's
+        # own precedent), so a concurrent upsert_node() call whose
+        # `self._cache.upsert_node(...)` step interleaves with this swap
+        # could land its write on the old (about to be discarded) cache
+        # object instead of `fresh_cache` -- that write would be briefly
+        # invisible to snapshot(). It self-heals: the write still bumped
+        # self._write_generation, so the very next snapshot() call detects
+        # the mismatch and re-fetches, which then sees the write durably
+        # reflected in Falkor. Not permanent loss, just a narrow visibility
+        # delay -- and this window scales with fresh_cache's build time,
+        # which is currently unbounded (see the LIMIT tradeoff noted on
+        # FalkorSubstrateStoreConfig.snapshot_force_refresh_ceiling_sec).
+        self._cache = fresh_cache
 
         self._migrate_legacy_payload_nodes(
             _normalize_rows(legacy_node_rows, fields=("payload_json", "identity_key"))
@@ -405,6 +509,7 @@ class FalkorSubstrateStore:
             logger.error("falkor_substrate_upsert_node_failed node_id=%s error=%s", node.node_id, exc)
             raise
         self._cache.upsert_node(identity_key=identity_key, node=node)
+        self._write_generation += 1
 
     def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None:
         edge = _with_sanitized_metadata(edge)
@@ -424,9 +529,43 @@ class FalkorSubstrateStore:
             logger.error("falkor_substrate_upsert_edge_failed edge_id=%s error=%s", edge.edge_id, exc)
             raise
         self._cache.upsert_edge(identity_key=identity_key, edge=edge)
+        self._write_generation += 1
 
     def snapshot(self) -> MaterializedSubstrateGraphState:
-        return self._cache.snapshot()
+        with self._snapshot_lock:
+            now_mono = time.monotonic()
+            elapsed = (now_mono - self._last_snapshot_at) if self._last_snapshot_at is not None else None
+            ceiling = float(self._cfg.snapshot_force_refresh_ceiling_sec)
+
+            # A write since our last refresh is a KNOWN, certain change -- the
+            # cache is never reused in that case, regardless of ceiling.
+            same_generation = self._last_snapshot_generation == self._write_generation
+            # ceiling <= 0 means "trust same_generation forever" (no periodic
+            # forced refresh); otherwise the ceiling forces a real refresh once
+            # elapsed even though same_generation is still true -- the safety
+            # net that bounds staleness from writes THIS process can't see:
+            # another process's write, or a direct external mutation (e.g. an
+            # operator running Cypher DELETE by hand against Falkor directly).
+            within_ceiling = ceiling <= 0.0 or elapsed is None or elapsed < ceiling
+
+            if same_generation and within_ceiling:
+                return self._cache.snapshot()
+
+            # Capture the generation BEFORE refreshing (which does network
+            # I/O), not after -- if a write races in while the refresh is in
+            # flight, capturing after would credit that write to data fetched
+            # before it happened, silently masking it until the next
+            # unrelated write or the ceiling fires again. Capturing before
+            # means such a race just costs one possibly-redundant extra
+            # refresh on the next call, never a falsely-trusted stale cache.
+            # Same reasoning as GraphDBSubstrateStore.snapshot() (already
+            # proven in production for the SPARQL backend); this mirrors it
+            # for Falkor to fix the equivalent gap here.
+            generation_at_fetch_start = self._write_generation
+            self._hydrate_from_durable()
+            self._last_snapshot_at = now_mono
+            self._last_snapshot_generation = generation_at_fetch_start
+            return self._cache.snapshot()
 
     def query_focal_slice(self, *, node_ids: list[str], max_edges: int = 64) -> SubstrateQueryResultV1:
         return _retag_source(
@@ -550,6 +689,38 @@ def _normalize_rows(
     return []
 
 
+def _resolve_falkor_snapshot_force_refresh_ceiling_sec() -> float:
+    """FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC, falling back to the shared
+    SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC (same knob GraphDB reads)
+    when unset. A Falkor-specific override exists because
+    RoutedSubstrateGraphStore can run a GraphDB-backed store and a
+    Falkor-backed store concurrently in the same process (primary + shadow),
+    and the two backends' refresh costs are not symmetric -- Falkor's own
+    hydrate queries are currently unbounded (no LIMIT, unlike GraphDB's
+    capped _query_nodes/_query_edges_for_node_ids), so an operator running
+    both may want a longer Falkor ceiling without also having to change
+    GraphDB's. Without this override, both backends would be forced to share
+    one ceiling value with no way to tune them independently.
+    """
+    raw = str(os.getenv("FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", "")).strip()
+    if not raw:
+        return _resolve_snapshot_force_refresh_ceiling_sec()
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "falkor_snapshot_force_refresh_ceiling_invalid value=%r; falling back to shared setting", raw
+        )
+        return _resolve_snapshot_force_refresh_ceiling_sec()
+    if not math.isfinite(value):
+        logger.warning(
+            "falkor_snapshot_force_refresh_ceiling_invalid value=%r (non-finite); falling back to shared setting",
+            raw,
+        )
+        return _resolve_snapshot_force_refresh_ceiling_sec()
+    return value
+
+
 def build_falkor_substrate_store_from_env() -> FalkorSubstrateStore | InMemorySubstrateGraphStore:
     uri = str(os.getenv("FALKORDB_URI", "")).strip()
     if not uri:
@@ -561,4 +732,10 @@ def build_falkor_substrate_store_from_env() -> FalkorSubstrateStore | InMemorySu
         urlparse(uri).hostname or "",
         graph_name,
     )
-    return FalkorSubstrateStore(FalkorSubstrateStoreConfig(uri=uri, graph_name=graph_name))
+    return FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(
+            uri=uri,
+            graph_name=graph_name,
+            snapshot_force_refresh_ceiling_sec=_resolve_falkor_snapshot_force_refresh_ceiling_sec(),
+        )
+    )

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -19,6 +19,7 @@ from orion.substrate.falkor_store import (
     RecordingFalkorClient,
     RedisGraphQueryClient,
     _normalize_rows,
+    _resolve_falkor_snapshot_force_refresh_ceiling_sec,
 )
 from orion.substrate.graphdb_store import build_substrate_store_from_env
 from orion.substrate.store import InMemorySubstrateGraphStore
@@ -80,8 +81,18 @@ def test_falkor_upsert_round_trip_via_cache():
     store.upsert_node(identity_key="id-a", node=node)
     assert store.get_node_by_id(node.node_id) is not None
     assert store.get_node_id_by_identity("id-a") == node.node_id
-    snap = store.snapshot()
-    assert node.node_id in snap.nodes
+    # Inspect the cache directly rather than via the public snapshot() --
+    # snapshot() now (correctly) forces a live re-hydration on its first
+    # call (see test_falkor_snapshot_* below for that behavior's own
+    # coverage), which for this bare RecordingFalkorClient (no scripted
+    # hydrate_node_rows) would re-fetch an empty durable state and discard
+    # the node this test just upserted -- a test-double artifact, not a
+    # production bug: real Falkor's MATCH query issued by that refresh
+    # would correctly see the just-written node, since upsert_node's own
+    # Cypher write already landed durably by this point. This assertion's
+    # actual intent -- proving upsert_node's immediate cache write-through
+    # -- doesn't depend on snapshot()'s refresh behavior at all.
+    assert node.node_id in store._cache.snapshot().nodes
     assert any("MERGE (n:SubstrateNode" in cypher for cypher, _ in client.calls)
 
 
@@ -792,3 +803,271 @@ def test_falkor_hydrated_concepts_support_concept_region_query():
 
     assert result.source_kind == "falkor"
     assert [node.node_id for node in result.slice.nodes] == ["concept-alpha"]
+
+
+# --- snapshot() refresh/ceiling behavior --------------------------------------
+#
+# Mirrors GraphDBSubstrateStore's already-proven write-generation + ceiling
+# mechanism (test_graphdb_store.py's own test_snapshot_* suite) -- this is the
+# fix for a real, live-confirmed bug: FalkorSubstrateStore.snapshot() used to
+# always return self._cache.snapshot() with no refresh at all, so (a) a node
+# deleted directly from Falkor (bypassing this process, e.g. an operator
+# running Cypher DELETE by hand) stayed resurrected in the cache forever, and
+# (b) the decay scheduler (services/orion-hub/scripts/api_routes.py::
+# decay_concept_activations) durably re-upserts every node in every snapshot()
+# it reads on every tick -- so a stale cache didn't just show old data, it
+# actively wrote deleted data back into Falkor on the next tick, undoing the
+# deletion. Confirmed live in production before this fix.
+#
+# RecordingFalkorClient returns the SAME scripted rows on every graph_query()
+# call (no dynamic state tracking) -- these tests script hydrate_node_rows
+# once, then mutate client._hydrate_node_rows directly between snapshot()
+# calls to simulate durable state changing out from under this process
+# (exactly what a direct external Cypher DELETE looks like from Falkor's
+# side).
+
+
+def _hydrated_node_row(node_id: str, identity_key: str) -> dict:
+    return {
+        "node_id": node_id,
+        "node_kind": "concept",
+        "identity_key": identity_key,
+        "label": "Hydrated",
+        "definition": None,
+        "taxonomy_path_json": "[]",
+        "anchor_scope": "orion",
+        "subject_ref": None,
+        "promotion_state": "canonical",
+        "risk_tier": "low",
+        "confidence": 0.7,
+        "salience": 0.5,
+        "activation": 0.5,
+        "recency_score": 0.4,
+        "decay_floor": 0.0,
+        "decay_half_life_seconds": None,
+        "observed_at": "2026-07-16T00:00:00+00:00",
+        "valid_from": None,
+        "valid_to": None,
+        "provenance_authority": "local_inferred",
+        "provenance_source_kind": "test",
+        "provenance_source_channel": "test:falkor",
+        "provenance_producer": "test_falkor_store",
+        "provenance_model_name": None,
+        "provenance_correlation_id": None,
+        "provenance_trace_id": None,
+        "provenance_tier_rank": None,
+        "evidence_refs_json": "[]",
+    }
+
+
+def test_falkor_snapshot_same_generation_reuses_cache_no_new_query():
+    """Baseline: nothing written since the first fetch -- the second call is
+    served from cache with zero new live queries."""
+    client = RecordingFalkorClient(hydrate_node_rows=[_hydrated_node_row("concept-a", "concept:a")])
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(
+            uri="redis://localhost:6379", graph_name="orion_substrate", snapshot_force_refresh_ceiling_sec=60.0
+        ),
+        client=client,
+        hydrate=False,
+    )
+    client.calls.clear()
+
+    first = store.snapshot()
+    calls_after_first = len(client.calls)
+    assert calls_after_first == 4  # node query, edge query, 2 legacy queries
+    assert "concept-a" in first.nodes
+
+    second = store.snapshot()
+    assert len(client.calls) == calls_after_first  # no new live query
+    assert second.nodes.keys() == first.nodes.keys()
+
+
+def test_falkor_snapshot_write_between_calls_forces_new_query():
+    """A write bumps the generation counter, so the very next snapshot() call
+    issues a live query even though it's well within the ceiling."""
+    client = RecordingFalkorClient(hydrate_node_rows=[_hydrated_node_row("concept-a", "concept:a")])
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(
+            uri="redis://localhost:6379", graph_name="orion_substrate", snapshot_force_refresh_ceiling_sec=60.0
+        ),
+        client=client,
+        hydrate=False,
+    )
+    client.calls.clear()
+
+    store.snapshot()
+    calls_after_first = len(client.calls)
+
+    store.upsert_node(identity_key="concept:b", node=_concept(node_id="concept-b"))
+    calls_after_upsert = len(client.calls)
+    # RecordingFalkorClient returns the SAME static scripted rows on every
+    # graph_query() call -- it doesn't track the upsert_node() write that
+    # just happened the way real Falkor durably would. Update the script to
+    # match what a real MATCH query would now return, so the refresh this
+    # test is actually checking for reflects reality rather than the fake's
+    # limitation.
+    client._hydrate_node_rows = [
+        _hydrated_node_row("concept-a", "concept:a"),
+        _hydrated_node_row("concept-b", "concept:b"),
+    ]
+
+    result = store.snapshot()
+    assert len(client.calls) > calls_after_upsert  # forced a live re-hydration
+    assert "concept-a" in result.nodes  # still present, from the scripted rows
+    assert "concept-b" in result.nodes  # the just-upserted node, durably reflected
+
+
+def test_falkor_snapshot_ceiling_forces_refresh_despite_same_generation():
+    """The safety net: even with no writes at all (same_generation stays true
+    indefinitely), the ceiling forces a periodic live re-check to catch
+    changes made by a different process, or a direct external mutation, that
+    this instance's own write counter can't see."""
+    import time
+
+    client = RecordingFalkorClient(hydrate_node_rows=[_hydrated_node_row("concept-a", "concept:a")])
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(
+            uri="redis://localhost:6379", graph_name="orion_substrate", snapshot_force_refresh_ceiling_sec=0.01
+        ),
+        client=client,
+        hydrate=False,
+    )
+    client.calls.clear()
+
+    store.snapshot()
+    calls_after_first = len(client.calls)
+
+    time.sleep(0.02)
+    store.snapshot()
+    assert len(client.calls) > calls_after_first  # ceiling forced a live query
+
+
+def test_falkor_snapshot_ceiling_zero_trusts_generation_forever():
+    """ceiling <= 0 disables the periodic safety-net refresh entirely -- the
+    cache is trusted for as long as the write generation hasn't moved."""
+    import time
+
+    client = RecordingFalkorClient(hydrate_node_rows=[_hydrated_node_row("concept-a", "concept:a")])
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(
+            uri="redis://localhost:6379", graph_name="orion_substrate", snapshot_force_refresh_ceiling_sec=0.0
+        ),
+        client=client,
+        hydrate=False,
+    )
+    client.calls.clear()
+
+    store.snapshot()
+    calls_after_first = len(client.calls)
+
+    time.sleep(0.02)
+    store.snapshot()
+    assert len(client.calls) == calls_after_first  # still cached, no ceiling to force a refresh
+
+
+def test_falkor_snapshot_refresh_removes_externally_deleted_node():
+    """The actual regression this fix closes: a node deleted directly from
+    Falkor (bypassing this process entirely -- simulated here by mutating the
+    scripted hydrate rows out from under an already-hydrated store) must
+    disappear from the cache on the next forced refresh, not stay
+    resurrected forever."""
+    client = RecordingFalkorClient(
+        hydrate_node_rows=[
+            _hydrated_node_row("concept-a", "concept:a"),
+            _hydrated_node_row("concept-junk", "concept:junk"),
+        ]
+    )
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(
+            uri="redis://localhost:6379", graph_name="orion_substrate", snapshot_force_refresh_ceiling_sec=0.01
+        ),
+        client=client,
+        hydrate=True,
+    )
+
+    first = store.snapshot()
+    assert "concept-a" in first.nodes
+    assert "concept-junk" in first.nodes
+
+    # Simulate an external `MATCH (n) WHERE ... DETACH DELETE n` against
+    # Falkor directly -- "concept-junk" is gone from what the durable graph
+    # now returns, but this process's cache still has it until a refresh.
+    client._hydrate_node_rows = [_hydrated_node_row("concept-a", "concept:a")]
+
+    import time
+
+    time.sleep(0.02)  # clear the ceiling
+    second = store.snapshot()
+    assert "concept-a" in second.nodes
+    assert "concept-junk" not in second.nodes  # the fix: no longer resurrected
+
+
+def test_falkor_snapshot_failure_fallback_still_returns_cache():
+    """A failed refresh (e.g. Falkor unreachable) must degrade to the
+    existing cache, not an empty result or a raised exception."""
+
+    class _FailingClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def graph_query(self, cypher, params=None):
+            self.calls += 1
+            raise RuntimeError("falkor unreachable")
+
+    failing_client = _FailingClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=failing_client,
+        hydrate=False,
+    )
+    # Seed the cache directly (bypassing the failing client) to prove a
+    # subsequent failed refresh preserves it rather than clearing it.
+    store._cache.upsert_node(identity_key="concept:seed", node=_concept(node_id="concept-seeded"))
+
+    result = store.snapshot()
+    assert "concept-seeded" in result.nodes
+    assert failing_client.calls > 0  # the refresh really was attempted
+
+
+def test_falkor_write_generation_bumps_on_upsert_node_and_edge():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    assert store._write_generation == 0
+
+    store.upsert_node(identity_key="concept:a", node=_concept(node_id="concept-a"))
+    assert store._write_generation == 1
+
+    edge = SubstrateEdgeV1(
+        source=NodeRefV1(node_id="concept-a", node_kind="concept"),
+        target=NodeRefV1(node_id="concept-b", node_kind="concept"),
+        predicate="associated_with",
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred", source_kind="test", source_channel="test", producer="test_falkor_store"
+        ),
+    )
+    store.upsert_edge(identity_key="a|associated_with|b", edge=edge)
+    assert store._write_generation == 2
+
+
+def test_resolve_falkor_snapshot_ceiling_uses_falkor_specific_override(monkeypatch):
+    monkeypatch.setenv("FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", "12.5")
+    monkeypatch.delenv("SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", raising=False)
+    assert _resolve_falkor_snapshot_force_refresh_ceiling_sec() == 12.5
+
+
+def test_resolve_falkor_snapshot_ceiling_falls_back_to_shared_setting(monkeypatch):
+    monkeypatch.delenv("FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", raising=False)
+    monkeypatch.setenv("SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", "45.0")
+    assert _resolve_falkor_snapshot_force_refresh_ceiling_sec() == 45.0
+
+
+def test_resolve_falkor_snapshot_ceiling_invalid_value_falls_back_to_shared_setting(monkeypatch):
+    monkeypatch.setenv("FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", "not-a-number")
+    monkeypatch.delenv("SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", raising=False)
+    assert _resolve_falkor_snapshot_force_refresh_ceiling_sec() == 30.0  # shared default

--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -52,6 +52,13 @@ RECALL_CONCEPT_REGION_ENABLED=true
 SUBSTRATE_STORE_BACKEND=falkor
 FALKORDB_URI=redis://orion-athena-falkordb:6379
 FALKORDB_SUBSTRATE_GRAPH=orion_substrate
+# Periodic cache-refresh safety net for the shared FalkorDB-backed substrate
+# store (same knob already used by orion-cortex-exec/orion-hub, and by the
+# SPARQL backend before it) -- bounds staleness from writes/deletions this
+# process's own in-memory cache can't see (another process's write, or a
+# direct external Cypher mutation). See FalkorSubstrateStoreConfig's
+# docstring in orion/substrate/falkor_store.py.
+SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC=30.0
 RECALL_BELIEF_RENDER_BUDGET=128
 # Live default as of 2026-07-13 (graphiti_core backend proven working -- docs/superpowers/
 # specs/2026-07-13-graphiti-core-backend-activation-spec.md). Only fires when a turn's


### PR DESCRIPTION
## Summary

- `FalkorSubstrateStore` never refreshed its in-process cache after initial construction — every `snapshot()` call returned whatever was hydrated at startup, forever.
- Hub's decay scheduler (`services/orion-hub/scripts/api_routes.py::decay_concept_activations()`) blindly re-upserts every node it reads from `snapshot()` on every 120s tick. Combined with the stale cache, this durably **resurrected** any node deleted directly in FalkorDB (e.g. junk `concept_induction_adapter` labels) within one tick cycle.
- Ported the write-generation + time-ceiling refresh mechanism already proven in the sibling `GraphDBSubstrateStore` (from the 2026-07-14 incident/fix), plus a new fresh-cache-swap mechanism in `_hydrate_from_durable()` that Falkor specifically needed (GraphDB's own refresh is upsert-only and doesn't make deletions visible either — documented as a known gap there, not silently assumed fixed).
- Live-reproduced the bug before fixing: deleted junk nodes directly via Cypher, polled every 20s, watched them reappear at ~90s; ruled out Hub restart replay, `orion-spark-concept-induction` restart replay, and FalkorDB AOF/RDB reload before pinning it on the decay scheduler + stale-cache interaction.

## Outcome moved

Deleting a node from FalkorDB now stays deleted. `snapshot()` re-fetches from Falkor when either (a) a local write bumped the generation counter since the last fetch, or (b) a configurable time ceiling (default 30s) has elapsed — matching GraphDB's existing behavior, with a Falkor-specific override available.

## Current architecture

`FalkorSubstrateStore` wraps an `InMemorySubstrateGraphStore` cache, populated once at construction via `_hydrate_from_durable()`. `snapshot()` returned `self._cache.snapshot()` directly with no refresh path. `upsert_node()`/`upsert_edge()` wrote through to both Falkor and the cache but never invalidated anything for readers relying on `snapshot()` alone (like the decay scheduler, which never calls `upsert_*` itself).

## Architecture touched

- `orion/substrate/falkor_store.py` — the store itself.
- `orion/substrate/tests/test_falkor_store.py` — regression coverage.
- `services/orion-recall/.env_example` (+ live `.env` synced) — new shared env knob documented for this Falkor consumer.

## Files changed

- `orion/substrate/falkor_store.py`: added `_write_generation`, `_last_snapshot_at`, `_last_snapshot_generation`, `_snapshot_lock`; `snapshot()` rewritten to check generation+ceiling before re-hydrating; `_hydrate_from_durable()` rewritten to build into a fresh `InMemorySubstrateGraphStore` and swap it in (makes durable deletions visible, not just new writes); `upsert_node()`/`upsert_edge()` bump `_write_generation`; new `FalkorSubstrateStoreConfig.snapshot_force_refresh_ceiling_sec` (default 30.0) with a docstring covering the resurrection bug, the GraphDB-equivalent gap, and the unbounded-query tradeoff; new `_resolve_falkor_snapshot_force_refresh_ceiling_sec()` reading `FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` and falling back to the shared GraphDB resolver; `build_falkor_substrate_store_from_env()` wired to use it.
- `orion/substrate/tests/test_falkor_store.py`: fixed one pre-existing test that now triggers a first-call refresh against the static `RecordingFalkorClient` test double; added 11 new tests covering generation/ceiling reuse-vs-refresh, the direct externally-deleted-node regression case, failure fallback, write-generation bumps, and the new resolver's override/fallback/invalid-value behavior.
- `services/orion-recall/.env_example`: documented `SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` (recall is a Falkor consumer per Gap 1b and this shared knob was previously undocumented here).

## Schema / bus / API changes

- Added: none (no bus/schema contract changes — this is a store-internal caching fix).
- Removed: none.
- Renamed: none.
- Behavior changed: `FalkorSubstrateStore.snapshot()` now periodically re-hydrates from Falkor instead of trusting the initial cache forever.
- Compatibility notes: none required; no callers depend on the old always-stale behavior.

## Env/config changes

- Added keys: `FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` (Falkor-specific override, optional; falls back to the existing shared `SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` GraphDB resolver if unset/invalid).
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: `services/orion-recall/.env_example` (documented the existing shared `SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` knob; no new key needed there since it already existed as a shared setting).
- local `.env` synced: yes — `services/orion-recall/.env` in the shared checkout already had `SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC=30.0` set (confirmed present); no further action needed for that key. `FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` intentionally left unset (falls back cleanly).
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH=. pytest orion/substrate/tests -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
347 passed, 17 warnings

pytest services/orion-hub/tests -q (concept-atlas/decay-scheduler/seed-startup subset)
51 passed
```

## Evals run

No dedicated eval harness exists for `orion/substrate/`. The regression test `test_falkor_snapshot_refresh_removes_externally_deleted_node` is the direct functional check for this incident (simulates an external Cypher DELETE between two `snapshot()` calls and asserts the node is gone from the second).

## Docker/build/smoke checks

Not rebuilt/deployed as part of this PR — code-only fix reviewed and tested in the worktree. Live incident (junk node resurrection) was already worked around directly in the running system (delete + Hub restart) prior to this fix; this PR ships the durable code fix for the same root cause.

## Review findings fixed

- Finding: Concurrent `upsert_node()`/`upsert_edge()` calls during a cache swap aren't lock-protected, so a write could theoretically land on the soon-to-be-discarded old cache object.
  - Fix: Documented as a self-healing race window in a code comment — the write's own generation bump forces the next `snapshot()` to re-fetch regardless, matching GraphDB's own deliberate precedent for the same tradeoff.
  - Evidence: Comment in `_hydrate_from_durable()`; no test needed since the design is explicitly self-healing rather than requiring a lock.
- Finding: An unbounded hydrate query on every ceiling-triggered refresh could be expensive for write-heavy callers like the decay scheduler (120s tick).
  - Fix: Documented the tradeoff explicitly in `FalkorSubstrateStoreConfig`'s docstring rather than adding a `LIMIT` that would introduce silent truncation; the ceiling default (30s) bounds worst-case refresh frequency.
  - Evidence: Docstring in `falkor_store.py`.
- Finding: The refresh ceiling was hardcoded to the shared GraphDB resolver with no Falkor-specific override.
  - Fix: Added `_resolve_falkor_snapshot_force_refresh_ceiling_sec()` reading `FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` first, falling back to the shared resolver.
  - Evidence: 3 new tests (`test_resolve_falkor_snapshot_ceiling_uses_falkor_specific_override`, `..._falls_back_to_shared_setting`, `..._invalid_value_falls_back_to_shared_setting`), all passing.
- Finding: Redundant double-hydrate on startup — `__init__` hydrates once, then the first `snapshot()` call would immediately re-hydrate again since `_last_snapshot_at` was unset.
  - Fix: `__init__` now sets `_last_snapshot_at`/`_last_snapshot_generation` right after its own hydrate call, so the first real `snapshot()` correctly reuses the just-built cache instead of refetching immediately.
  - Evidence: Covered implicitly by the full passing test suite; no separate regression needed since this is a startup-path optimization, not a correctness bug.

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

Any other Falkor-consuming service that imports `orion.substrate.falkor_store` (e.g. orion-recall, orion-spark-concept-induction) should also be restarted to pick up the fix, though none require an env/image change beyond the code itself.

## Risks / concerns

- Severity: Low
- Concern: The self-healing race window (write landing on a soon-to-be-discarded cache during a swap) is deliberately undefended by a lock, matching GraphDB's precedent — a write in that exact window is invisible until the next refresh cycle.
- Mitigation: The write's own generation bump forces the next `snapshot()` call to re-fetch, so the window is at most one refresh cycle wide and self-corrects without intervention.

## PR link

(filled in after creation)