### PR TITLE
feat(substrate): promote contributing_turn_ids to durable Falkor property + wire two consumers

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-18-prediction-error-attribution-wiring-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-18-prediction-error-attribution-wiring-pr.md
@@ -1,0 +1,258 @@
+# Prediction-error attribution wiring — durable `contributing_turn_ids` + two consumers
+
+## Summary
+
+- Closed the durability gap PR #1205 disclosed: `orion/substrate/falkor_codec.py`'s
+  `DYNAMICS_METADATA_KEYS` allowlist silently dropped `metadata['contributing_turn_ids']`
+  on every durable FalkorDB round trip. Promoted it to a native Cypher property
+  (`contributing_turn_ids_json`, same `_json_list()`/`_parse_json_list()` JSON-string
+  pattern as `taxonomy_path_json`/`evidence_refs_json`).
+- Decode is fail-open on malformed/missing/wrong-shape values (unlike `evidence_refs_json`,
+  which intentionally raises — that field is load-bearing identity data, this one is
+  best-effort attribution).
+- Wired the now-durable list into two real consumers, satisfying the codec's own
+  "promote only with a second consumer" rule:
+  - `orion/substrate/attention_broadcast.py::substrate_pressure_signals()` — appends
+    `contributing_turn_ids` onto `AttentionSignalV1.evidence_refs`.
+  - `orion/substrate/attention_self_model.py::reduce_attention_self_model()` — new optional
+    `harness_closure_signal` kwarg enriches the `field_salience_only` branch's
+    `reason_narrative` with a sustained-surprise clause; every other branch and every
+    existing caller is untouched (regression test proves byte-identical narrative when
+    omitted).
+- Design doc, PR report, and README status notes (per Juniper's explicit ask for both, sent
+  mid-task) recording the decision: why the promotion is justified now, why there is zero
+  `goal.drive_origin`/`GoalProposalEngine` coupling (checked against the full charter), and
+  why the enrichment is scoped to `field_salience_only` only.
+- `DYNAMICS_ENGINE_OWNED_METADATA_KEYS`, the 20-entry cap, and
+  `_write_prediction_error_node()`'s carry-forward/dedup logic are all unchanged — this
+  patch only makes the already-produced list durable and consumable.
+
+## Outcome moved
+
+The harness-closure prediction-error node's per-turn attribution (`contributing_turn_ids`)
+now survives a `SubstrateDynamicsEngine.tick()`-triggered cache rebuild instead of silently
+vanishing, and two real, already-shipped surfaces (`AttentionSignalV1.evidence_refs`, the
+AST/HOT reducer's narrative) can now actually read it — closing the gap between "produced"
+and "consumable" that PR #1205 explicitly disclosed and deferred.
+
+## Current architecture
+
+Before this patch: `_write_prediction_error_node()` (`services/orion-substrate-runtime/app/
+worker.py`) wrote `metadata['contributing_turn_ids']` in-process, but `falkor_codec.py`'s
+closed 5-key `DYNAMICS_METADATA_KEYS` allowlist had no slot for it, so the value was dropped
+on every durable Falkor round trip. Zero consumers existed downstream of the in-process
+write, since nothing durable could have fed one anyway.
+
+## Architecture touched
+
+- `orion/substrate/falkor_codec.py` — allowlist + encode/decode (contract layer).
+- `orion/substrate/attention_broadcast.py` — one consumer (`evidence_refs`).
+- `orion/substrate/attention_self_model.py` — one consumer (reducer narrative).
+- `orion/sentience_striving_program/README.md`, `services/orion-substrate-runtime/README.md`
+  — status/documentation only, no behavior change.
+- No service, Docker, bus, or env surface touched. No new schema fields.
+
+## Files changed
+
+- `orion/substrate/falkor_codec.py`: `DYNAMICS_METADATA_KEYS` gains `contributing_turn_ids`
+  (6th entry, was 5); `_dynamics_properties_from_metadata()` encodes
+  `contributing_turn_ids_json`; `_dynamics_metadata_from_row()` decodes it fail-open,
+  omitting the key when absent/empty/malformed.
+- `orion/substrate/tests/test_falkor_codec.py`: dict-equality fixtures updated for the new
+  always-present `contributing_turn_ids_json` key; 6 new tests (encode, decode, round-trip,
+  empty-omitted, missing-key, malformed-JSON, wrong-shape-JSON).
+- `orion/substrate/attention_broadcast.py`: `substrate_pressure_signals()` appends
+  `contributing_turn_ids` (stringified) onto `evidence_refs`.
+- `orion/substrate/tests/test_attention_broadcast.py`: 2 new tests (present/absent).
+- `orion/substrate/attention_self_model.py`: `reduce_attention_self_model()` gains
+  `harness_closure_signal: dict | None = None`; `field_salience_only` branch appends a
+  narrative clause when `prediction_error > 0.0` and `contributing_turn_ids` is non-empty.
+- `orion/substrate/tests/test_attention_self_model.py`: new `TestHarnessClosureSignal` class,
+  5 tests (enrichment, byte-identical-when-omitted regression, zero-error non-enrichment,
+  empty-turns non-enrichment, branch-isolation).
+- `docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md`: new
+  design-mode doc, the decision record for this patch.
+- `orion/sentience_striving_program/README.md`: status notes under §6 item 2 and §9b
+  items 2/3, dated 2026-07-18.
+- `services/orion-substrate-runtime/README.md`: documents `_write_prediction_error_node`'s
+  fixed-node-id + `contributing_turn_ids` mechanism and this patch's durability/consumer
+  wiring, under the existing "Unified turn bus listeners" section.
+- `docs/superpowers/pr-reports/2026-07-18-prediction-error-attribution-wiring-pr.md`: this
+  report.
+
+`orion/substrate/README.md` does not exist in this repo — checked, not invented.
+
+## Schema / bus / API changes
+
+- Added: `contributing_turn_ids_json` native Cypher property (concept nodes,
+  `falkor_codec.py`); `reduce_attention_self_model(..., harness_closure_signal: dict | None
+  = None)` optional keyword-only parameter.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `AttentionSignalV1.evidence_refs` for substrate-pressure signals now
+  includes contributing-turn ids when present on the source node (previously node-id-only).
+  `AttentionSelfModelV1.reason_narrative`'s `field_salience_only` text gains a clause only
+  when a caller explicitly supplies `harness_closure_signal` with non-trivial data — no
+  existing caller does yet, so no live output changes until a future patch wires the caller.
+- Compatibility notes: `DYNAMICS_METADATA_KEYS` growing by one key is additive and backward
+  compatible — existing rows without `contributing_turn_ids_json` decode with the key simply
+  absent from `metadata` (verified by a dedicated missing-key test). No `AttentionSelfModelV1`
+  schema field added; `reason_narrative: str` already covers the new clause.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: n/a (no service touched).
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a, not needed.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/substrate/tests -q
+→ 381 passed, 17 warnings (pre-existing warnings, unrelated to this patch)
+
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest scripts/analysis/tests/test_measure_ast_hot_reducer.py -q
+→ 8 passed
+
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py -q
+→ 14 passed, 1 failed (test_write_prediction_error_node_preserves_dynamics_state_on_rewrite)
+   Confirmed pre-existing and unrelated to this patch: stashed all changes, re-ran against
+   unmodified origin/main HEAD (commit c214033e), same test fails identically. Not touched
+   by this patch (DYNAMICS_ENGINE_OWNED_METADATA_KEYS is unchanged). Matches PR #1205's own
+   report, which found "16 failed (pre-existing, confirmed identical on unmodified main via
+   stash-and-rerun)" in this same test directory.
+```
+
+## Evals run
+
+No dedicated eval harness exists for `orion/substrate/` beyond
+`scripts/analysis/measure_ast_hot_reducer.py` (a real-data replay script, run below in lieu
+of a formal eval). Per CLAUDE.md §11, the touched-service eval gap for `orion/substrate/`
+generally is a known, standing gap (not introduced by this patch) — the module's own unit
+test suite (381 tests) is the primary coverage.
+
+## Docker/build/smoke checks
+
+Not applicable at code-review time — no service, Dockerfile, or compose file touched.
+`scripts/safe_graphify_update.sh` run after edits (see below).
+
+**Live-data check (manual, in lieu of wiring FalkorDB reads into the Postgres-only
+`measure_ast_hot_reducer.py` replay script — judged disproportionate for this patch, per the
+task's own explicit escape hatch):**
+
+```bash
+redis-cli -p 6380 GRAPH.LIST
+# graphiti_temporal, orion_substrate, orion_recall
+
+redis-cli -p 6380 GRAPH.QUERY orion_substrate \
+  "MATCH (n {node_id: 'node:substrate.harness_closure'}) RETURN n.node_id, n.dynamic_pressure, ..."
+# empty result -- node does not exist yet
+
+redis-cli -p 6380 GRAPH.QUERY orion_substrate \
+  "MATCH (n) WHERE n.node_id CONTAINS 'harness_closure' RETURN n.node_id, labels(n)"
+# harness_closure:<uuid> x3 -- pre-#1205 legacy per-event nodes, not the new shared node
+
+docker inspect orion-athena-substrate-runtime --format '{{.Created}}'
+# 2026-07-18T22:06:37Z -- container created after PR #1205 merged (21:59:55Z), and
+# `docker exec orion-athena-substrate-runtime grep 'node:substrate.harness_closure'
+# /app/app/worker.py` returns real matches, confirming the running image already has
+# PR #1205's fixed-shared-node code (but not yet this patch's codec/consumer changes,
+# which land with the restart below).
+
+docker exec orion-athena-substrate-runtime env | grep -E \
+  "SUBSTRATE_WRITE_PREDICTION_ERROR_NODES|ENABLE_POST_TURN_CLOSURE_LISTENER"
+# SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true
+# ENABLE_POST_TURN_CLOSURE_LISTENER=true
+```
+
+**Finding, reported plainly per CLAUDE.md's "runtime truth beats config truth":** the live
+`orion-substrate-runtime` container already runs PR #1205's fixed-shared-node code, with the
+feature flag enabled, but `node:substrate.harness_closure` does not yet exist as a node in
+`orion_substrate` — zero `surprise_unresolved=True` `HarnessPostTurnClosureV1` events have
+landed since that container's last restart. This means the live end-to-end durability claim
+("`contributing_turn_ids` survives a tick-triggered cache rebuild in production") is
+**UNVERIFIED** pending a real unresolved harness-closure event post-deploy of *this* patch.
+The codec/consumer wiring itself is fully covered by unit tests against the real production
+schemas (`ConceptNodeV1`, `AttentionSignalV1`, `AttentionSelfModelV1`) — this is an honest
+gap in live proof, not in test coverage.
+
+```bash
+scripts/safe_graphify_update.sh
+```
+
+## Review findings fixed
+
+- Finding: Design doc claimed `DYNAMICS_METADATA_KEYS` gains a "7th entry, was 5" and that
+  the codec's docstring comment was "updated" to a new hardcoded count — both wrong; the
+  tuple has 6 entries (5 original + 1 new), and the actual code comment was rewritten to
+  drop the hardcoded count entirely rather than being bumped to a new number.
+  - Fix: corrected the design doc's "Proposed schema / API changes" section to say "6th
+    entry, was 5" and accurately describe the comment rewrite.
+  - Evidence: `docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md`,
+    commit after the review pass; `grep -n "5-key\|5 key" orion/substrate/falkor_codec.py`
+    returns zero matches, confirming the comment no longer states a stale count.
+- Finding: Design doc's "Files likely to touch" section referenced this PR report file
+  before it existed on disk.
+  - Fix: wrote this PR report in the same patch, resolving the reference.
+  - Evidence: this file.
+- Findings (a)/(b)/(c) from the task's explicit review checklist — fail-open JSON round-trip,
+  regression-proof optional param, zero accidental goal_drive_origin/GoalProposalV1
+  coupling — all independently verified correct by the reviewing subagent with no fixes
+  needed. Full detail: reviewer confirmed `_dynamics_metadata_from_row()` catches
+  `ValueError` from `_parse_json_list()` and degrades to omission (not raise); confirmed
+  `harness_closure_signal` is structurally unreachable from the `top_down_override`/
+  `bottom_up_salience` branches (the variable is never referenced there); confirmed zero new
+  `goal_drive_origin`/`GoalProposalEngine`/`GoalProposalV1`/`capability_policy` references
+  anywhere in the diff outside the design doc's own explanatory prose.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml \
+  up -d --build
+```
+
+Required for the `contributing_turn_ids_json` durability fix and the two consumer changes to
+take effect live. No other service touched.
+
+## Risks / concerns
+
+- Severity: **informational, not blocking**
+  Concern: The live end-to-end durability claim (`contributing_turn_ids` surviving a real
+  tick-triggered cache rebuild in production) is `UNVERIFIED` — no `node:substrate.
+  harness_closure` write has occurred against the currently-running container since its last
+  restart, so there is nothing live to observe yet.
+  Mitigation: Post-deploy check named explicitly below. Codec/consumer logic is fully unit-
+  tested against real production schemas in the interim.
+- Severity: **pre-existing, not introduced by this patch**
+  Concern: `test_write_prediction_error_node_preserves_dynamics_state_on_rewrite`
+  (`services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py`) fails on
+  unmodified `origin/main` too (confirmed via stash-and-rerun), consistent with PR #1205's
+  own disclosed "16 failed (pre-existing)" finding in this test directory.
+  Mitigation: None needed from this patch; flagged for whoever picks up that pre-existing gap
+  next, not silently absorbed into this PR's scope.
+
+## What to check live post-deploy
+
+After the restart above, once a real unresolved harness-closure event occurs (a harness turn
+with `surprise_unresolved=True`):
+
+```bash
+redis-cli -p 6380 GRAPH.QUERY orion_substrate \
+  "MATCH (n {node_id: 'node:substrate.harness_closure'}) RETURN n.dynamic_pressure, n.prediction_error, n.contributing_turn_ids_json"
+```
+
+Confirm `contributing_turn_ids_json` is populated, and re-run the same query again after the
+next `SubstrateDynamicsEngine.tick()` cadence (~30s, `SUBSTRATE_DYNAMICS_TICK_INTERVAL_SEC`)
+to confirm the value is still present — i.e. it survived the cache rebuild that used to
+silently drop it before this patch.
+
+## PR link
+
+<populated by `gh pr create` below>

