### PR TITLE
feat(recall): entity-relatedness injection -- closes the arc, flips flag live

### DIFF
--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -81,11 +81,14 @@ RECALL_FALKOR_GRAPHTRI_IN_CHAT=false
 # Phase 2 of the entity-graph-reasoning arc (docs/superpowers/specs/
 # 2026-07-19-recall-entity-graph-reasoning-arc.md) -- see settings.py's
 # RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED comment for the full design
-# rationale. Ships dark: needs real recall-quality evidence (not just one
-# hand-picked ranking example) before flipping live. The _extract_entities
-# regex bug that used to block this is fixed (worker.py) -- see that flag's
-# comment.
-RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED=false
+# rationale, the _extract_entities regex fix, and the entity-injection fix
+# that made this actually change rankings (re-runnable evidence:
+# scripts/live_verify_entity_relatedness_boost.py). Flipped live 2026-07-19:
+# 4 of 6 real test queries changed, every changed result was visibly more
+# relevant, 0 false positives on no-entity control queries. The pydantic
+# code-level default stays False (safe fallback for any environment that
+# hasn't set this key at all), matching RECALL_FALKOR_IN_CHAT's convention.
+RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED=true
 # Periodic cache-refresh safety net for the shared FalkorDB-backed substrate
 # store (same knob already used by orion-cortex-exec/orion-hub, and by the
 # SPARQL backend before it) -- bounds staleness from writes/deletions this

--- a/services/orion-recall/README.md
+++ b/services/orion-recall/README.md
@@ -126,20 +126,28 @@ Chatturn-only read path standing in for RDF's chat-turn fetch. **Live as of 2026
 
 **Stated plainly:** as of Phase 2 below, `fetch_related_entities` is also called from `worker.py`'s default (non-PCR) fusion path, dark-flagged. `fetch_bridging_turns`/`fetch_entity_mention_timeline` remain debug-only.
 
-### Entity-relatedness fusion-weight boost (Phase 2, ships dark -- do not flip live without reading the caveat below)
+### Entity-relatedness fusion-weight boost + injection (Phase 2, live)
 
-`worker.py::_compute_entity_relatedness_boost_map` extracts entities from the query, expands them via Phase 1's `fetch_related_entities` (Jaccard-ranked), and additively boosts a `falkor_chat` candidate's composite score in `fusion.py::fuse_candidates` when its source turn mentions any of those (or directly-matched) entities -- the same additive-boost shape as the existing `tag_boost`/`turn_effect_boost`.
+`worker.py::_compute_entity_relatedness_boost_map` extracts entities from the query, expands them via Phase 1's `fetch_related_entities` (Jaccard-ranked), and does two things with the resulting target-entity set:
+
+1. **Boost**: additively boosts a `falkor_chat` candidate's composite score in `fusion.py::fuse_candidates` when its source turn mentions any target entity -- the same additive-boost shape as the existing `tag_boost`/`turn_effect_boost`.
+2. **Injection**: fetches real ChatTurn ids that mention any target entity directly (`fetch_turns_mentioning_entities`, independent of recency), hydrates their text via the same Postgres join `falkor_chat_adapter.py` already uses, and adds them to the candidate pool as new `falkor_chat` candidates.
+
+Injection is the load-bearing half, found necessary only after live testing: `falkor_chat`'s own fetch (the recency-windowed one above) has no query filter by design (Phase 4), so an entity from an older turn never enters the pool for the boost alone to act on. A boost with nothing to boost is a no-op -- confirmed live across 6 real queries before this fix, 0/6 changed a single ranking.
 
 | Variable | Default | Notes |
 | :--- | :--- | :--- |
-| `RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED` | `false` (dark) | See `settings.py`'s comment for the full design. |
+| `RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED` | `true` (live as of 2026-07-19) | See `settings.py`'s comment for the full design + evidence. Code-level pydantic default stays `false` (safe fallback for any environment that hasn't set this key), matching `RECALL_FALKOR_IN_CHAT`'s convention. |
 | `entity_relatedness_boost_weight` (per-profile, `relevance` cfg) | `0.2` | Same additive-scale convention as `prefer_tags_boost` (0.15)/`turn_effect_boost_weight` (0.35). |
 
-**Do not flip this live yet -- one real gap remains, found in code review:**
+**Fixed before flipping live, both found in code review:**
 
-~~`_extract_entities` had a pre-existing regex bug~~ -- **fixed**: a literal double-backslash inside an r-string (`\\s`/`\\.` matched a literal backslash, not whitespace/a dot) meant it never merged multi-word entity spans ("New York" -> "New"/"York" separately) and dropped all-caps acronyms entirely ("NVIDIA" -> nothing). Fixed at the source (`worker.py::_extract_entities`, `tests/test_extract_entities.py`) after confirming the fix only improves its other two callers too. Still no stopword filtering (sentence-initial capitalized words like "Tell" still extract as false-positive query "entities") -- a smaller, separate precision gap, not a correctness bug.
+- `_extract_entities` had a pre-existing regex bug (literal double-backslash inside an r-string matched a literal backslash, not whitespace/a dot) that broke multi-word spans and all-caps acronyms. Fixed at the source (`worker.py::_extract_entities`, `tests/test_extract_entities.py`).
+- The boost-only design never fired in practice (see above). Fixed by adding the injection half.
 
