### PR TITLE
feat(substrate): shadow-measure biometrics_prediction_error() instrument

### DIFF
--- a/docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md
+++ b/docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md
@@ -1,0 +1,225 @@
+# Biometrics prediction-error shadow instrument
+
+Status: design mode + implemented in the same PR (root `CLAUDE.md`'s implementation-mode
+follow-through requirement — this doc captures the decision record, the code lands alongside
+it, not as a separate follow-up). Shadow-measure only, per the Sentience Striving Program
+charter (`orion/sentience_striving_program/README.md`) §6 item 3: "Phased: shadow-measure
+one producer domain before migrating any live."
+
+## Arsonist summary
+
+Charter §9b item 3 (Predictive Processing/Active Inference) named `execution_prediction_
+error()`/`transport_prediction_error()` as the real field-native substrate for this theory
+thread, and left an open question: "whether the other three reducers (biometrics, chat,
+route) have equivalent instrumentation, or whether coverage is genuinely incomplete." This
+patch answers that for one of the three — `biometrics` — by adding a third instrument,
+`biometrics_prediction_error()`, that mirrors the already-live pattern exactly: diff two
+successive `NodeBiometricsProjectionV1` snapshots, produce a 0-1 surprise score, and (when
+`SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true`) write it onto a durable `node:substrate.
+biometrics` node using the same shared `_write_prediction_error_node()` writer the other two
+already use. Chat and route remain open.
+
+## Naming-mistake context (why this matters here)
+
+A prior draft of this same task named the new signal `coherence_prediction_error`, sourced
+from `turn_effect` — a `SelfStateV1`/`concept_induction`-adjacent field, in direct violation
+of charter §7's standing rule ("field-native only — no `SelfStateV1`-anchored substrate for
+new instrumentation") and §6 item 3's explicit reframing ("not a port of `tensions.py`'s
+hand-classified kind vocabulary onto field channels"). That draft was corrected before this
+patch. This instrument is named for its actual source domain (`biometrics`, the reducer key
+in `REDUCER_SPECS[0]`), reads only `NodeBiometricsProjectionV1` (a reducer projection built
+from `orion-biometrics` grammar events, never `SelfStateV1`), and the diff was run to confirm
+zero references to `concept_induction`, `turn_effect`, `SelfStateV1`, or `self_state_id`
+anywhere in the new code.
+
+## Current architecture
+
+- **Producer:** `services/orion-substrate-runtime/app/worker.py`'s `_tick()`
+  (`REDUCER_SPECS[0]`, `reducer_key="biometrics"`) — fetches `orion-biometrics` grammar
+  events, runs `process_biometrics_grammar_events()`, saves via `self._store.
+  save_node_biometrics`, projection type `NodeBiometricsProjectionV1`
+  (`orion/schemas/biometrics_projection.py`), loaded via a local `load_node_bio()` closure
+  keyed on `NODE_BIOMETRICS_PROJECTION_ID`.
+- **Existing pattern (unchanged):** `orion/substrate/prediction_error.py`'s
+  `execution_prediction_error()`/`transport_prediction_error()`, wired into `_execution_tick`/
+  `_transport_tick` (lines ~1704-1758, ~1824-1880 pre-patch). Both diff two successive
+  projection snapshots per-entity (per `trace_id` / per `bus_id`) over a *fixed* small key
+  set, average the absolute deltas, and scale by `min(1.0, mean/0.30)`.
+  `_write_prediction_error_node()` (`app/worker.py` ~line 691) is the shared durable writer:
+  it internally checks `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES`
+  (`_prediction_error_nodes_enabled()`, line 727 — the flag check lives inside the shared
+  method, not duplicated by each caller) and is otherwise fail-open (never raises out of a
+  tick).
+- **Current gap:** no third instrument existed for the biometrics reducer before this patch.
+
+## Why a dynamic key set, not a fixed four-key list like execution's
+
+Read `orion/substrate/biometrics_loop/grammar_extract.py::extract_node_state_from_events()`
+(the actual producer of `pressure_hints` for biometrics nodes) before deciding this — the
+task's own instruction was not to assume. Unlike execution's four fixed keys
+(`execution_load`, `execution_friction`, `failure_pressure`, `reasoning_load`, present on
+every run), biometrics `pressure_hints` keys are populated *conditionally per node role*:
+
+- `strain` — set whenever a `body_state` atom carries a `salience` value (most nodes).
+- `gpu` — set only when the node's catalog profile has `capabilities.local_llm_heavy`
+  (GPU inference nodes).
+- `memory_pressure` / `thermal_pressure` / `disk_pressure` — each set only when the matching
+  pressure-signal atom (`memory_pressure_signal` / `thermal_pressure_signal` /
+  `disk_pressure_signal`) is present in the event batch.
+
+Confirmed live against real data (`substrate_node_biometrics_projection`, queried directly via
+`psql -h localhost -p 55432 -U postgres -d conjourney`, 2026-07-21T03:29 UTC row):
+
+- `atlas` (role `inference_gpu`, `local_llm_heavy` capability): `pressure_hints = {"gpu": 0.8,
+  "strain": 0.076}`.
+- `circe` (role `burst_gpu`): `pressure_hints = {"gpu": 0.8, "strain": 0.099}`.
+- `athena` (role `orchestration`, no `local_llm_heavy`): `pressure_hints = {"strain": 0.183,
+  "disk_pressure": 0.063, "memory_pressure": 0.254, "thermal_pressure": 0.429}`.
+
+No single fixed key list covers every node's real key set. `biometrics_prediction_error()`
+therefore diffs the *union* of keys present on either side of a given node
+(`set(prev.pressure_hints) | set(curr.pressure_hints)`), defaulting an absent key to `0.0` —
+the same default-to-zero behavior `execution_prediction_error` already uses for a key that
+happens to be missing on one side, just applied to a key set that is itself dynamic instead
+of fixed. This is documented directly in the function's docstring, not just here.
+
+## Metric quality gate (root `CLAUDE.md` §0A) — findings
+
+Run fresh for this new metric, not inherited from execution/transport's prior pass.
+
+1. **Trace provenance to real code.** `biometrics_prediction_error(prev, curr)` in
+   `orion/substrate/prediction_error.py` (new function). Called from `_tick()` in
+   `services/orion-substrate-runtime/app/worker.py`, which loads `prev_projection` via
+   `load_node_bio()` *before* `process_biometrics_grammar_events()` runs and
+   `curr_projection` via the same closure immediately after, when `last_id is not None`. The
+   underlying `pressure_hints` values are traced one level further back to
+   `extract_node_state_from_events()` (`orion/substrate/biometrics_loop/grammar_extract.py`
+   lines 105-125), which reads `atom.salience` off real `orion-biometrics` grammar events.
+2. **Independence check.** Not redundant with `execution_prediction_error`/
+   `transport_prediction_error`: those diff `ExecutionTrajectoryProjectionV1` (per-`trace_id`
+   execution-load/friction/failure/reasoning pressure from `orion-cortex-exec` grammar
+   events) and `TransportBusProjectionV1` (per-`bus_id` bus health/delivery/transport
+   pressure from `orion-bus` grammar events), respectively. `NodeBiometricsProjectionV1` is
+   built from an entirely separate event stream (`orion-biometrics`, hardware/infra
+   telemetry — CPU/GPU/memory/thermal/disk), a separate reducer (`REDUCER_SPECS[0]`, not
+   `[1]`/`[2]`), and a separate node-keying scheme (physical/logical node id, not trace/bus
+   id). The causal chain from "this host got hot" to "an execution run's reasoning_load
+   changed" is real but long and indirect (mediated by, at minimum, thermal throttling
+   affecting inference latency) — not a monotonic transform of an already-included signal.
+   This is a genuinely separate sensor and a genuinely separate upstream computation, not
+   redundant signal.
+3. **Theory anchor.** Same anchor already used for execution/transport, charter §9b item 3:
+   Predictive Processing / Active Inference — a 0-1 surprise score computed as the magnitude
+   of change in a reducer's own pressure-hint state between successive observations, written
+   onto `FieldStateV1` nodes so `orion/substrate/dynamics.py::prediction_error_pressure()`
+   can seed activation pressure from real, measured surprise rather than a hand-asserted
+   value. The biometrics domain is a natural fit for this same anchor: infra load spiking or
+   dropping unexpectedly is exactly the kind of "prediction violated" event the theory
+   anchors to, no new theoretical justification needed beyond what already grounds the other
+   two instruments.
+4. **Live-data sanity check.** Confirmed non-degenerate: the three real node rows quoted
+   above carry distinct, non-zero, non-saturated float values across different key sets —
+   not flat, not always-null, not always-1.0. `substrate_node_biometrics_projection` is a
+   **singleton upsert row** (`projection_id` primary key), same storage shape as execution/
+   transport's own projection tables — there is no history table to replay multiple
+   historical deltas against (the same structural gap the AST/HOT reducer's Phase 1 status
+   note in the charter §6 item 2 already disclosed for a different singleton table). This
+   patch does not fabricate a historical replay: the live-data check here is "current
+   snapshot is real and non-degenerate," not "N historical deltas were replayed and looked
+   reasonable." Honest limitation, stated plainly rather than glossed over.
+5. **Existing-mechanism check.** `grep -rn "biometrics_prediction_error"` across the repo
+   before this patch: zero hits outside this patch's own new code. No prior instrument for
+   this signal exists.
+6. **Reversibility.** Fully reversible: gated behind the existing
+   `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` flag (no new flag — see below), writes to a
+   single fixed `node_id` (`node:substrate.biometrics`) that collapses on repeat writes (no
+   unbounded growth), and the function itself is a pure diff with no persisted schema/
+   manifest dependency. Deleting `biometrics_prediction_error()` and its two call sites in
+   `_tick()` would leave execution/transport untouched and would not break any consumer,
+   since `orion/substrate/dynamics.py::prediction_error_pressure()` reads generically off
+   `node.metadata.get("prediction_error")` for whatever nodes exist — removing this node
+   simply removes one more seed source, not a hardcoded dependency.
+
+## Shadow-only confirmation
+
+`orion/substrate/dynamics.py::_compute_pressures()` (called from `SubstrateDynamicsEngine.
+tick()`) iterates `nodes.values()` generically and calls `prediction_error_pressure(node,
+...)` for every node in the graph — it is **not** hardcoded to `node:substrate.execution`/
+`node:substrate.transport`. This was confirmed by reading the function body (`orion/
+substrate/dynamics.py` lines 201-220), not assumed. This means `node:substrate.biometrics`
+is automatically picked up by the same already-live mechanism the other two instruments use
+once written — this is the existing wire, not a new consumer being added. No change was made
+to `capability_policy.py`, `top_down.py`, or `goal_context.py`, and no new bus consumer was
+wired.
+
+## Proposed schema / API changes
+
+- `orion/substrate/prediction_error.py`: new function `biometrics_prediction_error(prev:
+  NodeBiometricsProjectionV1, curr: NodeBiometricsProjectionV1) -> float`. No schema changes
+  — `NodeBiometricsStateV1.pressure_hints: dict[str, Any]` already exists.
+- `services/orion-substrate-runtime/app/worker.py`'s `_tick()`: captures `prev_projection =
+  load_node_bio()` before `process_batch` runs; after a non-`None` `last_id`, reloads
+  `curr_projection`, computes `error`, and on `error > 0.0` saves a `_prediction_error_
+  receipt(reducer_key="node_biometrics", node_id="node:substrate.biometrics", ...)` and calls
+  `self._write_prediction_error_node(node_id="node:substrate.biometrics", ...,
+  reducer_key="node_biometrics", contributing_id=last_id)`. `_tick()`'s return signature
+  (`tuple[str | None, list[GrammarEventV1]]`) is unchanged.
+- No new env key. Reuses `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` (already `true` in
+  `.env_example`) — this is the same generic "write prediction-error nodes" switch execution/
+  transport already share, not a per-domain flag.
+
+## Files likely to touch (this patch's actual diff)
+
+- `orion/substrate/prediction_error.py` — new `biometrics_prediction_error()`.
+- `orion/substrate/tests/test_prediction_error.py` — new unit test file (no prior dedicated
+  test file for this module existed to mirror; found via repo-wide grep before writing).
+- `services/orion-substrate-runtime/app/worker.py` — `_tick()` wiring, import update.
+- `services/orion-substrate-runtime/README.md` — document the third instrument alongside
+  execution/transport in the "Dynamics tick" / "Unified turn bus listeners" sections.
+- `orion/sentience_striving_program/README.md` — §6 item 3 status note, §9b item 3 open-
+  question line updated (biometrics now covered, chat/route remain open).
+- This doc.
+
+## Non-goals
+
+- Not migrating any producer off `tensions.py`'s bucket-vote layer — that is a separate,
+  later step in charter §6 item 3, gated on every producer domain first being shadow-
+  measured.
+- Not adding a chat or route instrument — explicitly out of scope per the task; the charter's
+  open-question line is updated to say only biometrics is now covered.
+- Not touching `capability_policy.py`, `top_down.py`, `goal_context.py`, or any bus consumer.
+- Not adding a new env key.
+- Not building a historical-replay script for this instrument (unlike `measure_origination_
+  gate.py`/`measure_ast_hot_reducer.py`) — the singleton-table limitation named above makes a
+  meaningful replay impossible today; a follow-up companion to the append-only
+  `substrate_attention_broadcast_log` pattern (charter §6 item 2) would be needed first.
+
+## Acceptance checks
+
+- `pytest orion/substrate/tests/test_prediction_error.py -q` passes (zero delta, partial
+  delta, disjoint key sets, multi-node averaging, empty projections, node absent from prev,
+  clamp-to-1.0).
+- `_tick()`'s existing return signature and poison-isolation behavior are unchanged for
+  callers (`_biometrics_poll_loop`) — confirmed by running the full
+  `services/orion-substrate-runtime/tests/` suite (excluding the always-broken, pre-existing
+  `test_grammar_consumer_integration.py` module-collection error, unrelated to this service's
+  own code) with this patch applied and with it reverted: both produce the identical
+  `13 failed, 137 passed, 9 errors`. This patch changes zero pre-existing pass/fail outcomes —
+  see the PR report for the full pre-existing-failure list, none of which reference
+  `biometrics_prediction_error`, `_tick`, or `NodeBiometricsProjectionV1`.
+- Grep of the final diff for `concept_induction`, `turn_effect`, `SelfStateV1`,
+  `self_state_id`: zero hits.
+- Live check: `node:substrate.biometrics` write is gated behind
+  `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` like the other two lanes; no live write was forced
+  as part of this patch (shadow-only, per the task). `UNVERIFIED` for end-to-end live
+  durability until a real biometrics batch with a non-zero delta lands post-deploy — same
+  honesty standard the harness-closure lane's own design doc used.
+
+## Recommended next patch
+
+- After deploy, confirm a live `node:substrate.biometrics` write via `redis-cli GRAPH.QUERY`
+  against the running FalkorDB backend, the same manual-check pattern used for
+  `node:substrate.harness_closure`.
+- Build the equivalent shadow instrument for `chat_grammar` and `route_grammar` (the two
+  remaining reducers named in charter §9b item 3's open question), closing that question
+  fully rather than partially.

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -199,6 +199,17 @@ first place. Full reasoning and phased detail:
    bucket-vote layer only once every producer has moved and the item-2 reducer is proven a
    real legibility replacement for `dominant_drive`. Includes replacing `goal.drive_origin`
    with a field-native goal-provenance concept — this is what actually unblocks item 6.
+   **Status (2026-07-21): first shadow-measure slice built.**
+   `biometrics_prediction_error()` (`orion/substrate/prediction_error.py`, wired into
+   `services/orion-substrate-runtime/app/worker.py`'s `_tick()`, writes
+   `node:substrate.biometrics` via the same `_write_prediction_error_node()` shared writer
+   execution/transport already use, gated behind the existing
+   `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` flag — no new flag) is the first producer domain
+   shadow-measured under this item, answering half of §9b item 3's open question below.
+   Design record + metric-quality-gate findings: `docs/superpowers/specs/2026-07-21-
+   biometrics-prediction-error-shadow-design.md`. Shadow-only: no consumer changed, no live
+   migration of the bucket-vote layer, `capability_policy.py`/`top_down.py`/`goal_context.py`
+   untouched. Chat and route reducers remain unmeasured.
 4. **Stand up read-only measurement for the remaining consciousness-theory instruments** (§9)
    — RPT/Lamme and predictive processing are already live (items 2-3 build on them directly,
    not duplicate them); IIT continues independently via the mood-arc encoder, not gated by
@@ -365,9 +376,13 @@ fix — see §7.
    (confirmed `true`). Verified against real Postgres data: `node:substrate.execution`'s
    channel carries real values, sparse/event-driven (currently in a quiet decay tail,
    consistent with the field-digester README's own "quiet-so-far-but-correctly-wired,
-   reaches real values like 0.92 periodically" characterization of this exact channel). Open
-   question, not yet checked: whether the other three reducers (biometrics, chat, route)
-   have equivalent instrumentation, or whether coverage is genuinely incomplete.
+   reaches real values like 0.92 periodically" characterization of this exact channel).
+   **Updated 2026-07-21:** of the three other reducers named below (biometrics, chat,
+   route), `biometrics` now has equivalent instrumentation —
+   `biometrics_prediction_error()`, writing `node:substrate.biometrics`, same shared
+   `_write_prediction_error_node()` writer, same flag. See §6 item 3's status note above and
+   `docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md`. Chat and
+   route remain open — not yet checked, coverage still genuinely incomplete for those two.
    **Attribution durability + consumers (2026-07-18):** the harness-closure variant of this
    same mechanism (`node:substrate.harness_closure`, PR #1205) accumulates per-turn
    attribution in `metadata['contributing_turn_ids']`, but that list was silently dropped on

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from orion.schemas.biometrics_projection import NodeBiometricsProjectionV1
 from orion.schemas.execution_projection import ExecutionTrajectoryProjectionV1
 from orion.schemas.transport_projection import TransportBusProjectionV1
 
@@ -40,5 +41,45 @@ def transport_prediction_error(
         for field in ("bus_health", "delivery_confidence", "transport_pressure"):
             pv = getattr(prev_bus, field, 0.0)
             cv = getattr(curr_bus, field, 0.0)
+            deltas.append(abs(cv - pv))
+    return min(1.0, _mean(deltas) / _THRESHOLD) if deltas else 0.0
+
+
+def biometrics_prediction_error(
+    prev: NodeBiometricsProjectionV1,
+    curr: NodeBiometricsProjectionV1,
+) -> float:
+    """0-1 surprise score: how much did node biometrics pressure hints change this batch?
+
+    Unlike ``execution_prediction_error``'s fixed four-key set, biometrics
+    ``pressure_hints`` keys are not enumerable in advance -- they are populated
+    conditionally per node role by ``orion/substrate/biometrics_loop/
+    grammar_extract.py::extract_node_state_from_events()`` (``strain`` always when a
+    body_state atom carries salience, ``gpu`` only for ``local_llm_heavy`` nodes,
+    ``memory_pressure``/``thermal_pressure``/``disk_pressure`` only when the
+    matching pressure-signal atom is present). Confirmed live against real
+    ``substrate_node_biometrics_projection`` data 2026-07-21: a GPU node (``atlas``)
+    carries ``{"gpu", "strain"}`` while an orchestration node (``athena``) carries
+    ``{"strain", "disk_pressure", "memory_pressure", "thermal_pressure"}`` -- no
+    single fixed key list covers every node. So this diffs the union of keys
+    present on either side of a given node, defaulting a missing key to 0.0 the
+    same way ``execution_prediction_error`` defaults a missing fixed key.
+    """
+    deltas: list[float] = []
+    for node_id, curr_node in curr.nodes.items():
+        prev_node = prev.nodes.get(node_id)
+        if prev_node is None:
+            continue
+        keys = set(prev_node.pressure_hints) | set(curr_node.pressure_hints)
+        for key in keys:
+            # pressure_hints is typed dict[str, Any] (unlike execution's pydantic-
+            # enforced dict[str, float]), since node role gates which keys ever get
+            # set -- coerce defensively rather than let a malformed/non-numeric
+            # value raise out of a poll tick.
+            try:
+                pv = float(prev_node.pressure_hints.get(key, 0.0) or 0.0)
+                cv = float(curr_node.pressure_hints.get(key, 0.0) or 0.0)
+            except (TypeError, ValueError):
+                continue
             deltas.append(abs(cv - pv))
     return min(1.0, _mean(deltas) / _THRESHOLD) if deltas else 0.0

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -1,0 +1,117 @@
+"""Unit tests for the field-native prediction-error instruments in
+``orion/substrate/prediction_error.py`` -- 0-1 surprise scores diffing successive
+reducer-projection snapshots (not ``SelfStateV1``, not ``tensions.py``'s bucket
+vocabulary; see the Sentience Striving Program charter §9b item 3)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from orion.schemas.biometrics_projection import (
+    NodeBiometricsProjectionV1,
+    NodeBiometricsStateV1,
+)
+from orion.substrate.prediction_error import biometrics_prediction_error
+
+_NOW = datetime(2026, 7, 21, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _node(node_id: str, pressure_hints: dict) -> NodeBiometricsStateV1:
+    return NodeBiometricsStateV1(node_id=node_id, pressure_hints=pressure_hints)
+
+
+def _projection(nodes: dict[str, NodeBiometricsStateV1]) -> NodeBiometricsProjectionV1:
+    return NodeBiometricsProjectionV1(
+        projection_id="node_biometrics_projection",
+        generated_at=_NOW,
+        nodes=nodes,
+    )
+
+
+def test_biometrics_prediction_error_zero_when_no_change() -> None:
+    prev = _projection({"atlas": _node("atlas", {"gpu": 0.8, "strain": 0.1})})
+    curr = _projection({"atlas": _node("atlas", {"gpu": 0.8, "strain": 0.1})})
+    assert biometrics_prediction_error(prev, curr) == 0.0
+
+
+def test_biometrics_prediction_error_scales_with_delta_magnitude() -> None:
+    prev = _projection({"atlas": _node("atlas", {"gpu": 0.5})})
+    curr = _projection({"atlas": _node("atlas", {"gpu": 0.8})})
+    # |0.8 - 0.5| = 0.3 == _THRESHOLD -> saturates at 1.0
+    assert biometrics_prediction_error(prev, curr) == pytest.approx(1.0)
+
+
+def test_biometrics_prediction_error_partial_delta_below_threshold() -> None:
+    prev = _projection({"atlas": _node("atlas", {"gpu": 0.5})})
+    curr = _projection({"atlas": _node("atlas", {"gpu": 0.65})})
+    # |0.65 - 0.5| = 0.15 -> 0.15 / 0.30 = 0.5
+    assert biometrics_prediction_error(prev, curr) == pytest.approx(0.5)
+
+
+def test_biometrics_prediction_error_zero_when_node_not_in_prev() -> None:
+    """A brand-new node in curr with no prev counterpart contributes no delta --
+    mirrors execution_prediction_error's ``prev_run is None: continue`` skip."""
+    prev = _projection({})
+    curr = _projection({"circe": _node("circe", {"gpu": 0.9})})
+    assert biometrics_prediction_error(prev, curr) == 0.0
+
+
+def test_biometrics_prediction_error_zero_when_projections_empty() -> None:
+    prev = _projection({})
+    curr = _projection({})
+    assert biometrics_prediction_error(prev, curr) == 0.0
+
+
+def test_biometrics_prediction_error_handles_disjoint_pressure_hint_keys() -> None:
+    """Real biometrics nodes carry different pressure_hints key sets depending on
+    node role (GPU nodes: gpu/strain; orchestration nodes: disk/memory/thermal
+    pressure) -- confirmed live 2026-07-21 against substrate_node_biometrics_
+    projection. A key appearing only on one side of the diff (e.g. a pressure
+    signal that newly starts or stops firing) must still be diffed against an
+    implicit 0.0, not silently dropped."""
+    prev = _projection({"athena": _node("athena", {"disk_pressure": 0.1})})
+    curr = _projection(
+        {"athena": _node("athena", {"disk_pressure": 0.1, "thermal_pressure": 0.3})}
+    )
+    # thermal_pressure delta: |0.3 - 0.0| = 0.3; disk_pressure delta: 0.0
+    # mean(0.3, 0.0) = 0.15 -> 0.15 / 0.30 = 0.5
+    assert biometrics_prediction_error(prev, curr) == pytest.approx(0.5)
+
+
+def test_biometrics_prediction_error_averages_across_multiple_nodes() -> None:
+    prev = _projection(
+        {
+            "atlas": _node("atlas", {"gpu": 0.5}),
+            "athena": _node("athena", {"memory_pressure": 0.2}),
+        }
+    )
+    curr = _projection(
+        {
+            "atlas": _node("atlas", {"gpu": 0.8}),  # delta 0.3
+            "athena": _node("athena", {"memory_pressure": 0.2}),  # delta 0.0
+        }
+    )
+    # mean(0.3, 0.0) = 0.15 -> 0.15 / 0.30 = 0.5
+    assert biometrics_prediction_error(prev, curr) == pytest.approx(0.5)
+
+
+def test_biometrics_prediction_error_clamps_to_one() -> None:
+    prev = _projection({"atlas": _node("atlas", {"gpu": 0.0})})
+    curr = _projection({"atlas": _node("atlas", {"gpu": 1.0})})
+    assert biometrics_prediction_error(prev, curr) == pytest.approx(1.0)
+
+
+def test_biometrics_prediction_error_fail_open_on_non_numeric_value() -> None:
+    """pressure_hints is dict[str, Any] (unlike execution's dict[str, float]) --
+    a malformed/non-numeric value for one key must not raise, just be skipped,
+    while a real numeric key on the same node still contributes its delta."""
+    prev = _projection(
+        {"athena": _node("athena", {"thermal_pressure": "not-a-number", "gpu": 0.5})}
+    )
+    curr = _projection(
+        {"athena": _node("athena", {"thermal_pressure": "still-not-a-number", "gpu": 0.8})}
+    )
+    # thermal_pressure delta skipped (non-numeric); gpu delta: |0.8-0.5| = 0.3 -> 1.0
+    assert biometrics_prediction_error(prev, curr) == pytest.approx(1.0)

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -136,8 +136,9 @@ Accepted-pressure reducer output publishes to `orion:grammar:accepted-pressure` 
 
 ## Dynamics tick (rung-1 pacemaker)
 
-`SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true` writes execution/transport prediction-error
-values onto durable substrate graph nodes (`metadata['prediction_error']`), but by itself
+`SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true` writes execution/transport/biometrics
+prediction-error values onto durable substrate graph nodes (`metadata['prediction_error']`),
+but by itself
 nothing ever reads them back — the seeded surprise just sits inert on the node. Set
 `SUBSTRATE_DYNAMICS_TICK_ENABLED=true` to run a periodic, bounded, fail-open
 `SubstrateDynamicsEngine.tick()` against the same shared substrate graph store, which
@@ -188,8 +189,20 @@ Post-turn closure logs `post_turn_closure received …` on ingest. When
 or `…_skipped` otherwise). Full Task 21 strain reducers are not implemented here.
 
 `_write_prediction_error_node()` (`app/worker.py`) writes to a single, fixed `node_id` per
-lane (`node:substrate.execution`, `node:substrate.transport`, `node:substrate.harness_closure`
-for post-turn closure), so repeat writes collapse instead of spawning a new node per event.
+lane (`node:substrate.execution`, `node:substrate.transport`, `node:substrate.biometrics`,
+`node:substrate.harness_closure` for post-turn closure), so repeat writes collapse instead of
+spawning a new node per event.
+
+`node:substrate.biometrics` (`biometrics_prediction_error()`, `orion/substrate/
+prediction_error.py`, wired into `_tick()`) is the third instrument in this family, shadow-
+built 2026-07-21 per the Sentience Striving Program charter §6 item 3. Unlike execution's
+fixed four-key `pressure_hints` diff, biometrics `pressure_hints` keys vary per node role
+(GPU nodes carry `gpu`/`strain`; orchestration nodes carry `disk_pressure`/
+`memory_pressure`/`thermal_pressure` — confirmed live against real
+`substrate_node_biometrics_projection` data), so this instrument diffs the union of keys
+present on either side of a given node rather than a fixed list. See `docs/superpowers/
+specs/2026-07-21-biometrics-prediction-error-shadow-design.md` for the full metric-quality-
+gate writeup.
 Repeat writes to the same node accumulate bounded per-event attribution in
 `metadata['contributing_turn_ids']` (capped at 20, deduped, oldest dropped) — this is
 attribution, not the pressure/dormancy state itself, which `DYNAMICS_ENGINE_OWNED_METADATA_

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -39,6 +39,7 @@ from orion.substrate.transport_loop.constants import (
     TRANSPORT_GRAMMAR_CURSOR_NAME,
 )
 from orion.substrate.prediction_error import (
+    biometrics_prediction_error,
     execution_prediction_error,
     transport_prediction_error,
 )
