### PR TITLE
docs: audit concept-atlas READMEs against today's 4 PRs, fix two stale claims

### DIFF
--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -460,11 +460,21 @@ lives at the schema boundary: `ConceptNodeV1` now has a `model_validator(mode="a
 `signals.activation` at its pure schema default — covering every current and future
 producer, not just the ones that remember to opt in. `orion/substrate/adapters/_common.py::make_activation()`
 remains available for a producer that wants an explicit, non-default initial value.
+
+**Golden concepts still needed a second fix, same day:** the schema-boundary validator above
+seeds `activation = salience`, but `orion/substrate/seed.py`'s three golden concepts
+(Orion, Juniper, the relationship) never had a `salience` in `seed_concepts.yaml` at all —
+so even after the validator fix, they seeded to `activation = 0.0` (a real number now, but
+still flat zero). Fixed in the same PR (#1173): `seed.py` now constructs them with
+`signals=SubstrateSignalBundleV1(confidence=1.0, salience=1.0)` — defensible for
+`promotion_state="canonical"`/`authority="human_verified"` concepts, not a magic number.
+
 Reinforcement-on-recall (bumping activation when a concept is actually retrieved in a live
 turn, mirroring `orion/memory/crystallization/dynamics.py::recall_boost()`'s existing
-precedent for the separate crystallization system) is not wired yet — deferred, see the
-concept_region collector at §15 of `services/orion-recall/README.md` for the natural call
-site.
+precedent for the separate crystallization system) shipped in the same follow-up, PR #1173
+— see the concept_region collector at §15 of `services/orion-recall/README.md` for how it's
+wired, and `services/orion-recall/app/collectors/CONCEPT_REINFORCEMENT_DESIGN.md` for the
+full design conversation (sync-write-vs-bus, which fields move and why).
 
 **Side effect caught in review:** `GET /api/substrate/concepts/summary`'s `_at_risk_concepts()`
 used to treat "every concept node's activation is identical" as a proxy for "no live decay
@@ -474,6 +484,38 @@ up as "at risk of decaying toward its floor" on its very first tick — it hasn'
 all, it just started low. Fixed by replacing the variance proxy with an explicit age gate
 (`_AT_RISK_MIN_AGE_SECONDS`, one hour): a concept must have existed long enough for real
 decay ticks to plausibly have run before it's eligible for `at_risk` at all.
+
+**A shipped fix that silently reverted itself within one restart, if you're ever debugging
+"why did my Falkor write not stick" (PR #1175, fixed):** live-verifying the golden-concept
+salience fix above turned up a separate, previously-undiscovered bug in
+`FalkorSubstrateStore._migrate_legacy_payload_nodes()` (`orion/substrate/falkor_store.py`) —
+the legacy-payload rewrite path that runs on every hydrate. It read a node still carrying an
+old `payload_json` blob, parsed it, and rewrote it via the normal `upsert_node()` path — but
+that write's `MERGE (n:SubstrateNode:<type-label> {node_id})` can never match the legacy row
+itself (labeled `SubstrateNode` only, no type label yet), so the write always landed on a
+*different* node and the legacy row's `payload_json` was never removed. It persisted forever,
+got re-parsed on every future hydrate, and re-clobbered the canonical node's real data —
+this is exactly what reverted the golden-concept salience fix within one Hub restart cycle,
+live, the same day it shipped. It also cascaded into duplicate relationships (one edge existed
+as 4 near-identical copies) via the same bare-label MERGE ambiguity on edge source/target
+matching. Fixed with an explicit cleanup delete after a successful migration write
+(`_delete_orphaned_legacy_node_duplicate()`), using `DETACH DELETE` so the cascaded duplicate
+edges get cleaned up as a side effect with no separate edge-dedup logic needed. Self-healing —
+no manual data migration was required, the fix took effect for every affected node the next
+time that node's hydrate ran.
+
+**Edges silently lost their real source/target linkage on every hydrate, if
+`edge_counts_by_predicate` on the summary route ever reads empty despite real edges existing
+(PR #1179, fixed):** found immediately after live-verifying the #1175 fix above — the edge
+hydration query read `source_id`/`target_id` as edge *properties*
+(`e.source_id`/`e.target_id`), but `upsert_edge()` deliberately never writes those two fields
+onto the edge (the real linkage already lives in the graph topology, the
+`(source)-[e]->(target)` pattern itself). So they always read back `NULL`, and
+`decode_edge()` `str()`-coerced that into the literal string `"None"` for every edge's
+source/target node_id, forever, since before this session. Fixed by deriving `source_id`/
+`target_id` from the already-MATCH-bound `source`/`target` node variables instead
+(`orion/substrate/falkor_store.py::_edge_hydrate_return_clause()`). Same self-healing
+property — no stored data was wrong, this was purely a read-path bug.
 
 **Autonomous scheduler window math, if debugging why a training run didn't fire:**
 `trigger_topic_foundry_training_run()` floors its rolling window's `end_at` to a UTC day
@@ -494,8 +536,11 @@ scripts/safe_docker_build.sh orion-hub up -d --build
 ```
 
 See also: PRs #1128 (stance repoint), #1131 (decay scheduler), #1132 (relation classifier),
-#1133 (recall wiring), #1136 (autonomous scheduler) for the full review history including
-every bug caught and fixed before each shipped, and
+#1133 (recall wiring), #1136 (autonomous scheduler), #1166 (decay was structurally inert --
+schema-boundary activation seed), #1173 (golden-concept salience + reinforcement-on-recall),
+#1175 (legacy-migration duplicate-node bug that silently reverted #1173), #1179 (edge
+hydration losing every edge's real source/target node_id) for the full review history
+including every bug caught and fixed before each shipped, and
 [docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md](../../docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md)
 for the original design.
 

