### PR TITLE
fix(substrate): stop identity_yaml adapter from reifying policy prose as concept nodes

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-17-identity-yaml-no-concept-nodes-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-17-identity-yaml-no-concept-nodes-pr.md
@@ -1,0 +1,87 @@
+# Fix: identity_yaml adapter no longer reifies policy prose as concept nodes
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1165
+Branch: `fix/identity-yaml-no-concept-nodes`
+
+Supersedes: PR #1162 (`fix/concept-induction-pg-chat-source`, closed — built on a wrong
+root-cause diagnosis, see below).
+
+## What actually happened this session
+
+Juniper reported chat-stance artifacts bleeding into "the new orion concept induction" —
+concrete example: "speak as an ongoing presence rather than customer support software"
+appearing as if it were a graph concept.
+
+**First pass (wrong):** traced the bus-envelope → concept-induction extraction path
+(`orion-spark-concept-induction`) and shipped PR #1162 to read chat-history text from
+Postgres instead of the bus envelope. Juniper corrected this directly: "nowhere in
+chathistory log doe the prompts contain any of the stance shit." Checked live data (should
+have done this first): recent `chat_history_log` rows are clean (verified via direct
+`psql`); the old April rows that did match were a different, already-fixed bug (raw
+`<think>` reasoning trace bleeding into the `response` column before `thought_process`
+was split into its own column). PR #1162 closed.
+
+**Second pass (correct):** queried the live FalkorDB `orion_substrate` graph directly
+(`redis-cli -h localhost -p 6380 GRAPH.QUERY orion_substrate ...`) instead of guessing from
+code, and found the actual node:
+
+```
+label: "speak as a real ongoing presence rather than customer-support software"
+node_kind: concept
+provenance_producer: identity_yaml_adapter
+provenance_source_kind: identity_yaml
+promotion_state: canonical
+observed_at: 2026-07-17T18:29:03Z
+```
+
+Traced to `orion/substrate/relational/adapters/identity_yaml.py:map_identity_yaml_to_substrate`,
+which turned every line of `ctx["orion_identity_summary"]` into a `ConceptNodeV1`. That
+ctx key is built by `orion/cognition/personality/identity_context.py:build_identity_context`
+as a flat merge of `orion_identity.yaml`'s `nature`, `core_drives`, `self_permissions`, and
+`anti_patterns` blocks — confirmed the exact source line in
+`orion/cognition/personality/orion_identity.yaml`:
+
+```yaml
+core_drives:
+  - "speak as a real ongoing presence rather than customer-support software"
+```
+
+An operator-authored behavioral directive, mechanically reified as a graph "Concept" node
+with equal standing to genuine self-model facts.
+
+## Fix
+
+Removed the `ConceptNodeV1` loop from `map_identity_yaml_to_substrate` entirely, per
+Juniper's explicit scope ("I only want the chat history going in, not this other
+bullshit" — concepts in the graph should only come from real induction, never from
+operator config). The `StateSnapshotNodeV1` (the thing `chat_stance.py`'s stance-brief
+compilation actually reads) is unchanged, so prompt assembly is unaffected. Confirmed via
+subagent review: no other consumer depends on identity_yaml producing concept-kind nodes
+specifically.
+
+## Live cleanup (pending)
+
+14 already-materialized bad nodes remain in the live `orion_substrate` FalkorDB graph
+(10 from the real `orion_identity.yaml`, 4 from `chat_stance.py`'s
+`FALLBACK_ORION_IDENTITY_SUMMARY` constants, all written 2026-07-17). The code fix only
+stops new ones. Snapshot taken to `/tmp/identity-yaml-concept-cleanup/snapshot_before_delete.txt`
+before any deletion; deletion itself needs an explicit go-ahead (destructive action on
+shared live infra) — asked, not yet executed as of this report.
+
+## Pre-existing flake found, not fixed
+
+`services/orion-cortex-exec/tests/test_chat_stance_brief.py::test_build_chat_stance_inputs_falls_back_when_identity_missing`
+fails when run after other tests in specific worktree environments. Confirmed via
+`git stash` in the same worktree that this is unrelated to this fix (reverting the fix
+in-place makes it *worse* — 3 failures instead of 1 — while the primary checkout stays
+clean at 0). Looks like `CognitiveUnificationLayer`'s `ThreadPoolExecutor`-based fan-out
+(`orion/substrate/relational/layer.py`) interacting with the module-level
+`_UNIFICATION_LAYER` singleton in `chat_stance.py`. Not investigated further — flagging
+for a separate session.
+
+## Status
+
+DONE_WITH_CONCERNS — code fix complete, reviewed, tested (127 passed, scoped to
+`orion/substrate/relational/tests`), pushed, PR open. Concerns: (1) live graph cleanup of
+the 14 existing bad nodes still needs explicit go-ahead and execution, (2) pre-existing
+test flake found but not fixed (out of scope, documented).

