### PR TITLE
fix(recall): worker.py's _extract_entities double-backslash regex bug

### DIFF
--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -82,9 +82,9 @@ RECALL_FALKOR_GRAPHTRI_IN_CHAT=false
 # 2026-07-19-recall-entity-graph-reasoning-arc.md) -- see settings.py's
 # RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED comment for the full design
 # rationale. Ships dark: needs real recall-quality evidence (not just one
-# hand-picked ranking example) before flipping live, and a known upstream
-# bug in _extract_entities (worker.py) currently limits which real entity
-# mentions this can even match -- see that flag's comment.
+# hand-picked ranking example) before flipping live. The _extract_entities
+# regex bug that used to block this is fixed (worker.py) -- see that flag's
+# comment.
 RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED=false
 # Periodic cache-refresh safety net for the shared FalkorDB-backed substrate
 # store (same knob already used by orion-cortex-exec/orion-hub, and by the

--- a/services/orion-recall/README.md
+++ b/services/orion-recall/README.md
@@ -132,13 +132,14 @@ Chatturn-only read path standing in for RDF's chat-turn fetch. **Live as of 2026
 
 | Variable | Default | Notes |
 | :--- | :--- | :--- |
-| `RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED` | `false` (dark) | See `settings.py`'s comment for the full design + a real, pre-existing limitation this needs fixed first (below). |
+| `RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED` | `false` (dark) | See `settings.py`'s comment for the full design. |
 | `entity_relatedness_boost_weight` (per-profile, `relevance` cfg) | `0.2` | Same additive-scale convention as `prefer_tags_boost` (0.15)/`turn_effect_boost_weight` (0.35). |
 
-**Do not flip this live yet -- two real gaps, found in code review, both need closing first:**
+**Do not flip this live yet -- one real gap remains, found in code review:**
 
