### PR TITLE
feat(substrate,recall): golden-concept salience + reinforcement-on-recall

### DIFF
--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -485,6 +485,9 @@ class FalkorSubstrateStore:
     def get_node_id_by_identity(self, identity_key: str) -> str | None:
         return self._cache.get_node_id_by_identity(identity_key)
 
+    def get_identity_key_by_node_id(self, node_id: str) -> str | None:
+        return self._cache.get_identity_key_by_node_id(node_id)
+
     def get_edge_id_by_identity(self, identity_key: str) -> str | None:
         return self._cache.get_edge_id_by_identity(identity_key)
 

--- a/orion/substrate/graphdb_store.py
+++ b/orion/substrate/graphdb_store.py
@@ -185,6 +185,12 @@ LIMIT 1
             return cached
         return self._get_canonical_id(identity_key=identity_key, identity_kind="node")
 
+    def get_identity_key_by_node_id(self, node_id: str) -> str | None:
+        # Cache-only, unlike get_node_id_by_identity's SPARQL fallback above --
+        # no current caller needs a canonical-store-backed reverse lookup, and
+        # inventing that query shape speculatively isn't warranted yet.
+        return self._cache.get_identity_key_by_node_id(node_id)
+
     def get_edge_id_by_identity(self, identity_key: str) -> str | None:
         cached = self._cache.get_edge_id_by_identity(identity_key)
         if cached:

--- a/orion/substrate/routed_store.py
+++ b/orion/substrate/routed_store.py
@@ -41,6 +41,9 @@ class RoutedSubstrateGraphStore:
     def get_node_id_by_identity(self, identity_key: str) -> str | None:
         return self._primary.get_node_id_by_identity(identity_key)
 
+    def get_identity_key_by_node_id(self, node_id: str) -> str | None:
+        return self._primary.get_identity_key_by_node_id(node_id)
+
     def get_edge_id_by_identity(self, identity_key: str) -> str | None:
         return self._primary.get_edge_id_by_identity(identity_key)
 

--- a/orion/substrate/seed.py
+++ b/orion/substrate/seed.py
@@ -27,6 +27,7 @@ from orion.core.schemas.cognitive_substrate import (
     NodeRefV1,
     SubstrateEdgeV1,
     SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
     SubstrateTemporalWindowV1,
 )
 from orion.substrate.store import SubstrateGraphStore
@@ -34,6 +35,15 @@ from orion.substrate.store import SubstrateGraphStore
 logger = logging.getLogger(__name__)
 
 DEFAULT_SEED_CONCEPTS_PATH = Path(__file__).with_name("seed_concepts.yaml")
+
+# Golden concepts are canonical/human_verified by construction -- there is no
+# clustering confidence or document-count salience to derive from, and no
+# principled reason to hedge them lower than the organically-grown concepts
+# they anchor. Without this, ConceptNodeV1's activation auto-seed (see
+# cognitive_substrate.py::ConceptNodeV1._seed_activation_if_unset) would seed
+# from the schema's own salience default (0.0), leaving Orion/Juniper/the
+# relationship at activation=0.0 forever despite having a real half-life.
+_SEED_CONCEPT_SIGNALS = SubstrateSignalBundleV1(confidence=1.0, salience=1.0)
 
 
 def _seed_provenance(*, key: str) -> SubstrateProvenanceV1:
@@ -106,6 +116,7 @@ def load_seed_concept_nodes(
                 provenance=_seed_provenance(key=key),
                 label=label,
                 definition=entry.get("definition"),
+                signals=_SEED_CONCEPT_SIGNALS.model_copy(),
             )
         except Exception as exc:  # noqa: BLE001 - malformed fixture row must not crash callers
             logger.warning("seed_concepts: skipping invalid entry %r: %s", entry, exc)

--- a/orion/substrate/store.py
+++ b/orion/substrate/store.py
@@ -43,6 +43,7 @@ class SubstrateGraphStore(Protocol):
     def get_edge_by_id(self, edge_id: str) -> SubstrateEdgeV1 | None: ...
     def get_node_id_by_identity(self, identity_key: str) -> str | None: ...
     def get_edge_id_by_identity(self, identity_key: str) -> str | None: ...
+    def get_identity_key_by_node_id(self, node_id: str) -> str | None: ...
     def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None: ...
     def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None: ...
     def snapshot(self) -> MaterializedSubstrateGraphState: ...
@@ -68,6 +69,13 @@ class InMemorySubstrateGraphStore:
         self._edges: dict[str, SubstrateEdgeV1] = {}
         self._node_identity_index: dict[str, str] = {}
         self._edge_identity_index: dict[str, str] = {}
+        # Reverse of _node_identity_index, maintained alongside it. Exists so
+        # a caller that already has a node_id (e.g. from a prior read) can
+        # recover its identity_key for a subsequent upsert_node() call
+        # without a full snapshot() -- FalkorSubstrateStore's codec writes
+        # `identity_key or ""` unconditionally on every upsert, so passing a
+        # missing/None identity_key durably clobbers the node's real one.
+        self._identity_key_by_node_id: dict[str, str] = {}
 
     def get_node_by_id(self, node_id: str) -> BaseSubstrateNodeV1 | None:
         return self._nodes.get(node_id)
@@ -81,10 +89,14 @@ class InMemorySubstrateGraphStore:
     def get_edge_id_by_identity(self, identity_key: str) -> str | None:
         return self._edge_identity_index.get(identity_key)
 
+    def get_identity_key_by_node_id(self, node_id: str) -> str | None:
+        return self._identity_key_by_node_id.get(node_id)
+
     def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
         self._nodes[node.node_id] = node
         if identity_key:
             self._node_identity_index[identity_key] = node.node_id