--- a/orion/substrate/relational/adapters/identity_yaml.py
+++ b/orion/substrate/relational/adapters/identity_yaml.py
@@ -1,21 +1,33 @@
 """Identity YAML adapter — operator_static tier.
 
-Converts operator-authored identity facts from ctx into ``ConceptNodeV1`` +
-``StateSnapshotNodeV1`` nodes anchored to ``orion``.  Hub must populate
+Converts operator-authored identity facts from ctx into a single
+``StateSnapshotNodeV1`` anchored to ``orion``.  Hub must populate
 ``orion_identity_summary``, ``juniper_relationship_summary``, and
 ``response_policy_summary`` in ctx before the first ``beliefs_for_stance`` call;
 there is no disk-reading path in this adapter.  Results are written to the
 durable substrate store and protected from overwrite by lower tiers.
+
+Does NOT emit ``ConceptNodeV1`` nodes. ``orion_identity_summary`` is a flat
+merge of ``orion_identity.yaml``'s ``nature``, ``core_drives``,
+``self_permissions``, and ``anti_patterns`` blocks (see
+``orion/cognition/personality/identity_context.py``) — operator-authored
+identity facts and response-style directives ("speak as a real ongoing
+presence rather than customer-support software") with no distinction between
+them. Concept graph nodes are supposed to represent things Orion actually
+induced, not operator config reified verbatim; a prior version of this
+adapter turned every line into a ``concept``-kind graph node and polluted the
+substrate concept graph with policy prose. The snapshot's metadata still
+carries the full lists for stance-brief prompt assembly
+(``chat_stance.py:_project_identity_from_beliefs`` reads it by
+``snapshot_source``), which is unaffected by this change.
 """
 
 from __future__ import annotations
 
-import hashlib
 from datetime import datetime, timezone
 from typing import Any
 
 from orion.core.schemas.cognitive_substrate import (
-    ConceptNodeV1,
     StateSnapshotNodeV1,
     SubstrateGraphRecordV1,
     SubstrateProvenanceV1,
@@ -55,28 +67,12 @@ def map_identity_yaml_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV
 
     now = datetime.now(timezone.utc)
     temporal = make_temporal(observed_at=now)
-    prov = _make_op_static_provenance(source_kind="identity_yaml")
     high_signals = SubstrateSignalBundleV1(confidence=0.95, salience=0.8)
 
-    nodes: list[Any] = []
-
-    for i, label in enumerate(orion_summary[:12]):
-        digest = hashlib.sha256(label.encode("utf-8", errors="ignore")).hexdigest()[:12]
-        nodes.append(
-            ConceptNodeV1(
-                node_id=f"sub-identity-orion-{digest}",
-                anchor_scope="orion",
-                label=label[:120],
-                temporal=temporal,
-                provenance=prov,
-                signals=high_signals,
-                metadata={"identity_facet": "orion_summary", "facet_index": i},
-                promotion_state="canonical",
-            )
-        )
-
     # Single StateSnapshotNodeV1 carrying all three summary lists in metadata —
-    # the projection helper reads these back by snapshot_source.
+    # the projection helper (chat_stance.py:_project_identity_from_beliefs) reads
+    # these back by snapshot_source for stance-brief prompt assembly. No
+    # ConceptNodeV1 nodes are emitted — see module docstring.
     snapshot = StateSnapshotNodeV1(
         node_id="sub-identity-snapshot-orion",
         anchor_scope="orion",
@@ -92,6 +88,5 @@ def map_identity_yaml_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV
         },
         promotion_state="canonical",
     )