--- a/services/orion-recall/README.md
+++ b/services/orion-recall/README.md
@@ -781,6 +781,18 @@ neighborhood fragment scoped to that turn. Matching is deliberately dumb — cas
 label substring match, no embedding/LLM call — and it never does a store read at all if the
 turn text matches nothing.
 
+**Reinforcement-on-recall, live since PR #1173:** the actual live call site in `app/worker.py`
+uses `fetch_concept_region_fragment_and_reinforce()`, not the plain read-only function above
+directly. It composes the same read (unchanged, same "never persists" contract) with a new
+write: whatever concept nodes matched get a small activation bump
+(`reinforce_matched_concepts()`, same math and boost constant as
+`orion/memory/crystallization/dynamics.py::recall_boost()` — `activation = current +
+(1-current)*0.08`, asymptotic toward 1.0). This is the counterpart to
+`services/orion-hub/README.md` §5.5's decay scheduler: being surfaced in a live turn is a
+real "this concept is still relevant" signal, not just monotonic decay. Full design
+conversation (why sync-write over async-via-bus, which fields move and which deliberately
+don't) is in `app/collectors/CONCEPT_REINFORCEMENT_DESIGN.md`.
+
 **Env vars:**
 
 | Var | Default | Meaning |
@@ -797,9 +809,23 @@ substrate store failed to construct (bad `FALKORDB_URI`, FalkorDB unreachable), 
 degrades to `[]` silently — check Hub's own Concept Atlas tab or `orion-hub` logs for
 `recall_substrate_store_init_failed` first.
 
-**Known limitation:** `FalkorSubstrateStore` hydrates its snapshot once at process start and
-never refreshes — concepts added by `orion-hub`'s topic-foundry scheduler after this service's
-first `concept_region` call are invisible here until `orion-recall` restarts. Not specific to
-this collector (shared `orion/substrate/falkor_store.py` behavior), but this is the first
-continuously-changing-data consumer of the store in this service, so it's the first place the
-limitation is actually load-bearing. See PR #1133.
+**Formerly a known limitation, fixed by PR #1159:** `FalkorSubstrateStore` used to hydrate its
+snapshot once at process start and never refresh — concepts added by `orion-hub`'s
+topic-foundry scheduler after this service's first `concept_region` call were invisible here
+until `orion-recall` restarted (originally flagged in PR #1133, when this was the first
+continuously-changing-data consumer of the store in this service to make it load-bearing).
+PR #1159 added write-generation + time-ceiling refresh logic (mirroring
+`GraphDBSubstrateStore`'s existing pattern), so `snapshot()`/`read_concept_region()` now pick
+up durable changes made by other processes without a restart, bounded by
+`SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC` (`FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC`
+for a Falkor-specific override, default 30s). Root cause of PR #1159 itself: the same stale
+cache also meant directly-deleted-in-Falkor nodes got silently resurrected by `orion-hub`'s
+decay scheduler, which blindly re-upserts everything it reads on every tick — see that PR's
+description for the full incident.
+
+Two more `FalkorSubstrateStore`-level bugs (shared code, not specific to this collector, but
+this service constructs the same store) were found and fixed the same day: PR #1175 (a
+legacy-payload migration path that orphaned duplicate node rows forever, silently reverting
+any concept-node write on the next hydrate) and PR #1179 (edge hydration losing every edge's
+real source/target node_id). See `services/orion-hub/README.md` §5.5 for the full incident
+writeups.


### PR DESCRIPTION
## Summary

- Requested directly: audit concept-induction-related READMEs to make sure future agents have good history and don't miss important context from today's work (PRs #1166, #1173, #1175, #1179).
- Found two genuinely stale/false claims, not just missing history, and fixed both.
- Added documentation for two significant, previously-undocumented incidents (#1175, #1179) to the README section that already existed for exactly this purpose.

## Outcome moved

A future agent reading `services/orion-hub/README.md` §5.5 or `services/orion-recall/README.md` §15 now gets an accurate picture of the concept-atlas pipeline's current state and full incident history, instead of two claims that were true when written but silently went stale the same day.

## Files changed

- `services/orion-hub/README.md`: 
  - Fixed "reinforcement-on-recall is not wired yet -- deferred" (it shipped in PR #1173, the very next commit).
  - Added the golden-concept salience gap (schema-boundary fix alone wasn't enough -- `seed.py` never set a salience at all).
  - Documented PR #1175 (legacy-migration duplicate-node bug) and PR #1179 (edge hydration losing source/target node_id) in full.
  - Updated the "See also" PR list (was 5 PRs behind, stopped at #1136).
- `services/orion-recall/README.md`:
  - Fixed "hydrates its snapshot once and never refreshes" (true when written in PR #1133, false since PR #1159).
  - Added documentation of the live reinforcement-on-recall mechanism (`fetch_concept_region_fragment_and_reinforce()`), previously undocumented here even though it's the actual live call site.
  - Cross-referenced #1175/#1179 since this service constructs the same `FalkorSubstrateStore` and was equally exposed to both bugs.

## Schema / bus / API changes

None. Documentation only.

## Env/config changes

None.

## Tests run

Not applicable -- documentation-only change, no code touched.

## Evals run

Not applicable.

## Docker/build/smoke checks

Not applicable.

## Review findings fixed

Not applicable -- no code review dispatched for a docs-only change; content was verified against the actual shipped code (re-read `orion/substrate/falkor_store.py`, `orion/core/schemas/cognitive_substrate.py`, `orion/substrate/seed.py`, `services/orion-recall/app/collectors/concept_region.py` before writing each claim) rather than from memory.

## Restart required

```text
No restart required.
```

## Risks / concerns

None -- documentation-only.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1183