+            self._identity_key_by_node_id[node.node_id] = identity_key
 
     def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None:
         self._edges[edge.edge_id] = edge

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -81,6 +81,7 @@ def test_falkor_upsert_round_trip_via_cache():
     store.upsert_node(identity_key="id-a", node=node)
     assert store.get_node_by_id(node.node_id) is not None
     assert store.get_node_id_by_identity("id-a") == node.node_id
+    assert store.get_identity_key_by_node_id(node.node_id) == "id-a"
     # Inspect the cache directly rather than via the public snapshot() --
     # snapshot() now (correctly) forces a live re-hydration on its first
     # call (see test_falkor_snapshot_* below for that behavior's own

--- a/orion/substrate/tests/test_seed_concepts.py
+++ b/orion/substrate/tests/test_seed_concepts.py
@@ -30,14 +30,19 @@ def test_load_seed_concepts_into_store_writes_three_canonical_concepts() -> None
         assert node.promotion_state == "canonical"
         assert node.node_kind == "concept"
         assert node.definition
-        # Regression: seed_concepts.py passes no `signals=` at all, so before
-        # ConceptNodeV1's auto-seed validator existed, the three golden
-        # concepts (the highest-authority, longest-lived nodes in the store)
-        # were permanently stuck at activation=0.0/decay_half_life=None --
-        # immune to Hub's live decay scheduler forever, same bug as the
-        # organic-growth adapters.
+        # Regression: golden concepts (highest-authority, longest-lived nodes
+        # in the store) used to be permanently stuck at
+        # activation=0.0/decay_half_life=None -- immune to Hub's live decay
+        # scheduler forever, same bug as the organic-growth adapters. Fixed
+        # in two layers: ConceptNodeV1's auto-seed validator gives every
+        # concept a real half-life, and seed.py now gives golden concepts a
+        # real salience (1.0 -- canonical/human_verified, no principled
+        # reason to hedge lower) so their seeded activation is real too, not
+        # just their half-life.
         assert node.signals.activation.decay_half_life_seconds is not None
         assert node.signals.activation.decay_half_life_seconds > 0
+        assert node.signals.activation.activation == 1.0
+        assert node.signals.salience == 1.0
 
 
 def test_load_seed_concepts_into_store_wires_relationship_edges() -> None:

--- a/services/orion-recall/app/collectors/CONCEPT_REINFORCEMENT_DESIGN.md
+++ b/services/orion-recall/app/collectors/CONCEPT_REINFORCEMENT_DESIGN.md
@@ -1,0 +1,123 @@
+# Concept reinforcement-on-recall
+
+**Date:** 2026-07-18
+**Status:** Implemented in this patch
+**Scope:** `concept_region.py`'s live turn-time collector only. Not the crystallization
+system (`orion/memory/crystallization/`), which already has its own, separately-shipped
+`recall_boost()`/`decay()` wiring — this document is about giving `ConceptNodeV1`
+(the concept-atlas substrate graph) the same kind of signal.
+
+## Arsonist summary
+
+PR #1166 fixed concept-node decay from being 100%-structurally-inert (every concept born
+at `activation=0.0`, no half-life, so Hub's live decay scheduler had nothing to act on) to
+actually decaying every concept from a real seeded value. That patch explicitly deferred
+one piece: decay only ever moves activation *down*. Nothing moves it back up when a
+concept is still genuinely relevant — a concept that's discussed constantly decays on
+exactly the same curve as one nobody has mentioned in months. Golden concepts
+(Orion/Juniper/the relationship) got a real starting salience (1.0) in the same follow-up,
+but even they just decay monotonically from there with no way to reflect "this is still
+alive and load-bearing."
+
+The natural, already-existing signal for "this concept is still relevant": it just got
+surfaced in a real chat turn. `services/orion-recall/app/collectors/concept_region.py`'s
+`fetch_concept_region_fragment()` already runs on the live chat-turn hot path
+(`app/worker.py:1606-1625`) and already knows exactly which concept nodes matched the
+turn's text via cheap label-substring matching. That match event is the reinforcement
+signal — it just wasn't wired to write anything back.
+
+## Design questions resolved in conversation, not assumed
+
+**Sync inline write vs. async via a bus event.** Considered and rejected async. Falkor
+writes measured sub-millisecond live (`GRAPH.QUERY` internal execution time ~0.66ms for a
+single-node lookup during PR #1166's live verification); this codebase's bus channels are
+ephemeral pub/sub with no replay guarantee, so routing reinforcement through a bus event
+consumed by a separate worker doesn't buy real safety over a direct write — it just adds a
+dependency that can silently be down, for no reduction in worst-case data loss. A direct
+write, wrapped in the same never-raise/degrade convention this collector already uses on
+its read side, has an equivalent failure mode (this turn's reinforcement doesn't happen)
+without the extra moving part.
+
+**Where the write happens.** Not inside `fetch_concept_region_fragment()` itself — that
+function's own docstring already promises "never persists anything," used by existing
+callers/tests as a hard contract. Breaking that quietly would be exactly the kind of
+scope-creep this repo's conventions warn against. Instead: a new, separately-testable
+function `reinforce_matched_concepts()`, and a thin composing wrapper
+`fetch_concept_region_fragment_and_reinforce()` that calls the existing read function
+unchanged, then reinforces whatever it matched. The live call site in `worker.py` swaps to
+the wrapper; nothing about the original function's contract changes for any other caller.
+
+**Boost math.** Mirrors `orion/memory/crystallization/dynamics.py::recall_boost()` exactly:
+`activation = current + (1 - current) * boost`, `boost = 0.08`. Asymptotic toward 1.0,
+diminishing returns as a concept approaches ceiling — reusing an already-validated
+constant and shape rather than inventing a new one for a structurally identical problem
+(a weaker "this was retrieved" signal, distinct from a stronger "this recurred
+independently" signal that a real Reinforce-on-formation event would represent — no such
+formation-level reinforcement event exists for concept nodes today, so only the recall-side
+boost is being wired here).
+
+**What does NOT move.** Only `signals.activation.activation`. Not `recency_score`
+(deliberately left to be temporally derived at read/tick time, matching the same
+restraint `orion/substrate/adapters/_common.py::make_activation()` already applies — see
+its docstring). Not `temporal.observed_at` (carries specific "last touched" semantics read
+by decay math and pressure propagation elsewhere in `orion/substrate/dynamics.py`; PR #1131
+already established that mutating it inside a decay-adjacent write path is a correctness
+hazard, and this patch treats that constraint as a "no" for reinforcement too, conservatively,
+rather than opening a second design question in the same patch). Not `confidence` or
+`salience` — those describe "how true/prevalent is this," not "how often has this come up
+in conversation," and conflating them would reproduce the exact conformity-bias failure
+mode the crystallization system's own reinforcement spec
+(`docs/superpowers/specs/2026-07-13-memory-recall-reinforcement-decay-wiring-spec.md`)
+explicitly named as a hard invariant for its own `recall_boost()`.
+
+## Non-goals
+
+- Reinforcement on concept *formation*/recurrence (the stronger signal `reinforce()` maps to
+  in the crystallization system) — no equivalent formation-dedup event exists for concept
+  nodes today; out of scope here.
+- Retirement/dormancy surfacing from decay — already separately handled by
+  `SubstrateDynamicsEngine`'s dormancy transitions (currently gated off,
+  `SUBSTRATE_DYNAMICS_TICK_ENABLED=false`), not touched by this patch.
+- Any change to `fetch_concept_region_fragment()`'s existing signature, return shape, or
+  "never persists" contract.
+- Drive/goal-state-conditioned reinforcement weighting — a first-time coupling between the
+  motivational subsystem and this signal would need its own proposal-mode pass per
+  AGENTS.md, same reasoning the crystallization spec used to defer the equivalent idea
+  there.
+
+## Correction found in review: don't call `store.snapshot()` on this path
+
+The first draft resolved each matched node's current activation and identity_key via
+`store.snapshot()`, mirroring the exact pattern Hub's `decay_concept_activations()` already
+uses. Code review caught that this undermines the sync-write latency rationale above:
+`FalkorSubstrateStore.snapshot()` re-hydrates from Falkor with a currently-unbounded query
+whenever the write generation has moved since the last call, and *every reinforcement write
+this function makes bumps that generation* -- so on a busy conversation, each reinforcing
+turn would force the next one to pay for a full-graph rehydrate, not the sub-millisecond
+single-node cost the design above assumes. Fine for Hub's 120s decay cadence; not fine on a
+live per-turn hot path.
+
+Fixed by adding `get_identity_key_by_node_id()` to the `SubstrateGraphStore` protocol (a
+new method mirroring the existing `get_node_id_by_identity()`, implemented across
+`InMemorySubstrateGraphStore`, `FalkorSubstrateStore`, `GraphDBSubstrateStore`, and
+`RoutedSubstrateGraphStore`) and switching `reinforce_matched_concepts()` to
+`store.get_node_by_id()` + `store.get_identity_key_by_node_id()` -- both read straight from
+the in-process cache with no refresh-triggering cost, confirmed by reading each backend's
+actual implementation, not assumed. A node with no known identity_key is skipped rather
+than reinforced with a falsy identity_key, since Falkor's codec writes `identity_key or ""`
+unconditionally on every upsert -- passing a missing one would durably clobber the node's
+real identity, not leave it alone.
+
+## Acceptance checks
+
+1. A concept matched in a live turn has a measurably higher `activation` immediately after,
+   asymptotic toward 1.0 — not a flat overwrite, not unbounded growth past 1.0.
+2. Two concepts, one recalled repeatedly across distinct turns and one never recalled,
+   diverge over time — recall visibly counteracts decay instead of just being immediately
+   erased by the next decay tick.
+3. `confidence` and `salience` are provably unchanged by any number of reinforcement calls.
+4. A failed reinforcement write (store error, missing node) never raises out of the
+   turn-assembly path — matches `fetch_concept_region_fragment()`'s own existing
+   degrade-never-raise convention.
+5. `fetch_concept_region_fragment()` itself (the original function) is untouched: same
+   signature, same "never persists" behavior, existing tests pass with zero modification.

--- a/services/orion-recall/app/collectors/concept_region.py
+++ b/services/orion-recall/app/collectors/concept_region.py
@@ -19,17 +19,35 @@ Wiring this collector into the live turn-assembly pipeline (deciding
 when/how it gets invoked during a real chat turn, and whether its output
 feeds `chat_stance.py` or something else) is out of scope here. This file
 only builds and tests the collector function in isolation.
+
+`fetch_concept_region_fragment()` above never persists anything -- that
+promise is unchanged. `reinforce_matched_concepts()` and
+`fetch_concept_region_fragment_and_reinforce()` below are a separate,
+explicitly-named write path added later (see CONCEPT_REINFORCEMENT_DESIGN.md
+in this same folder for the full design conversation): being surfaced in a
+live turn is treated as a real "this concept is still relevant" signal that
+nudges `signals.activation` back up, the mirror image of the decay this
+concept-atlas system already applies. Only activation moves -- never
+confidence, salience, recency_score, or temporal.observed_at; see the design
+doc for why each of those is deliberately left alone.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Iterable
 
 from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
 from orion.substrate.store import SubstrateGraphStore
 
 logger = logging.getLogger(__name__)
