### PR TITLE
fix(recall): entity-boost document-frequency discount -- live regression from user report

### DIFF
--- a/services/orion-recall/README.md
+++ b/services/orion-recall/README.md
@@ -149,6 +149,13 @@ Injection is the load-bearing half, found necessary only after live testing: `fa
 
 **Known, disclosed, unproven-live gap**: injected candidates don't pass through `_suppress_self_hits` (which runs earlier in `process_recall`, before injection). Low risk in practice -- entity extraction from a turn is async/post-persist, so the current turn's own entities aren't normally in Falkor yet when recall runs for that same turn -- but not proven impossible. Worth a follow-up test, not treated as blocking the live flip.
 
+**Third fix, same day, found from real live usage**: a mundane message that simply addresses the assistant by name ("Orion, what do you think about the deploy?") extracted "orion" as a query entity and scored it a flat `1.0` -- "orion"/"juniper" are the two most frequent nodes in the whole graph (282/260 mentions, confirmed live), so this injected generic filler turns ("thanks, appreciated.", "word, good advice") at full boost strength purely because they happened to mention Orion/Juniper by name. Fixed with a two-part change:
+
+1. `fetch_entity_degrees` applies an IDF-style discount (`K/degree`) to every target entity's score, direct-matched or Jaccard-related alike.
+2. Discounting the score alone was live-confirmed insufficient -- an injected candidate still carries the same fixed `base_score` as a genuinely recency-fetched one. Entities whose discounted score falls below a minimum floor can still weakly boost an already-present candidate, but can no longer single-handedly pull a new turn into the pool.
+
+Re-verified live: "Orion, what do you think..." now correctly falls back to plain recency (no entity signal strong enough to act on) instead of injecting 6 generic turns; "Tesla gpu setup"/"Atlas" (genuinely specific entities) are unaffected.
+
 ### Vector / Chroma
 
 | Variable | Default | Notes |

--- a/services/orion-recall/app/settings.py
+++ b/services/orion-recall/app/settings.py
@@ -360,6 +360,31 @@ class Settings(BaseSettings):
     # post-persist, so the current turn's own entities are not normally in
     # Falkor yet when recall runs for that same turn, but not proven
     # impossible. Worth a follow-up test, not treated as blocking.
+    #
+    # THIRD FIX, same day, found from real live usage (not synthetic test
+    # queries): a mundane message that simply addresses the assistant by
+    # name ("Orion, what do you think about the deploy?") extracted "orion"
+    # as a query entity and scored it a flat 1.0 -- "orion"/"juniper" are
+    # the two most frequent nodes in the WHOLE graph (282/260 mentions,
+    # confirmed live), so this injected generic filler turns ("thanks,
+    # appreciated.", "word, good advice") at full boost strength purely
+    # because they happened to mention Orion/Juniper by name. Two-part fix:
+    # (a) fetch_entity_degrees applies an IDF-style discount (K/degree) to
+    # EVERY target entity's score, direct-matched or Jaccard-related alike
+    # -- Jaccard-related scores already had partial frequency awareness via
+    # their own degree2 denominator, the direct-match path had none.
+    # (b) Discounting the SCORE alone was live-confirmed insufficient: an
+    # injected candidate still carries the same fixed base_score as a
+    # genuinely recency-fetched one, so a heavily-discounted-but-nonzero
+    # boost still let a "thanks, appreciated." turn place top-4. Entities
+    # whose discounted score falls below _ENTITY_RELATEDNESS_MIN_INJECTION_
+    # SCORE can still weakly BOOST an already-present candidate, but can no
+    # longer single-handedly pull a new turn INTO the pool. Re-verified
+    # live: "Orion, what do you think..." now correctly falls back to plain
+    # recency (no entity signal strong enough to act on -- the honest
+    # pre-Phase-2 baseline) instead of injecting 6 generic turns; "Tesla gpu
+    # setup"/"Atlas" (genuinely specific entities) are unaffected and still
+    # surface real, relevant content.
     RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED: bool = Field(
         default=False, validation_alias=AliasChoices("RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED")
     )

--- a/services/orion-recall/app/storage/falkor_entity_relatedness.py
+++ b/services/orion-recall/app/storage/falkor_entity_relatedness.py
@@ -311,10 +311,46 @@ async def fetch_turns_mentioning_entities(
     ]
 
 
+async def fetch_entity_degrees(*, names: List[str]) -> Dict[str, int]:
+    """Phase 2 fix: live-confirmed the entity-relatedness boost's direct-
+    query-entity-match path scored EVERY extracted query entity at a flat
+    1.0, with no document-frequency awareness -- unlike the Jaccard-ranked
+    "related entities" expansion, which was specifically designed to avoid
+    exactly this failure mode (see fetch_related_entities' own docstring).
+    A mundane message that simply addresses the assistant by name ("Orion,
+    what do you think...") extracted "Orion" as a query entity and, because
+    "orion" is one of the two most frequent nodes in the whole graph (282
+    mentions, confirmed live -- nearly every turn), injected 6 generic
+    filler turns ("thanks, appreciated.", "I'm all good.") at full boost
+    strength, purely because they happened to mention Orion by name.
+
+    This returns each name's live mention-count (same shape as
+    fetch_related_entities' internal degree1/degree2, just not currently
+    exposed there), letting the caller apply the identical document-
+    frequency principle to DIRECT matches that Jaccard already applies to
+    RELATED ones -- one query, not one round trip per entity.
+    """
+    client = get_recall_falkor_client()
+    if client is None or not names:
+        return {}
+
+    rows = await _safe_graph_query(
+        client,
+        "UNWIND $names AS name "
+        "MATCH (e:Entity {name: name})<-[r:MENTIONS_ENTITY]-() "
+        "RETURN name, count(r) AS degree",
+        {"names": list(names)},
+        log_ctx="fetch_entity_degrees",
+    )
+
+    return {str(r.get("name")): int(r.get("degree") or 0) for r in rows if r.get("name")}
+
+
 __all__ = [
     "fetch_related_entities",
     "fetch_bridging_turns",
     "fetch_entity_mention_timeline",
     "fetch_entity_matches_for_turns",
     "fetch_turns_mentioning_entities",
+    "fetch_entity_degrees",
 ]

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -47,6 +47,7 @@ try:
         fetch_related_entities,
         fetch_entity_matches_for_turns,
         fetch_turns_mentioning_entities,
+        fetch_entity_degrees,
     )
     from .sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments
     from .sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps, fetch_chat_turns_by_id, _to_epoch
@@ -84,6 +85,7 @@ except ImportError as _e:  # pragma: no cover - fallback for runtime pathing
             fetch_related_entities,
             fetch_entity_matches_for_turns,
             fetch_turns_mentioning_entities,
+            fetch_entity_degrees,
         )
         from app.sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments  # type: ignore
         from app.sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps, fetch_chat_turns_by_id, _to_epoch  # type: ignore
@@ -609,6 +611,32 @@ async def _fetch_graphtri_fragments(
 _ENTITY_RELATEDNESS_MAX_QUERY_ENTITIES = 3
 _ENTITY_RELATEDNESS_MAX_RELATED_PER_ENTITY = 15
 _ENTITY_RELATEDNESS_MAX_INJECTED_TURNS = 6
+# IDF-style discount constant: an entity at exactly this degree keeps full
+# (1.0x) weight; above it, weight falls off as K/degree. Calibrated against
+# live data: nvidia(23)->0.65x, atlas(17)->0.88x, tesla(7)/p4(13)->1.0x
+# (capped) stay near full weight (genuinely specific entities); orion(282)
+# ->0.05x, juniper(260)->0.06x are correctly suppressed (near-universal,
+# near-zero discriminative value).
+_ENTITY_RELATEDNESS_DEGREE_DISCOUNT_K = 15
+# An entity whose discounted score falls below this floor can still
+# contribute to BOOSTING an already-present candidate (weakly), but can no
+# longer single-handedly drive a new turn INTO the pool -- see the
+# injection_target_names comment below for why the score discount alone
+# wasn't sufficient. For a DIRECT query-entity match (base score 1.0), K=15
+# excludes anything with degree greater than ~100 (orion/juniper at
+# 260-282 land at 0.05-0.06, well below); genuinely specific entities
+# (nvidia=23 -> 0.65, atlas=17 -> 0.88) clear it easily. For a Jaccard-
+# RELATED entity (base score already <1.0 before this discount), the
+# effective degree cutoff is proportionally lower -- e.g. jaccard=0.3 hits
+# the floor around degree=30, not degree=100 -- this is intentional
+# (double-discounting a low-jaccard, moderate-frequency related entity is
+# correct), not a bug, but the "~100" figure above only describes the
+# direct-match case.
+_ENTITY_RELATEDNESS_MIN_INJECTION_SCORE = 0.15
+# Fallback discount for an entity fetch_entity_degrees has no data for --
+# see the discount loop's own comment for why this must stay conservative
+# (below the injection floor), not "no discount" (score * 1.0).
+_ENTITY_RELATEDNESS_UNKNOWN_DEGREE_DISCOUNT = 0.1
 
 
 async def _compute_entity_relatedness_boost_map(
@@ -638,7 +666,11 @@ async def _compute_entity_relatedness_boost_map(
     3. Build a target->score map: the query entities THEMSELVES score 1.0
        (a candidate turn directly mentioning what the query is about is
        stronger evidence than "related to" it), related entities score
-       their own Jaccard value.
+       their own Jaccard value. Then apply a document-frequency discount
+       (fetch_entity_degrees) to EVERY target entity, direct or related --
+       see the constant's own comment for why this is load-bearing, not
+       cosmetic (a near-universal entity like "orion" must not score a
+       flat 1.0 just because it was directly mentioned).
     4. Batch-lookup (one query) which EXISTING falkor_chat candidate turns
        mention any target entity, for boosting.
     5. ALSO fetch actual ChatTurn ids that mention any target entity,
@@ -688,14 +720,70 @@ async def _compute_entity_relatedness_boost_map(
                 if name and score > target_scores.get(name, 0.0):
                     target_scores[name] = score
 
+        # Document-frequency discount, applied uniformly to every target
+        # entity (both direct query matches and Jaccard-related ones).
+        # Live-confirmed bug this closes: a mundane message that simply
+        # addresses the assistant by name ("Orion, what do you think...")
+        # extracted "orion" as a query entity and scored it a flat 1.0 --
+        # "orion" is one of the two most frequent nodes in the whole graph
+        # (282 mentions, confirmed live), so this injected generic filler
+        # turns ("thanks, appreciated.") at full boost strength purely
+        # because they happened to mention Orion by name. Jaccard-related
+        # scores already have partial frequency awareness (their own
+        # degree2 sits in the denominator), but the direct-match path had
+        # none at all. K/degree is a real IDF instance, not a stoplist --
+        # self-correcting as the graph grows, no hardcoded entity names.
+        degrees = await fetch_entity_degrees(names=list(target_scores.keys()))
+        for name in list(target_scores.keys()):
+            degree = degrees.get(name)
+            if degree and degree > 0:
+                discount = min(1.0, _ENTITY_RELATEDNESS_DEGREE_DISCOUNT_K / degree)
+            else:
+                # A name absent from `degrees` is indistinguishable, from
+                # here, between "genuinely brand-new entity, no live
+                # mentions yet" and "the degree lookup call itself failed"
+                # -- _safe_graph_query swallows Falkor errors into an empty
+                # result, never a raised exception (found in code review).
+                # Treating "unknown" as "no discount" would reopen this
+                # patch's own bug on any transient Falkor hiccup on this one
+                # call, indistinguishable in the logs from "working as
+                # designed". Biasing conservative here is deliberate: a
+                # missed injection opportunity for a genuinely rare entity
+                # is a far smaller cost than silently reintroducing generic-
+                # filler injection. Set below the injection floor so an
+                # unverified entity can still weakly boost an existing
+                # candidate but can never single-handedly drive injection.
+                discount = _ENTITY_RELATEDNESS_UNKNOWN_DEGREE_DISCOUNT
+            target_scores[name] *= discount
+
         existing_turn_ids = {
             str(c.get("uri") or c.get("id") or "").strip()
             for c in candidates
             if str(c.get("source") or "") == "falkor_chat" and (c.get("uri") or c.get("id"))
         } - {""}
 
-        mentioning = await fetch_turns_mentioning_entities(
-            target_names=list(target_scores.keys()), max_results=_ENTITY_RELATEDNESS_MAX_INJECTED_TURNS
+        # Discounting the SCORE alone isn't enough to stop low-value
+        # injection: an injected fragment still carries the same fixed
+        # base_score (0.50) as any genuinely recency-fetched falkor_chat
+        # candidate, so even a heavily-discounted entity boost doesn't stop
+        # it from competing on base_score+recency alone once it's already
+        # in the pool (live-confirmed: a "thanks, appreciated." turn still
+        # placed top-4 with only a ~0.01 discounted boost). The real fix is
+        # upstream of injection: entities whose discounted score falls
+        # below this floor never drive a fetch_turns_mentioning_entities
+        # call at all, so a near-universal entity like "orion" can't inject
+        # ANY turn on its own -- it can still contribute to boosting a
+        # turn that ALSO independently earned its way into the pool via a
+        # real entity, since that pathway isn't gated here.
+        injection_target_names = [
+            name for name, score in target_scores.items() if score >= _ENTITY_RELATEDNESS_MIN_INJECTION_SCORE
+        ]
+        mentioning = (
+            await fetch_turns_mentioning_entities(
+                target_names=injection_target_names, max_results=_ENTITY_RELATEDNESS_MAX_INJECTED_TURNS
+            )
+            if injection_target_names
+            else []
         )
         new_turn_ids = [
             t

--- a/services/orion-recall/tests/test_entity_relatedness_boost_map.py
+++ b/services/orion-recall/tests/test_entity_relatedness_boost_map.py
@@ -3,14 +3,24 @@ docs/superpowers/specs/2026-07-19-recall-entity-graph-reasoning-arc.md):
 best-effort (boost_map, injected_candidates) computation. Must degrade to
 ({}, []) on any failure -- never a hard dependency.
 
-Returns a tuple now, not just a dict -- live evidence (6 real queries, 3
+Returns a tuple, not just a dict -- live evidence (6 real queries, 3
 profiles) showed the boost-only design never actually changed a ranking:
 falkor_chat's own fetch is recency-windowed with no query filter, so an
 entity from an older turn never entered the candidate pool for the boost to
-act on. injected_candidates is what closes that gap: real ChatTurn ids that
-mention the query's own entities (or Jaccard-related ones), fetched and
-hydrated independent of recency, added to the pool alongside whatever the
-recency fetch already found."""
+act on. injected_candidates is what closes that gap.
+
+A SECOND live regression was found after shipping the above: a mundane
+message that simply addresses the assistant by name ("Orion, what do you
+think...") extracted "orion" as a query entity and scored it a flat 1.0 --
+since "orion"/"juniper" are the two most frequent nodes in the whole graph
+(near-universal), this injected generic filler turns at full boost
+strength purely because they mentioned Orion by name. Fixed with a
+document-frequency discount (fetch_entity_degrees) applied to every target
+entity, PLUS a minimum-score floor gating which entities are even allowed
+to drive injection in the first place (discounting the score alone wasn't
+enough -- an injected candidate still carries the same fixed base_score as
+a genuinely recency-fetched one, so a heavily-discounted-but-nonzero boost
+still let low-value injections compete)."""
 
 from __future__ import annotations
 
@@ -20,6 +30,15 @@ from unittest.mock import patch
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+# Every non-early-return test needs fetch_entity_degrees mocked now (called
+# unconditionally once target_scores is non-empty) -- default to returning
+# {} (unknown degree -> the CONSERVATIVE fallback discount applies, not "no
+# discount" -- see test_degree_lookup_gap_does_not_bypass_the_discount for
+# why treating "unknown" as "full trust" was itself a live regression)
+# unless a test cares about the discount specifically.
+_NO_DEGREES = {}
 
 
 def test_returns_empty_when_flag_disabled():
@@ -54,11 +73,16 @@ def test_returns_empty_when_no_query_entities_extracted():
         assert injected == []
 
 
-def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
+def test_direct_query_entity_match_scores_full_and_related_scores_jaccard_when_rare():
+    """A genuinely rare direct-matched entity (low degree, confirmed via
+    fetch_entity_degrees) scores close to 1.0, and a Jaccard-related one
+    keeps close to its own score -- both cleared by the frequency floor."""
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities",
         return_value=[{"name": "tesla", "shared_turns": 4, "jaccard": 0.5}],
     ) as mock_related, patch(
+        "app.worker.fetch_entity_degrees", return_value={"nvidia": 5, "tesla": 5}
+    ), patch(
         "app.worker.fetch_turns_mentioning_entities", return_value=[]
     ), patch(
         "app.worker.fetch_entity_matches_for_turns",
@@ -79,6 +103,8 @@ def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
             )
         )
 
+        # degree=5 < K=15 -> discount capped at 1.0, i.e. no discount for
+        # either entity here.
         assert boost_map == {"turn-direct": 1.0, "turn-related": 0.5}
         assert injected == []
         mock_related.assert_called_once()
@@ -90,12 +116,116 @@ def test_direct_query_entity_match_scores_full_and_related_scores_jaccard():
         assert "tesla" in call_kwargs["target_names"]
 
 
-def test_injects_entity_matched_turns_not_already_in_pool():
-    """The actual fix for the live-confirmed gap: a turn that mentions the
-    query's entity but was never fetched by the recency-windowed falkor_chat
-    path gets fetched, hydrated, and returned as a new candidate."""
+def test_degree_lookup_gap_does_not_bypass_the_discount():
+    """CRITICAL regression, found in code review: fetch_entity_degrees
+    returning {} for an entity is indistinguishable, from the caller's
+    side, between 'genuinely brand-new entity' and 'the Falkor call itself
+    failed' (_safe_graph_query swallows exceptions into an empty result,
+    never raises). A transient Falkor hiccup on this ONE call must not
+    silently reopen the near-universal-entity bug this whole patch exists
+    to fix -- 'orion' with NO degree data available must still be blocked
+    from driving injection, not default back to a flat 1.0."""
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities", return_value=[]
+    ), patch(
+        "app.worker.fetch_entity_degrees", return_value=_NO_DEGREES  # simulates the failure/unknown case
+    ), patch(
+        "app.worker.fetch_turns_mentioning_entities"
+    ) as mock_mentioning, patch(
+        "app.worker.fetch_entity_matches_for_turns", return_value={"turn-1": ["orion"]}
+    ):
+        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+
+        from app.worker import _compute_entity_relatedness_boost_map
+
+        boost_map, injected = _run(
+            _compute_entity_relatedness_boost_map(
+                query_text="Orion, what do you think about the deploy?",
+                candidates=[{"source": "falkor_chat", "uri": "turn-1"}],
+            )
+        )
+
+        # Must NOT be 1.0 -- the conservative fallback discount applies.
+        # 0.15 matches app.worker._ENTITY_RELATEDNESS_MIN_INJECTION_SCORE.
+        assert boost_map.get("turn-1", 0.0) < 0.15
+        mock_mentioning.assert_not_called()
+        assert injected == []
+
+
+def test_near_universal_entity_gets_discounted_and_does_not_drive_injection():
+    """The actual regression this patch fixes, live-confirmed: 'orion' at
+    degree 282 must not score anywhere near 1.0, and must not be able to
+    single-handedly pull generic filler turns into the pool."""
+    with patch("app.worker.settings") as mock_settings, patch(
+        "app.worker.fetch_related_entities", return_value=[]
+    ), patch(
+        "app.worker.fetch_entity_degrees", return_value={"orion": 282}
+    ), patch(
+        "app.worker.fetch_turns_mentioning_entities"
+    ) as mock_mentioning, patch(
+        "app.worker.fetch_entity_matches_for_turns", return_value={"turn-1": ["orion"]}
+    ):
+        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+
+        from app.worker import _compute_entity_relatedness_boost_map
+
+        boost_map, injected = _run(
+            _compute_entity_relatedness_boost_map(
+                query_text="Orion, what do you think about the deploy?",
+                candidates=[{"source": "falkor_chat", "uri": "turn-1"}],
+            )
+        )
+
+        # Discounted: 15/282 ~= 0.053, nowhere near the old flat 1.0.
+        assert boost_map.get("turn-1", 0.0) < 0.1
+        # Below the injection floor -- fetch_turns_mentioning_entities must
+        # not even be called with "orion" as a target, since target_names
+        # passed in would be empty after the floor filter.
+        mock_mentioning.assert_not_called()
+        assert injected == []
+
+
+def test_specific_entity_clears_injection_floor_and_still_injects():
+    """A genuinely rare/specific entity (low degree) must NOT be caught by
+    the same floor that suppresses near-universal ones -- confirms the fix
+    doesn't just kill injection outright."""
+    with patch("app.worker.settings") as mock_settings, patch(
+        "app.worker.fetch_related_entities", return_value=[]
+    ), patch(
+        "app.worker.fetch_entity_degrees", return_value={"nvidia": 23}
+    ), patch(
+        "app.worker.fetch_turns_mentioning_entities",
+        return_value=[{"turn_id": "gpu-turn", "ts": "2026-05-01T00:00:00"}],
+    ) as mock_mentioning, patch(
+        "app.worker.fetch_chat_turns_by_id",
+        return_value={"gpu-turn": ("show nvidia status", "gpu ok")},
+    ), patch(
+        "app.worker.fetch_entity_matches_for_turns", return_value={"gpu-turn": ["nvidia"]}
+    ):
+        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+
+        from app.worker import _compute_entity_relatedness_boost_map
+
+        boost_map, injected = _run(
+            _compute_entity_relatedness_boost_map(query_text="tell me about Nvidia", candidates=[])
+        )
+
+        mock_mentioning.assert_called_once()
+        assert mock_mentioning.call_args.kwargs["target_names"] == ["nvidia"]
+        assert len(injected) == 1
+        assert injected[0]["id"] == "gpu-turn"
+        # 15/23 ~= 0.65 -- discounted from 1.0 but well above the 0.15 floor.
+        assert 0.5 < boost_map.get("gpu-turn", 0.0) < 1.0
+
+
+def test_injects_entity_matched_turns_not_already_in_pool():
+    """A turn that mentions the query's entity but was never fetched by the
+    recency-windowed falkor_chat path gets fetched, hydrated, and returned
+    as a new candidate."""
+    with patch("app.worker.settings") as mock_settings, patch(
+        "app.worker.fetch_related_entities", return_value=[]
+    ), patch(
+        "app.worker.fetch_entity_degrees", return_value={"nvidia": 5}  # rare -> clears the injection floor
     ), patch(
         "app.worker.fetch_turns_mentioning_entities",
         return_value=[{"turn_id": "old-turn-not-in-pool", "ts": "2025-10-21T00:00:00"}],
@@ -131,6 +261,8 @@ def test_does_not_inject_turn_already_in_existing_pool():
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities", return_value=[]
     ), patch(
+        "app.worker.fetch_entity_degrees", return_value={"nvidia": 5}  # rare -> clears the injection floor
+    ), patch(
         "app.worker.fetch_turns_mentioning_entities",
         return_value=[{"turn_id": "already-here", "ts": "2025-10-21T00:00:00"}],
     ), patch("app.worker.fetch_chat_turns_by_id") as mock_hydrate, patch(
@@ -157,6 +289,8 @@ def test_injected_turn_skipped_if_postgres_hydration_missing_it():
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities", return_value=[]
     ), patch(
+        "app.worker.fetch_entity_degrees", return_value={"nvidia": 5}  # rare -> clears the injection floor
+    ), patch(
         "app.worker.fetch_turns_mentioning_entities",
         return_value=[{"turn_id": "orphaned-turn", "ts": "2025-10-21T00:00:00"}],
     ), patch("app.worker.fetch_chat_turns_by_id", return_value={}), patch(
@@ -175,9 +309,29 @@ def test_injected_turn_skipped_if_postgres_hydration_missing_it():
 def test_failure_in_fetch_related_entities_degrades_not_raises():
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities", side_effect=RuntimeError("falkor down")
-    ), patch("app.worker.fetch_turns_mentioning_entities", return_value=[]), patch(
+    ), patch("app.worker.fetch_entity_degrees", return_value=_NO_DEGREES), patch(
+        "app.worker.fetch_turns_mentioning_entities", return_value=[]
+    ), patch(
         "app.worker.fetch_entity_matches_for_turns", return_value={}
     ):
+        mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
+
+        from app.worker import _compute_entity_relatedness_boost_map
+
+        boost_map, injected = _run(
+            _compute_entity_relatedness_boost_map(
+                query_text="tell me about Nvidia",
+                candidates=[{"source": "falkor_chat", "uri": "turn-1"}],
+            )
+        )
+        assert boost_map == {}
+        assert injected == []
+
+
+def test_failure_in_fetch_entity_degrees_degrades_not_raises():
+    with patch("app.worker.settings") as mock_settings, patch(
+        "app.worker.fetch_related_entities", return_value=[]
+    ), patch("app.worker.fetch_entity_degrees", side_effect=RuntimeError("falkor down")):
         mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
 
         from app.worker import _compute_entity_relatedness_boost_map
@@ -195,7 +349,9 @@ def test_failure_in_fetch_related_entities_degrades_not_raises():
 def test_failure_in_fetch_turns_mentioning_entities_degrades_not_raises():
     with patch("app.worker.settings") as mock_settings, patch(
         "app.worker.fetch_related_entities", return_value=[]
-    ), patch("app.worker.fetch_turns_mentioning_entities", side_effect=RuntimeError("falkor down")):
+    ), patch("app.worker.fetch_entity_degrees", return_value=_NO_DEGREES), patch(
+        "app.worker.fetch_turns_mentioning_entities", side_effect=RuntimeError("falkor down")
+    ):
         mock_settings.RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED = True
 
         from app.worker import _compute_entity_relatedness_boost_map

--- a/services/orion-recall/tests/test_falkor_entity_relatedness.py
+++ b/services/orion-recall/tests/test_falkor_entity_relatedness.py
@@ -244,3 +244,30 @@ def test_fetch_turns_mentioning_entities_none_client_returns_empty(monkeypatch) 
     monkeypatch.setattr(falkor_entity_relatedness, "get_recall_falkor_client", lambda: None)
     out = _run(falkor_entity_relatedness.fetch_turns_mentioning_entities(target_names=["nvidia"]))
     assert out == []
+
+
+def test_fetch_entity_degrees_full_shape(monkeypatch) -> None:
+    rows = [{"name": "orion", "degree": 282}, {"name": "nvidia", "degree": 23}]
+    fake_client = _FakeFalkorClient(rows=rows)
+    monkeypatch.setattr(falkor_entity_relatedness, "get_recall_falkor_client", lambda: fake_client)
+
+    out = _run(falkor_entity_relatedness.fetch_entity_degrees(names=["orion", "nvidia"]))
+
+    assert out == {"orion": 282, "nvidia": 23}
+    cypher, params = fake_client.calls[0]
+    assert "MENTIONS_ENTITY" in cypher
+    assert params["names"] == ["orion", "nvidia"]
+
+
+def test_fetch_entity_degrees_empty_names_returns_empty(monkeypatch) -> None:
+    fake_client = _FakeFalkorClient(rows=[])
+    monkeypatch.setattr(falkor_entity_relatedness, "get_recall_falkor_client", lambda: fake_client)
+    out = _run(falkor_entity_relatedness.fetch_entity_degrees(names=[]))
+    assert out == {}
+    assert fake_client.calls == []
+
+
+def test_fetch_entity_degrees_none_client_returns_empty(monkeypatch) -> None:
+    monkeypatch.setattr(falkor_entity_relatedness, "get_recall_falkor_client", lambda: None)
+    out = _run(falkor_entity_relatedness.fetch_entity_degrees(names=["orion"]))
+    assert out == {}


### PR DESCRIPTION
## Summary

User reported real conversation quality had gone "generic." Root-caused live against the user's own real query text, not guessed.

`_compute_entity_relatedness_boost_map` extracted "orion"/"juniper" (the assistant's/user's own names, near-universal in the entity graph -- 282/260 mentions out of ~735 total entities) as query "entities" from mundane messages that simply addressed the assistant by name, and injected generic filler turns ("thanks, appreciated.", "word, good advice") into recall results at full boost strength -- confirmed via a direct flag-on/flag-off A/B test against the user's own real query, byte-identical for unrelated queries, but injecting junk for name-addressed ones.

## Fix

1. New `app/storage/falkor_entity_relatedness.py::fetch_entity_degrees` -- batched query, each entity's live `MENTIONS_ENTITY` count.
2. IDF-style discount (`K=15`, `discount=min(1.0, K/degree)`) applied to every target entity's score, direct-matched or Jaccard-related alike.
3. Live-verified the discount alone was insufficient: an injected candidate still carries the same fixed `base_score` as a genuinely recency-fetched one, so a heavily-discounted-but-nonzero boost still let a "thanks, appreciated." turn place top-4. Added a separate minimum-score floor (`_ENTITY_RELATEDNESS_MIN_INJECTION_SCORE=0.15`) gating which entities can drive NEW-candidate injection.

## A critical bug caught reviewing my own fix

The discount loop originally iterated `degrees.items()`, so any entity **absent** from the `fetch_entity_degrees` result -- indistinguishable between "genuinely brand-new entity" and "the Falkor call itself transiently failed" (`_safe_graph_query` swallows exceptions into an empty result, never raises) -- kept its undiscounted score forever, silently reopening this exact bug on any Falkor hiccup. Fixed by iterating `target_scores.keys()` instead and applying a conservative fallback discount (below the injection floor) to any entity with no verified degree, rather than defaulting to full trust. New regression test locks this in: `test_degree_lookup_gap_does_not_bypass_the_discount`.

## Live re-verification

```
'Orion, what do you think about the deploy?' -> injected=0  (was 6)
  top: "No, I meant, what group do you think I should join..." (real recent turn)

'Tesla gpu setup' -> injected=6  (unaffected)
  top: "Show NVIDIA GPU status on this node." (genuinely relevant)
```

## Tests run

```
$ .venv/bin/python -m pytest services/orion-recall/tests/ -q
219 passed, 3 failed (pre-existing, unrelated -- same 3 as every prior PR in this migration)
```

## Restart required

Already done as part of verification:

```bash
docker restart orion-athena-recall
```

## PR link

See gh output for actual PR number.