### PR TITLE
fix(fcc): move CLAUDE_CONFIG_DIR default out of the read-only .fcc mount

### DIFF
--- a/orion/fcc/context_budget.py
+++ b/orion/fcc/context_budget.py
@@ -13,7 +13,6 @@ DEFAULT_MAX_CONTEXT_TOKENS = 65536
 DEFAULT_CHARS_PER_TOKEN = 4
 DEFAULT_PRESSURE_THRESHOLD_PCT = 70.0
 DEFAULT_MCP_TOOL_RESULT_MAX_CHARS = 12_000
-DEFAULT_CLAUDE_CONFIG_DIR = "~/.claude-fcc"
 
 CONTEXT_PRESSURE_NUDGE = (
     "Context nearly full — answer from what you have; no more tools."
@@ -78,27 +77,40 @@ def mcp_tool_result_max_chars() -> int:
     )
 
 
-def orion_fcc_claude_config_dir() -> str:
-    """Isolated CLAUDE_CONFIG_DIR for FCC's claude subprocess.
+def orion_fcc_claude_config_dir() -> str | None:
+    """Isolated CLAUDE_CONFIG_DIR for FCC's claude subprocess, or None to
+    leave CLAUDE_CONFIG_DIR untouched entirely.
 
     Orion's FCC turns must never inherit the operator's personal
     ~/.claude/CLAUDE.md (or hooks/settings) -- that file is Juniper's own
     coding-session preferences, not instructions for Orion's cognition
-    subprocess. Pointing CLAUDE_CONFIG_DIR at a dedicated Orion-owned
-    directory gives FCC its own (currently empty) CLAUDE.md/settings.json
-    instead, fully isolated from the operator's global config.
+    subprocess.
 
