### PR TITLE
fix(field-digester,cortex-exec): attribute reasoning_load to the node that actually served the LLM call

### DIFF
--- a/orion/schemas/execution_projection.py
+++ b/orion/schemas/execution_projection.py
@@ -25,6 +25,7 @@ class ExecutionRunStateV1(BaseModel):
     final_text_present: bool = False
     reasoning_present: bool = False
     thinking_source: str = "none"
+    llm_serving_node: str | None = None
     pressure_hints: dict[str, float] = Field(default_factory=dict)
     evidence_event_ids: list[str] = Field(default_factory=list)
     last_updated_at: datetime

--- a/orion/substrate/execution_loop/grammar_extract.py
+++ b/orion/substrate/execution_loop/grammar_extract.py
@@ -42,6 +42,14 @@ def compute_pressure_hints(
     status_fail = run.status.lower() in {"fail", "partial", "failed", "error"}
     failure_pressure = 1.0 if status_fail or failed > 0 else 0.0
     egress_confidence = 1.0 if egress_emitted else 0.25
+    # llm_serving_node is NOT injected here: pressure_hints must stay
+    # float-only -- orion/substrate/relational/adapters/execution_ctx.py's
+    # map_execution_ctx_to_substrate() does max(hints.values()) over this
+    # exact dict, and a str value would raise TypeError there (caught, but
+    # silently degrades that producer on every run). run.llm_serving_node is
+    # already a first-class field on ExecutionRunStateV1 -- consumers that
+    # need it (services/orion-field-digester/app/ingest/state_deltas.py)
+    # should read it from there directly, not from pressure_hints.
     return {
         "execution_load": execution_load,
         "execution_friction": execution_friction,
@@ -127,6 +135,7 @@ def extract_execution_state_from_events(
             run.final_text_present = _boolish(kv.get("final_text_present"))
             run.reasoning_present = _boolish(kv.get("reasoning_present"))
             run.thinking_source = kv.get("thinking_source", run.thinking_source)
+            run.llm_serving_node = kv.get("llm_serving_node") or run.llm_serving_node
         elif role == "exec_result_emitted":
             egress_emitted = True
 

--- a/orion/substrate/execution_loop/merge.py
+++ b/orion/substrate/execution_loop/merge.py
@@ -52,6 +52,8 @@ def merge_execution_run_state(
     merged.final_text_present = existing.final_text_present or incoming.final_text_present
     merged.reasoning_present = existing.reasoning_present or incoming.reasoning_present
     merged.thinking_source = _pick_thinking_source(existing.thinking_source, incoming.thinking_source)
+    if incoming.llm_serving_node:
+        merged.llm_serving_node = incoming.llm_serving_node
     merged.status = _pick_status(existing.status, incoming.status)
     if incoming.verb != "unknown":
         merged.verb = incoming.verb

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -2548,6 +2548,35 @@ def _local_skill_payload_failure_reason(skill_payload: Dict[str, Any]) -> str | 
     return None
 
 
+# config/field/orion_field_topology.v1.yaml's closed node set. Validated
+# against explicitly rather than trusting llm-gateway's free-text
+# meta.served_by label -- a misconfigured or off-convention served_by value
+# (wrong case, missing "-worker" suffix, a future node not yet in the
+# topology) must degrade to None, not create a phantom node_vectors entry in
+# field-digester (services/orion-field-digester/app/digestion/perturbation.py
+# creates whatever node_id it's handed, with no whitelist of its own).
+_KNOWN_FIELD_NODES = frozenset({"atlas", "athena", "circe", "prometheus"})
+
+
+def _normalize_served_by_to_node(served_by: Any) -> str | None:
+    """Reduce llm-gateway's meta.served_by worker label (e.g. "atlas-worker-1",
+    "atlas-worker-fast-1") to the canonical field-topology node id ("atlas").
+
+    llm-gateway's LLM_GATEWAY_ROUTE_TABLE_JSON labels workers as
+    "{node}-worker[-lane][-N]" (config/field/orion_field_topology.v1.yaml's
+    node ids are the prefix before the first "-worker"). Not every served_by
+    value is guaranteed to follow this convention (misconfigured or future
+    route entries), so an unrecognized shape degrades to None rather than
+    guessing -- the field-digester side falls back to attributing
+    reasoning_load to the orchestrating node when this is None, so a bad
+    served_by value can't ever paint a wrong node, only lose attribution.
+    """
+    if not isinstance(served_by, str) or not served_by.strip():
+        return None
+    node = served_by.strip().lower().split("-worker")[0]
+    return node if node in _KNOWN_FIELD_NODES else None
+
+
 def _forward_llm_uncertainty_metadata(payload: Any, ctx: Dict[str, Any]) -> None:
     """Copy gateway meta.llm_uncertainty into execution ctx metadata for Hub spark_meta merge."""
     gw_meta = payload.get("meta") if isinstance(payload, dict) else None
@@ -2557,6 +2586,9 @@ def _forward_llm_uncertainty_metadata(payload: Any, ctx: Dict[str, Any]) -> None
             md = ctx.setdefault("metadata", {})
             if isinstance(md, dict):
                 md["llm_uncertainty"] = unc
+        node = _normalize_served_by_to_node(gw_meta.get("served_by"))
+        if node:
+            ctx["llm_serving_node"] = node
 
 
 def _attempt_mind_handoff_chat_stance_shortcut(

--- a/services/orion-cortex-exec/app/grammar_emit.py
+++ b/services/orion-cortex-exec/app/grammar_emit.py
@@ -334,8 +334,17 @@ class CortexExecGrammarCollector:
         final_text_present: bool,
         reasoning_present: bool,
         thinking_source: str,
+        llm_serving_node: str | None = None,
     ) -> None:
         ref = f"cortex.exec.result:{self.correlation_id}"
+        summary = (
+            f"Final result assembled: status={status}, "
+            f"final_text_present={final_text_present}, "
+            f"reasoning_present={reasoning_present}, "
+            f"thinking_source={thinking_source}"
+        )
+        if llm_serving_node:
+            summary += f", llm_serving_node={llm_serving_node}"
         self._put_atom(
             "exec_result_assembled",
             GrammarAtomV1(
@@ -345,12 +354,7 @@ class CortexExecGrammarCollector:
                 semantic_role="exec_result_assembled",
                 layer="result",
                 dimensions=["execution", "speech", "reasoning"],
-                summary=(
-                    f"Final result assembled: status={status}, "
-                    f"final_text_present={final_text_present}, "
-                    f"reasoning_present={reasoning_present}, "
-                    f"thinking_source={thinking_source}"
-                ),
+                summary=summary,
                 confidence=0.95,
                 salience=0.95,
                 source_event_id=self.correlation_id,
@@ -494,6 +498,7 @@ def record_assembled_grammar(
     final_text_present: bool,
     reasoning_present: bool,
     thinking_source: str,
+    llm_serving_node: str | None = None,
 ) -> None:
     collector = ctx.get("_cortex_exec_grammar_collector")
     if collector is None:
@@ -503,6 +508,7 @@ def record_assembled_grammar(
         final_text_present=final_text_present,
         reasoning_present=reasoning_present,
         thinking_source=thinking_source,
+        llm_serving_node=llm_serving_node,
     )
 
 

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -1578,6 +1578,7 @@ class PlanRunner:
             final_text_present=bool((final_text or "").strip()),
             reasoning_present=bool(reasoning_content or reasoning_trace or metacog_traces),
             thinking_source=str(thinking_source or "none"),
+            llm_serving_node=ctx.get("llm_serving_node"),
         )
 
         if settings.publish_reasoning_telemetry:

--- a/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
+++ b/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
@@ -165,6 +165,49 @@ def test_step_failure_emits_exec_step_failed() -> None:
     assert "exec_step_completed" not in roles
 
 
+def test_result_assembled_summary_includes_llm_serving_node_when_present() -> None:
+    collector = CortexExecGrammarCollector(
+        node_name=NODE,
+        correlation_id=CORR,
+        code_version="0.2.0",
+        observed_at=FIXED_OBS,
+    )
+    collector.record_result_assembled(
+        status="success",
+        final_text_present=True,
+        reasoning_present=True,
+        thinking_source="provider_reasoning",
+        llm_serving_node="atlas",
+    )
+    events = build_cortex_exec_grammar_events(collector)
+    assembled = [
+        e for e in events if e.atom and e.atom.semantic_role == "exec_result_assembled"
+    ]
+    assert len(assembled) == 1
+    assert "llm_serving_node=atlas" in (assembled[0].atom.summary or "")
+
+
+def test_result_assembled_summary_omits_llm_serving_node_when_absent() -> None:
+    collector = CortexExecGrammarCollector(
+        node_name=NODE,
+        correlation_id=CORR,
+        code_version="0.2.0",
+        observed_at=FIXED_OBS,
+    )
+    collector.record_result_assembled(
+        status="success",
+        final_text_present=True,
+        reasoning_present=False,
+        thinking_source="none",
+    )
+    events = build_cortex_exec_grammar_events(collector)
+    assembled = [
+        e for e in events if e.atom and e.atom.semantic_role == "exec_result_assembled"
+    ]
+    assert len(assembled) == 1
+    assert "llm_serving_node" not in (assembled[0].atom.summary or "")
+
+
 def test_no_raw_prompt_or_llm_blobs_in_atoms() -> None:
     collector = CortexExecGrammarCollector(
         node_name=NODE,

--- a/services/orion-cortex-exec/tests/test_llm_uncertainty_metadata.py
+++ b/services/orion-cortex-exec/tests/test_llm_uncertainty_metadata.py
@@ -49,6 +49,37 @@ def test_forward_llm_uncertainty_metadata_from_gateway_payload() -> None:
     assert ctx["metadata"]["llm_uncertainty"]["available"] is True
 
 
+def test_forward_llm_uncertainty_metadata_normalizes_served_by_to_node() -> None:
+    ctx: dict = {}
+    payload = {"content": "hello", "meta": {"served_by": "atlas-worker-1"}}
+    _forward_llm_uncertainty_metadata(payload, ctx)
+    assert ctx["llm_serving_node"] == "atlas"
+
+
+def test_forward_llm_uncertainty_metadata_no_served_by_leaves_ctx_unset() -> None:
+    ctx: dict = {}
+    payload = {"content": "hello", "meta": {"served_by": None}}
+    _forward_llm_uncertainty_metadata(payload, ctx)
+    assert "llm_serving_node" not in ctx
+
+
+def test_forward_llm_uncertainty_metadata_served_by_is_case_insensitive() -> None:
+    ctx: dict = {}
+    payload = {"content": "hello", "meta": {"served_by": "Atlas-Worker-1"}}
+    _forward_llm_uncertainty_metadata(payload, ctx)
+    assert ctx["llm_serving_node"] == "atlas"
+
+
+def test_forward_llm_uncertainty_metadata_unknown_served_by_degrades_to_unset() -> None:
+    """A served_by value that doesn't resolve to a known field-topology node
+    (typo, off-convention label, a future node not yet in the topology) must
+    never paint a phantom node -- see _KNOWN_FIELD_NODES in app/executor.py."""
+    ctx: dict = {}
+    payload = {"content": "hello", "meta": {"served_by": "some-other-label"}}
+    _forward_llm_uncertainty_metadata(payload, ctx)
+    assert "llm_serving_node" not in ctx
+
+
 def test_autonomy_payload_exports_llm_uncertainty_from_ctx_metadata() -> None:
     md = _autonomy_payload_from_ctx(
         {

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -510,6 +510,18 @@ subset for the mood-arc windowed-autoencoder spike (see
   (evidence-only).
 - **Live-data verdict**: real signal — the cleanest channel in the corpus,
   continuously varying, small amplitude. Confirmed live 2026-07-16.
+  **Update 2026-07-18**: this verdict was `node:athena`-only. `node:atlas`'s
+  `reasoning_load` was permanently `0.0` (48h live-confirmed) because
+  `execution_run` deltas always carried `node_id=athena` (cortex-exec's own
+  static `NODE_NAME`), regardless of which physical node actually served the
+  LLM call. Fixed: `execution_run`'s `pressure_hints` gained a companion
+  `llm_serving_node` field (sourced from llm-gateway's response
+  `meta.served_by`, already live in `LLM_GATEWAY_ROUTE_TABLE_JSON`) that
+  routes this specific channel's perturbation to the real serving node —
+  see `app/ingest/state_deltas.py`'s `execution_run` branch and
+  `orion/substrate/execution_loop/`. `node:athena`'s reading is unaffected
+  (still the orchestrating-node value); `node:atlas` should now show real
+  variation once live LLM traffic accumulates post-deploy.
 
 #### `failure_pressure`
 - **Meaning**: recent execution failure rate/severity on a node.
@@ -829,6 +841,22 @@ subset for the mood-arc windowed-autoencoder spike (see
   any future "is reasoning_pressure real" question as answered for
   `orchestration`; `llm_inference`'s side needs a `node:atlas` instrumentation
   fix, not a merge-logic fix, before it contributes anything.
+
+  **Update 2026-07-18**: the `node:atlas` instrumentation fix above shipped.
+  Root cause was narrower than "never instrumented" implied: `node:atlas`
+  never received *any* `execution_run`-derived channels (not just
+  `reasoning_load`) because `execution_run`'s `node_id` always came from
+  cortex-exec's own static `NODE_NAME` (`athena`), never from which physical
+  node actually served the LLM call. Fixed by threading llm-gateway's
+  `meta.served_by` (already live) through as a new `llm_serving_node` field
+  on the run, and routing `reasoning_load`'s perturbation to that node
+  specifically instead of the orchestrating node — see `reasoning_load`'s
+  entry above and `app/ingest/state_deltas.py`. Deliberately scoped to
+  `reasoning_load` only; `execution_load`/`execution_friction`/
+  `failure_pressure` are legitimately orchestrator-node concerns and stay on
+  `node:athena`. Re-verify `capability:llm_inference.reasoning_pressure`'s
+  liveness against `substrate_field_state` once post-deploy LLM traffic has
+  accumulated — not yet re-measured as of this fix landing.
 
 #### `reliability_pressure`
 - **Meaning**: capability-level pressure representing risk to reliability

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -203,16 +203,32 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
     if delta.target_kind == "execution_run":
         hints = dict(after.get("pressure_hints") or {})
         node_key = _node_key(str(after.get("node_id") or delta.target_id))
-        for channel, key in (
-            ("execution_load", "execution_load"),
-            ("execution_friction", "execution_friction"),
-            ("reasoning_load", "reasoning_load"),
-            ("failure_pressure", "failure_pressure"),
+        # reasoning_load is attributed to whichever node actually served the
+        # LLM call (after["llm_serving_node"], a first-class ExecutionRunStateV1
+        # field threaded from llm-gateway's response meta.served_by -- see
+        # orion/substrate/execution_loop/grammar_extract.py) rather than
+        # node_key, the orchestrating service's own static identity. Read
+        # from `after`, not `hints`/pressure_hints -- the latter must stay
+        # float-only (orion/substrate/relational/adapters/execution_ctx.py
+        # does max(hints.values()) over it). node_key is always athena today
+        # (cortex-exec's NODE_NAME), which permanently zeroed
+        # node:atlas.reasoning_load -- see this service's README.md,
+        # reasoning_pressure glossary entry, for the live-confirmed root
+        # cause. Falls back to node_key when a run made no LLM call.
+        llm_serving_node = after.get("llm_serving_node")
+        reasoning_node_key = (
+            _node_key(str(llm_serving_node)) if llm_serving_node else node_key
+        )
+        for channel, key, target_node in (
+            ("execution_load", "execution_load", node_key),
+            ("execution_friction", "execution_friction", node_key),
+            ("reasoning_load", "reasoning_load", reasoning_node_key),
+            ("failure_pressure", "failure_pressure", node_key),
         ):
             if key in hints:
                 out.append(
                     Perturbation(
-                        node_id=node_key,
+                        node_id=target_node,
                         channel=channel,
                         intensity=float(hints[key]),
                         label=delta.delta_id,

--- a/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from orion.schemas.state_delta import StateDeltaV1
+
+from app.ingest.state_deltas import delta_to_perturbations
+
+
+def _make_execution_run_delta(
+    *,
+    node_id: str = "athena",
+    pressure_hints: dict | None = None,
+    llm_serving_node: str | None = None,
+) -> StateDeltaV1:
+    after: dict = {"node_id": node_id, "pressure_hints": pressure_hints or {}}
+    if llm_serving_node is not None:
+        after["llm_serving_node"] = llm_serving_node
+    return StateDeltaV1(
+        delta_id="delta_exec_1",
+        target_projection="active_execution_trajectory",
+        target_kind="execution_run",
+        target_id=f"cortex.exec:{node_id}:corr-1",
+        operation="update",
+        after=after,
+        caused_by_event_ids=["gev_exec_1"],
+        reducer_id="execution_trajectory_reducer",
+    )
+
+
+def test_execution_run_without_llm_serving_node_targets_run_node() -> None:
+    """Backward-compat: a run that never called an LLM keeps every channel,
+    including reasoning_load, attributed to the orchestrating node -- exactly
+    today's behavior."""
+    delta = _make_execution_run_delta(
+        pressure_hints={
+            "execution_load": 0.5,
+            "execution_friction": 0.1,
+            "reasoning_load": 0.05,
+            "failure_pressure": 0.0,
+        },
+    )
+    perturbations = delta_to_perturbations(delta)
+    by_channel = {p.channel: p for p in perturbations}
+    assert by_channel["reasoning_load"].node_id == "node:athena"
+    assert by_channel["execution_load"].node_id == "node:athena"
+
+
+def test_execution_run_with_llm_serving_node_routes_reasoning_load_only() -> None:
+    """A run whose LLM call was served by atlas attributes reasoning_load to
+    node:atlas specifically, while execution_load/execution_friction/
+    failure_pressure stay on the orchestrating node (athena) -- see
+    services/orion-field-digester/README.md's reasoning_pressure glossary
+    entry for why node:atlas.reasoning_load was permanently 0.0 before this.
+    llm_serving_node lives on the top-level ExecutionRunStateV1 field (not
+    inside pressure_hints, which must stay float-only -- see
+    orion/substrate/relational/adapters/execution_ctx.py's max(hints.values())
+    over the same dict)."""
+    delta = _make_execution_run_delta(
+        pressure_hints={
+            "execution_load": 0.5,
+            "execution_friction": 0.1,
+            "reasoning_load": 0.35,
+            "failure_pressure": 0.0,
+        },
+        llm_serving_node="atlas",
+    )
+    perturbations = delta_to_perturbations(delta)
+    by_channel = {p.channel: p for p in perturbations}
+    assert by_channel["reasoning_load"].node_id == "node:atlas"
+    assert by_channel["reasoning_load"].intensity == 0.35
+    assert by_channel["execution_load"].node_id == "node:athena"
+    assert by_channel["execution_friction"].node_id == "node:athena"
+    assert by_channel["failure_pressure"].node_id == "node:athena"
+
+
+def test_execution_run_noop_delta_skipped() -> None:
+    delta = _make_execution_run_delta(
+        pressure_hints={"reasoning_load": 0.35},
+        llm_serving_node="atlas",
+    )
+    delta = delta.model_copy(update={"operation": "noop"})
+    assert delta_to_perturbations(delta) == []

--- a/tests/test_execution_substrate_reducer.py
+++ b/tests/test_execution_substrate_reducer.py
@@ -117,6 +117,44 @@ def test_pressure_hints_failure_pressure() -> None:
     assert hints["failure_pressure"] == 1.0
 
 
+def test_extract_parses_llm_serving_node_from_summary() -> None:
+    run = extract_execution_state_from_events(
+        [
+            _exec_atom(
+                "exec_result_assembled",
+                "Final result assembled: status=success, final_text_present=True, "
+                "reasoning_present=True, thinking_source=provider_reasoning, "
+                "llm_serving_node=atlas",
+            )
+        ],
+        now=FIXED_TS,
+    )
+    assert run.llm_serving_node == "atlas"
+
+
+def test_pressure_hints_never_contain_llm_serving_node() -> None:
+    """pressure_hints must stay float-only regardless of llm_serving_node --
+    orion/substrate/relational/adapters/execution_ctx.py does
+    max(hints.values()) over this exact dict, so a str value would raise
+    TypeError there. llm_serving_node is a first-class ExecutionRunStateV1
+    field; consumers read run.llm_serving_node directly, not pressure_hints."""
+    run = extract_execution_state_from_events(
+        [
+            _exec_atom(
+                "exec_result_assembled",
+                "Final result assembled: status=success, final_text_present=True, "
+                "reasoning_present=True, thinking_source=provider_reasoning, "
+                "llm_serving_node=atlas",
+            )
+        ],
+        now=FIXED_TS,
+    )
+    assert run.llm_serving_node == "atlas"
+    hints = compute_pressure_hints(run, egress_emitted=False)
+    assert "llm_serving_node" not in hints
+    assert all(isinstance(v, float) for v in hints.values())
+
+
 def test_reducer_emits_execution_run_delta() -> None:
     events = [
         _exec_atom(
@@ -235,6 +273,16 @@ def test_merge_does_not_downgrade_status_or_flags() -> None:
     assert merged.status == "success"
     assert merged.final_text_present is True
     assert merged.reasoning_present is True
+
+
+def test_merge_preserves_llm_serving_node_when_incoming_lacks_it() -> None:
+    full = _run_with_full_egress()
+    full.llm_serving_node = "atlas"
+    partial = extract_execution_state_from_events(_partial_batch_no_egress(), now=FIXED_TS)
+    assert partial.llm_serving_node is None
+    merged = merge_execution_run_state(full, partial)
+    assert merged.llm_serving_node == "atlas"
+    assert "llm_serving_node" not in merged.pressure_hints
 
 
 def test_merge_unions_evidence_event_ids() -> None:


### PR DESCRIPTION
## Summary
- `node:atlas`'s `reasoning_load` was permanently `0.0` (48h live-confirmed, zero variance) because `execution_run` traces always carry `node_id=athena` -- cortex-exec's own static `NODE_NAME` -- regardless of which physical node actually served the LLM call.
- llm-gateway already resolves the real serving node (`meta.served_by`, live via `LLM_GATEWAY_ROUTE_TABLE_JSON` -- e.g. `"atlas-worker-1"`) and threads it through every response path already; zero llm-gateway changes needed.
- Cortex-exec now captures `meta.served_by`, normalizes it to a canonical node id, and threads it through the shared `orion/substrate/execution_loop` schema/reducer as a new `llm_serving_node` field on `ExecutionRunStateV1`.
- field-digester routes `reasoning_load`'s perturbation specifically to that node when present; `execution_load`/`execution_friction`/`failure_pressure` stay on the orchestrating node exactly as before.
- Deliberately does **not** touch `node_id`/`trace_id` -- that's the grammar ledger's primary key and run-continuity anchor; mutating it mid-run was identified as a real fragmentation risk during design and explicitly rejected in favor of this narrower, additive field.

## Outcome moved
`capability:llm_inference.reasoning_pressure` (one of the 5/8 channels PR #1171 found structurally dead for that capability) should now receive real signal once post-deploy LLM traffic accumulates, instead of remaining permanently zeroed.

## Current architecture
`execution_run` state deltas carried only `node_id` (always the orchestrator's static identity) and float-only `pressure_hints`. `node:atlas` never received any `execution_run`-derived channel.

## Architecture touched
- `orion/schemas/execution_projection.py`: shared execution-loop schema
- `orion/substrate/execution_loop/{grammar_extract.py,merge.py}`: shared reducer package (consumed by both cortex-exec and harness-governor)
- `services/orion-cortex-exec/app/{executor.py,router.py,grammar_emit.py}`: producer side
- `services/orion-field-digester/app/ingest/state_deltas.py`: consumer side

## Files changed
- `services/orion-cortex-exec/app/executor.py`: `_normalize_served_by_to_node()` (case-insensitive, validated against `config/field/orion_field_topology.v1.yaml`'s known node set) + `_forward_llm_uncertainty_metadata()` extended to capture `meta.served_by`
- `services/orion-cortex-exec/app/router.py`: threads `ctx.get("llm_serving_node")` into `record_assembled_grammar()`
- `services/orion-cortex-exec/app/grammar_emit.py`: `record_assembled_grammar()`/`record_result_assembled()` gain an optional `llm_serving_node` param, appended to the `exec_result_assembled` atom's kv summary
- `orion/schemas/execution_projection.py`: `ExecutionRunStateV1.llm_serving_node: str | None = None`
- `orion/substrate/execution_loop/grammar_extract.py`: parses `llm_serving_node` from the atom summary; `pressure_hints` stays `dict[str, float]` (see review findings below)
- `orion/substrate/execution_loop/merge.py`: merges `llm_serving_node` (incoming preferred, same convention as `session_id`/`turn_id`)
- `services/orion-field-digester/app/ingest/state_deltas.py`: routes `reasoning_load` to `llm_serving_node` when present
- `services/orion-field-digester/README.md`: updated `reasoning_load`/`reasoning_pressure` glossary entries to reflect the fix
- Tests: `services/orion-field-digester/tests/test_field_execution_run_perturbations.py` (new), `tests/test_execution_substrate_reducer.py`, `services/orion-cortex-exec/tests/{test_llm_uncertainty_metadata.py,test_exec_grammar_emit.py}`

## Schema / bus / API changes
- Added: `ExecutionRunStateV1.llm_serving_node: str | None = None`
- Behavior changed: `execution_run` deltas' `reasoning_load` perturbation targets `llm_serving_node` when present, else the run's own `node_id` (unchanged default)
- Compatibility notes: fully additive/optional; a run with no LLM call (or from harness-governor, which doesn't call llm-gateway directly) behaves exactly as before
- No `orion/bus/channels.yaml` / `orion/schemas/registry.py` changes needed -- not a bus channel, and the schema stays registered under the same class name

## Env/config changes
None. `LLM_GATEWAY_ROUTE_TABLE_JSON`'s `served_by` values were already live in `.env`.

## Tests run
```
pytest services/orion-field-digester/tests -q        # 103 passed
pytest tests/test_execution_substrate_reducer.py tests/test_execution_loop_ids.py -q   # 29 passed
pytest services/orion-cortex-exec/tests/test_llm_uncertainty_metadata.py services/orion-cortex-exec/tests/test_exec_grammar_emit.py -q   # 25 passed
```
Also confirmed the pre-fix regression (see review findings) is closed by direct reproduction: constructed an `ExecutionRunStateV1` with `llm_serving_node` set, called `compute_pressure_hints()`, and verified `max(hints.values())` (the exact call `execution_ctx.py` makes) no longer raises.

Broader ~600-test cortex-exec suite has pre-existing order-dependent test pollution unrelated to this diff (reproduced an equivalent failure-count delta against unmodified `main`; the specific "extra" failures shift to different, unrelated tests depending on exact file scoping -- confirmed not caused by this patch).

## Evals run
No eval harness exists for this seam; live re-verification of `capability:llm_inference.reasoning_pressure`'s variance (same psql query used to diagnose this bug) is the natural follow-up once post-deploy LLM traffic accumulates -- noted in the README update.

## Docker/build/smoke checks
Not run -- pure Python logic change, no config/dependency/compose changes.

## Review findings fixed

- Finding: **[CRITICAL, independently confirmed by 4 of 8 review angles]** `ExecutionRunStateV1.pressure_hints` was widened from `dict[str, float]` to `dict[str, float | str]` to smuggle `llm_serving_node` through it. `orion/substrate/relational/adapters/execution_ctx.py`'s live `map_execution_ctx_to_substrate()` producer does `max(hints.values())` over that exact dict -- a string value raises `TypeError`, caught by a broad exception handler upstream but silently degrading the `execution` self-model belief-node producer on every run that made an LLM call (i.e. most runs, going forward).
  - Fix: reverted the type widening entirely. `llm_serving_node` is read from `ExecutionRunStateV1`'s own top-level field (already serialized into the delta's `after` payload by the reducer) instead of being duplicated into `pressure_hints`. `pressure_hints` never contains a non-float value.
  - Evidence: reproduced the original crash directly (`max({'reasoning_load': 0.35, 'llm_serving_node': 'atlas', ...}.values())` raises `TypeError`), then reproduced the same construction post-fix and confirmed it no longer raises. New test `test_pressure_hints_never_contain_llm_serving_node` locks this in.

- Finding: `_normalize_served_by_to_node()` split on the case-sensitive literal `"-worker"` before lowercasing, so a differently-cased `served_by` label (e.g. `"Atlas-Worker-1"`) failed to strip the suffix and would have produced an unrecognized node id; separately, the function had no validation against the real field-topology node set, so any off-convention label would flow straight through to `_node_key()` and create a phantom `node_vectors` entry with no whitelist check anywhere downstream -- contradicting the function's own docstring claim that "a bad served_by value can't ever paint a wrong node."
  - Fix: lowercase before splitting; validate the result against `_KNOWN_FIELD_NODES = frozenset({"atlas", "athena", "circe", "prometheus"})` (mirrors `config/field/orion_field_topology.v1.yaml`'s closed node set), returning `None` for anything unrecognized.
  - Evidence: new tests `test_forward_llm_uncertainty_metadata_served_by_is_case_insensitive` and `test_forward_llm_uncertainty_metadata_unknown_served_by_degrades_to_unset`.

- Finding: `services/orion-field-digester/README.md`'s `reasoning_pressure`/`reasoning_load` glossary entries (which this patch's own code comments point readers at as ground truth) described the pre-fix state as current fact and would have directly contradicted the shipped fix.
  - Fix: added "Update 2026-07-18" sections to both entries documenting the fix and flagging that live re-verification of `capability:llm_inference.reasoning_pressure`'s variance is still open (not yet re-measured against post-deploy traffic).
  - Evidence: `services/orion-field-digester/README.md` diff.

- Finding (surfaced, not fixed -- lower severity / pre-existing scope): `_harvest_llm_uncertainty_from_steps()` only inspects the *last* step (in reverse order) with an `LLMGatewayService` payload and returns immediately, so a multi-LLM-call run whose final call errors out or omits `served_by` would lose an earlier call's valid `llm_serving_node`. This limitation is inherited from the function's pre-existing `llm_uncertainty`-harvesting behavior (unchanged by this diff, not a new regression) and the common case (single LLM call per run) is unaffected. Left as a known limitation rather than expanding this patch's scope; worth a follow-up if multi-LLM-call-per-run plans become common.
- Finding (verified refuted): harness-governor was flagged as "half-fixed" since it doesn't get this wiring. Traced and confirmed harness-governor never calls llm-gateway directly (no `LLMGatewayService`/`run_llm_chat` references in its codebase) -- it has no `llm_serving_node` to report in the first place, so there's nothing to wire.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-field-digester/.env -f services/orion-field-digester/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: low
- Concern: `capability:llm_inference.reasoning_pressure`'s actual live variance post-deploy hasn't been re-measured yet (needs real LLM traffic to accumulate first).
- Mitigation: flagged explicitly in the README update; natural follow-up is re-running the same psql query used to diagnose this bug.

## PR link
(filled in by `gh pr create` output)