### PR TITLE
feat(fcc): skip project-level CLAUDE.md/hooks on FCC claude turns

### DIFF
--- a/orion/fcc/claude_spawn.py
+++ b/orion/fcc/claude_spawn.py
@@ -67,3 +67,31 @@ def auto_approve_from_env(env_key: str | None = None) -> bool:
     if os.geteuid() == 0:
         return True
     return True
+
+
+def setting_sources_argv(env_key: str) -> List[str]:
+    """--setting-sources for FCC's claude subprocess: skip the repo's
+    project-level CLAUDE.md/settings.json/hooks by default.
+
+    Orion's FCC turns don't need the repo's own AGENTS.md development
+    contract (written for a coding agent editing this repo, not a headless
+    cognition turn) or the project-level hooks that come with it -- and
+    dropping them isn't a safety regression: both orion-hub and
+    orion-harness-governor bind-mount the repo read-only, so the
+    destructive_git_guard hook this also drops has nothing left to protect
+    that the read-only mount doesn't already block. MCP tool access is
+    unaffected either way -- it's pre-approved via explicit
+    --mcp-config/--allowedTools argv (extend_mcp_argv), never through
+    settings.json, so --setting-sources has no bearing on it.
+
+    Confirmed live: a `claude -p` call from a directory with a marker
+    CLAUDE.md echoed the marker with default sources, returned nothing
+    with `--setting-sources user,local`.
+
+    Set the env key to empty to fall back to Claude Code's normal default
+    (all three scopes: user, project, local).
+    """
+    raw = (os.environ[env_key] if env_key in os.environ else "user,local").strip()
+    if not raw:
+        return []
+    return ["--setting-sources", raw]