@@ -614,6 +615,8 @@ class BiometricsSubstrateWorker:
             loaded = self._store.load_active_pressure(ACTIVE_NODE_PRESSURE_PROJECTION_ID)
             return loaded or _empty_pressure(now)
 
+        prev_projection = load_node_bio()
+
         def publish_hook(accepted: list[GrammarEventV1]) -> None:
             published.extend(accepted)
 
@@ -641,6 +644,27 @@ class BiometricsSubstrateWorker:
             events=events,
             process_batch=process_batch,
         )
+
+        if last_id is not None:
+            curr_projection = load_node_bio()
+            error = biometrics_prediction_error(prev_projection, curr_projection)
+            if error > 0.0:
+                self._store.save_receipt(
+                    _prediction_error_receipt(
+                        reducer_key="node_biometrics",
+                        node_id="node:substrate.biometrics",
+                        prediction_error=error,
+                        now=now,
+                    )
+                )
+                self._write_prediction_error_node(
+                    node_id="node:substrate.biometrics",
+                    error=error,
+                    now=now,
+                    reducer_key="node_biometrics",
+                    contributing_id=last_id,
+                )
+
         return last_id, published
 
     def _get_substrate_graph_store(self, *, log_label: str):


### PR DESCRIPTION
## Summary

- Adds `biometrics_prediction_error()` to `orion/substrate/prediction_error.py`, a third field-native prediction-error instrument mirroring the already-live `execution_prediction_error()`/`transport_prediction_error()` pattern.
- Wires it into `services/orion-substrate-runtime/app/worker.py`'s `_tick()` (`REDUCER_SPECS[0]`, biometrics reducer): captures `prev_projection` before processing, `curr_projection` after, computes the error, and on `error > 0.0` writes to `node:substrate.biometrics` via the existing shared `_write_prediction_error_node()`.
- Reuses the existing `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` flag -- no new env key.
- Unlike execution's fixed four-key `pressure_hints` diff, this diffs the *union* of keys present on either side of a node, since biometrics `pressure_hints` keys are role-conditional (confirmed live: GPU nodes carry `{gpu, strain}`, orchestration nodes carry `{strain, disk_pressure, memory_pressure, thermal_pressure}`).
- Shadow-only: no bus consumer added, `capability_policy.py`/`top_down.py`/`goal_context.py` untouched. This is the first producer domain shadow-measured under Sentience Striving Program charter §6 item 3.
- Design doc + metric-quality-gate writeup: `docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md`.