--- a/docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md
+++ b/docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md
@@ -127,8 +127,10 @@ branch's own docstring/tests anticipate it.
 ## Proposed schema / API changes
 
 - `orion/substrate/falkor_codec.py`:
-  - `DYNAMICS_METADATA_KEYS` gains `"contributing_turn_ids"` (7th entry, was 5 — module
-    docstring's "closed 5-key allowlist" comment updated accordingly).
+  - `DYNAMICS_METADATA_KEYS` gains `"contributing_turn_ids"` (6th entry, was 5) — the
+    comment above the tuple was rewritten to drop the hardcoded "closed 5-key allowlist"
+    count entirely (now refers to the tuple itself, so it can't go stale again on the next
+    addition) rather than being bumped to a new fixed number.
   - `DYNAMICS_ENGINE_OWNED_METADATA_KEYS` unchanged (4 entries) — `contributing_turn_ids` is
     owned by `_write_prediction_error_node()`'s own carry-forward logic, a distinct
     mechanism from `SubstrateDynamicsEngine.tick()`'s pressure/dormancy computation.

--- a/docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md
+++ b/docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md
@@ -1,0 +1,221 @@
+# Prediction-error attribution wiring — durable `contributing_turn_ids` + two consumers
+
+Status: design mode + implemented in the same PR (root CLAUDE.md's implementation-mode
+follow-through requirement — this doc captures the decision record, the code lands alongside
+it, not as a separate follow-up).
+
+## Arsonist summary
+
+PR #1205 (`feat/harness-closure-pressure-accumulation`) gave the harness-closure
+prediction-error lane a shared, fixed `node_id` (`node:substrate.harness_closure`) so
+repeated unresolved-surprise events accumulate onto one node instead of spawning a new node
+per turn, and added `metadata['contributing_turn_ids']` (capped at 20, deduped, oldest
+dropped) to attribute which harness turns contributed to that node's current pressure. That
+PR shipped with a disclosed, deliberate gap: `orion/substrate/falkor_codec.py`'s
+`DYNAMICS_METADATA_KEYS` is a closed 5-key allowlist for native Cypher scalar properties on
+concept nodes, and `contributing_turn_ids` was not in it — so every value written into that
+key was silently dropped the next time `SubstrateDynamicsEngine.tick()`'s ~30s cache rebuild
+re-hydrated the node from durable Falkor rows (`_hydrate_from_durable()`). The in-process
+write briefly held the full value; nothing durable did. PR #1205's own brief explicitly
+scoped `falkor_codec.py` out ("do not touch `DYNAMICS_ENGINE_OWNED_METADATA_KEYS` or
+`falkor_codec.py`"), so the fix was deferred, not skipped.
+
+This patch closes that gap and, per the codec's own documented rule ("promote to
+first-class Cypher properties only with a second consumer"), wires the now-durable list into
+two real consumers in the same changeset — satisfying the rule rather than promoting the key
+speculatively ahead of any consumer.
+
+## Current architecture
+
+- **Producer (unchanged by this patch):** `services/orion-substrate-runtime/app/worker.py`'s
+  `_write_prediction_error_node()` accumulates `metadata['contributing_turn_ids']` on
+  repeat writes to a shared `node_id` (PR #1205). Carry-forward logic, the 20-entry cap, and
+  dedup are all already shipped and untouched here.
+- **Codec gap (fixed by this patch):** `orion/substrate/falkor_codec.py`'s
+  `DYNAMICS_METADATA_KEYS` allowlist controlled which metadata keys survive an
+  encode→Falkor-write→decode round trip as native Cypher scalar properties.
+  `contributing_turn_ids` (a `list[str]`) could not be added directly — Cypher properties on
+  a node are scalars, not arrays — so it needed the same JSON-string-encoding pattern already
+  used for `taxonomy_path_json`/`evidence_refs_json` (`_json_list()`/`_parse_json_list()`
+  helpers, `encode_node_properties()`/`_provenance_from_row()`).
+- **Consumers before this patch:** zero real consumers of `contributing_turn_ids` existed
+  downstream of the in-process write — the durability gap meant nothing could have consumed
+  a durable value even if it wanted to.
+
+## Why `contributing_turn_ids` qualifies for promotion now
+
+`falkor_codec.py`'s own comment on `DYNAMICS_METADATA_KEYS` states the rule: promote a
+metadata key to a native Cypher property "only with a second consumer" — i.e. the codec
+allowlist is not a dumping ground for anything a producer happens to write; it exists because
+two already-shipped consumers (`SubstrateDynamicsEngine.tick()`, `attention_broadcast.
+_node_salience()`) genuinely read those keys back out. `contributing_turn_ids` had a
+producer (PR #1205) but zero consumers, which is exactly the state the rule is designed to
+block from silently accumulating unused allowlist entries.
+
+This patch adds two real consumers in the same changeset, which is what makes the promotion
+legitimate rather than speculative:
+
+1. `orion/substrate/attention_broadcast.py::substrate_pressure_signals()` — already builds
+   `AttentionSignalV1.evidence_refs` from the node id. This patch appends
+   `contributing_turn_ids` (stringified) onto that list, so a workspace-competition signal
+   sourced from a sustained-surprise node carries the specific harness turns that produced
+   it, not just an opaque node id.
+2. `orion/substrate/attention_self_model.py::reduce_attention_self_model()` — the AST/HOT
+   reducer (PR #1196/#1196-follow-ups). Gains an optional `harness_closure_signal` kwarg
+   that, when the `field_salience_only` branch fires, enriches `reason_narrative` with a
+   clause naming the contributing-turn count and current `prediction_error` magnitude.
+
+Both consumers read the same underlying data (`contributing_turn_ids` + `prediction_error`
+off the one shared node), but they are not redundant with each other in the sense the metric
+quality gate's independence check cares about: `evidence_refs` is a flat inspectability list
+consumed by whatever reads `AttentionSignalV1` (debug surfaces, downstream salience scoring),
+while the reducer's narrative is a distinct textual "why" artifact consumed by a different
+read-only measurement path (`scripts/analysis/measure_ast_hot_reducer.py`). Per the metric
+quality gate (root CLAUDE.md §0A): this is not a *new* metric being minted, it is the same
+already-gated `prediction_error`/`contributing_turn_ids` signal (traced to
+`_write_prediction_error_node()`, theory-anchored to the charter's §9b item 3 Predictive
+Processing thread, already confirmed live 2026-07-18 per the README) becoming durable and
+inspectable through two seams that already existed. No new independence/theory-anchor
+analysis is owed here beyond what PR #1205 and the README's item 3 entry already did.
+
+## Why this has zero coupling to `goal.drive_origin` / the halted `GoalProposalEngine`
+
+Checked against the full `orion/sentience_striving_program/README.md` charter, not just a
+grep for the string:
+
+- `goal.drive_origin` is produced by `GoalProposalEngine`
+  (`orion/spark/concept_induction/`), which the charter's §8 explicitly halted. The only
+  charter item that currently depends on `goal.drive_origin` is §6 item 6
+  ("Revisit `capability_policy.py`'s coupling to live salience"), gated on §6 item 3 closing
+  that dependency first — neither item 6 nor `capability_policy.v1.yaml` is touched by this
+  patch.
+- The prediction-error lane this patch extends is §9b item 3 (Predictive Processing/Active
+  Inference), confirmed in the README as field-native substrate — `execution_prediction_
+  error()`/`transport_prediction_error()` writing directly onto `FieldStateV1` nodes, no
+  `SelfStateV1` or `goal.drive_origin` anchor. `node:substrate.harness_closure` (this
+  patch's actual subject) is the same `_write_prediction_error_node()` mechanism, same
+  no-goal-provenance shape.
+- The AST/HOT reducer's `voluntary_override`/`goal_drive_origin` field (used only in the
+  *separate* `top_down_override` branch, `VoluntaryOverrideV1.goal_drive_origin`) is
+  explicitly untouched by this patch — the new `harness_closure_signal` kwarg only affects
+  the `field_salience_only` branch, which has no `goal_drive_origin` field at all in its
+  narrative. Grepped the full diff for `goal_drive_origin`/`GoalProposalV1`/
+  `capability_policy` post-patch: zero matches outside the pre-existing, untouched
+  `top_down_override` branch.
+
+## Why this is scoped to the `field_salience_only` branch only
+
+`reduce_attention_self_model()` has three narrative-bearing branches:
+
+- `top_down_override` — already has a real, specific "why" (`VoluntaryOverrideV1`'s
+  chosen/beaten loop ids, applied bias, goal artifact/drive-origin). Not touched.
+- `bottom_up_salience` — already has a real "why" (pure salience dispatch, no override
+  active). Not touched.
+- `field_salience_only` — the fallback branch when the GWT-dispatch lane is stale/absent.
+  Before this patch, its narrative only reported an aggregate `field_overall_salience`
+  number with no per-node attribution — the one branch with no specific "why" beyond a bare
+  salience reading. This is exactly the gap `harness_closure_signal` fills: when a real,
+  sustained prediction-error node exists, the narrative can now say *which* recent turns
+  drove that surprise and how large it currently is, instead of staying silent on it.
+
+Widening the two other branches to also read `harness_closure_signal` was considered and
+rejected: both already have a real, specific, non-generic "why" from their own primary
+signal (`VoluntaryOverrideV1` / fresh broadcast salience) — adding a second, unrelated signal
+into an already-answered "why" would blur rather than sharpen the narrative, and neither
+branch's own docstring/tests anticipate it.
+
+## Proposed schema / API changes
+
+- `orion/substrate/falkor_codec.py`:
+  - `DYNAMICS_METADATA_KEYS` gains `"contributing_turn_ids"` (7th entry, was 5 — module
+    docstring's "closed 5-key allowlist" comment updated accordingly).
+  - `DYNAMICS_ENGINE_OWNED_METADATA_KEYS` unchanged (4 entries) — `contributing_turn_ids` is
+    owned by `_write_prediction_error_node()`'s own carry-forward logic, a distinct
+    mechanism from `SubstrateDynamicsEngine.tick()`'s pressure/dormancy computation.
+  - New native Cypher property: `contributing_turn_ids_json` (JSON-encoded string list,
+    same pattern as `taxonomy_path_json`/`evidence_refs_json`). Decode is fail-open
+    (malformed/missing → key omitted from `metadata`, no raise) — deliberately different
+    from `evidence_refs_json`'s raise-on-corruption behavior, because `evidence_refs` is
+    load-bearing identity/provenance data and `contributing_turn_ids` is best-effort
+    attribution metadata.
+- `orion/substrate/attention_broadcast.py::substrate_pressure_signals()`:
+  `AttentionSignalV1.evidence_refs` now includes `contributing_turn_ids` (stringified)
+  appended after the node id, when present. No schema change to `AttentionSignalV1` itself
+  (already a `list[str]` field).
+- `orion/substrate/attention_self_model.py::reduce_attention_self_model()`: new
+  keyword-only, optional parameter `harness_closure_signal: dict | None = None` — a plain
+  dict (`{"prediction_error": float, "contributing_turn_ids": list[str]}`), not a Pydantic
+  model, not a raw graph node import. No `AttentionSelfModelV1` schema field added —
+  `reason_narrative: str` is sufficient (per the task's own scope check, confirmed by
+  reading `orion/schemas/attention_self_model.py`).
+
+## Files likely to touch (this patch's actual diff)
+
+- `orion/substrate/falkor_codec.py` — allowlist + encode/decode.
+- `orion/substrate/tests/test_falkor_codec.py` — round-trip, omitted-when-empty, fail-open
+  malformed/missing coverage.
+- `orion/substrate/attention_broadcast.py` — `evidence_refs` wiring.
+- `orion/substrate/tests/test_attention_broadcast.py` — present/absent coverage.
+- `orion/substrate/attention_self_model.py` — `harness_closure_signal` kwarg +
+  `field_salience_only` narrative clause.
+- `orion/substrate/tests/test_attention_self_model.py` — enrichment, byte-identical
+  regression, zero-error/empty-turns non-enrichment, branch-isolation coverage.
+- `orion/sentience_striving_program/README.md` — §6 item 2 and §9b items 2/3 status notes.
+- `docs/superpowers/pr-reports/2026-07-18-prediction-error-attribution-wiring-pr.md` — PR
+  report (this patch's follow-through artifact).
+- This doc.
+
+## Non-goals
+
+- Not touching `DYNAMICS_ENGINE_OWNED_METADATA_KEYS`, the 20-entry cap, or the dedup/carry-
+  forward logic in `_write_prediction_error_node()` — all already shipped by PR #1205,
+  unchanged here.
+- Not touching `top_down_override`, `TopDownBiasCombiner`, `GoalContext`, `goal_context.py`,
+  `orion/substrate/attention/top_down.py`, `capability_policy.v1.yaml`, or anything
+  Objective-6-related.
+- Not adding a bus consumer/producer for `AttentionSelfModelV1` — it stays read-only per
+  Phase 1's explicit scope (module docstring, `orion/substrate/attention_self_model.py`).
+- Not wiring a live FalkorDB read into `scripts/analysis/measure_ast_hot_reducer.py` (a
+  Postgres-only replay script) — disproportionate for this patch's scope; the live check for
+  this PR was done manually via `redis-cli GRAPH.QUERY` against the running
+  `orion-athena-falkordb` container and reported in the PR report instead.
+- Not adding a new `AttentionSelfModelV1` schema field — `reason_narrative: str` already
+  covers the new clause.
+
+## Acceptance checks
+
+- `pytest orion/substrate/tests -q` passes with the new/updated tests (round-trip,
+  fail-open decode, `evidence_refs` present/absent, narrative enrichment/regression/branch-
+  isolation).
+- A concept node's `metadata['contributing_turn_ids']` survives
+  `encode_node_properties()` → `decode_concept_node()` without requiring the in-process
+  cache — i.e. it now survives a `SubstrateDynamicsEngine.tick()`-triggered
+  `_hydrate_from_durable()` rebuild, closing PR #1205's disclosed gap.
+- `substrate_pressure_signals()` on a node with `contributing_turn_ids` set produces an
+  `AttentionSignalV1.evidence_refs` list containing both the node id and every contributing
+  turn id; a node without the key produces the old (node-id-only) behavior unchanged.
+- `reduce_attention_self_model(..., harness_closure_signal=None)` (every existing caller)
+  reproduces today's narrative byte-for-byte; passing a real `harness_closure_signal` only
+  changes `reason_narrative` in the `field_salience_only` branch, never `attention_reason`,
+  never the `top_down_override`/`bottom_up_salience` branches.
+- Live check (manual, `redis-cli -p 6380 GRAPH.QUERY orion_substrate ...` against
+  `orion-athena-falkordb`): confirmed the running `orion-substrate-runtime` container
+  (created 2026-07-18T22:06:37Z) already carries PR #1205's fixed-node-id code and
+  `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true` live, but `node:substrate.harness_closure`
+  does not yet exist as a node in `orion_substrate` (only pre-#1205 legacy
+  `harness_closure:<uuid>` nodes are present) — no `surprise_unresolved=True`
+  `HarnessPostTurnClosureV1` event has landed since that container's last restart. This is
+  an honest `UNVERIFIED` for the live end-to-end durability claim until a real unresolved
+  harness closure occurs post-deploy of *this* patch; the codec/reducer/broadcast wiring
+  itself is fully covered by unit tests against the real production schemas.
+
+## Recommended next patch
+
+- After this patch deploys and a live `node:substrate.harness_closure` write with
+  `contributing_turn_ids` occurs, re-run the manual `redis-cli GRAPH.QUERY` check (or a
+  short one-off script) to confirm the value survives a subsequent dynamics tick in
+  production, not just in unit tests.
+- If `scripts/analysis/measure_ast_hot_reducer.py`'s Postgres replay is ever extended to
+  cover FalkorDB-sourced inputs generally (not just for this one node), wiring
+  `harness_closure_signal` into that replay becomes proportionate — tracked here as a real
+  follow-up, not silently dropped.

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -177,6 +177,19 @@ first place. Full reasoning and phased detail:
    oscillation period, 3500+ zero-crossings each over 84k samples) — the upstream field-
    level fix has not fully propagated. Full detail, headline numbers, and the resulting
    Juniper sign-off decision: PR report for this patch.
+   **Durability + consumer wiring (2026-07-18, follow-up patch):** PR #1205 gave the
+   harness-closure prediction-error lane a shared node (`node:substrate.harness_closure`)
+   with per-turn attribution in `metadata['contributing_turn_ids']`, but disclosed that
+   `orion/substrate/falkor_codec.py`'s closed allowlist silently dropped that list on every
+   durable Falkor round trip. Closed in this follow-up: `contributing_turn_ids` promoted to
+   a durable native Cypher property (`contributing_turn_ids_json`), and wired into two real
+   consumers — `substrate_pressure_signals()`'s `evidence_refs` and this reducer's
+   `field_salience_only` narrative (new optional `harness_closure_signal` kwarg, narrative-
+   only, no `attention_reason`/schema change). See
+   `docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md` and
+   this PR's report for the decision record and a live-data caveat (no
+   `node:substrate.harness_closure` write has occurred yet post-deploy to prove the
+   end-to-end durability live, confirmed via manual FalkorDB query).
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live
@@ -337,7 +350,10 @@ fix — see §7.
    hard signal-quality check on exactly those `SelfStateV1` fields before Phase 1 is called
    done. See `docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-
    roadmap-design.md` Phase 1 and §6 item 2's status note above.** Built 2026-07-18:
-   `orion/substrate/attention_self_model.py`.
+   `orion/substrate/attention_self_model.py`. **Durability + consumer wiring (2026-07-18
+   follow-up):** see item 3's note below — same patch, same
+   `node:substrate.harness_closure` data, now consumed by this reducer's
+   `field_salience_only` narrative too.
 3. **Predictive Processing/Active Inference** — **not** `orion/self_state/prediction.py`
    (`SelfStateV1`-anchored, same violation as IIT above). The real field-native substrate,
    confirmed live 2026-07-18: `services/orion-substrate-runtime/app/worker.py`'s
@@ -352,6 +368,22 @@ fix — see §7.
    reaches real values like 0.92 periodically" characterization of this exact channel). Open
    question, not yet checked: whether the other three reducers (biometrics, chat, route)
    have equivalent instrumentation, or whether coverage is genuinely incomplete.
+   **Attribution durability + consumers (2026-07-18):** the harness-closure variant of this
+   same mechanism (`node:substrate.harness_closure`, PR #1205) accumulates per-turn
+   attribution in `metadata['contributing_turn_ids']`, but that list was silently dropped on
+   every durable Falkor round trip — `orion/substrate/falkor_codec.py`'s allowlist didn't
+   carry it. Fixed in a same-day follow-up: promoted to a durable Cypher property
+   (`contributing_turn_ids_json`, same JSON-string pattern as `taxonomy_path_json`), and
+   wired into two consumers — `substrate_pressure_signals()`'s `evidence_refs` (turn ids now
+   ride alongside the node id) and item 2's AST/HOT reducer (`field_salience_only`
+   narrative names the contributing-turn count + current magnitude). Design record:
+   `docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md`. Zero
+   `goal.drive_origin`/`GoalProposalEngine` coupling — confirmed against this charter in
+   full, not just a grep. Live caveat: as of this patch, no `node:substrate.harness_closure`
+   write has occurred against the redeployed container yet (checked manually via
+   `redis-cli GRAPH.QUERY`), so the end-to-end live-durability claim is `UNVERIFIED` pending
+   a real unresolved harness-closure event post-deploy — the codec/consumer wiring itself is
+   fully unit-tested against the real production schemas.
 4. **Higher-Order Theories** — architecturally close to AST's missing piece; a
    higher-order representation built once, reading the same field/reducer-projection data,
    may serve both theories. Served by the same Phase 1 reducer as #2 above, including its

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -193,7 +193,10 @@ def substrate_pressure_signals(
                     signal_kind=f"substrate_{kind}",
                     salience=salience,
                     confidence=confidence,
-                    evidence_refs=[node_id] if node_id else [],
+                    evidence_refs=(
+                        ([node_id] if node_id else [])
+                        + [str(t) for t in metadata.get("contributing_turn_ids") or []]
+                    ),
                     provenance={"detector": "substrate_pressure", "signal_driver": kind},
                 )
             )

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -47,6 +47,7 @@ def reduce_attention_self_model(
     *,
     now: datetime | None = None,
     broadcast_stale_threshold_sec: float = DEFAULT_BROADCAST_STALE_THRESHOLD_SEC,
+    harness_closure_signal: dict | None = None,
 ) -> AttentionSelfModelV1:
     """Unify the GWT-dispatch lane and the general field lane into one
     inspectable AST/HOT self-model. Never raises: any of the three inputs may
@@ -58,6 +59,21 @@ def reduce_attention_self_model(
     Falls back to `self_state.generated_at`, then `broadcast.generated_at`,
     then wall-clock `datetime.now(timezone.utc)` if none of the three inputs
     are present.
+
+    `harness_closure_signal` is an optional, intentionally-minimal plain dict
+    -- `{"prediction_error": float, "contributing_turn_ids": list[str]}` --
+    built by the caller from the `node:substrate.harness_closure` FalkorDB
+    node's now-durable metadata (`orion/substrate/falkor_codec.py`'s
+    `contributing_turn_ids_json`, PR #1205 + this patch). Deliberately not a
+    raw graph node or a `falkor_codec` import: this reducer stays decoupled
+    from the store layer, matching every other input here (already-parsed
+    Pydantic/plain data, not raw store objects). When present and non-trivial
+    (`prediction_error > 0.0` and `contributing_turn_ids` non-empty), it only
+    enriches the `field_salience_only` branch's `reason_narrative` with a
+    clause naming sustained prediction-error surprise -- it never changes
+    `attention_reason` itself, and every other branch (`top_down_override`,
+    `bottom_up_salience`) ignores it entirely. Omitting this argument (the
+    default) reproduces today's narrative byte-for-byte.
     """
 
     reference_ts = (
@@ -183,11 +199,25 @@ def reduce_attention_self_model(
             else "no GWT-dispatch-lane data available"
         )
         n_targets = len(model.field_salient_target_ids)
-        model.reason_narrative = (
+        narrative = (
             f"{stale_note}; reading field-lane salience only "
             f"({n_targets} dominant target(s), "
-            f"overall_salience={model.field_overall_salience})."
+            f"overall_salience={model.field_overall_salience})"
         )
+        harness_error = 0.0
+        harness_turn_ids: list = []
+        if harness_closure_signal:
+            try:
+                harness_error = float(harness_closure_signal.get("prediction_error") or 0.0)
+            except (TypeError, ValueError):
+                harness_error = 0.0
+            harness_turn_ids = list(harness_closure_signal.get("contributing_turn_ids") or [])
+        if harness_error > 0.0 and harness_turn_ids:
+            narrative += (
+                f"; sustained prediction-error surprise across {len(harness_turn_ids)} "
+                f"recent turn(s) (current magnitude={harness_error:.2f})"
+            )
+        model.reason_narrative = narrative + "."
     else:
         model.attention_reason = "no_data"
         model.reason_narrative = "No attention data available from either lane."

--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -119,18 +119,23 @@ def encode_node_properties(node: BaseSubstrateNodeV1, identity_key: str | None) 
 
 
 # Closed allowlist of dynamics-engine metadata keys promoted to native Cypher
-# scalar properties (concept nodes only). These are the only metadata keys two
-# already-shipped consumers (SubstrateDynamicsEngine.tick() and
-# attention_broadcast._node_salience()) actually read/write; see
-# docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
+# scalar properties (concept nodes only). These are the only metadata keys
+# already-shipped consumers (SubstrateDynamicsEngine.tick(),
+# attention_broadcast._node_salience(), substrate_pressure_signals()'s
+# evidence_refs, and the AST/HOT reducer's optional harness_closure_signal
+# narrative -- orion/substrate/attention_self_model.py) actually read/write;
+# see docs/superpowers/specs/2026-07-16-cypher-native-substrate-postgres-bus-split-design.md
 # item 3's "promote to first-class Cypher properties only with a second
-# consumer" escape hatch. Do NOT add a generic metadata-dump path here.
+# consumer" escape hatch. `contributing_turn_ids` was added under this same
+# rule once a second real consumer existed (see the two consumers named
+# above). Do NOT add a generic metadata-dump path here.
 DYNAMICS_METADATA_KEYS: tuple[str, ...] = (
     "dynamic_pressure",
     "dynamic_pressure_reason",
     "dormant",
     "dormancy_updated_at",
     "prediction_error",
+    "contributing_turn_ids",
 )
 
 # Subset of DYNAMICS_METADATA_KEYS owned by SubstrateDynamicsEngine.tick()
@@ -171,6 +176,7 @@ def _dynamics_properties_from_metadata(metadata: Mapping[str, Any] | None) -> di
         "dormant": bool(meta.get("dormant", False)),
         "dormancy_updated_at": meta.get("dormancy_updated_at"),
         "prediction_error": _safe_float(meta.get("prediction_error"), default=None),
+        "contributing_turn_ids_json": _json_list(meta.get("contributing_turn_ids")),
     }
 
 
@@ -250,7 +256,8 @@ def _dynamics_metadata_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
     # attention_broadcast.py) still read it via `.get(key) or 0.0` and so do
     # not yet observe the difference themselves. This preserves headroom for
     # a future consumer that does need the distinction, per the closed
-    # 5-key allowlist this codec owns.
+    # DYNAMICS_METADATA_KEYS allowlist this codec owns. contributing_turn_ids
+    # follows the same "omit when absent/empty" convention, decoded below.
     metadata: dict[str, Any] = {
         "dynamic_pressure": _safe_float(row.get("dynamic_pressure"), default=0.0),
         "dormant": bool(row.get("dormant") or False),
@@ -264,6 +271,25 @@ def _dynamics_metadata_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
     prediction_error = _safe_float(row.get("prediction_error"), default=None)
     if prediction_error is not None:
         metadata["prediction_error"] = prediction_error
+    # Fail-open, matching every other decode field in this function: a
+    # malformed contributing_turn_ids_json value (corrupt JSON, wrong shape)
+    # must not abort decoding the whole node -- treat it as absent rather
+    # than raising, same tolerance _parse_json_list already gives callers
+    # that choose to swallow the error (contrast with _provenance_from_row's
+    # evidence_refs_json, which intentionally does raise -- that field is
+    # load-bearing identity data; contributing_turn_ids is best-effort
+    # attribution, so silent omission on corruption is the safer default).
+    try:
+        contributing_turn_ids = [
+            str(item)
+            for item in _parse_json_list(
+                row.get("contributing_turn_ids_json"), field="contributing_turn_ids_json"
+            )
+        ]
+    except ValueError:
+        contributing_turn_ids = []
+    if contributing_turn_ids:
+        metadata["contributing_turn_ids"] = contributing_turn_ids
     return metadata
 
 

--- a/orion/substrate/tests/test_attention_broadcast.py
+++ b/orion/substrate/tests/test_attention_broadcast.py
@@ -184,6 +184,40 @@ def test_malformed_nodes_are_skipped_not_fatal() -> None:
     assert [s.target_text for s in signals] == ["well formed node"]
 
 
+def test_evidence_refs_include_contributing_turn_ids() -> None:
+    """A node whose metadata carries contributing_turn_ids (populated by
+    _write_prediction_error_node's carry-forward logic, PR #1205, now durable
+    via falkor_codec.py's contributing_turn_ids_json) must surface those turn
+    ids in the resulting AttentionSignalV1.evidence_refs alongside the node
+    id itself -- making the harness turns that contributed to this pressure
+    node inspectable from the attention signal, not just the node id."""
+    nodes = [
+        _node(
+            "node:substrate.harness_closure",
+            "sustained prediction-error surprise",
+            dynamic_pressure=0.6,
+            contributing_turn_ids=["turn-1", "turn-2"],
+        ),
+    ]
+    signals = substrate_pressure_signals(nodes, min_salience=0.0)
+    assert signals
+    assert signals[0].evidence_refs == [
+        "node:substrate.harness_closure",
+        "turn-1",
+        "turn-2",
+    ]
+
+
+def test_evidence_refs_omit_contributing_turn_ids_when_absent() -> None:
+    """Regression guard: a node with no contributing_turn_ids in metadata
+    (the common case) must keep today's behavior -- evidence_refs is just
+    the node id, nothing appended."""
+    nodes = [_node("node:plain", "plain concept", dynamic_pressure=0.6)]
+    signals = substrate_pressure_signals(nodes, min_salience=0.0)
+    assert signals
+    assert signals[0].evidence_refs == ["node:plain"]
+
+
 def test_projection_carries_selected_coalition() -> None:
     nodes = [_node("node:hot", "hot node", dynamic_pressure=0.9)]
     frame = build_substrate_attention_frame(nodes=nodes, now=_NOW)

--- a/orion/substrate/tests/test_attention_self_model.py
+++ b/orion/substrate/tests/test_attention_self_model.py
@@ -223,3 +223,86 @@ def test_reference_tick_falls_back_to_self_state_when_no_field_frame() -> None:
     model = reduce_attention_self_model(None, None, state)
 
     assert model.generated_at == NOW
+
+
+class TestHarnessClosureSignal:
+    """harness_closure_signal only enriches the field_salience_only branch's
+    reason_narrative -- see reduce_attention_self_model's own docstring. Not
+    touched: top_down_override/bottom_up_salience branches, attention_reason
+    itself, or any other field."""
+
+    def test_harness_closure_signal_appends_narrative_clause(self) -> None:
+        model = reduce_attention_self_model(
+            None,
+            _field_frame(),
+            None,
+            now=NOW,
+            harness_closure_signal={
+                "prediction_error": 0.42,
+                "contributing_turn_ids": ["turn-1", "turn-2", "turn-3"],
+            },
+        )
+
+        assert model.attention_reason == "field_salience_only"
+        assert "sustained prediction-error surprise across 3 recent turn(s)" in model.reason_narrative
+        assert "current magnitude=0.42" in model.reason_narrative
+        # attention_reason itself must not change -- enrichment is narrative-only.
+        assert model.attention_reason == "field_salience_only"
+
+    def test_harness_closure_signal_absent_is_byte_identical_to_default(self) -> None:
+        """Regression guard: omitting harness_closure_signal (the default,
+        every existing caller) must reproduce today's narrative exactly."""
+        baseline = reduce_attention_self_model(None, _field_frame(), None, now=NOW)
+        with_none = reduce_attention_self_model(
+            None, _field_frame(), None, now=NOW, harness_closure_signal=None
+        )
+
+        assert baseline.reason_narrative == with_none.reason_narrative
+        assert "sustained prediction-error surprise" not in baseline.reason_narrative
+
+    def test_harness_closure_signal_zero_prediction_error_does_not_enrich(self) -> None:
+        model = reduce_attention_self_model(
+            None,
+            _field_frame(),
+            None,
+            now=NOW,
+            harness_closure_signal={
+                "prediction_error": 0.0,
+                "contributing_turn_ids": ["turn-1"],
+            },
+        )
+
+        assert "sustained prediction-error surprise" not in model.reason_narrative
+
+    def test_harness_closure_signal_empty_contributing_turn_ids_does_not_enrich(self) -> None:
+        model = reduce_attention_self_model(
+            None,
+            _field_frame(),
+            None,
+            now=NOW,
+            harness_closure_signal={
+                "prediction_error": 0.75,
+                "contributing_turn_ids": [],
+            },
+        )
+
+        assert "sustained prediction-error surprise" not in model.reason_narrative
+
+    def test_harness_closure_signal_ignored_outside_field_salience_only_branch(self) -> None:
+        """A fresh, non-stale broadcast with no override takes the
+        bottom_up_salience branch -- harness_closure_signal must not leak
+        its narrative clause in there even if it's provided."""
+        broadcast = _broadcast(override=None)
+        model = reduce_attention_self_model(
+            broadcast,
+            _field_frame(),
+            _self_state(),
+            now=NOW,
+            harness_closure_signal={
+                "prediction_error": 0.9,
+                "contributing_turn_ids": ["turn-1"],
+            },
+        )
+
+        assert model.attention_reason == "bottom_up_salience"
+        assert "sustained prediction-error surprise" not in model.reason_narrative

--- a/orion/substrate/tests/test_falkor_codec.py
+++ b/orion/substrate/tests/test_falkor_codec.py
@@ -131,6 +131,7 @@ def test_encode_concept_node_properties_are_native_scalars_without_payload_json(
         "dormant": False,
         "dormancy_updated_at": None,
         "prediction_error": None,
+        "contributing_turn_ids_json": "[]",
     }
 
 
@@ -289,6 +290,7 @@ def _concept_with_dynamics_metadata() -> ConceptNodeV1:
                 "dormant": True,
                 "dormancy_updated_at": "2026-07-17T00:00:00+00:00",
                 "prediction_error": 0.8,
+                "contributing_turn_ids": ["turn-1", "turn-2"],
             }
         }
     )
@@ -304,6 +306,7 @@ def test_encode_promotes_dynamics_metadata_keys_to_native_scalars():
     assert props["dormant"] is True
     assert props["dormancy_updated_at"] == "2026-07-17T00:00:00+00:00"
     assert props["prediction_error"] == 0.8
+    assert props["contributing_turn_ids_json"] == '["turn-1", "turn-2"]'
 
 
 def test_decode_reconstructs_dynamics_metadata_from_row():
@@ -317,6 +320,7 @@ def test_decode_reconstructs_dynamics_metadata_from_row():
     assert node.metadata.get("dormant") is True
     assert node.metadata.get("dormancy_updated_at") == "2026-07-17T00:00:00+00:00"
     assert node.metadata.get("prediction_error") == 0.8
+    assert node.metadata.get("contributing_turn_ids") == ["turn-1", "turn-2"]
 
 
 def test_dynamics_metadata_round_trips_through_encode_decode():
@@ -331,8 +335,65 @@ def test_dynamics_metadata_round_trips_through_encode_decode():
         "dormant",
         "dormancy_updated_at",
         "prediction_error",
+        "contributing_turn_ids",
     ):
         assert decoded.metadata.get(key) == original.metadata.get(key)
+
+
+def test_contributing_turn_ids_empty_list_is_omitted_on_decode():
+    """metadata['contributing_turn_ids'] absent entirely (the common case --
+    most concept nodes are never touched by _write_prediction_error_node)
+    must encode to an empty JSON list and decode back to the key being
+    absent from metadata, not an empty list sitting in the dict -- mirrors
+    the existing omit-when-absent convention for prediction_error/
+    dynamic_pressure_reason/dormancy_updated_at.
+    """
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+    assert row["contributing_turn_ids_json"] == "[]"
+
+    node = decode_concept_node(row)
+    assert node is not None
+    assert "contributing_turn_ids" not in node.metadata
+
+
+def test_contributing_turn_ids_missing_json_key_decodes_without_raising():
+    """A row missing contributing_turn_ids_json entirely (e.g. a node written
+    before this patch shipped) must decode fail-open, not raise -- same
+    tolerance every other decode field in this module gives a missing key.
+    """
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+    del row["contributing_turn_ids_json"]
+
+    node = decode_concept_node(row)
+    assert node is not None
+    assert "contributing_turn_ids" not in node.metadata
+
+
+def test_contributing_turn_ids_malformed_json_decodes_fail_open_not_raise():
+    """Unlike evidence_refs_json (load-bearing identity data, intentionally
+    raises on corruption -- see test_decode_rejects_corrupt_evidence_refs_json),
+    contributing_turn_ids is best-effort attribution metadata: a corrupted
+    value must not abort decoding the whole node.
+    """
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+    row["contributing_turn_ids_json"] = "{not-json"
+
+    node = decode_concept_node(row)
+    assert node is not None
+    assert "contributing_turn_ids" not in node.metadata
+
+
+def test_contributing_turn_ids_wrong_json_shape_decodes_fail_open_not_raise():
+    """A JSON value that parses but isn't a list (e.g. an object) must also
+    be tolerated, not raised -- same fail-open contract as the malformed-JSON
+    case above.
+    """
+    row = encode_node_properties(_concept(), identity_key="concept:alpha")
+    row["contributing_turn_ids_json"] = '{"not": "a list"}'
+
+    node = decode_concept_node(row)
+    assert node is not None
+    assert "contributing_turn_ids" not in node.metadata
 
 
 def test_concept_with_no_dynamics_metadata_encodes_and_decodes_with_sane_defaults():

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -187,6 +187,22 @@ Post-turn closure logs `post_turn_closure received …` on ingest. When
 `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true` (logs `post_turn_closure_prediction_error_write`
 or `…_skipped` otherwise). Full Task 21 strain reducers are not implemented here.
 
+`_write_prediction_error_node()` (`app/worker.py`) writes to a single, fixed `node_id` per
+lane (`node:substrate.execution`, `node:substrate.transport`, `node:substrate.harness_closure`
+for post-turn closure), so repeat writes collapse instead of spawning a new node per event.
+Repeat writes to the same node accumulate bounded per-event attribution in
+`metadata['contributing_turn_ids']` (capped at 20, deduped, oldest dropped) — this is
+attribution, not the pressure/dormancy state itself, which `DYNAMICS_ENGINE_OWNED_METADATA_
+KEYS` (`orion/substrate/falkor_codec.py`) separately carries forward on every rewrite so
+`SubstrateDynamicsEngine.tick()`'s computed state doesn't get clobbered. `contributing_turn_
+ids` is durable against the live Falkor backend via `orion/substrate/falkor_codec.py`'s
+`DYNAMICS_METADATA_KEYS` allowlist (JSON-string-encoded as `contributing_turn_ids_json`,
+same pattern as `taxonomy_path_json`) and is consumed by `orion/substrate/attention_
+broadcast.py::substrate_pressure_signals()` (`evidence_refs`) and `orion/substrate/
+attention_self_model.py::reduce_attention_self_model()`'s optional `harness_closure_signal`
+narrative enrichment — see `docs/superpowers/specs/2026-07-18-prediction-error-attribution-
+wiring-design.md`.
+
 **Reverie semantic lift:** unresolved closures also upsert human referent rows into
 `substrate_turn_referent` via `turn_referent_store.persist_turn_referent`. Apply
 `services/orion-sql-db/manual_migration_substrate_turn_referent_v1.sql` before enabling


### PR DESCRIPTION
## Summary

- Closed the durability gap PR #1205 disclosed: `orion/substrate/falkor_codec.py`'s `DYNAMICS_METADATA_KEYS` allowlist silently dropped `metadata['contributing_turn_ids']` on every durable FalkorDB round trip. Promoted it to a native Cypher property (`contributing_turn_ids_json`, same `_json_list()`/`_parse_json_list()` JSON-string pattern as `taxonomy_path_json`/`evidence_refs_json`), decoding fail-open on malformed/missing/wrong-shape values.
- Wired the now-durable list into two real consumers, satisfying the codec's own "promote only with a second consumer" rule: `substrate_pressure_signals()`'s `evidence_refs`, and `reduce_attention_self_model()`'s new optional `harness_closure_signal` kwarg (narrative-only enrichment, `field_salience_only` branch only, byte-identical output when omitted).
- `DYNAMICS_ENGINE_OWNED_METADATA_KEYS`, the 20-entry cap, and `_write_prediction_error_node()`'s carry-forward/dedup logic are all unchanged.
- Design doc + PR report + README status notes recording the decision: why the promotion is justified now, zero `goal.drive_origin`/`GoalProposalEngine` coupling (checked against the full charter), and why the enrichment is scoped to `field_salience_only` only.

Full report: `docs/superpowers/pr-reports/2026-07-18-prediction-error-attribution-wiring-pr.md`
Design doc: `docs/superpowers/specs/2026-07-18-prediction-error-attribution-wiring-design.md`

## Tests run

```
pytest orion/substrate/tests -q
→ 381 passed

pytest scripts/analysis/tests/test_measure_ast_hot_reducer.py -q
→ 8 passed

pytest services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py -q
→ 14 passed, 1 failed (pre-existing, confirmed identical on unmodified origin/main via stash-and-rerun; matches PR #1205's own disclosed pre-existing-failure count in this directory)
```

## Live-data check

Manual `redis-cli GRAPH.QUERY` against the running `orion-athena-falkordb` (in lieu of wiring live Falkor reads into the Postgres-only `measure_ast_hot_reducer.py` replay script — judged disproportionate). Finding: the live `orion-substrate-runtime` container already runs PR #1205's fixed-shared-node code with the feature flag enabled, but `node:substrate.harness_closure` does not yet exist — zero unresolved harness-closure events have landed since the container's last restart. Live end-to-end durability is `UNVERIFIED` pending a real event post-deploy; codec/consumer wiring is fully unit-tested against real production schemas.

## Review

Code review dispatched via `orion-repo-agent` subagent, specifically checking (a) fail-open JSON round-trip, (b) regression-proof optional param, (c) no accidental `goal_drive_origin`/`GoalProposalV1` coupling — all three verified correct. Two should-fix findings in the design doc's prose (miscounted allowlist entry count, dangling PR-report file reference) — both fixed.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml \
  up -d --build
```

## Post-deploy check

After restart, once a real unresolved harness-closure event occurs:

```bash
redis-cli -p 6380 GRAPH.QUERY orion_substrate \
  "MATCH (n {node_id: 'node:substrate.harness_closure'}) RETURN n.dynamic_pressure, n.prediction_error, n.contributing_turn_ids_json"
```

Confirm `contributing_turn_ids_json` is populated, then re-query after the next `SubstrateDynamicsEngine.tick()` (~30s) to confirm it survives the cache rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)