### PR TITLE
fix(meta-tags): restore chat.history observer-gate scoping

### DIFF
--- a/services/orion-meta-tags/README.md
+++ b/services/orion-meta-tags/README.md
@@ -56,6 +56,22 @@ Runs off the event loop via `asyncio.to_thread` — the underlying `redis.comman
 
 Not yet wired: `social.turn.stored.v1` (Phase 6), historical backfill (Phase 3), any read-side change in `orion-recall` (Phase 4).
 
+## Dual persistence pathway: chat-turn tags go to two graph stores
+
+Every `chat.history` turn's tag/entity data currently materializes into **two independent graph stores**, both fed from the same `tags.enriched` publish on `orion:tags:chat:enriched` (`CHANNEL_EVENTS_TAGGED_CHAT`):
+
+1. **Fuseki (RDF, legacy).** `orion-rdf-writer` consumes this channel and builds a `ChatTurn` subject with `hasTag`/`hasEntity` predicates under the `orion:enrichment` graph (`rdf_builder.py`, `enrichment_type == "chat_tagging"`). This is a *separate* path from the raw `chat.history`/`chat.history.message.v1` → `ChatTurn`/`ChatMessage` RDF materialization that was deliberately killed on 2026-07-17 for covering only ~11-18% of real chat volume — that removal did not touch this enrichment path, which stays live.
+2. **FalkorDB (Cypher, Phase 2).** This service's own `falkor_recall_writer.py` writes the same turn's entities/sentiment directly into `orion_recall`, gated by `RECALL_FALKOR_TAG_ENTITY_ENABLED` (see above).
+
+Falkor is **additive, not a cutover** — it does not replace the Fuseki write, and nothing currently reads from Falkor for recall. This is intentionally a shadow-write phase (Phase 4 is the read-side migration, not yet started).
+
+**Why this needs a named callout:** both pathways were effectively dark for ~6 months. A gate-ordering bug (`services/orion-meta-tags/app/main.py`'s `handle_triage_event` — see the fix in `fix/meta-tags-chat-history-observer-gate`) unconditionally skipped every real `chat.history` turn before it ever reached tagging, so neither the Fuseki `chat_tagging` enrichment path nor the Falkor writer had ever run against real production volume. Fixing that gate means **both stores see real chat traffic for the first time simultaneously**, on the same deploy. Neither side has been load-tested:
+
+- `orion-rdf-writer`'s write queue for this channel (`RDF_WRITE_QUEUE_MAXSIZE=5000`, 8 workers) drops to a dead-letter file on overflow rather than crashing, but dead-letter growth isn't currently alerted on.
+- The Falkor writer does up to 4 sequential Cypher round-trips per turn inside one `asyncio.to_thread` call, and the spaCy NER call in `handle_triage_event` (`SPA_MODEL=en_core_web_trf`, a transformer model) runs synchronously inline with no rate-limiting — both stack under this service's serial (non-`concurrent_handlers`) Hunter dispatch, so a slow turn delays the next one.
+
+If real chat volume turns out to be high enough for either of these to matter, watch consumer lag on `orion:chat:history:turn`/`orion:chat:social:stored` and `orion-rdf-writer`'s dead-letter file size after deploy before assuming this is fine at scale. This is also the natural point to revisit whether `orion-rdf-writer` should keep consuming `orion:tags:chat:enriched` at all, given RDF's broader deprioritization elsewhere in the codebase — not decided here, just flagged as the next real question once live volume is observed.
+
 ## Running & Testing
 
 ### Run via Docker

--- a/services/orion-meta-tags/app/main.py
+++ b/services/orion-meta-tags/app/main.py
@@ -178,15 +178,30 @@ async def handle_triage_event(envelope: BaseEnvelope) -> None:
 
     try:
         raw_payload = envelope.payload if isinstance(envelope.payload, dict) else {}
-        if not should_route_to_triage(raw_payload):
-            logger.info(
-                "skip meta-tags: non_strict kind=%s id=%s observer=%s source_service=%s",
-                envelope.kind,
-                raw_payload.get("id") or raw_payload.get("event_id"),
-                raw_payload.get("observer"),
-                raw_payload.get("source_service"),
-            )
-            return
+        # should_route_to_triage (Juniper-observer gate) intentionally does
+        # NOT run here for chat.history/social.turn.stored.v1 -- it's scoped
+        # to the generic collapse-mirror branch below, restoring the
+        # structure from commit ebd3b9d9 ("Gate collapse meta-tags by
+        # observer"). Commit aaf66d58 ("Enforce metacog draft/enrich patch
+        # contracts", 2026-01-30, unrelated to chat tagging in its own
+        # message/intent) moved this check in front of the chat.history
+        # branch as an apparent accidental side effect. Evidence this was
+        # live-broken, not just theoretical: `git show ebd3b9d9` vs
+        # `aaf66d58` diffs the gate's position directly, and
+        # ChatHistoryTurnV1 (orion/schemas/chat_history.py) has no `observer`
+        # field at all -- should_route_to_triage's own logic (
+        # orion/schemas/collapse_mirror.py) treats a missing observer as
+        # non-Juniper and returns False, so every real chat turn was
+        # unconditionally skipped for ~6 months. should_route_to_triage
+        # itself is not chat-kind-aware on purpose: it's a shared function
+        # also called directly by orion-collapse-mirror's own bus_runtime.py
+        # and orion/collapse/service.py, so making it skip chat kinds would
+        # leak a meta-tags-specific concept into an unrelated service's
+        # routing decision -- scoping the check to this file's generic branch
+        # instead keeps that a meta-tags-only concern. The generic branch
+        # already has its own independent Juniper/Orion gate
+        # (_is_juniper/_is_orion below) -- moving this check does not remove
+        # any gating there.
         if envelope.kind in {"chat.history", "social.turn.stored.v1"}:
             turn_id = raw_payload.get("turn_id") or raw_payload.get("correlation_id")
             if not turn_id and envelope.correlation_id:
@@ -255,6 +270,16 @@ async def handle_triage_event(envelope: BaseEnvelope) -> None:
 
             await meta_tagger.bus.publish(settings.CHANNEL_EVENTS_TAGGED_CHAT, out_env)
             logger.info("✅ Published chat tags for %s -> %s", turn_id, settings.CHANNEL_EVENTS_TAGGED_CHAT)
+            return
+
+        if not should_route_to_triage(raw_payload):
+            logger.info(
+                "skip meta-tags: non_strict kind=%s id=%s observer=%s source_service=%s",
+                envelope.kind,
+                raw_payload.get("id") or raw_payload.get("event_id"),
+                raw_payload.get("observer"),
+                raw_payload.get("source_service"),
+            )
             return
 
         # VALIDATION & TEXT EXTRACTION

--- a/services/orion-meta-tags/tests/test_chat_history_observer_gate.py
+++ b/services/orion-meta-tags/tests/test_chat_history_observer_gate.py
@@ -1,0 +1,154 @@
+"""Regression test for the chat.history observer-gate fix.
+
+Commit aaf66d58 ("Enforce metacog draft/enrich patch contracts") moved
+should_route_to_triage's Juniper-observer check in front of the
+chat.history/social.turn.stored.v1 branch as an apparent side effect of an
+unrelated refactor. ChatHistoryTurnV1 (orion-hub's real chat.history
+payload) has no `observer` field, so this unconditionally skipped every
+real chat turn for ~6 months. This test locks in the fix: chat.history
+bypasses that gate; the generic collapse-mirror path still requires it.
+
+app.main can't be imported directly in this environment -- a pre-existing
+numpy/spacy/thinc binary incompatibility in the shared test venv (unrelated
+to this change, confirmed via traceback in earlier sessions) blocks it.
+Mocking spacy out of sys.modules before import sidesteps that entirely,
+since the failure is inside spacy's own C-extension import chain, not
+anything this test exercises.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+sys.path[:0] = [str(ROOT), str(SERVICE_ROOT)]
+
+
+@pytest.fixture
+def main_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ORION_BUS_URL", "redis://example.test/0")
+
+    # A fake entity with real `.text` content (not just an empty ents=[])
+    # so the extraction line (`entities = [ent.text for ent in doc.ents]`)
+    # is actually exercised, not just left permanently dead under the mock.
+    fake_doc = SimpleNamespace(ents=[SimpleNamespace(text="Circe")])
+    fake_nlp = MagicMock(return_value=fake_doc)
+    fake_spacy = MagicMock()
+    fake_spacy.load.return_value = fake_nlp
+    monkeypatch.setitem(sys.modules, "spacy", fake_spacy)
+
+    # monkeypatch.delitem (not plain `del`) so teardown restores whatever
+    # was in sys.modules before this fixture ran -- a bare `del` here would
+    # leave the fake-spacy-backed module installed for any later test in the
+    # same pytest process that does a plain `import app.main`.
+    monkeypatch.delitem(sys.modules, "app.main", raising=False)
+    monkeypatch.delitem(sys.modules, "app.settings", raising=False)
+    import app.main as m
+
+    m.meta_tagger = MagicMock()
+    m.meta_tagger.bus.publish = AsyncMock()
+    m.settings.RECALL_FALKOR_TAG_ENTITY_ENABLED = False
+    return m
+
+
+def _envelope(main_module, *, kind: str, payload: dict):
+    from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+
+    return BaseEnvelope(
+        kind=kind,
+        source=ServiceRef(name="hub", node="athena", version="0.4.0"),
+        payload=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_history_turn_with_no_observer_still_publishes(main_module) -> None:
+    """The actual regression: a real hub chat.history payload (no `observer`
+    field, matching ChatHistoryTurnV1's real schema) must NOT be skipped."""
+    envelope = _envelope(
+        main_module,
+        kind="chat.history",
+        payload={"session_id": "sess-1", "prompt": "hi", "response": "hello"},
+    )
+    await main_module.handle_triage_event(envelope)
+    main_module.meta_tagger.bus.publish.assert_awaited_once()
+    call_args = main_module.meta_tagger.bus.publish.call_args
+    assert call_args[0][0] == main_module.settings.CHANNEL_EVENTS_TAGGED_CHAT
+
+
+@pytest.mark.asyncio
+async def test_generic_collapse_event_without_observer_is_still_skipped(main_module) -> None:
+    """The generic (non-chat) collapse-mirror path must still require a
+    Juniper observer -- this fix does not weaken that gate."""
+    envelope = _envelope(
+        main_module,
+        kind="collapse.mirror.entry",
+        payload={"id": "c1", "text": "some collapse text", "observer": None},
+    )
+    await main_module.handle_triage_event(envelope)
+    main_module.meta_tagger.bus.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generic_collapse_event_with_juniper_observer_still_publishes(main_module) -> None:
+    envelope = _envelope(
+        main_module,
+        kind="collapse.mirror.entry",
+        payload={"id": "c2", "text": "some collapse text", "observer": "Juniper"},
+    )
+    await main_module.handle_triage_event(envelope)
+    main_module.meta_tagger.bus.publish.assert_awaited_once()
+    call_args = main_module.meta_tagger.bus.publish.call_args
+    assert call_args[0][0] == main_module.settings.CHANNEL_EVENTS_TAGGED
+
+
+@pytest.mark.asyncio
+async def test_chat_history_turn_writes_to_falkor_when_flag_enabled(main_module, monkeypatch) -> None:
+    """Closes the coverage gap noted in PR #1180: the asyncio.to_thread
+    wiring for the Falkor write was previously untestable in this
+    environment. Confirms it actually fires end-to-end for a real
+    chat.history turn, now that app.main can be imported via the spacy
+    mock above."""
+    from orion.graph.falkor_client import RecordingFalkorClient
+
+    fake_client = RecordingFalkorClient()
+    main_module.settings.RECALL_FALKOR_TAG_ENTITY_ENABLED = True
+    monkeypatch.setattr(main_module, "_falkor_client", fake_client)
+
+    envelope = _envelope(
+        main_module,
+        kind="chat.history",
+        payload={"session_id": "sess-2", "prompt": "hi Circe", "response": "hello"},
+    )
+    await main_module.handle_triage_event(envelope)
+
+    main_module.meta_tagger.bus.publish.assert_awaited_once()
+    assert fake_client.calls, "expected at least one Cypher write to the Falkor client"
+    assert any("MERGE (t:ChatTurn" in cypher for cypher, _ in fake_client.calls)
+    # The fake NER doc (see main_module fixture) returns one entity, "Circe".
+    # Confirms the extraction line actually feeds real content through to
+    # the Falkor write, not just an always-empty ents=[] that would pass
+    # even if `ent.text` were swapped for the wrong attribute.
+    entity_calls = [params for cypher, params in fake_client.calls if "MENTIONS_ENTITY" in cypher]
+    assert entity_calls and "circe" in entity_calls[0]["names"]
+
+
+@pytest.mark.asyncio
+async def test_social_turn_stored_bypasses_gate_like_chat_history(main_module) -> None:
+    """social.turn.stored.v1 shares handle_triage_event's chat branch (see
+    module docstring) -- must not regress independently of chat.history."""
+    envelope = _envelope(
+        main_module,
+        kind="social.turn.stored.v1",
+        payload={"session_id": "sess-3", "prompt": "hi", "response": "hello"},
+    )
+    await main_module.handle_triage_event(envelope)
+    main_module.meta_tagger.bus.publish.assert_awaited_once()
+    call_args = main_module.meta_tagger.bus.publish.call_args
+    assert call_args[0][0] == main_module.settings.CHANNEL_EVENTS_TAGGED_CHAT


### PR DESCRIPTION
## Summary

- `should_route_to_triage` (a Juniper-observer gate scoped to the generic collapse-mirror path) was accidentally moved in front of the `chat.history`/`social.turn.stored.v1` branch by commit `aaf66d58` ("Enforce metacog draft/enrich patch contracts"), an unrelated refactor.
- `ChatHistoryTurnV1` (orion-hub's real chat.history payload) has no `observer` field, so `should_route_to_triage` unconditionally returned `False` for every real chat turn — silently killing the `tags.enriched` publish on `orion:tags:chat:enriched` for ~6 months, and with it PR #1180's Falkor recall write (which sits behind the same branch).
- Fix: moved the gate check to after the chat-kind branch's own `return`, restoring the pre-`aaf66d58` structure from commit `ebd3b9d9`. The generic collapse-mirror branch keeps its own independent `_is_juniper`/`_is_orion` gate — no coverage lost there.
- Added `services/orion-meta-tags/tests/test_chat_history_observer_gate.py` (5 tests) — unlocks real `app.main` unit testing for the first time via a spaCy-mocking technique that sidesteps a pre-existing numpy/spacy/thinc binary incompatibility in the shared test venv.
- Documented the "dual persistence pathway" (Fuseki via `orion-rdf-writer` + FalkorDB via this service's own Phase 2 writer) in the service README, since this fix brings both live simultaneously for the first time.

## Outcome moved

Real chat turns are tagged (entities/sentiment) again — this pipeline was completely dead in production for ~6 months. PR #1180's Falkor recall write also becomes live traffic for the first time.

## Current architecture

`orion-meta-tags`'s `handle_triage_event` is one function dispatching on `envelope.kind`: `chat.history`/`social.turn.stored.v1` → chat-tagging branch (spaCy NER + sentiment heuristic + optional Falkor write) → publish to `orion:tags:chat:enriched`; anything else → generic collapse-mirror branch, gated by `should_route_to_triage`, → publish to `orion:tags:enriched`.

## Architecture touched

- `services/orion-meta-tags/app/main.py` — gate check relocated; no schema/contract change.
- `services/orion-meta-tags/README.md` — new "Dual persistence pathway" section.

## Files changed

- `services/orion-meta-tags/app/main.py`: move `should_route_to_triage` check to after the chat-kind branch; expanded comment citing the two commits, the schema gap, and why `should_route_to_triage` itself wasn't made chat-kind-aware (it's called directly by `orion-collapse-mirror` and `orion/collapse/service.py`).
- `services/orion-meta-tags/tests/test_chat_history_observer_gate.py`: new — 5 tests (chat.history bypasses gate with no observer; social.turn.stored.v1 same; generic collapse path still gated both ways; Falkor write fires end-to-end with real entity content).
- `services/orion-meta-tags/README.md`: new "Dual persistence pathway" section documenting the Fuseki+Falkor dual-write and the untested-at-volume operational risk this fix surfaces.

## Schema / bus / API changes

None. No channel, payload shape, or contract change — this restores intended routing behavior on existing channels.

## Env/config changes

None.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/pytest services/orion-meta-tags/tests -q
15 passed, 95 warnings (warnings are pre-existing pydantic protected-namespace deprecation noise, unrelated)
```