## Outcome moved

Charter §9b item 3's open question ("whether the other three reducers -- biometrics, chat, route -- have equivalent instrumentation") is now answered for `biometrics`: yes, as of this patch. Chat and route remain open, explicitly noted as such in the charter update.

## Current architecture

`orion/substrate/prediction_error.py` had two live instruments (`execution_prediction_error`, `transport_prediction_error`), each diffing a fixed small key set between two successive reducer-projection snapshots and writing a 0-1 surprise score onto a durable substrate node via `_write_prediction_error_node()` (`services/orion-substrate-runtime/app/worker.py`), gated behind `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES`. No instrument existed yet for the biometrics reducer (`REDUCER_SPECS[0]`, `_tick()`).

## Architecture touched

- `orion/substrate/prediction_error.py` -- new function, same module, no schema change.
- `services/orion-substrate-runtime/app/worker.py` -- `_tick()` wiring only; return signature and poison-isolation behavior unchanged.
- No bus/schema/API contract changes.

## Files changed

- `orion/substrate/prediction_error.py`: new `biometrics_prediction_error()`, diffing the union of `pressure_hints` keys (dynamic, not fixed) between two `NodeBiometricsProjectionV1` snapshots. Fail-open on non-numeric `pressure_hints` values (schema types it `dict[str, Any]`, unlike execution's `dict[str, float]`).
- `orion/substrate/tests/test_prediction_error.py`: new unit test file (no prior dedicated test file for this module existed to mirror). 9 tests: zero-delta, saturating delta, partial delta, node-absent-from-prev, empty projections, disjoint key sets (the actual design justification), multi-node averaging, clamp-to-1.0, fail-open on non-numeric value.
- `services/orion-substrate-runtime/app/worker.py`: `_tick()` captures `prev_projection` before `process_batch`, reloads `curr_projection` after a non-`None` `last_id`, computes error, saves a receipt + writes the prediction-error node on `error > 0.0` -- exact mirror of `_execution_tick()`'s pattern.
- `services/orion-substrate-runtime/README.md`: documents the third instrument alongside execution/transport.
- `orion/sentience_striving_program/README.md`: §6 item 3 status note + §9b item 3 open-question line updated (biometrics now covered, chat/route remain open).
- `docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md`: design doc with full metric-quality-gate findings, live-data sanity check, and the naming-mistake context this patch corrects (a prior draft named the signal `coherence_prediction_error` sourced from `turn_effect`, violating the charter's field-native-only rule).

## Schema / bus / API changes

- Added: none (new pure function, no schema fields added).
- Removed: none.
- Renamed: none.
- Behavior changed: `_tick()` now additionally writes a prediction-error node when `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true` and a non-zero delta is observed -- default-on in `.env_example` today (same flag execution/transport already use), fail-open, no raise on write failure.
- Compatibility notes: `_tick()`'s return signature (`tuple[str | None, list[GrammarEventV1]]`) is unchanged; `_biometrics_poll_loop` requires no changes.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: no (reuses existing `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true`).
- local `.env` synced: not applicable (no env template change).
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH=. /tmp/orion-test-venv/bin/python -m pytest orion/substrate/tests/test_prediction_error.py -q
9 passed

cd services/orion-substrate-runtime && PYTHONPATH=<repo>:. /tmp/orion-test-venv/bin/python -m pytest tests/ -q --ignore=tests/test_grammar_consumer_integration.py
13 failed, 137 passed, 9 errors

(Identical failed/error count confirmed with this patch applied and reverted --
zero regressions from this diff. None of the pre-existing failures reference
biometrics_prediction_error, _tick, or NodeBiometricsProjectionV1. Pre-existing,
unrelated failures: test_worker_independent_reducers.py::test_start_spawns_
independent_reducer_poll_tasks (poll-count assertion stale re: chat/route
pollers added later), test_worker_reducer.py::test_advance_cursor_records_
commit_failure_when_created_at_missing and test_worker_falkor_routed_store.py::
test_write_prediction_error_node_preserves_dynamics_state_on_rewrite (both fail
identically in isolation, pre-existing global-registry/environment issues),
plus test_grammar_consumer_integration.py (module-collection ImportError,
pre-existing, unrelated cwd/module-path issue), test_cursor_reset_auth.py and
test_quarantine_truth.py errors (pre-existing, unrelated to this diff), and
test_reducer_health.py::test_record_success_clears_blocked_state (pre-existing).)

tests/test_biometrics_grammar_extract.py, tests/test_biometrics_pipeline.py,
tests/test_biometrics_pressure_organ.py, tests/test_node_biometrics_reducer.py -q
25 passed, 2 pre-existing unrelated failures (test_extract_circe_offline_expected,
test_circe_expected_offline_preserved -- node-catalog "circe expected offline"
config drift, unrelated to prediction-error logic; confirmed live node catalog
already reports circe as expected_online=true, matching the failure)
```

## Evals run

No dedicated eval harness exists for `orion/substrate/prediction_error.py` or the biometrics reducer beyond the unit tests above. Live-data sanity check (part of the metric quality gate, documented in the design doc) substitutes for a replay-based eval here, since `substrate_node_biometrics_projection` is a singleton-upsert table with no history to replay against -- same structural limitation already disclosed for other singleton projection tables in this charter.

## Docker/build/smoke checks

Not run -- this patch is pure Python logic (new function + additive `_tick()` wiring), no config read at boot, no dependency/port/health-check changes. Live data was inspected directly via `psql -h localhost -p 55432 -U postgres -d conjourney` against the running `substrate_node_biometrics_projection` table (read-only) as part of the metric quality gate's live-data sanity check.

## Review findings fixed

- Finding: Design doc's acceptance-checks section claimed "two pre-existing, unrelated failures" without verifying the real count.
  - Fix: Ran the full `services/orion-substrate-runtime/tests/` suite with the patch applied and reverted; both produce identical `13 failed, 137 passed, 9 errors`. Design doc updated to state the accurate methodology and count instead of an invented number.
  - Evidence: `docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md` "Acceptance checks" section; test run output above.
- Finding: `biometrics_prediction_error()`'s `float()` coercion could raise on a non-numeric `pressure_hints` value, since the schema types the field `dict[str, Any]` (unlike execution's `dict[str, float]`) -- an uncaught exception here would propagate out of `_tick()` and retry-loop forever on the same batch.
  - Fix: Wrapped the coercion in `try/except (TypeError, ValueError): continue`, fail-open per the same pattern used elsewhere in this worker.
  - Evidence: `orion/substrate/prediction_error.py` lines ~74-81; new regression test `test_biometrics_prediction_error_fail_open_on_non_numeric_value`.
- Finding: Two tests used exact float equality (`== 1.0`, `== 0.5`) instead of `pytest.approx`, inconsistent with the rest of the file.
  - Fix: Converted both to `pytest.approx`.
  - Evidence: `orion/substrate/tests/test_prediction_error.py`.

## Restart required

```text
No restart required for this patch's own review-fix changes. If deploying to
pick up the new instrument in a running orion-substrate-runtime container:

docker compose \
  --env-file .env \
  --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml \
  up -d --build orion-substrate-runtime
```

## Risks / concerns

- Severity: low
- Concern: `substrate_node_biometrics_projection` is a singleton-upsert row (no history table), so no historical replay was possible for the live-data sanity check -- only "current snapshot is real and non-degenerate" was confirmed, not a multi-sample replay like `measure_origination_gate.py` did for a different signal.
- Mitigation: Disclosed explicitly in the design doc rather than glossed over; recommended next patch is a live post-deploy check via `redis-cli GRAPH.QUERY` for `node:substrate.biometrics`, the same pattern already used for `node:substrate.harness_closure`.

- Severity: low
- Concern: `services/orion-substrate-runtime/tests/` has a real, pre-existing baseline of 13 failed + 9 errored tests unrelated to this diff (node-catalog config drift, stale poll-count assertions, global-registry test-isolation issues). Not introduced or worsened by this patch, but they exist in the same suite this PR's tests run alongside.
- Mitigation: Listed explicitly above with per-test reasoning; confirmed identical before/after this patch via isolated reruns.

## PR link

(filled in after creation)
