### PR TITLE
fix(substrate): concept-node activation/decay was structurally inert since inception

### DIFF
--- a/orion/core/schemas/cognitive_substrate.py
+++ b/orion/core/schemas/cognitive_substrate.py
@@ -84,6 +84,13 @@ class SubstrateActivationV1(BaseModel):
     decay_floor: float = Field(default=0.0, ge=0.0, le=1.0)
 
 
+# Default half-life for concept-node activation decay, used by ConceptNodeV1's
+# auto-seed validator below when a producer doesn't set one explicitly. Mirrors
+# orion.memory.crystallization's own precedent for the separate crystallization
+# system (orion/memory/crystallization/schemas.py: decay_half_life_days = 30.0).
+DEFAULT_CONCEPT_ACTIVATION_HALF_LIFE_SECONDS = 30 * 24 * 60 * 60
+
+
 class SubstrateTemporalWindowV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -154,6 +161,39 @@ class ConceptNodeV1(BaseSubstrateNodeV1):
     label: str = Field(min_length=1)
     definition: Optional[str] = None
     taxonomy_path: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _seed_activation_if_unset(self) -> "ConceptNodeV1":
+        """Auto-seed activation/half-life when a producer left `signals.activation`
+        at the pure schema default (activation=0.0, decay_half_life_seconds=None).
+
+        Every real ConceptNodeV1 producer historically left this sub-object
+        untouched, which made Hub's live decay scheduler
+        (services/orion-hub/scripts/api_routes.py::decay_concept_activations())
+        a permanent no-op: decay_activation() treats a falsy half-life as "clamp
+        to floor, don't decay." Enforcing the seed here, at the schema boundary,
+        means every current and future producer gets working decay for free
+        instead of each adapter needing to remember to call a helper by hand
+        (16+ live construction sites were found still missing it when this was
+        first patched at the adapter level alone -- see
+        orion/substrate/adapters/_common.py::make_activation() for the
+        opt-in helper adapters can still use to seed a non-default value
+        explicitly, e.g. from a real confidence/salience prior).
+
+        Only fires when BOTH fields are still at their literal schema
+        defaults, so a producer that explicitly sets activation (even to
+        0.0 with a real half-life, or vice versa) is never overridden.
+        """
+        activation = self.signals.activation
+        if activation.activation == 0.0 and activation.decay_half_life_seconds is None:
+            seeded = activation.model_copy(
+                update={
+                    "activation": self.signals.salience,
+                    "decay_half_life_seconds": DEFAULT_CONCEPT_ACTIVATION_HALF_LIFE_SECONDS,
+                }
+            )
+            self.signals = self.signals.model_copy(update={"activation": seeded})
+        return self
 
 
 class EventNodeV1(BaseSubstrateNodeV1):

--- a/orion/substrate/adapters/_common.py
+++ b/orion/substrate/adapters/_common.py
@@ -3,7 +3,46 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from orion.core.schemas.cognitive_substrate import SubstrateProvenanceV1, SubstrateTemporalWindowV1
+from orion.core.schemas.cognitive_substrate import (
+    DEFAULT_CONCEPT_ACTIVATION_HALF_LIFE_SECONDS,
+    SubstrateActivationV1,
+    SubstrateProvenanceV1,
+    SubstrateTemporalWindowV1,
+)
+
+__all__ = [
+    "DEFAULT_CONCEPT_ACTIVATION_HALF_LIFE_SECONDS",
+    "make_activation",
+    "make_provenance",
+    "make_temporal",
+]
+
+
+def make_activation(
+    *,
+    initial_activation: float,
+    decay_half_life_seconds: int = DEFAULT_CONCEPT_ACTIVATION_HALF_LIFE_SECONDS,
+) -> SubstrateActivationV1:
+    """Explicitly seed a concept node's activation signal.
+
+    Optional for callers: `ConceptNodeV1` itself now auto-seeds `activation`
+    from `salience` and applies `DEFAULT_CONCEPT_ACTIVATION_HALF_LIFE_SECONDS`
+    whenever a producer leaves `signals.activation` at its pure schema default
+    (see `ConceptNodeV1._seed_activation_if_unset` in
+    `orion/core/schemas/cognitive_substrate.py`) -- that fix applies to every
+    producer, not just the ones that call this helper. Use this directly when
+    a producer wants a specific initial value other than raw `salience`, or
+    wants to be explicit about it at the call site.
+
+    `recency_score` is deliberately left at its schema default (0.0) here --
+    it is meant to be derived from `temporal.observed_at` at read/tick time
+    (see `orion/substrate/dynamics.py::_compute_activations`), not fabricated
+    at construction time from an unrelated salience/confidence value.
+    """
+    return SubstrateActivationV1(
+        activation=min(1.0, max(0.0, initial_activation)),
+        decay_half_life_seconds=decay_half_life_seconds,
+    )
 
 
 def _ensure_tz(value: datetime | None) -> datetime:

--- a/orion/substrate/adapters/concept_induction.py
+++ b/orion/substrate/adapters/concept_induction.py
@@ -13,7 +13,7 @@ from orion.core.schemas.cognitive_substrate import (
     SubstrateGraphRecordV1,
 )
 
-from ._common import make_provenance, make_temporal
+from ._common import make_activation, make_provenance, make_temporal
 
 
 def map_concept_profile_to_substrate(
@@ -29,6 +29,7 @@ def map_concept_profile_to_substrate(
     evidence_to_concepts: dict[str, list[str]] = defaultdict(list)
     for concept in profile.concepts:
         concept_node_id = f"sub-concept-{concept.concept_id}"
+        concept_salience = min(1.0, max(0.0, concept.salience))
         nodes.append(
             ConceptNodeV1(
                 node_id=concept_node_id,
@@ -46,7 +47,8 @@ def map_concept_profile_to_substrate(
                 taxonomy_path=[str(concept.type)] if concept.type else [],
                 signals={
                     "confidence": concept.confidence,
-                    "salience": min(1.0, max(0.0, concept.salience)),
+                    "salience": concept_salience,
+                    "activation": make_activation(initial_activation=concept_salience),
                 },
                 metadata={"concept_id": concept.concept_id, "aliases": list(concept.aliases), "embedding_ref": concept.embedding_ref},
             )

--- a/orion/substrate/adapters/topic_foundry.py
+++ b/orion/substrate/adapters/topic_foundry.py
@@ -31,7 +31,7 @@ from orion.core.schemas.cognitive_substrate import (
     SubstrateSignalBundleV1,
 )
 
-from ._common import make_provenance, make_temporal
+from ._common import make_activation, make_provenance, make_temporal
 
 # --- Caps (this repo requires capped collections everywhere; see
 # docs/superpowers/pr-reports/... incident where an uncapped evidence-id list
@@ -259,7 +259,11 @@ def _build(
                 label=info["label"],
                 definition=None,
                 taxonomy_path=[],
-                signals=SubstrateSignalBundleV1(confidence=confidence, salience=salience),
+                signals=SubstrateSignalBundleV1(
+                    confidence=confidence,
+                    salience=salience,
+                    activation=make_activation(initial_activation=salience),
+                ),
                 metadata=metadata,
             )
         )

--- a/orion/substrate/tests/test_relation_classification.py
+++ b/orion/substrate/tests/test_relation_classification.py
@@ -233,8 +233,15 @@ def test_activation_stale_decayed_does_not_cross_threshold() -> None:
 def test_activation_unset_degrades_gracefully() -> None:
     # Default SubstrateActivationV1() has activation=0.0 -- schema default,
     # indistinguishable from "never seeded"; must degrade, not raise/guess.
-    node_a = _concept(node_id="concept-a", label="a")
-    node_b = _concept(node_id="concept-b", label="b")
+    # salience=0.0 explicitly here (unlike _concept()'s own default of 0.1):
+    # ConceptNodeV1 now auto-seeds activation from salience whenever a
+    # producer leaves signals.activation untouched (see
+    # cognitive_substrate.py::ConceptNodeV1._seed_activation_if_unset), so a
+    # nonzero salience would no longer read as "unset" -- this test's actual
+    # intent is an activation signal that reads as a real zero, which is
+    # still exactly what a zero-salience, never-reinforced concept produces.
+    node_a = _concept(node_id="concept-a", label="a", salience=0.0)
+    node_b = _concept(node_id="concept-b", label="b", salience=0.0)
 
     assert decayed_activation_score(node_a) is None
     assert worth_classifying_activation(node_a, node_b) is False

--- a/orion/substrate/tests/test_seed_concepts.py
+++ b/orion/substrate/tests/test_seed_concepts.py
@@ -30,6 +30,14 @@ def test_load_seed_concepts_into_store_writes_three_canonical_concepts() -> None
         assert node.promotion_state == "canonical"
         assert node.node_kind == "concept"
         assert node.definition
+        # Regression: seed_concepts.py passes no `signals=` at all, so before
+        # ConceptNodeV1's auto-seed validator existed, the three golden
+        # concepts (the highest-authority, longest-lived nodes in the store)
+        # were permanently stuck at activation=0.0/decay_half_life=None --
+        # immune to Hub's live decay scheduler forever, same bug as the
+        # organic-growth adapters.
+        assert node.signals.activation.decay_half_life_seconds is not None
+        assert node.signals.activation.decay_half_life_seconds > 0
 
 
 def test_load_seed_concepts_into_store_wires_relationship_edges() -> None:

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -443,6 +443,38 @@ an ever-growing elapsed-since-creation window, collapsing activation to `decay_f
 roughly one configured half-life regardless of the half-life value (a real bug caught in
 review during PR #1131 — see that PR's description for the numeric trace).
 
+**Activation was seeded at 0.0 with no half-life until 2026-07-17 (fixed):** decay math
+being correct is meaningless if there's nothing to decay. No `ConceptNodeV1` producer ever
+set `signals.activation` when constructing a node — every concept was born at the schema
+default (`activation=0.0`, `decay_half_life_seconds=None`), and `decay_activation()` treats
+a falsy half-life as "clamp to floor, don't decay." So the live scheduler above was decaying
+an input that was permanently `(0.0, None)` — 120s ticks that correctly computed nothing,
+forever. This was not limited to the two organic-growth adapters (`topic_foundry.py`,
+`concept_induction.py`) — a code-review pass on the first version of this fix found 16+ live
+`ConceptNodeV1` construction sites still missing it, including the three golden/seed
+concepts (`orion/substrate/seed.py`) and every `orion/substrate/relational/adapters/*.py`
+producer. Rather than patch each call site by hand (and risk missing the next one), the fix
+lives at the schema boundary: `ConceptNodeV1` now has a `model_validator(mode="after")`
+(`orion/core/schemas/cognitive_substrate.py::_seed_activation_if_unset`) that auto-seeds
+`activation = salience` and a 30-day default half-life whenever a producer leaves
+`signals.activation` at its pure schema default — covering every current and future
+producer, not just the ones that remember to opt in. `orion/substrate/adapters/_common.py::make_activation()`
+remains available for a producer that wants an explicit, non-default initial value.
+Reinforcement-on-recall (bumping activation when a concept is actually retrieved in a live
+turn, mirroring `orion/memory/crystallization/dynamics.py::recall_boost()`'s existing
+precedent for the separate crystallization system) is not wired yet — deferred, see the
+concept_region collector at §15 of `services/orion-recall/README.md` for the natural call
+site.
+
+**Side effect caught in review:** `GET /api/substrate/concepts/summary`'s `_at_risk_concepts()`
+used to treat "every concept node's activation is identical" as a proxy for "no live decay
+signal exists yet" and returned an empty, explained `at_risk` list in that case. Once
+activation is seeded at construction, a brand-new low-salience concept would otherwise show
+up as "at risk of decaying toward its floor" on its very first tick — it hasn't decayed at
+all, it just started low. Fixed by replacing the variance proxy with an explicit age gate
+(`_AT_RISK_MIN_AGE_SECONDS`, one hour): a concept must have existed long enough for real
+decay ticks to plausibly have run before it's eligible for `at_risk` at all.
+
 **Autonomous scheduler window math, if debugging why a training run didn't fire:**
 `trigger_topic_foundry_training_run()` floors its rolling window's `end_at` to a UTC day
 boundary before computing `start_at` from it — NOT `datetime.now()` verbatim. This is load-

--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -55,10 +55,14 @@ _VALID_ANCHOR_SCOPES = {"orion", "juniper", "relationship", "world", "session"}
 # endpoint's response instead of round-tripping it server-side.
 
 # Concept nodes sitting within this margin of their own decay_floor are
-# treated as "at risk" in the summary response. This is only meaningful once
-# a node's activation has moved off its schema default of 0.0 — see the
-# comment in ``_at_risk_concepts`` below.
+# treated as "at risk" in the summary response.
 _AT_RISK_MARGIN = 0.05
+
+# A concept must be at least this old before it's eligible for "at risk" --
+# see ``_at_risk_concepts`` for why (a node born with low salience hasn't
+# decayed, it just started low). One hour comfortably exceeds one 120s decay
+# tick interval.
+_AT_RISK_MIN_AGE_SECONDS = 3600.0
 
 # Max co_occurs_with pairs classified for a typed relationship (supports/
 # contradicts/refines) per ingestion call. Each classified pair costs one
@@ -418,31 +422,48 @@ def _classify_typed_concept_relations(store: Any) -> int:
         return 0
 
 
-def _at_risk_concepts(concept_nodes: list[Any]) -> tuple[list[dict[str, Any]], Optional[str]]:
+def _at_risk_concepts(
+    concept_nodes: list[Any], *, now: Optional[datetime] = None
+) -> tuple[list[dict[str, Any]], Optional[str]]:
     """Concepts whose activation is decaying toward their decay_floor.
 
-    Honesty note: ``SubstrateActivationV1.activation`` defaults to 0.0 and no
-    live writer currently drives concept-node decay in the default
-    ``InMemorySubstrateGraphStore`` path (per the design spec's Current
-    architecture section: "present in schema, no confirmed live writer").
-    Returning every node at the default as "at risk" would be a fabricated
-    signal, not a real one. So: if every concept node's activation is exactly
-    the same value (almost always 0.0 today), this returns an empty list and
-    an explanatory note instead of pretending the field carries real
-    information yet.
+    Honesty note: this used to gate on "does activation show any variance
+    across nodes" as a proxy for "is a live decay writer actually wired" --
+    back when every ConceptNodeV1 was born with the exact same schema
+    default (activation=0.0, decay_half_life_seconds=None), same-value
+    across the board really did mean no real signal existed yet. Two fixes
+    landed since (services/orion-hub/scripts/api_routes.py::decay_concept_activations,
+    a live 120s scheduler; and ConceptNodeV1's own activation=salience
+    auto-seed at construction time) mean activation is now a real signal
+    from the moment a node is created, so the variance proxy is retired --
+    it would otherwise misfire the other way, hiding genuinely-at-risk nodes
+    the instant any two concepts happened to share a salience value.
+
+    What replaces it: a concept born with low salience is not yet
+    meaningfully "at risk of decaying" -- it just started low, it hasn't
+    lost anything. So nodes younger than ``_AT_RISK_MIN_AGE_SECONDS`` (one
+    hour -- comfortably more than one 120s decay tick, giving real decay a
+    chance to actually run) are excluded regardless of how low their
+    activation already is. This is still a real, non-fabricated filter, not
+    a returned-empty placeholder.
     """
     if not concept_nodes:
         return [], None
-    activations = {float(n.signals.activation.activation) for n in concept_nodes}
-    if len(activations) <= 1:
-        return [], (
-            "activation shows no variance across concept nodes yet (no live decay "
-            "writer wired to this store today) -- at_risk is intentionally empty "
-            "rather than fabricated"
-        )
+
+    reference = now or datetime.now(timezone.utc)
     at_risk: list[dict[str, Any]] = []
+    eligible_count = 0
     for n in concept_nodes:
         act = n.signals.activation
+        observed_at = getattr(getattr(n, "temporal", None), "observed_at", None)
+        if observed_at is None:
+            continue
+        if observed_at.tzinfo is None:
+            observed_at = observed_at.replace(tzinfo=timezone.utc)
+        age_seconds = (reference - observed_at).total_seconds()
+        if age_seconds < _AT_RISK_MIN_AGE_SECONDS:
+            continue
+        eligible_count += 1
         if float(act.activation) <= float(act.decay_floor) + _AT_RISK_MARGIN:
             at_risk.append(
                 {
@@ -454,7 +475,15 @@ def _at_risk_concepts(concept_nodes: list[Any]) -> tuple[list[dict[str, Any]], O
                 }
             )
     at_risk.sort(key=lambda row: row["activation"])
-    return at_risk[:20], None
+
+    note = None
+    if not at_risk and eligible_count == 0:
+        note = (
+            f"no concept node is older than {int(_AT_RISK_MIN_AGE_SECONDS)}s yet -- "
+            "at_risk is intentionally empty rather than judging a node's real decay "
+            "before it has had a chance to run"
+        )
+    return at_risk[:20], note
 
 
 @router.get("/api/substrate/concepts/summary")

--- a/services/orion-hub/tests/test_concept_atlas_routes.py
+++ b/services/orion-hub/tests/test_concept_atlas_routes.py
@@ -71,13 +71,15 @@ def _provenance():
     )
 
 
-def _temporal():
+def _temporal(observed_at=None):
     from orion.core.schemas.cognitive_substrate import SubstrateTemporalWindowV1
 
-    return SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc))
+    return SubstrateTemporalWindowV1(observed_at=observed_at or datetime.now(timezone.utc))
 
 
-def _concept_node(node_id, label, *, anchor_scope="orion", promotion_state="proposed", activation=0.0, decay_floor=0.0):
+def _concept_node(
+    node_id, label, *, anchor_scope="orion", promotion_state="proposed", activation=0.0, decay_floor=0.0, observed_at=None
+):
     from orion.core.schemas.cognitive_substrate import ConceptNodeV1, SubstrateActivationV1, SubstrateSignalBundleV1
 
     return ConceptNodeV1(
@@ -85,7 +87,7 @@ def _concept_node(node_id, label, *, anchor_scope="orion", promotion_state="prop
         label=label,
         anchor_scope=anchor_scope,
         promotion_state=promotion_state,
-        temporal=_temporal(),
+        temporal=_temporal(observed_at),
         provenance=_provenance(),
         signals=SubstrateSignalBundleV1(
             confidence=0.7,
@@ -164,20 +166,24 @@ def test_summary_counts_with_seeded_nodes(client: TestClient, monkeypatch: pytes
     assert body["by_anchor_scope"]["world"] == 1
     assert body["edge_counts_by_predicate"]["co_occurs_with"] == 1
     assert body["edge_counts_by_predicate"]["contradicts"] == 1
-    # All three seeded nodes share activation=0.0 -> no fabricated at_risk signal.
+    # All three seeded nodes were just created (observed_at ~= now) -> too
+    # young for _AT_RISK_MIN_AGE_SECONDS, regardless of their activation.
     assert body["at_risk"] == []
     assert body["at_risk_note"]
 
 
-def test_summary_at_risk_reported_when_activation_has_real_variance(
+def test_summary_at_risk_reported_for_old_low_activation_nodes(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    from datetime import timedelta
+
     from scripts import concept_atlas_routes
     from orion.substrate.store import InMemorySubstrateGraphStore
 
     store = InMemorySubstrateGraphStore()
-    healthy = _concept_node("concept-healthy", "Healthy", activation=0.9, decay_floor=0.1)
-    decaying = _concept_node("concept-decaying", "Decaying", activation=0.05, decay_floor=0.02)
+    old_enough = datetime.now(timezone.utc) - timedelta(hours=2)
+    healthy = _concept_node("concept-healthy", "Healthy", activation=0.9, decay_floor=0.1, observed_at=old_enough)
+    decaying = _concept_node("concept-decaying", "Decaying", activation=0.05, decay_floor=0.02, observed_at=old_enough)
     store.upsert_node(identity_key="concept:healthy", node=healthy)
     store.upsert_node(identity_key="concept:decaying", node=decaying)
     monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
@@ -188,6 +194,37 @@ def test_summary_at_risk_reported_when_activation_has_real_variance(
     at_risk_ids = {row["node_id"] for row in body["at_risk"]}
     assert "concept-decaying" in at_risk_ids
     assert "concept-healthy" not in at_risk_ids
+
+
+def test_summary_at_risk_excludes_freshly_born_low_salience_node(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression: ConceptNodeV1 now auto-seeds activation=salience at
+    # construction time, so a brand-new, low-salience concept could
+    # otherwise show up as "at risk of decaying" on its very first tick --
+    # it hasn't decayed at all, it just started low. The age gate must
+    # exclude it even though its activation already sits at/under the
+    # decay_floor + margin threshold.
+    from scripts import concept_atlas_routes
+    from orion.core.schemas.cognitive_substrate import ConceptNodeV1, SubstrateSignalBundleV1
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fresh_low_salience = ConceptNodeV1(
+        node_id="concept-fresh-low",
+        label="Fresh Low Salience",
+        anchor_scope="world",
+        temporal=_temporal(),
+        provenance=_provenance(),
+        signals=SubstrateSignalBundleV1(confidence=0.5, salience=0.01),
+    )
+    store.upsert_node(identity_key="concept:fresh-low", node=fresh_low_salience)
+    monkeypatch.setattr(concept_atlas_routes, "_get_substrate_store", lambda: store)
+
+    r = client.get("/api/substrate/concepts/summary")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["at_risk"] == []
 
 
 # --- network -----------------------------------------------------------------

--- a/tests/test_cognitive_substrate_phase1.py
+++ b/tests/test_cognitive_substrate_phase1.py
@@ -123,6 +123,52 @@ def test_temporal_and_activation_support_fields_validate() -> None:
     assert node.signals.activation.decay_half_life_seconds == 60
 
 
+def test_concept_node_auto_seeds_activation_when_producer_leaves_it_unset() -> None:
+    # Regression: every real ConceptNodeV1 producer historically left
+    # signals.activation at the pure schema default (activation=0.0,
+    # decay_half_life_seconds=None), which made Hub's live decay scheduler
+    # a permanent no-op (decay_activation() treats a falsy half-life as
+    # "clamp to floor, don't decay"). ConceptNodeV1 now auto-seeds both
+    # fields from salience whenever a producer passes no `signals=` at all
+    # -- exactly the construction pattern orion/substrate/seed.py's golden
+    # concepts (Orion, Juniper, the relationship) use.
+    node = ConceptNodeV1(anchor_scope="orion", temporal=_temporal(), provenance=_provenance(), label="unseeded")
+    assert node.signals.activation.decay_half_life_seconds is not None
+    assert node.signals.activation.decay_half_life_seconds > 0
+    assert node.signals.activation.activation == node.signals.salience
+
+
+def test_concept_node_auto_seed_respects_nonzero_salience() -> None:
+    node = ConceptNodeV1(
+        anchor_scope="orion",
+        temporal=_temporal(),
+        provenance=_provenance(),
+        label="salient",
+        signals={"confidence": 0.9, "salience": 0.73},
+    )
+    assert node.signals.activation.activation == 0.73
+    assert node.signals.activation.decay_half_life_seconds is not None
+
+
+def test_concept_node_auto_seed_never_overrides_explicit_activation() -> None:
+    # An explicitly-set activation (even a nonzero one paired with an
+    # explicit half-life) must be respected verbatim, not clobbered by the
+    # auto-seed -- covered generally by
+    # test_temporal_and_activation_support_fields_validate above; this adds
+    # the edge case of an explicit *zero* activation paired with a real
+    # half-life, which the auto-seed's guard condition must still leave alone
+    # since decay_half_life_seconds is not None.
+    node = ConceptNodeV1(
+        anchor_scope="orion",
+        temporal=_temporal(),
+        provenance=_provenance(),
+        label="deliberately-cold",
+        signals={"confidence": 0.9, "salience": 0.6, "activation": {"activation": 0.0, "decay_half_life_seconds": 3600}},
+    )
+    assert node.signals.activation.activation == 0.0
+    assert node.signals.activation.decay_half_life_seconds == 3600
+
+
 def test_registry_and_exports_include_substrate_contracts() -> None:
     assert "SubstrateEdgeV1" in _REGISTRY
     assert "EntityNodeV1" in _REGISTRY

--- a/tests/test_cognitive_substrate_phase2_domain_mappings.py
+++ b/tests/test_cognitive_substrate_phase2_domain_mappings.py
@@ -58,6 +58,21 @@ def test_concept_adapter_maps_profile_and_preserves_scope_subject_and_provenance
     assert concept_nodes[0].provenance.source_kind == "concept_induction.profile"
 
 
+def test_concept_adapter_seeds_activation_and_half_life_from_salience() -> None:
+    # Regression: signals.activation used to be left at the schema default
+    # (activation=0.0, decay_half_life_seconds=None), making Hub's decay
+    # scheduler a permanent no-op for every concept node it touched.
+    profile = _concept_profile()
+    out = map_concept_profile_to_substrate(profile=profile, anchor_scope="orion")
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert concept_nodes
+    node = concept_nodes[0]
+    assert node.signals.activation.activation == node.signals.salience
+    assert node.signals.activation.activation > 0.0
+    assert node.signals.activation.decay_half_life_seconds is not None
+    assert node.signals.activation.decay_half_life_seconds > 0
+
+
 def test_concept_delta_adapter_only_emits_contradiction_when_semantics_support_it() -> None:
     now = datetime.now(timezone.utc)
     delta = ConceptProfileDelta(profile_id="p1", from_rev=1, to_rev=2, added=["c2"], removed=["c1"], rationale="concept conflict")

--- a/tests/test_cognitive_substrate_topic_foundry_adapter.py
+++ b/tests/test_cognitive_substrate_topic_foundry_adapter.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
+from orion.core.activation_decay import decay_activation
 from orion.core.schemas.cognitive_substrate import SubstrateGraphRecordV1
 from orion.substrate.adapters.topic_foundry import map_topic_foundry_run_to_substrate
 
@@ -189,6 +192,40 @@ def test_malformed_segment_topic_map_degrades_gracefully() -> None:
     assert isinstance(out, SubstrateGraphRecordV1)
     # The single concept node still forms; the malformed window is simply skipped.
     assert len([n for n in out.nodes if n.node_kind == "concept"]) == 1
+
+
+def test_concept_node_seeds_activation_and_half_life_from_salience() -> None:
+    # Regression: ConceptNodeV1's signals.activation used to be left at the
+    # schema default (activation=0.0, decay_half_life_seconds=None), which
+    # made Hub's decay scheduler a permanent no-op for every concept node
+    # (decay_activation() treats a falsy half_life as "don't decay").
+    topics = [{"topic_id": 0, "count": 200, "outlier_pct": 0.0, "label": "hot topic"}]
+    out = map_topic_foundry_run_to_substrate(run_id="run-1", topics=topics, keywords_by_topic={})
+    concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
+    assert concept_nodes
+    node = concept_nodes[0]
+    assert node.signals.activation.activation == node.signals.salience
+    assert node.signals.activation.activation > 0.0
+    assert node.signals.activation.decay_half_life_seconds is not None
+    assert node.signals.activation.decay_half_life_seconds > 0
+
+
+def test_seeded_activation_actually_decays_past_half_life() -> None:
+    # End-to-end acceptance check: a seeded concept node's activation, fed
+    # through the same decay_activation() Hub's scheduler calls, measurably
+    # drops after real elapsed time -- not just "the fields are non-None."
+    topics = [{"topic_id": 0, "count": 200, "outlier_pct": 0.0, "label": "hot topic"}]
+    out = map_topic_foundry_run_to_substrate(run_id="run-1", topics=topics, keywords_by_topic={})
+    activation_signal = [n for n in out.nodes if n.node_kind == "concept"][0].signals.activation
+
+    decayed = decay_activation(
+        current=activation_signal.activation,
+        elapsed_seconds=activation_signal.decay_half_life_seconds,  # exactly one half-life
+        half_life_seconds=activation_signal.decay_half_life_seconds,
+        floor=activation_signal.decay_floor,
+    )
+    assert decayed == pytest.approx(activation_signal.activation / 2, rel=1e-6)
+    assert decayed < activation_signal.activation
 
 
 def test_observed_at_and_subject_ref_propagate() -> None:


### PR DESCRIPTION
## Summary

- Every `ConceptNodeV1` producer left `signals.activation` at the pure schema default (`activation=0.0`, `decay_half_life_seconds=None`). Hub's live decay scheduler correctly decays whatever it's given, but `decay_activation()` treats a falsy half-life as "clamp to floor, don't decay" — so decay has been a permanent no-op for every concept node since the concept-graph pipeline's inception.
- Fixed at the schema boundary, not per-adapter: `ConceptNodeV1` now auto-seeds `activation = salience` and a 30-day default half-life via a `model_validator` whenever a producer leaves the field untouched — covering all 16+ live construction sites (including `orion/substrate/seed.py`'s golden concepts) instead of the 2 a first pass covered.
- Two real interactions with existing behavior found via code review and fixed properly: a relation-classifier test that relied on the old "unset = 0.0" semantics, and a Hub summary-route heuristic (`_at_risk_concepts()`) that would have started mislabeling freshly-created low-salience concepts as "at risk of decaying" on their first tick.
- Reinforcement-on-recall (bumping activation when a concept is actually retrieved live) is explicitly deferred, not silently dropped — flagged in the README as the natural next step.

## Outcome moved

Concept-node decay goes from 100%-inert (every node frozen at `activation=0.0` forever) to functioning as designed: every concept — organic (topic-foundry, legacy concept-induction) and canonical (golden seed concepts) — now has a real, decaying activation value that Hub's existing 120s scheduler actually moves.

## Current architecture

`FalkorSubstrateStore`/`InMemorySubstrateGraphStore` hold `ConceptNodeV1` records; Hub's `decay_concept_activations()` (`services/orion-hub/scripts/api_routes.py`, live since PR shipping `e5d037c4`, 120s tick, `SUBSTRATE_DECAY_SCHEDULER_ENABLED=true` by default) reads every `node_kind=="concept"` node from the store's `snapshot()` and applies `orion.core.activation_decay.decay_activation()`. The scheduler itself is correct and was already tested — the bug was entirely upstream, in what producers handed it.

## Architecture touched

- `orion/core/schemas/cognitive_substrate.py` — schema-level fix (new constant + validator on `ConceptNodeV1`).
- `orion/substrate/adapters/_common.py`, `topic_foundry.py`, `concept_induction.py` — first-pass adapter-level seeding, kept as an opt-in explicit helper.
- `services/orion-hub/scripts/concept_atlas_routes.py` — `_at_risk_concepts()` heuristic fix (age gate replaces a now-broken variance proxy).
- Tests across `tests/`, `orion/substrate/tests/`, `services/orion-hub/tests/`.
- `services/orion-hub/README.md` — existing Concept Atlas section updated with the real root-cause narrative.

## Files changed

- `orion/core/schemas/cognitive_substrate.py`: added `DEFAULT_CONCEPT_ACTIVATION_HALF_LIFE_SECONDS` (30 days) and `ConceptNodeV1._seed_activation_if_unset` (`model_validator(mode="after")`) — auto-seeds `activation`/`decay_half_life_seconds` only when both are still at their literal schema defaults; never overrides an explicit value.
- `orion/substrate/adapters/_common.py`: `make_activation()` kept as an opt-in helper; docstring/comment corrected to describe the real (schema-level) enforcement mechanism instead of overclaiming adapter-level coverage.
- `orion/substrate/adapters/topic_foundry.py`, `concept_induction.py`: explicitly seed activation from salience at construction (redundant with the schema fix, but explicit and self-documenting at these two high-volume producers).
- `services/orion-hub/scripts/concept_atlas_routes.py`: `_at_risk_concepts()` rewritten — dropped the stale "activation shows no variance = no real signal" proxy (broken by this patch, since activation is now real from birth) in favor of an explicit `_AT_RISK_MIN_AGE_SECONDS` (3600s) age gate.
- `orion/substrate/tests/test_relation_classification.py`: `test_activation_unset_degrades_gracefully` updated to pass `salience=0.0` explicitly, preserving its original intent (a genuinely-zero activation must still degrade to `None`) now that a nonzero default salience would no longer read as "unset."
- `orion/substrate/tests/test_seed_concepts.py`: new assertions proving the three golden concepts get a real `decay_half_life_seconds`.
- `tests/test_cognitive_substrate_phase1.py`: 3 new tests for the validator (auto-seeds when unset, respects nonzero salience, never overrides an explicit value).
- `tests/test_cognitive_substrate_phase2_domain_mappings.py`, `tests/test_cognitive_substrate_topic_foundry_adapter.py`: regression tests per adapter, including one that runs the seeded value through real `decay_activation()` and asserts a measurable drop at one half-life.
- `services/orion-hub/tests/test_concept_atlas_routes.py`: `_temporal()`/`_concept_node()` extended to accept an `observed_at` override; existing variance test renamed/fixed to use old-enough nodes; new test proving a freshly-born low-salience node is correctly excluded from `at_risk`.
- `services/orion-hub/README.md`: root-cause narrative + at-risk interaction fix documented in place of the (now corrected) earlier overclaim.

## Schema / bus / API changes

- Added: none (no bus/channel changes). `ConceptNodeV1`'s validator changes behavior, not shape — same fields, same wire format.
- Removed: none.
- Renamed: none.
- Behavior changed: `ConceptNodeV1(...)` construction now returns a node with non-default `signals.activation` whenever the caller didn't set one explicitly. `GET /api/substrate/concepts/summary`'s `at_risk`/`at_risk_note` fields now reflect an age-gated real signal instead of a variance-based placeholder.
- Compatibility notes: no consumer depends on the old always-`(0.0, None)` activation state in a way that survived review (the one that did — `relation_classification.py`'s unused `"activation"` strategy — was fixed at the test level; the live `"count"` strategy is untouched).

## Env/config changes

None. No new env keys, no `.env_example` changes.

## Tests run

```text
PYTHONPATH=. pytest tests/test_cognitive_substrate_phase1.py tests/test_cognitive_substrate_phase2_domain_mappings.py \
  tests/test_cognitive_substrate_topic_foundry_adapter.py orion/substrate/tests orion/substrate/relational/tests \
  orion/spark/concept_induction/tests -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
666 passed

(services/orion-hub) PYTHONPATH=../..:. pytest tests/test_concept_atlas_routes.py \
  tests/test_substrate_concept_decay_scheduler.py tests/test_concept_atlas_ingest_topic_foundry.py \
  tests/test_concept_relation_classifier.py -q
60 passed

(services/orion-substrate-runtime) pytest tests -k "concept or activation or dynamics" --ignore=tests/test_grammar_consumer_integration.py -q
7 passed

(services/orion-recall) pytest tests/test_concept_region_collector.py tests/test_concept_region_wiring.py -q
19 passed
```

Two pre-existing failures on `main`, unrelated to this change, confirmed by reproducing them identically against a clean unmodified `main` checkout: `tests/test_cognitive_substrate_phase8_frontier_invocation.py::test_signal_derivation_and_task_selection_are_deterministic`, `tests/test_cognitive_substrate_phase9_consolidation.py::test_outcomes_cover_reinforce_requeue_damp_retire_and_priority`. Not touched here.

## Evals run

No dedicated eval harness exists for `orion/substrate/`. The new `tests/test_cognitive_substrate_topic_foundry_adapter.py::test_seeded_activation_actually_decays_past_half_life` test is the direct functional acceptance check for this fix: it feeds a seeded node's real activation through the actual `decay_activation()` the scheduler calls and asserts a real numeric drop at one half-life.

## Docker/build/smoke checks

Not rebuilt/deployed as part of this PR — code-only fix, tested in the worktree. No runtime/config/Docker surface changed.

## Review findings fixed

- Finding: "every ConceptNodeV1 producer"/"fixed" claims in the first-pass diff overstated scope — only 2 of 16+ live construction sites were actually touched, including missing the three golden/seed concepts.
  - Fix: moved the fix to the schema boundary (`ConceptNodeV1.model_validator`) so it applies to every current and future producer regardless of whether it calls a helper.
  - Evidence: `orion/substrate/tests/test_seed_concepts.py` new assertions pass against `orion/substrate/seed.py`'s actual golden-concept construction path (no `signals=` passed at all).
- Finding: pydantic v2 mutation safety of `self.signals = self.signals.model_copy(...)` inside the validator was unverified.
  - Fix: confirmed via review — no `frozen=True`/`validate_assignment=True` anywhere in the model chain, so the reassignment neither raises nor re-triggers validation recursively.
  - Evidence: full test suite passes with no recursion/frozen errors; reviewed `model_config` on every class in the chain directly.
- Finding: `services/orion-hub/scripts/concept_atlas_routes.py::_at_risk_concepts()`'s "no variance across activation = no real signal" guard would misfire once activation is seeded at birth — a fresh low-salience concept would immediately read as "at risk," which is misleading (it hasn't decayed, it just started low).
  - Fix: replaced the variance proxy with an explicit `_AT_RISK_MIN_AGE_SECONDS` (1 hour) age gate.
  - Evidence: new tests `test_summary_at_risk_reported_for_old_low_activation_nodes` (old + low activation still surfaces) and `test_summary_at_risk_excludes_freshly_born_low_salience_node` (fresh + low activation does not), both passing.
- Finding: `orion/substrate/tests/test_relation_classification.py::test_activation_unset_degrades_gracefully` broke because its default fixture's nonzero salience (0.1) no longer produces an "unset-looking" activation post-fix.
  - Fix: pass `salience=0.0` explicitly, preserving the test's real intent (a genuinely-zero activation reading must still degrade to `None`).
  - Evidence: test passes; confirmed the live call site uses `strategy="count"`, not the `"activation"` strategy this test exercises, so the interaction was real but not production-impacting.

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

Any other service that imports `orion.core.schemas.cognitive_substrate` and constructs `ConceptNodeV1` (orion-recall, orion-spark-concept-induction, orion-substrate-runtime, orion-cortex-orch, orion-cortex-exec) should also be restarted to pick up the fix, though none require an env/image change beyond the code itself.

## Risks / concerns

- Severity: Low
- Concern: the auto-seed guard (`activation == 0.0 and decay_half_life_seconds is None`) can't distinguish "producer never touched this field" from "producer explicitly set both to exactly those default-looking values on purpose" — an inherent limitation of value-based unset-detection without a sentinel.
- Mitigation: no live producer in this diff hits that combination (every explicit-seeding call site uses `make_activation()`, which always sets a real half-life), so it's a documented, currently-dormant edge case, not a live bug.
- Severity: Low
- Concern: golden/seed concepts (`orion/substrate/seed.py`) have no `salience` in their YAML fixture, so their auto-seeded `activation` stays at `0.0` even after this fix — only `decay_half_life_seconds` becomes real for them. Honestly disclosed in the README diff, not hidden.
- Mitigation: reinforcement-on-recall (deferred, see README) is the natural mechanism to eventually give these three nodes real activation; not required for this patch's scope (decay math is real now, even if these three specific nodes have nothing to decay from yet).

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1166