-    nodes.append(snapshot)
 
-    return SubstrateGraphRecordV1(anchor_scope="orion", nodes=nodes)
+    return SubstrateGraphRecordV1(anchor_scope="orion", nodes=[snapshot])

--- a/orion/substrate/relational/tests/test_adapters.py
+++ b/orion/substrate/relational/tests/test_adapters.py
@@ -21,14 +21,20 @@ class TestIdentityYamlAdapter:
     def test_returns_none_for_none_ctx(self):
         assert map_identity_yaml_to_substrate(None) is None  # type: ignore[arg-type]
 
-    def test_produces_concept_nodes_for_orion_summary(self):
+    def test_does_not_produce_concept_nodes_for_orion_summary(self):
+        # orion_identity_summary is a flat merge of nature + core_drives +
+        # self_permissions + anti_patterns (identity_context.py) -- operator
+        # config, not induced concepts. Reifying every line as a graph Concept
+        # node polluted the substrate concept graph with response-style
+        # directives (e.g. "speak as a real ongoing presence rather than
+        # customer-support software"); this adapter must never emit them.
         ctx = {"orion_identity_summary": ["Orion is a cognitive presence.", "Not a generic assistant."]}
         record = map_identity_yaml_to_substrate(ctx)
         assert record is not None
         concept_nodes = [n for n in record.nodes if n.node_kind == "concept"]
-        assert len(concept_nodes) == 2
+        assert concept_nodes == []
 
-    def test_concept_nodes_have_operator_static_tier_rank(self):
+    def test_snapshot_node_has_operator_static_tier_rank(self):
         ctx = {"orion_identity_summary": ["Orion is a cognitive presence."]}
         record = map_identity_yaml_to_substrate(ctx)
         assert record is not None
@@ -59,12 +65,12 @@ class TestIdentityYamlAdapter:
         assert snap.metadata["response_policy_summary"] == ["answer directly"]
         assert snap.snapshot_source == "identity_yaml"
 
-    def test_empty_string_items_are_skipped(self):
+    def test_empty_string_items_are_skipped_from_snapshot_metadata(self):
         ctx = {"orion_identity_summary": ["", "  ", "real fact"]}
         record = map_identity_yaml_to_substrate(ctx)
         assert record is not None
