### PR TITLE
fix(biometrics,llm-gateway): circe expected_online stale, route label mislabeled

### DIFF
--- a/config/biometrics/node_catalog.yaml
+++ b/config/biometrics/node_catalog.yaml
@@ -43,7 +43,12 @@ nodes:
       - circe
       - circe.tail348bbe.ts.net
     role: burst_gpu
-    expected_online: false
+    # Was false: circe was intermittent/burst-only. A real llamacpp chat worker
+    # (orion-atlas-llamacpp-chat, port 8011) has been running on circe continuously
+    # for days (2026-07-18) -- expected_online=false was making pressure_organ.py
+    # suppress circe's real strain pressure as "expected staleness" instead of
+    # surfacing it (see orion/substrate/biometrics_loop/pressure_organ.py:125).
+    expected_online: true
     capabilities:
       local_llm_heavy: true
       local_llm_quick: true

--- a/services/orion-llm-gateway/.env_example
+++ b/services/orion-llm-gateway/.env_example
@@ -44,7 +44,7 @@ ATLAS_METACOG_HOST_PORT=8012
 # Deployment note: worker URLs are Tailscale/LAN-specific. Point chat+agent at your
 # local llamacpp chat worker (e.g. circe :8011); adjust IPs when copying this file.
 LLM_ROUTE_DEFAULT=quick
-LLM_GATEWAY_ROUTE_TABLE_JSON='{"chat":{"url":"http://100.112.254.99:8011","served_by":"atlas-worker-1","backend":"llamacpp"},"agent":{"url":"http://100.112.254.99:8011","served_by":"atlas-worker-1","backend":"llamacpp"},"metacog":{"url":"http://100.121.214.30:8012","served_by":"atlas-worker-2","backend":"llamacpp"},"quick":{"url":"http://100.121.214.30:8013","served_by":"atlas-worker-fast-1","backend":"llamacpp"}}'
+LLM_GATEWAY_ROUTE_TABLE_JSON='{"chat":{"url":"http://100.112.254.99:8011","served_by":"circe-worker-1","backend":"llamacpp"},"agent":{"url":"http://100.112.254.99:8011","served_by":"circe-worker-1","backend":"llamacpp"},"metacog":{"url":"http://100.121.214.30:8012","served_by":"atlas-worker-2","backend":"llamacpp"},"quick":{"url":"http://100.121.214.30:8013","served_by":"atlas-worker-fast-1","backend":"llamacpp"}}'
 # Optional future split mode:
 # LLM_GATEWAY_ROUTE_TABLE_JSON='{"chat":{"url":"http://100.121.214.30:8011","served_by":"atlas-worker-1","backend":"llamacpp"},"agent":{"url":"http://100.121.214.30:8014","served_by":"atlas-worker-agent-1","backend":"llamacpp"},"metacog":{"url":"http://100.121.214.30:8012","served_by":"atlas-worker-2","backend":"llamacpp"},"quick":{"url":"http://100.121.214.30:8013","served_by":"atlas-worker-fast-1","backend":"llamacpp"}}'
 # Legacy per-route aliases remain available for backward compatibility, but are


### PR DESCRIPTION
## Summary

- `config/biometrics/node_catalog.yaml`: `circe.expected_online` was `false`, causing `pressure_organ.py:125` (`if expected_online is False and stale: emit node_pressure_suppressed`) to actively suppress circe's real strain pressure as "expected staleness." Circe has run a real llamacpp chat worker continuously for days — flipped to `true`.
- `services/orion-llm-gateway/.env_example` + live `.env`: the chat/agent route table's `served_by` label named the circe-hosted worker (`http://100.112.254.99:8011`) `"atlas-worker-1"`. Corrected to `"circe-worker-1"`.

## Outcome moved

Live-confirmed root cause of a separate finding (Phase 1 AST/HOT attention-self-model replay, PR #1196/#1198): `substrate_attention_broadcast_projection`'s `open_loops` was ~always 0 despite real pressure existing (`atlas`/`circe` both at `pressure_score=0.8`, floor is `0.2`) — because circe's pressure was being suppressed at the source, not because no real signal existed.

## Current architecture

`orion/substrate/biometrics_loop/pressure_organ.py` gates whether node staleness is treated as a real "strain" pressure signal or suppressed, based on `NodeCatalog.resolve(node_id).expected_online` from `config/biometrics/node_catalog.yaml`. Circe was catalogued `burst_gpu`/`expected_online: false` (intermittent), which was accurate until a persistent chat worker was deployed there.

## Files changed

- `config/biometrics/node_catalog.yaml`: `circe.expected_online: false -> true`, with an inline comment explaining why and pointing at the suppression code path.
- `services/orion-llm-gateway/.env_example`: `served_by` label fixed for the `chat`/`agent` route entries pointing at circe's `:8011` worker.

## Env/config changes

- No keys added/removed/renamed — value corrections only.
- `.env_example` updated: yes.
- Local `.env` synced: yes, manually edited the live `services/orion-llm-gateway/.env` route-table value to match (same JSON blob, no key change, so `sync_local_env_from_example.py` doesn't apply here).
- Live Postgres/service restart: `orion-substrate-runtime`/`orion-biometrics` need a restart to reload `node_catalog.yaml`; `orion-llm-gateway` needs a restart to reload the corrected route table.

## Tests run

```
/mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest \
  services/orion-llm-gateway/tests/test_route_catalog.py \
  services/orion-llm-gateway/tests/test_llm_backend.py \
  tests/test_biometrics_pressure_organ.py -q
41 passed, 7 warnings in 3.71s
```

## Evals run

None applicable — config value correction, no new behavior/metric introduced.

## Review findings fixed

Self-reviewed given the trivial diff size (2 value corrections): confirmed no `LLM_ROUTE_*_SERVED_BY` matcher env var is currently set live, so the `served_by` relabel has no routing side effects today (verified via `grep` against the live `.env`); confirmed via `grep` that `test_route_catalog.py`/`test_llm_backend.py` use self-contained inline fixture JSON, not `.env_example`, so they were unaffected.

## Restart required

```bash
scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
scripts/safe_docker_build.sh orion-biometrics up -d --build
scripts/safe_docker_build.sh orion-llm-gateway up -d --build
```

## Risks / concerns

- Severity: low
- Concern: circe's `expected_online: true` now means genuine circe outages will surface as real strain pressure instead of being silently suppressed — this is the intended fix, but it does mean new visible signal (and potentially new attention-broadcast open loops) that didn't exist before.
- Mitigation: this is exactly what was broken; worth a quick live check after restart to confirm `substrate_active_node_pressure_projection`'s circe entry stops showing `suppressed_pressures: ["strain"]`.