### PR TITLE
feat(sentience-striving-program): AST/HOT attention self-model reducer (Phase 1)

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-18-ast-hot-attention-self-model-phase1-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-18-ast-hot-attention-self-model-phase1-pr.md
@@ -1,0 +1,118 @@
+# PR report: AST/HOT attention self-model reducer (Phase 1)
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1196
+Branch: `feat/ast-hot-attention-self-model-phase1`
+Status: **DONE_WITH_CONCERNS**
+
+## Summary
+
+- Phase 1 of `docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-roadmap-design.md`: a read-only, pure-function reducer (`reduce_attention_self_model`) that unifies the two real, previously-disconnected attention self-models — the GWT-dispatch lane (`AttentionBroadcastProjectionV1`, Lamme `voluntary_override`) and the general field lane (`FieldAttentionFrameV1` + `SelfStateV1`) — into one inspectable `AttentionSelfModelV1` artifact.
+- New schema `orion/schemas/attention_self_model.py`, registered in `orion/schemas/registry.py`. Not published to any bus channel and not wired into any live decision path — measurement instrument only, per the spec's explicit Phase 1 scoping.
+- Two new read-only Postgres replay scripts under `scripts/analysis/`, mirroring `measure_origination_gate.py`'s pure-replay/I/O-layer split and CLAUDE.md sec 14's background-job report contract: `measure_ast_hot_reducer.py` (the acceptance-check replay) and `measure_self_state_signal_quality.py` (the Phase 1 "hard gate" signal-quality pass).
+- **Load-bearing finding, discovered while building the replay script**: `substrate_attention_broadcast_projection` is a singleton upsert table (PRIMARY KEY on `projection_id`, exactly one row, always) — not a history table. There is no per-tick history for the GWT-dispatch lane in Postgres, so the spec's acceptance check ("find a real historical `voluntary_override` tick") is **NOT MET via Postgres replay** — honestly reported, not smoothed over.
+- **Hard-gate finding**: real 48h replay of `SelfStateV1` confirms the coherence/uncertainty sawtooth named in the program charter's Missing Question 4 is still live in `SelfStateV1`'s own values (median 5-tick oscillation period, 3500+ zero-crossings each over ~84k samples) — reported for Juniper's sign-off, not fixed here (explicitly out of scope).
+- 30 new unit tests (reducer + both scripts' pure layers), all passing; `orion/sentience_striving_program/README.md` updated with Phase 1 status and a correction to two stale "no `SelfStateV1`" lines in Sec 9b that predated the roadmap doc's Phase 1 scope revision.
+
+## Outcome moved
+
+The AST/HOT consciousness-theory scaffolding gap named in the program charter (§9b items 2/4) now has a real, inspectable, unit-tested artifact instead of "nothing builds a model of that attention." Objective 3's routing math (Phase 2+) has something real to be informed by once Juniper signs off, per the roadmap doc's own gating.
+
+## Current architecture
+
+Before this patch: `FieldAttentionFrameV1` (Layer 5, `orion-attention-runtime`, ~2s tick) and `AttentionBroadcastProjectionV1`/`AttentionFrameV1.voluntary_override` (GWT-dispatch/Lamme lane, `orion/substrate/attention_broadcast.py`, ~30s tick) existed as two live, real, but disconnected attention self-models — nothing unified them into a single "what's salient, why, how confident" artifact. `SelfStateV1` (Layer 6) already carried `attention_schema_type`/`attention_dwell_ticks` fields but no reducer consumed the broadcast lane at all.
+
+## Architecture touched
+
+- `orion/schemas/` — new schema file + registry entries (read/contract layer only).
+- `orion/substrate/` — new pure reducer module + its unit tests (no existing files' behavior changed).
+- `scripts/analysis/` — two new standalone, read-only measurement scripts + their unit tests, following the existing `measure_origination_gate.py`/`measure_autonomy_gate.py` pattern.
+- `orion/sentience_striving_program/README.md` — status + correction only, no rewrite of the roadmap spec doc itself.
+
+No service, Docker, bus, or env surface touched.
+
+## Files changed
+
+- `orion/schemas/attention_self_model.py`: new `AttentionSelfModelV1` schema.
+- `orion/schemas/registry.py`: registers `AttentionSelfModelV1`, `AttentionBroadcastProjectionV1`, `VoluntaryOverrideV1` (the latter two existed as real schemas but were never registered — found while wiring this patch).
+- `orion/substrate/attention_self_model.py`: `reduce_attention_self_model()`, pure function, no I/O.
+- `orion/substrate/tests/test_attention_self_model.py`: 13 unit tests (override present/absent, fresh/stale/future broadcast, each input `None`, predicted-shift derivation).
+- `scripts/analysis/measure_ast_hot_reducer.py`: real-data replay + report/csv/progress-log, matching CLAUDE.md sec 14.
+- `scripts/analysis/measure_self_state_signal_quality.py`: Phase 1 hard-gate signal-quality pass.
+- `scripts/analysis/tests/test_measure_ast_hot_reducer.py`, `scripts/analysis/tests/test_measure_self_state_signal_quality.py`: 17 unit tests for both scripts' pure layers.
+- `orion/sentience_striving_program/README.md`: Phase 1 status note (§6 item 2) + correction of stale "no `SelfStateV1`" constraint text (§9b items 2/4).
+
+## Schema / bus / API changes
+
+- Added: `AttentionSelfModelV1` (`attention.self_model.v1`), registered but **not published to any bus channel**.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: none (read-only, additive).
+- Compatibility notes: `AttentionBroadcastProjectionV1`/`VoluntaryOverrideV1` were real, already-live schemas that had never been added to `orion/schemas/registry.py` — added in the same patch since this reducer imports them; no behavior change to their existing producer/consumers.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: n/a (no service touched).
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a, not needed.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```
+source venv/bin/activate && export PYTHONPATH=<worktree>
+python -m pytest orion/substrate/tests/test_attention_self_model.py scripts/analysis/tests/ -q
+# 111 passed (30 new: 13 reducer + 8 ast-hot-reducer-script + 9 signal-quality-script;
+# 81 pre-existing scripts/analysis + orion/substrate tests, unaffected)
+
+python -m pytest orion/substrate/tests/ -q
+# 370 passed, 8 warnings (pre-existing warnings, unrelated to this patch)
+```
+
+## Evals run
+
+Both new scripts ARE the eval/measurement harness for this patch (per CLAUDE.md sec 11's "if the repo has no eval harness, add the smallest useful one" — these are it, following the `measure_origination_gate.py` precedent exactly). Run against real live Postgres (`postgresql://postgres:postgres@localhost:55432/conjourney`), `--window-hours 48`:
+
+```
+python scripts/analysis/measure_ast_hot_reducer.py --window-hours 48
+```
+Headline: 84,992 field-lane ticks replayed. `substrate_attention_broadcast_projection` confirmed live as a singleton (row count = 1). 0/84,992 ticks could be honestly joined to the single broadcast snapshot (it postdates the entire window). `attention_reason` distribution: `field_salience_only`=84,992 (100%), all others 0. **Acceptance check: NOT MET via Postgres replay** — reasoning and compensating unit-test evidence in the report; also ran a live 15-minute background poll of the broadcast projection table during this session (30s cadence, matching its real update interval) — no live `voluntary_override` observed in that window either. Full report: `/tmp/ast-hot-reducer/report.md`.
+
+```
+python scripts/analysis/measure_self_state_signal_quality.py --window-hours 48
+```
+Headline: 84,413 `substrate_self_state` rows replayed across all 12 real `SelfStateDimensionV1` dimensions. `coherence`: median oscillation period 5 ticks, 3,529 zero-crossings. `uncertainty`: median oscillation period 5 ticks, 3,531 zero-crossings. `transport_integrity`: median period 2 ticks, 17,572 zero-crossings (fastest of all 12). 8/12 dimensions flagged `pinned_or_flat`; 4 flagged `fast_oscillation_sawtooth_suspect`; `agency_readiness`/`execution_pressure` came back `nominal`. Full report: `/tmp/self-state-signal-quality/report.md`.
+
+## Docker/build/smoke checks
+
+Not applicable — no service, Dockerfile, or compose file touched. `scripts/safe_graphify_update.sh` was run per repo convention; it hit the known, pre-existing 2026-07-14 incremental-update bug (unrelated to this patch, node count dropped from 32,529 to 2,496) and correctly auto-restored `graph.json`/`manifest.json` — nothing graphify-related committed.
+
+## Review findings fixed
+
+- Finding: `pinned_or_flat` and `fast_oscillation_sawtooth_suspect` can co-occur on the same dimension (confirmed live for `coherence`/`uncertainty`) in a way that reads as contradictory without explanation (local rolling-std flatness vs. global zero-crossing frequency are different measurements).
+  - Fix: added a "Reading `pinned_or_flat` + `fast_oscillation_sawtooth_suspect` together" paragraph to `measure_self_state_signal_quality.py`'s report renderer explaining why both can be true simultaneously (step/plateau sawtooth pattern).
+  - Evidence: `scripts/analysis/measure_self_state_signal_quality.py` diff, commit `06f60c17`; re-ran `--window-hours 48` after the fix, report now includes the explanation, `coherence`/`uncertainty` numbers unchanged.
+- Three additional nits noted by review (coalition_stability_score default-1.0 honesty risk one layer up in the producer, missing boundary-condition unit test for the exact staleness threshold, a cosmetic missing comment header) — reviewed and judged genuinely low-risk / out of this patch's scope; not fixed.
+
+Full review (dispatched via `orion-repo-agent` subagent, independently verified Postgres state and re-ran tests/scripts rather than trusting prior claims): verdict **ship as-is**, no blocking or should-fix issues.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+## Risks / concerns
+
+- Severity: **informational, not blocking**
+  Concern: The Phase 1 acceptance check as literally written in the spec ("real historical window containing a `voluntary_override` event") cannot currently be satisfied via Postgres replay, because `substrate_attention_broadcast_projection` is a singleton upsert table with no history. The reducer's why-branching logic is proven correct via unit tests against the real `VoluntaryOverrideV1` schema, and a live 15-minute poll during this session found no override firing either — but a genuine end-to-end historical proof is currently impossible with the existing table design.
+  Mitigation: Recommendation recorded in both the replay script's report and the README: if Phase 2+ (e.g. Phase 3's shadow comparison) needs real historical replay of the GWT-dispatch lane, `substrate_attention_broadcast_projection` needs an append-only companion or `AttentionBroadcastProjectionV1` needs to be published to a bus channel with retained history — a schema/bus contract change per CLAUDE.md sec 6, explicitly out of scope for this patch.
+
+- Severity: **needs Juniper sign-off (per the spec's own hard-gate framing, not a blocker I can resolve)**
+  Concern: The Phase 1 hard gate confirms the coherence/uncertainty sawtooth named in the program charter's Missing Question 4 is still live in `SelfStateV1`'s own values today (not just historically, not just at the field level) — median 5-tick oscillation period, 3,500+ zero-crossings each over 84k real samples in the last 48h.
+  Mitigation: Reported plainly per the spec's own instruction ("do NOT block Phase 1 on fixing any such finding yourself... just report it clearly as a finding for Juniper's sign-off"). No `SelfStateV1` v2 attempted here. This is the concrete decision point the spec anticipated: whether `SelfStateV1` needs replacing before anything downstream of Phase 1's reducer output can be trusted.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1196

--- a/orion/schemas/attention_self_model.py
+++ b/orion/schemas/attention_self_model.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from orion.schemas.attention_frame import VoluntaryOverrideV1
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+AttentionReasonV1 = Literal[
+    "top_down_override",
+    "bottom_up_salience",
+    "field_salience_only",
+    "no_data",
+]
+
+
+class AttentionSelfModelV1(BaseModel):
+    """AST/HOT instrumentation — a single inspectable model *of* Orion's own
+    current attention (Attention Schema Theory / Higher-Order Theory,
+    `orion/sentience_striving_program/README.md` sec 9b items 2 and 4).
+
+    Unifies the two real, previously-disconnected attention self-models found
+    live during the 2026-07-18 Objective 3 roadmap scoping pass
+    (`docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-roadmap-design.md`,
+    Phase 1):
+
+    - The GWT-dispatch lane: `AttentionBroadcastProjectionV1`
+      (`orion/schemas/attention_frame.py`), which wraps `AttentionFrameV1` and
+      carries Lamme's `voluntary_override` (top-down goal bias flipping the
+      workspace-competition winner — `orion/substrate/attention/top_down.py`).
+      Persisted as a *singleton* upsert row in
+      `substrate_attention_broadcast_projection` (confirmed live 2026-07-18:
+      PK on `projection_id`, exactly one row at any time) — there is no
+      per-tick history for this lane, only the most recent snapshot.
+    - The general field lane (Layer 5/6): `FieldAttentionFrameV1` +
+      `SelfStateV1`, updated on a continuous ~2s tick by
+      `orion-attention-runtime`, with real per-tick history in
+      `substrate_attention_frames` / `substrate_self_state`.
+
+    This is a read-only measurement artifact (Phase 1 scope). It is not
+    published to any bus channel and not consumed by any live decision path —
+    that wiring is explicitly future work (Phase 3+ of the roadmap doc).
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_version: Literal["attention.self_model.v1"] = "attention.self_model.v1"
+    generated_at: datetime = Field(default_factory=_utc_now)
+
+    # --- What's currently salient (field lane) -----------------------------
+    field_lane_present: bool = False
+    field_overall_salience: float | None = Field(default=None, ge=0.0, le=1.0)
+    field_salient_target_ids: list[str] = Field(default_factory=list)
+
+    # --- What was last dispatched (GWT-dispatch / broadcast lane) ----------
+    broadcast_lane_present: bool = False
+    broadcast_selected_action_type: str | None = None
+    broadcast_selected_open_loop_id: str | None = None
+    broadcast_selected_description: str | None = None
+    broadcast_attended_node_ids: list[str] = Field(default_factory=list)
+
+    # --- Why: the aboutness claim AST/HOT instrumentation must make honestly
+    attention_reason: AttentionReasonV1 = "no_data"
+    voluntary_override: VoluntaryOverrideV1 | None = None
+    reason_narrative: str = ""
+
+    # --- How confident, derived from a real signal, never invented ---------
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    confidence_basis: str = ""
+
+    # --- What's predicted to shift next (modest, honestly scoped) ----------
+    predicted_shift: str | None = None
+    predicted_shift_basis: str = ""
+
+    # --- Explicit, honest cadence-mismatch state ----------------------------
+    # The broadcast lane updates far less often than the field lane (real
+    # config confirmed live 2026-07-18: ORION_ATTENTION_BROADCAST_INTERVAL_SEC
+    # =30s vs. the field lane's ~2s tick). "No new GWT-dispatch-lane activity
+    # since last frame" must be a distinct, named state from "nothing
+    # salient" — never silently collapsed into the same output.
+    broadcast_lane_stale: bool = True
+    broadcast_lane_age_sec: float | None = None
+
+    self_state_present: bool = False

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -542,7 +542,14 @@ from orion.schemas.thought import (
     StanceReactRequestV1,
     ThoughtEventV1,
 )
-from orion.schemas.attention_frame import AttentionFrameV1, AttentionSignalV1, SalienceFeaturesV1
+from orion.schemas.attention_frame import (
+    AttentionBroadcastProjectionV1,
+    AttentionFrameV1,
+    AttentionSignalV1,
+    SalienceFeaturesV1,
+    VoluntaryOverrideV1,
+)
+from orion.schemas.attention_self_model import AttentionSelfModelV1
 from orion.schemas.attention_salience import (
     AttentionLoopOutcomeV1,
     AttentionSalienceTraceV1,
@@ -798,6 +805,9 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "AttentionFrameV1": AttentionFrameV1,
     "AttentionSignalV1": AttentionSignalV1,
     "SalienceFeaturesV1": SalienceFeaturesV1,
+    "AttentionBroadcastProjectionV1": AttentionBroadcastProjectionV1,
+    "VoluntaryOverrideV1": VoluntaryOverrideV1,
+    "AttentionSelfModelV1": AttentionSelfModelV1,
     "AttentionSalienceTraceV1": AttentionSalienceTraceV1,
     "AttentionLoopOutcomeV1": AttentionLoopOutcomeV1,
     "PendingAttentionCardV1": PendingAttentionCardV1,
@@ -1420,6 +1430,21 @@ SCHEMA_REGISTRY: Dict[str, SchemaRegistration] = {
     "GraphWriteIntentV1": SchemaRegistration(
         model=GraphWriteIntentV1,
         kind="graph.write_intent.v1",
+    ),
+    "AttentionBroadcastProjectionV1": SchemaRegistration(
+        model=AttentionBroadcastProjectionV1,
+        kind="attention.broadcast.projection.v1",
+    ),
+    # AST/HOT reducer output (Phase 1, docs/superpowers/specs/
+    # 2026-07-18-objective-3-consciousness-scaffolded-roadmap-design.md).
+    # Registered per CLAUDE.md sec 6 even though this artifact is not yet
+    # published to any bus channel -- read-only measurement instrument only,
+    # not wired into a live consumer/producer path. See
+    # orion/substrate/attention_self_model.py and
+    # scripts/analysis/measure_ast_hot_reducer.py.
+    "AttentionSelfModelV1": SchemaRegistration(
+        model=AttentionSelfModelV1,
+        kind="attention.self_model.v1",
     ),
 }
 

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -143,6 +143,24 @@ first place. Full reasoning and phased detail:
    `SelfStateV1`, produces an explicit "what's salient, why, how confident" artifact. Must
    exist and pass its own acceptance check *before* item 3 below, on purpose — writing
    routing logic without this first is how the six-drive taxonomy happened.
+   **Phase 1 status (2026-07-18): built.** `reduce_attention_self_model()`
+   (`orion/substrate/attention_self_model.py`, output schema
+   `orion/schemas/attention_self_model.py::AttentionSelfModelV1`, registered in
+   `orion/schemas/registry.py`) unifies all three real inputs the roadmap doc's Phase 1
+   correction named — `AttentionBroadcastProjectionV1` (GWT-dispatch/Lamme lane),
+   `FieldAttentionFrameV1`, and `SelfStateV1` — read-only, not wired to any bus consumer.
+   Acceptance check **NOT MET via Postgres replay**: a real, load-bearing finding surfaced
+   while building the replay script (`scripts/analysis/measure_ast_hot_reducer.py`) —
+   `substrate_attention_broadcast_projection` is a singleton upsert table (one row, ever),
+   not a history table, so no historical `voluntary_override` event is recoverable to
+   replay against, even though the reducer's why-branching on it is proven correct via
+   unit tests (`orion/substrate/tests/test_attention_self_model.py`). Hard-gate signal-
+   quality pass (`scripts/analysis/measure_self_state_signal_quality.py`) run against real
+   48h `substrate_self_state` history: confirms the coherence/uncertainty sawtooth named in
+   §4's Missing Question 4 is **still live in `SelfStateV1`'s own values** (median 5-tick
+   oscillation period, 3500+ zero-crossings each over 84k samples) — the upstream field-
+   level fix has not fully propagated. Full detail, headline numbers, and the resulting
+   Juniper sign-off decision: PR report for this patch.
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live
@@ -293,8 +311,17 @@ fix — see §7.
 2. **Attention Schema Theory** — Layer 5 computes real attention state; nothing builds a
    model *of* that attention as an inspectable object. Missing piece: one small reducer
    reading `FieldAttentionFrameV1`/`FieldStateV1` directly, producing an explicit "what I'm
-   attending to, why, how confident, what I predict shifts next" artifact — must not be
-   built as a `SelfStateV1` consumer/producer.
+   attending to, why, how confident, what I predict shifts next" artifact.
+   **Correction (2026-07-18, superseding "must not be built as a `SelfStateV1`
+   consumer/producer" below): the roadmap doc's Phase 1 scoping pass found a second real,
+   disconnected attention lane (`AttentionBroadcastProjectionV1`, GWT-dispatch/Lamme) that
+   this instrument must also unify, and `SelfStateV1` is the only real source today for two
+   of the artifact's real fields (predicted-shift trajectory, a confidence fallback) — an
+   explicit, narrow exception to §7's standing rule, not a repeal of it, gated behind a
+   hard signal-quality check on exactly those `SelfStateV1` fields before Phase 1 is called
+   done. See `docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-
+   roadmap-design.md` Phase 1 and §6 item 2's status note above.** Built 2026-07-18:
+   `orion/substrate/attention_self_model.py`.
 3. **Predictive Processing/Active Inference** — **not** `orion/self_state/prediction.py`
    (`SelfStateV1`-anchored, same violation as IIT above). The real field-native substrate,
    confirmed live 2026-07-18: `services/orion-substrate-runtime/app/worker.py`'s
@@ -311,7 +338,9 @@ fix — see §7.
    have equivalent instrumentation, or whether coverage is genuinely incomplete.
 4. **Higher-Order Theories** — architecturally close to AST's missing piece; a
    higher-order representation built once, reading the same field/reducer-projection data,
-   may serve both theories. Same constraint as #2: no `SelfStateV1` dependency.
+   may serve both theories. Served by the same Phase 1 reducer as #2 above, including its
+   narrow, hard-gated `SelfStateV1` exception (see #2's 2026-07-18 correction) — not a
+   separate instrument.
 5. **Recurrent Processing Theory (Lamme)** — confirmed real, tight, per-tick recurrence
    inside Layer 5 itself (`novelty_for_target()` reads the *previous*
    `FieldAttentionFrameV1`) — already field-native, no correction needed here. Top-down

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -1,0 +1,195 @@
+"""AST/HOT attention self-model reducer — rung 4 (read-only, Phase 1).
+
+Pure function, no I/O. Takes the three already-parsed real inputs and
+returns one `AttentionSelfModelV1` answering: what's currently salient, what
+was last dispatched, *why* (top-down goal bias vs. pure bottom-up salience —
+the "aboutness" claim AST/HOT instrumentation needs to make honestly), how
+confident, and what's predicted to shift next.
+
+Mirrors `scripts/analysis/measure_origination_gate.py`'s separation of a pure
+replay/summary layer from an I/O layer, for the same testability reason that
+script documents: this function is exercised directly with synthetic
+fixtures, no DB or bus involved, by `orion/substrate/tests/
+test_attention_self_model.py`.
+
+Read-only. This module has no bus consumer/producer wiring — see
+`docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-roadmap-design.md`
+Phase 1: the reducer must be measured against real historical data
+(`scripts/analysis/measure_ast_hot_reducer.py`) before anything downstream
+consumes it, matching the program charter's own "measure before minting"
+process rule (sec 7).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
+from orion.schemas.attention_self_model import AttentionSelfModelV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+# 2x the live ORION_ATTENTION_BROADCAST_INTERVAL_SEC default (30s, confirmed
+# live 2026-07-18 via `docker exec orion-athena-substrate-runtime env`) —
+# same 2x-tick-interval convention `orion/substrate/felt_state_reader.py`
+# already uses for its own staleness gates (curiosity_signals, reverie).
+DEFAULT_BROADCAST_STALE_THRESHOLD_SEC = 60.0
+
+
+def _round_or_none(value: float | None, digits: int = 4) -> float | None:
+    return None if value is None else round(float(value), digits)
+
+
+def reduce_attention_self_model(
+    broadcast: AttentionBroadcastProjectionV1 | None,
+    field_frame: FieldAttentionFrameV1 | None,
+    self_state: SelfStateV1 | None,
+    *,
+    now: datetime | None = None,
+    broadcast_stale_threshold_sec: float = DEFAULT_BROADCAST_STALE_THRESHOLD_SEC,
+) -> AttentionSelfModelV1:
+    """Unify the GWT-dispatch lane and the general field lane into one
+    inspectable AST/HOT self-model. Never raises: any of the three inputs may
+    be `None` (partial data honestly represented, not a crash).
+
+    `now` is the reference tick this self-model is being generated *for* —
+    normally the field-lane tick's own `generated_at` (the highest-frequency
+    real signal, so it drives the replay/live cadence per the Phase 1 design).
+    Falls back to `self_state.generated_at`, then `broadcast.generated_at`,
+    then wall-clock `datetime.now(timezone.utc)` if none of the three inputs
+    are present.
+    """
+
+    reference_ts = (
+        now
+        or (field_frame.generated_at if field_frame is not None else None)
+        or (self_state.generated_at if self_state is not None else None)
+        or (broadcast.generated_at if broadcast is not None else None)
+        or datetime.now(timezone.utc)
+    )
+    if reference_ts.tzinfo is None:
+        reference_ts = reference_ts.replace(tzinfo=timezone.utc)
+
+    model = AttentionSelfModelV1(generated_at=reference_ts)
+
+    # --- Field lane: what's currently salient -------------------------------
+    if field_frame is not None:
+        model.field_lane_present = True
+        model.field_overall_salience = _round_or_none(field_frame.overall_salience)
+        model.field_salient_target_ids = [t.target_id for t in field_frame.dominant_targets]
+
+    # --- Self-state: predicted shift + a confidence fallback ---------------
+    if self_state is not None:
+        model.self_state_present = True
+        top_drift_dim: str | None = None
+        top_drift_val = 0.0
+        for dim_id, delta in (self_state.dimension_trajectory or {}).items():
+            if abs(delta) > abs(top_drift_val):
+                top_drift_dim, top_drift_val = dim_id, delta
+        if self_state.trajectory_condition != "unknown":
+            if top_drift_dim is not None:
+                model.predicted_shift = (
+                    f"trajectory={self_state.trajectory_condition}; "
+                    f"largest-moving dimension={top_drift_dim} (delta={top_drift_val:+.3f})"
+                )
+                model.predicted_shift_basis = (
+                    "self_state.trajectory_condition + self_state.dimension_trajectory"
+                )
+            else:
+                model.predicted_shift = f"trajectory={self_state.trajectory_condition}"
+                model.predicted_shift_basis = "self_state.trajectory_condition"
+
+    # --- Broadcast lane: what was last dispatched + cadence-mismatch state -
+    broadcast_age_sec: float | None = None
+    broadcast_stale = True
+    if broadcast is not None:
+        model.broadcast_lane_present = True
+        model.broadcast_selected_action_type = broadcast.selected_action_type
+        model.broadcast_selected_open_loop_id = broadcast.selected_open_loop_id
+        model.broadcast_selected_description = broadcast.selected_description
+        model.broadcast_attended_node_ids = list(broadcast.attended_node_ids)
+
+        b_ts = broadcast.generated_at
+        if b_ts.tzinfo is None:
+            b_ts = b_ts.replace(tzinfo=timezone.utc)
+        broadcast_age_sec = (reference_ts - b_ts).total_seconds()
+        # A negative age means the broadcast snapshot is *newer* than the
+        # reference tick (the only real-world case this occurs today: the
+        # broadcast lane is a singleton upsert row — see module docstring —
+        # so a historical replay tick that predates the single available
+        # snapshot has, honestly, no broadcast data at all for that moment;
+        # treat it as absent rather than guessing what an earlier snapshot
+        # might have looked like).
+        if broadcast_age_sec < 0:
+            model.broadcast_lane_present = False
+            model.broadcast_selected_action_type = None
+            model.broadcast_selected_open_loop_id = None
+            model.broadcast_selected_description = None
+            model.broadcast_attended_node_ids = []
+            broadcast_age_sec = None
+            broadcast_stale = True
+        else:
+            broadcast_stale = broadcast_age_sec > broadcast_stale_threshold_sec
+
+    model.broadcast_lane_age_sec = _round_or_none(broadcast_age_sec, 3)
+    model.broadcast_lane_stale = broadcast_stale
+
+    # --- Why: branch explicitly on voluntary_override -----------------------
+    override = None
+    if (
+        broadcast is not None
+        and model.broadcast_lane_present
+        and not broadcast_stale
+        and broadcast.frame is not None
+    ):
+        override = broadcast.frame.voluntary_override
+
+    if override is not None:
+        model.attention_reason = "top_down_override"
+        model.voluntary_override = override
+        model.confidence = _round_or_none(broadcast.coalition_stability_score)
+        model.confidence_basis = "broadcast.coalition_stability_score (fresh, top-down)"
+        model.reason_narrative = (
+            f"Top-down goal bias flipped the winner: loop '{override.chosen_loop_id}' "
+            f"(bottom_up={override.chosen_bottom_up:.2f}) beat '{override.beat_loop_id}' "
+            f"(bottom_up={override.beat_bottom_up:.2f}) via applied_bias="
+            f"{override.applied_bias:.2f}, effort_spent={override.effort_spent:.2f}, "
+            f"goal_artifact_id={override.goal_artifact_id!r}, "
+            f"goal_drive_origin={override.goal_drive_origin!r}."
+        )
+    elif model.broadcast_lane_present and not broadcast_stale:
+        model.attention_reason = "bottom_up_salience"
+        model.confidence = _round_or_none(broadcast.coalition_stability_score)
+        model.confidence_basis = "broadcast.coalition_stability_score (fresh, bottom-up)"
+        model.reason_narrative = (
+            f"Pure bottom-up dispatch: '{model.broadcast_selected_open_loop_id}' "
+            f"selected by salience alone; no active goal override at this tick."
+        )
+    elif model.field_lane_present or model.self_state_present:
+        model.attention_reason = "field_salience_only"
+        if self_state is not None:
+            model.confidence = _round_or_none(self_state.overall_confidence)
+            model.confidence_basis = "self_state.overall_confidence (broadcast lane stale/absent)"
+        elif field_frame is not None and field_frame.dominant_targets:
+            scores = [t.confidence_score for t in field_frame.dominant_targets]
+            model.confidence = _round_or_none(sum(scores) / len(scores))
+            model.confidence_basis = (
+                "mean(field_attention_frame.dominant_targets[].confidence_score) "
+                "(broadcast lane stale/absent)"
+            )
+        stale_note = (
+            "no new GWT-dispatch-lane activity since last frame"
+            if model.broadcast_lane_present
+            else "no GWT-dispatch-lane data available"
+        )
+        n_targets = len(model.field_salient_target_ids)
+        model.reason_narrative = (
+            f"{stale_note}; reading field-lane salience only "
+            f"({n_targets} dominant target(s), "
+            f"overall_salience={model.field_overall_salience})."
+        )
+    else:
+        model.attention_reason = "no_data"
+        model.reason_narrative = "No attention data available from either lane."
+
+    return model

--- a/orion/substrate/tests/test_attention_self_model.py
+++ b/orion/substrate/tests/test_attention_self_model.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from orion.schemas.attention_frame import (
+    AttentionBroadcastProjectionV1,
+    AttentionFrameV1,
+    VoluntaryOverrideV1,
+)
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
+from orion.schemas.self_state import SelfStateV1
+from orion.substrate.attention_self_model import (
+    DEFAULT_BROADCAST_STALE_THRESHOLD_SEC,
+    reduce_attention_self_model,
+)
+
+NOW = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _broadcast(
+    *,
+    generated_at: datetime = NOW,
+    override: VoluntaryOverrideV1 | None = None,
+    selected_open_loop_id: str = "loop-1",
+) -> AttentionBroadcastProjectionV1:
+    frame = AttentionFrameV1(generated_at=generated_at, voluntary_override=override)
+    return AttentionBroadcastProjectionV1(
+        generated_at=generated_at,
+        frame=frame,
+        selected_action_type="watch",
+        selected_open_loop_id=selected_open_loop_id,
+        selected_description="a dispatched open loop",
+        attended_node_ids=["node-a", "node-b"],
+        dwell_ticks=2,
+        coalition_stability_score=0.8,
+    )
+
+
+def _override(**overrides: object) -> VoluntaryOverrideV1:
+    base = dict(
+        goal_artifact_id="goal-123",
+        goal_drive_origin="curiosity",
+        chosen_loop_id="loop-1",
+        beat_loop_id="loop-2",
+        chosen_bottom_up=0.4,
+        beat_bottom_up=0.6,
+        applied_bias=0.3,
+        effort_spent=0.1,
+    )
+    base.update(overrides)
+    return VoluntaryOverrideV1(**base)
+
+
+def _field_frame(*, generated_at: datetime = NOW, overall_salience: float = 0.7) -> FieldAttentionFrameV1:
+    target = FieldAttentionTargetV1(
+        target_id="node-a",
+        target_kind="node",
+        salience_score=0.7,
+        pressure_score=0.5,
+        novelty_score=0.3,
+        urgency_score=0.4,
+        confidence_score=0.65,
+    )
+    return FieldAttentionFrameV1(
+        frame_id="field-frame-1",
+        generated_at=generated_at,
+        source_field_tick_id="tick-1",
+        source_field_generated_at=generated_at,
+        overall_salience=overall_salience,
+        dominant_targets=[target],
+    )
+
+
+def _self_state(*, generated_at: datetime = NOW, overall_confidence: float = 0.55) -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id="self-state-1",
+        generated_at=generated_at,
+        source_field_tick_id="tick-1",
+        source_field_generated_at=generated_at,
+        source_attention_frame_id="field-frame-1",
+        source_attention_generated_at=generated_at,
+        overall_condition="steady",
+        overall_intensity=0.5,
+        overall_confidence=overall_confidence,
+        trajectory_condition="improving",
+        dimension_trajectory={"coherence": 0.12, "uncertainty": -0.04},
+    )
+
+
+class TestVoluntaryOverridePresent:
+    def test_override_present_narrates_top_down_reason(self) -> None:
+        override = _override()
+        broadcast = _broadcast(override=override)
+        model = reduce_attention_self_model(broadcast, _field_frame(), _self_state(), now=NOW)
+
+        assert model.attention_reason == "top_down_override"
+        assert model.voluntary_override is not None
+        assert model.voluntary_override.chosen_loop_id == "loop-1"
+        assert "Top-down goal bias flipped the winner" in model.reason_narrative
+        assert "loop-1" in model.reason_narrative
+        assert "loop-2" in model.reason_narrative
+        assert model.confidence == pytest.approx(0.8)
+        assert model.confidence_basis.startswith("broadcast.coalition_stability_score")
+
+    def test_override_absent_narrates_bottom_up_reason(self) -> None:
+        broadcast = _broadcast(override=None)
+        model = reduce_attention_self_model(broadcast, _field_frame(), _self_state(), now=NOW)
+
+        assert model.attention_reason == "bottom_up_salience"
+        assert model.voluntary_override is None
+        assert "Pure bottom-up dispatch" in model.reason_narrative
+        assert "no active goal override" in model.reason_narrative
+
+
+class TestCadenceMismatch:
+    def test_fresh_broadcast_is_not_stale(self) -> None:
+        broadcast = _broadcast(generated_at=NOW - timedelta(seconds=5))
+        model = reduce_attention_self_model(broadcast, _field_frame(), None, now=NOW)
+
+        assert model.broadcast_lane_stale is False
+        assert model.broadcast_lane_age_sec == pytest.approx(5.0, abs=0.01)
+        assert model.attention_reason == "bottom_up_salience"
+
+    def test_stale_broadcast_is_distinct_from_nothing_salient(self) -> None:
+        stale_age = DEFAULT_BROADCAST_STALE_THRESHOLD_SEC + 30.0
+        broadcast = _broadcast(generated_at=NOW - timedelta(seconds=stale_age))
+        model = reduce_attention_self_model(broadcast, _field_frame(), _self_state(), now=NOW)
+
+        assert model.broadcast_lane_stale is True
+        assert model.broadcast_lane_age_sec == pytest.approx(stale_age, abs=0.01)
+        # Distinct state: broadcast lane WAS present (a real snapshot exists)
+        # but it's stale -- this must not be conflated with "no data at all".
+        assert model.broadcast_lane_present is True
+        assert model.attention_reason == "field_salience_only"
+        assert "no new GWT-dispatch-lane activity" in model.reason_narrative
+
+    def test_broadcast_from_the_future_relative_to_reference_tick_is_treated_as_absent(self) -> None:
+        # The broadcast lane is a singleton upsert row (confirmed live
+        # 2026-07-18: substrate_attention_broadcast_projection has exactly
+        # one row, PK on projection_id). A historical replay tick that
+        # predates the single available snapshot has no honest broadcast
+        # data for that moment -- must not silently reuse a snapshot from
+        # later in time as if it applied retroactively.
+        broadcast = _broadcast(generated_at=NOW + timedelta(seconds=10))
+        model = reduce_attention_self_model(broadcast, _field_frame(), None, now=NOW)
+
+        assert model.broadcast_lane_present is False
+        assert model.broadcast_lane_age_sec is None
+        assert model.attention_reason == "field_salience_only"
+        assert "no GWT-dispatch-lane data available" in model.reason_narrative
+
+
+class TestPartialData:
+    def test_all_none_is_no_data_not_a_crash(self) -> None:
+        model = reduce_attention_self_model(None, None, None)
+
+        assert model.attention_reason == "no_data"
+        assert model.field_lane_present is False
+        assert model.broadcast_lane_present is False
+        assert model.self_state_present is False
+        assert model.voluntary_override is None
+        assert model.reason_narrative == "No attention data available from either lane."
+
+    def test_only_broadcast_present(self) -> None:
+        broadcast = _broadcast(override=_override())
+        model = reduce_attention_self_model(broadcast, None, None, now=NOW)
+
+        assert model.field_lane_present is False
+        assert model.self_state_present is False
+        assert model.attention_reason == "top_down_override"
+        assert model.predicted_shift is None  # no self_state -> honestly absent, not invented
+
+    def test_only_field_frame_present(self) -> None:
+        model = reduce_attention_self_model(None, _field_frame(), None, now=NOW)
+
+        assert model.broadcast_lane_present is False
+        assert model.field_lane_present is True
+        assert model.attention_reason == "field_salience_only"
+        assert model.confidence_basis.startswith(
+            "mean(field_attention_frame.dominant_targets"
+        )
+
+    def test_only_self_state_present(self) -> None:
+        model = reduce_attention_self_model(None, None, _self_state(), now=NOW)
+
+        assert model.self_state_present is True
+        assert model.attention_reason == "field_salience_only"
+        assert model.confidence_basis == "self_state.overall_confidence (broadcast lane stale/absent)"
+        assert model.predicted_shift is not None
+        assert "coherence" in model.predicted_shift
+
+
+class TestPredictedShift:
+    def test_uses_real_self_state_trajectory_fields_not_invented(self) -> None:
+        state = _self_state()
+        model = reduce_attention_self_model(None, None, state, now=NOW)
+
+        assert model.predicted_shift_basis == (
+            "self_state.trajectory_condition + self_state.dimension_trajectory"
+        )
+        assert "trajectory=improving" in model.predicted_shift
+
+    def test_unknown_trajectory_yields_no_prediction(self) -> None:
+        state = _self_state()
+        state = state.model_copy(update={"trajectory_condition": "unknown", "dimension_trajectory": {}})
+        model = reduce_attention_self_model(None, None, state, now=NOW)
+
+        assert model.predicted_shift is None
+        assert model.predicted_shift_basis == ""
+
+
+def test_reference_tick_defaults_to_field_frame_generated_at() -> None:
+    field_frame = _field_frame(generated_at=NOW)
+    model = reduce_attention_self_model(None, field_frame, None)
+
+    assert model.generated_at == NOW
+
+
+def test_reference_tick_falls_back_to_self_state_when_no_field_frame() -> None:
+    state = _self_state(generated_at=NOW)
+    model = reduce_attention_self_model(None, None, state)
+
+    assert model.generated_at == NOW

--- a/scripts/analysis/measure_ast_hot_reducer.py
+++ b/scripts/analysis/measure_ast_hot_reducer.py
@@ -1,0 +1,663 @@
+#!/usr/bin/env python3
+"""Read-only AST/HOT attention self-model reducer measurement + replay.
+
+Phase 1 of `docs/superpowers/specs/2026-07-18-objective-3-consciousness-
+scaffolded-roadmap-design.md`. Replays the REAL, pure production reducer
+(`reduce_attention_self_model`, `orion/substrate/attention_self_model.py`)
+over real historical Postgres data for two of its three inputs
+(`substrate_attention_frames` -> `FieldAttentionFrameV1`, `substrate_
+self_state` -> `SelfStateV1`), joined by nearest-preceding timestamp with the
+field lane's own tick cadence driving the replay (it is the highest-
+frequency real signal, per the Phase 1 design).
+
+**Load-bearing finding, discovered while building this script (2026-07-18):
+`substrate_attention_broadcast_projection` -- the third input,
+`AttentionBroadcastProjectionV1`, the GWT-dispatch/Lamme lane -- is a
+SINGLETON UPSERT table.** Confirmed live via `\\d
+substrate_attention_broadcast_projection` (PRIMARY KEY on `projection_id`)
+and a row-count query (exactly 1 row, always). There is no per-tick history
+for this lane in Postgres -- only the single most-recent snapshot is ever
+observable. This script does NOT fabricate history for it: the same single
+broadcast row is passed to the reducer for every replayed field-lane tick,
+and the reducer itself (see its own docstring/logic) honestly reports the
+broadcast lane as *absent* for any tick that predates the snapshot's own
+`generated_at` (rather than silently reusing a future snapshot as if it
+applied retroactively), and as *stale* for ticks more than
+`DEFAULT_BROADCAST_STALE_THRESHOLD_SEC` after it. In practice this means only
+a small tail of the most-recent replayed ticks (near the moment this script
+was run) can ever show broadcast data at all -- the rest of the window
+honestly shows `broadcast_lane_present=False`. See the report's own
+"Broadcast lane coverage" and "Acceptance check" sections for the concrete
+numbers this produces on a real run, and root CLAUDE.md's "runtime truth
+beats config truth" mandate for why this is reported plainly rather than
+smoothed over.
+
+This performs NO writes, emits NO events, flips NO flags. It reports:
+
+  1. The distribution of `attention_reason` over the replay window.
+  2. Broadcast-lane coverage: how many ticks could honestly be joined to the
+     single available broadcast snapshot at all, and how many of those were
+     stale vs. fresh.
+  3. The acceptance check: does the replay window contain at least one real
+     `voluntary_override` event, and if so, a concrete before/after
+     narrative example proving the reducer's "why" branches on it (not just
+     a generic salience reading). If the window contains none (the honest,
+     confirmed-live state of `substrate_attention_broadcast_projection` as
+     of this script's own design pass), that is reported as NOT MET via
+     Postgres replay, with the reasoning above, rather than asserted as
+     passing.
+
+Run:
+    python scripts/analysis/measure_ast_hot_reducer.py --window-hours 48
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import time
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("orion.analysis.ast_hot_reducer")
+
+DEFAULT_WINDOW_HOURS: float = 48.0
+MAX_ROWS: int = 200_000
+
+OUTPUT_DIR = Path("/tmp/ast-hot-reducer")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+CSV_PATH = OUTPUT_DIR / "ticks.csv"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+
+# ===========================================================================
+# Pure replay/summary layer -- no I/O. Calls the REAL production reducer
+# (reduce_attention_self_model), itself pure (no I/O -- verified by reading
+# orion/substrate/attention_self_model.py), so this whole layer has no I/O
+# of its own and is exercised directly by unit tests, no DB involved.
+# ===========================================================================
+
+
+@dataclass
+class ReplayTick:
+    generated_at: datetime
+    attention_reason: str
+    confidence: Optional[float]
+    broadcast_lane_present: bool
+    broadcast_lane_stale: bool
+    broadcast_lane_age_sec: Optional[float]
+    field_lane_present: bool
+    self_state_present: bool
+    has_voluntary_override: bool
+    reason_narrative: str
+
+
+def replay_reducer(
+    field_rows: list[tuple[datetime, dict]],
+    self_state_rows: list[tuple[datetime, dict]],
+    broadcast_row: Optional[tuple[datetime, dict]],
+) -> tuple[list[ReplayTick], int, int]:
+    """Replay the real `reduce_attention_self_model` over ordered field-lane
+    ticks (the highest-frequency real signal -- drives replay cadence),
+    joining `self_state_rows` by nearest-preceding timestamp and passing the
+    single `broadcast_row` (or None) to every call -- see module docstring
+    for why a per-tick broadcast join is not possible with the current
+    schema. Returns (ticks, field_rows_skipped, self_state_rows_skipped).
+    """
+    from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
+    from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+    from orion.schemas.self_state import SelfStateV1
+    from orion.substrate.attention_self_model import reduce_attention_self_model
+
+    broadcast_model: Optional[AttentionBroadcastProjectionV1] = None
+    if broadcast_row is not None:
+        try:
+            broadcast_model = AttentionBroadcastProjectionV1.model_validate(broadcast_row[1])
+        except Exception:
+            logger.warning("broadcast_row_parse_failed", exc_info=True)
+            broadcast_model = None
+
+    self_states: list[tuple[datetime, SelfStateV1]] = []
+    self_state_skipped = 0
+    for ts, payload in self_state_rows:
+        try:
+            self_states.append((ts, SelfStateV1.model_validate(payload)))
+        except Exception:
+            self_state_skipped += 1
+
+    ticks: list[ReplayTick] = []
+    field_skipped = 0
+    ss_idx = 0  # two-pointer: both field_rows and self_states are ASC-sorted
+    current_self_state: Optional[SelfStateV1] = None
+
+    for ts, payload in field_rows:
+        try:
+            field_model = FieldAttentionFrameV1.model_validate(payload)
+        except Exception:
+            field_skipped += 1
+            continue
+
+        while ss_idx < len(self_states) and self_states[ss_idx][0] <= ts:
+            current_self_state = self_states[ss_idx][1]
+            ss_idx += 1
+
+        model = reduce_attention_self_model(
+            broadcast_model, field_model, current_self_state, now=ts
+        )
+        ticks.append(
+            ReplayTick(
+                generated_at=ts,
+                attention_reason=model.attention_reason,
+                confidence=model.confidence,
+                broadcast_lane_present=model.broadcast_lane_present,
+                broadcast_lane_stale=model.broadcast_lane_stale,
+                broadcast_lane_age_sec=model.broadcast_lane_age_sec,
+                field_lane_present=model.field_lane_present,
+                self_state_present=model.self_state_present,
+                has_voluntary_override=model.voluntary_override is not None,
+                reason_narrative=model.reason_narrative,
+            )
+        )
+    return ticks, field_skipped, self_state_skipped
+
+
+def reason_histogram(ticks: list[ReplayTick]) -> Counter:
+    return Counter(t.attention_reason for t in ticks)
+
+
+def find_override_examples(ticks: list[ReplayTick], *, context: int = 1) -> list[list[ReplayTick]]:
+    """Contiguous windows of `ticks` (ordered) around every tick where
+    `has_voluntary_override` is True, `context` ticks either side, for a
+    concrete before/after narrative example.
+    """
+    examples: list[list[ReplayTick]] = []
+    for i, t in enumerate(ticks):
+        if t.has_voluntary_override:
+            lo = max(0, i - context)
+            hi = min(len(ticks), i + context + 1)
+            examples.append(ticks[lo:hi])
+    return examples
+
+
+# ===========================================================================
+# I/O layer -- psycopg2 read-only. Mirrors measure_origination_gate.py's
+# connection contract exactly (refuses a non-read-only session).
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def _rows_to_payload_list(rows, *, ts_col_idx: int = 1, payload_col_idx: int = 0) -> tuple[list[tuple[datetime, dict]], bool]:
+    out: list[tuple[datetime, dict]] = []
+    for row in rows:
+        payload, ts = row[payload_col_idx], row[ts_col_idx]
+        if ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except Exception:
+                continue
+        if not isinstance(payload, dict):
+            continue
+        out.append((ts, payload))
+    return out, len(rows) >= MAX_ROWS
+
+
+def fetch_field_attention_rows(conn, since: datetime) -> tuple[list[tuple[datetime, dict]], bool]:
+    if conn is None:
+        return [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT frame_json, generated_at
+                FROM substrate_attention_frames
+                WHERE generated_at >= %s
+                ORDER BY generated_at ASC
+                LIMIT %s
+                """,
+                (since, MAX_ROWS),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch substrate_attention_frames", exc_info=True)
+        return [], False
+    return _rows_to_payload_list(rows)
+
+
+def fetch_self_state_rows(conn, since: datetime) -> tuple[list[tuple[datetime, dict]], bool]:
+    if conn is None:
+        return [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT self_state_json, generated_at
+                FROM substrate_self_state
+                WHERE generated_at >= %s
+                ORDER BY generated_at ASC
+                LIMIT %s
+                """,
+                (since, MAX_ROWS),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch substrate_self_state", exc_info=True)
+        return [], False
+    return _rows_to_payload_list(rows)
+
+
+def fetch_broadcast_row_count(conn) -> Optional[int]:
+    """Cross-check the singleton-table finding live, every run -- not just
+    asserted once in a docstring. None on failure (degrades quietly).
+    """
+    if conn is None:
+        return None
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM substrate_attention_broadcast_projection")
+            row = cur.fetchone()
+    except Exception:
+        logger.warning("broadcast row-count query failed", exc_info=True)
+        return None
+    return int(row[0]) if row else None
+
+
+def fetch_latest_broadcast_row(conn) -> Optional[tuple[datetime, dict]]:
+    if conn is None:
+        return None
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT projection_json, generated_at
+                FROM substrate_attention_broadcast_projection
+                ORDER BY generated_at DESC
+                LIMIT 1
+                """
+            )
+            row = cur.fetchone()
+    except Exception:
+        logger.error("failed to fetch substrate_attention_broadcast_projection", exc_info=True)
+        return None
+    if not row:
+        return None
+    rows, _ = _rows_to_payload_list([row])
+    return rows[0] if rows else None
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def write_ticks_csv(path: Path, ticks: list[ReplayTick]) -> None:
+    import csv
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            [
+                "generated_at", "attention_reason", "confidence",
+                "broadcast_lane_present", "broadcast_lane_stale", "broadcast_lane_age_sec",
+                "field_lane_present", "self_state_present", "has_voluntary_override",
+            ]
+        )
+        for t in ticks:
+            writer.writerow(
+                [
+                    t.generated_at.isoformat(), t.attention_reason,
+                    "" if t.confidence is None else f"{t.confidence:.4f}",
+                    t.broadcast_lane_present, t.broadcast_lane_stale,
+                    "" if t.broadcast_lane_age_sec is None else f"{t.broadcast_lane_age_sec:.3f}",
+                    t.field_lane_present, t.self_state_present, t.has_voluntary_override,
+                ]
+            )
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.4f}"
+
+
+def render_report(
+    *,
+    window_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    ticks: list[ReplayTick],
+    field_rows_truncated: bool,
+    field_rows_skipped: int,
+    self_state_rows_skipped: int,
+    broadcast_row_count: Optional[int],
+    broadcast_row: Optional[tuple[datetime, dict]],
+    override_examples: list[list[ReplayTick]],
+    caveats: list[str],
+) -> str:
+    hist = reason_histogram(ticks)
+    n = len(ticks)
+
+    def pct(count: int) -> str:
+        return "n/a" if n == 0 else f"{100.0 * count / n:.1f}%"
+
+    hist_lines = "\n".join(
+        f"| {reason} | {hist.get(reason, 0)} | {pct(hist.get(reason, 0))} |"
+        for reason in ("top_down_override", "bottom_up_salience", "field_salience_only", "no_data")
+    )
+
+    n_broadcast_present = sum(1 for t in ticks if t.broadcast_lane_present)
+    n_broadcast_fresh = sum(1 for t in ticks if t.broadcast_lane_present and not t.broadcast_lane_stale)
+    n_broadcast_stale = sum(1 for t in ticks if t.broadcast_lane_present and t.broadcast_lane_stale)
+
+    broadcast_singleton_line = (
+        "n/a (query failed)" if broadcast_row_count is None
+        else f"{broadcast_row_count} row(s) (confirmed singleton if this is 1, every run)"
+    )
+    broadcast_current_line = (
+        "none (table empty)" if broadcast_row is None
+        else f"generated_at={broadcast_row[0].isoformat()}, voluntary_override="
+             f"{'present' if (broadcast_row[1].get('frame') or {}).get('voluntary_override') else 'null'}"
+    )
+
+    lines = [
+        "# AST/HOT Attention Self-Model Reducer Measurement",
+        "",
+        "Read-only. No writes, no events, no flag/config changes. Replays the real "
+        "`reduce_attention_self_model` production function over historical "
+        "`substrate_attention_frames` (field lane, drives cadence) and "
+        "`substrate_self_state` rows, joined by nearest-preceding timestamp.",
+        "",
+        f"- Window: last {window_label} ({window_start.isoformat()} -> {window_end.isoformat()})",
+        f"- Field-lane (FieldAttentionFrameV1) ticks replayed: {n}",
+        f"- Field-lane rows truncated at MAX_ROWS={MAX_ROWS}: {field_rows_truncated}",
+        f"- Field-lane rows skipped (failed to parse): {field_rows_skipped}",
+        f"- Self-state rows skipped (failed to parse): {self_state_rows_skipped}",
+        "",
+        "## Broadcast lane: singleton-table finding (load-bearing)",
+        "",
+        "`substrate_attention_broadcast_projection` is a singleton upsert table "
+        "(PRIMARY KEY on `projection_id`) -- confirmed live by this run's own "
+        "row-count query, not just asserted from an earlier session:",
+        "",
+        f"- Live row count: {broadcast_singleton_line}",
+        f"- Current (only) snapshot: {broadcast_current_line}",
+        f"- Field-lane ticks in this window that could be honestly joined to the "
+        f"single broadcast snapshot at all (i.e. tick.generated_at >= broadcast."
+        f"generated_at): **{n_broadcast_present}** / {n} ({pct(n_broadcast_present)})",
+        f"  - of those, fresh (within staleness threshold): {n_broadcast_fresh}",
+        f"  - of those, stale (\"no new GWT-dispatch-lane activity since last frame\"): "
+        f"{n_broadcast_stale}",
+        "",
+        "This is why the acceptance check below is scoped the way it is: there is no "
+        "per-tick broadcast history in Postgres to replay against older ticks, only the "
+        "single most-recent snapshot, honestly joined only to the small tail of ticks "
+        "at or after its own timestamp.",
+        "",
+        "## attention_reason distribution",
+        "",
+        "| reason | count | pct |",
+        "| --- | --- | --- |",
+        hist_lines,
+        "",
+        "## Acceptance check: does the window contain a real voluntary_override event, "
+        "narrated correctly?",
+        "",
+    ]
+
+    if override_examples:
+        lines.append(
+            f"**MET.** Found {len(override_examples)} tick(s) with a real, non-null "
+            f"`voluntary_override` in the replay window. Concrete before/after example "
+            f"(first occurrence):"
+        )
+        lines.append("")
+        for t in override_examples[0]:
+            marker = " <-- OVERRIDE TICK" if t.has_voluntary_override else ""
+            lines.append(
+                f"- `{t.generated_at.isoformat()}` reason=**{t.attention_reason}** "
+                f"confidence={_fmt(t.confidence)}{marker}"
+            )
+            lines.append(f"  narrative: {t.reason_narrative}")
+        lines.append("")
+        lines.append(
+            "The reducer's `attention_reason` visibly branches from "
+            "`bottom_up_salience`/`field_salience_only` to `top_down_override` at the "
+            "marked tick, and `reason_narrative` names the specific goal/loop involved -- "
+            "proving the two inputs are unified (the override is narrated as *the* reason "
+            "for that tick's attention state), not just both present in the schema."
+        )
+    else:
+        lines.extend(
+            [
+                "**NOT MET via Postgres replay.** Zero ticks in this window carry a "
+                "non-null `voluntary_override`. This is a direct consequence of the "
+                "singleton-table finding above, not a reducer bug: "
+                f"`substrate_attention_broadcast_projection`'s single current snapshot "
+                f"({broadcast_current_line}) does not currently carry a "
+                "voluntary_override, and no earlier snapshot is recoverable from "
+                "Postgres to search further back -- the row is overwritten in place on "
+                "every broadcast tick (every "
+                "`ORION_ATTENTION_BROADCAST_INTERVAL_SEC` seconds, confirmed live=30s), "
+                "so any historical override event (including the one an earlier session "
+                "reported observing live in this same table) has already been "
+                "overwritten by the time this script runs.",
+                "",
+                "Compensating evidence that the reducer's why-branching logic is real and "
+                "correct (see `orion/substrate/tests/test_attention_self_model.py`, run "
+                "as part of this PR):",
+                "",
+                "- `TestVoluntaryOverridePresent` exercises the reducer with a real "
+                "`VoluntaryOverrideV1` shape (the exact production schema, not a "
+                "simplified stand-in) and asserts `attention_reason == "
+                "\"top_down_override\"` plus a narrative naming the specific "
+                "chosen/beaten loop IDs and applied_bias -- the same branch this replay "
+                "would exercise if a live override were present in the window.",
+                "- `TestCadenceMismatch` exercises the exact singleton-table scenario "
+                "found here: a broadcast snapshot dated after the reference tick is "
+                "honestly treated as absent, not reused retroactively.",
+                "",
+                "**Recommendation for Juniper's sign-off**: if a genuine historical replay "
+                "of the GWT-dispatch lane's `voluntary_override` events is needed for "
+                "Phase 2+ (e.g. Phase 3's shadow comparison), "
+                "`substrate_attention_broadcast_projection` needs an append-only "
+                "companion (or `AttentionBroadcastProjectionV1` needs to also be "
+                "published to a bus channel with retained history) -- the current "
+                "singleton-upsert design cannot support it. Not built here: out of "
+                "Phase 1 scope, and a schema/bus contract change per CLAUDE.md sec 6, "
+                "not a reducer change.",
+            ]
+        )
+
+    lines.extend(["", "## Reading this", ""])
+    lines.extend(
+        [
+            "- `top_down_override` count > 0 with a narrative naming real loop IDs is the "
+            "only thing that satisfies the Phase 1 acceptance check as written; a "
+            "nonzero `bottom_up_salience`/`field_salience_only` count alone is not "
+            "sufficient (that would just prove the two inputs are both present, not "
+            "unified).",
+            "- A high `field_salience_only` fraction is expected and correct given the "
+            "singleton-table finding above -- it is not a sign the reducer is failing to "
+            "read the broadcast lane, it is the honest consequence of that lane having "
+            "no queryable history.",
+            "",
+        ]
+    )
+    lines.extend(["## Coverage caveats", ""])
+    if caveats:
+        lines.extend(f"- {c}" for c in caveats)
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(window: timedelta, window_label: str) -> int:
+    now = datetime.now(timezone.utc)
+    window_start = now - window
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    progress = ProgressLog(PROGRESS_PATH)
+    caveats: list[str] = []
+
+    progress.emit("connect", percent=0.0, processed=0, total=0)
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        caveats.append("postgres unavailable or not read-only; nothing measured")
+        progress.close()
+        print("ERROR: could not open a read-only postgres connection; see log")
+        return 2
+
+    field_rows, field_truncated = fetch_field_attention_rows(conn, window_start)
+    if field_truncated:
+        caveats.append(f"field-attention rows truncated at MAX_ROWS={MAX_ROWS}")
+    progress.emit("field_attention loaded", percent=25.0, processed=len(field_rows), total=len(field_rows))
+
+    self_state_rows, self_state_truncated = fetch_self_state_rows(conn, window_start)
+    if self_state_truncated:
+        caveats.append(f"self-state rows truncated at MAX_ROWS={MAX_ROWS}")
+    progress.emit("self_state loaded", percent=45.0, processed=len(self_state_rows), total=len(self_state_rows))
+
+    broadcast_row_count = fetch_broadcast_row_count(conn)
+    broadcast_row = fetch_latest_broadcast_row(conn)
+    progress.emit("broadcast loaded", percent=55.0, processed=1 if broadcast_row else 0, total=1)
+
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+    if not field_rows:
+        caveats.append("no substrate_attention_frames rows in window; nothing to replay")
+        progress.close()
+        report = render_report(
+            window_label=window_label, window_start=window_start, window_end=now,
+            ticks=[], field_rows_truncated=field_truncated, field_rows_skipped=0,
+            self_state_rows_skipped=0, broadcast_row_count=broadcast_row_count,
+            broadcast_row=broadcast_row, override_examples=[], caveats=caveats,
+        )
+        REPORT_PATH.write_text(report, encoding="utf-8")
+        print(report)
+        return 2
+
+    progress.emit("replaying", percent=60.0, processed=0, total=len(field_rows))
+    ticks, field_skipped, self_state_skipped = replay_reducer(field_rows, self_state_rows, broadcast_row)
+    progress.emit("replay done", percent=95.0, processed=len(ticks), total=len(field_rows))
+
+    override_examples = find_override_examples(ticks)
+
+    write_ticks_csv(CSV_PATH, ticks)
+    report = render_report(
+        window_label=window_label,
+        window_start=window_start,
+        window_end=now,
+        ticks=ticks,
+        field_rows_truncated=field_truncated,
+        field_rows_skipped=field_skipped,
+        self_state_rows_skipped=self_state_skipped,
+        broadcast_row_count=broadcast_row_count,
+        broadcast_row=broadcast_row,
+        override_examples=override_examples,
+        caveats=caveats,
+    )
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    progress.emit("done", percent=100.0, processed=len(ticks), total=len(field_rows))
+    progress.close()
+
+    print(report)
+    print(f"\nartifacts: {REPORT_PATH}, {CSV_PATH}, {PROGRESS_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read-only AST/HOT attention self-model reducer measurement.")
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"analysis window in hours (default {DEFAULT_WINDOW_HOURS})",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    window = timedelta(hours=args.window_hours)
+    window_label = f"{args.window_hours:g}h"
+    return run(window, window_label)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/measure_self_state_signal_quality.py
+++ b/scripts/analysis/measure_self_state_signal_quality.py
@@ -432,6 +432,17 @@ def render_report(
         f"{HIGH_DRIFT_PER_HOUR_THRESHOLD}; fast-oscillation/sawtooth-suspect if median "
         f"oscillation period < {FAST_OSCILLATION_TICK_THRESHOLD} ticks.",
         "",
+        "**Reading `pinned_or_flat` + `fast_oscillation_sawtooth_suspect` together (not a "
+        "contradiction):** `noise_floor_std` is a *local* rolling-window statistic (median "
+        "of trailing 20-sample std), while the oscillation period is a *global* "
+        "zero-crossing measurement over the whole series. A dimension that jumps between a "
+        "small number of discrete plateau values (e.g. a coherence/uncertainty sawtooth "
+        "step-function) can show near-zero local variance within each plateau -- so "
+        "`noise_floor_std` reads as flat -- while still crossing its own mean rapidly and "
+        "repeatedly across the full window -- so the oscillation period reads as fast. Both "
+        "measurements are correct simultaneously; seeing them together is itself evidence of "
+        "a step/sawtooth pattern rather than smooth noise.",
+        "",
         "## Findings for Juniper's sign-off",
         "",
     ]

