### PR TITLE
fix(meta-tags,rdf-writer): kill Fuseki dual-write for chat/social tags, Falkor-only now

### DIFF
--- a/docs/architecture/rdf_store_v1_cutover.md
+++ b/docs/architecture/rdf_store_v1_cutover.md
@@ -40,9 +40,9 @@ Copy from `services/orion-rdf-writer/.env_example` (including the **RDF Store V1
 - Payload kind: **`rdf.write.request`** (`RdfWriteRequest` and related build kinds).
 - The writer also subscribes to other catalog channels; see `Settings.get_all_subscribe_channels()` in `app/settings.py`.
 
-## Falkor migration in progress (does not touch this service)
+## Falkor migration: chat/social tag enrichment fully cut over (this service no longer touches it)
 
-As of 2026-07-18, `tags.enriched` (the `orion:tags:chat:enriched` channel specifically) also gets a **separate, additive** Cypher-native write into FalkorDB by `orion-meta-tags` itself, alongside this service's unchanged Fuseki write of the same event. This service is not modified by that work and continues writing exactly as documented above. See `docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md` and `services/orion-meta-tags/README.md`. `orion-rdf-writer`'s own role stays "legacy RDF materialize" per the FalkorDB doctrine's service-ownership table — new Falkor writes belong in the originating producer service, not here.
+`orion:tags:chat:enriched` (`CHANNEL_EVENTS_TAGGED_CHAT`) is **removed as of 2026-07-18**: this service no longer subscribes to it, and `orion-meta-tags` no longer publishes to it. Chat/social-turn tag+entity enrichment (`enrichment_type == "chat_tagging"`) now lands exclusively in FalkorDB, written directly by `orion-meta-tags` (`app/falkor_recall_writer.py`) — no RDF, no bus publish for this data at all. This was briefly a dual-write (both Fuseki and Falkor, ~1 day) before the redundant Fuseki side was killed; see `docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md`'s amendment note and `services/orion-meta-tags/README.md`'s "Historical note" section for the full before/after. `orion-rdf-writer`'s own role stays "legacy RDF materialize" per the FalkorDB doctrine's service-ownership table — new Falkor writes belong in the originating producer service, not here. The generic collapse-mirror `tags.enriched` path (`orion:tags:enriched`, `enrichment_type == "tagging"`) is unaffected and still writes here as documented above.
 
 ## Legacy writer (quarantined)
 

--- a/docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md
+++ b/docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md
@@ -5,6 +5,8 @@
 **Implements:** Phase 2 of `docs/superpowers/specs/2026-07-17-recall-rdf-writer-falkor-cutover-phase2-spec.md`, applying the routing/property doctrine in `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md`.
 **Mode:** Implementation (this doc records the design that was reviewed and approved before building; not a fresh proposal)
 
+**Amendment (2026-07-18, same day, later patch):** the "alongside (not replacing) the existing Fuseki write" framing below is now historical. Once `fix/meta-tags-chat-history-observer-gate` fixed a dark ~6-month gate bug that had kept both this writer and the Fuseki copy from ever running against real traffic, the very next patch (`fix/meta-tags-kill-rdf-chat-dual-write`) killed the Fuseki side as redundant and extended this writer to also cover `social.turn.stored.v1` (removing the `chat.history`-only gate mentioned in "Corrected scope" item 1 below and in the deferred-scope note near the end of this doc) — Fuseki was social.turn.stored.v1's *only* persistence path, so leaving that gate in place would have deleted that data outright. See `services/orion-meta-tags/README.md`'s "Historical note" section for the live-verified before/after.
+
 ---
 
 ## What this is
@@ -17,6 +19,8 @@ A live, dark-shipped Cypher-native write of chat tag/entity data into FalkorDB, 
 2. **This does not live in `orion-rdf-writer`.** That service's own doctrine role is explicitly scoped to "Legacy RDF materialize" (`docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md`'s service-ownership table) and its canonical-writer doc (`docs/architecture/rdf_store_v1_cutover.md`) says its job is RDF materialization from the bus, specifically. Every real Falkor producer in the codebase lives in the originating service instead: `orion-substrate-runtime` for substrate, `orion-graphiti-adapter` for crystallizations, `orion-spark-concept-induction` for concept profiles (that one is the closest precedent — the producer writes directly to Falkor and stops routing through `orion-rdf-writer` for that data). This writer belongs in **`orion-meta-tags`**, the actual producer of tag/entity extraction, not bolted onto the RDF service as a second branch.
 
 ## Current architecture (verified this session, not assumed)
+
+**This section is a snapshot from when this doc was written -- see the amendment at the top. The `publishes kind="tags.enriched" to CHANNEL_EVENTS_TAGGED_CHAT` claim below is no longer true as of the same-day follow-up patch; there is no bus publish for this data anymore.**
 
 - **Producer**: `services/orion-meta-tags/app/main.py::handle_triage_event`. Subscribed to `orion:collapse:triage`, `orion:chat:history:turn`, `orion:chat:social:stored`. For `envelope.kind in {"chat.history", "social.turn.stored.v1"}`, runs spaCy NER (`entities = [ent.text for ent in doc.ents]`, `tags = list(entities)`), a crude keyword-heuristic sentiment tag (`"sentiment:positive"|"sentiment:negative"|"sentiment:neutral"`, appended into `tags`), builds a `MetaTagsPayload` (aliased `Enrichment`), and publishes `kind="tags.enriched"` to `CHANNEL_EVENTS_TAGGED_CHAT` (`orion:tags:chat:enriched`).
 - **`MetaTagsPayload`** (`orion/schemas/telemetry/meta_tags.py`) fields: `service_name, service_version, node, timestamp, source_message_id, correlation_id, tags, entities, processing_meta, id, collapse_id, enrichment_type`. **No `session_id` field.**

--- a/docs/superpowers/specs/2026-07-17-recall-rdf-writer-falkor-cutover-phase2-spec.md
+++ b/docs/superpowers/specs/2026-07-17-recall-rdf-writer-falkor-cutover-phase2-spec.md
@@ -41,6 +41,12 @@ orion:rdf:enqueue              # RdfWriteRequest from orion-cortex-exec, orion-v
 orion:rdf-collapse:enqueue
 orion:collapse:*  (CHANNEL_EVENTS_COLLAPSE)
 orion:tags:*      (CHANNEL_EVENTS_TAGGED, CHANNEL_EVENTS_TAGGED_CHAT)  -> Claim nodes (tags.enriched, emit_claims=True)
+                  # STALE as of 2026-07-18 (this snapshot predates it): CHANNEL_EVENTS_TAGGED_CHAT
+                  # (orion:tags:chat:enriched) removed -- FalkorDB-only now, see
+                  # services/orion-meta-tags/README.md "Historical note". This whole block is a
+                  # frozen point-in-time snapshot already out of date for other kills too
+                  # (orion:worker:rdf / CORTEX_LOG_CHANNEL below were removed by PR #1167) --
+                  # trust settings.py::get_all_subscribe_channels() over this list.
 orion:chat:social:stored        -> SocialRoomTurn / SocialConceptEvidence
 orion:core:events (CHANNEL_CORE_EVENTS)
 orion:worker:rdf  (CHANNEL_WORKER_RDF)

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1282,8 +1282,12 @@ channels:
   - name: "orion:tags:chat:enriched"
     kind: "event"
     schema_id: "MetaTagsPayload"
-    producer_services: ["orion-meta-tags"]
-    consumer_services: ["orion-rdf-writer"]
+    # Both sides removed 2026-07-18: chat/social-turn tag+entity enrichment
+    # is FalkorDB-only now (orion-meta-tags writes it directly in-process,
+    # no bus publish). orion-rdf-writer's Fuseki `chat_tagging` copy was a
+    # redundant second materialization of the same data. Do not re-add.
+    producer_services: []
+    consumer_services: []
     stability: "experimental"
     since: "2026-01-18"
 

--- a/services/orion-meta-tags/.env_example
+++ b/services/orion-meta-tags/.env_example
@@ -18,18 +18,22 @@ CHANNEL_EVENTS_CHAT_TURN=orion:chat:history:turn
 
 # outgoing to meta-writer
 CHANNEL_EVENTS_TAGGED=orion:tags:enriched
-CHANNEL_EVENTS_TAGGED_CHAT=orion:tags:chat:enriched
+# CHANNEL_EVENTS_TAGGED_CHAT removed 2026-07-18: chat/social-turn tag+entity
+# enrichment is no longer bus-published. FalkorDB (below) is the sole
+# persistence target now; orion-rdf-writer's Fuseki copy was redundant.
 
 # --- Runtime ---
 STARTUP_DELAY=5
 LOG_LEVEL=INFO
 
-# --- Recall Falkor writer (Phase 2, dark by default) ---
+# --- Recall Falkor writer (Phase 2) ---
 # docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md