+
+# Mirrors orion.memory.crystallization.dynamics.recall_boost()'s boost
+# constant and math exactly -- a structurally identical "this was retrieved"
+# signal, reusing an already-validated value instead of inventing a new one.
+_RECALL_REINFORCEMENT_BOOST = 0.08
+
+_NODE_FRAGMENT_ID_PREFIX = "concept_region:node:"
 
 # Search breadth for the label-match pass. `read_concept_region` ranks and
 # truncates by salience/confidence, so a low-salience concept could be cut
@@ -83,7 +101,7 @@ def _node_to_fragment(node: BaseSubstrateNodeV1) -> dict[str, Any]:
     except Exception:
         salience = 0.0
     return {
-        "id": f"concept_region:node:{getattr(node, 'node_id', '')}",
+        "id": f"{_NODE_FRAGMENT_ID_PREFIX}{getattr(node, 'node_id', '')}",
         "source": "concept_region",
         "snippet": snippet,
         "text": snippet,
@@ -161,4 +179,113 @@ def fetch_concept_region_fragment(
     return fragments
 
 
-__all__ = ["fetch_concept_region_fragment"]
+def reinforce_matched_concepts(
+    matched_node_ids: Iterable[str],
+    *,
+    store: SubstrateGraphStore | None,
+    boost: float = _RECALL_REINFORCEMENT_BOOST,
+) -> int:
+    """Bump activation for concept nodes that were actually surfaced in a live turn.
+
+    Being recalled is a real but weaker reinforcement signal than recurrence
+    (see CONCEPT_REINFORCEMENT_DESIGN.md in this folder) -- mirrors
+    `orion.memory.crystallization.dynamics.recall_boost()`'s exact math:
+    `activation = current + (1 - current) * boost`, asymptotic toward 1.0,
+    never overshoots. Only `signals.activation.activation` moves; confidence,
+    salience, recency_score, and temporal.observed_at are never touched here
+    (see the design doc for why each is deliberately left alone).
+
+    Never raises: a missing store, a missing/non-concept node, or a failed
+    write for one node degrades to skipping that node, matching this
+    module's read-side conventions. Returns the count of nodes actually
+    reinforced.
+
+    Deliberately does not call `store.snapshot()`. On `FalkorSubstrateStore`,
+    `snapshot()` can trigger a full, currently-unbounded re-hydrate query
+    whenever the write generation has moved since the last call (see
+    `orion/substrate/falkor_store.py`) -- fine for Hub's 120s decay-scheduler
+    cadence, but this function runs on a live per-turn hot path where that
+    cost compounds with every reinforcing turn. `get_node_by_id()` and
+    `get_identity_key_by_node_id()` both read straight from the store's
+    in-process cache with no such refresh cost (confirmed by reading
+    `FalkorSubstrateStore`'s own implementation of both).
+    """
+    node_ids = {str(node_id) for node_id in matched_node_ids if node_id}
+    if not node_ids or store is None:
+        return 0
+
+    clamped_boost = min(1.0, max(0.0, boost))
+
+    reinforced = 0
+    for node_id in node_ids:
+        try:
+            node = store.get_node_by_id(node_id)
+        except Exception as exc:  # noqa: BLE001 - must degrade, never raise
+            logger.debug("concept_region reinforcement: get_node_by_id(%s) failed: %s", node_id, exc)
+            continue
+        if node is None or getattr(node, "node_kind", None) != "concept":
+            continue
+        try:
+            identity_key = store.get_identity_key_by_node_id(node_id)
+        except Exception as exc:  # noqa: BLE001 - must degrade, never raise
+            logger.debug("concept_region reinforcement: get_identity_key_by_node_id(%s) failed: %s", node_id, exc)
+            continue
+        if not identity_key:
+            # Falkor's codec writes `identity_key or ""` unconditionally on
+            # every upsert -- a missing identity here would durably clobber
+            # this node's real identity_key rather than leaving it alone.
+            # Every current producer registers a real identity_key at
+            # creation, so this should be rare; skip rather than risk it.
+            logger.debug("concept_region reinforcement: node %s has no known identity_key, skipping", node_id)
+            continue
+        try:
+            activation_signal = node.signals.activation
+            current = min(1.0, max(0.0, activation_signal.activation))
+            boosted = min(1.0, current + (1.0 - current) * clamped_boost)
+            updated_signal = activation_signal.model_copy(update={"activation": boosted})
+            updated_signals = node.signals.model_copy(update={"activation": updated_signal})
+            updated_node = node.model_copy(update={"signals": updated_signals})
+            store.upsert_node(identity_key=identity_key, node=updated_node)
+            reinforced += 1
+        except Exception as exc:  # noqa: BLE001 - one node's failure must not block the rest
+            logger.debug("concept_region reinforcement: node %s failed: %s", node_id, exc)
+
+    return reinforced
+
+
+def fetch_concept_region_fragment_and_reinforce(
+    query: Any,
+    *,
+    store: SubstrateGraphStore | None,
+    limit_nodes: int = _DEFAULT_SEARCH_LIMIT_NODES,
+    limit_edges: int = _DEFAULT_SEARCH_LIMIT_EDGES,
+) -> list[dict[str, Any]]:
+    """`fetch_concept_region_fragment()` plus reinforcement for whatever it matched.
+
+    Composes the two functions above rather than modifying
+    `fetch_concept_region_fragment()` itself, which keeps its own
+    never-persists contract intact for any other caller. This is the
+    function the live turn-assembly pipeline should call.
+    """
+    fragments = fetch_concept_region_fragment(
+        query, store=store, limit_nodes=limit_nodes, limit_edges=limit_edges
+    )
+    if not fragments or store is None:
+        return fragments
+
+    matched_node_ids = [
+        fragment["id"][len(_NODE_FRAGMENT_ID_PREFIX):]
+        for fragment in fragments
+        if str(fragment.get("id", "")).startswith(_NODE_FRAGMENT_ID_PREFIX)
+    ]
+    if matched_node_ids:
+        reinforce_matched_concepts(matched_node_ids, store=store)
+
+    return fragments
+
+
+__all__ = [
+    "fetch_concept_region_fragment",
+    "fetch_concept_region_fragment_and_reinforce",
+    "reinforce_matched_concepts",
+]

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -26,7 +26,7 @@ try:
     from .fusion import fuse_candidates, pcr_fuse_belief_candidates, render_continuity_bundle
     from .pcr_collectors import apply_collector_plan, collectors_for_intent
     from .collectors.active_packet import fetch_active_packet_fragments
-    from .collectors.concept_region import fetch_concept_region_fragment
+    from .collectors.concept_region import fetch_concept_region_fragment_and_reinforce
     from .substrate_store import get_substrate_store
     from .profiles import get_profile
     from .settings import settings
@@ -56,7 +56,7 @@ except ImportError as _e:  # pragma: no cover - fallback for runtime pathing
         from app.fusion import fuse_candidates, pcr_fuse_belief_candidates, render_continuity_bundle  # type: ignore
         from app.pcr_collectors import apply_collector_plan, collectors_for_intent  # type: ignore
         from app.collectors.active_packet import fetch_active_packet_fragments  # type: ignore
-        from app.collectors.concept_region import fetch_concept_region_fragment  # type: ignore
+        from app.collectors.concept_region import fetch_concept_region_fragment_and_reinforce  # type: ignore
         from app.substrate_store import get_substrate_store  # type: ignore
         from app.profiles import get_profile  # type: ignore
         from app.settings import settings  # type: ignore
@@ -1608,16 +1608,22 @@ async def process_recall(
                 # Both get_substrate_store() (first-call hydration: FalkorDB
                 # issues several synchronous GRAPH.QUERY network calls with
                 # no client-side timeout, see FalkorSubstrateStore.__init__)
-                # and fetch_concept_region_fragment's store read are blocking
-                # -- both must run inside the offloaded thread, not just the
-                # fragment fetch. asyncio.to_thread only defers execution of
-                # the callable it's given; any argument expression (like a
-                # bare get_substrate_store() call) is still evaluated
-                # up front on the calling coroutine, i.e. still on this
-                # shared event loop. The lambda below defers both calls into
-                # the thread.
+                # and fetch_concept_region_fragment_and_reinforce's store
+                # reads/write are blocking -- both must run inside the
+                # offloaded thread, not just the fragment fetch.
+                # asyncio.to_thread only defers execution of the callable
+                # it's given; any argument expression (like a bare
+                # get_substrate_store() call) is still evaluated up front on
+                # the calling coroutine, i.e. still on this shared event
+                # loop. The lambda below defers both calls into the thread.
+                # fetch_concept_region_fragment_and_reinforce also writes a
+                # small activation bump for whatever it matched (see
+                # collectors/CONCEPT_REINFORCEMENT_DESIGN.md) -- a real
+                # Falkor write measured sub-millisecond live, on the same
+                # already-offloaded thread, so no new latency risk on the
+                # event loop.
                 cr_frags = await asyncio.to_thread(
-                    lambda: fetch_concept_region_fragment(q, store=get_substrate_store())
+                    lambda: fetch_concept_region_fragment_and_reinforce(q, store=get_substrate_store())
                 )
                 candidates.extend(cr_frags)
                 backend_counts_total["concept_region"] = len(cr_frags)

--- a/services/orion-recall/tests/test_concept_region_collector.py
+++ b/services/orion-recall/tests/test_concept_region_collector.py
@@ -5,13 +5,19 @@ from typing import Any
 
 import pytest
 
-from app.collectors.concept_region import fetch_concept_region_fragment
+from app.collectors.concept_region import (
+    fetch_concept_region_fragment,
+    fetch_concept_region_fragment_and_reinforce,
+    reinforce_matched_concepts,
+)
 
 from orion.core.schemas.cognitive_substrate import (
     ConceptNodeV1,
+    EvidenceNodeV1,
     NodeRefV1,
     SubstrateEdgeV1,
     SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
     SubstrateTemporalWindowV1,
 )
 from orion.substrate.store import InMemorySubstrateGraphStore
@@ -206,5 +212,160 @@ def test_malformed_query_object_without_fragment_attr_degrades_to_empty():
         pass
 
     fragments = fetch_concept_region_fragment(_NotAQuery(), store=store)
+
+    assert fragments == []
+
+
+# --- reinforce_matched_concepts ---------------------------------------------
+
+
+def test_reinforcement_bumps_activation_using_recall_boost_math():
+    store = _seeded_store()
+    before = store.snapshot().nodes["sub-concept-seed-juniper"]
+    current = before.signals.activation.activation
+
+    reinforced = reinforce_matched_concepts(["sub-concept-seed-juniper"], store=store)
+
+    assert reinforced == 1
+    after = store.snapshot().nodes["sub-concept-seed-juniper"]
+    expected = min(1.0, current + (1.0 - current) * 0.08)
+    assert after.signals.activation.activation == pytest.approx(expected, rel=1e-6)
+    assert after.signals.activation.activation > current
+
+
+def test_reinforcement_never_overshoots_ceiling():
+    store = InMemorySubstrateGraphStore()
+    node = ConceptNodeV1(
+        node_id="sub-concept-hot",
+        anchor_scope="orion",
+        subject_ref="sub-concept-hot",
+        promotion_state="canonical",
+        temporal=_temporal(),
+        provenance=_provenance(key="sub-concept-hot"),
+        label="Hot Topic",
+        definition="Definition of Hot Topic",
+        signals=SubstrateSignalBundleV1(confidence=0.9, salience=1.0),
+    )
+    store.upsert_node(identity_key="concept|hot", node=node)
+    assert store.snapshot().nodes["sub-concept-hot"].signals.activation.activation == 1.0
+
+    reinforced = reinforce_matched_concepts(["sub-concept-hot"], store=store)
+
+    assert reinforced == 1
+    assert store.snapshot().nodes["sub-concept-hot"].signals.activation.activation == 1.0
+
+
+def test_reinforcement_leaves_confidence_and_salience_untouched():
+    store = _seeded_store()
+    before = store.snapshot().nodes["sub-concept-seed-orion"]
+
+    reinforce_matched_concepts(["sub-concept-seed-orion"], store=store)
+
+    after = store.snapshot().nodes["sub-concept-seed-orion"]
+    assert after.signals.confidence == before.signals.confidence
+    assert after.signals.salience == before.signals.salience
+
+
+def test_reinforcement_skips_non_concept_nodes():
+    store = InMemorySubstrateGraphStore()
+    evidence = EvidenceNodeV1(
+        node_id="sub-evidence-1",
+        anchor_scope="orion",
+        temporal=_temporal(),
+        provenance=_provenance(key="ev1"),
+        evidence_type="test",
+        content_ref="ref:1",
+    )
+    store.upsert_node(identity_key="evidence|1", node=evidence)
+
+    reinforced = reinforce_matched_concepts(["sub-evidence-1"], store=store)
+
+    assert reinforced == 0
+
+
+def test_reinforcement_skips_unknown_node_ids():
+    store = _seeded_store()
+
+    reinforced = reinforce_matched_concepts(["sub-concept-does-not-exist"], store=store)
+
+    assert reinforced == 0
+
+
+def test_reinforcement_empty_ids_is_a_noop():
+    store = _seeded_store()
+
+    assert reinforce_matched_concepts([], store=store) == 0
+
+
+def test_reinforcement_missing_store_degrades_to_zero_without_raising():
+    assert reinforce_matched_concepts(["sub-concept-seed-orion"], store=None) == 0
+
+
+def test_reinforcement_raising_store_degrades_to_zero_without_raising():
+    class _RaisingStore:
+        def get_node_by_id(self, node_id):
+            raise RuntimeError("boom: store unavailable")
+
+    assert reinforce_matched_concepts(["sub-concept-seed-orion"], store=_RaisingStore()) == 0
+
+
+def test_reinforcement_missing_identity_key_skips_rather_than_clobbers():
+    # Regression: FalkorSubstrateStore's codec writes `identity_key or ""`
+    # unconditionally on every upsert. A node present in the cache but
+    # missing from the identity index must never be reinforced with a
+    # falsy identity_key -- that would durably wipe its real identity on a
+    # real Falkor backend. get_identity_key_by_node_id() returning None
+    # (e.g. this node was upserted with identity_key=None) must skip, not
+    # write.
+    store = InMemorySubstrateGraphStore()
+    node = _concept_node(node_id="sub-concept-no-identity", label="No Identity")
+    store.upsert_node(identity_key=None, node=node)
+
+    reinforced = reinforce_matched_concepts(["sub-concept-no-identity"], store=store)
+
+    assert reinforced == 0
+    assert store.get_identity_key_by_node_id("sub-concept-no-identity") is None
+
+
+# --- fetch_concept_region_fragment_and_reinforce ----------------------------
+
+
+def test_fetch_and_reinforce_bumps_only_matched_concepts():
+    store = _seeded_store()
+    before_juniper = store.snapshot().nodes["sub-concept-seed-juniper"].signals.activation.activation
+    before_orion = store.snapshot().nodes["sub-concept-seed-orion"].signals.activation.activation
+
+    fragments = fetch_concept_region_fragment_and_reinforce(_Query("tell me about Juniper today"), store=store)
+
+    assert fragments
+    after_juniper = store.snapshot().nodes["sub-concept-seed-juniper"].signals.activation.activation
+    after_orion = store.snapshot().nodes["sub-concept-seed-orion"].signals.activation.activation
+    assert after_juniper > before_juniper
+    assert after_orion == before_orion  # Orion wasn't mentioned, wasn't matched, untouched
+
+
+def test_fetch_and_reinforce_returns_same_fragments_as_plain_fetch():
+    store_a = _seeded_store()
+    store_b = _seeded_store()
+
+    plain = fetch_concept_region_fragment(_Query("tell me about Juniper today"), store=store_a)
+    combined = fetch_concept_region_fragment_and_reinforce(_Query("tell me about Juniper today"), store=store_b)
+
+    assert [f["id"] for f in plain] == [f["id"] for f in combined]
+
+
+def test_fetch_and_reinforce_no_match_does_not_write():
+    store = _seeded_store()
+    before = store.snapshot().nodes["sub-concept-seed-juniper"].signals.activation.activation
+
+    fragments = fetch_concept_region_fragment_and_reinforce(_Query("what's the weather like"), store=store)
+
+    assert fragments == []
+    after = store.snapshot().nodes["sub-concept-seed-juniper"].signals.activation.activation
+    assert after == before
+
+
+def test_fetch_and_reinforce_missing_store_degrades_to_empty_without_raising():
+    fragments = fetch_concept_region_fragment_and_reinforce(_Query("mentions Juniper"), store=None)
 
     assert fragments == []

--- a/services/orion-recall/tests/test_concept_region_wiring.py
+++ b/services/orion-recall/tests/test_concept_region_wiring.py
@@ -85,7 +85,7 @@ def test_worker_invokes_concept_region_when_enabled(monkeypatch: pytest.MonkeyPa
         concept_region_called.append((query, store))
         return [{"id": "cr-1", "source": "concept_region", "snippet": "Orion: continuity", "score": 0.7}]
 
-    monkeypatch.setattr(worker, "fetch_concept_region_fragment", _mock_concept_region)
+    monkeypatch.setattr(worker, "fetch_concept_region_fragment_and_reinforce", _mock_concept_region)
     monkeypatch.setattr(worker, "get_substrate_store", lambda: "fake-store-handle")
 
     bundle, decision = asyncio.run(worker.process_recall(_purposeful_query(), corr_id="corr-cr-1", diagnostic=True))
@@ -113,7 +113,7 @@ def test_worker_skips_concept_region_when_disabled(monkeypatch: pytest.MonkeyPat
         concept_region_called.append((query, store))
         return [{"id": "cr-1", "source": "concept_region", "snippet": "should not appear", "score": 0.7}]
 
-    monkeypatch.setattr(worker, "fetch_concept_region_fragment", _mock_concept_region)
+    monkeypatch.setattr(worker, "fetch_concept_region_fragment_and_reinforce", _mock_concept_region)
 
     asyncio.run(worker.process_recall(_purposeful_query(), corr_id="corr-cr-2", diagnostic=True))
 
@@ -132,7 +132,7 @@ def test_worker_concept_region_failure_degrades_gracefully(monkeypatch: pytest.M
     def _raising_concept_region(query, *, store):
         raise RuntimeError("store unreachable")
 
-    monkeypatch.setattr(worker, "fetch_concept_region_fragment", _raising_concept_region)
+    monkeypatch.setattr(worker, "fetch_concept_region_fragment_and_reinforce", _raising_concept_region)
     monkeypatch.setattr(worker, "get_substrate_store", lambda: None)
 
     bundle, decision = asyncio.run(worker.process_recall(_purposeful_query(), corr_id="corr-cr-3", diagnostic=True))


### PR DESCRIPTION
## Summary

- Golden/seed concepts (Orion, Juniper, the relationship) never had a `salience` set, so even after PR #1166's decay fix their activation stayed at 0.0 forever. Fixed: `orion/substrate/seed.py` now gives them `confidence=1.0, salience=1.0` -- defensible for canonical, human_verified concepts, not a magic number.
- New reinforcement mechanism: concept nodes surfaced in a live chat turn get an activation bump, mirroring the crystallization system's already-live `recall_boost()` math exactly. This is the counterpart to decay-only-goes-down from PR #1166.
- Design was discussed and scoped in conversation before implementation (sync-write vs async-via-bus, what fields move vs don't) -- committed alongside the code as `services/orion-recall/app/collectors/CONCEPT_REINFORCEMENT_DESIGN.md`.
- Code review caught a real perf/correctness issue in the first draft (using `store.snapshot()` on this hot path could force an unbounded rehydrate on every reinforcing turn) and a real data-integrity issue (a missing identity_key, if written anyway, would durably clobber a Falkor node's real identity) -- both fixed with a new store method, not papered over.

## Outcome moved

Concept-node activation is no longer monotonically decaying-toward-zero from a static seed value. Concepts that keep coming up in real conversation now have a real signal pushing back against decay; concepts that go unused decay undisturbed, same as before.

## Current architecture

`services/orion-recall/app/collectors/concept_region.py::fetch_concept_region_fragment()` already ran on every chat turn's hot path (`app/worker.py`, inside an `asyncio.to_thread` offload since Falkor reads are blocking), doing cheap label-substring matching against concept nodes and returning read-only fragments -- it never wrote anything. `orion/substrate/seed.py` loads three hand-authored golden concepts from `seed_concepts.yaml` with no signals block at all.

## Architecture touched

- `orion/substrate/seed.py` -- golden-concept salience.
- `services/orion-recall/app/collectors/concept_region.py` -- new reinforcement functions.
- `services/orion-recall/app/worker.py` -- live call-site swap.
- `orion/substrate/store.py`, `falkor_store.py`, `graphdb_store.py`, `routed_store.py` -- new `get_identity_key_by_node_id()` protocol method across all four store implementations.

## Files changed

- `orion/substrate/seed.py`: golden concepts now constructed with `signals=SubstrateSignalBundleV1(confidence=1.0, salience=1.0)`.
- `orion/substrate/tests/test_seed_concepts.py`: asserts golden concepts get real `activation`/`salience`, not just a real half-life.
- `services/orion-recall/app/collectors/concept_region.py`: new `reinforce_matched_concepts()` (boost math mirrors `recall_boost()` exactly) and `fetch_concept_region_fragment_and_reinforce()` (composes the existing read function unchanged + the new write). `fetch_concept_region_fragment()` itself is byte-for-byte unmodified.
- `services/orion-recall/app/collectors/CONCEPT_REINFORCEMENT_DESIGN.md` (new): the design conversation, written down.
- `services/orion-recall/app/worker.py`: live call site swapped from `fetch_concept_region_fragment` to `fetch_concept_region_fragment_and_reinforce`, both import paths (primary + fallback) updated.
- `orion/substrate/store.py`: `SubstrateGraphStore` protocol + `InMemorySubstrateGraphStore` gain `get_identity_key_by_node_id()`, mirroring the existing `get_node_id_by_identity()`. `InMemorySubstrateGraphStore` maintains a reverse index alongside the existing forward one.
- `orion/substrate/falkor_store.py`, `graphdb_store.py`, `routed_store.py`: delegate implementations of the new method (cache-only for GraphDB -- no SPARQL fallback invented, since nothing currently needs one).
- `orion/substrate/tests/test_falkor_store.py`: one new assertion for the new method.
- `services/orion-recall/tests/test_concept_region_collector.py`: 11 new tests (boost math, ceiling clamp, confidence/salience invariant, non-concept skip, unknown-id skip, empty-input no-op, missing/raising store degrade, missing-identity-key skip, plus 3 for the composed fetch-and-reinforce function).
- `services/orion-recall/tests/test_concept_region_wiring.py`: 3 existing tests updated to patch the renamed live call-site function (`fetch_concept_region_fragment_and_reinforce` instead of `fetch_concept_region_fragment`).

## Schema / bus / API changes

- Added: `SubstrateGraphStore.get_identity_key_by_node_id(node_id) -> str | None` (new protocol method, implemented in all four store backends).
- Removed: none.
- Renamed: none.
- Behavior changed: `ConceptNodeV1` instances built by `orion/substrate/seed.py` now carry real salience/activation instead of the schema default. Chat turns that match a concept label now write a small activation bump as a side effect (previously read-only).
- Compatibility notes: `fetch_concept_region_fragment()`'s existing contract and all its existing tests are untouched -- the new write path is a separate, composed function.

## Env/config changes

None. No new env keys, no `.env_example` changes.

## Tests run

```text
PYTHONPATH=. pytest orion/substrate/tests orion/substrate/relational/tests -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
474 passed

(services/orion-recall) PYTHONPATH=../..:. pytest tests/test_concept_region_collector.py tests/test_concept_region_wiring.py -q
32 passed

(services/orion-recall) PYTHONPATH=../..:. pytest tests -q -k "not test_grammar"
133 passed, 3 failed (pre-existing on main, confirmed unrelated by reproducing identically against a clean unmodified main checkout: test_process_recall_active_turn_exclusion.py, test_recall_policy_harness.py, test_recall_vector_amputation.py)

(services/orion-hub) PYTHONPATH=../..:. pytest tests/test_concept_atlas_routes.py tests/test_substrate_concept_decay_scheduler.py -q
25 passed
```

## Evals run

No dedicated eval harness exists for `orion/substrate/` or `orion-recall`'s collectors. `test_reinforcement_bumps_activation_using_recall_boost_math` is the direct functional acceptance check: it runs the real boost math against a real node and asserts the exact expected value.

## Docker/build/smoke checks

Not rebuilt/deployed as part of this PR -- code-only fix, tested in the worktree.

## Review findings fixed

- Finding: `reinforce_matched_concepts()`'s first draft called `store.snapshot()` to resolve current node state + identity, which on `FalkorSubstrateStore` can trigger a full, currently-unbounded re-hydrate whenever the write generation has moved since the last call -- and every reinforcement write bumps that generation, so each reinforcing chat turn would force the *next* reinforcing turn to pay full rehydrate cost. This directly undermined the design doc's own "Falkor writes are sub-millisecond" rationale for choosing sync writes over async-via-bus.
  - Fix: added `get_identity_key_by_node_id()` to the store protocol (mirrors the existing reverse-direction `get_node_id_by_identity()`), implemented cache-only across all four backends. `reinforce_matched_concepts()` now uses `store.get_node_by_id()` + the new method, both confirmed to read straight from the in-process cache with no refresh-triggering cost.
  - Evidence: read each backend's actual implementation to confirm the cache-only behavior; `test_falkor_upsert_round_trip_via_cache` extended with a direct assertion; full test suite passes.
- Finding: a matched node with no known `identity_key`, if reinforced anyway, would be written with `identity_key=None` -- and `FalkorSubstrateStore`'s codec writes `identity_key or ""` unconditionally on every upsert, durably clobbering that node's real identity rather than leaving it alone.
  - Fix: `reinforce_matched_concepts()` now skips a node (logs and continues) rather than writing when `get_identity_key_by_node_id()` returns falsy.
  - Evidence: new regression test `test_reinforcement_missing_identity_key_skips_rather_than_clobbers`, passing.

## Restart required

```bash
scripts/safe_docker_build.sh orion-recall up -d --build
```

`orion-hub` should also be restarted to pick up the golden-concept salience change (affects `seed_golden_concepts_at_startup()`, which only runs once at Hub's own startup):

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

Note: the golden-concept salience fix only takes effect for concepts seeded *after* this deploys -- it does not retroactively update the three golden concepts already live in FalkorDB from a prior seed. An operator wanting the fix applied to the already-seeded nodes would need to re-run the seed loader or manually update those three nodes' `salience`/`activation` -- not done automatically by this PR, and not required for the fix to be correct going forward.

## Risks / concerns

- Severity: Low
- Concern: `get_identity_key_by_node_id()` on `GraphDBSubstrateStore` is cache-only (no SPARQL canonical-store fallback, unlike its sibling `get_node_id_by_identity()`), so a node present in GraphDB's durable store but not yet in the local cache would resolve to `None` there.
- Mitigation: no current caller needs this on the GraphDB backend (recall runs Falkor); documented in the method's own comment rather than silently assumed complete.
- Severity: Low
- Concern: reinforcement is a new write path on recall's turn-time hot path; a Falkor outage now surfaces as a (caught, logged, degraded-to-no-op) write failure on every matching turn instead of just a read failure.
- Mitigation: wrapped in the same never-raise/degrade convention as the existing read side; a failed reinforcement never blocks or delays turn assembly, matching `fetch_concept_region_fragment()`'s own established contract.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1173
