### PR TITLE
feat(fcc): isolate FCC claude subprocess from operator's personal CLAUDE.md

### DIFF
--- a/orion/fcc/context_budget.py
+++ b/orion/fcc/context_budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from typing import Any, Literal
 
 ContextRisk = Literal["ok", "warn", "critical"]
@@ -12,6 +13,7 @@ DEFAULT_MAX_CONTEXT_TOKENS = 65536
 DEFAULT_CHARS_PER_TOKEN = 4
 DEFAULT_PRESSURE_THRESHOLD_PCT = 70.0
 DEFAULT_MCP_TOOL_RESULT_MAX_CHARS = 12_000
+DEFAULT_CLAUDE_CONFIG_DIR = "~/.fcc/claude-config"
 
 CONTEXT_PRESSURE_NUDGE = (
     "Context nearly full — answer from what you have; no more tools."
@@ -76,6 +78,23 @@ def mcp_tool_result_max_chars() -> int:
     )
 
 
+def orion_fcc_claude_config_dir() -> str:
+    """Isolated CLAUDE_CONFIG_DIR for FCC's claude subprocess.
+
+    Orion's FCC turns must never inherit the operator's personal
+    ~/.claude/CLAUDE.md (or hooks/settings) -- that file is Juniper's own
+    coding-session preferences, not instructions for Orion's cognition
+    subprocess. Pointing CLAUDE_CONFIG_DIR at a dedicated Orion-owned
+    directory gives FCC its own (currently empty) CLAUDE.md/settings.json
+    instead, fully isolated from the operator's global config.
+    """
+    for key in ("HARNESS_FCC_CLAUDE_CONFIG_DIR", "HUB_AGENT_CLAUDE_CONFIG_DIR"):
+        raw = str(os.environ.get(key) or "").strip()
+        if raw:
+            return str(Path(raw).expanduser())
+    return str(Path(DEFAULT_CLAUDE_CONFIG_DIR).expanduser())
+
+
 def extend_fcc_subprocess_env(env: dict[str, str], *, workspace: str | None = None) -> None:
     """Ensure MCP stdio proxy and orion package resolve in claude subprocess."""
     roots: list[str] = []
