### PR TITLE
fix(bus): drop dead consumers from orion:kg:edge:ingest.v1

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -342,7 +342,12 @@ channels:
     kind: "event"
     schema_id: "KgEdgeIngestV1"
     producer_services: ["orion-topic-foundry"]
-    consumer_services: ["orion-rdf-writer", "orion-graphdb"]
+    # orion-rdf-writer removed 2026-07-17: Fuseki is being decommissioned, and
+    # this channel was never actually consumed by it (not in settings.py's
+    # get_all_subscribe_channels()). orion-graphdb was never a real service
+    # either -- no directory under services/. No live consumer as of this
+    # change; orion-topic-foundry still publishes (kg_edges.py).
+    consumer_services: []
     stability: "experimental"
     since: "2026-01-08"
 


### PR DESCRIPTION
## Summary
- Fuseki is being decommissioned; `orion:kg:edge:ingest.v1`'s documented consumers (`orion-rdf-writer`, `orion-graphdb`) were both already dead in practice.
- `orion-rdf-writer` never subscribed to this channel — absent from `settings.py`'s `get_all_subscribe_channels()`.
- `orion-graphdb` was never a real service — no `services/orion-graphdb` directory exists.
- `orion-topic-foundry` still actively publishes to this channel (`kg_edges.py`), so it's left in place as producer-only/currently-unconsumed rather than deleted outright.

## Files changed
- `orion/bus/channels.yaml`: `orion:kg:edge:ingest.v1` consumer_services set to `[]`, with a comment explaining why.

## Tests run
YAML parse check only (`python3 -c "import yaml; yaml.safe_load(open('orion/bus/channels.yaml'))"` — 262 channels, parses clean). No dedicated `check_bus_channels.py` gate script exists in this repo despite AGENTS.md referencing one.

## Restart required
No restart required — contract/docs-only change, no service reads this consumer list at runtime.