### PR TITLE
fix(substrate): edge hydration lost every edge's real source/target node_id

### DIFF
--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -193,6 +193,47 @@ def _return_clause(alias: str, fields: tuple[str, ...]) -> str:
 # (2026-07-18, zero substrate coupling), imported above under its old name.
 
 
+def _edge_hydrate_return_clause(fields: tuple[str, ...]) -> str:
+    """Like `_return_clause("e", fields)`, except `source_id`/`target_id`
+    are derived from the matched `source`/`target` node variables
+    (`source.node_id`, `target.node_id`) instead of read as properties on
+    the edge itself.
+
+    `upsert_edge()` deliberately never writes `source_id`/`target_id` onto
+    the edge (`skip={"edge_id", "source_id", "target_id"}` in its
+    `_set_assignments()` call) -- the real linkage lives in the graph
+    topology the MATCH pattern itself encodes, not a redundant edge
+    property. Reading `e.source_id`/`e.target_id` therefore always returned
+    NULL, which `decode_edge()` then `str()`-coerced into the literal
+    string `"None"` for every hydrated edge's source/target node_id --
+    confirmed live (2026-07-18): every edge in the running graph lost its
+    real source/target linkage on every hydrate, silently, since nothing
+    downstream raised on a `"None"`-string node_id.
+
+    Column order and field names must stay identical to `_return_clause`'s
+    output for the same `fields` tuple -- `_normalize_rows()` zips
+    positional (list/tuple) query results against that same tuple by
+    index, and `decode_edge()` looks fields up by name from the result.
+
+    Tied to this file's one edge-hydration call site specifically: `source`
+    and `target` are hardcoded literal Cypher variable names matching that
+    query's own `MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode)`
+    pattern, not a general parameter. Reusing this for a query that binds
+    those variables under different names would produce Cypher referencing
+    undefined identifiers -- a loud parse/execution error, not a silent
+    wrong-value bug, but not a drop-in generic helper either.
+    """
+    parts = []
+    for field in fields:
+        if field == "source_id":
+            parts.append("source.node_id AS source_id")
+        elif field == "target_id":
+            parts.append("target.node_id AS target_id")
+        else:
+            parts.append(f"e.{field} AS {field}")
+    return ", ".join(parts)
+
+
 ### RecordingFalkorClient / RedisGraphQueryClient / _header_field_names /
 ### _rows_from_query_result moved to orion.graph.falkor_client (2026-07-18),
 ### imported at the top of this file and re-exported via __all__.
