### PR TITLE
feat(substrate-runtime): flip ORION_ATTENTION_TOPDOWN_ENABLED on

### DIFF
--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -158,11 +158,16 @@ ORION_ATTENTION_SALIENCE_V2_ENABLED=true
 ORION_ATTENTION_HABITUATION_ENABLED=true
 # Optional JSON override for combiner weights; empty = hand-seeded seed-v1.
 ORION_ATTENTION_SALIENCE_WEIGHTS=
-# Voluntary attention override (spec 2026-07-07 Step 2) — DEFAULT-OFF proposal
-# mode. Lets an active goal bias attention against bottom-up salience under a
-# bounded effort budget (biased competition). Enable only after review; off =
-# pure bottom-up, byte-identical to today.
-ORION_ATTENTION_TOPDOWN_ENABLED=false
+# Voluntary attention override (spec 2026-07-07 Step 2). Lets an active goal
+# bias attention against bottom-up salience under a bounded effort budget
+# (biased competition, Desimone & Duncan) -- can flip the attention winner
+# away from pure bottom-up when a goal's priority x relevance beats it. Off =
+# pure bottom-up, byte-identical to pre-flip behavior. Flipped on 2026-07-18
+# per orion/sentience_striving_program/README.md's Recurrent Processing
+# Theory (Lamme) instrumentation thread -- eval (orion/substrate/attention/
+# evals/run_topdown_eval.py) and unit tests (tests/test_top_down.py,
+# tests/test_voluntary_attention_wiring.py) verified green before the flip.
+ORION_ATTENTION_TOPDOWN_ENABLED=true
 ATTENTION_TOPDOWN_GAIN=0.6
 ATTENTION_EFFORT_MAX=1.0
 ATTENTION_EFFORT_SCALE_BY_AGENCY=true


### PR DESCRIPTION
## Summary
- Flips `ORION_ATTENTION_TOPDOWN_ENABLED` on in `.env_example` (and live `.env` on the shared checkout, gitignored, not part of this diff) -- voluntary attention override / biased-competition top-down bias (Desimone & Duncan), code-complete since spec 2026-07-07, previously left flag-off in production despite being tested and eval-green.
- Traced this session as the concrete answer to the Recurrent Processing Theory (Lamme) instrumentation thread in `orion/sentience_striving_program/README.md`: the mechanism for real top-down feedback (a goal's priority can flip which open loop wins bottom-up attention competition) already exists and works correctly -- it was simply never turned on.

## Outcome moved
Recurrent/top-down attention processing goes from "built but inert" to actually live -- the cheapest of the five consciousness-theory threads named in the program charter to verify, since no new code was needed.

## Current architecture
`orion/substrate/attention/top_down.py`'s `TopDownBiasCombiner` -- pure math, deterministic, degrades to a no-op (pure bottom-up) on any error or when no goal is present. `top_down_enabled()` gates it via `ORION_ATTENTION_TOPDOWN_ENABLED`, default false until this change.

## Architecture touched
`services/orion-substrate-runtime/.env_example` only. No code changes.

## Files changed
- `services/orion-substrate-runtime/.env_example`: flag flipped false -> true, comment updated with rationale and the eval/test evidence checked before flipping.

## Schema / bus / API changes
None.

## Env/config changes
- `ORION_ATTENTION_TOPDOWN_ENABLED`: `false` -> `true` in `.env_example`.
- Live `.env` on the shared checkout synced to match (gitignored, not committed) -- per explicit instruction.
- Skipped keys requiring operator action: none -- this is the only key touched.

## Tests run
```
PYTHONPATH=. .venv/bin/pytest tests/test_top_down.py tests/test_voluntary_attention_wiring.py -q
18 passed
```

## Evals run
```
PYTHONPATH=. .venv/bin/python3 orion/substrate/attention/evals/run_topdown_eval.py
RESULT: PASS (4/4 checks: override rate rises with priority, falls under effort scarcity, strong bottom-up beats weak bias, no goal -> no override)
```

## Docker/build/smoke checks
Not run -- config-only change, no image rebuild needed. `orion-substrate-runtime` needs a restart to pick up the new `.env` value (see Restart required below).

## Review findings fixed
N/A -- config flip only, verified via existing tests/eval re-run rather than a new review pass.

## Restart required
```bash
docker compose \
  --env-file .env \
  --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml \
  up -d --build
```
(Juniper to run -- not executed by this session.)

## Risks / concerns
- Severity: low
- Concern: this changes which open loop wins attention competition whenever a goal is present -- a real, live behavioral change, not purely additive.
- Mitigation: off = byte-identical to prior behavior (verified by the eval's own "no goal -> no override" check); grants no new capability and bypasses no policy gate; fully reversible by flipping the flag back.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/topdown-attention-flip