### PR TITLE
fix(hub): wire repair_pressure_appraisal publish into the unified-turn path

### DIFF
--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -251,13 +251,17 @@ async def _run_pre_turn_appraisal(
     if bus is None or not getattr(settings, "ENABLE_PRE_TURN_APPRAISAL", False):
         return None
     from scripts.pre_turn_appraisal_client import PreTurnAppraisalClient
+    from scripts.pre_turn_appraisal_wiring import (
+        _publish_repair_pressure_appraisal,
+        build_repair_pressure_summary,
+    )
 
     turn_window = build_turn_window(
         continuity_messages or [{"role": "user", "content": user_message}]
     )
     paradigms = str(getattr(settings, "PRE_TURN_APPRAISAL_PARADIGMS", "repair_pressure"))
     timeout_ms = int(getattr(settings, "PRE_TURN_APPRAISAL_TIMEOUT_MS", 60000))
-    return await PreTurnAppraisalClient(bus).appraise(
+    bundle = await PreTurnAppraisalClient(bus).appraise(
         PreTurnAppraisalRequestV1(
             correlation_id=correlation_id,
             session_id=str(session_id or "anonymous"),
@@ -268,6 +272,22 @@ async def _run_pre_turn_appraisal(
         ),
         correlation_id=correlation_id,
     )
+    # Unified-turn (mode="orion"/harness-governor) is a second, independent
+    # caller of PreTurnAppraisalClient alongside pre_turn_appraisal_wiring's
+    # websocket/HTTP "brain" path. Both must publish, or
+    # orion-equilibrium-service's relational metacog gate silently never
+    # sees appraisals from whichever caller skips it -- confirmed live
+    # 2026-07-21: this path was the one skipping it, so every real
+    # orion-mode/journal turn since deploy had a computed repair_pressure
+    # result that never reached the bus.
+    summary = build_repair_pressure_summary(bundle)
+    if summary is not None:
+        await _publish_repair_pressure_appraisal(
+            bus,
+            correlation_id=correlation_id,
+            summary=summary,
+        )
+    return bundle
 
 
 async def execute_unified_turn(

--- a/services/orion-hub/scripts/pre_turn_appraisal_wiring.py
+++ b/services/orion-hub/scripts/pre_turn_appraisal_wiring.py
@@ -16,18 +16,16 @@ from orion.substrate.appraisal.view_model import pressure_label
 logger = logging.getLogger("hub.pre_turn_appraisal_wiring")
 
 
-def apply_pre_turn_appraisal_bundle(
-    req: CortexChatRequest,
+def build_repair_pressure_summary(
     bundle: TurnAppraisalBundleV1 | None,
-    *,
-    enabled: bool,
 ) -> dict[str, Any] | None:
-    if not enabled or bundle is None:
+    """Pure extraction of the repair_pressure summary dict from an appraisal
+    bundle -- shared by every caller of PreTurnAppraisalClient.appraise() so
+    the orion:repair_pressure:appraisal publish (see
+    _publish_repair_pressure_appraisal) can never be wired to only one of
+    them again."""
+    if bundle is None:
         return None
-    if bundle.metadata_attachments:
-        meta = dict(req.metadata or {})
-        meta.update(bundle.metadata_attachments)
-        req.metadata = meta
     rp = bundle.paradigms.get("repair_pressure")
     if rp is None:
         return None
@@ -53,6 +51,21 @@ def apply_pre_turn_appraisal_bundle(
         "changed_behavior": behavior,
         "chip_label": f"{behavior or 'no behavior change'} · {pressure_label(level)} repair pressure · {len(rp.evidence)} evidence drivers",
     }
+
+
+def apply_pre_turn_appraisal_bundle(
+    req: CortexChatRequest,
+    bundle: TurnAppraisalBundleV1 | None,
+    *,
+    enabled: bool,
+) -> dict[str, Any] | None:
+    if not enabled or bundle is None:
+        return None
+    if bundle.metadata_attachments:
+        meta = dict(req.metadata or {})
+        meta.update(bundle.metadata_attachments)
+        req.metadata = meta
+    return build_repair_pressure_summary(bundle)
 
 
 async def run_pre_turn_appraisal_wiring(

--- a/services/orion-hub/tests/test_pre_turn_appraisal_wiring.py
+++ b/services/orion-hub/tests/test_pre_turn_appraisal_wiring.py
@@ -17,6 +17,37 @@ assert _spec and _spec.loader
 _wiring = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_wiring)
 apply_pre_turn_appraisal_bundle = _wiring.apply_pre_turn_appraisal_bundle
+build_repair_pressure_summary = _wiring.build_repair_pressure_summary
+
+
+def test_build_repair_pressure_summary_matches_apply_bundle_output() -> None:
+    """build_repair_pressure_summary is the pure extraction apply_pre_turn_appraisal_bundle
+    now delegates to -- also the piece orion/hub/turn_orchestrator.py's
+    _run_pre_turn_appraisal calls directly, since that caller has no
+    CortexChatRequest to attach metadata onto."""
+    bundle = TurnAppraisalBundleV1(
+        correlation_id="c1",
+        paradigms={
+            "repair_pressure": TurnAppraisalParadigmSliceV1(
+                appraisal_kind="repair_pressure",
+                level=0.42,
+                confidence=0.65,
+            )
+        },
+    )
+    summary = build_repair_pressure_summary(bundle)
+    assert summary is not None
+    assert summary["level"] == 0.42
+    assert summary["confidence"] == 0.65
+
+
+def test_build_repair_pressure_summary_none_when_bundle_none() -> None:
+    assert build_repair_pressure_summary(None) is None
+
+
+def test_build_repair_pressure_summary_none_when_paradigm_missing() -> None:
+    bundle = TurnAppraisalBundleV1(correlation_id="c1", paradigms={})
+    assert build_repair_pressure_summary(bundle) is None
 
 
 def test_apply_bundle_attaches_metadata_when_mode_changes() -> None:

--- a/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
+++ b/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
@@ -4,6 +4,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -110,6 +111,89 @@ def _hub_client_patches(*, thought: ThoughtEventV1, harness_run: HarnessRunV1 | 
             harness_run if isinstance(harness_run, AsyncMock) else AsyncMock(return_value=harness_run),
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_run_pre_turn_appraisal_publishes_repair_pressure_appraisal() -> None:
+    """Regression for a live-confirmed gap (2026-07-21): turn_orchestrator's
+    _run_pre_turn_appraisal is a second, independent caller of
+    PreTurnAppraisalClient alongside pre_turn_appraisal_wiring's
+    websocket/HTTP 'brain'-mode path. Only the latter published to
+    orion:repair_pressure:appraisal, so every real mode="orion" turn
+    (which is what the autonomous journal loop, and very plausibly real
+    interactive chat, actually uses) computed a repair_pressure result that
+    never reached orion-equilibrium-service's relational metacog gate."""
+    _ensure_hub_import_paths()
+    from orion.hub.turn_orchestrator import _run_pre_turn_appraisal
+    from orion.schemas.pre_turn_appraisal import TurnAppraisalBundleV1, TurnAppraisalParadigmSliceV1
+    import scripts.pre_turn_appraisal_client as pta_client_mod
+
+    bundle = TurnAppraisalBundleV1(
+        correlation_id=_CORR_ID,
+        paradigms={
+            "repair_pressure": TurnAppraisalParadigmSliceV1(
+                appraisal_kind="repair_pressure",
+                level=0.42,
+                confidence=0.65,
+            )
+        },
+    )
+    settings = SimpleNamespace(
+        ENABLE_PRE_TURN_APPRAISAL=True,
+        PRE_TURN_APPRAISAL_PARADIGMS="repair_pressure",
+        PRE_TURN_APPRAISAL_TIMEOUT_MS=800,
+    )
+    publish_mock = AsyncMock()
+    with patch.object(
+        pta_client_mod.PreTurnAppraisalClient, "appraise", AsyncMock(return_value=bundle)
+    ), patch(
+        "scripts.pre_turn_appraisal_wiring._publish_repair_pressure_appraisal", publish_mock
+    ):
+        result = await _run_pre_turn_appraisal(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="hello",
+            continuity_messages=None,
+            settings=settings,
+        )
+
+    assert result is bundle
+    publish_mock.assert_awaited_once()
+    _, kwargs = publish_mock.await_args
+    assert kwargs["correlation_id"] == _CORR_ID
+    assert kwargs["summary"]["level"] == 0.42
+
+
+@pytest.mark.asyncio
+async def test_run_pre_turn_appraisal_skips_publish_when_no_repair_pressure_paradigm() -> None:
+    _ensure_hub_import_paths()
+    from orion.hub.turn_orchestrator import _run_pre_turn_appraisal
+    from orion.schemas.pre_turn_appraisal import TurnAppraisalBundleV1
+    import scripts.pre_turn_appraisal_client as pta_client_mod
+
+    bundle = TurnAppraisalBundleV1(correlation_id=_CORR_ID, paradigms={})
+    settings = SimpleNamespace(
+        ENABLE_PRE_TURN_APPRAISAL=True,
+        PRE_TURN_APPRAISAL_PARADIGMS="repair_pressure",
+        PRE_TURN_APPRAISAL_TIMEOUT_MS=800,
+    )
+    publish_mock = AsyncMock()
+    with patch.object(
+        pta_client_mod.PreTurnAppraisalClient, "appraise", AsyncMock(return_value=bundle)
+    ), patch(
+        "scripts.pre_turn_appraisal_wiring._publish_repair_pressure_appraisal", publish_mock
+    ):
+        await _run_pre_turn_appraisal(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="hello",
+            continuity_messages=None,
+            settings=settings,
+        )
+
+    publish_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `orion/hub/turn_orchestrator.py`'s `execute_unified_turn` (`mode="orion"`/harness-governor path — what the autonomous `orion_journal` loop uses, and very plausibly real interactive chat too) had its own independent caller of `PreTurnAppraisalClient`, computing real `repair_pressure` results via RPC but **never publishing** them to `orion:repair_pressure:appraisal`.
- Only the websocket/HTTP "brain"-mode path (`services/orion-hub/scripts/pre_turn_appraisal_wiring.py::run_pre_turn_appraisal_wiring`) had the publish wired in — a missed seam from the original PR #1208 implementation, which assumed there was one caller.
- Confirmed live before this fix: 0 real publishes to the channel in 46+ hours of production traffic outside my own manual "brain"-mode testing at deploy time, despite cortex-exec computing valid `repair_pressure` results on every single turn. `orion-equilibrium-service`'s relational metacog trigger has never fired — 0 of 27 `orion_metacog` entries are `trigger_kind="relational"`.
- Extracted the summary-dict-building logic out of `apply_pre_turn_appraisal_bundle` into a pure `build_repair_pressure_summary(bundle)` helper, now shared by both callers, and wired the existing `_publish_repair_pressure_appraisal` helper into `turn_orchestrator.py`'s `_run_pre_turn_appraisal`.

## Outcome moved

Closes the gap that made the relational metacog trigger and `repair_pressure_appraisal_log`'s durable observability effectively dead in production since the original deploy — every caller of `PreTurnAppraisalClient` now publishes consistently.

## Current architecture

Two independent call sites RPC `orion:cortex:pre_turn_appraisal:request` and get back a `TurnAppraisalBundleV1`: `run_pre_turn_appraisal_wiring` (websocket_handler.py / api_routes.py `handle_chat_request`, "brain" mode) and `turn_orchestrator.execute_unified_turn` → `_run_pre_turn_appraisal` (mode="orion", harness-governor). Only the first published the result onward.

## Architecture touched

- `services/orion-hub/scripts/pre_turn_appraisal_wiring.py`
- `orion/hub/turn_orchestrator.py`

## Files changed

- `services/orion-hub/scripts/pre_turn_appraisal_wiring.py`: extracted `build_repair_pressure_summary(bundle)` pure function; `apply_pre_turn_appraisal_bundle` now delegates to it (behavior unchanged for existing callers).
- `orion/hub/turn_orchestrator.py`: `_run_pre_turn_appraisal` now calls `build_repair_pressure_summary` + `_publish_repair_pressure_appraisal` after getting the bundle back, matching the existing wiring path's behavior.
- `services/orion-hub/tests/test_pre_turn_appraisal_wiring.py`: 3 new tests for `build_repair_pressure_summary`.
- `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py`: 2 new regression tests — `_run_pre_turn_appraisal` publishes when a `repair_pressure` paradigm is present, and skips when absent.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: `orion:repair_pressure:appraisal` will now receive a publish on every `mode="orion"` turn where `ENABLE_PRE_TURN_APPRAISAL` is on, not just "brain"-mode turns. This roughly doubles/increases publish volume on that channel — no evidence found of downstream capacity limits in `orion-equilibrium-service` or `orion-sql-writer` that this would strain.
- Compatibility notes: none, additive publish only.

## Env/config changes

None.

## Tests run

```text
venv/bin/python3 -m pytest services/orion-hub/tests/test_pre_turn_appraisal_wiring.py services/orion-hub/tests/test_turn_orchestrator_ws_frames.py -q
10 passed (wiring) / 21 passed (turn_orchestrator)

venv/bin/python3 -m pytest orion/hub/tests -q
8 passed

venv/bin/python3 -m pytest services/orion-hub/tests -q
945 passed, 32 failed, 2 skipped, 2 errors -- all 32 failures/errors confirmed pre-existing on main (unrelated areas: memory_consolidation, recall_strategy_profiles, substrate_observability, e2e-live; spot-checked test_substrate_effect_endpoint.py fails identically on main with a pydantic-settings ValidationError from a missing sandbox env var, unrelated to this change)
```

## Evals run

None applicable -- this is a wiring/plumbing fix, not a model-quality change.

## Docker/build/smoke checks

Not yet run from this worktree -- pending before merge (see Restart required).

## Review findings fixed

- Finding: `repair_pressure_metacog_gate.py`'s docstring says the channel is published "by services/orion-hub/scripts/pre_turn_appraisal_wiring.py" -- now inaccurate since `turn_orchestrator.py` is a second publisher.
  - Fix: not yet applied in this PR (low severity, doc-only) -- flagging as a fast-follow.
  - Evidence: `services/orion-equilibrium-service/app/repair_pressure_metacog_gate.py:22`
- Reviewer also confirmed: no double-publish risk (the two call sites are mutually exclusive branches on `mode`), no third duplicate `PreTurnAppraisalClient` caller exists (grep-confirmed), and the underscore-prefixed cross-module import pattern is consistent with ~25+ existing examples in this codebase.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build hub
```

## Risks / concerns

- Severity: low
- Concern: publish volume on `orion:repair_pressure:appraisal` increases once merged and deployed (every `mode="orion"` turn now publishes, not just "brain" mode).
- Mitigation: both consumers (`orion-equilibrium-service`, `orion-sql-writer`) already handle the channel; no capacity concerns found. Recommend a quick post-deploy check that `repair_pressure_appraisal_log` starts accumulating rows again and that `orion_metacog` eventually produces a `relational` trigger_kind entry.

## PR link

(filled in by gh pr create)