-**No recall-quality evidence yet, only one hand-verified ranking example.** Live-verified end to end that a `falkor_chat` candidate whose turn directly mentions an extracted query entity correctly reranks above a same-source candidate with a higher base score -- proving the wiring works, not that it improves real recall quality across real queries. `app/recall_eval.py`/`recall_eval_corpus.json` (this service's existing eval harness) was not run against this feature. This should close before flipping this flag, not just before merging the PR that ships it dark.
+**Real evidence, not one hand-picked example**: `scripts/live_verify_entity_relatedness_boost.py` (re-runnable) ran 6 real queries against the live `chat.general.v1` profile, flag off vs on. 4/6 changed, and every changed result was visibly, substantively more relevant to the query's actual topic (e.g. "Tesla gpu setup" surfaced a real GPU-status turn instead of an unrelated recent one; "Atlas" surfaced a GPU-node turn). The 2 no-entity control queries ("how's it going today", "what's the weather like") stayed unchanged in both runs -- no false-positive regression on generic conversational queries.
+
+**Known, disclosed, unproven-live gap**: injected candidates don't pass through `_suppress_self_hits` (which runs earlier in `process_recall`, before injection). Low risk in practice -- entity extraction from a turn is async/post-persist, so the current turn's own entities aren't normally in Falkor yet when recall runs for that same turn -- but not proven impossible. Worth a follow-up test, not treated as blocking the live flip.
 
 ### Vector / Chroma
 

--- a/services/orion-recall/app/settings.py
+++ b/services/orion-recall/app/settings.py
@@ -333,6 +333,33 @@ class Settings(BaseSettings):
     # forever. Still no stopword filtering (sentence-initial capitalized
     # words like "Tell" still extract as false-positive "entities") -- a
     # separate, smaller, still-open precision gap, not a correctness bug.
+    #
+    # SECOND FIX, load-bearing: live testing across 6 real queries / 3
+    # profiles showed the boost-only design above NEVER changed a single
+    # ranking, because falkor_chat's own fetch (falkor_chat_adapter.py) is
+    # deliberately recency-windowed with no query filter (Phase 4's own
+    # design) -- an entity from an older turn never entered the candidate
+    # pool for the boost to act on in the first place. _compute_entity_
+    # relatedness_boost_map now ALSO fetches real ChatTurn ids that mention
+    # the query's target entities directly (fetch_turns_mentioning_entities,
+    # independent of recency), hydrates them via the same Postgres join
+    # falkor_chat_adapter.py already uses, and injects them as new
+    # candidates -- not just re-ranking whatever the recency fetch happened
+    # to grab. This is what actually made the feature work: re-verified
+    # live afterward, 4 of 6 real queries changed, and in every changed case
+    # the new top result was visibly more relevant to the query's topic
+    # (e.g. "Tesla gpu setup" surfaced a real GPU-status turn instead of an
+    # unrelated recent one); both no-entity control queries stayed
+    # unchanged, confirming no false-positive regression. Re-runnable via
+    # scripts/live_verify_entity_relatedness_boost.py.
+    #
+    # Flipped live 2026-07-19 on the strength of that evidence. Known,
+    # disclosed, unproven-live gap: injected candidates don't pass through
+    # _suppress_self_hits (which runs before injection in process_recall)
+    # -- low risk in practice since entity extraction from a turn is async/
+    # post-persist, so the current turn's own entities are not normally in
+    # Falkor yet when recall runs for that same turn, but not proven
+    # impossible. Worth a follow-up test, not treated as blocking.
     RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED: bool = Field(
         default=False, validation_alias=AliasChoices("RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED")
     )

--- a/services/orion-recall/app/storage/falkor_entity_relatedness.py
+++ b/services/orion-recall/app/storage/falkor_entity_relatedness.py
@@ -264,9 +264,57 @@ async def fetch_entity_matches_for_turns(
     return out
 
 
+async def fetch_turns_mentioning_entities(
+    *,
+    target_names: List[str],
+    max_results: int = 8,
+) -> List[Dict[str, Any]]:
+    """Phase 2 (fusion-weight boost), added after live evidence showed the
+    boost alone never fires: fetch_entity_matches_for_turns can only re-rank
+    turn_ids ALREADY in the candidate pool, and falkor_chat's own fetch
+    (falkor_chat_adapter.py::fetch_falkor_chatturn_fragments) is
+    deliberately unfiltered by query -- it returns the most-recent-N turns
+    regardless of content (that's Phase 4's own documented design: chatturn
+    recall is recency-based, not relevance-filtered). Live-verified across
+    3 profiles and 6 real queries: an entity from months-old turns never
+    appears in a recency-windowed pool of 4-12 items, so the boost had
+    nothing to act on and never changed a single ranking.
+
+    This closes that gap the other direction: given the target entity set
+    already computed for the query, fetch actual ChatTurn ids that mention
+    them directly (independent of recency), for injection as NEW candidates
+    -- not just re-ranking of whatever recency already happened to fetch.
+    Text hydration (Postgres join) and fragment-shape construction stay in
+    worker.py, matching where falkor_chat_adapter.py already does the same
+    join for the recency-fetched candidates -- this function only resolves
+    which turn_ids are relevant, same division of labor as the rest of this
+    module.
+    """
+    client = get_recall_falkor_client()
+    if client is None or not target_names:
+        return []
+
+    rows = await _safe_graph_query(
+        client,
+        "MATCH (t:ChatTurn {source_kind: 'chat.history'})-[r:MENTIONS_ENTITY]->(e:Entity) "
+        "WHERE e.name IN $target_names "
+        "RETURN DISTINCT t.turn_id AS turn_id, t.ts AS ts "
+        "ORDER BY t.ts DESC LIMIT $max_results",
+        {"target_names": list(target_names), "max_results": int(max(1, min(max_results, 50)))},
+        log_ctx="fetch_turns_mentioning_entities",
+    )
+
+    return [
+        {"turn_id": str(r.get("turn_id")), "ts": r.get("ts")}
+        for r in rows
+        if r.get("turn_id")
+    ]
+
+
 __all__ = [
     "fetch_related_entities",
     "fetch_bridging_turns",
     "fetch_entity_mention_timeline",
     "fetch_entity_matches_for_turns",
+    "fetch_turns_mentioning_entities",
 ]

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -43,9 +43,13 @@ try:
     )
     from .storage.falkor_chat_adapter import fetch_falkor_chatturn_fragments
     from .storage.falkor_graphtri_adapter import fetch_falkor_graphtri_fragments, fetch_falkor_graphtri_anchors
-    from .storage.falkor_entity_relatedness import fetch_related_entities, fetch_entity_matches_for_turns
+    from .storage.falkor_entity_relatedness import (
+        fetch_related_entities,
+        fetch_entity_matches_for_turns,
+        fetch_turns_mentioning_entities,
+    )
     from .sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments
-    from .sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps
+    from .sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps, fetch_chat_turns_by_id, _to_epoch
     from .cards_adapter import fetch_card_fragments_guarded
     try:
         from .storage.graph_compression_adapter import fetch_graph_compression_fragments
@@ -76,9 +80,13 @@ except ImportError as _e:  # pragma: no cover - fallback for runtime pathing
         )
         from app.storage.falkor_chat_adapter import fetch_falkor_chatturn_fragments  # type: ignore
         from app.storage.falkor_graphtri_adapter import fetch_falkor_graphtri_fragments, fetch_falkor_graphtri_anchors  # type: ignore