--- a/scripts/analysis/measure_self_state_signal_quality.py
+++ b/scripts/analysis/measure_self_state_signal_quality.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Read-only SelfStateV1 signal-quality assessment.
+
+Phase 1 hard gate, `docs/superpowers/specs/2026-07-18-objective-3-
+consciousness-scaffolded-roadmap-design.md`: before the AST/HOT reducer's
+Phase 1 output can be trusted for anything downstream, `SelfStateV1`'s own
+signal quality must be measured against real historical data -- noise floor,
+drift, oscillation period, per dimension -- not assumed. Real problems are
+already known (not hypothetical) from the design pass this script implements:
+a `confidence`/`available_capacity` merge-polarity masking bug, several
+dead/folded-away `channel_dimension_map` entries, and a pre-fix coherence/
+uncertainty sawtooth whose upstream field-level cause is closed but whose
+full propagation through to `SelfStateV1`'s own values was never
+independently re-checked.
+
+Method: replay real historical `substrate_self_state` rows (same fetch
+pattern as `scripts/analysis/measure_origination_gate.py`'s
+`fetch_self_state_rows`), parse each into the real `SelfStateV1` model, and
+for every dimension `SelfStateDimensionV1.dimension_id` can carry, compute
+basic time-series diagnostics: rolling-std noise floor, a simple linear
+drift-per-hour estimate, and a zero-crossing-based oscillation period
+estimate. This is deliberately not sophisticated -- the spec's own bar is
+"the same kind of measurement discipline used everywhere else in this
+program," not a new ML pipeline.
+
+This performs NO writes, emits NO events, flips NO flags, and proposes NO
+`SelfStateV1` v2. Findings are reported plainly, including anything that
+looks broken (e.g. a dimension still pinned or oscillating) -- fixing any
+such finding is explicitly out of scope for this script and for Phase 1;
+see the report's own "Findings for Juniper's sign-off" section.
+
+Run:
+    python scripts/analysis/measure_self_state_signal_quality.py --window-hours 48
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("orion.analysis.self_state_signal_quality")
+
+DEFAULT_WINDOW_HOURS: float = 48.0
+MAX_ROWS: int = 200_000
+ROLLING_WINDOW: int = 20
+
+# All twelve real dimension_ids SelfStateDimensionV1 can carry
+# (orion/schemas/self_state.py) -- measured unconditionally, in this fixed
+# order, so a dimension that never appears in the window (e.g. a dead/
+# folded-away channel) is still visible in the report as "n=0", not silently
+# omitted.
+DIMENSION_IDS: tuple[str, ...] = (
+    "field_intensity",
+    "coherence",
+    "uncertainty",
+    "agency_readiness",
+    "resource_pressure",
+    "execution_pressure",
+    "reasoning_pressure",
+    "reliability_pressure",
+    "continuity_pressure",
+    "introspection_pressure",
+    "social_pressure",
+    "transport_integrity",
+)
+
+# Heuristic thresholds -- deliberately simple, named so they're easy to
+# argue with later, not buried magic numbers.
+PINNED_STD_THRESHOLD = 0.01          # noise floor below this -> "pinned/flat"
+HIGH_DRIFT_PER_HOUR_THRESHOLD = 0.05  # |slope| above this -> "drifting"
+FAST_OSCILLATION_TICK_THRESHOLD = 6.0  # median period below this many ticks -> "oscillating fast"
+
+OUTPUT_DIR = Path("/tmp/self-state-signal-quality")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+CSV_PATH = OUTPUT_DIR / "dimensions.csv"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+
+# ===========================================================================
+# Pure summary layer -- no I/O, unit-testable on synthetic series.
+# ===========================================================================
+
+
+@dataclass
+class DimensionSample:
+    generated_at: datetime
+    score: float
+    confidence: float
+
+
+@dataclass
+class DimensionDiagnostics:
+    dimension_id: str
+    n: int = 0
+    score_median: Optional[float] = None
+    score_min: Optional[float] = None
+    score_max: Optional[float] = None
+    confidence_median: Optional[float] = None
+    noise_floor_std: Optional[float] = None
+    drift_per_hour: Optional[float] = None
+    oscillation_period_ticks: Optional[float] = None
+    zero_crossings: int = 0
+    flags: list[str] = field(default_factory=list)
+
+
+def _median(values: list[float]) -> Optional[float]:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        return float(ordered[mid])
+    return float((ordered[mid - 1] + ordered[mid]) / 2.0)
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def rolling_std(values: list[float], window: int = ROLLING_WINDOW) -> list[float]:
+    """Population std over a trailing window per point; first `window - 1`
+    points use whatever's available so short series still produce output.
+    """
+    out: list[float] = []
+    for i in range(len(values)):
+        lo = max(0, i - window + 1)
+        chunk = values[lo : i + 1]
+        m = _mean(chunk)
+        var = _mean([(v - m) ** 2 for v in chunk])
+        out.append(var ** 0.5)
+    return out
+
+
+def linear_drift_per_hour(times_sec: list[float], values: list[float]) -> Optional[float]:
+    """Simple least-squares slope of value vs. time (seconds), converted to
+    per-hour. None if fewer than 2 points or time has zero variance.
+    """
+    n = len(values)
+    if n < 2:
+        return None
+    t_mean = _mean(times_sec)
+    v_mean = _mean(values)
+    num = sum((t - t_mean) * (v - v_mean) for t, v in zip(times_sec, values))
+    den = sum((t - t_mean) ** 2 for t in times_sec)
+    if den == 0:
+        return None
+    slope_per_sec = num / den
+    return slope_per_sec * 3600.0
+
+
+def zero_crossing_period_estimate(values: list[float]) -> tuple[Optional[float], int]:
+    """Median distance (in tick count) between sign changes of
+    `value - mean(values)`. A short median period relative to the series
+    length indicates fast oscillation (e.g. a sawtooth). Returns
+    (median_period_ticks, zero_crossing_count); period is None if fewer than
+    2 crossings.
+    """
+    if len(values) < 3:
+        return None, 0
+    m = _mean(values)
+    centered = [v - m for v in values]
+    crossing_indices: list[int] = []
+    prev_sign = None
+    for i, v in enumerate(centered):
+        if v == 0:
+            continue
+        sign = v > 0
+        if prev_sign is not None and sign != prev_sign:
+            crossing_indices.append(i)
+        prev_sign = sign
+    if len(crossing_indices) < 2:
+        return None, len(crossing_indices)
+    gaps = [b - a for a, b in zip(crossing_indices, crossing_indices[1:])]
+    return _median([float(g) for g in gaps]), len(crossing_indices)
+
+
+def diagnose_dimension(dimension_id: str, samples: list[DimensionSample]) -> DimensionDiagnostics:
+    diag = DimensionDiagnostics(dimension_id=dimension_id, n=len(samples))
+    if not samples:
+        diag.flags.append("no_data")
+        return diag
+
+    ordered = sorted(samples, key=lambda s: s.generated_at)
+    scores = [s.score for s in ordered]
+    confidences = [s.confidence for s in ordered]
+    t0 = ordered[0].generated_at
+    times_sec = [(s.generated_at - t0).total_seconds() for s in ordered]
+
+    diag.score_median = _median(scores)
+    diag.score_min = min(scores)
+    diag.score_max = max(scores)
+    diag.confidence_median = _median(confidences)
+
+    stds = rolling_std(scores)
+    diag.noise_floor_std = _median(stds)
+
+    diag.drift_per_hour = linear_drift_per_hour(times_sec, scores)
+
+    period, crossings = zero_crossing_period_estimate(scores)
+    diag.oscillation_period_ticks = period
+    diag.zero_crossings = crossings
+
+    if diag.noise_floor_std is not None and diag.noise_floor_std < PINNED_STD_THRESHOLD:
+        diag.flags.append("pinned_or_flat")
+    if diag.drift_per_hour is not None and abs(diag.drift_per_hour) > HIGH_DRIFT_PER_HOUR_THRESHOLD:
+        diag.flags.append("drifting")
+    if period is not None and period < FAST_OSCILLATION_TICK_THRESHOLD:
+        diag.flags.append("fast_oscillation_sawtooth_suspect")
+    if not diag.flags:
+        diag.flags.append("nominal")
+    return diag
+
+
+# ===========================================================================
+# I/O layer -- psycopg2 read-only. Mirrors measure_origination_gate.py's
+# fetch_self_state_rows exactly.
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_self_state_rows(conn, since: datetime, max_rows: int = MAX_ROWS) -> tuple[list[tuple[datetime, dict]], bool]:
+    """Fetch (generated_at, self_state_json) ordered ASC. Returns (rows, truncated).
+    Identical fetch shape to measure_origination_gate.py's function of the
+    same name -- deliberately not shared as a common import so this script
+    stays a standalone, independently-runnable measurement like its sibling.
+    """
+    if conn is None:
+        return [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT generated_at, self_state_json
+                FROM substrate_self_state
+                WHERE generated_at >= %s
+                ORDER BY generated_at ASC
+                LIMIT %s
+                """,
+                (since, max_rows),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch substrate_self_state", exc_info=True)
+        return [], False
+    out: list[tuple[datetime, dict]] = []
+    for generated_at, raw_json in rows:
+        if generated_at.tzinfo is None:
+            generated_at = generated_at.replace(tzinfo=timezone.utc)
+        payload = raw_json
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except Exception:
+                continue
+        if not isinstance(payload, dict):
+            continue
+        out.append((generated_at, payload))
+    return out, len(rows) >= max_rows
+
+
+def parse_and_bucket_by_dimension(
+    rows: list[tuple[datetime, dict]],
+) -> tuple[dict[str, list[DimensionSample]], int]:
+    from orion.schemas.self_state import SelfStateV1
+
+    buckets: dict[str, list[DimensionSample]] = {d: [] for d in DIMENSION_IDS}
+    skipped = 0
+    for generated_at, payload in rows:
+        try:
+            state = SelfStateV1.model_validate(payload)
+        except Exception:
+            skipped += 1
+            continue
+        for dim_id, dim in state.dimensions.items():
+            if dim_id not in buckets:
+                buckets.setdefault(dim_id, [])
+            buckets[dim_id].append(
+                DimensionSample(generated_at=generated_at, score=dim.score, confidence=dim.confidence)
+            )
+    return buckets, skipped
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def write_dimensions_csv(path: Path, diagnostics: list[DimensionDiagnostics]) -> None:
+    import csv
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            [
+                "dimension_id", "n", "score_median", "score_min", "score_max",
+                "confidence_median", "noise_floor_std", "drift_per_hour",
+                "oscillation_period_ticks", "zero_crossings", "flags",
+            ]
+        )
+        for d in diagnostics:
+            writer.writerow(
+                [
+                    d.dimension_id, d.n,
+                    _fmt(d.score_median), _fmt(d.score_min), _fmt(d.score_max),
+                    _fmt(d.confidence_median), _fmt(d.noise_floor_std), _fmt(d.drift_per_hour),
+                    _fmt(d.oscillation_period_ticks), d.zero_crossings,
+                    ";".join(d.flags),
+                ]
+            )
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "" if value is None else f"{value:.4f}"
+
+
+def render_report(
+    *,
+    window_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    n_rows: int,
+    rows_truncated: bool,
+    rows_skipped: int,
+    diagnostics: list[DimensionDiagnostics],
+    caveats: list[str],
+) -> str:
+    table_lines = "\n".join(
+        f"| {d.dimension_id} | {d.n} | {_fmt(d.score_median)} | "
+        f"[{_fmt(d.score_min)}, {_fmt(d.score_max)}] | {_fmt(d.noise_floor_std)} | "
+        f"{_fmt(d.drift_per_hour)} | {_fmt(d.oscillation_period_ticks)} | "
+        f"{d.zero_crossings} | {', '.join(d.flags)} |"
+        for d in diagnostics
+    )
+
+    flagged = [d for d in diagnostics if d.flags and d.flags != ["nominal"] and d.flags != ["no_data"]]
+    no_data = [d for d in diagnostics if "no_data" in d.flags]
+
+    lines = [
+        "# SelfStateV1 Signal-Quality Assessment (Phase 1 hard gate)",
+        "",
+        "Read-only. No writes, no events, no flag/config changes, no SelfStateV1 v2 "
+        "proposed. Replays real `substrate_self_state` rows through the real "
+        "`SelfStateV1` model and computes basic time-series diagnostics per dimension.",
+        "",
+        f"- Window: last {window_label} ({window_start.isoformat()} -> {window_end.isoformat()})",
+        f"- self_state rows replayed: {n_rows}",
+        f"- Rows truncated at MAX_ROWS={MAX_ROWS}: {rows_truncated}",
+        f"- Rows skipped (failed to parse): {rows_skipped}",
+        "",
+        "## Per-dimension diagnostics",
+        "",
+        "| dimension_id | n | score median | score range | noise_floor (rolling std) | "
+        "drift/hour | oscillation period (ticks) | zero-crossings | flags |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        table_lines or "| (no data) | | | | | | | | |",
+        "",
+        f"Thresholds used (named, not buried): pinned/flat if noise_floor < "
+        f"{PINNED_STD_THRESHOLD}; drifting if |drift_per_hour| > "
+        f"{HIGH_DRIFT_PER_HOUR_THRESHOLD}; fast-oscillation/sawtooth-suspect if median "
+        f"oscillation period < {FAST_OSCILLATION_TICK_THRESHOLD} ticks.",
+        "",
+        "## Findings for Juniper's sign-off",
+        "",
+    ]
+
+    if no_data:
+        lines.append(
+            f"- **{len(no_data)} dimension(s) with ZERO samples in this window**: "
+            f"{', '.join(d.dimension_id for d in no_data)}. Consistent with the spec's "
+            f"already-known \"dead/folded-away channel_dimension_map entries\" finding "
+            f"-- these dimension_ids are never populated by the live builder over this "
+            f"real window, not just theoretically unused."
+        )
+    if flagged:
+        for d in flagged:
+            lines.append(
+                f"- **{d.dimension_id}**: flags=[{', '.join(d.flags)}] "
+                f"(n={d.n}, noise_floor={_fmt(d.noise_floor_std)}, "
+                f"drift/hour={_fmt(d.drift_per_hour)}, "
+                f"oscillation_period_ticks={_fmt(d.oscillation_period_ticks)}, "
+                f"zero_crossings={d.zero_crossings})"
+            )
+    if not no_data and not flagged:
+        lines.append(
+            "- No dimension in this window tripped the pinned/drifting/fast-oscillation "
+            "heuristics above. This does NOT by itself clear the "
+            "confidence/available_capacity merge-polarity bug named in the spec (that "
+            "bug is about a cross-field merge, not a single dimension's own time "
+            "series, and is out of scope to re-diagnose here) -- it only reports what "
+            "this specific per-dimension pass found."
+        )
+
+    lines.extend(
+        [
+            "",
+            "This is a **report only** -- per the spec's own framing, if any finding "
+            "above looks like it needs fixing (a SelfStateV1 v2), that is a blocking "
+            "prerequisite decision for Juniper, not something this script or Phase 1's "
+            "reducer patch attempts to resolve.",
+            "",
+            "## Coverage caveats",
+            "",
+        ]
+    )
+    if caveats:
+        lines.extend(f"- {c}" for c in caveats)
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(window: timedelta, window_label: str) -> int:
+    now = datetime.now(timezone.utc)
+    window_start = now - window
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    progress = ProgressLog(PROGRESS_PATH)
+    caveats: list[str] = []
+
+    progress.emit("connect", percent=0.0, processed=0, total=0)
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        caveats.append("postgres unavailable or not read-only; nothing measured")
+        progress.close()
+        print("ERROR: could not open a read-only postgres connection; see log")
+        return 2
+
+    rows, truncated = fetch_self_state_rows(conn, window_start)
+    if truncated:
+        caveats.append(f"self-state rows truncated at MAX_ROWS={MAX_ROWS}")
+    progress.emit("self_state loaded", percent=30.0, processed=len(rows), total=len(rows))
+
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+    if not rows:
+        caveats.append("no substrate_self_state rows in window; nothing to measure")
+        progress.close()
+        report = render_report(
+            window_label=window_label, window_start=window_start, window_end=now,
+            n_rows=0, rows_truncated=truncated, rows_skipped=0, diagnostics=[], caveats=caveats,
+        )
+        REPORT_PATH.write_text(report, encoding="utf-8")
+        print(report)
+        return 2
+
+    progress.emit("bucketing + diagnosing", percent=50.0, processed=0, total=len(rows))
+    buckets, skipped = parse_and_bucket_by_dimension(rows)
+
+    diagnostics = [diagnose_dimension(dim_id, buckets.get(dim_id, [])) for dim_id in DIMENSION_IDS]
+    extra_dims = sorted(set(buckets) - set(DIMENSION_IDS))
+    if extra_dims:
+        caveats.append(f"unexpected dimension_ids present in live data (not in the known 12): {extra_dims}")
+        diagnostics.extend(diagnose_dimension(dim_id, buckets[dim_id]) for dim_id in extra_dims)
+
+    progress.emit("diagnosis done", percent=95.0, processed=len(rows), total=len(rows))
+
+    write_dimensions_csv(CSV_PATH, diagnostics)
+    report = render_report(
+        window_label=window_label,
+        window_start=window_start,
+        window_end=now,
+        n_rows=len(rows),
+        rows_truncated=truncated,
+        rows_skipped=skipped,
+        diagnostics=diagnostics,
+        caveats=caveats,
+    )
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    progress.emit("done", percent=100.0, processed=len(rows), total=len(rows))
+    progress.close()
+
+    print(report)
+    print(f"\nartifacts: {REPORT_PATH}, {CSV_PATH}, {PROGRESS_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read-only SelfStateV1 signal-quality assessment.")
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"analysis window in hours (default {DEFAULT_WINDOW_HOURS})",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    window = timedelta(hours=args.window_hours)
+    window_label = f"{args.window_hours:g}h"
+    return run(window, window_label)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_measure_ast_hot_reducer.py
+++ b/scripts/analysis/tests/test_measure_ast_hot_reducer.py
@@ -1,0 +1,153 @@
+"""Deterministic unit tests for measure_ast_hot_reducer.py.
+
+No DB. The replay layer calls the REAL `reduce_attention_self_model`
+(pure, no I/O -- see orion/substrate/attention_self_model.py), so it is
+exercised directly with synthetic field/self-state/broadcast payload dicts,
+same fixture-loading pattern as
+scripts/analysis/tests/test_measure_origination_gate.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "measure_ast_hot_reducer.py"
+_spec = importlib.util.spec_from_file_location("measure_ast_hot_reducer", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_ast_hot_reducer"] = mod
+_spec.loader.exec_module(mod)
+
+from orion.schemas.attention_frame import (  # noqa: E402
+    AttentionBroadcastProjectionV1,
+    AttentionFrameV1,
+    VoluntaryOverrideV1,
+)
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1  # noqa: E402
+from orion.schemas.self_state import SelfStateV1  # noqa: E402
+
+UTC = timezone.utc
+BASE = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def _field_payload(ts: datetime) -> dict:
+    frame = FieldAttentionFrameV1(
+        frame_id=f"frame-{ts.isoformat()}",
+        generated_at=ts,
+        source_field_tick_id="tick",
+        source_field_generated_at=ts,
+        overall_salience=0.6,
+        dominant_targets=[
+            FieldAttentionTargetV1(
+                target_id="node-1", target_kind="node", salience_score=0.6,
+                pressure_score=0.4, novelty_score=0.2, urgency_score=0.3, confidence_score=0.5,
+            )
+        ],
+    )
+    return frame.model_dump(mode="json")
+
+
+def _self_state_payload(ts: datetime) -> dict:
+    state = SelfStateV1(
+        self_state_id=f"ss-{ts.isoformat()}", generated_at=ts,
+        source_field_tick_id="tick", source_field_generated_at=ts,
+        source_attention_frame_id="frame", source_attention_generated_at=ts,
+        overall_intensity=0.5, overall_confidence=0.5,
+    )
+    return state.model_dump(mode="json")
+
+
+def _broadcast_payload(ts: datetime, *, override: VoluntaryOverrideV1 | None = None) -> dict:
+    frame = AttentionFrameV1(generated_at=ts, voluntary_override=override)
+    projection = AttentionBroadcastProjectionV1(
+        generated_at=ts, frame=frame, selected_action_type="watch",
+        selected_open_loop_id="loop-1", coalition_stability_score=0.7,
+    )
+    return projection.model_dump(mode="json")
+
+
+def test_replay_reducer_joins_self_state_by_nearest_preceding_timestamp() -> None:
+    field_rows = [
+        (BASE, _field_payload(BASE)),
+        (BASE + timedelta(seconds=10), _field_payload(BASE + timedelta(seconds=10))),
+    ]
+    self_state_rows = [(BASE - timedelta(seconds=1), _self_state_payload(BASE - timedelta(seconds=1)))]
+
+    ticks, field_skipped, ss_skipped = mod.replay_reducer(field_rows, self_state_rows, None)
+
+    assert field_skipped == 0
+    assert ss_skipped == 0
+    assert len(ticks) == 2
+    assert all(t.self_state_present for t in ticks)
+
+
+def test_replay_reducer_skips_unparseable_rows_without_raising() -> None:
+    field_rows = [(BASE, {"not": "a valid frame"})]
+    ticks, field_skipped, ss_skipped = mod.replay_reducer(field_rows, [], None)
+
+    assert ticks == []
+    assert field_skipped == 1
+    assert ss_skipped == 0
+
+
+def test_replay_reducer_surfaces_real_voluntary_override() -> None:
+    override = VoluntaryOverrideV1(
+        goal_artifact_id="goal-1", goal_drive_origin="curiosity",
+        chosen_loop_id="loop-1", beat_loop_id="loop-2",
+        chosen_bottom_up=0.3, beat_bottom_up=0.5, applied_bias=0.4, effort_spent=0.1,
+    )
+    broadcast_row = (BASE, _broadcast_payload(BASE, override=override))
+    field_rows = [(BASE + timedelta(seconds=1), _field_payload(BASE + timedelta(seconds=1)))]
+
+    ticks, _, _ = mod.replay_reducer(field_rows, [], broadcast_row)
+
+    assert len(ticks) == 1
+    assert ticks[0].has_voluntary_override is True
+    assert ticks[0].attention_reason == "top_down_override"
+    assert "loop-1" in ticks[0].reason_narrative
+
+
+def test_replay_reducer_honestly_absent_when_broadcast_predates_nothing_reference() -> None:
+    """A broadcast snapshot dated AFTER the field tick must not be joined to
+    it -- mirrors the real singleton-table finding this script's own
+    docstring documents."""
+    broadcast_row = (BASE + timedelta(hours=1), _broadcast_payload(BASE + timedelta(hours=1)))
+    field_rows = [(BASE, _field_payload(BASE))]
+
+    ticks, _, _ = mod.replay_reducer(field_rows, [], broadcast_row)
+
+    assert len(ticks) == 1
+    assert ticks[0].broadcast_lane_present is False
+
+
+def test_reason_histogram_counts_each_category() -> None:
+    ticks = [
+        mod.ReplayTick(BASE, "top_down_override", 0.5, True, False, 1.0, True, True, True, ""),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, True, False, ""),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, True, False, ""),
+    ]
+    hist = mod.reason_histogram(ticks)
+    assert hist["top_down_override"] == 1
+    assert hist["bottom_up_salience"] == 2
+
+
+def test_find_override_examples_returns_context_window() -> None:
+    ticks = [
+        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, True, False, "a"),
+        mod.ReplayTick(BASE, "top_down_override", 0.9, True, False, 1.0, True, True, True, "override!"),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.7, True, False, 1.0, True, True, False, "c"),
+    ]
+    examples = mod.find_override_examples(ticks, context=1)
+    assert len(examples) == 1
+    assert len(examples[0]) == 3
+    assert examples[0][1].has_voluntary_override is True
+
+
+def test_find_override_examples_empty_when_no_override_present() -> None:
+    ticks = [
+        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, True, False, "a"),
+    ]
+    assert mod.find_override_examples(ticks) == []

