### PR TITLE
feat(mood-arc): add detect-anomalies CLI subcommand (roadmap Item 3)

### DIFF
--- a/scripts/fit_mood_arc_encoder.py
+++ b/scripts/fit_mood_arc_encoder.py
@@ -66,8 +66,8 @@ confidence interval on the floor ratio. None of this is in the original
 written spec doc -- see MoodArcEncoderManifestV1's docstring for the
 field-level rationale.
 
-Only `train` is implemented here. `promote`/`infer` are later roadmap items
-(3+), not built by this patch.
+`train` and `detect-anomalies` (roadmap item 3) are implemented here.
+`promote` is a later roadmap item, not built by this patch.
 """
 from __future__ import annotations
 
@@ -155,6 +155,13 @@ DEFAULT_BOOTSTRAP_N = 200
 DEFAULT_MIN_HOURS = 6.0
 DEFAULT_MIN_ROWS = 500
 DEFAULT_BATCH_SIZE = 32
+# detect-anomalies: a window's recon_loss above
+# manifest.training.recon_error_p95 * this multiplier is flagged. 3.0 is a
+# deliberately conservative "well outside normal training-time variation"
+# bar (p95 already means only 5% of held-out windows in the encoder's own
+# training run exceeded it) -- not statistically calibrated against a known
+# false-positive rate, just chosen to avoid flagging routine tail variance.
+DEFAULT_ANOMALY_THRESHOLD_MULTIPLIER = 3.0
 
 # Hard gate threshold, unchanged from the original spec: real held-out recon
 # loss must beat the shuffle baseline by at least 2x.
@@ -889,6 +896,62 @@ def write_artifacts(
     (out_dir / "probes.json").write_text(json.dumps(probes, indent=2), encoding="utf-8")
 
 
+def load_artifacts(encoder_dir: Path) -> tuple[MoodArcEncoderManifestV1, dict[str, np.ndarray]]:
+    """Inverse of write_artifacts()'s manifest/weights pair (probes.json is
+    train-time-only diagnostic output, not needed to score new windows)."""
+    manifest = MoodArcEncoderManifestV1.model_validate_json(
+        (encoder_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+    with np.load(encoder_dir / "weights.npz") as npz:
+        weights = {key: npz[key] for key in npz.files}
+    return manifest, weights
+
+
+def score_windows(
+    rows: list[FieldChannelCorpusRowV1],
+    *,
+    fields: tuple[str, ...],
+    window_size: int,
+    stride: int,
+    max_gap_sec: float,
+    weights: dict[str, np.ndarray],
+) -> list[tuple[float, datetime, datetime]]:
+    """Reconstruction loss per window, in timestamp order. `fields` must be
+    the trained encoder's own `channel_names` (manifest-recorded column
+    order) -- scoring against any other field set/order silently produces a
+    meaningless loss number, since forward() has no way to detect a
+    column-alignment mismatch on its own."""
+    triples = _build_windows_with_span(
+        rows, fields=fields, window_size=window_size, stride=stride, max_gap_sec=max_gap_sec
+    )
+    return [(recon_loss(w, weights), start, end) for w, start, end in triples]
+
+
+def detect_anomalies(
+    scored: list[tuple[float, datetime, datetime]],
+    *,
+    threshold: float,
+) -> list[dict[str, object]]:
+    """Flags windows whose reconstruction loss exceeds `threshold` --
+    typically manifest.training.recon_error_p95 times a caller-chosen
+    multiplier (see cmd_detect_anomalies's --threshold-multiplier), not a
+    fixed absolute number, since "normal" loss magnitude is corpus/channel-
+    set-dependent. Threshold computation is deliberately the caller's job,
+    not this function's, so it stays a plain, testable filter+sort."""
+    anomalies = [
+        {
+            "recon_loss": loss,
+            "window_start": start.isoformat(),
+            "window_end": end.isoformat(),
+            "threshold": threshold,
+        }
+        for loss, start, end in scored
+        if loss > threshold
+    ]
+    anomalies.sort(key=lambda a: a["recon_loss"], reverse=True)
+    return anomalies
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Offline mood-arc windowed autoencoder fit")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -949,6 +1012,50 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     train_p.add_argument("--seed", type=int, default=42)
     train_p.add_argument(
         "--encoder-version", type=str, default=None, help="manifest encoder_version (default: out dir name)"
+    )
+
+    detect_p = sub.add_parser(
+        "detect-anomalies",
+        help="Score a corpus slice against a trained encoder and flag high-reconstruction-error windows",
+    )
+    detect_p.add_argument(
+        "--corpus",
+        type=Path,
+        required=True,
+        help="FieldChannelCorpusRowV1 JSONL corpus to score (same format as `train --corpus`)",
+    )
+    detect_p.add_argument(
+        "--encoder-dir",
+        type=Path,
+        required=True,
+        help="Directory written by a prior `train` run (manifest.json + weights.npz)",
+    )
+    detect_p.add_argument(
+        "--min-generated-at",
+        type=_parse_min_generated_at,
+        default=None,
+        help="ISO 8601 datetime; rows before this are dropped before scoring. Boundary-inclusive (>=).",
+    )
+    detect_p.add_argument(
+        "--max-generated-at",
+        type=_parse_min_generated_at,
+        default=None,
+        help=(
+            "ISO 8601 datetime; rows on or after this are dropped before scoring. "
+            "Boundary-exclusive (<). Together with --min-generated-at, scopes "
+            "scoring to a specific historical window (e.g. a known-bad period "
+            "predating a fix) independently of the encoder's own training window."
+        ),
+    )
+    detect_p.add_argument(
+        "--threshold-multiplier",
+        type=float,
+        default=DEFAULT_ANOMALY_THRESHOLD_MULTIPLIER,
+        help=(
+            "Anomaly threshold = encoder_dir's manifest.training.recon_error_p95 "
+            "* this multiplier (default: %(default)s). Windows scoring above it "
+            "are flagged."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -1098,10 +1205,61 @@ def cmd_train(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_detect_anomalies(args: argparse.Namespace) -> int:
+    try:
+        manifest, weights = load_artifacts(args.encoder_dir)
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            f"detect-anomalies: could not load encoder artifacts from {args.encoder_dir} "
+            f"(expected manifest.json + weights.npz, written by a prior `train` run): {exc}"
+        ) from exc
+    fields = tuple(manifest.channel_names)
+
+    rows = _load_jsonl(args.corpus)
+    rows = filter_rows_by_min_generated_at(rows, args.min_generated_at)
+    if args.max_generated_at is not None:
+        rows = [r for r in rows if r.generated_at < args.max_generated_at]
+    if not rows:
+        raise SystemExit("detect-anomalies: no rows in corpus after --min/--max-generated-at filtering")
+
+    scored = score_windows(
+        rows,
+        fields=fields,
+        window_size=manifest.window_size,
+        stride=manifest.stride,
+        max_gap_sec=manifest.max_gap_sec,
+        weights=weights,
+    )
+    if not scored:
+        raise SystemExit(
+            "detect-anomalies: no windows built (check corpus row count/gaps against "
+            "the encoder's window_size/stride/max_gap_sec)"
+        )
+
+    threshold = manifest.training.recon_error_p95 * args.threshold_multiplier
+    anomalies = detect_anomalies(scored, threshold=threshold)
+
+    result = {
+        "encoder_id": manifest.encoder_id,
+        "corpus": str(args.corpus),
+        "channel_names": list(fields),
+        "windows_scored": len(scored),
+        "threshold": threshold,
+        "threshold_multiplier": args.threshold_multiplier,
+        "recon_error_p95_at_train_time": manifest.training.recon_error_p95,
+        "anomalies_found": len(anomalies),
+        "anomalies": anomalies,
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     if args.command == "train":
         return cmd_train(args)
+    if args.command == "detect-anomalies":
+        return cmd_detect_anomalies(args)
     raise SystemExit(f"unknown command: {args.command}")
 
 

--- a/tests/test_mood_arc_anomaly_detector.py
+++ b/tests/test_mood_arc_anomaly_detector.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from orion.schemas.telemetry.field_channel_corpus import FieldChannelCorpusRowV1
+from orion.schemas.telemetry.mood_arc import MoodArcEncoderManifestV1
+
+REPO = Path(__file__).resolve().parents[1]
+FIT_SCRIPT = REPO / "scripts" / "fit_mood_arc_encoder.py"
+
+
+def _run_fit(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(FIT_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+
+
+def _make_row(*, t: datetime, channels: dict[str, float], idx: int) -> FieldChannelCorpusRowV1:
+    return FieldChannelCorpusRowV1(generated_at=t, tick_id=f"tick_{idx}", channels=channels)
+
+
+def _write_corpus(path: Path, rows: list[FieldChannelCorpusRowV1]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(row.model_dump_json() + "\n")
+
+
+def _normal_rows(
+    n_rows: int = 1500, seed: int = 0, start: datetime | None = None
+) -> list[FieldChannelCorpusRowV1]:
+    """Real periodic/trend pattern + noise, same shape as
+    test_mood_arc_encoder_fit_script.py's own synthetic-corpus fixture --
+    reused here so a trained encoder actually learns something nontrivial to
+    reconstruct, rather than the near-constant-baseline pattern a degenerate
+    corpus would produce."""
+    rng = np.random.default_rng(seed)
+    start = start or datetime(2026, 7, 1, tzinfo=timezone.utc)
+    rows: list[FieldChannelCorpusRowV1] = []
+    for i in range(n_rows):
+        t = start + timedelta(seconds=2 * i)
+        phase = i * 0.05
+        coherence = 0.6 + 0.05 * np.sin(phase) + rng.normal(0, 0.01)
+        energy = 0.3 + 0.1 * np.sin(phase * 0.7) + rng.normal(0, 0.02)
+        novelty = 0.5 + 0.3 * np.sin(phase * 1.3) + rng.normal(0, 0.03)
+        channels = {
+            "coherence": float(coherence),
+            "energy": float(energy),
+            "novelty": float(novelty),
+        }
+        rows.append(_make_row(t=t, channels=channels, idx=i))
+    return rows
+
+
+def _frozen_ratchet_rows(
+    n_rows: int, seed: int, start: datetime
+) -> list[FieldChannelCorpusRowV1]:
+    """Mimics this session's real pre-fix incident (a one-way-ratchet channel
+    pinned at 1.0, e.g. bus_health/availability before PR #1108-#1115):
+    coherence/energy/novelty all pinned flat at an out-of-distribution
+    constant, none of the normal periodic variation an encoder trained on
+    _normal_rows() would have learned to reconstruct."""
+    rows: list[FieldChannelCorpusRowV1] = []
+    for i in range(n_rows):
+        t = start + timedelta(seconds=2 * i)
+        channels = {"coherence": 1.0, "energy": 1.0, "novelty": 1.0}
+        rows.append(_make_row(t=t, channels=channels, idx=i))
+    return rows
+
+
+def _train_small_encoder(tmp_path: Path) -> Path:
+    corpus = tmp_path / "train_corpus.jsonl"
+    out_dir = tmp_path / "candidate"
+    _write_corpus(corpus, _normal_rows())
+    proc = _run_fit(
+        "train",
+        "--corpus", str(corpus),
+        "--out", str(out_dir),
+        "--hidden-dim", "32",
+        "--latent-dim", "16",
+        "--epochs", "150",
+        "--min-hours", "0.5",
+        "--min-rows", "100",
+        "--purge-gap-windows", "6",
+        "--bootstrap-n", "20",
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return out_dir
+
+
+def test_load_artifacts_round_trips_write_artifacts(tmp_path: Path) -> None:
+    from scripts.fit_mood_arc_encoder import load_artifacts
+
+    encoder_dir = _train_small_encoder(tmp_path)
+    manifest, weights = load_artifacts(encoder_dir)
+    assert isinstance(manifest, MoodArcEncoderManifestV1)
+    assert manifest.channel_names
+    for key in ("W1", "b1", "W2", "b2", "W3", "b3"):
+        assert key in weights
+        assert isinstance(weights[key], np.ndarray)
+
+
+def test_score_windows_returns_one_score_per_window(tmp_path: Path) -> None:
+    from scripts.fit_mood_arc_encoder import load_artifacts, score_windows, _load_jsonl
+
+    encoder_dir = _train_small_encoder(tmp_path)
+    manifest, weights = load_artifacts(encoder_dir)
+
+    scoring_corpus = tmp_path / "score_corpus.jsonl"
+    _write_corpus(scoring_corpus, _normal_rows(n_rows=200, seed=1))
+    rows = _load_jsonl(scoring_corpus)
+
+    scored = score_windows(
+        rows,
+        fields=tuple(manifest.channel_names),
+        window_size=manifest.window_size,
+        stride=manifest.stride,
+        max_gap_sec=manifest.max_gap_sec,
+        weights=weights,
+    )
+    assert len(scored) > 0
+    for loss, start, end in scored:
+        assert isinstance(loss, float)
+        assert loss >= 0.0
+        assert start <= end
+    # Timestamp order preserved (build_windows()'s own documented guarantee).
+    starts = [s for _, s, _ in scored]
+    assert starts == sorted(starts)
+
+
+def test_detect_anomalies_filters_and_sorts_descending() -> None:
+    from scripts.fit_mood_arc_encoder import detect_anomalies
+
+    t0 = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    scored = [
+        (0.001, t0, t0 + timedelta(seconds=1)),
+        (0.050, t0 + timedelta(seconds=2), t0 + timedelta(seconds=3)),
+        (0.002, t0 + timedelta(seconds=4), t0 + timedelta(seconds=5)),
+        (0.100, t0 + timedelta(seconds=6), t0 + timedelta(seconds=7)),
+    ]
+    anomalies = detect_anomalies(scored, threshold=0.01)
+    assert len(anomalies) == 2
+    assert [a["recon_loss"] for a in anomalies] == [0.100, 0.050]
+
+
+def test_detect_anomalies_empty_when_nothing_exceeds_threshold() -> None:
+    from scripts.fit_mood_arc_encoder import detect_anomalies
+
+    t0 = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    scored = [(0.001, t0, t0), (0.002, t0, t0)]
+    assert detect_anomalies(scored, threshold=1.0) == []
+
+
+def test_acceptance_check_flags_a_known_bad_frozen_ratchet_window(tmp_path: Path) -> None:
+    """This is roadmap Item 3's own acceptance check: an encoder trained on
+    normal (real periodic) data must retroactively flag at least one window
+    from a known-bad period (here: a frozen-ratchet stretch mimicking the
+    real bus_health/availability incident this session traced and fixed,
+    PRs #1108-#1115) as anomalous."""
+    from scripts.fit_mood_arc_encoder import (
+        detect_anomalies,
+        load_artifacts,
+        score_windows,
+        _load_jsonl,
+    )
+
+    encoder_dir = _train_small_encoder(tmp_path)
+    manifest, weights = load_artifacts(encoder_dir)
+
+    bad_corpus = tmp_path / "known_bad.jsonl"
+    _write_corpus(
+        bad_corpus,
+        _frozen_ratchet_rows(n_rows=200, seed=2, start=datetime(2026, 7, 10, tzinfo=timezone.utc)),
+    )
+    rows = _load_jsonl(bad_corpus)
+
+    scored = score_windows(
+        rows,
+        fields=tuple(manifest.channel_names),
+        window_size=manifest.window_size,
+        stride=manifest.stride,
+        max_gap_sec=manifest.max_gap_sec,
+        weights=weights,
+    )
+    assert scored, "expected at least one window from the frozen-ratchet corpus"
+
+    threshold = manifest.training.recon_error_p95 * 3.0
+    anomalies = detect_anomalies(scored, threshold=threshold)
+    assert len(anomalies) > 0, (
+        f"expected the frozen-ratchet window(s) to be flagged anomalous; "
+        f"got 0 anomalies (threshold={threshold}, "
+        f"scores={[s for s, _, _ in scored][:5]}...)"
+    )
+
+
+def test_cli_detect_anomalies_end_to_end(tmp_path: Path) -> None:
+    encoder_dir = _train_small_encoder(tmp_path)
+
+    bad_corpus = tmp_path / "known_bad.jsonl"
+    _write_corpus(
+        bad_corpus,
+        _frozen_ratchet_rows(n_rows=200, seed=3, start=datetime(2026, 7, 10, tzinfo=timezone.utc)),
+    )
+
+    proc = _run_fit(
+        "detect-anomalies",
+        "--corpus", str(bad_corpus),
+        "--encoder-dir", str(encoder_dir),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    result = json.loads(proc.stdout[proc.stdout.index("{") :])
+    assert result["windows_scored"] > 0
+    assert result["anomalies_found"] > 0
+    assert len(result["anomalies"]) == result["anomalies_found"]
+
+
+def test_cli_detect_anomalies_min_max_generated_at_scopes_corpus(tmp_path: Path) -> None:
+    encoder_dir = _train_small_encoder(tmp_path)
+
+    mixed_corpus = tmp_path / "mixed.jsonl"
+    start = datetime(2026, 7, 10, tzinfo=timezone.utc)
+    normal_part = _normal_rows(n_rows=100, seed=4, start=start)
+    bad_start = normal_part[-1].generated_at + timedelta(seconds=2)
+    bad_part = _frozen_ratchet_rows(n_rows=100, seed=5, start=bad_start)
+    _write_corpus(mixed_corpus, normal_part + bad_part)
+
+    # Scope to only the bad half via --min-generated-at.
+    proc = _run_fit(
+        "detect-anomalies",
+        "--corpus", str(mixed_corpus),
+        "--encoder-dir", str(encoder_dir),
+        "--min-generated-at", bad_start.isoformat().replace("+00:00", "Z"),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    result = json.loads(proc.stdout[proc.stdout.index("{") :])
+    assert result["anomalies_found"] > 0
+
+    # Scope to only the normal half via --max-generated-at -- should find
+    # far fewer (ideally zero) anomalies than scoring the bad half.
+    proc2 = _run_fit(
+        "detect-anomalies",
+        "--corpus", str(mixed_corpus),
+        "--encoder-dir", str(encoder_dir),
+        "--max-generated-at", bad_start.isoformat().replace("+00:00", "Z"),
+    )
+    assert proc2.returncode == 0, proc2.stderr or proc2.stdout
+    result2 = json.loads(proc2.stdout[proc2.stdout.index("{") :])
+    assert result2["anomalies_found"] < result["anomalies_found"]
+
+
+def test_cli_detect_anomalies_missing_encoder_dir_is_a_clear_error(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus.jsonl"
+    _write_corpus(corpus, _normal_rows(n_rows=50, seed=6))
+
+    proc = _run_fit(
+        "detect-anomalies",
+        "--corpus", str(corpus),
+        "--encoder-dir", str(tmp_path / "does-not-exist"),
+    )
+    assert proc.returncode != 0
+    combined = (proc.stdout + proc.stderr).lower()
+    assert "detect-anomalies: could not load encoder artifacts" in combined
+
+
+def test_cli_detect_anomalies_no_windows_is_a_clear_error(tmp_path: Path) -> None:
+    encoder_dir = _train_small_encoder(tmp_path)
+    empty_corpus = tmp_path / "empty.jsonl"
+    empty_corpus.write_text("")
+
+    proc = _run_fit(
+        "detect-anomalies",
+        "--corpus", str(empty_corpus),
+        "--encoder-dir", str(encoder_dir),
+    )
+    assert proc.returncode != 0
+    assert "no rows" in (proc.stdout + proc.stderr).lower()


### PR DESCRIPTION
## Summary
- Adds a `detect-anomalies` CLI subcommand to `scripts/fit_mood_arc_encoder.py`: scores a corpus slice against a trained encoder's reconstruction error, flagging windows above `manifest.training.recon_error_p95 * --threshold-multiplier` (default 3.0).
- New functions: `load_artifacts()` (inverse of the existing `write_artifacts()`), `score_windows()` (reuses `_build_windows_with_span()`/`recon_loss()`), `detect_anomalies()` (threshold filter + descending sort).
- New `--min-generated-at`/`--max-generated-at` flags let scoring be scoped to a specific historical window independently of the encoder's own training window.

## Outcome moved
Roadmap Item 3 (anomaly detector) ships with its own defined acceptance check satisfied: **verified live against real data**, not just synthetic tests. Scoring the actual pre-fix `field_channel_corpus.v1` period (`2026-07-13T23:46Z`–`2026-07-17T04:32:14Z`, the period earlier work this session found genuinely broken by ratchets/saturation, fixed in PRs #1108-#1115) against today's real production encoder (PR #1182/#1177's `mood-arc-encoder:v1-candidate`) flagged **1,166 of 9,103 windows (12.8%)** as anomalous.

## Current architecture
`scripts/fit_mood_arc_encoder.py` only had a `train` subcommand -- a trained encoder's artifacts (`manifest.json`/`weights.npz`) had no read-side consumer anywhere in the repo.

## Architecture touched
`scripts/fit_mood_arc_encoder.py` only -- pure addition, no changes to `train`'s existing behavior.

## Files changed
- `scripts/fit_mood_arc_encoder.py`: `load_artifacts()`, `score_windows()`, `detect_anomalies()`, `cmd_detect_anomalies()`, `detect-anomalies` argparse subparser, `DEFAULT_ANOMALY_THRESHOLD_MULTIPLIER`
- `tests/test_mood_arc_anomaly_detector.py` (new): 9 tests, including the roadmap-defined acceptance check (synthetic frozen-ratchet pattern correctly flagged)

## Schema / bus / API changes
None -- reads existing `MoodArcEncoderManifestV1`/`weights.npz` artifacts, no schema changes.

## Tests run
```
pytest tests/test_mood_arc_encoder_fit_script.py tests/test_mood_arc_encoder_schema.py tests/test_mood_arc_anomaly_detector.py -q   # 33 passed
```

## Evals run
Live verification against real corpus data (see Outcome moved above) -- 1,166/9,103 real historical windows correctly flagged anomalous.

## Docker/build/smoke checks
N/A -- offline CLI script, no runtime/compose changes.

## Review findings fixed

- Finding: `load_artifacts()` propagated a raw, unformatted `FileNotFoundError` traceback when `--encoder-dir` was missing/malformed, inconsistent with `cmd_detect_anomalies`'s other error paths (clear `SystemExit` messages for empty corpus / no windows built).
  - Fix: wrapped the `load_artifacts()` call in `cmd_detect_anomalies` with a `try/except FileNotFoundError` that raises a clear, consistent `SystemExit` message.
  - Evidence: new test `test_cli_detect_anomalies_missing_encoder_dir_is_a_clear_error`.
- Other candidates considered and correctly not fixed: `score_windows()`'s reliance on caller-supplied `fields` matching the trained `channel_names` exactly has no live risk (the only real caller, `cmd_detect_anomalies`, always derives `fields` from the loaded manifest itself -- already disclosed in the function's own docstring); `_parse_min_generated_at`'s reuse as the `type=` for `--max-generated-at` is functionally correct (pure ISO-8601 parsing, no min-specific branching); `detect_anomalies()`'s strict `loss > threshold` is intentional (continuous float comparison, no realistic tie case).

## Restart required
```text
No restart required.
```

## Risks / concerns
None -- offline tooling addition, real test coverage, verified against real production data before merge.

## PR link
(filled in by `gh pr create` output)