--- a/orion/fcc/tests/test_claude_spawn.py
+++ b/orion/fcc/tests/test_claude_spawn.py
@@ -124,3 +124,33 @@ def test_claude_permission_argv_non_root_uses_skip(monkeypatch: pytest.MonkeyPat
     assert claude_spawn.claude_permission_argv(auto_approve=True) == [
         "--dangerously-skip-permissions",
     ]
+
+
+def test_setting_sources_argv_defaults_to_user_local_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HARNESS_FCC_SETTING_SOURCES", raising=False)
+    assert claude_spawn.setting_sources_argv("HARNESS_FCC_SETTING_SOURCES") == [
+        "--setting-sources",
+        "user,local",
+    ]
+
+
+def test_setting_sources_argv_respects_explicit_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HARNESS_FCC_SETTING_SOURCES", "user,project,local")
+    assert claude_spawn.setting_sources_argv("HARNESS_FCC_SETTING_SOURCES") == [
+        "--setting-sources",
+        "user,project,local",
+    ]
+
+
+def test_setting_sources_argv_explicit_empty_means_no_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Present-but-empty is a deliberate opt-out, distinct from unset --
+    falls back to Claude Code's own default (all three scopes) instead of
+    forcing --setting-sources at all."""
+    monkeypatch.setenv("HARNESS_FCC_SETTING_SOURCES", "")
+    assert claude_spawn.setting_sources_argv("HARNESS_FCC_SETTING_SOURCES") == []

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -12,7 +12,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
-from orion.fcc.claude_spawn import claude_permission_argv, extend_mcp_argv
+from orion.fcc.claude_spawn import claude_permission_argv, extend_mcp_argv, setting_sources_argv
 from orion.fcc.context_budget import (
     annotate_harness_step,
     apply_context_overflow_hint,
@@ -498,6 +498,7 @@ async def run_fcc_turn(
         "--model",
         model_id,
     ]
+    argv.extend(setting_sources_argv("HARNESS_FCC_SETTING_SOURCES"))
     if mcp_config_path is not None:
         extra_allowed_tools: Optional[List[str]] = None
         if _env_truthy("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"):

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -335,6 +335,8 @@ async def test_run_fcc_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.Mon
     assert captured_argv[idx + 2] == "mcp__firecrawl"
     dis_idx = captured_argv.index("--disallowedTools")
     assert captured_argv[dis_idx + 1] == "Bash(gh *)"
+    ss_idx = captured_argv.index("--setting-sources")
+    assert captured_argv[ss_idx + 1] == "user,local"
 
 
 @pytest.mark.asyncio

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -50,6 +50,17 @@ HARNESS_FCC_CLAUDE_BIN_HOST=
 # you do, never point it under ~/.fcc (bind-mounted read-only in-container
 # for operator secrets; claude couldn't write its own session state there).
 HARNESS_FCC_CLAUDE_CONFIG_DIR=
+# --setting-sources passed to the FCC claude subprocess. Default (user,local)
+# skips the repo's own project-level CLAUDE.md/AGENTS.md + project-level
+# hooks/permissions (.claude/settings.json) -- that file is a coding-agent
+# development contract, not instructions for a headless cognition turn, and
+# dropping it is not a safety regression here: the repo is bind-mounted
+# read-only in this container, so the destructive_git_guard hook this also
+# drops has nothing left to protect that the mount doesn't already block.
+# MCP tool access is unaffected either way (pre-approved via --mcp-config/
+# --allowedTools argv, not settings.json). Set empty to fall back to Claude
+# Code's normal default (all three scopes: user, project, local).
+HARNESS_FCC_SETTING_SOURCES=user,local
 # Absolute host path to repo root for workspace + volume mount (required when compose runs from a git worktree)
 HARNESS_REPO_MOUNT=/mnt/scripts/Orion-Sapienform
 # Orion-mode FCC MCP — secrets in ~/.fcc/.env (see config/fcc.env_example)

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -109,6 +109,14 @@ class HarnessGovernorSettings(BaseSettings):
     harness_fcc_claude_config_dir: str = Field(
         "", alias="HARNESS_FCC_CLAUDE_CONFIG_DIR"
     )
+    # --setting-sources for the FCC claude subprocess, read directly from the
+    # environment by orion.fcc.claude_spawn.setting_sources_argv; mirrored
+    # here so operators see the effective value. Default skips the repo's
+    # own project-level CLAUDE.md/hooks (not needed for a headless cognition
+    # turn, not a safety regression since the repo mount here is read-only).
+    harness_fcc_setting_sources: str = Field(
+        "user,local", alias="HARNESS_FCC_SETTING_SOURCES"
+    )
 
     # (D) embodiment: publish a deliberate approach intent on the turn correlation_id
     # after a finalized relational turn. Default-off, fail-open (never breaks a turn).

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -70,6 +70,17 @@ HUB_AGENT_CLAUDE_WORKSPACE=/repo
 # (${HOME}/.fcc:/root/.fcc:ro) for operator secrets; claude can't write
 # session state there from inside the container.
 HUB_AGENT_CLAUDE_CONFIG_DIR=~/.claude-fcc
+# --setting-sources passed to the FCC claude subprocess. Default (user,local)
+# skips the repo's own project-level CLAUDE.md/AGENTS.md + project-level
+# hooks/permissions (.claude/settings.json) -- that file is a coding-agent
+# development contract, not instructions for a headless cognition turn, and
+# dropping it is not a safety regression here: the repo is bind-mounted
+# read-only in this container, so the destructive_git_guard hook this also
+# drops has nothing left to protect that the mount doesn't already block.
+# MCP tool access is unaffected either way (pre-approved via --mcp-config/
+# --allowedTools argv, not settings.json). Set empty to fall back to Claude
+# Code's normal default (all three scopes: user, project, local).
+HUB_AGENT_CLAUDE_SETTING_SOURCES=user,local
 HUB_AGENT_CLAUDE_TIMEOUT_SEC=900
 HUB_AGENT_CLAUDE_MAX_CONCURRENT=1
 # Max bytes for one claude stream-json stdout line (tool/file payloads can be large)

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -131,6 +131,18 @@ class Settings(BaseSettings):
             "mirrored here so operators see the effective value."
         ),
     )
+    HUB_AGENT_CLAUDE_SETTING_SOURCES: str = Field(
+        default="user,local",
+        alias="HUB_AGENT_CLAUDE_SETTING_SOURCES",
+        description=(
+            "--setting-sources for the FCC claude subprocess, read directly from "
+            "the environment by orion.fcc.claude_spawn.setting_sources_argv; "
+            "mirrored here so operators see the effective value. Default skips "
+            "the repo's own project-level CLAUDE.md/hooks (not needed for a "
+            "headless cognition turn, not a safety regression since the repo "
+            "mount here is read-only)."
+        ),
+    )
     HUB_AGENT_CLAUDE_TIMEOUT_SEC: float = Field(
         default=900.0,
         alias="HUB_AGENT_CLAUDE_TIMEOUT_SEC",

--- a/services/orion-hub/scripts/fcc_claude_bridge.py
+++ b/services/orion-hub/scripts/fcc_claude_bridge.py
@@ -13,7 +13,12 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
 from scripts.fcc_env_catalog import load_fcc_env, resolve_auth_token
 from scripts.fcc_model_mapping import DEFAULT_FCC_MODEL_LABEL, label_to_claude_model_id
-from orion.fcc.claude_spawn import auto_approve_from_env, claude_permission_argv, extend_mcp_argv
+from orion.fcc.claude_spawn import (
+    auto_approve_from_env,
+    claude_permission_argv,
+    extend_mcp_argv,
+    setting_sources_argv,
+)
 from orion.fcc.context_budget import (
     annotate_harness_step,
     apply_context_overflow_hint,
@@ -332,6 +337,7 @@ async def run_turn(
         "--model",
         model_id,
     ]
+    argv.extend(setting_sources_argv("HUB_AGENT_CLAUDE_SETTING_SOURCES"))
     if mcp_config_path is not None:
         extend_mcp_argv(argv, mcp_config_path)
     perm = claude_permission_argv(

--- a/services/orion-hub/tests/test_fcc_claude_bridge_mcp.py
+++ b/services/orion-hub/tests/test_fcc_claude_bridge_mcp.py
@@ -84,6 +84,8 @@ async def test_run_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.MonkeyP
     assert captured_argv[idx + 2] == "mcp__firecrawl"
     dis_idx = captured_argv.index("--disallowedTools")
     assert captured_argv[dis_idx + 1] == "Bash(gh *)"
+    ss_idx = captured_argv.index("--setting-sources")
+    assert captured_argv[ss_idx + 1] == "user,local"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Orion's FCC subprocess (Hub Agent Claude + harness motor) still read the repo's own project-level `CLAUDE.md`/`AGENTS.md` via normal cwd-based discovery, unaffected by the earlier `CLAUDE_CONFIG_DIR` isolation work (PRs #1200, #1202), which only touches the user-level file.
- That contract is written for a coding agent editing this repo (worktree rules, PR-report templates, env-parity gates, etc.), not a headless cognition turn, and it's a lot of tokens to burn every turn against FCC's deliberately small local-model context ceiling (65536-131072 tokens).
- Added `setting_sources_argv()` to `orion/fcc/claude_spawn.py` (the shared argv-helpers module both bridges already import from — same module as `claude_permission_argv`/`extend_mcp_argv`) and wired it into both spawn sites: `--setting-sources user,local`, dropping only the `project` scope.

## Outcome moved
FCC turns no longer load the project's own development contract or its four project-level hooks (SessionStart worktree-summary + agent-board, Stop agent-board, PreToolUse graphify-nudge + destructive-git-guard) — freeing up real context budget and cutting per-turn hook overhead that was never meaningful for a headless turn in the first place (the agent-board hooks were already no-op'ing themselves via `ORION_FCC_SUBPROCESS`, just after paying the cost of firing).

## Current architecture
See PRs #1200/#1202 for the `CLAUDE_CONFIG_DIR` isolation this is complementary to (that one handles the *user*-level file; this handles the *project*-level one via a different mechanism, since `CLAUDE_CONFIG_DIR` has no effect on project-level discovery).

## Architecture touched
`orion/fcc/claude_spawn.py` (shared helper), `services/orion-hub/scripts/fcc_claude_bridge.py`, `orion/harness/fcc_motor.py` (both argv builders), `.env_example`/`settings.py` for both services.

## Files changed
- `orion/fcc/claude_spawn.py`: new `setting_sources_argv(env_key)` — returns `["--setting-sources", <value>]`, defaulting to `user,local` when the env key is unset; present-but-empty is a deliberate opt-out (falls back to Claude Code's normal default, all three scopes).
- `orion/fcc/tests/test_claude_spawn.py`: 3 new tests (default, explicit override, explicit-empty opt-out).
- `services/orion-hub/scripts/fcc_claude_bridge.py`, `orion/harness/fcc_motor.py`: import + wire `setting_sources_argv()` into the base argv list, before MCP/permission argv extension.
- `orion/harness/tests/test_fcc_motor_mcp.py`, `services/orion-hub/tests/test_fcc_claude_bridge_mcp.py`: added `--setting-sources`/`user,local` assertions to the existing MCP-argv happy-path tests (confirms the wiring, not just the helper).
- `services/orion-harness-governor/.env_example`, `services/orion-harness-governor/app/settings.py`: new `HARNESS_FCC_SETTING_SOURCES` key, default `user,local`.
- `services/orion-hub/.env_example`, `services/orion-hub/app/settings.py`: new `HUB_AGENT_CLAUDE_SETTING_SOURCES` key, default `user,local`.

## Schema / bus / API changes
None.

## Env/config changes
- Added keys: `HARNESS_FCC_SETTING_SOURCES` (orion-harness-governor), `HUB_AGENT_CLAUDE_SETTING_SOURCES` (orion-hub), both defaulting to `user,local`.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes, both services.
- local `.env` synced: yes — added directly to both live `.env` files on this machine. Safe to sync immediately (unlike the #1202 `CLAUDE_CONFIG_DIR` case): these are brand-new keys the currently-deployed code doesn't look for at all, so their presence is inert until this PR's code actually deploys — no version-mismatch window.
- skipped keys requiring operator action: none.

## Tests run
```text
python -m pytest orion/fcc/tests -q                                    → 57 passed
python -m pytest orion/harness/tests -q                                 → 160 passed, 3 failed (pre-existing on main, same 3 confirmed unrelated across every round of this thread: test_grounding_capsule_consumers.py x2, test_harness_runner_surfaces_fcc_error_code)
python -m pytest services/orion-hub/tests/test_fcc_claude_bridge_mcp.py services/orion-hub/tests/test_fcc_claude_bridge_run.py services/orion-hub/tests/test_fcc_claude_bridge_parse.py -q → 15 passed
```

## Evals run
No eval harness for this seam; not applicable.

## Docker/build/smoke checks
Not run (pure Python argv-construction change, no container config/port/dependency changes). Live-verified the underlying CLI mechanism directly instead (see below) — stronger evidence than a container smoke would give for this specific claim.

Live probes run directly against the `claude` binary (not through Docker, but through the exact mechanism the code now invokes):
```text
# Confirms --setting-sources genuinely gates project-level CLAUDE.md:
default sources            → marker echoed ("kumquat-trombone-4471")
--setting-sources user,local → NONE

# Confirms "user" scope is symmetrically preserved/dropped (basis for trusting
# orion-harness-governor's live HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=true
# plugin, installed at user scope, survives this change):
--setting-sources user,local    → user-scope marker echoed ("walnut-cascade-7734")
--setting-sources project,local → NONE
```

## Review findings fixed
Self-reviewed given the small diff (113 insertions across 10 files, mostly docs/tests): traced all `claude_bin`-spawning call sites in the repo to confirm only two production spawn points exist (`fcc_claude_bridge.py`, `fcc_motor.py`; `orion/harness/runner.py` only calls into `fcc_motor.run_fcc_turn`, doesn't build its own argv) — both now covered. Confirmed `scripts/context_mode_hooks_smoke.py` (a third `claude_bin` spawn site) is a standalone diagnostic script whose entire purpose is verifying hook/plugin behavior — correctly left untouched, since applying this flag there would be self-defeating for what it's testing.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-harness-governor/.env -f services/orion-harness-governor/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: low
- Concern: this was validated by directly invoking the `claude` CLI with representative marker files/scratch config dirs, not by installing the real Context Mode plugin end-to-end and confirming its hooks still fire under `--setting-sources user,local` in the live harness-governor container. The "user" scope symmetry test is strong indirect evidence but not a 1:1 replacement for that specific live check.
- Mitigation: none applied preemptively; if Context Mode's plugin behavior looks off after this deploys, `HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED`'s smoke script (`scripts/context_mode_hooks_smoke.py`) already exists as a targeted diagnostic — run it post-deploy to confirm directly, or set `HARNESS_FCC_SETTING_SOURCES=` (empty) as an instant rollback for that one service without touching code.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/fcc-skip-project-claude-md