-    Do NOT default this under ~/.fcc: both orion-hub and
-    orion-harness-governor bind-mount ${HOME}/.fcc:/root/.fcc:ro
-    (operator secrets, read-only by design), so `claude` couldn't write
-    its own session state there from inside either container -- confirmed
-    live (mkdir/touch both fail with "Read-only file system").
+    orion-harness-governor's docker-compose.yml already isolates this for
+    free: a named volume (harness-claude-config:/root/.claude) is mounted at
+    Claude Code's own default lookup path, so leaving CLAUDE_CONFIG_DIR unset
+    there is *correct*, not an oversight -- it also keeps the operator's
+    documented plugin-install workflow (see that service's README) pointed
+    at the same volume the actual claude subprocess reads. So
+    HARNESS_FCC_CLAUDE_CONFIG_DIR is opt-in: set but empty (the operator
+    default) means "inherit, don't override" -> None. Set to a real path
+    means override.
+
+    orion-hub has no equivalent volume, so HUB_AGENT_CLAUDE_CONFIG_DIR
+    always carries a real default in its own .env_example/settings.py --
+    there is no "inherit" case for hub.
+
+    Do NOT point either override at ~/.fcc: both orion-hub and
+    orion-harness-governor bind-mount ${HOME}/.fcc:/root/.fcc:ro (operator
+    secrets, read-only by design), so `claude` couldn't write its own
+    session state there from inside either container -- confirmed live
+    (mkdir/touch both fail with "Read-only file system").
     """
-    for key in ("HARNESS_FCC_CLAUDE_CONFIG_DIR", "HUB_AGENT_CLAUDE_CONFIG_DIR"):
-        raw = str(os.environ.get(key) or "").strip()
-        if raw:
-            return str(Path(raw).expanduser())
-    return str(Path(DEFAULT_CLAUDE_CONFIG_DIR).expanduser())
+    if "HARNESS_FCC_CLAUDE_CONFIG_DIR" in os.environ:
+        raw = os.environ["HARNESS_FCC_CLAUDE_CONFIG_DIR"].strip()
+        return str(Path(raw).expanduser()) if raw else None
+    raw = str(os.environ.get("HUB_AGENT_CLAUDE_CONFIG_DIR") or "").strip()
+    return str(Path(raw).expanduser()) if raw else None
 
 
 def extend_fcc_subprocess_env(env: dict[str, str], *, workspace: str | None = None) -> None:
@@ -126,8 +138,9 @@ def extend_fcc_subprocess_env(env: dict[str, str], *, workspace: str | None = No
     env.setdefault("ENABLE_TOOL_SEARCH", "true")
     if not env.get("CLAUDE_CONFIG_DIR"):
         config_dir = orion_fcc_claude_config_dir()
-        Path(config_dir).mkdir(parents=True, exist_ok=True)
-        env["CLAUDE_CONFIG_DIR"] = config_dir
+        if config_dir:
+            Path(config_dir).mkdir(parents=True, exist_ok=True)
+            env["CLAUDE_CONFIG_DIR"] = config_dir
 
 
 def context_pressure_threshold_chars() -> int:

--- a/orion/fcc/context_budget.py
+++ b/orion/fcc/context_budget.py
@@ -13,7 +13,7 @@ DEFAULT_MAX_CONTEXT_TOKENS = 65536
 DEFAULT_CHARS_PER_TOKEN = 4
 DEFAULT_PRESSURE_THRESHOLD_PCT = 70.0
 DEFAULT_MCP_TOOL_RESULT_MAX_CHARS = 12_000
-DEFAULT_CLAUDE_CONFIG_DIR = "~/.fcc/claude-config"
+DEFAULT_CLAUDE_CONFIG_DIR = "~/.claude-fcc"
 
 CONTEXT_PRESSURE_NUDGE = (
     "Context nearly full — answer from what you have; no more tools."
@@ -87,6 +87,12 @@ def orion_fcc_claude_config_dir() -> str:
     subprocess. Pointing CLAUDE_CONFIG_DIR at a dedicated Orion-owned
     directory gives FCC its own (currently empty) CLAUDE.md/settings.json
     instead, fully isolated from the operator's global config.
+
+    Do NOT default this under ~/.fcc: both orion-hub and
+    orion-harness-governor bind-mount ${HOME}/.fcc:/root/.fcc:ro
+    (operator secrets, read-only by design), so `claude` couldn't write
+    its own session state there from inside either container -- confirmed
+    live (mkdir/touch both fail with "Read-only file system").
     """
     for key in ("HARNESS_FCC_CLAUDE_CONFIG_DIR", "HUB_AGENT_CLAUDE_CONFIG_DIR"):
         raw = str(os.environ.get(key) or "").strip()

--- a/orion/fcc/tests/test_context_budget.py
+++ b/orion/fcc/tests/test_context_budget.py
@@ -94,22 +94,22 @@ def test_extend_fcc_subprocess_env_preserves_auto_tool_search_override() -> None
     assert env["ENABLE_TOOL_SEARCH"] == "auto:5"
 
 
-def test_orion_fcc_claude_config_dir_defaults_under_dot_fcc(monkeypatch) -> None:
+def test_orion_fcc_claude_config_dir_returns_none_when_unconfigured(monkeypatch) -> None:
+    """Neither key set -> inherit whatever the deployment already provides
+    (e.g. orion-harness-governor's harness-claude-config volume at
+    /root/.claude) rather than forcing an override."""
     monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.delenv("HUB_AGENT_CLAUDE_CONFIG_DIR", raising=False)
-    monkeypatch.setenv("HOME", "/home/test-user")
-    assert orion_fcc_claude_config_dir() == "/home/test-user/.claude-fcc"
+    assert orion_fcc_claude_config_dir() is None
 
 
-def test_orion_fcc_claude_config_dir_default_is_not_nested_under_dot_fcc(monkeypatch) -> None:
-    """Regression guard: both orion-hub and orion-harness-governor bind-mount
-    ${HOME}/.fcc:/root/.fcc:ro (operator secrets). A default nested under
-    ~/.fcc would be unwritable by `claude` from inside either container --
-    confirmed live (mkdir/touch both fail with "Read-only file system")."""
-    monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
-    monkeypatch.delenv("HUB_AGENT_CLAUDE_CONFIG_DIR", raising=False)
-    monkeypatch.setenv("HOME", "/home/test-user")
-    assert "/.fcc/" not in orion_fcc_claude_config_dir()
+def test_orion_fcc_claude_config_dir_harness_set_but_empty_means_inherit(monkeypatch) -> None:
+    """orion-harness-governor's .env_example ships this key present but
+    empty by default -- an explicit "don't override" signal, distinct from
+    the key being absent entirely."""
+    monkeypatch.setenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", "")
+    monkeypatch.setenv("HUB_AGENT_CLAUDE_CONFIG_DIR", "/tmp/hub-claude-config")
+    assert orion_fcc_claude_config_dir() is None
 
 
 def test_orion_fcc_claude_config_dir_prefers_harness_env(monkeypatch) -> None:
@@ -122,6 +122,32 @@ def test_orion_fcc_claude_config_dir_falls_back_to_hub_env(monkeypatch) -> None:
     monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HUB_AGENT_CLAUDE_CONFIG_DIR", "/tmp/hub-claude-config")
     assert orion_fcc_claude_config_dir() == "/tmp/hub-claude-config"
+
+
+def test_orion_fcc_claude_config_dir_hub_default_is_not_nested_under_dot_fcc(monkeypatch) -> None:
+    """Regression guard for orion-hub's real .env_example default value:
+    both orion-hub and orion-harness-governor bind-mount
+    ${HOME}/.fcc:/root/.fcc:ro (operator secrets). A value nested under
+    ~/.fcc would be unwritable by `claude` from inside either container --
+    confirmed live (mkdir/touch both fail with "Read-only file system")."""
+    monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HUB_AGENT_CLAUDE_CONFIG_DIR", "~/.claude-fcc")
+    resolved = orion_fcc_claude_config_dir()
+    assert resolved is not None
+    assert "/.fcc/" not in resolved
+
+
+def test_extend_fcc_subprocess_env_leaves_claude_config_dir_untouched_when_unconfigured(
+    monkeypatch,
+) -> None:
+    """orion-harness-governor's real deployment: neither key configured ->
+    don't set CLAUDE_CONFIG_DIR at all, so claude falls through to its own
+    default (the harness-claude-config volume at /root/.claude)."""
+    monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("HUB_AGENT_CLAUDE_CONFIG_DIR", raising=False)
+    env: dict[str, str] = {}
+    extend_fcc_subprocess_env(env)
+    assert "CLAUDE_CONFIG_DIR" not in env
 
 
 def test_extend_fcc_subprocess_env_sets_and_creates_claude_config_dir(monkeypatch, tmp_path) -> None:

--- a/orion/fcc/tests/test_context_budget.py
+++ b/orion/fcc/tests/test_context_budget.py
@@ -98,7 +98,18 @@ def test_orion_fcc_claude_config_dir_defaults_under_dot_fcc(monkeypatch) -> None
     monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.delenv("HUB_AGENT_CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", "/home/test-user")
-    assert orion_fcc_claude_config_dir() == "/home/test-user/.fcc/claude-config"
+    assert orion_fcc_claude_config_dir() == "/home/test-user/.claude-fcc"
+
+
+def test_orion_fcc_claude_config_dir_default_is_not_nested_under_dot_fcc(monkeypatch) -> None:
+    """Regression guard: both orion-hub and orion-harness-governor bind-mount
+    ${HOME}/.fcc:/root/.fcc:ro (operator secrets). A default nested under
+    ~/.fcc would be unwritable by `claude` from inside either container --
+    confirmed live (mkdir/touch both fail with "Read-only file system")."""
+    monkeypatch.delenv("HARNESS_FCC_CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("HUB_AGENT_CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/home/test-user")
+    assert "/.fcc/" not in orion_fcc_claude_config_dir()
 
 
 def test_orion_fcc_claude_config_dir_prefers_harness_env(monkeypatch) -> None:

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -42,7 +42,13 @@ HARNESS_FCC_CLAUDE_BIN_HOST=
 # Isolated CLAUDE_CONFIG_DIR for the FCC claude subprocess -- keeps Orion's
 # cognition turns from reading the operator's personal ~/.claude/CLAUDE.md,
 # hooks, or settings.json. Set via orion.fcc.context_budget.extend_fcc_subprocess_env.
-HARNESS_FCC_CLAUDE_CONFIG_DIR=~/.fcc/claude-config
+# Do NOT point this under ~/.fcc -- that dir is bind-mounted read-only
+# (${HOME}/.fcc:/root/.fcc:ro) for operator secrets; claude can't write
+# session state there from inside the container. (Note: this container also
+# has a separate, already-isolated harness-claude-config volume at
+# /root/.claude -- see docker-compose.yml -- this env var is a distinct,
+# explicit override path for when CLAUDE_CONFIG_DIR itself needs setting.)
+HARNESS_FCC_CLAUDE_CONFIG_DIR=~/.claude-fcc
 # Absolute host path to repo root for workspace + volume mount (required when compose runs from a git worktree)
 HARNESS_REPO_MOUNT=/mnt/scripts/Orion-Sapienform
 # Orion-mode FCC MCP — secrets in ~/.fcc/.env (see config/fcc.env_example)

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -39,16 +39,17 @@ HARNESS_FCC_SERVER_URL=http://host.docker.internal:8082
 HARNESS_FCC_WORKSPACE=/mnt/scripts/Orion-Sapienform
 HARNESS_FCC_CLAUDE_BIN=claude
 HARNESS_FCC_CLAUDE_BIN_HOST=
-# Isolated CLAUDE_CONFIG_DIR for the FCC claude subprocess -- keeps Orion's
-# cognition turns from reading the operator's personal ~/.claude/CLAUDE.md,
-# hooks, or settings.json. Set via orion.fcc.context_budget.extend_fcc_subprocess_env.
-# Do NOT point this under ~/.fcc -- that dir is bind-mounted read-only
-# (${HOME}/.fcc:/root/.fcc:ro) for operator secrets; claude can't write
-# session state there from inside the container. (Note: this container also
-# has a separate, already-isolated harness-claude-config volume at
-# /root/.claude -- see docker-compose.yml -- this env var is a distinct,
-# explicit override path for when CLAUDE_CONFIG_DIR itself needs setting.)
-HARNESS_FCC_CLAUDE_CONFIG_DIR=~/.claude-fcc
+# Opt-in override for the FCC claude subprocess's CLAUDE_CONFIG_DIR. Left
+# empty by default: this container already isolates Claude Code's own
+# default config path (harness-claude-config volume mounted at /root/.claude
+# -- see docker-compose.yml), which also keeps the operator's documented
+# plugin-install workflow (README "Context Mode... plugin") pointed at the
+# same place the real claude subprocess reads. Only set this if running
+# harness-governor bare on a host (not via docker-compose), where nothing
+# redirects /root/.claude away from the operator's real ~/.claude -- and if
+# you do, never point it under ~/.fcc (bind-mounted read-only in-container
+# for operator secrets; claude couldn't write its own session state there).
+HARNESS_FCC_CLAUDE_CONFIG_DIR=
 # Absolute host path to repo root for workspace + volume mount (required when compose runs from a git worktree)
 HARNESS_REPO_MOUNT=/mnt/scripts/Orion-Sapienform
 # Orion-mode FCC MCP — secrets in ~/.fcc/.env (see config/fcc.env_example)

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -100,11 +100,14 @@ class HarnessGovernorSettings(BaseSettings):
     harness_fcc_context_mode_hooks_enabled: bool = Field(
         False, alias="HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"
     )
-    # CLAUDE_CONFIG_DIR for the FCC claude subprocess, read directly from the
-    # environment by orion.fcc.context_budget.orion_fcc_claude_config_dir;
-    # mirrored here so operators see the effective value.
+    # Opt-in CLAUDE_CONFIG_DIR override for the FCC claude subprocess, read
+    # directly from the environment by
+    # orion.fcc.context_budget.orion_fcc_claude_config_dir; mirrored here so
+    # operators see the effective value. Empty by default -- this container
+    # already isolates Claude Code's own default via the harness-claude-config
+    # volume mounted at /root/.claude (see docker-compose.yml).
     harness_fcc_claude_config_dir: str = Field(
-        "~/.claude-fcc", alias="HARNESS_FCC_CLAUDE_CONFIG_DIR"
+        "", alias="HARNESS_FCC_CLAUDE_CONFIG_DIR"
     )
 
     # (D) embodiment: publish a deliberate approach intent on the turn correlation_id

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -104,7 +104,7 @@ class HarnessGovernorSettings(BaseSettings):
     # environment by orion.fcc.context_budget.orion_fcc_claude_config_dir;
     # mirrored here so operators see the effective value.
     harness_fcc_claude_config_dir: str = Field(
-        "~/.fcc/claude-config", alias="HARNESS_FCC_CLAUDE_CONFIG_DIR"
+        "~/.claude-fcc", alias="HARNESS_FCC_CLAUDE_CONFIG_DIR"
     )
 
     # (D) embodiment: publish a deliberate approach intent on the turn correlation_id

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -66,7 +66,10 @@ HUB_AGENT_CLAUDE_WORKSPACE=/repo
 # Isolated CLAUDE_CONFIG_DIR for the FCC claude subprocess -- keeps Orion's
 # cognition turns from reading the operator's personal ~/.claude/CLAUDE.md,
 # hooks, or settings.json. Set via orion.fcc.context_budget.extend_fcc_subprocess_env.
-HUB_AGENT_CLAUDE_CONFIG_DIR=~/.fcc/claude-config
+# Do NOT point this under ~/.fcc -- that dir is bind-mounted read-only
+# (${HOME}/.fcc:/root/.fcc:ro) for operator secrets; claude can't write
+# session state there from inside the container.
+HUB_AGENT_CLAUDE_CONFIG_DIR=~/.claude-fcc
 HUB_AGENT_CLAUDE_TIMEOUT_SEC=900
 HUB_AGENT_CLAUDE_MAX_CONCURRENT=1
 # Max bytes for one claude stream-json stdout line (tool/file payloads can be large)

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -123,7 +123,7 @@ class Settings(BaseSettings):
         alias="HUB_AGENT_CLAUDE_WORKSPACE",
     )
     HUB_AGENT_CLAUDE_CONFIG_DIR: str = Field(
-        default="~/.fcc/claude-config",
+        default="~/.claude-fcc",
         alias="HUB_AGENT_CLAUDE_CONFIG_DIR",
         description=(
             "CLAUDE_CONFIG_DIR for the FCC claude subprocess, read directly from "


### PR DESCRIPTION
## Summary
- **Commit 1:** PR #1200's default (`~/.fcc/claude-config`) nested the isolated `CLAUDE_CONFIG_DIR` inside `${HOME}/.fcc`, which both `orion-hub` and `orion-harness-governor` bind-mount **read-only** (`:ro`) for operator secrets. Live-verified: `mkdir`/`touch` under `/root/.fcc` fail with `Read-only file system` from inside both running containers. Fixed by moving the default to `~/.claude-fcc` (outside `.fcc` entirely).
- **Commit 2 (Juniper caught this):** `orion-harness-governor`'s docker-compose.yml already has a proper, persistent isolation mechanism for this exact purpose — a named volume `harness-claude-config:/root/.claude`, which is Claude Code's own default lookup path when `CLAUDE_CONFIG_DIR` is unset. Documented in that service's README as the target for an operator plugin-install workflow (`claude plugin install context-mode@context-mode`). Commit 1's unconditional override silently redirected the FCC subprocess away from that volume to a new, non-persistent path — orphaning the documented plugin workflow. Fixed: `orion_fcc_claude_config_dir()` now returns `None` ("don't touch `CLAUDE_CONFIG_DIR`, inherit whatever the deployment already provides") when neither override key is configured; `HARNESS_FCC_CLAUDE_CONFIG_DIR` now ships empty by default (opt-in only). `orion-hub` has no equivalent volume, so its override is unchanged and still active by default.

## Outcome moved
`orion-harness-governor`'s FCC turns now reuse the existing, working, persistent `harness-claude-config` volume instead of a competing, ephemeral, newly-invented path — no orphaned plugin-install workflow, no second "isolated Claude config" location for future agents to trip on. `orion-hub` (which has no equivalent volume) still gets active isolation via its own override, unaffected by this change.

## Current architecture
See PR #1200 for the original context_budget.py wiring this iterates on.

## Architecture touched
Same files as before: `orion/fcc/context_budget.py` (shared helper — `orion_fcc_claude_config_dir()` return type changed to `str | None`), `services/orion-harness-governor` `.env_example`/`settings.py` (opt-in empty default). `orion-hub` untouched in this commit.

## Files changed
- `orion/fcc/context_budget.py`: removed the unconditional `DEFAULT_CLAUDE_CONFIG_DIR` fallback; `orion_fcc_claude_config_dir()` now returns `None` when unconfigured (harness key present-but-empty is a distinct "inherit" signal from key-absent, both resolve to `None`); `extend_fcc_subprocess_env()` skips setting `CLAUDE_CONFIG_DIR` entirely when the resolved value is `None`.
- `orion/fcc/tests/test_context_budget.py`: replaced the old default-path tests with tests for the new None/inherit semantics; kept a regression guard (now against `orion-hub`'s real default value) asserting it's never nested under `/.fcc/`.
- `services/orion-harness-governor/.env_example`, `services/orion-harness-governor/app/settings.py`: default flipped from an active override to empty/opt-in, with a comment explaining why (existing volume already isolates this).

## Schema / bus / API changes
None.

## Env/config changes
- Added keys: none (same keys as #1200's original commit).
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes — `orion-harness-governor`'s key now defaults empty.
- local `.env` synced: **NOT YET, intentionally.** The currently-deployed container still runs commit 1's code, which would treat an empty override as "fall through to the old buggy internal default" (read-only path) — flipping the live value now would reintroduce the crash before this fix is actually deployed. **After merging and redeploying this PR**, flip `HARNESS_FCC_CLAUDE_CONFIG_DIR` to empty in `services/orion-harness-governor/.env` (currently still `~/.claude-fcc`, which remains correct/safe under both the old and new code, just no longer necessary once this ships).
- skipped keys requiring operator action: `HARNESS_FCC_CLAUDE_CONFIG_DIR` live `.env` value — see above.

## Tests run
```text
python -m pytest orion/fcc/tests -q                                                              → 54 passed
python -m pytest orion/harness/tests services/orion-hub/tests/test_fcc_claude_bridge_*.py services/orion-harness-governor/tests -q
  → 189 passed, 3 failed (pre-existing on main, confirmed by re-running against unpatched main in the prior commit's testing — unrelated: test_grounding_capsule_consumers.py x2, test_harness_runner_surfaces_fcc_error_code)
```

## Evals run
No eval harness for this seam; not applicable.

## Docker/build/smoke checks
Not re-run in this commit (no container-affecting change beyond the env default; the actual writability of the fallback path was already live-verified in commit 1).

## Review findings fixed
Self-reviewed: grepped for all callers of `orion_fcc_claude_config_dir()` to confirm the `str -> str | None` return-type change has no other consumers besides `context_budget.py` itself and its tests (settings.py mentions are comments, not calls) — confirmed safe.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-harness-governor/.env -f services/orion-harness-governor/docker-compose.yml up -d --build
```
Then flip `HARNESS_FCC_CLAUDE_CONFIG_DIR=` (empty) in `services/orion-harness-governor/.env` and restart that service again, per the note above.

## Risks / concerns
- Severity: low
- Concern: the live `.env` value for `HARNESS_FCC_CLAUDE_CONFIG_DIR` is intentionally left as `~/.claude-fcc` (not yet empty) until this PR is actually deployed, to avoid a live mismatch window. Easy to forget the follow-up flip.
- Mitigation: flagged explicitly here and in memory; leaving it as `~/.claude-fcc` post-deploy is harmless (just redundantly overrides an already-correct default with another writable, if non-persistent, path) — not urgent, just tidy-up.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/1202