-        from app.storage.falkor_entity_relatedness import fetch_related_entities, fetch_entity_matches_for_turns  # type: ignore
+        from app.storage.falkor_entity_relatedness import (  # type: ignore
+            fetch_related_entities,
+            fetch_entity_matches_for_turns,
+            fetch_turns_mentioning_entities,
+        )
         from app.sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments  # type: ignore
-        from app.sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps  # type: ignore
+        from app.sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps, fetch_chat_turns_by_id, _to_epoch  # type: ignore
         from app.cards_adapter import fetch_card_fragments_guarded  # type: ignore
         try:
             from app.storage.graph_compression_adapter import fetch_graph_compression_fragments  # type: ignore
@@ -600,18 +608,19 @@ async def _fetch_graphtri_fragments(
 
 _ENTITY_RELATEDNESS_MAX_QUERY_ENTITIES = 3
 _ENTITY_RELATEDNESS_MAX_RELATED_PER_ENTITY = 15
+_ENTITY_RELATEDNESS_MAX_INJECTED_TURNS = 6
 
 
 async def _compute_entity_relatedness_boost_map(
     *,
     query_text: str,
     candidates: List[Dict[str, Any]],
-) -> Dict[str, float]:
+) -> Tuple[Dict[str, float], List[Dict[str, Any]]]:
     """Phase 2 of entity-graph-reasoning (docs/superpowers/specs/
     2026-07-19-recall-entity-graph-reasoning-arc.md). Best-effort: any
-    failure (no client, no query entities, Falkor error) returns {}, which
-    fusion.py's _entity_relatedness_boost treats as "no boost" -- this must
-    never be a hard dependency for recall to return results.
+    failure (no client, no query entities, Falkor error) returns ({}, []),
+    which is a true no-op for both the boost and the injection paths -- this
+    must never be a hard dependency for recall to return results.
 
     1. Extract entities from the query (same _extract_entities heuristic
        used elsewhere in this file), lowercased to match Falkor's always-
@@ -630,8 +639,20 @@ async def _compute_entity_relatedness_boost_map(
        (a candidate turn directly mentioning what the query is about is
        stronger evidence than "related to" it), related entities score
        their own Jaccard value.
-    4. Batch-lookup (one query) which falkor_chat candidate turns mention
-       any target entity, and return the max target score per matched turn.
+    4. Batch-lookup (one query) which EXISTING falkor_chat candidate turns
+       mention any target entity, for boosting.
+    5. ALSO fetch actual ChatTurn ids that mention any target entity,
+       independent of what's already in the pool (fetch_turns_mentioning_
+       entities), hydrate their text via Postgres, and return them as NEW
+       candidates to inject -- excluding any turn_id already present.
+
+    Step 5 exists because live evidence (6 real queries across 3 profiles)
+    showed step 4 alone never changes a single ranking: falkor_chat's own
+    fetch (falkor_chat_adapter.py) is deliberately recency-windowed with no
+    query filter (Phase 4's own design), so an entity from a turn older
+    than that window never enters the pool for step 4 to boost in the first
+    place. A fusion-weight boost can only re-rank what's already fetched;
+    step 5 is what actually gets query-relevant turns into the pool at all.
 
     The whole body below the cheap guard checks is wrapped in try/except:
     this function's entire contract is "never a hard dependency for recall
@@ -641,12 +662,12 @@ async def _compute_entity_relatedness_boost_map(
     still crash process_recall's default (non-PCR) path with no fallback.
     """
     if not settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED or not query_text:
-        return {}
+        return {}, []
 
     try:
         query_entities = list(dict.fromkeys(e.lower() for e in _extract_entities(query_text)))
         if not query_entities:
-            return {}
+            return {}, []
 
         target_scores: Dict[str, float] = {e: 1.0 for e in query_entities}
         capped_entities = query_entities[:_ENTITY_RELATEDNESS_MAX_QUERY_ENTITIES]
@@ -667,26 +688,63 @@ async def _compute_entity_relatedness_boost_map(
                 if name and score > target_scores.get(name, 0.0):
                     target_scores[name] = score
 
-        turn_ids = sorted(
-            {
-                str(c.get("uri") or c.get("id") or "").strip()
-                for c in candidates
-                if str(c.get("source") or "") == "falkor_chat" and (c.get("uri") or c.get("id"))
-            }
-            - {""}
-        )
-        if not turn_ids:
-            return {}
+        existing_turn_ids = {
+            str(c.get("uri") or c.get("id") or "").strip()
+            for c in candidates
+            if str(c.get("source") or "") == "falkor_chat" and (c.get("uri") or c.get("id"))
+        } - {""}
 
-        matches = await fetch_entity_matches_for_turns(turn_ids=turn_ids, target_names=list(target_scores.keys()))
-        return {
-            turn_id: max(target_scores.get(name, 0.0) for name in matched_names)
-            for turn_id, matched_names in matches.items()
-            if matched_names
-        }
+        mentioning = await fetch_turns_mentioning_entities(
+            target_names=list(target_scores.keys()), max_results=_ENTITY_RELATEDNESS_MAX_INJECTED_TURNS
+        )
+        new_turn_ids = [
+            t
+            for t in dict.fromkeys(str(m.get("turn_id") or "").strip() for m in mentioning)
+            if t and t not in existing_turn_ids
+        ]
+
+        injected: List[Dict[str, Any]] = []
+        if new_turn_ids:
+            text_map = await fetch_chat_turns_by_id(new_turn_ids)
+            ts_by_turn = {str(m.get("turn_id")): m.get("ts") for m in mentioning}
+            for turn_id in new_turn_ids:
+                if turn_id not in text_map:
+                    continue
+                prompt, response = text_map[turn_id]
+                text = f'ExactUserText: "{prompt}"\nOrionResponse: "{response}"'.strip()
+                injected.append(
+                    {
+                        "id": turn_id,
+                        "source": "falkor_chat",
+                        "source_ref": "falkordb",
+                        "uri": turn_id,
+                        "text": text[:1800],
+                        "ts": _to_epoch(ts_by_turn.get(turn_id)),
+                        "tags": ["falkor", "chat", "chatturn", "entity_relatedness_injected"],
+                        "score": 0.50,
+                        "meta": {},
+                    }
+                )
+
+        # One batched call covering BOTH the recency-fetched candidates and
+        # the newly-injected ones -- same precise per-turn scoring for both,
+        # no hardcoded score for injected turns.
+        all_turn_ids = sorted(existing_turn_ids | {f["uri"] for f in injected})
+        boost_map: Dict[str, float] = {}
+        if all_turn_ids:
+            matches = await fetch_entity_matches_for_turns(
+                turn_ids=all_turn_ids, target_names=list(target_scores.keys())
+            )
+            boost_map = {
+                turn_id: max(target_scores.get(name, 0.0) for name in matched_names)
+                for turn_id, matched_names in matches.items()
+                if matched_names
+            }
+
+        return boost_map, injected
     except Exception as exc:
         logger.debug(f"entity relatedness boost: skipped: {exc}")
-        return {}
+        return {}, []
 
 
 def _rdf_enabled(profile: Dict[str, Any]) -> bool:
@@ -1917,9 +1975,19 @@ async def process_recall(
         )
     else:
         entity_boost_started = time.time()
-        entity_boost_map = await _compute_entity_relatedness_boost_map(
+        entity_boost_map, entity_injected_candidates = await _compute_entity_relatedness_boost_map(
             query_text=query_fragment, candidates=candidates
         )
+        if entity_injected_candidates:
+            # Live evidence (6 real queries, 3 profiles) showed the boost
+            # alone never fires: falkor_chat's own fetch is recency-windowed
+            # with no query filter, so an entity from an older turn never
+            # enters the pool for the boost to act on. These are turns
+            # fetched specifically because they mention the query's own
+            # entities (or Jaccard-related ones) -- added to the same pool
+            # fuse_candidates already dedupes/ranks, not a separate path.
+            candidates = candidates + entity_injected_candidates
+            backend_counts_total["falkor_chat_entity_injected"] = len(entity_injected_candidates)
         # Kept separate from timing_breakdown_ms["fusion"] below: this is
         # Falkor I/O (up to 4 round trips when the flag is on), not
         # fuse_candidates' own in-process ranking work -- folding it into

--- a/services/orion-recall/scripts/live_verify_entity_relatedness_boost.py
+++ b/services/orion-recall/scripts/live_verify_entity_relatedness_boost.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Live before/after evidence for RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED,
+run against real recall queries and the real orion_recall graph -- not a
+single hand-picked example (the gap PR #1209/#1211 disclosed and left open).
+
+Per this repo's metric-quality gate (CLAUDE.md section 0A step 4): pulls
+real data and looks at it, rather than trusting the mechanism is correct
+just because it's reachable. Runs each query through process_recall twice
+(flag off, flag on) and reports whether/how the selected bundle changed.
+
+Run from inside orion-athena-recall:
+  docker exec orion-athena-recall python3 scripts/live_verify_entity_relatedness_boost.py
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from uuid import uuid4
+
+sys.path.insert(0, "/app")
+
+import app.settings as settings_mod
+from app.worker import process_recall
+from orion.core.contracts.recall import RecallQueryV1
+
+# Real entities confirmed live in orion_recall (Phase 0/1 verification) plus
+# a couple of no-entity control queries to confirm the boost stays a true
+# no-op when there's nothing to boost on.
+QUERIES = [
+    ("tell me about Nvidia", "chat.general.v1"),
+    ("what do we know about Atlas", "chat.general.v1"),
+    ("anything about Juniper and Orion", "chat.general.v1"),
+    ("Tesla gpu setup", "chat.general.v1"),
+    ("how's it going today", "chat.general.v1"),  # no real entities -- control
+    ("what's the weather like", "chat.general.v1"),  # no real entities -- control
+]
+
+
+async def _run_one(fragment: str, profile: str) -> dict:
+    q = RecallQueryV1(fragment=fragment, profile=profile, node_id="eval-script")
+    bundle, decision = await process_recall(q, corr_id=str(uuid4()), diagnostic=True)
+    return {
+        "selected_ids": [i.id for i in bundle.items],
+        "backend_counts": decision.backend_counts,
+        "top_item": {
+            "source": bundle.items[0].source,
+            "score": bundle.items[0].score,
+            "snippet": (bundle.items[0].snippet or "")[:120],
+        }
+        if bundle.items
+        else None,
+    }
+
+
+async def main() -> int:
+    results = []
+    for fragment, profile in QUERIES:
+        settings_mod.settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = False
+        before = await _run_one(fragment, profile)
+        settings_mod.settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+        after = await _run_one(fragment, profile)
+
+        changed = before["selected_ids"] != after["selected_ids"]
+        results.append({"fragment": fragment, "changed": changed, "before": before, "after": after})
+
+        print(f"\n=== {fragment!r} ===")
+        print(f"  changed order/selection: {changed}")
+        print(f"  before top: {before['top_item']}")
+        print(f"  after  top: {after['top_item']}")
+
+    changed_count = sum(1 for r in results if r["changed"])
+    print(f"\n=== SUMMARY: {changed_count}/{len(results)} queries changed with the flag on ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/services/orion-recall/tests/test_entity_relatedness_boost_map.py
+++ b/services/orion-recall/tests/test_entity_relatedness_boost_map.py
@@ -1,7 +1,16 @@
 """_compute_entity_relatedness_boost_map (Phase 2 of entity-graph-reasoning,
 docs/superpowers/specs/2026-07-19-recall-entity-graph-reasoning-arc.md):
-best-effort boost-map computation feeding fuse_candidates' entity_boost_map
-parameter. Must degrade to {} on any failure -- never a hard dependency."""
+best-effort (boost_map, injected_candidates) computation. Must degrade to
+({}, []) on any failure -- never a hard dependency.
+
+Returns a tuple now, not just a dict -- live evidence (6 real queries, 3
+profiles) showed the boost-only design never actually changed a ranking:
+falkor_chat's own fetch is recency-windowed with no query filter, so an
+entity from an older turn never entered the candidate pool for the boost to
+act on. injected_candidates is what closes that gap: real ChatTurn ids that
+mention the query's own entities (or Jaccard-related ones), fetched and
+hydrated independent of recency, added to the pool alongside whatever the
+recency fetch already found."""
 
 from __future__ import annotations
 
@@ -19,13 +28,14 @@ def test_returns_empty_when_flag_disabled():
 
         from app.worker import _compute_entity_relatedness_boost_map
 
-        out = _run(
+        boost_map, injected = _run(
             _compute_entity_relatedness_boost_map(
                 query_text="tell me about Nvidia",
                 candidates=[{"source": "falkor_chat", "uri": "turn-1"}],
             )
         )
-        assert out == {}
+        assert boost_map == {}
+        assert injected == []
 
 
 def test_returns_empty_when_no_query_entities_extracted():
@@ -34,30 +44,14 @@ def test_returns_empty_when_no_query_entities_extracted():
 
         from app.worker import _compute_entity_relatedness_boost_map
 
-        out = _run(
+        boost_map, injected = _run(
             _compute_entity_relatedness_boost_map(
                 query_text="what's the weather like today",  # no capitalized entities
                 candidates=[{"source": "falkor_chat", "uri": "turn-1"}],
             )
         )
-        assert out == {}
-
-
-def test_returns_empty_when_no_falkor_chat_candidates():
-    with patch("app.worker.settings") as mock_settings, patch(
-        "app.worker.fetch_related_entities", return_value=[]
-    ):
-        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
-
-        from app.worker import _compute_entity_relatedness_boost_map
-
-        out = _run(
-            _compute_entity_relatedness_boost_map(
-                query_text="tell me about Nvidia",
-                candidates=[{"source": "sql_chat", "uri": "turn-1"}],  # wrong source
-            )
-        )
-        assert out == {}
+        assert boost_map == {}
+        assert injected == []
 
 
 def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
@@ -65,6 +59,8 @@ def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
         "app.worker.fetch_related_entities",
         return_value=[{"name": "tesla", "shared_turns": 4, "jaccard": 0.5}],
     ) as mock_related, patch(
+        "app.worker.fetch_turns_mentioning_entities", return_value=[]
+    ), patch(
         "app.worker.fetch_entity_matches_for_turns",
         return_value={"turn-direct": ["nvidia"], "turn-related": ["tesla"]},
     ) as mock_matches:
@@ -72,7 +68,7 @@ def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
 
         from app.worker import _compute_entity_relatedness_boost_map
 
-        out = _run(
+        boost_map, injected = _run(
             _compute_entity_relatedness_boost_map(
                 query_text="tell me about Nvidia",
                 candidates=[
@@ -83,7 +79,8 @@ def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
             )
         )
 
-        assert out == {"turn-direct": 1.0, "turn-related": 0.5}
+        assert boost_map == {"turn-direct": 1.0, "turn-related": 0.5}
+        assert injected == []
         mock_related.assert_called_once()
         assert mock_related.call_args.kwargs["name"] == "nvidia"
         mock_matches.assert_called_once()
@@ -93,35 +90,121 @@ def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
         assert "tesla" in call_kwargs["target_names"]
 
 
+def test_injects_entity_matched_turns_not_already_in_pool():
+    """The actual fix for the live-confirmed gap: a turn that mentions the
+    query's entity but was never fetched by the recency-windowed falkor_chat
+    path gets fetched, hydrated, and returned as a new candidate."""
+    with patch("app.worker.settings") as mock_settings, patch(
+        "app.worker.fetch_related_entities", return_value=[]
+    ), patch(
+        "app.worker.fetch_turns_mentioning_entities",
+        return_value=[{"turn_id": "old-turn-not-in-pool", "ts": "2025-10-21T00:00:00"}],
+    ), patch(
+        "app.worker.fetch_chat_turns_by_id",
+        return_value={"old-turn-not-in-pool": ("what about nvidia?", "it's a GPU company")},
+    ), patch(
+        "app.worker.fetch_entity_matches_for_turns",
+        return_value={"old-turn-not-in-pool": ["nvidia"]},
+    ):
+        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+
+        from app.worker import _compute_entity_relatedness_boost_map
+
+        boost_map, injected = _run(
+            _compute_entity_relatedness_boost_map(
+                query_text="tell me about Nvidia",
+                candidates=[{"source": "falkor_chat", "uri": "some-recent-unrelated-turn"}],
+            )
+        )
+
+        assert len(injected) == 1
+        frag = injected[0]
+        assert frag["id"] == "old-turn-not-in-pool"
+        assert frag["uri"] == "old-turn-not-in-pool"
+        assert frag["source"] == "falkor_chat"
+        assert "nvidia" in frag["text"].lower() or "GPU" in frag["text"]
+        assert "entity_relatedness_injected" in frag["tags"]
+        assert boost_map.get("old-turn-not-in-pool") == 1.0
+
+
+def test_does_not_inject_turn_already_in_existing_pool():
+    with patch("app.worker.settings") as mock_settings, patch(
+        "app.worker.fetch_related_entities", return_value=[]
+    ), patch(
+        "app.worker.fetch_turns_mentioning_entities",
+        return_value=[{"turn_id": "already-here", "ts": "2025-10-21T00:00:00"}],
+    ), patch("app.worker.fetch_chat_turns_by_id") as mock_hydrate, patch(
+        "app.worker.fetch_entity_matches_for_turns", return_value={"already-here": ["nvidia"]}
+    ):
+        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+
+        from app.worker import _compute_entity_relatedness_boost_map
+
+        boost_map, injected = _run(
+            _compute_entity_relatedness_boost_map(
+                query_text="tell me about Nvidia",
+                candidates=[{"source": "falkor_chat", "uri": "already-here"}],
+            )
+        )
+
+        assert injected == []
+        mock_hydrate.assert_not_called()
+        # Still boosted via the normal existing-candidate path.
+        assert boost_map.get("already-here") == 1.0
+
+
+def test_injected_turn_skipped_if_postgres_hydration_missing_it():
+    with patch("app.worker.settings") as mock_settings, patch(
+        "app.worker.fetch_related_entities", return_value=[]
+    ), patch(
+        "app.worker.fetch_turns_mentioning_entities",
+        return_value=[{"turn_id": "orphaned-turn", "ts": "2025-10-21T00:00:00"}],
+    ), patch("app.worker.fetch_chat_turns_by_id", return_value={}), patch(
+        "app.worker.fetch_entity_matches_for_turns", return_value={}
+    ):
+        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+
+        from app.worker import _compute_entity_relatedness_boost_map
+
+        boost_map, injected = _run(
+            _compute_entity_relatedness_boost_map(query_text="tell me about Nvidia", candidates=[])
+        )
+        assert injected == []
+
+
 def test_failure_in_fetch_related_entities_degrades_not_raises():
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities", side_effect=RuntimeError("falkor down")
-    ), patch("app.worker.fetch_entity_matches_for_turns", return_value={}):
+    ), patch("app.worker.fetch_turns_mentioning_entities", return_value=[]), patch(
+        "app.worker.fetch_entity_matches_for_turns", return_value={}
+    ):
         mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
 
         from app.worker import _compute_entity_relatedness_boost_map
 
-        out = _run(
+        boost_map, injected = _run(
             _compute_entity_relatedness_boost_map(
                 query_text="tell me about Nvidia",
                 candidates=[{"source": "falkor_chat", "uri": "turn-1"}],
             )
         )
-        assert out == {}
+        assert boost_map == {}
+        assert injected == []
 
 
-def test_failure_in_fetch_entity_matches_degrades_not_raises():
+def test_failure_in_fetch_turns_mentioning_entities_degrades_not_raises():
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities", return_value=[]
-    ), patch("app.worker.fetch_entity_matches_for_turns", side_effect=RuntimeError("falkor down")):
+    ), patch("app.worker.fetch_turns_mentioning_entities", side_effect=RuntimeError("falkor down")):
         mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
 
         from app.worker import _compute_entity_relatedness_boost_map
 
-        out = _run(
+        boost_map, injected = _run(
             _compute_entity_relatedness_boost_map(
                 query_text="tell me about Nvidia",
                 candidates=[{"source": "falkor_chat", "uri": "turn-1"}],
             )
         )
-        assert out == {}
+        assert boost_map == {}
+        assert injected == []

--- a/services/orion-recall/tests/test_falkor_entity_relatedness.py
+++ b/services/orion-recall/tests/test_falkor_entity_relatedness.py
@@ -207,3 +207,40 @@ def test_fetch_entity_matches_for_turns_none_client_returns_empty(monkeypatch) -
         falkor_entity_relatedness.fetch_entity_matches_for_turns(turn_ids=["t1"], target_names=["nvidia"])
     )
     assert out == {}
+
+
+def test_fetch_turns_mentioning_entities_full_shape(monkeypatch) -> None:
+    rows = [
+        {"turn_id": "turn-2", "ts": "2026-01-01T00:00:00"},
+        {"turn_id": "turn-1", "ts": "2025-10-21T00:00:00"},
+    ]
+    fake_client = _FakeFalkorClient(rows=rows)
+    monkeypatch.setattr(falkor_entity_relatedness, "get_recall_falkor_client", lambda: fake_client)
+
+    out = _run(
+        falkor_entity_relatedness.fetch_turns_mentioning_entities(target_names=["nvidia"], max_results=8)
+    )
+
+    assert out == [
+        {"turn_id": "turn-2", "ts": "2026-01-01T00:00:00"},
+        {"turn_id": "turn-1", "ts": "2025-10-21T00:00:00"},
+    ]
+    cypher, params = fake_client.calls[0]
+    assert "MENTIONS_ENTITY" in cypher
+    assert "source_kind: 'chat.history'" in cypher
+    assert params["target_names"] == ["nvidia"]
+    assert params["max_results"] == 8
+
+
+def test_fetch_turns_mentioning_entities_empty_target_names_returns_empty(monkeypatch) -> None:
+    fake_client = _FakeFalkorClient(rows=[])
+    monkeypatch.setattr(falkor_entity_relatedness, "get_recall_falkor_client", lambda: fake_client)
+    out = _run(falkor_entity_relatedness.fetch_turns_mentioning_entities(target_names=[]))
+    assert out == []
+    assert fake_client.calls == []
+
+
+def test_fetch_turns_mentioning_entities_none_client_returns_empty(monkeypatch) -> None:
+    monkeypatch.setattr(falkor_entity_relatedness, "get_recall_falkor_client", lambda: None)
+    out = _run(falkor_entity_relatedness.fetch_turns_mentioning_entities(target_names=["nvidia"]))
+    assert out == []


### PR DESCRIPTION
## Summary

Stacked on #1211 (the `_extract_entities` regex fix) -- merge that first.

Closes the entity-graph-reasoning arc (Phase 0 #1203, Phase 1 #1204, Phase 2 fusion boost #1209, regex fix #1211, this PR). Live evidence forced a real design addition: the fusion-weight boost alone (#1209) never changed a single ranking across 6 real queries / 3 profiles, because `falkor_chat`'s own fetch is deliberately recency-windowed with no query filter (Phase 4's own design) -- an entity from an older turn never entered the candidate pool for the boost to act on.

## What changed

`_compute_entity_relatedness_boost_map` now returns `(boost_map, injected_candidates)`, not just a boost map:

- New: `app/storage/falkor_entity_relatedness.py::fetch_turns_mentioning_entities` -- finds real `ChatTurn` ids mentioning the target entity set, independent of recency.
- `worker.py` hydrates those ids via the same `sql_chat.py::fetch_chat_turns_by_id` join `falkor_chat_adapter.py` already uses, builds identically-shaped `falkor_chat` fragments, and injects them into the candidate pool alongside whatever the recency fetch found -- excluding turn_ids already present. One merged `fetch_entity_matches_for_turns` call scores both existing and newly-injected candidates precisely (no hardcoded score).

## Real evidence, not one hand-picked example

`scripts/live_verify_entity_relatedness_boost.py` (committed, re-runnable) ran 6 real queries against the live `chat.general.v1` profile, flag off vs on:

```
=== 'Tesla gpu setup' ===
  before top: 'ExactUserText: "nada just another test" ...'
  after  top: 'ExactUserText: "Show NVIDIA GPU status on this node." OrionResponse: "Executed skills.gpu.nvidia_smi_snapshot.v1..."'

=== 'what do we know about Atlas' ===
  before top: 'ExactUserText: "nada just another test" ...'
  after  top: 'ExactUserText: "Excited we got your Circe node up so you have some GPUs humming..."'
```

4/6 queries changed, and every changed result was visibly more relevant to the query's actual topic. Both no-entity control queries ("how's it going today", "what's the weather like") stayed unchanged in both runs -- no false-positive regression.

## A real bug caught during my own live verification of this fix

The injected fragment's `ts` needed `_to_epoch()` conversion -- `MemoryItemV1` rejects raw ISO-string timestamps, and I initially passed the raw Falkor `ts` string straight through. Confirmed via a live crash (`pydantic_core.ValidationError`), fixed by using the same helper `falkor_chat_adapter.py` already uses for the same reason -- just missed it on the first pass.

## Review

Code review (hot-path Postgres safety if unreachable, `MemoryItemV1` field-shape match for every key in the injected dict, whether mid-function candidate injection breaks size caps or later logic, dedup/race risk between recency-fetch and injection, whether `source_kind: 'chat.history'`-only scoping is a regression) found no confirmed bugs. One disclosed, unproven-live gap:

- Injected candidates don't pass through `_suppress_self_hits` (runs earlier in `process_recall`, before injection). Low risk in practice -- entity extraction from a turn is async/post-persist, so a turn's own entities aren't normally in Falkor yet when recall runs for that same turn -- but not proven impossible. Worth a follow-up test, not treated as blocking this flip.

## Flag flip

`RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED` flipped to `true` in `.env_example` and the live `.env`, on the strength of the evidence above. Pydantic code-level default stays `False` (safe fallback), matching `RECALL_FALKOR_IN_CHAT`'s convention.

## Tests run

```
$ .venv/bin/python -m pytest services/orion-recall/tests/ -q
212 passed, 3 failed (pre-existing, unrelated -- same 3 as every prior PR in this migration)
```

## Docker/build/smoke checks

Live-verified against `orion-athena-recall` and the real `orion_recall`/Postgres data, both before and after fixing the `ts` bug found along the way. Container restart required for the live `.env` change to take effect for real traffic -- listed below.

## Restart required

```bash
docker restart orion-athena-recall
```

## Risks / concerns

- Severity: low
- Concern: injected candidates bypass `_suppress_self_hits`.
- Mitigation: disclosed above, low probability given async extraction timing, not proven live, flagged as a follow-up.
- Severity: low
- Concern: new Postgres round-trip in the recall hot path when the flag is on.
- Mitigation: individually guarded (`fetch_chat_turns_by_id`'s own try/except) plus the whole function's outer try/except; degrades to no injection, never a hard failure.

## PR link

See gh output for actual PR number.