--- a/scripts/analysis/tests/test_measure_self_state_signal_quality.py
+++ b/scripts/analysis/tests/test_measure_self_state_signal_quality.py
@@ -1,0 +1,106 @@
+"""Deterministic unit tests for measure_self_state_signal_quality.py.
+
+No DB. All pure functions operate on synthetic float series / DimensionSample
+lists, same module-loading pattern as
+scripts/analysis/tests/test_measure_origination_gate.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "measure_self_state_signal_quality.py"
+_spec = importlib.util.spec_from_file_location("measure_self_state_signal_quality", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_self_state_signal_quality"] = mod
+_spec.loader.exec_module(mod)
+
+UTC = timezone.utc
+BASE = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def test_rolling_std_zero_for_constant_series() -> None:
+    stds = mod.rolling_std([0.5] * 30, window=10)
+    assert all(s == 0.0 for s in stds)
+
+
+def test_rolling_std_nonzero_for_varying_series() -> None:
+    stds = mod.rolling_std([0.0, 1.0, 0.0, 1.0, 0.0, 1.0], window=3)
+    assert stds[-1] > 0.0
+
+
+def test_linear_drift_per_hour_detects_upward_slope() -> None:
+    # +1.0 per hour, sampled every 600s (10 min)
+    times = [i * 600.0 for i in range(7)]
+    values = [t / 3600.0 for t in times]
+    drift = mod.linear_drift_per_hour(times, values)
+    assert drift is not None
+    assert drift == pytest.approx(1.0)
+
+
+def test_linear_drift_per_hour_none_for_single_point() -> None:
+    assert mod.linear_drift_per_hour([0.0], [0.5]) is None
+
+
+def test_zero_crossing_period_estimate_flat_series_has_no_crossings() -> None:
+    period, crossings = mod.zero_crossing_period_estimate([0.5] * 20)
+    assert crossings == 0
+    assert period is None
+
+
+def test_zero_crossing_period_estimate_detects_fast_alternation() -> None:
+    series = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+    period, crossings = mod.zero_crossing_period_estimate(series)
+    assert crossings >= 2
+    assert period is not None
+    assert period <= 3.0
+
+
+def test_diagnose_dimension_flags_pinned_flat_series() -> None:
+    samples = [
+        mod.DimensionSample(generated_at=BASE + timedelta(seconds=i), score=0.5, confidence=0.9)
+        for i in range(30)
+    ]
+    diag = mod.diagnose_dimension("coherence", samples)
+    assert diag.n == 30
+    assert "pinned_or_flat" in diag.flags
+
+
+def test_diagnose_dimension_flags_fast_oscillation() -> None:
+    samples = [
+        mod.DimensionSample(
+            generated_at=BASE + timedelta(seconds=i), score=(0.9 if i % 2 == 0 else 0.1), confidence=0.9
+        )
+        for i in range(40)
+    ]
+    diag = mod.diagnose_dimension("uncertainty", samples)
+    assert "fast_oscillation_sawtooth_suspect" in diag.flags
+
+
+def test_diagnose_dimension_no_data_flag_for_empty_series() -> None:
+    diag = mod.diagnose_dimension("social_pressure", [])
+    assert diag.n == 0
+    assert diag.flags == ["no_data"]
+
+
+def test_diagnose_dimension_nominal_for_healthy_slow_varying_series() -> None:
+    # A real, non-trivial sine (amplitude 0.1, period 60 ticks) sampled over
+    # ~3.3 periods: has real noise floor (not flat), a slow oscillation
+    # period well above the fast-oscillation threshold, and near-zero net
+    # drift over the full window -- should trip none of the three
+    # heuristics.
+    samples = []
+    for i in range(200):
+        score = 0.5 + 0.1 * math.sin(2 * math.pi * i / 60.0)
+        samples.append(
+            mod.DimensionSample(generated_at=BASE + timedelta(minutes=i), score=score, confidence=0.9)
+        )
+    diag = mod.diagnose_dimension("execution_pressure", samples)
+    assert diag.flags == ["nominal"]


### PR DESCRIPTION
## Summary

- Phase 1 of `docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-roadmap-design.md`: a read-only, pure-function reducer (`reduce_attention_self_model`) that unifies the two real, previously-disconnected attention self-models — the GWT-dispatch lane (`AttentionBroadcastProjectionV1`, Lamme `voluntary_override`) and the general field lane (`FieldAttentionFrameV1` + `SelfStateV1`) — into one inspectable `AttentionSelfModelV1` artifact.
- New schema `orion/schemas/attention_self_model.py`, registered in `orion/schemas/registry.py`. Not published to any bus channel and not wired into any live decision path — measurement instrument only, per the spec's explicit Phase 1 scoping.
- Two new read-only Postgres replay scripts under `scripts/analysis/`, mirroring `measure_origination_gate.py`'s pure-replay/I/O-layer split and CLAUDE.md sec 14's background-job report contract: `measure_ast_hot_reducer.py` (the acceptance-check replay) and `measure_self_state_signal_quality.py` (the Phase 1 "hard gate" signal-quality pass).
- **Load-bearing finding, discovered while building the replay script**: `substrate_attention_broadcast_projection` is a singleton upsert table (PRIMARY KEY on `projection_id`, exactly one row, always) — not a history table. There is no per-tick history for the GWT-dispatch lane in Postgres, so the spec's acceptance check ("find a real historical `voluntary_override` tick") is **NOT MET via Postgres replay** — honestly reported, not smoothed over.
- **Hard-gate finding**: real 48h replay of `SelfStateV1` confirms the coherence/uncertainty sawtooth named in the program charter's Missing Question 4 is still live in `SelfStateV1`'s own values (median 5-tick oscillation period, 3500+ zero-crossings each over ~84k samples) — reported for Juniper's sign-off, not fixed here (explicitly out of scope).
- 30 new unit tests (reducer + both scripts' pure layers), all passing; `orion/sentience_striving_program/README.md` updated with Phase 1 status and a correction to two stale "no `SelfStateV1`" lines in Sec 9b that predated the roadmap doc's Phase 1 scope revision.

## Outcome moved

The AST/HOT consciousness-theory scaffolding gap named in the program charter (§9b items 2/4) now has a real, inspectable, unit-tested artifact instead of "nothing builds a model of that attention." Objective 3's routing math (Phase 2+) has something real to be informed by once Juniper signs off, per the roadmap doc's own gating.

## Current architecture

Before this patch: `FieldAttentionFrameV1` (Layer 5, `orion-attention-runtime`, ~2s tick) and `AttentionBroadcastProjectionV1`/`AttentionFrameV1.voluntary_override` (GWT-dispatch/Lamme lane, `orion/substrate/attention_broadcast.py`, ~30s tick) existed as two live, real, but disconnected attention self-models — nothing unified them into a single "what's salient, why, how confident" artifact. `SelfStateV1` (Layer 6) already carried `attention_schema_type`/`attention_dwell_ticks` fields but no reducer consumed the broadcast lane at all.

## Architecture touched

- `orion/schemas/` — new schema file + registry entries (read/contract layer only).
- `orion/substrate/` — new pure reducer module + its unit tests (no existing files' behavior changed).
- `scripts/analysis/` — two new standalone, read-only measurement scripts + their unit tests, following the existing `measure_origination_gate.py`/`measure_autonomy_gate.py` pattern.
- `orion/sentience_striving_program/README.md` — status + correction only, no rewrite of the roadmap spec doc itself.

No service, Docker, bus, or env surface touched.

## Files changed

- `orion/schemas/attention_self_model.py`: new `AttentionSelfModelV1` schema.
- `orion/schemas/registry.py`: registers `AttentionSelfModelV1`, `AttentionBroadcastProjectionV1`, `VoluntaryOverrideV1` (the latter two existed as real schemas but were never registered — found while wiring this patch).
- `orion/substrate/attention_self_model.py`: `reduce_attention_self_model()`, pure function, no I/O.
- `orion/substrate/tests/test_attention_self_model.py`: 13 unit tests (override present/absent, fresh/stale/future broadcast, each input `None`, predicted-shift derivation).
- `scripts/analysis/measure_ast_hot_reducer.py`: real-data replay + report/csv/progress-log, matching CLAUDE.md sec 14.
- `scripts/analysis/measure_self_state_signal_quality.py`: Phase 1 hard-gate signal-quality pass.
- `scripts/analysis/tests/test_measure_ast_hot_reducer.py`, `scripts/analysis/tests/test_measure_self_state_signal_quality.py`: 17 unit tests for both scripts' pure layers.
- `orion/sentience_striving_program/README.md`: Phase 1 status note (§6 item 2) + correction of stale "no `SelfStateV1`" constraint text (§9b items 2/4).

## Schema / bus / API changes

- Added: `AttentionSelfModelV1` (`attention.self_model.v1`), registered but **not published to any bus channel**.
- Removed: none.
- Renamed: none.
- Behavior changed: none (read-only, additive).
- Compatibility notes: `AttentionBroadcastProjectionV1`/`VoluntaryOverrideV1` were real, already-live schemas that had never been added to `orion/schemas/registry.py` — added in the same patch since this reducer imports them; no behavior change to their existing producer/consumers.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: n/a (no service touched).
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a, not needed.
- skipped keys requiring operator action: none.

## Tests run

```
source venv/bin/activate && export PYTHONPATH=<worktree>
python -m pytest orion/substrate/tests/test_attention_self_model.py scripts/analysis/tests/ -q
# 111 passed (30 new: 13 reducer + 8 ast-hot-reducer-script + 9 signal-quality-script;
# 81 pre-existing scripts/analysis + orion/substrate tests, unaffected)

python -m pytest orion/substrate/tests/ -q
# 370 passed, 8 warnings (pre-existing warnings, unrelated to this patch)
```

## Evals run

Both new scripts ARE the eval/measurement harness for this patch (per CLAUDE.md sec 11's "if the repo has no eval harness, add the smallest useful one" — these are it, following the `measure_origination_gate.py` precedent exactly). Run against real live Postgres (`postgresql://postgres:postgres@localhost:55432/conjourney`), `--window-hours 48`:

```
python scripts/analysis/measure_ast_hot_reducer.py --window-hours 48
```
Headline: 84,992 field-lane ticks replayed. `substrate_attention_broadcast_projection` confirmed live as a singleton (row count = 1). 0/84,992 ticks could be honestly joined to the single broadcast snapshot (it postdates the entire window). `attention_reason` distribution: `field_salience_only`=84,992 (100%), all others 0. **Acceptance check: NOT MET via Postgres replay** — reasoning and compensating unit-test evidence in the report; also ran a live 15-minute background poll of the broadcast projection table during this session (30s cadence, matching its real update interval) — no live `voluntary_override` observed in that window either. Full report: `/tmp/ast-hot-reducer/report.md`.

```
python scripts/analysis/measure_self_state_signal_quality.py --window-hours 48
```
Headline: 84,413 `substrate_self_state` rows replayed across all 12 real `SelfStateDimensionV1` dimensions. `coherence`: median oscillation period 5 ticks, 3,529 zero-crossings. `uncertainty`: median oscillation period 5 ticks, 3,531 zero-crossings. `transport_integrity`: median period 2 ticks, 17,572 zero-crossings (fastest of all 12). 8/12 dimensions flagged `pinned_or_flat`; 4 flagged `fast_oscillation_sawtooth_suspect`; `agency_readiness`/`execution_pressure` came back `nominal`. Full report: `/tmp/self-state-signal-quality/report.md`.

## Docker/build/smoke checks

Not applicable — no service, Dockerfile, or compose file touched. `scripts/safe_graphify_update.sh` was run per repo convention; it hit the known, pre-existing 2026-07-14 incremental-update bug (unrelated to this patch, node count dropped from 32,529 to 2,496) and correctly auto-restored `graph.json`/`manifest.json` — nothing graphify-related committed.

## Review findings fixed

- Finding: `pinned_or_flat` and `fast_oscillation_sawtooth_suspect` can co-occur on the same dimension (confirmed live for `coherence`/`uncertainty`) in a way that reads as contradictory without explanation (local rolling-std flatness vs. global zero-crossing frequency are different measurements).
  - Fix: added a "Reading `pinned_or_flat` + `fast_oscillation_sawtooth_suspect` together" paragraph to `measure_self_state_signal_quality.py`'s report renderer explaining why both can be true simultaneously (step/plateau sawtooth pattern).
  - Evidence: `scripts/analysis/measure_self_state_signal_quality.py` diff, commit `06f60c17`; re-ran `--window-hours 48` after the fix, report now includes the explanation, `coherence`/`uncertainty` numbers unchanged.
- Three additional nits noted by review (coalition_stability_score default-1.0 honesty risk one layer up in the producer, missing boundary-condition unit test for the exact staleness threshold, a cosmetic missing comment header) — reviewed and judged genuinely low-risk / out of this patch's scope; not fixed.

Full review (dispatched via `orion-repo-agent` subagent, independently verified Postgres state and re-ran tests/scripts rather than trusting prior claims): verdict **ship as-is**, no blocking or should-fix issues.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: **informational, not blocking**
  Concern: The Phase 1 acceptance check as literally written in the spec ("real historical window containing a `voluntary_override` event") cannot currently be satisfied via Postgres replay, because `substrate_attention_broadcast_projection` is a singleton upsert table with no history. The reducer's why-branching logic is proven correct via unit tests against the real `VoluntaryOverrideV1` schema, and a live 15-minute poll during this session found no override firing either — but a genuine end-to-end historical proof is currently impossible with the existing table design.
  Mitigation: Recommendation recorded in both the replay script's report and the README: if Phase 2+ (e.g. Phase 3's shadow comparison) needs real historical replay of the GWT-dispatch lane, `substrate_attention_broadcast_projection` needs an append-only companion or `AttentionBroadcastProjectionV1` needs to be published to a bus channel with retained history — a schema/bus contract change per CLAUDE.md sec 6, explicitly out of scope for this patch.

- Severity: **needs Juniper sign-off (per the spec's own hard-gate framing, not a blocker I can resolve)**
  Concern: The Phase 1 hard gate confirms the coherence/uncertainty sawtooth named in the program charter's Missing Question 4 is still live in `SelfStateV1`'s own values today (not just historically, not just at the field level) — median 5-tick oscillation period, 3,500+ zero-crossings each over 84k real samples in the last 48h.
  Mitigation: Reported plainly per the spec's own instruction ("do NOT block Phase 1 on fixing any such finding yourself... just report it clearly as a finding for Juniper's sign-off"). No `SelfStateV1` v2 attempted here. This is the concrete decision point the spec anticipated: whether `SelfStateV1` needs replacing before anything downstream of Phase 1's reducer output can be trusted.

## PR link

(populated by `gh pr create` below)