-1. **`_extract_entities` (the query-side entity extractor this boost depends on) has a pre-existing regex bug** -- a literal double-backslash inside an r-string (`\\s`/`\\.` match a literal backslash, not whitespace/a dot). Confirmed live: it never merges multi-word entity spans ("New York" -> "New"/"York" separately) and drops all-caps acronyms entirely ("NVIDIA" -> nothing, only "Nvidia" matches). Since Falkor's real `Entity.name` vocabulary is spaCy-NER-derived and includes exactly these shapes, this boost currently fails to match the majority of real entity mentions. This is a repo-wide function (also used for query-expansion fan-out elsewhere in `worker.py`), so fixing it is its own changeset, not something to sneak into this one.
-2. **No recall-quality evidence yet, only one hand-verified ranking example.** Live-verified end to end that a `falkor_chat` candidate whose turn directly mentions an extracted query entity correctly reranks above a same-source candidate with a higher base score -- proving the wiring works, not that it improves real recall quality across real queries. `app/recall_eval.py`/`recall_eval_corpus.json` (this service's existing eval harness) was not run against this feature. Both gaps should close before flipping this flag, not just before merging the PR that ships it dark.
+~~`_extract_entities` had a pre-existing regex bug~~ -- **fixed**: a literal double-backslash inside an r-string (`\\s`/`\\.` matched a literal backslash, not whitespace/a dot) meant it never merged multi-word entity spans ("New York" -> "New"/"York" separately) and dropped all-caps acronyms entirely ("NVIDIA" -> nothing). Fixed at the source (`worker.py::_extract_entities`, `tests/test_extract_entities.py`) after confirming the fix only improves its other two callers too. Still no stopword filtering (sentence-initial capitalized words like "Tell" still extract as false-positive query "entities") -- a smaller, separate precision gap, not a correctness bug.
+
+**No recall-quality evidence yet, only one hand-verified ranking example.** Live-verified end to end that a `falkor_chat` candidate whose turn directly mentions an extracted query entity correctly reranks above a same-source candidate with a higher base score -- proving the wiring works, not that it improves real recall quality across real queries. `app/recall_eval.py`/`recall_eval_corpus.json` (this service's existing eval harness) was not run against this feature. This should close before flipping this flag, not just before merging the PR that ships it dark.
 
 ### Vector / Chroma
 

--- a/services/orion-recall/app/settings.py
+++ b/services/orion-recall/app/settings.py
@@ -320,22 +320,19 @@ class Settings(BaseSettings):
     # turn_id (confirmed by reading falkor_chat_adapter.py) -- sql_chat's id
     # is a correlation_id/synthetic fallback that doesn't always match.
     #
-    # KNOWN LIMITATION, found in code review, NOT fixed here (pre-existing,
-    # repo-wide blast radius -- app/worker.py::_extract_entities is used
-    # elsewhere too, e.g. query-expansion fan-out): its regex has a literal
-    # double-backslash bug (`\\s`/`\\.` inside an r-string match a literal
-    # backslash, not whitespace/dot), confirmed live to (a) never capture
-    # multi-word entity spans ("New York" -> "New", "York" separately, never
-    # merged) and (b) drop all-caps acronyms entirely ("NVIDIA" -> nothing;
-    # only mixed-case "Nvidia" matches). Since Falkor's real Entity.name
-    # vocabulary is spaCy-NER-derived and includes exactly these shapes,
-    # this boost will silently fail to match the majority of real entity
-    # mentions until that regex is fixed in its own dedicated changeset
-    # (touching this shared function requires re-verifying every existing
-    # caller, not just this one). Do not flip this flag live and treat
-    # "no measurable effect" as proof the feature doesn't help -- it may
-    # just mean queries aren't hitting the multi-word/acronym case this bug
-    # breaks. Fix the regex and re-measure before drawing that conclusion.
+    # FIXED (was a known limitation): app/worker.py::_extract_entities had a
+    # literal double-backslash regex bug (`\\s`/`\\.` inside an r-string
+    # match a literal backslash, not whitespace/dot) that silently broke
+    # multi-word entity spans ("New York" -> "New","York" separately) and
+    # dropped all-caps acronyms ("NVIDIA" -> nothing). Fixed in its own
+    # changeset (worker.py::_extract_entities' docstring, and
+    # tests/test_extract_entities.py) after confirming, by reading every
+    # caller, that the fix only improves the other two call sites too (more
+    # precise SQL ILIKE patterns, better query-expansion signals) -- not
+    # something this boost feature should have carried a caveat about
+    # forever. Still no stopword filtering (sentence-initial capitalized
+    # words like "Tell" still extract as false-positive "entities") -- a
+    # separate, smaller, still-open precision gap, not a correctness bug.
     RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED: bool = Field(
         default=False, validation_alias=AliasChoices("RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED")
     )

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -207,10 +207,37 @@ def _source() -> ServiceRef:
 
 
 def _extract_entities(text: str) -> List[str]:
+    """Regression, found in code review (2026-07-19): the two patterns below
+    used to be r"...(?:\\s+...)*" and r"...\\.[..\\.]+" -- a literal
+    double-backslash inside an r-string matches a literal backslash
+    character, not whitespace/a dot. That silently broke this function's
+    entire multi-word-span and dotted-identifier purpose: "New York" could
+    only ever come back as "New"/"York" separately, and "settings.py"/
+    "example.com" never matched at all (confirmed live).
+
+    Two things caught in the SAME review pass and fixed before this shipped
+    (not separately, since both change the same line):
+    - [a-z]+ (one-or-more) widened to [a-zA-Z]+ (still one-or-more, not
+      zero-or-more) so all-caps acronyms match ("NVIDIA", not just
+      "Nvidia") -- but keeping the "at least 2 chars" floor. An earlier
+      version of this fix used [a-zA-Z]* (zero-or-more), which also matched
+      bare single capital letters like "I" -- a real regression on the
+      already-live (non-dark) sql_timeline.py::fetch_related_by_entities
+      call site, which builds an unbounded ILIKE '%I%' from it.
+    - The multi-word merge group capped at exactly one extra word (trailing
+      `?`, not `*`), matching the sibling extractor's own convention
+      already in this codebase (app/recall_v2.py::_extract_entities). `*`
+      would let a long Title-Case sentence collapse into one giant string
+      that then matches nothing real in Falkor or Postgres.
+
+    Still doesn't filter stopword-like capitalized sentence-starters
+    ("Tell" in "Tell me about...") -- a separate, disclosed, deliberately
+    deferred concern (services/orion-recall/README.md's entity-relatedness-
+    boost section), not something this fix attempts to solve."""
     ents = set()
-    ents.update(re.findall(r"[A-Z][a-z]+(?:\\s+[A-Z][a-z]+)*", text))
+    ents.update(re.findall(r"[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)?", text))
     ents.update(re.findall(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", text, flags=re.I))
-    ents.update(re.findall(r"[A-Za-z0-9_]+\\.[A-Za-z0-9_\\.]+", text))
+    ents.update(re.findall(r"[A-Za-z0-9_]+\.[A-Za-z0-9_.]+", text))
     return [e.strip() for e in ents if e.strip()]
 
 

--- a/services/orion-recall/tests/test_extract_entities.py
+++ b/services/orion-recall/tests/test_extract_entities.py
@@ -1,0 +1,84 @@
+"""_extract_entities: regression tests for a double-backslash regex bug found
+in code review (2026-07-19, during the entity-relatedness fusion-boost PR).
+A literal double-backslash inside an r-string (e.g. r"...\\s...") matches a
+literal backslash character, not whitespace/a dot -- this silently broke
+multi-word entity spans and dotted-identifier matching, and excluded
+all-caps acronyms, for as long as this function has existed. Never
+previously tested."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+_RECALL_ROOT = _REPO / "services" / "orion-recall"
+if str(_RECALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RECALL_ROOT))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from app.worker import _extract_entities
+
+
+def test_multi_word_entity_spans_merge_not_split() -> None:
+    """Regression: the double-backslash bug meant '\\s+' matched a literal
+    backslash, never whitespace, so this always came back as ["New",
+    "York"] separately -- never merged."""
+    out = _extract_entities("Tell me about New York and Elon Musk please.")
+    assert "New York" in out
+    assert "Elon Musk" in out
+    assert "New" not in out
+    assert "York" not in out
+
+
+def test_all_caps_acronym_matches() -> None:
+    """Regression: [A-Z][a-z]+ requires lowercase letters after the first
+    capital, so an all-caps word like 'NVIDIA' matched zero times."""
+    out = _extract_entities("Tell me about NVIDIA and Nvidia please.")
+    assert "NVIDIA" in out
+    assert "Nvidia" in out
+
+
+def test_dotted_identifiers_still_match() -> None:
+    """Regression: the double-backslash bug also broke the dotted-identifier
+    pattern (r"...\\.[...\\.]+") the same way -- 'settings.py'/'example.com'
+    never matched at all before this fix."""
+    out = _extract_entities("check services/orion-recall/settings.py and example.com")
+    assert "settings.py" in out
+    assert "example.com" in out
+
+
+def test_uuid_pattern_unaffected() -> None:
+    out = _extract_entities("turn f223ea80-1de3-46f8-8015-ffef48f5992b happened")
+    assert "f223ea80-1de3-46f8-8015-ffef48f5992b" in out
+
+
+def test_empty_text_returns_empty_list() -> None:
+    assert _extract_entities("") == []
+
+
+def test_no_capitalized_words_returns_empty_for_that_pattern() -> None:
+    out = _extract_entities("what's the weather like today")
+    assert out == []
+
+
+def test_bare_single_capital_letter_does_not_match() -> None:
+    """Regression: an earlier version of this fix used [a-zA-Z]* (zero-or-
+    more) instead of [a-zA-Z]+ (one-or-more), which also matched bare
+    single capital letters like the pronoun "I" -- a real regression on the
+    already-live sql_timeline.py::fetch_related_by_entities call site,
+    which would have built an unbounded ILIKE '%I%' from it."""
+    out = _extract_entities("I like pizza")
+    assert "I" not in out
+    assert out == []
+
+
+def test_multi_word_merge_capped_at_two_words() -> None:
+    """Regression: an unbounded merge group (`*` instead of `?`) would
+    collapse a long Title-Case sentence into one giant string that then
+    matches nothing real in Falkor or Postgres. Capped at one extra word,
+    matching app/recall_v2.py::_extract_entities' own existing convention."""
+    out = _extract_entities("Please Review The New Recall Entity Extraction Fix")
+    assert all(len(e.split()) <= 2 for e in out)
+    assert "Please Review The New" not in out


### PR DESCRIPTION
## Summary

Real, pre-existing bug found while reviewing PR #1209 (entity-relatedness fusion boost): `services/orion-recall/app/worker.py::_extract_entities`'s regex had a literal double-backslash inside an r-string (`r"...(?:\\s+...)*"`, `r"...\\.[..\\.]+"`) -- matches a literal backslash character, not whitespace/a dot. This silently broke the function's entire multi-word-span and dotted-identifier purpose since it was written: "New York" could only ever come back as "New"/"York" separately, and "settings.py"/"example.com" never matched at all.

Fixed to single-backslash. Also widened the trailing character class from `[a-z]+` to `[a-zA-Z]+` so all-caps acronyms match ("NVIDIA", not just "Nvidia") -- this closes the exact gap PR #1209 disclosed as blocking the entity-relatedness boost from matching real entity mentions.

## Why now, as its own PR

PR #1209 (already merged) explicitly deferred this: "the function has other callers too -- fixing it here would be undisclosed scope creep touching already-live behavior." Traced all 3 callers before touching anything: `_expand_query` (query-expansion signals), `_compute_entity_relatedness_boost_map` (PR #1209's fusion boost), and the `entities=` param feeding `sql_timeline.py::fetch_related_by_entities`'s SQL `ILIKE` patterns. The fix only improves each -- confirmed via tracing, live verification, and the full test suite.

## Review caught 2 real bugs in my own fix, both fixed before shipping

- **First draft used `[a-zA-Z]*` (zero-or-more)**, which also matched bare single capital letters like "I" -- a real regression on the already-live (non-dark) `fetch_related_by_entities` call site, which would have built an unbounded `ILIKE '%I%'` pattern matching nearly every row. Fixed to `[a-zA-Z]+` (one-or-more), preserving the original "at least 2 chars" floor.
- **First draft's multi-word merge group was unbounded (`*`)**, which could collapse a long Title-Case sentence into one giant string matching nothing real in Falkor or Postgres. Capped at one extra word (trailing `?`), matching `app/recall_v2.py::_extract_entities`'s own existing sibling convention already in this codebase (a repo-internal precedent I should have checked before writing the first draft).

## Files changed

- `services/orion-recall/app/worker.py`: the regex fix + docstring explaining both rounds of the bug.
- `services/orion-recall/tests/test_extract_entities.py` (new): 8 tests -- multi-word merge, acronyms, dotted identifiers, UUID passthrough, empty input, no-match case, the single-capital-letter regression, the unbounded-merge regression. This function had zero tests before.
- `services/orion-recall/app/settings.py`, `README.md`, `.env_example`: updated PR #1209's disclosed-limitation language to reflect the fix instead of continuing to describe it as open.

## Tests run

```
$ .venv/bin/python -m pytest services/orion-recall/tests/ -q
207 passed, 3 failed (pre-existing, unrelated -- same 3 as every prior PR in this migration)
```

## Docker/build/smoke checks

Live-verified against `orion-athena-recall` and the real `orion_recall` graph:

```
_extract_entities('I like pizza') -> []
_extract_entities('Tell me about NVIDIA and Elon Musk in New York')
  -> ['New York', 'NVIDIA', 'Tell', 'Elon Musk']
_extract_entities('Please Review The New Recall Entity Extraction Fix')
  -> ['The New', 'Please Review', 'Extraction Fix', 'Recall Entity']  # bounded, not one giant string

# Confirms the exact gap PR #1209 disclosed is now closed:
_compute_entity_relatedness_boost_map(query_text='Tell me about NVIDIA', ...)
  -> {'efb173fe-194c-4d0b-b48b-c96bcc1c1ea9': 1.0}  # all-caps query now matches the live 'nvidia' entity
```

## Restart required

Already done as part of verification:

```bash
docker restart orion-athena-recall
```

## Risks / concerns

- Severity: low
- Concern: still no stopword filtering for sentence-initial capitalized words ("Tell" still extracts as a false-positive "entity").
- Mitigation: pre-existing, disclosed, separate precision gap -- not a correctness bug, not something this fix attempts to solve (would need a different mechanism, e.g. a stopword list or NER confidence gate).

## PR link

See gh output for actual PR number.