@@ -272,7 +313,7 @@ class FalkorSubstrateStore:
             edge_rows = self._client.graph_query(
                 "MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode) "
                 "WHERE e.substrate_edge = true "
-                "RETURN " + _return_clause("e", NATIVE_EDGE_RETURN_FIELDS)
+                "RETURN " + _edge_hydrate_return_clause(NATIVE_EDGE_RETURN_FIELDS)
             )
             legacy_node_rows = self._client.graph_query(
                 "MATCH (n:SubstrateNode) WHERE n.payload_json IS NOT NULL "

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -622,6 +622,83 @@ def test_falkor_legacy_migration_still_skips_unsupported_node_kinds():
     assert write_calls == []
 
 
+def test_falkor_edge_hydrate_query_derives_source_target_from_matched_nodes():
+    # Regression (2026-07-18 incident): the edge hydration RETURN clause
+    # used to read e.source_id/e.target_id as edge *properties* -- but
+    # upsert_edge() deliberately never writes those two fields onto the
+    # edge (skip={"edge_id", "source_id", "target_id"}), since the real
+    # linkage lives in the graph topology the MATCH pattern itself already
+    # encodes. Reading them as properties always returned NULL, which
+    # decode_edge() then str()-coerced into the literal string "None" for
+    # every hydrated edge -- confirmed live: every edge in the running
+    # graph silently lost its real source/target node_id on every hydrate.
+    # This test asserts the query text itself, since RecordingFalkorClient
+    # is a scripted test double that can't execute real Cypher to prove
+    # the derivation actually happens end-to-end (see the round-trip test
+    # below for what a fixed query's *output* should decode to).
+    client = RecordingFalkorClient()
+    FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    edge_hydrate_calls = [
+        cypher for cypher, _ in client.calls if "MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode)" in cypher
+    ]
+    assert edge_hydrate_calls, "expected the edge hydration query to run"
+    cypher = edge_hydrate_calls[0]
+    assert "source.node_id AS source_id" in cypher
+    assert "target.node_id AS target_id" in cypher
+    assert "e.source_id AS source_id" not in cypher
+    assert "e.target_id AS target_id" not in cypher
+
+
+def test_falkor_hydrates_edge_source_target_node_ids_correctly():
+    # Complements the query-text test above: given a hydrate row shaped the
+    # way the *fixed* query actually returns results (source_id/target_id
+    # populated with real node_id strings, since they're now derived from
+    # the matched source/target nodes rather than absent edge properties),
+    # decode_edge() must produce real NodeRefV1.node_id values -- not the
+    # literal string "None" that a missing/NULL source_id previously
+    # produced via decode_edge()'s str(row["source_id"]) coercion.
+    client = RecordingFalkorClient(
+        hydrate_edge_rows=[
+            {
+                "edge_id": "sub-edge-a-b",
+                "identity_key": "a|supports|b",
+                "source_id": "sub-concept-a",
+                "source_kind": "concept",
+                "target_id": "sub-concept-b",
+                "target_kind": "concept",
+                "predicate": "supports",
+                "substrate_edge": True,
+                "confidence": 0.8,
+                "salience": 0.6,
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "provenance_authority": "local_inferred",
+                "provenance_source_kind": "test",
+                "provenance_source_channel": "test:edge",
+                "provenance_producer": "test_falkor_store",
+                "evidence_refs_json": "[]",
+            }
+        ]
+    )
+
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=True,
+    )
+
+    edge = store.get_edge_by_id("sub-edge-a-b")
+    assert edge is not None
+    assert edge.source.node_id == "sub-concept-a"
+    assert edge.target.node_id == "sub-concept-b"
+    assert edge.source.node_id != "None"
+    assert edge.target.node_id != "None"
+
+
 def test_recording_client_splits_node_and_edge_hydrate_rows():
     client = RecordingFalkorClient(
         hydrate_node_rows=[{"node_id": "n1", "node_kind": "concept"}],
@@ -874,6 +951,60 @@ def test_falkor_hydrates_from_redis_py_result_set_lists():
     assert migrated is not None
     assert migrated.label == "Legacy list"
     assert any("MERGE (n:SubstrateNode" in c for c, _ in client.calls)
+
+
+def test_falkor_hydrates_edge_from_redis_py_result_set_lists():
+    # Edge-path analog of test_falkor_hydrates_from_redis_py_result_set_lists
+    # above. That existing test forces _normalize_rows()'s real positional
+    # (list/tuple) zip path to run for *node* hydration -- a dict-shaped
+    # scripted row (as used by test_falkor_hydrates_edge_source_target_node_ids_correctly)
+    # bypasses that zip entirely (dict items pass through _normalize_rows
+    # near-verbatim), so it can't catch a column-order mismatch between
+    # NATIVE_EDGE_RETURN_FIELDS and _edge_hydrate_return_clause()'s emitted
+    # column order. This test closes that gap for edges specifically: a
+    # raw positional list, in NATIVE_EDGE_RETURN_FIELDS order, forces the
+    # real zip and proves source_id/target_id land in the right positions.
+    from orion.substrate.falkor_store import NATIVE_EDGE_RETURN_FIELDS
+
+    values = []
+    for field in NATIVE_EDGE_RETURN_FIELDS:
+        defaults = {
+            "edge_id": "sub-edge-redis-py",
+            "identity_key": "a|supports|b",
+            "source_id": "sub-concept-redis-py-a",
+            "source_kind": "concept",
+            "target_id": "sub-concept-redis-py-b",
+            "target_kind": "concept",
+            "predicate": "supports",
+            "substrate_edge": True,
+            "confidence": 0.8,
+            "salience": 0.6,
+            "observed_at": "2026-07-16T00:00:00+00:00",
+            "provenance_authority": "local_inferred",
+            "provenance_source_kind": "test",
+            "provenance_source_channel": "test:edge-redis-py",
+            "provenance_producer": "test_falkor_store",
+            "evidence_refs_json": "[]",
+        }
+        values.append(defaults.get(field))
+
+    class EdgeListRowClient:
+        def graph_query(self, cypher: str, params: dict | None = None):
+            if "MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode)" in cypher:
+                return [values]
+            return []
+
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=EdgeListRowClient(),
+        hydrate=True,
+    )
+
+    edge = store.get_edge_by_id("sub-edge-redis-py")
+    assert edge is not None
+    assert edge.source.node_id == "sub-concept-redis-py-a"
+    assert edge.target.node_id == "sub-concept-redis-py-b"
+    assert edge.predicate == "supports"
 
 
 def test_falkor_legacy_migrate_keeps_cache_when_rewrite_fails():


### PR DESCRIPTION
## Summary

- Found via live verification of PR #1175 (not hypothetical): after confirming the duplicate-node fix worked, checked the Concept Atlas summary endpoint and found `edge_counts_by_predicate` always empty despite 15 real edges existing in the live graph.
- Traced to `FalkorSubstrateStore`'s edge hydration query reading `source_id`/`target_id` as edge *properties* (`e.source_id`, `e.target_id`) -- but `upsert_edge()` deliberately never writes those two fields as edge properties, since the real linkage already lives in the graph topology (`(source)-[e]->(target)`). Every hydrated edge's `source.node_id`/`target.node_id` silently became the literal string `"None"`.
- Fix derives `source_id`/`target_id` from the already-MATCH-bound `source`/`target` node variables instead. Live-verified the corrected query directly against the running database before writing this up.
- Confirmed via code review that the sibling `GraphDBSubstrateStore` (SPARQL-backed) does not have an analogous bug -- genuinely different edge persistence model, not the same trap under a different backend.