-# Cypher-native write of chat-turn tag/entity enrichment into FalkorDB,
-# additive alongside orion-rdf-writer's existing Fuseki write of the same
-# tags.enriched event (not a replacement). Off by default -- flip to true
-# once ready to shadow-write.
-RECALL_FALKOR_TAG_ENTITY_ENABLED=false
+# Cypher-native write of chat-turn tag/entity enrichment into FalkorDB. As of
+# 2026-07-18 this is the ONLY persistence target for this data (also covers
+# social.turn.stored.v1 now, not just chat.history) -- the Fuseki dual-write
+# (via CHANNEL_EVENTS_TAGGED_CHAT) was killed the same day. Default is true:
+# false now means no persistence at all for this data, not "skip a shadow
+# write alongside a real Fuseki copy" like it used to.
+RECALL_FALKOR_TAG_ENTITY_ENABLED=true
 FALKORDB_URI=redis://orion-athena-falkordb:6379
 FALKORDB_RECALL_GRAPH=orion_recall

--- a/services/orion-meta-tags/README.md
+++ b/services/orion-meta-tags/README.md
@@ -9,13 +9,14 @@ The **Meta Tags** service provides automated enrichment for collapse events, cha
 | :--- | :--- | :--- | :--- |
 | `orion:collapse:triage` | `CHANNEL_EVENTS_TRIAGE` | `collapse.mirror` | Raw entries needing enrichment (Juniper-observed only; Orion's own outputs are skipped). |
 | `orion:chat:history:turn` | `CHANNEL_EVENTS_CHAT_TURN` | `chat.history` | Chat turns — the source of the Falkor recall write below. |
-| `orion:chat:social:stored` (hardcoded, no env var) | — | `social.turn.stored.v1` | Social-room turns. Shares the same tagging code path as chat turns; **not yet** wired to the Falkor writer (Phase 6, see the plan doc below). |
+| `orion:chat:social:stored` (hardcoded, no env var) | — | `social.turn.stored.v1` | Social-room turns. Shares the same tagging code path and, as of 2026-07-18, the same Falkor write as chat turns. |
 
 ### Published Channels
 | Channel | Env Var | Kind | Description |
 | :--- | :--- | :--- | :--- |
 | `orion:tags:enriched` | `CHANNEL_EVENTS_TAGGED` | `tags.enriched` | Enriched metadata for collapse-mirror events. |
-| `orion:tags:chat:enriched` | `CHANNEL_EVENTS_TAGGED_CHAT` | `tags.enriched` | Enriched metadata for chat/social turns (same `kind`, different channel). Consumed by `orion-rdf-writer` (Fuseki write) and, as of Phase 2 below, written to Falkor directly by this service too. |
+
+Chat/social-turn tag+entity enrichment is **not published to the bus at all** — it goes straight into FalkorDB (below). See "Historical note" at the end of this section for what used to be here.
 
 ### Environment Variables
 Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
@@ -25,8 +26,7 @@ Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
 | `CHANNEL_EVENTS_TRIAGE` | `orion:collapse:triage` | Intake channel. |
 | `CHANNEL_EVENTS_CHAT_TURN` | `orion:chat:history:turn` | Chat-turn intake channel. |
 | `CHANNEL_EVENTS_TAGGED` | `orion:tags:enriched` | Collapse-mirror output channel. |
-| `CHANNEL_EVENTS_TAGGED_CHAT` | `orion:tags:chat:enriched` | Chat/social output channel. |
-| `RECALL_FALKOR_TAG_ENTITY_ENABLED` | `false` | See Falkor writer section. |
+| `RECALL_FALKOR_TAG_ENTITY_ENABLED` | `true` | See Falkor writer section. Default is `true` because Falkor is the *only* persistence path for chat/social tags now — `false` means no persistence at all for this data, not "skip a shadow write." |
 | `FALKORDB_URI` | `redis://orion-athena-falkordb:6379` | Shared FalkorDB instance (same one substrate-runtime and graphiti-adapter use, different graph name). |
 | `FALKORDB_RECALL_GRAPH` | `orion_recall` | Graph name — separate from `orion_substrate` and `graphiti_temporal`. |
 
@@ -34,43 +34,36 @@ Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
 
 **Design/implementation:** `docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md`. **Doctrine:** `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md`.
 
-When `RECALL_FALKOR_TAG_ENTITY_ENABLED=true`, every `chat.history` turn also gets a **Cypher-native** write into FalkorDB (`app/falkor_recall_writer.py`), additive alongside — not replacing — `orion-rdf-writer`'s existing Fuseki write of the same `tags.enriched` event. No RDF/SPARQL anywhere in this path.
+When `RECALL_FALKOR_TAG_ENTITY_ENABLED=true` (default), every `chat.history` **and** `social.turn.stored.v1` turn gets a **Cypher-native** write into FalkorDB (`app/falkor_recall_writer.py`). As of 2026-07-18 this is the sole persistence path for chat/social-turn tag+entity enrichment — no RDF/SPARQL, no bus publish. See "Historical note" below for the Fuseki dual-write this replaced.
 
 This lives here, not in `orion-rdf-writer`, deliberately: that service's own doctrine role is "legacy RDF materialize" only. Every real Falkor producer in the codebase (`orion-substrate-runtime`, `orion-graphiti-adapter`, `orion-spark-concept-induction`'s concept-profile cutover) writes from its own originating service, not bolted onto the RDF sink. This service is the actual producer of tag/entity extraction, so it's the actual producer of the Falkor write too.
 
-**Tradeoff worth naming, not just settling:** this does add a graph-persistence client (`redis.commands.graph`) into a service whose entire prior purpose and dependency footprint (`fastapi`, `spacy`, `sentence-transformers`) was NLP extraction. The "not in orion-rdf-writer" reasoning above only rules out one alternative (bolting a second branch onto the RDF sink); it doesn't by itself prove a small dedicated recall-graph-writer service (subscribing to `tags.enriched` independently, same shape as `orion-rdf-writer` itself) wouldn't have kept this service's dependency/failure surface untouched. Went with "producer writes its own Falkor data" because that's the actual precedent every other Falkor producer in the repo follows, not because the alternative was evaluated and rejected on its own merits.
+**Tradeoff worth naming, not just settling:** this does add a graph-persistence client (`redis.commands.graph`) into a service whose entire prior purpose and dependency footprint (`fastapi`, `spacy`, `sentence-transformers`) was NLP extraction. The "not in orion-rdf-writer" reasoning above only rules out one alternative (bolting a second branch onto the RDF sink); it doesn't by itself prove a small dedicated recall-graph-writer service (subscribing independently, same shape as `orion-rdf-writer` itself) wouldn't have kept this service's dependency/failure surface untouched. Went with "producer writes its own Falkor data" because that's the actual precedent every other Falkor producer in the repo follows, not because the alternative was evaluated and rejected on its own merits.
 
 Shape written (graph `orion_recall`) -- and an honest caveat about what actually lands today, not what the schema supports in general:
 ```text
-(:ChatTurn {turn_id, session_id?, ts, correlation_id?})   # thin -- no prompt/response text, Postgres owns that
+(:ChatTurn {turn_id, source_kind, session_id?, ts, correlation_id?})   # thin -- no prompt/response text, Postgres owns that
 (:ChatSession {session_id})-[:HAS_TURN]->(:ChatTurn)
 (:Entity {name})  (:Tag {name})                            # canonical, deduplicated by normalized name
 (:ChatTurn)-[:MENTIONS_ENTITY {ts}]->(:Entity)
 (:ChatTurn)-[:HAS_TAG {ts}]->(:Tag)
 ```