@@ -99,6 +118,10 @@ def extend_fcc_subprocess_env(env: dict[str, str], *, workspace: str | None = No
     # Claude Code: custom ANTHROPIC_BASE_URL disables ToolSearch unless set explicitly.
     # Keep MCP attached; defer schema load until the model ToolSearches.
     env.setdefault("ENABLE_TOOL_SEARCH", "true")
+    if not env.get("CLAUDE_CONFIG_DIR"):
+        config_dir = orion_fcc_claude_config_dir()
+        Path(config_dir).mkdir(parents=True, exist_ok=True)
+        env["CLAUDE_CONFIG_DIR"] = config_dir
 
 
 def context_pressure_threshold_chars() -> int:

--- a/orion/fcc/tests/test_context_budget.py
+++ b/orion/fcc/tests/test_context_budget.py
@@ -13,6 +13,7 @@ from orion.fcc.context_budget import (
     extend_fcc_subprocess_env,
     is_context_overflow_text,
     measure_step_payload_chars,
+    orion_fcc_claude_config_dir,
 )
 from orion.fcc.mcp_stdio_proxy import _maybe_truncate_line
 
@@ -91,3 +92,42 @@ def test_extend_fcc_subprocess_env_preserves_auto_tool_search_override() -> None
     env = {"ENABLE_TOOL_SEARCH": "auto:5"}
     extend_fcc_subprocess_env(env)
     assert env["ENABLE_TOOL_SEARCH"] == "auto:5"
+
+
+def test_orion_fcc_claude_config_dir_defaults_under_dot_fcc(monkeypatch) -> None:
+    monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("HUB_AGENT_CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/home/test-user")
+    assert orion_fcc_claude_config_dir() == "/home/test-user/.fcc/claude-config"
+
+
+def test_orion_fcc_claude_config_dir_prefers_harness_env(monkeypatch) -> None:
+    monkeypatch.setenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", "/tmp/harness-claude-config")
+    monkeypatch.setenv("HUB_AGENT_CLAUDE_CONFIG_DIR", "/tmp/hub-claude-config")
+    assert orion_fcc_claude_config_dir() == "/tmp/harness-claude-config"
+
+
+def test_orion_fcc_claude_config_dir_falls_back_to_hub_env(monkeypatch) -> None:
+    monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HUB_AGENT_CLAUDE_CONFIG_DIR", "/tmp/hub-claude-config")
+    assert orion_fcc_claude_config_dir() == "/tmp/hub-claude-config"
+
+
+def test_extend_fcc_subprocess_env_sets_and_creates_claude_config_dir(monkeypatch, tmp_path) -> None:
+    config_dir = tmp_path / "claude-config"
+    monkeypatch.setenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", str(config_dir))
+    assert not config_dir.exists()
+    env: dict[str, str] = {}
+    extend_fcc_subprocess_env(env)
+    assert env["CLAUDE_CONFIG_DIR"] == str(config_dir)
+    assert config_dir.is_dir()
+
+
+def test_extend_fcc_subprocess_env_preserves_explicit_claude_config_dir_override(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", str(tmp_path / "unused"))
+    operator_dir = str(tmp_path / "operator-chosen")
+    env = {"CLAUDE_CONFIG_DIR": operator_dir}
+    extend_fcc_subprocess_env(env)
+    assert env["CLAUDE_CONFIG_DIR"] == operator_dir

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -39,6 +39,10 @@ HARNESS_FCC_SERVER_URL=http://host.docker.internal:8082
 HARNESS_FCC_WORKSPACE=/mnt/scripts/Orion-Sapienform
 HARNESS_FCC_CLAUDE_BIN=claude
 HARNESS_FCC_CLAUDE_BIN_HOST=
+# Isolated CLAUDE_CONFIG_DIR for the FCC claude subprocess -- keeps Orion's
+# cognition turns from reading the operator's personal ~/.claude/CLAUDE.md,
+# hooks, or settings.json. Set via orion.fcc.context_budget.extend_fcc_subprocess_env.
+HARNESS_FCC_CLAUDE_CONFIG_DIR=~/.fcc/claude-config
 # Absolute host path to repo root for workspace + volume mount (required when compose runs from a git worktree)
 HARNESS_REPO_MOUNT=/mnt/scripts/Orion-Sapienform
 # Orion-mode FCC MCP — secrets in ~/.fcc/.env (see config/fcc.env_example)

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -100,6 +100,12 @@ class HarnessGovernorSettings(BaseSettings):
     harness_fcc_context_mode_hooks_enabled: bool = Field(
         False, alias="HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"
     )
+    # CLAUDE_CONFIG_DIR for the FCC claude subprocess, read directly from the
+    # environment by orion.fcc.context_budget.orion_fcc_claude_config_dir;
+    # mirrored here so operators see the effective value.
+    harness_fcc_claude_config_dir: str = Field(
+        "~/.fcc/claude-config", alias="HARNESS_FCC_CLAUDE_CONFIG_DIR"
+    )
 
     # (D) embodiment: publish a deliberate approach intent on the turn correlation_id
     # after a finalized relational turn. Default-off, fail-open (never breaks a turn).

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -63,6 +63,10 @@ HUB_FCC_AUTH_TOKEN=
 HUB_AGENT_CLAUDE_BIN=claude
 # Host path: /mnt/scripts/Orion-Sapienform — Hub Docker (repo mount): /repo
 HUB_AGENT_CLAUDE_WORKSPACE=/repo
+# Isolated CLAUDE_CONFIG_DIR for the FCC claude subprocess -- keeps Orion's
+# cognition turns from reading the operator's personal ~/.claude/CLAUDE.md,
+# hooks, or settings.json. Set via orion.fcc.context_budget.extend_fcc_subprocess_env.
+HUB_AGENT_CLAUDE_CONFIG_DIR=~/.fcc/claude-config
 HUB_AGENT_CLAUDE_TIMEOUT_SEC=900
 HUB_AGENT_CLAUDE_MAX_CONCURRENT=1
 # Max bytes for one claude stream-json stdout line (tool/file payloads can be large)

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -122,6 +122,15 @@ class Settings(BaseSettings):
         default="/mnt/scripts/Orion-Sapienform",
         alias="HUB_AGENT_CLAUDE_WORKSPACE",
     )
+    HUB_AGENT_CLAUDE_CONFIG_DIR: str = Field(
+        default="~/.fcc/claude-config",
+        alias="HUB_AGENT_CLAUDE_CONFIG_DIR",
+        description=(
+            "CLAUDE_CONFIG_DIR for the FCC claude subprocess, read directly from "
+            "the environment by orion.fcc.context_budget.orion_fcc_claude_config_dir; "
+            "mirrored here so operators see the effective value."
+        ),
+    )
     HUB_AGENT_CLAUDE_TIMEOUT_SEC: float = Field(
         default=900.0,
         alias="HUB_AGENT_CLAUDE_TIMEOUT_SEC",


### PR DESCRIPTION
## Summary
- Hub Agent Claude (`services/orion-hub/scripts/fcc_claude_bridge.py`) and the harness motor (`orion/harness/fcc_motor.py`) both spawn `claude -p` for Orion's cognition turns, but never set `CLAUDE_CONFIG_DIR` — so both inherit the operator's real `~/.claude/CLAUDE.md`, hooks, and settings.json.
- Added `orion_fcc_claude_config_dir()` + wired it into the shared `extend_fcc_subprocess_env()` in `orion/fcc/context_budget.py` (already called by both spawn sites), so one patch covers both.
- FCC turns now get an isolated, dedicated `CLAUDE_CONFIG_DIR` (default `~/.fcc/claude-config`, empty until something populates it) instead of the operator's personal one.
- Overridable per-service via `HARNESS_FCC_CLAUDE_CONFIG_DIR` / `HUB_AGENT_CLAUDE_CONFIG_DIR`; left untouched if a caller already set `CLAUDE_CONFIG_DIR` explicitly.

## Outcome moved
Orion's autonomous FCC-routed `claude -p` turns no longer read Juniper's personal global CLAUDE.md (preferences, RTK setup, etc.) as system-prompt context. The repo's own project-level `CLAUDE.md`/`AGENTS.md` (discovered via cwd, unrelated to `CLAUDE_CONFIG_DIR`) is unaffected and continues to apply normally — that mechanism was investigated but not touched in this PR (see Risks below).

## Current architecture
`_build_subprocess_env()` in both `fcc_claude_bridge.py` and `fcc_motor.py` builds a per-turn env dict for the `claude` subprocess (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, context-budget vars, `ORION_FCC_SUBPROCESS` marker) and both call the shared `extend_fcc_subprocess_env()` for PYTHONPATH/MCP/context-budget env. Neither previously touched `CLAUDE_CONFIG_DIR`, so Claude Code fell back to its default `~/.claude`.

## Architecture touched
- `orion/fcc/context_budget.py`: new `orion_fcc_claude_config_dir()` + `CLAUDE_CONFIG_DIR` wiring in `extend_fcc_subprocess_env()`.
- `services/orion-harness-governor` and `services/orion-hub`: new env key + settings field each (mirrors, since the shared helper reads `os.environ` directly).

## Files changed
- `orion/fcc/context_budget.py`: added `orion_fcc_claude_config_dir()`, `DEFAULT_CLAUDE_CONFIG_DIR`, and `CLAUDE_CONFIG_DIR` env wiring (mkdir + setdefault-style guard) in `extend_fcc_subprocess_env()`.
- `orion/fcc/tests/test_context_budget.py`: 5 new tests — default resolution, harness/hub env precedence, directory creation, explicit-override preservation.
- `services/orion-harness-governor/.env_example`, `services/orion-harness-governor/app/settings.py`: `HARNESS_FCC_CLAUDE_CONFIG_DIR` key + mirrored settings field.
- `services/orion-hub/.env_example`, `services/orion-hub/app/settings.py`: `HUB_AGENT_CLAUDE_CONFIG_DIR` key + mirrored settings field.

## Schema / bus / API changes
- Added: none (no bus/schema contract touched).
- Removed: none.
- Renamed: none.
- Behavior changed: FCC's `claude -p` subprocess now reads `CLAUDE_CONFIG_DIR/CLAUDE.md` (currently nonexistent/empty) instead of `~/.claude/CLAUDE.md`.
- Compatibility notes: fully backward compatible — if an operator already sets `CLAUDE_CONFIG_DIR` explicitly in their env, this patch does not override it (checked via `if not env.get("CLAUDE_CONFIG_DIR")`).

## Env/config changes
- Added keys: `HARNESS_FCC_CLAUDE_CONFIG_DIR` (orion-harness-governor), `HUB_AGENT_CLAUDE_CONFIG_DIR` (orion-hub), both defaulting to `~/.fcc/claude-config`.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes, both services.
- local `.env` synced: yes — added directly to `services/orion-hub/.env` and `services/orion-harness-governor/.env` on this machine (both keys were brand new, no existing operator override to reconcile).
- skipped keys requiring operator action: none.

## Tests run
```text
python -m pytest orion/fcc/tests/test_context_budget.py -q            → 14 passed
python -m pytest orion/fcc/tests -q                                    → 51 passed
python -m pytest orion/harness/tests -q                                → 160 passed, 3 failed (pre-existing on main, confirmed by re-running against unpatched main — unrelated: test_grounding_capsule_consumers.py x2, test_harness_runner_surfaces_fcc_error_code)
python -m pytest services/orion-hub/tests -q                           → 936 passed, 32 failed (pre-existing on main, confirmed by re-running against unpatched main — unrelated: substrate/recall/response-feedback UI tests)
python -m pytest services/orion-harness-governor/tests -q              → 14 passed
python scripts/check_fcc_context_parity.py                             → ok
python scripts/check_service_env_compose_parity.py orion-hub           → N/A (env_file: passes all keys through)
python scripts/check_service_env_compose_parity.py orion-harness-governor → N/A (env_file: passes all keys through)
```

## Evals run
No eval harness exists for this seam; not applicable (pure env-plumbing change, covered by unit tests above).

## Docker/build/smoke checks
Not run — this is a pure Python env-wiring change with no port/health-check/dependency changes. No container image rebuild needed; only a process restart (see below).

## Review findings fixed
- Finding: `extend_fcc_subprocess_env()` created the default `~/.fcc/claude-config` directory unconditionally, even when a caller had already set an explicit `CLAUDE_CONFIG_DIR` override in the env dict — wasted I/O and a phantom empty directory every FCC turn.
  - Fix: guarded the mkdir + assignment behind `if not env.get("CLAUDE_CONFIG_DIR")`.
  - Evidence: `test_extend_fcc_subprocess_env_preserves_explicit_claude_config_dir_override` passes; re-ran full `test_context_budget.py` suite (14 passed) after the fix.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-harness-governor/.env -f services/orion-harness-governor/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: low
- Concern: The repo's own project-level `CLAUDE.md`/`AGENTS.md` (the "Orion Subagent Development Contract") is a separate, much larger file discovered via cwd — unaffected by this change, and intentionally not touched here. Juniper asked to research (not yet implement) excluding it from FCC's context too; the only documented way to skip project CLAUDE.md discovery (`--bare`) also disables hooks and MCP servers that the FCC motor depends on (agent-board no-op hook, GitHub/Firecrawl MCP), so a real fix there needs more investigation before it's safe to ship.
- Mitigation: none needed for this PR's scope; tracked as a follow-up research question.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/fcc-claude-config-dir-isolation