## Outcome moved

Every edge hydrated from Falkor now carries its real source/target node_id instead of the string `"None"`. Directly fixes `concept_atlas_summary()`'s always-empty `edge_counts_by_predicate`; removes a latent correctness hazard for anything else reading `snapshot().edges` and depending on real linkage (relation classification, co-occurrence, graph traversal).

## Current architecture

`FalkorSubstrateStore._hydrate_from_durable()` runs `MATCH (source:SubstrateNode)-[e]->(target:SubstrateNode) WHERE e.substrate_edge = true RETURN <fields>` on every hydrate (construction + periodic refresh). The RETURN clause was built generically via `_return_clause("e", NATIVE_EDGE_RETURN_FIELDS)`, which has no awareness that two of those fields aren't actually stored as edge properties.

## Architecture touched

`orion/substrate/falkor_store.py` only -- no schema, contract, or API changes.

## Files changed

- `orion/substrate/falkor_store.py`: new `_edge_hydrate_return_clause(fields)`, structurally identical to `_return_clause` except `source_id`/`target_id` map to `source.node_id`/`target.node_id`. Wired into the one edge-hydration call site. `NATIVE_EDGE_RETURN_FIELDS` itself untouched (preserves column-order compatibility with `_normalize_rows()`'s positional zip).
- `orion/substrate/tests/test_falkor_store.py`: 3 new tests -- corrected query text, a dict-shaped round-trip proving `decode_edge()` produces real node_ids, and a positional-list variant (mirroring this file's existing node-hydration precedent) proving the actual column-order alignment real `GRAPH.QUERY` results depend on.

## Schema / bus / API changes

None. Internal store-hydration behavior only.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. pytest orion/substrate/tests -q --ignore=orion/substrate/tests/test_refit_salience_stub.py
355 passed
```

## Evals run

No dedicated eval harness for `orion/substrate/`. Correctness independently verified against the live `orion-athena-falkordb` container: ran both the old and corrected query text directly via `redis-cli GRAPH.QUERY`, confirming the fix returns real node_id strings where the original returned nulls.

## Docker/build/smoke checks

Not rebuilt/deployed as part of this PR -- code-only fix, tested in the worktree and independently verified against the live database via direct Cypher queries (not through a running service).

## Review findings fixed

- Finding: the initial round-trip test scripted a dict-shaped hydrate row, which bypasses `_normalize_rows()`'s positional list/tuple zip path entirely -- it proved `decode_edge()` handles a well-formed row correctly, but not that `NATIVE_EDGE_RETURN_FIELDS`'s column order actually lines up with the new return-clause builder's emitted order.
  - Fix: added `test_falkor_hydrates_edge_from_redis_py_result_set_lists`, mirroring this file's own existing `test_falkor_hydrates_from_redis_py_result_set_lists` node-hydration precedent for the edge path -- a raw positional list built in field-tuple order, forcing the real zip to run.
  - Evidence: new test passing; confirmed by direct read that the new return-clause builder emits exactly one column per input field in the same order, with no bug found.
- Finding: `_edge_hydrate_return_clause()`'s docstring didn't disclose that `source`/`target` are hardcoded literal Cypher variable names tied to this file's one call site's own `MATCH` pattern, not a general parameter.
  - Fix: docstring now states this explicitly, including that misuse against a differently-named `MATCH` pattern fails loud (Cypher parse error) rather than silently.
  - Evidence: docstring updated in `falkor_store.py`.
- Also checked (no fix needed): whether `GraphDBSubstrateStore` has an analogous bug. Confirmed it does not -- its edge persistence model reconstructs edges from a full serialized JSON payload, never assembling a `NodeRefV1` from a separately-read `source_id` property the way Falkor's codec does.

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

Any other service constructing a `FalkorSubstrateStore` (orion-recall, orion-spark-concept-induction, orion-substrate-runtime) should also be restarted to pick up the fix -- it's self-healing on the next hydrate for each, no manual data migration required (the bug was in the READ path, not stored data; nothing needs to be repaired on disk).

## Risks / concerns

- Severity: Low
- Concern: full scope of what silently relied on `edge.source.node_id`/`edge.target.node_id` being real (beyond the one confirmed case, `concept_atlas_summary()`) wasn't exhaustively audited across every consumer of `snapshot().edges`.
- Mitigation: the fix corrects the read path universally for every consumer of edge hydration, not just the one confirmed symptom -- no consumer-specific workaround was needed or applied.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1179