-        concept_nodes = [n for n in record.nodes if n.node_kind == "concept"]
-        assert len(concept_nodes) == 1
+        snapshots = [n for n in record.nodes if n.node_kind == "state_snapshot"]
+        assert snapshots[0].metadata["orion_identity_summary"] == ["real fact"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `map_identity_yaml_to_substrate()` (`orion/substrate/relational/adapters/identity_yaml.py`) no longer emits `ConceptNodeV1` nodes.
- Root cause of the reported symptom: chat-stance/policy directives from `orion_identity.yaml` (`core_drives`, `self_permissions`, `anti_patterns` — not just `nature`) were being reified verbatim as graph "Concept" nodes, indistinguishable from genuine self-model concepts.
- Live-confirmed via a direct FalkorDB query against `orion_substrate`: a node labeled `"speak as a real ongoing presence rather than customer-support software"` — verbatim `core_drives[3]` from `orion/cognition/personality/orion_identity.yaml`.

## Outcome moved

Identity/policy config text stops being mistaken for induced concepts in the substrate concept graph. The `StateSnapshotNodeV1` (used by `chat_stance.py:_project_identity_from_beliefs` for actual stance-brief prompt assembly) is unchanged and unaffected.

## Current architecture

`map_identity_yaml_to_substrate(ctx)` read `ctx["orion_identity_summary"]` (a flat merge of `orion_identity.yaml`'s `nature` + `core_drives` + `self_permissions` + `anti_patterns` blocks, built by `orion/cognition/personality/identity_context.py:build_identity_context`) and turned every line (up to 12) into an individual `ConceptNodeV1`, in addition to the `StateSnapshotNodeV1` carrying the same data as metadata.

## Architecture touched

- `orion/substrate/relational/adapters/identity_yaml.py` — removed the `ConceptNodeV1` loop; only the snapshot node is emitted now.
- Confirmed via review: `orion/cognition/projection_builder.py` wires this same function into a second registry (orion-mind) — no separate copy to fix.

## Files changed

- `orion/substrate/relational/adapters/identity_yaml.py`: removed `ConceptNodeV1` loop + now-unused `hashlib`/`ConceptNodeV1` imports; docstring explains why.
- `orion/substrate/relational/tests/test_adapters.py`: updated 3 tests to assert zero concept nodes / assert against snapshot metadata instead of concept-node count.

## Schema / bus / API changes

None. No schema/contract change — this only changes what one producer adapter emits into the substrate graph (fewer nodes, not a new shape).

## Env/config changes

None.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-identity-yaml-no-concept-nodes
.venv/bin/python -m pytest orion/substrate/relational/tests -q
127 passed
```

A pre-existing, order-dependent flake was found in `services/orion-cortex-exec/tests/test_chat_stance_brief.py::test_build_chat_stance_inputs_falls_back_when_identity_missing` when run in combination with other tests in specific worktrees — confirmed via `git stash` in the same worktree that it is **not** caused by this change (reverting this fix in-place makes it *worse*: 3 failures instead of 1; the primary checkout is consistently clean at 0 failures). Root cause not investigated further (looks like `CognitiveUnificationLayer`'s `ThreadPoolExecutor`-based fan-out in `orion/substrate/relational/layer.py` combined with the module-level `_UNIFICATION_LAYER` singleton in `chat_stance.py`) — out of scope for this patch, flagging for a separate investigation.

## Evals run

No eval harness exists for this adapter; not applicable.

## Docker/build/smoke checks

Not run — no Docker available in this environment; this change has no runtime/service-boundary surface (pure function, no new deps, no config).

## Review findings fixed

Subagent review (correctness, test coverage, dead code, materialization-consumer check) found no material issues — confirmed no other consumer depends on `identity_yaml` producing concept-kind nodes specifically (`_project_concept_from_beliefs` reads concept nodes generically across all producers; identity_yaml's removed nodes never set `concept_type` metadata, so removing them only reduces noise). One pre-existing unused import (`SubstrateTemporalWindowV1`) noted as out-of-scope, left alone.

## Restart required

This is a substrate adapter loaded in-process by `orion-cortex-exec` and `orion-mind` (via `orion.substrate.relational.*`), not a standalone service — restart whichever of those containers picks up this package on next deploy:

```bash
docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build orion-cortex-exec
docker compose --env-file .env --env-file services/orion-mind/.env -f services/orion-mind/docker-compose.yml up -d --build orion-mind
```

## Risks / concerns

- Severity: low
- Concern: 14 already-materialized bad concept nodes remain live in the `orion_substrate` FalkorDB graph (written before this fix; this patch only stops new ones). Cleanup is a separate, explicit live-data deletion pending operator go-ahead — snapshot taken to `/tmp/identity-yaml-concept-cleanup/snapshot_before_delete.txt` before any deletion.
- Severity: low
- Concern: pre-existing test-order flake in `test_chat_stance_brief.py` (see Tests run) — confirmed unrelated to this change, not fixed here.

## PR link