## Evals run

No eval harness exists for orion-meta-tags. Not added — out of scope for a gate-scoping bug fix; the new regression tests are the deterministic gate for this behavior.

## Docker/build/smoke checks

Not run from this session — no code path other than the gate itself changed, and Docker rebuild/restart is listed below for Juniper to run.

## Review findings fixed

- Finding: New comment claimed "confirmed live" with no cited log line/correlation ID, violating this repo's "runtime truth beats config truth" rule.
  - Fix: Rewrote the comment to cite only inspectable evidence — the `ebd3b9d9`/`aaf66d58` diff and `ChatHistoryTurnV1`'s missing `observer` field plus `should_route_to_triage`'s own missing-observer-is-false logic.
  - Evidence: `services/orion-meta-tags/app/main.py` lines 181-201.
- Finding: Simplification alternative (extend `should_route_to_triage` itself) was considered and correctly rejected, but undocumented — risked a future "obvious cleanup" reintroducing cross-service coupling.
  - Fix: Documented in the same comment why that path was rejected (the function is called directly by `orion-collapse-mirror`'s `bus_runtime.py` and `orion/collapse/service.py`).
  - Evidence: Same comment block.
- Finding: `del sys.modules[...]` in the test fixture wasn't monkeypatch-tracked, leaking the fake-spacy-backed module into later tests in the same pytest process.
  - Fix: Switched to `monkeypatch.delitem(..., raising=False)`.
  - Evidence: `test_chat_history_observer_gate.py` line 50-51.
- Finding: Fake spaCy Doc always returned `ents=[]`, so no test exercised the real entity-extraction line's content.
  - Fix: Fake Doc now returns one real entity ("Circe"); Falkor test asserts it lands in the `MENTIONS_ENTITY` write.
  - Evidence: `test_chat_history_observer_gate.py` lines 37-40, 134-139.
- Finding: `social.turn.stored.v1` shares the exact gate-bypass branch but had zero test coverage, despite being named in the file's own docstring as affected.
  - Fix: Added `test_social_turn_stored_bypasses_gate_like_chat_history`.
  - Evidence: `test_chat_history_observer_gate.py` lines 142-153.
- Finding: Redundant `importlib.reload(m)` after an `import` that already fully re-executes the module (since it was just deleted from `sys.modules`).
  - Fix: Removed the reload call.
  - Evidence: Fixture no longer imports `importlib`.
- Finding (documented, not fixed): No rate-limiting on the transformer spaCy model now that it runs inline for real chat volume under serial Hunter dispatch; the Falkor write does up to 4 sequential Cypher round-trips per turn; `orion-rdf-writer`'s write queue for this channel is untested at real volume; a second, independent RDF materialization path (`chat_tagging` enrichment) stays live and untested. These are operational-risk findings, not code bugs — this fix restores correct routing, it doesn't introduce new load-handling code. Documented in the README's new "Dual persistence pathway" section as the next thing to watch post-deploy (consumer lag, dead-letter file size), not something to guess a fix for pre-deploy.
- Finding (documented, not fixed): `handle_triage_event` remains one large function where a check added above the kind-dispatch branch could silently re-affect chat.history again (the same structural pattern that caused this bug via commit `aaf66d58`). A real concern, but restructuring into a dispatch table is scope creep for a bug-fix PR — flagged as a follow-up, not built here.
- Finding (documented, not fixed): This is the second from-scratch spaCy-stub test pattern in the repo (`orion-cortex-exec/tests/conftest.py`'s `_stub_spacy_for_router_imports()` is the first). A shared `orion.testing` helper would be the right eventual fix but is a cross-service change beyond this PR's scope.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-meta-tags/.env \
  -f services/orion-meta-tags/docker-compose.yml \
  up -d --build orion-meta-tags
```

Note: live `.env` already has `RECALL_FALKOR_TAG_ENTITY_ENABLED=true`, so this restart activates both the chat-tagging pipeline and the Falkor recall write simultaneously — the first real production traffic either has ever seen. Watch consumer lag on `orion:chat:history:turn`/`orion:chat:social:stored` and `orion-rdf-writer`'s dead-letter file size after restart.

## Risks / concerns

- Severity: Medium
- Concern: Two previously-dead code paths (Fuseki chat_tagging enrichment, Falkor Phase 2 writer) go live simultaneously on this deploy, both untested at real chat volume, stacked under a transformer NLP call with no rate-limiting and serial (non-concurrent) Hunter dispatch.
- Mitigation: Documented in README; recommend watching consumer lag and `orion-rdf-writer` dead-letter file size immediately post-restart, and being ready to flip `RECALL_FALKOR_TAG_ENTITY_ENABLED` back to `false` independently of this fix if the Falkor write specifically proves to be the bottleneck (they're decoupled — the fix itself doesn't require the flag to be on).

## PR link

(filled in after creation)