### PR TITLE
docs(llm-gateway,field-digester): document circe-not-wired-into-routing gap

### DIFF
--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -521,7 +521,19 @@ subset for the mood-arc windowed-autoencoder spike (see
   see `app/ingest/state_deltas.py`'s `execution_run` branch and
   `orion/substrate/execution_loop/`. `node:athena`'s reading is unaffected
   (still the orchestrating-node value); `node:atlas` should now show real
-  variation once live LLM traffic accumulates post-deploy.
+  variation once live LLM traffic accumulates post-deploy. Live-verified
+  post-deploy (PR #1177, merged 2026-07-18T04:10:01Z): `node:atlas`'s
+  `reasoning_load` mean/std/max went from exactly `0`/`0`/`0` (767 rows,
+  pre-merge) to `0.003`/`0.012`/`0.05` (115 rows immediately post-merge),
+  climbing to `0.032`/`0.024`/`0.05` a few minutes later as more traffic
+  accumulated. `node:circe`'s `reasoning_load` is **still** permanently
+  `0.0` -- this is a separate, operational (not code) gap: circe is never
+  `served_by` in the live `LLM_GATEWAY_ROUTE_TABLE_JSON` today, so it never
+  produces an `execution_run` at all. See
+  `services/orion-llm-gateway/README.md`'s route-table section for the
+  known-gap note and what's needed to bring it online -- this fix is
+  already ready for circe (`circe` is in cortex-exec's
+  `_KNOWN_FIELD_NODES`), it just has no live traffic to attribute yet.
 
 #### `failure_pressure`
 - **Meaning**: recent execution failure rate/severity on a node.

--- a/services/orion-llm-gateway/README.md
+++ b/services/orion-llm-gateway/README.md
@@ -170,6 +170,27 @@ LLM_GATEWAY_ROUTE_TABLE_JSON='{
 
 `quick` is the FAST lane route used by user-facing quick chat and chat_general pass-1.
 
+> **Known gap (2026-07-18): circe is not wired into `LLM_GATEWAY_ROUTE_TABLE_JSON`.**
+> Every route above (`chat`/`agent`/`metacog`/`quick`) is `served_by` an
+> `atlas-worker-*` label. `config/llm_profiles.yaml` has real circe-hosted
+> profiles defined (2xV100, PIX-linked, benched 2026-07-09), but nothing in
+> the live route table points at them -- this was never deliberate, just
+> deprioritized while getting circe fully online. Consequence: `node:circe`
+> never appears as an `execution_run` producer, so `orion-field-digester`'s
+> `reasoning_load`/`execution_load`/etc. channels for `node:circe` read
+> permanently `0.0` -- not a code bug (see
+> `services/orion-field-digester/README.md`'s `reasoning_load` glossary
+> entry), just zero real traffic ever routing there. When circe comes
+> online: (1) add a route entry above with `"served_by": "circe-worker-N"`
+> (the live worker process's current name needs renaming to match this
+> `{node}-worker[-lane][-N]` convention -- `services/orion-cortex-exec/app/executor.py`'s
+> `_normalize_served_by_to_node()` only recognizes labels split on the
+> literal `"-worker"` substring, and only resolves to a node in
+> `_KNOWN_FIELD_NODES` if the prefix is exactly `atlas`/`athena`/`circe`/
+> `prometheus`); (2) no code changes needed beyond that -- `circe` is already
+> in `_KNOWN_FIELD_NODES` and the field topology
+> (`config/field/orion_field_topology.v1.yaml`).
+
 ### Route table example (optional split agent mode)
 ```bash
 LLM_GATEWAY_ROUTE_TABLE_JSON='{


### PR DESCRIPTION
## Summary
- circe has real hosted LLM profiles (`config/llm_profiles.yaml`, 2xV100 PIX-linked, benched 2026-07-09) but the live `LLM_GATEWAY_ROUTE_TABLE_JSON` routes (`chat`/`agent`/`metacog`/`quick`) are all `served_by` `atlas-worker-*`. Never deliberate -- just deprioritized while getting circe fully online.
- Consequence: `node:circe` never produces an `execution_run`, so its `reasoning_load`/`execution_load`/etc. channels read permanently `0.0` -- an operational gap, not a code bug. PR #1177's serving-node attribution fix is already ready for circe (it's in `_KNOWN_FIELD_NODES` and the field topology); it just has no live traffic to attribute yet.
- Documents the exact steps to close it when circe comes online: add a route entry with `served_by: "circe-worker-N"`, and rename the live circe worker process to match that convention so `_normalize_served_by_to_node()` resolves it.
- Added as a `followup`/`should` item on the agent board.

## Files changed
- `services/orion-llm-gateway/README.md`: known-gap note in the route-table section
- `services/orion-field-digester/README.md`: cross-reference in `reasoning_load`'s glossary entry, plus live before/after numbers from PR #1177's post-deploy verification

## Tests run
N/A -- documentation only.

## Restart required
No restart required.

## Risks / concerns
None -- doc-only.