+`source_kind` (`"chat.history"` or `"social.turn.stored.v1"`) exists because both kinds share this same `:ChatTurn`/`:ChatSession` label -- without it, a `turn_id` collision between a Hub chat turn and a social-room turn (both producer-supplied strings, not namespaced against each other) would silently fuse two unrelated conversations into one node with no way to tell them apart afterward. `:ChatSession` itself still has no discriminator (only `session_id`) -- a real, not-yet-closed gap if chat and social sessions ever share an ID space.
 `sentiment` lands as a real `ChatTurn` property, split out of the `sentiment:*` string-tag convention. Bare numbers, stopwords, and relative-time expressions (`"today"`, `"18 years ago"`, etc.) are rejected at write time, not graphed — see `filter_noise()`. `confidence`/`salience`/`extractor_service` are not carried — confirmed dead constants across all live historical data (Phase 0 spec's live audit), not something to fake as meaningful.
 
-**`:Tag`/`HAS_TAG` are essentially unused today, and that's not a bug to silently paper over:** in the `chat.history` code path above, `tags = list(entities)` plus one sentiment marker — meaning `tags` and `entities` are the same spaCy NER extraction by construction, not two independently meaningful signals. Passing both to the writer unchanged would have double-materialized every entity as both a `:Tag` and an `:Entity` node/edge for zero informational gain, so the call site only passes the sentiment marker as `tags` (which `extract_sentiment()` then consumes entirely, leaving `kept_tags` empty in practice). The `:Tag`/`HAS_TAG` schema stays real and general (a future producer with genuinely distinct tag content could use it), but for this producer specifically, only `:Entity`/`MENTIONS_ENTITY` carries real data right now. Same root cause as the historical Fuseki `hasTag`/`hasEntity` predicates: this pipeline has never actually differentiated them.
+**`:Tag`/`HAS_TAG` are essentially unused today, and that's not a bug to silently paper over:** `tags`/`entities` are the same spaCy NER extraction by construction, not two independently meaningful signals — see `handle_triage_event`'s chat-kind branch. Passing both to the writer unchanged would have double-materialized every entity as both a `:Tag` and an `:Entity` node/edge for zero informational gain, so the call site only passes the sentiment marker as `tags` (which `extract_sentiment()` then consumes entirely, leaving `kept_tags` empty in practice). The `:Tag`/`HAS_TAG` schema stays real and general (a future producer with genuinely distinct tag content could use it), but for this producer specifically, only `:Entity`/`MENTIONS_ENTITY` carries real data right now. Same root cause as the historical Fuseki `hasTag`/`hasEntity` predicates: this pipeline never actually differentiated them.
 
-Runs off the event loop via `asyncio.to_thread` — the underlying `redis.commands.graph` client is sync (same pattern as `orion/spark/concept_induction/bus_worker.py`'s Falkor write). A write failure is logged and swallowed, never breaks the `tags.enriched` publish it rides alongside — this is a dark, additive path, not a dependency the existing pipeline can fail on. Falkor client construction is lock-guarded against a future `concurrent_handlers=True` flip on this service's Hunter (currently serial dispatch, so not a live race, but four other services in the repo already use that flag).
+Runs off the event loop via `asyncio.to_thread` — the underlying `redis.commands.graph` client is sync (same pattern as `orion/spark/concept_induction/bus_worker.py`'s Falkor write). **A write failure is logged at ERROR and swallowed** (`falkor_recall_write_failed_data_lost`, not a WARNING — bumped 2026-07-18 alongside the Fuseki kill, to reflect that it's no longer a dark/additive path riding alongside a real copy elsewhere): a swallowed failure here means that turn's tag/entity data is not persisted anywhere, full stop. There is no retry and no dead-letter queue on this path (unlike `orion-rdf-writer`'s `RDF_WRITE_QUEUE_MAXSIZE` dead-letter behavior) — a sustained FalkorDB outage silently loses every turn's tags/entities for its duration, one ERROR log line each, with nothing currently alerting on that log pattern. Watch `falkor_recall_write_failed_data_lost` frequency and consumer lag on `orion:chat:history:turn`/`orion:chat:social:stored` if real volume turns out to be high enough for either to matter — this is the natural next thing to instrument if this path proves it needs it, not something built preemptively here. Falkor client construction is lock-guarded against a future `concurrent_handlers=True` flip on this service's Hunter (currently serial dispatch, so not a live race, but four other services in the repo already use that flag).
 
-Not yet wired: `social.turn.stored.v1` (Phase 6), historical backfill (Phase 3), any read-side change in `orion-recall` (Phase 4).
+Not yet wired: historical backfill (Phase 3), any read-side change in `orion-recall` (Phase 4).
 
-## Dual persistence pathway: chat-turn tags go to two graph stores
+### Historical note: the Fuseki dual-write (killed 2026-07-18)
 
-Every `chat.history` turn's tag/entity data currently materializes into **two independent graph stores**, both fed from the same `tags.enriched` publish on `orion:tags:chat:enriched` (`CHANNEL_EVENTS_TAGGED_CHAT`):
+From when this writer first shipped (PR #1180) until 2026-07-18, chat/social-turn tag+entity data was **also** published to the bus (`orion:tags:chat:enriched` / `CHANNEL_EVENTS_TAGGED_CHAT`) for `orion-rdf-writer` to materialize into Fuseki as a `ChatTurn` subject with `hasTag`/`hasEntity` predicates (`rdf_builder.py`, `enrichment_type == "chat_tagging"`) — a *different* path from the raw `chat.history` → `ChatTurn`/`ChatMessage` RDF materialization killed on 2026-07-17.
 
-1. **Fuseki (RDF, legacy).** `orion-rdf-writer` consumes this channel and builds a `ChatTurn` subject with `hasTag`/`hasEntity` predicates under the `orion:enrichment` graph (`rdf_builder.py`, `enrichment_type == "chat_tagging"`). This is a *separate* path from the raw `chat.history`/`chat.history.message.v1` → `ChatTurn`/`ChatMessage` RDF materialization that was deliberately killed on 2026-07-17 for covering only ~11-18% of real chat volume — that removal did not touch this enrichment path, which stays live.
-2. **FalkorDB (Cypher, Phase 2).** This service's own `falkor_recall_writer.py` writes the same turn's entities/sentiment directly into `orion_recall`, gated by `RECALL_FALKOR_TAG_ENTITY_ENABLED` (see above).
+Both the Fuseki copy and this Falkor writer were effectively dark for ~6 months due to an unrelated observer-gate bug (`fix/meta-tags-chat-history-observer-gate`) that unconditionally skipped every real chat turn before it reached tagging. Fixing that gate brought both stores live simultaneously for the first time; the very next change (this one) killed the now-redundant Fuseki side and extended the Falkor write to cover `social.turn.stored.v1` too (previously chat.history-only — that gap would otherwise have meant social-room turns lost persistence entirely once Fuseki was cut). Verified live before the cut: a real chat turn's `ChatTurn` node queryable directly via `GRAPH.QUERY` against `orion_recall`, matching the same `orion-rdf-writer` Fuseki enqueue log line for the identical `correlation_id`.
 
-Falkor is **additive, not a cutover** — it does not replace the Fuseki write, and nothing currently reads from Falkor for recall. This is intentionally a shadow-write phase (Phase 4 is the read-side migration, not yet started).
-
-**Why this needs a named callout:** both pathways were effectively dark for ~6 months. A gate-ordering bug (`services/orion-meta-tags/app/main.py`'s `handle_triage_event` — see the fix in `fix/meta-tags-chat-history-observer-gate`) unconditionally skipped every real `chat.history` turn before it ever reached tagging, so neither the Fuseki `chat_tagging` enrichment path nor the Falkor writer had ever run against real production volume. Fixing that gate means **both stores see real chat traffic for the first time simultaneously**, on the same deploy. Neither side has been load-tested:
-
-- `orion-rdf-writer`'s write queue for this channel (`RDF_WRITE_QUEUE_MAXSIZE=5000`, 8 workers) drops to a dead-letter file on overflow rather than crashing, but dead-letter growth isn't currently alerted on.
-- The Falkor writer does up to 4 sequential Cypher round-trips per turn inside one `asyncio.to_thread` call, and the spaCy NER call in `handle_triage_event` (`SPA_MODEL=en_core_web_trf`, a transformer model) runs synchronously inline with no rate-limiting — both stack under this service's serial (non-`concurrent_handlers`) Hunter dispatch, so a slow turn delays the next one.
-
-If real chat volume turns out to be high enough for either of these to matter, watch consumer lag on `orion:chat:history:turn`/`orion:chat:social:stored` and `orion-rdf-writer`'s dead-letter file size after deploy before assuming this is fine at scale. This is also the natural point to revisit whether `orion-rdf-writer` should keep consuming `orion:tags:chat:enriched` at all, given RDF's broader deprioritization elsewhere in the codebase — not decided here, just flagged as the next real question once live volume is observed.
+Do not re-add the Fuseki side without a real reason — it was a redundant second materialization of the exact same entities/sentiment, not an independent signal.
 
 ## Running & Testing
 

--- a/services/orion-meta-tags/app/falkor_recall_writer.py
+++ b/services/orion-meta-tags/app/falkor_recall_writer.py
@@ -1,9 +1,13 @@
-"""Cypher-native Falkor write of chat turn tag/entity enrichment.
+"""Cypher-native Falkor write of chat/social-turn tag/entity enrichment.
 
 Phase 2 of the recall/Falkor cutover
 (docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md).
-Dark-shipped, additive: this runs alongside orion-rdf-writer's existing
-Fuseki write of the same `tags.enriched` event, does not replace it.
+Originally shipped dark/additive alongside orion-rdf-writer's Fuseki write
+of the same `tags.enriched` event. As of 2026-07-18 (same-day follow-up,
+fix/meta-tags-kill-rdf-chat-dual-write) that Fuseki write was killed as
+redundant -- this is now the SOLE persistence path for this data, covering
+both `chat.history` and `social.turn.stored.v1` (previously chat.history
+only). See services/orion-meta-tags/README.md's "Historical note" section.
 
 No RDF/SPARQL anywhere in this module -- pure Cypher MERGE against
 FalkorDB via orion.graph.falkor_client.RedisGraphQueryClient.
@@ -94,6 +98,7 @@ def write_chat_turn_tags_to_falkor(
     client: FalkorGraphClient,
     *,
     turn_id: str,
+    source_kind: str,
     session_id: str | None,
     ts: str,
     correlation_id: str | None,
@@ -102,6 +107,14 @@ def write_chat_turn_tags_to_falkor(
 ) -> dict[str, Any]:
     """Synchronous Cypher write. Caller must keep this off the event loop
     (e.g. `asyncio.to_thread`) -- the underlying redis client is sync.
+
+    `source_kind` (the producing envelope's kind, e.g. "chat.history" or
+    "social.turn.stored.v1") is stored on the `:ChatTurn` node. Both kinds
+    share this same node label/shape -- without a discriminator property, a
+    `turn_id` collision between a Hub chat turn and a social-room turn (both
+    producer-supplied strings, not namespaced against each other) would
+    silently fuse two unrelated conversations into one node with no way to
+    tell them apart afterward.
     """
     sentiment, clean_tags = extract_sentiment(tags or [])
     kept_tags, rejected_tags = filter_noise(clean_tags)
@@ -116,10 +129,10 @@ def write_chat_turn_tags_to_falkor(
             rejected_entities,
         )
 
-    # turn_params always has at least "ts" beyond "turn_id" (a required,
-    # non-optional parameter), so set_clause is never empty -- no bare-anchor
-    # branch needed.
-    turn_params: dict[str, Any] = {"turn_id": turn_id, "ts": ts}
+    # turn_params always has at least "ts" and "source_kind" beyond "turn_id"
+    # (both required, non-optional parameters), so set_clause is never empty
+    # -- no bare-anchor branch needed.
+    turn_params: dict[str, Any] = {"turn_id": turn_id, "ts": ts, "source_kind": source_kind}
     if correlation_id:
         turn_params["correlation_id"] = correlation_id
     if sentiment:

--- a/services/orion-meta-tags/app/main.py
+++ b/services/orion-meta-tags/app/main.py
@@ -67,8 +67,16 @@ async def _write_chat_turn_tags_to_falkor_async(
     sentiment_tag: str, entities: list[str],
 ) -> None:
     """All field extraction happens inside the try block, including
-    envelope.created_at.isoformat() -- this is a dark/additive path and must
-    never raise into the caller, even on an unexpected envelope shape."""
+    envelope.created_at.isoformat().
+
+    As of 2026-07-18 this is the SOLE persistence path for chat/social-turn
+    tag+entity enrichment -- the Fuseki dual-write it used to ride alongside
+    was killed the same day. A swallowed exception here is no longer a
+    harmless missed shadow-copy; it means that turn's tags/entities are not
+    persisted anywhere. Still caught rather than raised (a bad write must not
+    crash triage intake for every subsequent event), but logged at ERROR, not
+    WARNING, to reflect that.
+    """
     if not settings.RECALL_FALKOR_TAG_ENTITY_ENABLED:
         return
     try:
@@ -80,6 +88,7 @@ async def _write_chat_turn_tags_to_falkor_async(
             write_chat_turn_tags_to_falkor,
             client,
             turn_id=turn_id,
+            source_kind=envelope.kind,
             session_id=raw_payload.get("session_id"),
             ts=envelope.created_at.isoformat(),
             correlation_id=str(envelope.correlation_id) if envelope.correlation_id else None,
@@ -96,9 +105,11 @@ async def _write_chat_turn_tags_to_falkor_async(
         )
         logger.info("falkor_recall_write_committed turn_id=%s result=%s", turn_id, result)
     except Exception as exc:
-        # Additive/dark path: never let a Falkor write failure break the
-        # existing tags.enriched publish it rides alongside.
-        logger.warning("falkor_recall_write_failed turn_id=%s error=%s", turn_id, exc)
+        # This is the sole persistence path now (see docstring) -- a caught
+        # exception here means real, permanent data loss for this turn, not
+        # a missed shadow-copy. Still swallowed (one bad write must not take
+        # down triage intake for every subsequent event) but at ERROR.
+        logger.error("falkor_recall_write_failed_data_lost turn_id=%s error=%s", turn_id, exc)
 
 
 def _svc_ref() -> ServiceRef:
@@ -171,8 +182,10 @@ async def handle_meta_tags_rpc(env: BaseEnvelope) -> BaseEnvelope:
 
 async def handle_triage_event(envelope: BaseEnvelope) -> None:
     """
-    Handler for 'orion:collapse:triage' streaming path.
-    Keeps your existing behavior: emits Enrichment -> tags.enriched.
+    Handler for 'orion:collapse:triage' streaming path (generic collapse-
+    mirror events -- emits Enrichment -> tags.enriched), plus chat.history
+    and social.turn.stored.v1 (their tag/entity enrichment is Falkor-only,
+    no bus publish -- see the comment inside the chat-kind branch below).
     """
     global meta_tagger
 
@@ -217,7 +230,6 @@ async def handle_triage_event(envelope: BaseEnvelope) -> None:
 
             doc = nlp(in_payload.text or "")
             entities = [ent.text for ent in doc.ents]
-            tags = list(entities)
 
             sentiment_tag = "sentiment:neutral"
             positive_keywords = {"triumphant", "relief", "capable", "good", "success"}
@@ -229,47 +241,26 @@ async def handle_triage_event(envelope: BaseEnvelope) -> None:
             elif tokens & negative_keywords:
                 sentiment_tag = "sentiment:negative"
 
-            tags.append(sentiment_tag)
-
-            # Phase 2 recall Falkor write (dark by default): gated to
-            # chat.history only, not social.turn.stored.v1 -- that's Phase 6,
-            # deliberately not touched here even though it shares this code
-            # path. All field extraction (session_id, ts, correlation_id)
-            # happens inside the async helper's own try block, not here --
-            # this call must never raise into the existing tags.enriched
-            # publish path below.
-            if envelope.kind == "chat.history":
-                await _write_chat_turn_tags_to_falkor_async(
-                    envelope=envelope,
-                    raw_payload=raw_payload,
-                    turn_id=str(turn_id),
-                    sentiment_tag=sentiment_tag,
-                    entities=entities,
-                )
-
-            enrichment = Enrichment(
-                id=turn_id,
-                collapse_id=turn_id,
-                service_name=settings.SERVICE_NAME,
-                service_version=settings.SERVICE_VERSION,
-                enrichment_type="chat_tagging",
-                tags=tags,
+            # FalkorDB is the sole persistence target for chat/social-turn
+            # tag+entity enrichment as of 2026-07-18 -- there is no longer a
+            # bus publish here at all. Previously this also published
+            # tags.enriched to orion:tags:chat:enriched for orion-rdf-writer
+            # to materialize into Fuseki (chat.history only had this AND the
+            # Falkor write below; social.turn.stored.v1 had ONLY the Fuseki
+            # copy, since the Falkor write was chat.history-gated). Killed
+            # both: the Fuseki copy was a redundant second materialization
+            # of the exact same entities/sentiment already durably written
+            # here, and extending the Falkor write to social.turn.stored.v1
+            # (removing the old chat.history-only gate) means neither kind
+            # loses persistence. See services/orion-meta-tags/README.md.
+            await _write_chat_turn_tags_to_falkor_async(
+                envelope=envelope,
+                raw_payload=raw_payload,
+                turn_id=str(turn_id),
+                sentiment_tag=sentiment_tag,
                 entities=entities,
-                salience=0.0,
-                ts=datetime.now(timezone.utc).isoformat(),
-                node=settings.NODE_NAME,
-                correlation_id=str(envelope.correlation_id) if envelope.correlation_id else str(turn_id),
-                source_message_id=str(envelope.id) if envelope.id else None,
             )
-
-            out_env = envelope.derive_child(
-                kind="tags.enriched",
-                source=_svc_ref(),
-                payload=enrichment,
-            )
-
-            await meta_tagger.bus.publish(settings.CHANNEL_EVENTS_TAGGED_CHAT, out_env)
-            logger.info("✅ Published chat tags for %s -> %s", turn_id, settings.CHANNEL_EVENTS_TAGGED_CHAT)
+            logger.info("✅ Falkor-wrote chat tags for %s (kind=%s)", turn_id, envelope.kind)
             return
 
         if not should_route_to_triage(raw_payload):

--- a/services/orion-meta-tags/app/settings.py
+++ b/services/orion-meta-tags/app/settings.py
@@ -27,17 +27,27 @@ class Settings(BaseSettings):
     CHANNEL_EVENTS_TRIAGE: str = Field(default="orion:collapse:triage", env="CHANNEL_EVENTS_TRIAGE")
     CHANNEL_EVENTS_TAGGED: str = Field(default="orion:tags:enriched", env="CHANNEL_EVENTS_TAGGED")
     CHANNEL_EVENTS_CHAT_TURN: str = Field(default="orion:chat:history:turn", env="CHANNEL_EVENTS_CHAT_TURN")
-    CHANNEL_EVENTS_TAGGED_CHAT: str = Field(default="orion:tags:chat:enriched", env="CHANNEL_EVENTS_TAGGED_CHAT")
+    # CHANNEL_EVENTS_TAGGED_CHAT (orion:tags:chat:enriched) removed
+    # 2026-07-18: chat/social-turn tag+entity enrichment is no longer
+    # bus-published at all -- FalkorDB (below) is the sole persistence
+    # target now, written directly in-process. orion-rdf-writer's Fuseki
+    # copy of this same publish was a redundant second materialization.
 
     # === NLP Model ===
     SPA_MODEL: str = Field(default="en_core_web_trf", env="SPA_MODEL")
 
-    # === Recall Falkor writer (Phase 2, dark by default) ===
+    # === Recall Falkor writer (Phase 2) ===
     # docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md
-    # Cypher-native, additive write of chat-turn tag/entity enrichment into
-    # FalkorDB, alongside (not replacing) orion-rdf-writer's existing Fuseki
-    # write of the same tags.enriched event. Off by default.
-    RECALL_FALKOR_TAG_ENTITY_ENABLED: bool = Field(default=False, env="RECALL_FALKOR_TAG_ENTITY_ENABLED")
+    # Cypher-native write of chat-turn tag/entity enrichment into FalkorDB.
+    # As of 2026-07-18 this is the ONLY persistence target for this data --
+    # the Fuseki dual-write (via orion:tags:chat:enriched) was killed the
+    # same day, and the Falkor write is no longer chat.history-gated (also
+    # covers social.turn.stored.v1 now). Default flipped True to match: when
+    # this was a shadow-write alongside a real Fuseki copy, False safely
+    # meant "skip the extra write." Now False means "no persistence at all"
+    # for this data, so the safe default has to be True. See
+    # services/orion-meta-tags/README.md.
+    RECALL_FALKOR_TAG_ENTITY_ENABLED: bool = Field(default=True, env="RECALL_FALKOR_TAG_ENTITY_ENABLED")
     FALKORDB_URI: str = Field(default="redis://orion-athena-falkordb:6379", env="FALKORDB_URI")
     FALKORDB_RECALL_GRAPH: str = Field(default="orion_recall", env="FALKORDB_RECALL_GRAPH")
 

--- a/services/orion-meta-tags/tests/test_chat_history_observer_gate.py
+++ b/services/orion-meta-tags/tests/test_chat_history_observer_gate.py
@@ -1,12 +1,25 @@
-"""Regression test for the chat.history observer-gate fix.
+"""Regression tests for chat/social-turn tagging in handle_triage_event.
 
-Commit aaf66d58 ("Enforce metacog draft/enrich patch contracts") moved
-should_route_to_triage's Juniper-observer check in front of the
-chat.history/social.turn.stored.v1 branch as an apparent side effect of an
-unrelated refactor. ChatHistoryTurnV1 (orion-hub's real chat.history
-payload) has no `observer` field, so this unconditionally skipped every
-real chat turn for ~6 months. This test locks in the fix: chat.history
-bypasses that gate; the generic collapse-mirror path still requires it.
+Two fixes live here:
+
+1. Observer-gate scoping (fix/meta-tags-chat-history-observer-gate, merged).
+   Commit aaf66d58 ("Enforce metacog draft/enrich patch contracts") moved
+   should_route_to_triage's Juniper-observer check in front of the
+   chat.history/social.turn.stored.v1 branch as an apparent side effect of
+   an unrelated refactor. ChatHistoryTurnV1 (orion-hub's real chat.history
+   payload) has no `observer` field, so this unconditionally skipped every
+   real chat turn for ~6 months. Fixed by scoping the gate to the generic
+   collapse-mirror branch only (restoring commit ebd3b9d9's structure).
+
+2. Kill the Fuseki dual-write (this branch). Once (1) was fixed, both the
+   Fuseki `chat_tagging` enrichment copy (via orion-rdf-writer, consuming
+   orion:tags:chat:enriched) and the Falkor Phase 2 write went live
+   simultaneously -- redundant materializations of the same data. FalkorDB
+   is now the sole persistence target: no bus publish for chat.history or
+   social.turn.stored.v1 at all anymore. The Falkor write, previously
+   chat.history-gated only, now also covers social.turn.stored.v1 (real
+   live traffic from orion-social-memory) so it doesn't lose persistence.
+   See services/orion-meta-tags/README.md.
 
 app.main can't be imported directly in this environment -- a pre-existing
 numpy/spacy/thinc binary incompatibility in the shared test venv (unrelated
@@ -28,6 +41,8 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 sys.path[:0] = [str(ROOT), str(SERVICE_ROOT)]
+
+from orion.graph.falkor_client import RecordingFalkorClient  # noqa: E402
 
 
 @pytest.fixture
@@ -53,7 +68,11 @@ def main_module(monkeypatch: pytest.MonkeyPatch):
 
     m.meta_tagger = MagicMock()
     m.meta_tagger.bus.publish = AsyncMock()
-    m.settings.RECALL_FALKOR_TAG_ENTITY_ENABLED = False
+    # Falkor is the sole persistence path now (settings.py default is True)
+    # -- default it on here too, with a recording fake client, so tests
+    # observe real writes rather than a silent no-op.
+    m.settings.RECALL_FALKOR_TAG_ENTITY_ENABLED = True
+    m._falkor_client = RecordingFalkorClient()
     return m
 
 
@@ -68,24 +87,89 @@ def _envelope(main_module, *, kind: str, payload: dict):
 
 
 @pytest.mark.asyncio
-async def test_chat_history_turn_with_no_observer_still_publishes(main_module) -> None:
-    """The actual regression: a real hub chat.history payload (no `observer`
-    field, matching ChatHistoryTurnV1's real schema) must NOT be skipped."""
+async def test_chat_history_turn_with_no_observer_writes_to_falkor_not_bus(main_module) -> None:
+    """The gate-scoping regression: a real hub chat.history payload (no
+    `observer` field, matching ChatHistoryTurnV1's real schema) must NOT be
+    skipped. And the dual-write-kill regression: it must land in Falkor,
+    not get published to the bus at all."""
     envelope = _envelope(
         main_module,
         kind="chat.history",
-        payload={"session_id": "sess-1", "prompt": "hi", "response": "hello"},
+        payload={"session_id": "sess-1", "prompt": "hi Circe", "response": "hello"},
     )
     await main_module.handle_triage_event(envelope)
-    main_module.meta_tagger.bus.publish.assert_awaited_once()
-    call_args = main_module.meta_tagger.bus.publish.call_args
-    assert call_args[0][0] == main_module.settings.CHANNEL_EVENTS_TAGGED_CHAT
+
+    main_module.meta_tagger.bus.publish.assert_not_awaited()
+    calls = main_module._falkor_client.calls
+    turn_calls = [params for cypher, params in calls if "MERGE (t:ChatTurn" in cypher]
+    assert turn_calls and turn_calls[0]["source_kind"] == "chat.history"
+    entity_calls = [params for cypher, params in calls if "MENTIONS_ENTITY" in cypher]
+    assert entity_calls and "circe" in entity_calls[0]["names"]
+
+
+@pytest.mark.asyncio
+async def test_social_turn_stored_also_writes_to_falkor(main_module) -> None:
+    """social.turn.stored.v1 (real live traffic from orion-social-memory)
+    shares this branch and was never wired to Falkor before this fix --
+    only to the now-killed Fuseki channel. Confirms it isn't losing
+    persistence: same ChatTurn write shape as chat.history."""
+    envelope = _envelope(
+        main_module,
+        kind="social.turn.stored.v1",
+        payload={"session_id": "sess-3", "prompt": "hi", "response": "hello"},
+    )
+    await main_module.handle_triage_event(envelope)
+
+    main_module.meta_tagger.bus.publish.assert_not_awaited()
+    calls = main_module._falkor_client.calls
+    turn_calls = [params for cypher, params in calls if "MERGE (t:ChatTurn" in cypher]
+    assert turn_calls and turn_calls[0]["source_kind"] == "social.turn.stored.v1"
+
+
+@pytest.mark.asyncio
+async def test_falkor_write_failure_is_swallowed_and_logged(main_module, caplog) -> None:
+    """The sole-persistence-path consequence of a Falkor write failure: no
+    exception propagates out of handle_triage_event (one bad write must not
+    take down triage intake for every subsequent event), but it's now logged
+    at ERROR (not WARNING) since there's no Fuseki fallback to catch it."""
+    main_module._falkor_client = MagicMock()
+    main_module._falkor_client.graph_query.side_effect = RuntimeError("falkor down")
+
+    envelope = _envelope(
+        main_module,
+        kind="chat.history",
+        payload={"session_id": "sess-5", "prompt": "hi", "response": "hello"},
+    )
+    with caplog.at_level("ERROR"):
+        await main_module.handle_triage_event(envelope)  # must not raise
+
+    main_module.meta_tagger.bus.publish.assert_not_awaited()
+    assert any("falkor_recall_write_failed_data_lost" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_chat_history_falkor_write_skipped_when_flag_disabled(main_module) -> None:
+    """Documents the real consequence of RECALL_FALKOR_TAG_ENTITY_ENABLED=false
+    now that Falkor is the only persistence path: nothing is written or
+    published anywhere for this turn. Not a bug -- the flag's meaning
+    genuinely changed (see settings.py's comment) -- but worth locking in
+    as intentional, not an accidental silent drop."""
+    main_module.settings.RECALL_FALKOR_TAG_ENTITY_ENABLED = False
+    envelope = _envelope(
+        main_module,
+        kind="chat.history",
+        payload={"session_id": "sess-4", "prompt": "hi", "response": "hello"},
+    )
+    await main_module.handle_triage_event(envelope)
+
+    main_module.meta_tagger.bus.publish.assert_not_awaited()
+    assert not main_module._falkor_client.calls
 
 
 @pytest.mark.asyncio
 async def test_generic_collapse_event_without_observer_is_still_skipped(main_module) -> None:
     """The generic (non-chat) collapse-mirror path must still require a
-    Juniper observer -- this fix does not weaken that gate."""
+    Juniper observer -- untouched by either fix in this file."""
     envelope = _envelope(
         main_module,
         kind="collapse.mirror.entry",
@@ -97,6 +181,10 @@ async def test_generic_collapse_event_without_observer_is_still_skipped(main_mod
 
 @pytest.mark.asyncio
 async def test_generic_collapse_event_with_juniper_observer_still_publishes(main_module) -> None:
+    """The generic collapse-mirror path still publishes to the bus
+    (orion:tags:enriched) -- only chat/social-turn tagging moved to
+    Falkor-only. orion-rdf-writer and orion-sql-writer both still consume
+    this channel."""
     envelope = _envelope(
         main_module,
         kind="collapse.mirror.entry",
@@ -106,49 +194,3 @@ async def test_generic_collapse_event_with_juniper_observer_still_publishes(main
     main_module.meta_tagger.bus.publish.assert_awaited_once()
     call_args = main_module.meta_tagger.bus.publish.call_args
     assert call_args[0][0] == main_module.settings.CHANNEL_EVENTS_TAGGED
-
-
-@pytest.mark.asyncio
-async def test_chat_history_turn_writes_to_falkor_when_flag_enabled(main_module, monkeypatch) -> None:
-    """Closes the coverage gap noted in PR #1180: the asyncio.to_thread
-    wiring for the Falkor write was previously untestable in this
-    environment. Confirms it actually fires end-to-end for a real
-    chat.history turn, now that app.main can be imported via the spacy
-    mock above."""
-    from orion.graph.falkor_client import RecordingFalkorClient
-
-    fake_client = RecordingFalkorClient()
-    main_module.settings.RECALL_FALKOR_TAG_ENTITY_ENABLED = True
-    monkeypatch.setattr(main_module, "_falkor_client", fake_client)
-
-    envelope = _envelope(
-        main_module,
-        kind="chat.history",
-        payload={"session_id": "sess-2", "prompt": "hi Circe", "response": "hello"},
-    )
-    await main_module.handle_triage_event(envelope)
-
-    main_module.meta_tagger.bus.publish.assert_awaited_once()
-    assert fake_client.calls, "expected at least one Cypher write to the Falkor client"
-    assert any("MERGE (t:ChatTurn" in cypher for cypher, _ in fake_client.calls)
-    # The fake NER doc (see main_module fixture) returns one entity, "Circe".
-    # Confirms the extraction line actually feeds real content through to
-    # the Falkor write, not just an always-empty ents=[] that would pass
-    # even if `ent.text` were swapped for the wrong attribute.
-    entity_calls = [params for cypher, params in fake_client.calls if "MENTIONS_ENTITY" in cypher]
-    assert entity_calls and "circe" in entity_calls[0]["names"]
-
-
-@pytest.mark.asyncio
-async def test_social_turn_stored_bypasses_gate_like_chat_history(main_module) -> None:
-    """social.turn.stored.v1 shares handle_triage_event's chat branch (see
-    module docstring) -- must not regress independently of chat.history."""
-    envelope = _envelope(
-        main_module,
-        kind="social.turn.stored.v1",
-        payload={"session_id": "sess-3", "prompt": "hi", "response": "hello"},
-    )
-    await main_module.handle_triage_event(envelope)
-    main_module.meta_tagger.bus.publish.assert_awaited_once()
-    call_args = main_module.meta_tagger.bus.publish.call_args
-    assert call_args[0][0] == main_module.settings.CHANNEL_EVENTS_TAGGED_CHAT

--- a/services/orion-meta-tags/tests/test_falkor_recall_writer.py
+++ b/services/orion-meta-tags/tests/test_falkor_recall_writer.py
@@ -53,6 +53,7 @@ def test_write_chat_turn_tags_to_falkor_full_shape() -> None:
     result = write_chat_turn_tags_to_falkor(
         client,
         turn_id="turn-1",
+        source_kind="chat.history",
         session_id="sess-1",
         ts="2026-07-18T00:00:00+00:00",
         correlation_id="corr-1",
@@ -79,6 +80,7 @@ def test_write_chat_turn_tags_to_falkor_full_shape() -> None:
     assert turn_params["correlation_id"] == "corr-1"
     assert turn_params["sentiment"] == "positive"
     assert "sentiment" in turn_call  # SET clause references it
+    assert turn_params["source_kind"] == "chat.history"
 
 
 def test_write_chat_turn_tags_to_falkor_no_session_id_skips_session_merge() -> None:
@@ -86,6 +88,7 @@ def test_write_chat_turn_tags_to_falkor_no_session_id_skips_session_merge() -> N
     write_chat_turn_tags_to_falkor(
         client,
         turn_id="turn-2",
+        source_kind="chat.history",
         session_id=None,
         ts="2026-07-18T00:00:00+00:00",
         correlation_id=None,
@@ -101,16 +104,19 @@ def test_write_chat_turn_tags_to_falkor_no_tags_or_entities_still_writes_anchor(
     result = write_chat_turn_tags_to_falkor(
         client,
         turn_id="turn-3",
+        source_kind="social.turn.stored.v1",
         session_id=None,
         ts="2026-07-18T00:00:00+00:00",
         correlation_id=None,
         tags=[],
         entities=[],
     )
-    # ts is a required (non-optional) parameter, so the SET clause always
-    # has at least "t.ts = $ts" -- there is no bare-anchor-with-no-SET path.
+    # ts and source_kind are both required (non-optional) parameters, so the
+    # SET clause always has at least these two -- there is no
+    # bare-anchor-with-no-SET path.
     assert len(client.calls) == 1
-    assert client.calls[0][0] == "MERGE (t:ChatTurn {turn_id: $turn_id}) SET t.ts = $ts"
+    assert client.calls[0][0] == "MERGE (t:ChatTurn {turn_id: $turn_id}) SET t.source_kind = $source_kind, t.ts = $ts"
+    assert client.calls[0][1]["source_kind"] == "social.turn.stored.v1"
     assert result["tags_written"] == 0
     assert result["entities_written"] == 0
 
@@ -126,6 +132,7 @@ def test_write_chat_turn_tags_to_falkor_entity_dedup_across_call() -> None:
     write_chat_turn_tags_to_falkor(
         client,
         turn_id="turn-4",
+        source_kind="chat.history",
         session_id=None,
         ts="2026-07-18T00:00:00+00:00",
         correlation_id=None,

--- a/services/orion-rdf-writer/.env_example
+++ b/services/orion-rdf-writer/.env_example
@@ -24,7 +24,10 @@ ORION_BUS_ENFORCE_CATALOG=true
 CHANNEL_RDF_ENQUEUE=orion:rdf:enqueue
 CHANNEL_EVENTS_COLLAPSE=orion:collapse:intake
 CHANNEL_EVENTS_TAGGED=orion:tags:enriched
-CHANNEL_EVENTS_TAGGED_CHAT=orion:tags:chat:enriched
+# CHANNEL_EVENTS_TAGGED_CHAT removed 2026-07-18: chat-turn tag/entity data
+# now lands in FalkorDB only (orion-meta-tags' Phase 2 writer); the Fuseki
+# `chat_tagging` copy was a redundant materialization of the same data.
+# orion-meta-tags no longer publishes to this channel either.
 CHANNEL_CORE_EVENTS=orion:core:events
 # CHANNEL_WORKER_RDF removed 2026-07-18: orion:rdf:worker has zero real
 # producers anywhere in the repo despite the channel registry claiming one;

--- a/services/orion-rdf-writer/app/rdf_builder.py
+++ b/services/orion-rdf-writer/app/rdf_builder.py
@@ -131,11 +131,16 @@ def build_triples_from_envelope(env_kind: str, payload: Any) -> Tuple[Optional[s
             else:
                 meta = payload
 
-            if meta.enrichment_type == "chat_tagging":
-                key = meta.collapse_id or meta.id
-                subject_uri = URIRef(f"http://conjourney.net/orion/chatTurn/{_sanitize_fragment(key)}")
-            else:
-                subject_uri = URIRef(f"http://conjourney.net/event/{meta.collapse_id or meta.id}")
+            # enrichment_type == "chat_tagging" (chat/social-turn tag+entity
+            # enrichment, published on the now-unsubscribed
+            # orion:tags:chat:enriched channel) deliberately no longer
+            # reaches this branch as of 2026-07-18: that data now lands in
+            # FalkorDB only (orion-meta-tags' Phase 2 writer,
+            # services/orion-meta-tags/README.md). The Fuseki chatTurn copy
+            # was a second, redundant materialization of the same
+            # entities/sentiment. Only generic collapse-mirror tagging
+            # (enrichment_type == "tagging") can reach here now.
+            subject_uri = URIRef(f"http://conjourney.net/event/{meta.collapse_id or meta.id}")
             _build_enrichment_graph(g, meta, subject_uri, emit_claims=(env_kind == "tags.enriched"))
             attach_provenance(g, subject_uri, meta.service_name)
             return g.serialize(format="nt"), "orion:enrichment"

--- a/services/orion-rdf-writer/app/settings.py
+++ b/services/orion-rdf-writer/app/settings.py
@@ -49,7 +49,15 @@ class Settings(BaseSettings):
     CHANNEL_RDF_ENQUEUE: str = Field(default="orion:rdf:enqueue", env="CHANNEL_RDF_ENQUEUE")
     CHANNEL_EVENTS_COLLAPSE: str = Field(default="orion:collapse:intake", env="CHANNEL_EVENTS_COLLAPSE")
     CHANNEL_EVENTS_TAGGED: str = Field(default="orion:tags:enriched", env="CHANNEL_EVENTS_TAGGED")
-    CHANNEL_EVENTS_TAGGED_CHAT: str = Field(default="orion:tags:chat:enriched", env="CHANNEL_EVENTS_TAGGED_CHAT")
+    # orion:tags:chat:enriched (CHANNEL_EVENTS_TAGGED_CHAT) deliberately not
+    # subscribed as of 2026-07-18: chat-turn tag/entity data now lands in
+    # FalkorDB only (orion-meta-tags' own Phase 2 writer,
+    # services/orion-meta-tags/README.md "Dual persistence pathway" ->
+    # single pathway after this change). Fuseki's `chat_tagging` enrichment
+    # copy of this same data was a second, redundant materialization of the
+    # same entities/sentiment already durably written to Falkor -- not an
+    # independent signal. orion-meta-tags no longer publishes to this
+    # channel either (see its main.py). Do not re-add.
     CHANNEL_CORE_EVENTS: str = Field(default="orion:core:events", env="CHANNEL_CORE_EVENTS")
     # orion:rdf:worker (CHANNEL_WORKER_RDF) deliberately not subscribed as of
     # 2026-07-18: channels.yaml claims orion-cortex-exec as producer, but no
@@ -117,7 +125,6 @@ class Settings(BaseSettings):
             "orion:rdf-collapse:enqueue",
             self.CHANNEL_EVENTS_COLLAPSE,
             self.CHANNEL_EVENTS_TAGGED,
-            self.CHANNEL_EVENTS_TAGGED_CHAT,
             "orion:chat:social:stored",
             self.CHANNEL_CORE_EVENTS,
             self.CHANNEL_COGNITION_TRACE_PUB,

--- a/services/orion-rdf-writer/docker-compose.yml
+++ b/services/orion-rdf-writer/docker-compose.yml
@@ -36,7 +36,8 @@ services:
       - CHANNEL_EVENTS_COLLAPSE=${CHANNEL_EVENTS_COLLAPSE}
       # Tagged/Enriched
       - CHANNEL_EVENTS_TAGGED=${CHANNEL_EVENTS_TAGGED}
-      - CHANNEL_EVENTS_TAGGED_CHAT=${CHANNEL_EVENTS_TAGGED_CHAT}
+      # CHANNEL_EVENTS_TAGGED_CHAT removed 2026-07-18: chat-turn tags now
+      # land in FalkorDB only; the Fuseki copy was redundant.
       # Core Events (Filtering targets="rdf")
       - CHANNEL_CORE_EVENTS=${CHANNEL_CORE_EVENTS}
       # CHANNEL_WORKER_RDF / CORTEX_LOG_CHANNEL removed 2026-07-18: zero real

--- a/services/orion-rdf-writer/tests/test_dead_channel_kill.py
+++ b/services/orion-rdf-writer/tests/test_dead_channel_kill.py
@@ -69,6 +69,18 @@ def test_world_pulse_graph_channel_not_subscribed():
     assert "orion:world_pulse:graph:upsert" not in _channels()
 
 
+def test_tags_chat_enriched_channel_not_subscribed():
+    """orion:tags:chat:enriched (2026-07-18, same day, later patch): chat/
+    social-turn tag+entity enrichment is FalkorDB-only now (orion-meta-tags'
+    Phase 2 writer). The Fuseki `chat_tagging` copy this channel fed was a
+    redundant second materialization of the same data -- unlike the other 4
+    channels above, this one HAD real live traffic (confirmed via a live
+    GRAPH.QUERY + matching rdf-writer enqueue log for the same
+    correlation_id right before this kill), it just became redundant once
+    Falkor covered the same data. Do not re-add."""
+    assert "orion:tags:chat:enriched" not in _channels()
+
+
 def test_cortex_worker_rdf_build_kind_is_quiet_noop():
     """cortex.worker.rdf_build (would-be CognitiveStepExecution) must not
     resurrect a dispatch branch -- unknown kind falls through to (None, None)."""
@@ -87,6 +99,35 @@ def test_goals_proposed_kind_is_quiet_noop():
     nt, graph_name = build_triples_from_envelope("memory.goals.proposed.v1", {"artifact_id": "goal-1"})
     assert nt is None
     assert graph_name is None
+
+
+def test_chat_tagging_enrichment_falls_through_to_generic_event_uri():
+    """2026-07-18 (same day, later patch): the dedicated
+    enrichment_type=="chat_tagging" subject_uri branch (chatTurn/{id}) was
+    removed since orion:tags:chat:enriched is no longer subscribed (see
+    test_tags_chat_enriched_channel_not_subscribed above), so this shape can
+    no longer reach build_triples_from_envelope via the live bus. This test
+    locks in what happens if it ever does anyway (dead-letter replay, a
+    stale queued message from before the cutover, a reintroduced producer):
+    it now falls through to the generic event/{id} URI scheme rather than
+    being rejected -- not a no-op like the other kinds in this file, a real
+    behavior change worth having a test name for."""
+    nt, graph_name = build_triples_from_envelope(
+        "tags.enriched",
+        {
+            "service_name": "orion-meta-tags",
+            "service_version": "0.2.0",
+            "id": "turn-1",
+            "collapse_id": "turn-1",
+            "enrichment_type": "chat_tagging",
+            "tags": ["sentiment:neutral"],
+            "entities": ["Circe"],
+        },
+    )
+    assert nt is not None
+    assert graph_name == "orion:enrichment"
+    assert "http://conjourney.net/orion/chatTurn/" not in nt
+    assert "http://conjourney.net/event/turn-1" in nt
 
 
 def test_world_pulse_graph_upsert_kind_is_quiet_noop():


### PR DESCRIPTION
## Summary

- Once #1184 fixed a ~6-month dark observer-gate bug, both the Fuseki `chat_tagging` enrichment path (`orion-rdf-writer` consuming `orion:tags:chat:enriched`) and the FalkorDB Phase 2 writer (#1180) went live simultaneously for the first time — redundant materializations of the same chat/social-turn tag+entity data.
- FalkorDB is now the sole persistence target: `orion-meta-tags` no longer publishes `tags.enriched` to `orion:tags:chat:enriched` at all; `orion-rdf-writer` no longer subscribes to that channel, and its `chat_tagging` dispatch branch in `rdf_builder.py` is removed.
- `social.turn.stored.v1` (real live traffic from `orion-social-memory`) shared this code path but had never been wired to Falkor — its tag/entity data ONLY ever reached Fuseki via the now-killed channel. Removed the `chat.history`-only gate on the Falkor write so it doesn't lose persistence entirely (confirmed via `AskUserQuestion` before implementing — the alternative was silent data loss for social-room turns).
- `RECALL_FALKOR_TAG_ENTITY_ENABLED` default flipped `false`→`true`: its meaning changed from "skip an optional shadow write" to "the only persistence this data gets," so the safe default had to change with it.
- Added a `source_kind` property on `:ChatTurn` nodes (`chat.history` vs `social.turn.stored.v1`) since both now share the same node label and a `turn_id` collision would otherwise silently fuse two unrelated conversations.
- Live-verified before the cut: a real chat turn's `ChatTurn` node directly queryable via `GRAPH.QUERY` against `orion_recall`, matching the same `orion-rdf-writer` Fuseki enqueue log line for the identical `correlation_id`.

## Outcome moved

Chat/social-turn tag+entity enrichment has exactly one persistence path (FalkorDB) instead of two redundant ones, and social-room turns (previously Fuseki-only) keep persistence instead of losing it when Fuseki is cut.

## Current architecture

`orion-meta-tags`'s `handle_triage_event` chat-kind branch ran spaCy NER, then both wrote to FalkorDB (`_write_chat_turn_tags_to_falkor_async`, `chat.history` only) AND published `tags.enriched` to `orion:tags:chat:enriched` for `orion-rdf-writer` to materialize into Fuseki as a `ChatTurn` subject (`enrichment_type == "chat_tagging"`).

## Architecture touched

- `services/orion-meta-tags/app/main.py`: removed the Enrichment/out_env construction and bus publish for the chat-kind branch; Falkor write no longer gated to `chat.history` only; bumped the Falkor write's failure log from WARNING to ERROR (`falkor_recall_write_failed_data_lost`) since a swallowed exception now means real data loss, not a missed shadow-copy.
- `services/orion-meta-tags/app/falkor_recall_writer.py`: `write_chat_turn_tags_to_falkor` takes a new required `source_kind` param, written onto `:ChatTurn`; module docstring updated (was stale — described a dual-write that no longer exists).
- `services/orion-meta-tags/app/settings.py`, `.env_example`: `CHANNEL_EVENTS_TAGGED_CHAT` removed; `RECALL_FALKOR_TAG_ENTITY_ENABLED` default `false`→`true`.
- `services/orion-meta-tags/README.md`: Published Channels / Env Vars tables updated; "Recall Falkor writer" section rewritten for sole-path reality (restored + adapted the "watch consumer lag" operational guidance that a prior draft of this section had dropped); new "Historical note" section documenting the killed dual-write for institutional memory.
- `services/orion-rdf-writer/app/rdf_builder.py`: removed the `enrichment_type == "chat_tagging"` subject-URI branch — falls through to the generic `event/{id}` URI now (locked in by a new test).
- `services/orion-rdf-writer/app/settings.py`, `.env_example`, `docker-compose.yml`: `CHANNEL_EVENTS_TAGGED_CHAT` no longer subscribed.
- `orion/bus/channels.yaml`: `orion:tags:chat:enriched` entry kept (matching this repo's established kill pattern) with `producer_services: []`/`consumer_services: []` and an explanatory comment.
- `docs/architecture/rdf_store_v1_cutover.md`, `docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md`, `docs/superpowers/specs/2026-07-17-recall-rdf-writer-falkor-cutover-phase2-spec.md`: updated/annotated to stop asserting the killed channel is live.

## Files changed

- `services/orion-meta-tags/app/main.py`: stop publishing to `orion:tags:chat:enriched`; Falkor write covers both chat.history and social.turn.stored.v1; error-level logging on write failure.
- `services/orion-meta-tags/app/falkor_recall_writer.py`: `source_kind` discriminator property; docstring fix.
- `services/orion-meta-tags/app/settings.py`, `.env_example`: channel removed, Falkor-enabled default flipped.
- `services/orion-meta-tags/README.md`: contract tables, Falkor section, historical note.
- `services/orion-meta-tags/tests/test_chat_history_observer_gate.py`: rewritten — no-bus-publish assertions, `source_kind` assertions, new Falkor-exception regression test.
- `services/orion-meta-tags/tests/test_falkor_recall_writer.py`: updated for the new required `source_kind` param.
- `services/orion-rdf-writer/app/rdf_builder.py`: removed `chat_tagging` branch.
- `services/orion-rdf-writer/app/settings.py`, `.env_example`, `docker-compose.yml`: channel unsubscribed.
- `services/orion-rdf-writer/tests/test_dead_channel_kill.py`: two new tests — channel-not-subscribed regression, and generic-URI-fallthrough lock-in — matching this file's established same-day pattern for the other 4 killed channels.
- `orion/bus/channels.yaml`, 3 docs files: registry/doc accuracy.

## Schema / bus / API changes

- **Removed:** `orion:tags:chat:enriched` (`CHANNEL_EVENTS_TAGGED_CHAT`) — both producer (`orion-meta-tags`) and consumer (`orion-rdf-writer`) sides killed.
- **Behavior changed:** Falkor `:ChatTurn` writes now cover `social.turn.stored.v1` in addition to `chat.history`; `:ChatTurn` nodes gain a `source_kind` property.
- **Compatibility notes:** no other consumer of this channel exists (repo-wide grep confirmed by 2 independent review angles); `orion-sql-writer` consumes the separate `orion:tags:enriched` channel, unaffected.

## Env/config changes

- Removed keys: `CHANNEL_EVENTS_TAGGED_CHAT` (both services).
- Changed default: `RECALL_FALKOR_TAG_ENTITY_ENABLED` `false`→`true` (both services).
- `.env_example` updated: yes, both services.
- local `.env` synced: yes, edited directly in the primary checkout (both services already matched the new defaults — `RECALL_FALKOR_TAG_ENTITY_ENABLED` was already `true` live from a prior session).
- Known risk (documented, not fixed): any *other* environment with `RECALL_FALKOR_TAG_ENTITY_ENABLED=false` explicitly pinned in a local `.env` from before this PR will keep that value after `sync_local_env_from_example.py` (this repo's sync script deliberately preserves local overrides) — after this deploy that means zero persistence for chat/social tags on that host, with no error thrown. Worth a manual check on any other deployed host.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/pytest services/orion-meta-tags/tests -q
16 passed, 105 warnings (warnings are pre-existing pydantic protected-namespace deprecation noise, unrelated)

/mnt/scripts/Orion-Sapienform/.venv/bin/pytest services/orion-rdf-writer/tests -q
48 passed, 554 warnings (same pre-existing warning noise)

python scripts/check_service_env_compose_parity.py orion-rdf-writer   # pre-existing 17-key gap, unchanged
python scripts/check_service_env_compose_parity.py orion-meta-tags    # pre-existing gap reduced by 1 (this PR's removal)
git diff --check   # clean
```

## Evals run

No eval harness exists for either service. Not added — out of scope for this patch; the new regression tests are the deterministic gate for this behavior.

## Docker/build/smoke checks

Not run from this session — live-verified the *predecessor* PR's behavior end-to-end via `docker logs` + `GRAPH.QUERY` before starting this one (see #1184's live verification). This patch's own live verification is pending the restart below.

## Review findings fixed

- Finding: `_write_chat_turn_tags_to_falkor_async`'s docstring/comments still called it a "dark/additive path" safe to fail because it "rides alongside" a bus publish this same PR deletes — found independently by all 4 review angles.
  - Fix: rewrote docstring and except-block comment to state the real stakes; bumped log level WARNING→ERROR.
  - Evidence: `services/orion-meta-tags/app/main.py`.
- Finding: `falkor_recall_writer.py`'s module docstring (untouched by the original diff) still claimed a Fuseki dual-write exists.
  - Fix: updated.
  - Evidence: `services/orion-meta-tags/app/falkor_recall_writer.py`.
- Finding: no test exercised the Falkor write's exception path.
  - Fix: added `test_falkor_write_failure_is_swallowed_and_logged`.
  - Evidence: `services/orion-meta-tags/tests/test_chat_history_observer_gate.py`.
- Finding: `:ChatTurn`/`:ChatSession` had no property distinguishing chat vs social provenance, risking a silent turn_id-collision conflation now that both kinds share the label.
  - Fix: added `source_kind`.
  - Evidence: `services/orion-meta-tags/app/falkor_recall_writer.py`, both test files.
- Finding: README deleted the only documented operational guidance (watch consumer lag / dead-letter growth) instead of updating it for the new higher-stakes reality.
  - Fix: restored and adapted.
  - Evidence: `services/orion-meta-tags/README.md`.
- Finding: this repo's own established pattern (`test_dead_channel_kill.py`, same day) for locking in a killed channel wasn't applied to this one.
  - Fix: added `test_tags_chat_enriched_channel_not_subscribed` and `test_chat_tagging_enrichment_falls_through_to_generic_event_uri`.
  - Evidence: `services/orion-rdf-writer/tests/test_dead_channel_kill.py`.
- Finding: two doc files still asserted the killed channel/routing as present-tense fact, contradicting the plan doc's own amendment note.
  - Fix: annotated both.
  - Evidence: `docs/superpowers/plans/2026-07-18-recall-tag-entity-falkor-writer-plan.md`, `docs/superpowers/specs/2026-07-17-recall-rdf-writer-falkor-cutover-phase2-spec.md`.
- Finding (documented, not fixed): `RECALL_FALKOR_TAG_ENTITY_ENABLED` default-flip risk for any *other* environment with a stale explicit `false` override — inherent to the env-sync script's (correct, previously-fixed) override-preserving behavior, not something to code around in this service.
  - Evidence: PR report's "Env/config changes" section above.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-meta-tags/.env \
  -f services/orion-meta-tags/docker-compose.yml \
  up -d --build orion-meta-tags

docker compose \
  --env-file .env \
  --env-file services/orion-rdf-writer/.env \
  -f services/orion-rdf-writer/docker-compose.yml \
  up -d --build orion-rdf-writer
```

## Risks / concerns

- Severity: Low-Medium
- Concern: the Falkor write's failure mode now means real, silent data loss (mitigated by ERROR-level logging, but no retry/DLQ/alerting exists yet).
- Mitigation: documented in README as the next thing to instrument if real volume shows it's needed, not built preemptively.
- Severity: Low
- Concern: any other deployed environment with a stale `RECALL_FALKOR_TAG_ENTITY_ENABLED=false` override.
- Mitigation: documented above; worth a manual check on other hosts before assuming this is fully rolled out everywhere.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1185