### PR TITLE
feat(hub): live Field Channel Glossary observability panel

### DIFF
--- a/config/field/field_channel_glossary.v1.yaml
+++ b/config/field/field_channel_glossary.v1.yaml
@@ -1,0 +1,201 @@
+# Structured index of FieldStateV1's 29 raw digester channels (23 NODE_CHANNELS
+# + 8 CAPABILITY_CHANNELS in services/orion-field-digester/app/tensor/channels.py,
+# overlapping on transport_pressure/contract_pressure).
+#
+# This is the machine-readable companion to
+# services/orion-field-digester/README.md's "Field channel glossary" section,
+# which stays the prose reference (full mechanism detail, live-data
+# investigation history). This file is the single structured source both
+# that doc and Hub's Field Channel Glossary panel
+# (services/orion-hub/scripts/field_channel_glossary_routes.py) read from, so
+# the two can't independently drift the way the README's own frozen verdicts
+# already have.
+#
+# Deliberately does NOT include a "verdict" field: liveness verdicts are
+# computed LIVE from substrate_field_state by
+# orion.self_state.field_channel_glossary.classify_channel_series(), not
+# hand-maintained here -- a static verdict column is exactly what already
+# went stale once (see the README's "Decay vs. injection-interval mismatch"
+# section).
+version: 1
+
+categories:
+  physical_substrate: "Physical substrate / embodiment -- pure hardware sensor readings, nothing cognitive."
+  task_execution: "Task-execution domain -- what Orion is actively doing computationally right now and how well it's going."
+  social_conversational: "Social / conversational domain -- the texture of the current chat interaction."
+  infra_transport: "Infrastructure / transport workload -- the bus's own workload/health as infrastructure, not a compute resource."
+  sensor_trust_liveness: "Sensor trust / liveness -- whether a source's other readings can be trusted right now, not what it's doing."
+  synthesized_rollup: "Synthesized / aggregate rollups -- capability-level composites blending multiple node-level signals."
+  self_monitoring: "Self-monitoring / introspection -- whether Orion's own internal model is consistent or accurate."
+
+channels:
+  - channel: availability
+    level: [node]
+    category: sensor_trust_liveness
+    meaning: "How available/reachable a compute node currently is."
+    self_state_dimension: coherence
+
+  - channel: staleness
+    level: [node]
+    category: sensor_trust_liveness
+    meaning: "Whether a node's most recent biometrics sample is too old to trust."
+    self_state_dimension: continuity_pressure
+
+  - channel: cpu_pressure
+    level: [node]
+    category: physical_substrate
+    meaning: "How loaded a node's CPU currently is."
+    evidence_dimension: resource_pressure
+
+  - channel: memory_pressure
+    level: [node]
+    category: physical_substrate
+    meaning: "Node RAM pressure."
+    evidence_dimension: resource_pressure
+
+  - channel: gpu_pressure
+    level: [node]
+    category: physical_substrate
+    meaning: "How loaded a node's GPU currently is."
+    evidence_dimension: resource_pressure
+
+  - channel: thermal_pressure
+    level: [node]
+    category: physical_substrate
+    meaning: "Node thermal/temperature pressure."
+    self_state_dimension: resource_pressure
+
+  - channel: disk_pressure
+    level: [node]
+    category: physical_substrate
+    meaning: "Node disk I/O pressure."
+    evidence_dimension: resource_pressure
+
+  - channel: expected_offline_suppression
+    level: [node]
+    category: sensor_trust_liveness
+    meaning: "Signals a node is expected to be offline, so its absence shouldn't be read as a failure."
+    self_state_dimension: coherence
+
+  - channel: execution_load
+    level: [node]
+    category: task_execution
+    meaning: "How much active execution work (agent runs, tool calls) is in flight on a node."
+    evidence_dimension: execution_pressure
+
+  - channel: execution_friction
+    level: [node]
+    category: task_execution
+    meaning: "How much resistance (retries/backoff) execution is encountering on a node."
+    evidence_dimension: reliability_pressure
+
+  - channel: reasoning_load
+    level: [node]
+    category: task_execution
+    meaning: "How much active LLM-reasoning work a node is doing."
+    evidence_dimension: reasoning_pressure
+
+  - channel: failure_pressure
+    level: [node]
+    category: task_execution
+    meaning: "Recent execution failure rate/severity on a node."
+    evidence_dimension: reliability_pressure
+
+  - channel: egress_confidence_deficit
+    level: [node]
+    category: task_execution
+    meaning: "1 - confidence that an execution's output actually reached its destination."
+    self_state_dimension: introspection_pressure
+
+  - channel: repair_pressure
+    level: [node]
+    category: social_conversational
+    meaning: "How much conversational \"repair\" (corrections, re-explaining) is happening in chat."
+    self_state_dimension: social_pressure
+
+  - channel: conversation_load
+    level: [node]
+    category: social_conversational
+    meaning: "How much active conversational load (turn volume/complexity) is occurring."
+    self_state_dimension: social_pressure
+
+  - channel: transport_pressure
+    level: [node, capability]
+    category: infra_transport
+    meaning: "Bus/transport-layer backpressure/congestion."
+    evidence_dimension: resource_pressure
+
+  - channel: contract_pressure
+    level: [node, capability]
+    category: infra_transport
+    meaning: "Pressure from bus/schema \"contract\" mismatches (precise real-world condition not otherwise documented in code)."
+
+  - channel: catalog_drift_pressure
+    level: [node]
+    category: infra_transport
+    meaning: "Drift/staleness in the bus event \"catalog\" (schema registry) relative to what's actually flowing."
+
+  - channel: delivery_confidence
+    level: [node]
+    category: sensor_trust_liveness
+    meaning: "Confidence that bus messages are actually being delivered end-to-end."
+    evidence_dimension: coherence
+
+  - channel: bus_health
+    level: [node]
+    category: sensor_trust_liveness
+    meaning: "Overall bus/transport subsystem health signal."
+    evidence_dimension: coherence
+
+  - channel: observer_failure_pressure
+    level: [node]
+    category: infra_transport
+    meaning: "Pressure from failures of the bus \"observer\" role (monitoring/subscriber-side failures)."
+
+  - channel: field_coherence_warning
+    level: [node]
+    category: self_monitoring
+    meaning: "Per-node incoherence score -- fires when two reducers that should agree about a node's state disagree."
+    self_state_dimension: coherence
+
+  - channel: prediction_error
+    level: [node]
+    category: self_monitoring
+    meaning: "How much a recent prediction (from the prediction/surprise subsystem) missed reality."
+    self_state_dimension: uncertainty
+
+  - channel: pressure
+    level: [capability]
+    category: synthesized_rollup
+    meaning: "Overall load/pressure for a given capability (llm_inference, orchestration, storage, graph, memory, transport)."
+    self_state_dimension: resource_pressure
+
+  - channel: confidence
+    level: [capability]
+    category: synthesized_rollup
+    meaning: "How confident the system is that a given capability is currently reliable/available."
+    self_state_dimension: coherence
+
+  - channel: available_capacity
+    level: [capability]
+    category: synthesized_rollup
+    meaning: "How much spare operating capacity a capability has right now."
+    self_state_dimension: coherence
+
+  - channel: execution_pressure
+    level: [capability]
+    category: task_execution
+    meaning: "Capability-level execution-load pressure."
+    self_state_dimension: execution_pressure
+
+  - channel: reasoning_pressure
+    level: [capability]
+    category: task_execution
+    meaning: "Capability-level reasoning-load pressure."
+    self_state_dimension: reasoning_pressure
+
+  - channel: reliability_pressure
+    level: [capability]
+    category: synthesized_rollup
+    meaning: "Capability-level pressure representing risk to reliability (from execution friction, failures, or observer failures)."
+    self_state_dimension: reliability_pressure

--- a/docs/superpowers/pr-reports/2026-07-21-field-channel-glossary-hub-panel-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-21-field-channel-glossary-hub-panel-pr.md
@@ -1,0 +1,114 @@
+# Field Channel Glossary Hub panel -- PR report
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1220
+Branch: `feat/field-channel-glossary-hub-panel`
+
+## Summary
+
+- New Hub tab ("Field Channels") lists field-digester's 29 raw `FieldStateV1` channels (23 node + 8 capability, 2 overlapping) with a **live-computed** clean/dead verdict, not the field-digester README's frozen prose verdicts -- those had already gone stale once as fixes landed (agent-board note flagged this before this branch started).
+- Structured channel metadata now lives at `config/field/field_channel_glossary.v1.yaml`, the machine-readable companion to the README's prose "Field channel glossary" section.
+- Liveness classifier (`orion/self_state/field_channel_glossary.py`) generalizes `scripts/analysis/measure_capability_channel_health.py`'s already-validated heuristic (1e-100 subnormal cutoff, "live" if max-median > 0.05) from that script's 8 capability channels to all 29.
+- New read-only API `services/orion-hub/scripts/field_channel_glossary_routes.py` (`GET /channels`, `GET /health?hours=1|6|24`), built on the existing `collect_field_channel_pressures()` merge so polarity/merge logic isn't re-derived.
+- Tab wired into `index.html`/`app.js`/`api_routes.py` following the existing Substrate Lattice tab pattern exactly.
+
+## Outcome moved
+
+Operators can now see, per channel: is it alive, quiet-but-wired, dead, never-produced, or a suspected one-way ratchet -- computed fresh from `substrate_field_state` on every load, closing the specific staleness gap the field-digester README's hand-written verdicts already hit once.
+
+## Current architecture
+
+`services/orion-field-digester`'s README documented all 29 channels in prose only, with a verdict column that's a point-in-time snapshot. `services/orion-hub/scripts/substrate_field_routes.py` already exposed a single-tick `FieldStateV1` snapshot API but nothing that classified liveness over time or listed the channel glossary. Hub had three prior tabs (Drives Analytics, Pressure Analytics, Substrate Lattice) using an identical static-HTML-iframe pattern this branch follows.
+
+## Architecture touched
+
+- `config/field/` (new glossary config)
+- `orion/self_state/` (new pure classifier module)
+- `services/orion-hub/scripts/api_routes.py` (router registration)
+- `services/orion-hub/templates/index.html`, `static/js/app.js` (tab wiring)
+- `services/orion-hub/static/` (new self-contained panel page)
+- `services/orion-field-digester/README.md` (cross-reference note)
+
+## Files changed
+
+- `config/field/field_channel_glossary.v1.yaml`: new structured 29-channel index
+- `orion/self_state/field_channel_glossary.py`: new liveness classifier + glossary loader
+- `services/orion-hub/scripts/field_channel_glossary_routes.py`: new FastAPI router
+- `services/orion-hub/static/field-channel-glossary.html`: new self-contained panel page
+- `services/orion-hub/scripts/api_routes.py`: registers the new router
+- `services/orion-hub/templates/index.html`, `services/orion-hub/static/js/app.js`: new tab nav/panel/hash-routing, copied from the Substrate Lattice pattern
+- `services/orion-field-digester/README.md`: cross-reference note pointing at the new live panel
+- `tests/test_field_channel_glossary.py`, `services/orion-hub/tests/test_field_channel_glossary_routes.py`, `services/orion-hub/tests/test_field_channel_glossary_hub_tab.py`: new tests
+
+## Schema / bus / API changes
+
+- Added: `GET /api/field-channel-glossary/channels`, `GET /api/field-channel-glossary/health`
+- Removed: none
+- Renamed: none
+- Behavior changed: none (new read-only surface only)
+- Compatibility notes: no bus/schema contract changes; reads existing `substrate_field_state` table and existing `FieldStateV1`/`collect_field_channel_pressures()`
+
+## Env/config changes
+
+- Added keys: none (reuses existing `POSTGRES_URI`)
+- Removed keys: none
+- Renamed keys: none
+- `.env_example` updated: not applicable, no new keys
+- local `.env` synced: not applicable, no new keys
+- skipped keys requiring operator action: none
+
+## Tests run
+
+```text
+# Pure-logic + glossary tests (repo-root venv)
+/tmp/orion-test-venv/bin/python -m pytest tests/test_field_channel_glossary.py tests/test_self_state_scoring.py -q
+26 passed
+
+# Hub route + tab-wiring tests (hub venv)
+/tmp/orion-hub-test-venv/bin/python -m pytest tests/test_field_channel_glossary_routes.py tests/test_field_channel_glossary_hub_tab.py tests/test_pressure_analytics_hub_tab.py tests/test_substrate_lattice_hub_tab.py tests/test_substrate_field_debug_api.py -q
+25 passed
+```
+
+Full `services/orion-hub/tests` suite was also run for regression-check purposes: 85-115 pre-existing failures (identical root cause -- missing `rdflib` in the test venv -- confirmed reproduced on unmodified `main` too, not introduced by this branch).
+
+## Evals run
+
+No eval harness exists for this observability surface; none added. This is a read-only debug/observability panel, not a cognition-affecting change, so no eval gap is being carried silently -- flagging explicitly per repo convention.
+
+## Docker/build/smoke checks
+
+Not run -- no Docker/runtime config changed (no new env keys, no compose changes, no dependency changes: PyYAML already in `services/orion-hub/requirements.txt`). Route dispatch was verified via a live `TestClient` request through the full `api_routes.router` aggregation (`GET /api/field-channel-glossary/channels` -> 200, 29 channels), since a newer FastAPI/Starlette version wraps included sub-routers as `_IncludedRouter` objects that don't show `.path` under naive `.routes` iteration -- confirmed this is a `.routes` inspection quirk, not a registration bug.
+
+## Review findings fixed
+
+- Finding: `/health` used `ORDER BY generated_at ASC LIMIT :row_cap`, so windows large enough to hit the row cap (hours=6/24 at ~1.8k rows/hour) silently classified from the *oldest* slice of the window instead of the newest -- the exact staleness failure mode this feature exists to replace.
+  - Fix: `ORDER BY generated_at DESC LIMIT :row_cap`, then reverse in Python before building series.
+  - Evidence: new test `test_health_endpoint_reverses_desc_rows_back_to_chronological_order`.
+- Finding: 5 channels (`expected_offline_suppression`, `transport_pressure`, `contract_pressure`, `catalog_drift_pressure`, `observer_failure_pressure`) that are genuinely wired but read exactly `0.0` this tick get dropped by `collect_field_channel_pressures()`'s merge gate, and were misclassified `never_produced` (implying broken wiring) instead of `dead` (implying no current signal).
+  - Fix: `build_channel_series()` now falls back to checking raw `node_vectors`/`capability_vectors` keys directly when a channel is missing from the merge, recording `0.0` if the key is structurally present; only a channel absent from every row's raw vectors all window is `never_produced`.
+  - Evidence: new tests `test_build_channel_series_quiet_zero_channel_is_dead_not_never_produced`, `test_build_channel_series_genuinely_never_produced_when_key_absent_everywhere`.
+- Finding: `ratchet_suspect` had no minimum-sample guard -- a 2-point up-step (a coin flip for any noisy-but-healthy channel) could false-positive as a suspected one-way ratchet.
+  - Fix: added `RATCHET_MIN_SAMPLES = 4` guard.
+  - Evidence: new tests `test_classify_two_point_up_step_is_not_ratchet_suspect`, `test_classify_ratchet_suspect_requires_minimum_sample_count`.
+- Finding: malformed/unparsable historical rows were silently discarded with no diagnostic, so "every channel dead" and "100% of rows failed to parse" looked identical in the response.
+  - Fix: added `unparsable_count` to the `/health` response and the static page's window-meta line.
+  - Evidence: new test `test_build_channel_series_counts_unparsable_rows_separately_from_dead`.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build orion-hub
+```
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `services/orion-hub/tests` has a pre-existing, wide `rdflib`-missing gap in the sandbox test venv (`/tmp/orion-hub-test-venv`) unrelated to this change; confirmed identical on unmodified `main`.
+- Mitigation: none needed for this PR; separate venv/dependency fix, out of scope here.
+
+- Severity: low
+- Concern: `graphify update .` hit the known pre-existing destructive-update bug (2026-07-14 incident) during this session; the `safe_graphify_update.sh` wrapper caught it and auto-restored `graph.json`/`manifest.json`, nothing was committed. A stray regenerated `GRAPH_REPORT.md`/`graph.html` left over from the refused run were reverted/removed before committing so this branch's diff stays scoped to the feature.
+- Mitigation: none needed; underlying graphify bug is a separate, already-tracked issue.
+
+## Status
+
+DONE

--- a/orion/self_state/field_channel_glossary.py
+++ b/orion/self_state/field_channel_glossary.py
@@ -1,0 +1,135 @@
+"""Loader + live-liveness classifier for FieldStateV1's 29 raw channels.
+
+Companion to config/field/field_channel_glossary.v1.yaml (the structured
+channel index) and services/orion-field-digester/README.md's "Field channel
+glossary" section (the prose reference). Built for Hub's Field Channel
+Glossary observability panel
+(services/orion-hub/scripts/field_channel_glossary_routes.py), which needs
+to answer "is this metric alive" from real data, not from the README's
+frozen prose verdicts -- those were already found stale once (see the
+README's "Decay vs. injection-interval mismatch" section) and the repo's
+own rule is that runtime truth beats config truth.
+
+classify_channel_series() generalizes the liveness heuristic
+scripts/analysis/measure_capability_channel_health.py already validated
+(1e-100 subnormal-float cutoff, "live" if max - median > 0.05) from that
+script's 8 capability channels / 2 targets to all 29 channels across every
+node and capability, operating on the same merged, correctly-polarized
+per-tick channel dict every cognition consumer reads
+(orion.self_state.scoring.collect_field_channel_pressures) rather than
+reimplementing merge/polarity logic here.
+"""
+
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_GLOSSARY_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "field" / "field_channel_glossary.v1.yaml"
+)
+
+# Same threshold scripts/analysis/measure_capability_channel_health.py uses:
+# strictly finer-grained than the smallest downstream decision boundary
+# (field_attention_policy.v1.yaml's min_salience=0.10) this data feeds, so a
+# channel that swings by less than this can never meaningfully move a
+# decision gated at those thresholds.
+LIVE_VARIANCE_THRESHOLD: float = 0.05
+
+# Below this magnitude, treat a value as "zero or numerically-decayed-to-dust
+# subnormal", not real signal -- channels here have repeatedly decayed to
+# values like 6.85e-322 instead of landing exactly on 0.0.
+SUBNORMAL_CUTOFF: float = 1e-100
+
+# Verdicts a Hub "clean channels" filter should keep.
+CLEAN_VERDICTS: frozenset[str] = frozenset({"live", "quiet"})
+
+# Minimum sample count before the monotonic-non-decreasing ratchet_suspect
+# check is trusted. With only 2 points, "non-decreasing" is true for ~half
+# of all noisy-but-healthy series (a coin flip, not a monotonicity signal) --
+# below this count, fall through to the ordinary quiet/live spread check
+# instead of flagging a possible one-way ratchet off a single up-step.
+RATCHET_MIN_SAMPLES: int = 4
+
+
+@dataclass(frozen=True)
+class FieldChannelGlossaryEntry:
+    channel: str
+    level: tuple[str, ...]
+    category: str
+    meaning: str
+    self_state_dimension: str | None = None
+    evidence_dimension: str | None = None
+
+
+@functools.lru_cache(maxsize=1)
+def load_glossary(path: Path | None = None) -> dict[str, Any]:
+    """Load config/field/field_channel_glossary.v1.yaml.
+
+    Cached (the file only changes on deploy); pass an explicit path to
+    bypass the cache in tests.
+    """
+    target = path or _GLOSSARY_PATH
+    with open(target, encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    entries = tuple(
+        FieldChannelGlossaryEntry(
+            channel=e["channel"],
+            level=tuple(e.get("level", [])),
+            category=e["category"],
+            meaning=e["meaning"],
+            self_state_dimension=e.get("self_state_dimension"),
+            evidence_dimension=e.get("evidence_dimension"),
+        )
+        for e in raw.get("channels", [])
+    )
+    return {"entries": entries, "categories": dict(raw.get("categories", {}))}
+
+
+def classify_channel_series(values: list[float]) -> str:
+    """Classify one channel's per-tick value series into a liveness verdict.
+
+    Verdicts:
+    - never_produced: the channel never appeared in any tick this window
+      (absent, not even at a reconciled-default 0.0).
+    - dead: present but every value is subnormal/zero -- functionally no
+      information (covers the README's "folded-away", "fully unproduced
+      past reconcile", and "quiet-but-only-subnormal-noise" cases alike;
+      from an observability standpoint all three mean the same thing: this
+      metric isn't telling you anything).
+    - ratchet_suspect: monotonically non-decreasing across the whole window
+      with a real net climb, and at least RATCHET_MIN_SAMPLES points --
+      consistent with a mode=add channel absent from NODE_DECAY_CHANNELS/
+      CAPABILITY_DECAY_CHANNELS. A heuristic, not a structural fact (see
+      module docstring); a channel that legitimately climbed once during a
+      short sampled window will also trip this. Below RATCHET_MIN_SAMPLES,
+      "non-decreasing" isn't a meaningful monotonicity signal (with 2 points
+      it's true ~half the time for any noisy-but-healthy series), so short
+      series fall through to the quiet/live spread check instead.
+    - quiet: present, genuinely wired, but low-variance in this window
+      (max - median <= LIVE_VARIANCE_THRESHOLD).
+    - live: present with real variance this window.
+    """
+    if not values:
+        return "never_produced"
+    if all(abs(v) < SUBNORMAL_CUTOFF for v in values):
+        return "dead"
+    non_decreasing = all(b >= a - 1e-12 for a, b in zip(values, values[1:]))
+    climbed = (values[-1] - values[0]) > LIVE_VARIANCE_THRESHOLD
+    if non_decreasing and climbed and len(values) >= RATCHET_MIN_SAMPLES:
+        return "ratchet_suspect"
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+    median = (
+        sorted_vals[n // 2]
+        if n % 2
+        else (sorted_vals[n // 2 - 1] + sorted_vals[n // 2]) / 2
+    )
+    spread = max(values) - median
+    if spread <= LIVE_VARIANCE_THRESHOLD:
+        return "quiet"
+    return "live"

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -228,6 +228,21 @@ not yet trained) — but several of these same channels also feed
 centralized doc previously existed for what each channel means, how it's
 calculated, or which self-state dimension (if any) it feeds.
 
+**Live observability (2026-07-21)**: the per-channel category/meaning/
+self-state-dimension metadata below is now also structured, machine-readable
+data at `config/field/field_channel_glossary.v1.yaml`
+(`orion.self_state.field_channel_glossary`), read by Hub's "Field Channels"
+tab (`services/orion-hub/static/field-channel-glossary.html`,
+`GET /api/field-channel-glossary/{channels,health}`). That panel does
+**not** read the verdicts below -- it computes a live clean/dead verdict
+per channel from real `substrate_field_state` data over a rolling window
+using the same subnormal-cutoff + variance heuristic
+`scripts/analysis/measure_capability_channel_health.py` validated, because
+the verdicts in this section are a point-in-time write-up and can (and,
+per the "Update" notes throughout this section, already have) go stale as
+fixes land. Treat this section as the prose mechanism reference and the
+Hub panel as the current-truth check.
+
 **Pipeline order** (`app/tensor/update_rules.py::run_digestion_tick`, called
 once per tick from `app/worker.py::_tick`): reconcile (seed any
 lattice-declared node/capability not yet present with

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -164,6 +164,7 @@ from .substrate_feedback_routes import router as substrate_feedback_router
 from .substrate_consolidation_routes import router as substrate_consolidation_router
 from .substrate_lattice_routes import router as substrate_lattice_router
 from .self_brain_routes import router as self_brain_router
+from .field_channel_glossary_routes import router as field_channel_glossary_router
 router.include_router(grammar_atlas_router)
 router.include_router(substrate_biometrics_router)
 router.include_router(substrate_field_router)
@@ -178,6 +179,7 @@ router.include_router(substrate_feedback_router)
 router.include_router(substrate_consolidation_router)
 router.include_router(substrate_lattice_router)
 router.include_router(self_brain_router)
+router.include_router(field_channel_glossary_router)
 
 
 def _hub_uses_host_network_mode() -> bool:

--- a/services/orion-hub/scripts/field_channel_glossary_routes.py
+++ b/services/orion-hub/scripts/field_channel_glossary_routes.py
@@ -1,0 +1,191 @@
+"""Read-only Hub API for the Field Channel Glossary observability panel.
+
+Serves two views over FieldStateV1's 29 raw digester channels
+(orion.self_state.field_channel_glossary + services/orion-field-digester's
+NODE_CHANNELS/CAPABILITY_CHANNELS):
+
+- GET /channels: static glossary metadata (meaning, category, self-state
+  dimension) from config/field/field_channel_glossary.v1.yaml.
+- GET /health: LIVE per-channel liveness verdict computed from
+  substrate_field_state over a rolling window, using the same
+  collect_field_channel_pressures() merge every cognition consumer reads
+  and the classifier orion.self_state.field_channel_glossary already
+  validates against scripts/analysis/measure_capability_channel_health.py's
+  thresholds. Deliberately NOT the README's frozen prose verdicts -- see
+  that module's docstring for why.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import create_engine, text
+
+from orion.schemas.field_state import FieldStateV1
+from orion.self_state.field_channel_glossary import (
+    CLEAN_VERDICTS,
+    classify_channel_series,
+    load_glossary,
+)
+from orion.self_state.scoring import collect_field_channel_pressures
+
+router = APIRouter(prefix="/api/field-channel-glossary", tags=["field-channel-glossary"])
+
+ALLOWED_HOURS: frozenset[int] = frozenset({1, 6, 24})
+DEFAULT_HOURS: int = 1
+ROW_CAP: int = 6000
+
+_engine_instance: Any = None
+
+
+def _engine():
+    global _engine_instance
+    if _engine_instance is None:
+        uri = os.getenv("POSTGRES_URI", "").strip()
+        if not uri:
+            raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+        _engine_instance = create_engine(uri, pool_pre_ping=True)
+    return _engine_instance
+
+
+def normalize_hours(hours: int | None) -> int:
+    if hours in ALLOWED_HOURS:
+        return int(hours)
+    return DEFAULT_HOURS
+
+
+def build_channel_series(
+    rows: list[Any], known_channels: list[str] | None = None
+) -> tuple[dict[str, list[float]], int]:
+    """Merged per-tick channel series from raw substrate_field_state rows.
+
+    Pure w.r.t. FieldStateV1 payloads (already-decoded dicts); reuses the
+    same collect_field_channel_pressures() merge SelfStateV1 scoring reads,
+    rather than re-deriving polarity/merge logic here.
+
+    collect_field_channel_pressures() only writes a channel into its merged
+    output when `channel in PRESSURE_CHANNELS or value > 0`
+    (orion.self_state.scoring) -- for the 5 channels in neither
+    PRESSURE_CHANNELS nor HIGHER_IS_BETTER_CHANNELS (expected_offline_
+    suppression, transport_pressure, contract_pressure,
+    catalog_drift_pressure, observer_failure_pressure), a tick where every
+    source reads exactly 0.0 means the channel is silently absent from the
+    merge, even though DEFAULT_NODE_VECTOR/DEFAULT_CAPABILITY_VECTOR
+    guarantee it's genuinely present on the raw FieldStateV1 payload. Without
+    correcting for this, classify_channel_series() would call a channel that
+    is present-and-correctly-quiet-at-zero "never_produced" (implying it was
+    never wired up), which is a different and more alarming claim than
+    "dead/no current signal". So: when a known channel is missing from the
+    merge for a given tick, fall back to checking the raw node_vectors/
+    capability_vectors keys directly (a structural presence check, not a
+    re-derivation of merge polarity) and record 0.0 if the key is there.
+    Only a channel absent from EVERY row's raw vectors for the whole window
+    is genuinely never_produced.
+
+    Returns (series, unparsable_row_count) so callers can distinguish "this
+    channel is genuinely dead" from "every row in this window failed to
+    parse" -- both would otherwise look identical (all channels empty).
+    """
+    series: dict[str, list[float]] = {ch: [] for ch in (known_channels or [])}
+    unparsable = 0
+    for payload in rows:
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        try:
+            state = FieldStateV1.model_validate(payload)
+        except Exception:  # noqa: BLE001 - count and skip unparsable historical rows
+            unparsable += 1
+            continue
+        merged, _provenance = collect_field_channel_pressures(state)
+        raw_keys: set[str] = set()
+        for vector in state.node_vectors.values():
+            raw_keys.update(vector.keys())
+        for vector in state.capability_vectors.values():
+            raw_keys.update(vector.keys())
+        seen_channels = set(series.keys()) | set(merged.keys())
+        for channel in seen_channels:
+            if channel in merged:
+                series.setdefault(channel, []).append(float(merged[channel]))
+            elif channel in raw_keys:
+                series.setdefault(channel, []).append(0.0)
+    return series, unparsable
+
+
+@router.get("/channels")
+async def channels() -> dict[str, Any]:
+    glossary = load_glossary()
+    return {
+        "categories": glossary["categories"],
+        "channels": [
+            {
+                "channel": e.channel,
+                "level": list(e.level),
+                "category": e.category,
+                "meaning": e.meaning,
+                "self_state_dimension": e.self_state_dimension,
+                "evidence_dimension": e.evidence_dimension,
+            }
+            for e in glossary["entries"]
+        ],
+    }
+
+
+@router.get("/health")
+async def health(hours: int = Query(DEFAULT_HOURS)) -> dict[str, Any]:
+    window_hours = normalize_hours(hours)
+    with _engine().connect() as conn:
+        # DESC + reverse (not ASC + LIMIT) so that when the window's row
+        # count exceeds ROW_CAP, the retained rows are the newest ticks, not
+        # the oldest -- an ASC LIMIT would silently classify the panel from
+        # the stalest slice of exactly the windows large enough to truncate
+        # (hours=6/24 at ~1.8k rows/hour), the same staleness failure mode
+        # this feature exists to replace.
+        result = conn.execute(
+            text(
+                """
+                SELECT field_json
+                FROM substrate_field_state
+                WHERE generated_at >= NOW() - (:hours * INTERVAL '1 hour')
+                ORDER BY generated_at DESC
+                LIMIT :row_cap
+                """
+            ),
+            {"hours": window_hours, "row_cap": ROW_CAP},
+        )
+        payloads = [row[0] for row in result]
+    payloads.reverse()
+
+    row_count = len(payloads)
+    glossary = load_glossary()
+    known_channels = [e.channel for e in glossary["entries"]]
+    series, unparsable_count = build_channel_series(payloads, known_channels)
+
+    out = []
+    for entry in glossary["entries"]:
+        values = series.get(entry.channel, [])
+        verdict = classify_channel_series(values)
+        out.append(
+            {
+                "channel": entry.channel,
+                "level": list(entry.level),
+                "category": entry.category,
+                "verdict": verdict,
+                "clean": verdict in CLEAN_VERDICTS,
+                "sample_count": len(values),
+                "min": min(values) if values else None,
+                "max": max(values) if values else None,
+                "last": values[-1] if values else None,
+            }
+        )
+
+    return {
+        "window_hours": window_hours,
+        "row_count": row_count,
+        "row_cap": ROW_CAP,
+        "truncated": row_count >= ROW_CAP,
+        "unparsable_count": unparsable_count,
+        "channels": out,
+    }

--- a/services/orion-hub/static/field-channel-glossary.html
+++ b/services/orion-hub/static/field-channel-glossary.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Field Channel Glossary</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    body { font-family: Inter, system-ui, sans-serif; }
+  </style>
+</head>
+<body class="bg-gray-950 text-gray-200 min-h-screen">
+  <div id="fieldChannelGlossaryRoot" class="p-3 md:p-4 max-w-[100vw]">
+    <div class="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100/90 mb-3">
+      Read-only observability. Verdicts below are computed live from <code>substrate_field_state</code> over the
+      selected window -- they are not the field-digester README's static prose verdicts, which are a point-in-time
+      write-up and can go stale as fixes land.
+    </div>
+
+    <div class="flex flex-wrap items-center gap-2 mb-3 text-xs text-gray-400">
+      <span>Last loaded: <span id="fcgLastLoaded" class="text-gray-200">&mdash;</span></span>
+      <button type="button" id="fcgRefresh" class="rounded border border-gray-600 bg-gray-800 px-2 py-1 text-gray-200 hover:bg-gray-700">Refresh</button>
+      <label class="inline-flex items-center gap-1.5 cursor-pointer">
+        <input type="checkbox" id="fcgAutoRefresh" class="rounded border-gray-600" />
+        <span>Auto-refresh (60s)</span>
+      </label>
+      <label class="inline-flex items-center gap-1 ml-2">
+        <span>Window</span>
+        <select id="fcgWindowHours" class="rounded border border-gray-700 bg-gray-900 px-2 py-1 text-gray-200">
+          <option value="1">1h</option>
+          <option value="6">6h</option>
+          <option value="24">24h</option>
+        </select>
+      </label>
+      <label class="inline-flex items-center gap-1.5 cursor-pointer ml-2">
+        <input type="checkbox" id="fcgShowAll" class="rounded border-gray-600" />
+        <span>Show dead / never-produced / ratchet-suspect too</span>
+      </label>
+      <span id="fcgWindowMeta" class="text-gray-500 ml-auto"></span>
+    </div>
+
+    <div id="fcgCategoryStrip" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-2 mb-3"></div>
+
+    <div id="fcgError" class="hidden rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100/90 mb-3"></div>
+
+    <div class="rounded-xl border border-gray-800 bg-gray-900/40 overflow-x-auto">
+      <table class="min-w-full text-xs" id="fcgTable">
+        <thead class="bg-gray-900/80 text-gray-400 uppercase tracking-wide text-[10px]">
+          <tr>
+            <th class="px-3 py-2 text-left">Channel</th>
+            <th class="px-3 py-2 text-left">Level</th>
+            <th class="px-3 py-2 text-left">Category</th>
+            <th class="px-3 py-2 text-left">Verdict</th>
+            <th class="px-3 py-2 text-right">Samples</th>
+            <th class="px-3 py-2 text-right">Min</th>
+            <th class="px-3 py-2 text-right">Max</th>
+            <th class="px-3 py-2 text-right">Last</th>
+            <th class="px-3 py-2 text-left">Self-state dimension</th>
+            <th class="px-3 py-2 text-left">Meaning</th>
+          </tr>
+        </thead>
+        <tbody id="fcgTableBody" class="divide-y divide-gray-800"></tbody>
+      </table>
+    </div>
+    <div id="fcgEmpty" class="hidden text-center text-gray-500 text-xs py-6">No channels match the current filter.</div>
+  </div>
+
+  <script>
+    const VERDICT_STYLE = {
+      live: { label: "live", cls: "bg-emerald-500/15 text-emerald-300 border-emerald-500/40" },
+      quiet: { label: "quiet (wired, low variance)", cls: "bg-sky-500/15 text-sky-300 border-sky-500/40" },
+      dead: { label: "dead", cls: "bg-rose-500/15 text-rose-300 border-rose-500/40" },
+      ratchet_suspect: { label: "ratchet-suspect", cls: "bg-amber-500/15 text-amber-300 border-amber-500/40" },
+      never_produced: { label: "never produced", cls: "bg-gray-700/40 text-gray-400 border-gray-600" },
+    };
+
+    const state = {
+      channels: [],
+      categories: {},
+      health: {},
+      windowHours: 1,
+      showAll: false,
+      windowMeta: null,
+    };
+
+    let autoRefreshTimer = null;
+
+    function fmtNum(v) {
+      if (v === null || v === undefined) return "—";
+      const n = Number(v);
+      if (!Number.isFinite(n)) return "—";
+      if (Math.abs(n) < 1e-6 && n !== 0) return n.toExponential(1);
+      return n.toFixed(3);
+    }
+
+    async function loadAll() {
+      const errEl = document.getElementById("fcgError");
+      errEl.classList.add("hidden");
+      try {
+        const hours = state.windowHours;
+        const [channelsResp, healthResp] = await Promise.all([
+          fetch("/api/field-channel-glossary/channels"),
+          fetch(`/api/field-channel-glossary/health?hours=${hours}`),
+        ]);
+        if (!channelsResp.ok) throw new Error(`channels ${channelsResp.status}`);
+        if (!healthResp.ok) throw new Error(`health ${healthResp.status}`);
+        const channelsJson = await channelsResp.json();
+        const healthJson = await healthResp.json();
+        state.channels = channelsJson.channels || [];
+        state.categories = channelsJson.categories || {};
+        state.health = {};
+        for (const row of healthJson.channels || []) {
+          state.health[row.channel] = row;
+        }
+        state.windowMeta = healthJson;
+        document.getElementById("fcgLastLoaded").textContent = new Date().toLocaleTimeString();
+        const metaEl = document.getElementById("fcgWindowMeta");
+        const truncNote = healthJson.truncated ? " (row cap hit -- kept newest ticks)" : "";
+        const unparsable = healthJson.unparsable_count || 0;
+        const unparsableNote = unparsable > 0 ? ` -- ${unparsable} row(s) failed to parse` : "";
+        metaEl.textContent = `${healthJson.row_count} ticks over ${healthJson.window_hours}h${truncNote}${unparsableNote}`;
+        render();
+      } catch (err) {
+        errEl.textContent = `Failed to load: ${err.message || err}`;
+        errEl.classList.remove("hidden");
+      }
+    }
+
+    function render() {
+      renderCategoryStrip();
+      renderTable();
+    }
+
+    function renderCategoryStrip() {
+      const strip = document.getElementById("fcgCategoryStrip");
+      strip.innerHTML = "";
+      const byCategory = {};
+      for (const ch of state.channels) {
+        const h = state.health[ch.channel];
+        const cat = ch.category || "uncategorized";
+        byCategory[cat] = byCategory[cat] || { clean: 0, total: 0 };
+        byCategory[cat].total += 1;
+        if (h && h.clean) byCategory[cat].clean += 1;
+      }
+      const order = Object.keys(state.categories).length
+        ? Object.keys(state.categories)
+        : Object.keys(byCategory);
+      for (const cat of order) {
+        const counts = byCategory[cat] || { clean: 0, total: 0 };
+        const card = document.createElement("div");
+        card.className = "rounded-lg border border-gray-800 bg-gray-900/60 px-3 py-2";
+        const allClean = counts.total > 0 && counts.clean === counts.total;
+        card.innerHTML = `
+          <div class="text-[10px] uppercase tracking-wide text-gray-500">${cat.replace(/_/g, " ")}</div>
+          <div class="text-sm font-semibold ${allClean ? "text-emerald-300" : "text-gray-100"}">${counts.clean} / ${counts.total} clean</div>
+        `;
+        strip.appendChild(card);
+      }
+    }
+
+    function renderTable() {
+      const tbody = document.getElementById("fcgTableBody");
+      tbody.innerHTML = "";
+      const rows = state.channels
+        .map((ch) => ({ ch, h: state.health[ch.channel] || null }))
+        .filter(({ h }) => state.showAll || (h && h.clean))
+        .sort((a, b) => a.ch.category.localeCompare(b.ch.category) || a.ch.channel.localeCompare(b.ch.channel));
+
+      document.getElementById("fcgEmpty").classList.toggle("hidden", rows.length > 0);
+
+      for (const { ch, h } of rows) {
+        const verdictKey = h ? h.verdict : "never_produced";
+        const vs = VERDICT_STYLE[verdictKey] || VERDICT_STYLE.never_produced;
+        const dim = ch.self_state_dimension
+          ? ch.self_state_dimension
+          : ch.evidence_dimension
+            ? `${ch.evidence_dimension} (evidence only)`
+            : "—";
+        const tr = document.createElement("tr");
+        tr.className = "hover:bg-gray-900/60";
+        tr.innerHTML = `
+          <td class="px-3 py-2 font-mono text-gray-100">${ch.channel}</td>
+          <td class="px-3 py-2 text-gray-400">${(ch.level || []).join(", ")}</td>
+          <td class="px-3 py-2 text-gray-400">${ch.category.replace(/_/g, " ")}</td>
+          <td class="px-3 py-2"><span class="inline-block rounded border px-2 py-0.5 text-[10px] ${vs.cls}">${vs.label}</span></td>
+          <td class="px-3 py-2 text-right text-gray-300">${h ? h.sample_count : 0}</td>
+          <td class="px-3 py-2 text-right text-gray-300">${fmtNum(h ? h.min : null)}</td>
+          <td class="px-3 py-2 text-right text-gray-300">${fmtNum(h ? h.max : null)}</td>
+          <td class="px-3 py-2 text-right text-gray-300">${fmtNum(h ? h.last : null)}</td>
+          <td class="px-3 py-2 text-gray-400">${dim}</td>
+          <td class="px-3 py-2 text-gray-400">${ch.meaning}</td>
+        `;
+        tbody.appendChild(tr);
+      }
+    }
+
+    function setAutoRefresh(enabled) {
+      if (autoRefreshTimer) {
+        clearInterval(autoRefreshTimer);
+        autoRefreshTimer = null;
+      }
+      if (enabled) {
+        autoRefreshTimer = setInterval(loadAll, 60000);
+      }
+    }
+
+    document.getElementById("fcgRefresh").addEventListener("click", loadAll);
+    document.getElementById("fcgAutoRefresh").addEventListener("change", (e) => setAutoRefresh(e.target.checked));
+    document.getElementById("fcgWindowHours").addEventListener("change", (e) => {
+      state.windowHours = Number(e.target.value) || 1;
+      loadAll();
+    });
+    document.getElementById("fcgShowAll").addEventListener("change", (e) => {
+      state.showAll = e.target.checked;
+      render();
+    });
+
+    loadAll();
+  </script>
+</body>
+</html>

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -643,6 +643,9 @@ document.addEventListener("DOMContentLoaded", () => {
   const substrateLatticeTabButton = document.getElementById("substrateLatticeTabButton");
   const substrateLatticePanelEl = document.getElementById("substrate-lattice");
   const substrateLatticeFrame = document.getElementById("substrateLatticeFrame");
+  const fieldChannelGlossaryTabButton = document.getElementById("fieldChannelGlossaryTabButton");
+  const fieldChannelGlossaryPanelEl = document.getElementById("field-channel-glossary");
+  const fieldChannelGlossaryFrame = document.getElementById("fieldChannelGlossaryFrame");
   const topicFoundryBaseLabel = document.getElementById("topicFoundryBaseLabel");
   const tsDatasetSelect = document.getElementById("tsDatasetSelect");
   const tsDatasetName = document.getElementById("tsDatasetName");
@@ -924,6 +927,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (tabKey === "substrate-lattice" && !substrateLatticePanelEl) {
       effectiveTab = "hub";
     }
+    if (tabKey === "field-channel-glossary" && !fieldChannelGlossaryPanelEl) {
+      effectiveTab = "hub";
+    }
     if (tabKey === "collapse-mirror" && !collapseMirrorPanel) {
       effectiveTab = "hub";
     }
@@ -941,6 +947,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const isMemory = effectiveTab === "memory";
     const isPressure = effectiveTab === "pressure";
     const isSubstrateLattice = effectiveTab === "substrate-lattice";
+    const isFieldChannelGlossary = effectiveTab === "field-channel-glossary";
     const isMind = effectiveTab === "mind";
     const isSignals = effectiveTab === "signals";
     const isCollapseMirror = effectiveTab === "collapse-mirror";
@@ -1031,6 +1038,13 @@ document.addEventListener("DOMContentLoaded", () => {
       const currentSrc = substrateLatticeFrame.getAttribute("src");
       substrateLatticeFrame.setAttribute("src", currentSrc);
     }
+    if (fieldChannelGlossaryPanelEl) {
+      fieldChannelGlossaryPanelEl.classList.toggle("hidden", !isFieldChannelGlossary);
+    }
+    if (fieldChannelGlossaryFrame && isFieldChannelGlossary) {
+      const currentSrc = fieldChannelGlossaryFrame.getAttribute("src");
+      fieldChannelGlossaryFrame.setAttribute("src", currentSrc);
+    }
     if (collapseMirrorPanel) {
       collapseMirrorPanel.classList.toggle("hidden", !isCollapseMirror);
     }
@@ -1074,6 +1088,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (substrateLatticeTabButton) {
       styleTabButton(substrateLatticeTabButton, isSubstrateLattice);
+    }
+    if (fieldChannelGlossaryTabButton) {
+      styleTabButton(fieldChannelGlossaryTabButton, isFieldChannelGlossary);
     }
     if (collapseMirrorTabButton) {
       styleTabButton(collapseMirrorTabButton, isCollapseMirror);
@@ -1653,6 +1670,8 @@ document.addEventListener("DOMContentLoaded", () => {
       setActiveTab("pressure");
     } else if (h === "#substrate-lattice" && substrateLatticePanelEl && substrateLatticeTabButton) {
       setActiveTab("substrate-lattice");
+    } else if (h === "#field-channel-glossary" && fieldChannelGlossaryPanelEl && fieldChannelGlossaryTabButton) {
+      setActiveTab("field-channel-glossary");
     } else if (h === "#memory" && memoryPanel && memoryTabButton) {
       setActiveTab("memory");
     } else if (h === "#mind" && mindPanel && mindTabButton) {
@@ -1667,6 +1686,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (
         h === "#pressure"
         || h === "#substrate-lattice"
+        || h === "#field-channel-glossary"
         || h === "#memory"
         || h === "#mind"
         || h === "#signals"
@@ -11299,6 +11319,13 @@ document.addEventListener("DOMContentLoaded", () => {
         event.preventDefault();
         setActiveTab("substrate-lattice");
         history.replaceState(null, "", "#substrate-lattice");
+      });
+    }
+    if (fieldChannelGlossaryTabButton && fieldChannelGlossaryPanelEl) {
+      fieldChannelGlossaryTabButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        setActiveTab("field-channel-glossary");
+        history.replaceState(null, "", "#field-channel-glossary");
       });
     }
     if (collapseMirrorTabButton && collapseMirrorPanel) {

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -112,6 +112,13 @@
             role="button"
           >Substrate Lattice</a>
           <a
+            id="fieldChannelGlossaryTabButton"
+            href="#field-channel-glossary"
+            data-hash-target="#field-channel-glossary"
+            class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
+            role="button"
+          >Field Channels</a>
+          <a
             id="collapseMirrorTabButton"
             href="#collapse-mirror"
             data-hash-target="#collapse-mirror"
@@ -2686,6 +2693,24 @@
             class="w-full h-full border-0 min-h-[40rem]"
             loading="lazy"
             title="Substrate Lattice"
+          ></iframe>
+        </div>
+      </section>
+
+      <section id="field-channel-glossary" data-panel="field-channel-glossary" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 class="text-xl font-bold text-white">Field Channels</h2>
+            <p class="text-xs text-gray-400 mt-0.5">Field digester's 29 raw channels -- live clean/dead verdicts, not stale doc prose.</p>
+          </div>
+        </div>
+        <div class="rounded-xl border border-gray-800 bg-gray-950/40 overflow-hidden flex-1 min-h-[40rem]">
+          <iframe
+            id="fieldChannelGlossaryFrame"
+            src="/static/field-channel-glossary.html?v={{HUB_UI_ASSET_VERSION}}"
+            class="w-full h-full border-0 min-h-[40rem]"
+            loading="lazy"
+            title="Field Channel Glossary"
           ></iframe>
         </div>
       </section>

--- a/services/orion-hub/tests/test_field_channel_glossary_hub_tab.py
+++ b/services/orion-hub/tests/test_field_channel_glossary_hub_tab.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+INDEX_HTML = HUB_ROOT / "templates" / "index.html"
+APP_JS = HUB_ROOT / "static" / "js" / "app.js"
+GLOSSARY_STATIC = HUB_ROOT / "static" / "field-channel-glossary.html"
+
+
+def test_index_has_field_channel_glossary_tab_nav_button() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert 'id="fieldChannelGlossaryTabButton"' in html
+    assert 'href="#field-channel-glossary"' in html
+    assert 'data-hash-target="#field-channel-glossary"' in html
+    assert ">Field Channels<" in html
+
+
+def test_index_has_field_channel_glossary_section_and_frame() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert '<section id="field-channel-glossary" data-panel="field-channel-glossary"' in html
+    assert 'id="fieldChannelGlossaryFrame"' in html
+    assert 'src="/static/field-channel-glossary.html?v={{HUB_UI_ASSET_VERSION}}"' in html
+
+
+def test_app_js_wires_field_channel_glossary_hash_and_tab() -> None:
+    js = APP_JS.read_text(encoding="utf-8")
+    assert 'getElementById("fieldChannelGlossaryTabButton")' in js
+    assert 'getElementById("field-channel-glossary")' in js
+    assert 'getElementById("fieldChannelGlossaryFrame")' in js
+    assert 'setActiveTab("field-channel-glossary")' in js
+    assert "#field-channel-glossary" in js
+
+
+def test_glossary_static_page_has_root_ids() -> None:
+    html = GLOSSARY_STATIC.read_text(encoding="utf-8")
+    for needle in [
+        'id="fieldChannelGlossaryRoot"',
+        'id="fcgCategoryStrip"',
+        'id="fcgTable"',
+        'id="fcgTableBody"',
+        'id="fcgWindowHours"',
+        'id="fcgShowAll"',
+    ]:
+        assert needle in html, f"Missing: {needle}"
+
+
+def test_glossary_static_page_fetches_both_endpoints() -> None:
+    html = GLOSSARY_STATIC.read_text(encoding="utf-8")
+    assert "/api/field-channel-glossary/channels" in html
+    assert "/api/field-channel-glossary/health" in html

--- a/services/orion-hub/tests/test_field_channel_glossary_routes.py
+++ b/services/orion-hub/tests/test_field_channel_glossary_routes.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+from scripts import field_channel_glossary_routes  # noqa: E402
+
+
+def _field_state_row(overrides: dict) -> dict:
+    node_vectors = {
+        "node:athena": {
+            "availability": 1.0,
+            "cpu_pressure": 0.0,
+            "expected_offline_suppression": 1.0,
+            "bus_health": 1.0,
+            "delivery_confidence": 1.0,
+        }
+    }
+    node_vectors["node:athena"].update(overrides)
+    return {
+        "schema_version": "field.state.v1",
+        "generated_at": "2026-07-20T00:00:00+00:00",
+        "tick_id": "tick-test",
+        "node_vectors": node_vectors,
+        "capability_vectors": {},
+        "edges": [],
+        "recent_perturbations": [],
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    field_channel_glossary_routes._engine_instance = None
+    app = FastAPI()
+    app.include_router(field_channel_glossary_routes.router)
+    return TestClient(app)
+
+
+def _fake_engine_with_rows(field_jsons: list[dict]):
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value = [(json.dumps(fj),) for fj in field_jsons]
+    return fake_engine
+
+
+def test_channels_endpoint_returns_29_entries(client):
+    r = client.get("/api/field-channel-glossary/channels")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["channels"]) == 29
+    assert len(body["categories"]) == 7
+
+
+def test_health_endpoint_classifies_dead_channel(client):
+    rows = [_field_state_row({"cpu_pressure": 0.0}) for _ in range(5)]
+    fake_engine = _fake_engine_with_rows(rows)
+
+    with patch.object(field_channel_glossary_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/field-channel-glossary/health?hours=1")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["window_hours"] == 1
+    assert body["row_count"] == 5
+    by_channel = {c["channel"]: c for c in body["channels"]}
+    assert by_channel["cpu_pressure"]["verdict"] == "dead"
+    assert by_channel["cpu_pressure"]["clean"] is False
+
+
+def test_health_endpoint_classifies_live_channel(client):
+    values = [0.1, 0.4, 0.15, 0.6, 0.2]
+    rows = [_field_state_row({"cpu_pressure": v}) for v in values]
+    fake_engine = _fake_engine_with_rows(rows)
+
+    with patch.object(field_channel_glossary_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/field-channel-glossary/health?hours=1")
+
+    body = r.json()
+    by_channel = {c["channel"]: c for c in body["channels"]}
+    assert by_channel["cpu_pressure"]["verdict"] == "live"
+    assert by_channel["cpu_pressure"]["clean"] is True
+    assert by_channel["cpu_pressure"]["sample_count"] == 5
+
+
+def test_health_endpoint_defaults_invalid_hours_to_default(client):
+    fake_engine = _fake_engine_with_rows([_field_state_row({})])
+
+    with patch.object(field_channel_glossary_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/field-channel-glossary/health?hours=999")
+
+    assert r.status_code == 200
+    assert r.json()["window_hours"] == field_channel_glossary_routes.DEFAULT_HOURS
+
+
+def test_build_channel_series_quiet_zero_channel_is_dead_not_never_produced():
+    # transport_pressure is never in PRESSURE_CHANNELS/HIGHER_IS_BETTER_CHANNELS,
+    # so a tick where every source reads exactly 0.0 means
+    # collect_field_channel_pressures() drops it from the merge -- but the
+    # raw node vector still genuinely carries the key at 0.0 (reconcile
+    # seeds it). build_channel_series() must record that as a real 0.0
+    # sample, not silently treat the channel as absent/never-wired.
+    rows = [_field_state_row({"transport_pressure": 0.0}) for _ in range(3)]
+    series, unparsable = field_channel_glossary_routes.build_channel_series(
+        rows, known_channels=["transport_pressure"]
+    )
+    assert unparsable == 0
+    assert series["transport_pressure"] == [0.0, 0.0, 0.0]
+    assert field_channel_glossary_routes.classify_channel_series(series["transport_pressure"]) == "dead"
+
+
+def test_build_channel_series_genuinely_never_produced_when_key_absent_everywhere():
+    rows = [_field_state_row({}) for _ in range(3)]
+    series, _unparsable = field_channel_glossary_routes.build_channel_series(
+        rows, known_channels=["transport_pressure"]
+    )
+    assert series["transport_pressure"] == []
+    assert field_channel_glossary_routes.classify_channel_series(series["transport_pressure"]) == "never_produced"
+
+
+def test_build_channel_series_counts_unparsable_rows_separately_from_dead():
+    rows = [_field_state_row({}), {"not": "a valid field state"}, _field_state_row({})]
+    series, unparsable = field_channel_glossary_routes.build_channel_series(
+        rows, known_channels=["cpu_pressure"]
+    )
+    assert unparsable == 1
+    assert len(series["cpu_pressure"]) == 2
+
+
+def test_health_endpoint_reverses_desc_rows_back_to_chronological_order(client):
+    # The route issues `ORDER BY generated_at DESC LIMIT :row_cap` -- when
+    # Postgres has already truncated to ROW_CAP rows (simulated here by the
+    # mock returning exactly that many, newest-first), the route must
+    # reverse them back to ascending chronological order before building
+    # series. Otherwise "last" (meant to be the most recent reading) would
+    # actually be the oldest one in the truncated set, and a monotonically
+    # climbing real signal would look like it was falling.
+    chronological_values = [0.1, 0.4, 0.7]  # oldest -> newest
+    rows_desc_from_db = [
+        _field_state_row({"cpu_pressure": v}) for v in reversed(chronological_values)
+    ]
+    fake_engine = _fake_engine_with_rows(rows_desc_from_db)
+
+    with patch.object(field_channel_glossary_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/field-channel-glossary/health?hours=1")
+
+    by_channel = {c["channel"]: c for c in r.json()["channels"]}
+    cpu = by_channel["cpu_pressure"]
+    # If the DESC rows were used as-is (bug), "last" would read 0.1 (the
+    # oldest tick, first in the DESC list) instead of 0.7 (the true most
+    # recent reading).
+    assert cpu["last"] == pytest.approx(0.7)
+    assert cpu["min"] == pytest.approx(0.1)
+    assert cpu["max"] == pytest.approx(0.7)

--- a/tests/test_field_channel_glossary.py
+++ b/tests/test_field_channel_glossary.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from orion.self_state.field_channel_glossary import (
+    CLEAN_VERDICTS,
+    LIVE_VARIANCE_THRESHOLD,
+    SUBNORMAL_CUTOFF,
+    classify_channel_series,
+    load_glossary,
+)
+
+
+def test_load_glossary_has_29_channels_matching_field_digester_channels_py():
+    glossary = load_glossary()
+    entries = glossary["entries"]
+    assert len(entries) == 29
+    names = {e.channel for e in entries}
+    assert "cpu_pressure" in names
+    assert "reliability_pressure" in names
+    # transport_pressure/contract_pressure are the two node+capability overlaps.
+    overlap = [e for e in entries if set(e.level) == {"node", "capability"}]
+    assert {e.channel for e in overlap} == {"transport_pressure", "contract_pressure"}
+
+
+def test_load_glossary_categories_cover_all_seven_semantic_groups():
+    glossary = load_glossary()
+    assert len(glossary["categories"]) == 7
+    used_categories = {e.category for e in glossary["entries"]}
+    assert used_categories <= set(glossary["categories"].keys())
+
+
+def test_classify_never_produced_on_empty_series():
+    assert classify_channel_series([]) == "never_produced"
+
+
+def test_classify_dead_when_all_values_subnormal_or_zero():
+    assert classify_channel_series([0.0, 0.0, 0.0]) == "dead"
+    assert classify_channel_series([SUBNORMAL_CUTOFF / 10, 0.0, SUBNORMAL_CUTOFF / 100]) == "dead"
+
+
+def test_classify_quiet_when_present_but_low_variance():
+    values = [0.5, 0.51, 0.49, 0.50, 0.52]
+    assert (max(values) - sorted(values)[len(values) // 2]) <= LIVE_VARIANCE_THRESHOLD
+    assert classify_channel_series(values) == "quiet"
+
+
+def test_classify_live_when_genuine_variance():
+    values = [0.1, 0.4, 0.15, 0.6, 0.2, 0.05, 0.55]
+    assert classify_channel_series(values) == "live"
+
+
+def test_classify_ratchet_suspect_when_monotonic_non_decreasing_with_real_climb():
+    values = [0.0, 0.05, 0.1, 0.2, 0.35, 0.5]
+    assert classify_channel_series(values) == "ratchet_suspect"
+
+
+def test_classify_not_ratchet_suspect_when_monotonic_but_flat():
+    # Monotonic non-decreasing but the net climb never exceeds the variance
+    # threshold -- correctly falls through to quiet, not a false ratchet flag.
+    values = [0.0, 0.01, 0.01, 0.02, 0.02]
+    assert classify_channel_series(values) == "quiet"
+
+
+def test_classify_two_point_up_step_is_not_ratchet_suspect():
+    # With only 2 samples, "non-decreasing" is true whenever the second
+    # value isn't lower than the first -- a coin flip for any noisy-but-
+    # healthy channel, not a real monotonicity signal. A single up-step
+    # (e.g. a channel that was quiet all window and got one real reading
+    # near the end) must not be flagged as a suspected one-way ratchet.
+    assert classify_channel_series([0.0, 0.3]) == "live"
+
+
+def test_classify_ratchet_suspect_requires_minimum_sample_count():
+    from orion.self_state.field_channel_glossary import RATCHET_MIN_SAMPLES
+
+    short_climb = [round(i * 0.5 / (RATCHET_MIN_SAMPLES - 2), 4) for i in range(RATCHET_MIN_SAMPLES - 1)]
+    assert len(short_climb) < RATCHET_MIN_SAMPLES
+    assert classify_channel_series(short_climb) != "ratchet_suspect"
+
+
+def test_clean_verdicts_excludes_broken_categories():
+    assert CLEAN_VERDICTS == {"live", "quiet"}
+    assert "dead" not in CLEAN_VERDICTS
+    assert "ratchet_suspect" not in CLEAN_VERDICTS
+    assert "never_produced" not in CLEAN_VERDICTS


### PR DESCRIPTION
## Summary

- New Hub tab ("Field Channels") lists field-digester's 29 raw `FieldStateV1` channels (23 node + 8 capability, 2 overlapping) with a **live-computed** clean/dead verdict, not the field-digester README's frozen prose verdicts -- those had already gone stale once as fixes landed (agent-board note flagged this before this branch started).
- Structured channel metadata now lives at `config/field/field_channel_glossary.v1.yaml`, the machine-readable companion to the README's prose "Field channel glossary" section.
- Liveness classifier (`orion/self_state/field_channel_glossary.py`) generalizes `scripts/analysis/measure_capability_channel_health.py`'s already-validated heuristic (1e-100 subnormal cutoff, "live" if max-median > 0.05) from that script's 8 capability channels to all 29.
- New read-only API `services/orion-hub/scripts/field_channel_glossary_routes.py` (`GET /channels`, `GET /health?hours=1|6|24`), built on the existing `collect_field_channel_pressures()` merge so polarity/merge logic isn't re-derived.
- Tab wired into `index.html`/`app.js`/`api_routes.py` following the existing Substrate Lattice tab pattern exactly (same iframe/static-page/nav-button shape).

## Outcome moved

Operators can now see, per channel: is it alive, quiet-but-wired, dead, never-produced, or a suspected one-way ratchet -- computed fresh from `substrate_field_state` on every load, closing the specific staleness gap the field-digester README's hand-written verdicts already hit once.

## Current architecture

`services/orion-field-digester`'s README documented all 29 channels in prose only, with a verdict column that's a point-in-time snapshot. `services/orion-hub/scripts/substrate_field_routes.py` already exposed a single-tick `FieldStateV1` snapshot API but nothing that classified liveness over time or listed the channel glossary. Hub had three prior tabs (Drives Analytics, Pressure Analytics, Substrate Lattice) using an identical static-HTML-iframe pattern this branch follows.

## Architecture touched

- `config/field/` (new glossary config)
- `orion/self_state/` (new pure classifier module)
- `services/orion-hub/scripts/api_routes.py` (router registration)
- `services/orion-hub/templates/index.html`, `static/js/app.js` (tab wiring)
- `services/orion-hub/static/` (new self-contained panel page)
- `services/orion-field-digester/README.md` (cross-reference note)

## Files changed

- `config/field/field_channel_glossary.v1.yaml`: new structured 29-channel index
- `orion/self_state/field_channel_glossary.py`: new liveness classifier + glossary loader
- `services/orion-hub/scripts/field_channel_glossary_routes.py`: new FastAPI router
- `services/orion-hub/static/field-channel-glossary.html`: new self-contained panel page
- `services/orion-hub/scripts/api_routes.py`: registers the new router
- `services/orion-hub/templates/index.html`, `services/orion-hub/static/js/app.js`: new tab nav/panel/hash-routing, copied from the Substrate Lattice pattern
- `services/orion-field-digester/README.md`: cross-reference note pointing at the new live panel, clarifying the README's own verdicts are the prose reference, not current truth
- `tests/test_field_channel_glossary.py`, `services/orion-hub/tests/test_field_channel_glossary_routes.py`, `services/orion-hub/tests/test_field_channel_glossary_hub_tab.py`: new tests

## Schema / bus / API changes

- Added: `GET /api/field-channel-glossary/channels`, `GET /api/field-channel-glossary/health`
- Removed: none
- Renamed: none
- Behavior changed: none (new read-only surface only)
- Compatibility notes: no bus/schema contract changes; reads existing `substrate_field_state` table and existing `FieldStateV1`/`collect_field_channel_pressures()`

## Env/config changes

- Added keys: none (reuses existing `POSTGRES_URI`)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: not applicable, no new keys
- local `.env` synced: not applicable, no new keys
- skipped keys requiring operator action: none

## Tests run

```text
# Pure-logic + glossary tests (repo-root venv)
/tmp/orion-test-venv/bin/python -m pytest tests/test_field_channel_glossary.py tests/test_self_state_scoring.py -q
26 passed

# Hub route + tab-wiring tests (hub venv)
/tmp/orion-hub-test-venv/bin/python -m pytest tests/test_field_channel_glossary_routes.py tests/test_field_channel_glossary_hub_tab.py tests/test_pressure_analytics_hub_tab.py tests/test_substrate_lattice_hub_tab.py tests/test_substrate_field_debug_api.py -q
25 passed
```

Full `services/orion-hub/tests` suite was also run for regression-check purposes: 85-115 pre-existing failures (identical root cause -- missing `rdflib` in the test venv -- confirmed reproduced on unmodified `main` too, not introduced by this branch).

## Evals run

No eval harness exists for this observability surface; none added. This is a read-only debug/observability panel, not a cognition-affecting change, so no eval gap is being carried silently -- flagging explicitly per repo convention.

## Docker/build/smoke checks

Not run -- no Docker/runtime config changed (no new env keys, no compose changes, no dependency changes: PyYAML already in `services/orion-hub/requirements.txt`). Route dispatch was verified via a live `TestClient` request through the full `api_routes.router` aggregation (`GET /api/field-channel-glossary/channels` -> 200, 29 channels), since a newer FastAPI/Starlette version wraps included sub-routers as `_IncludedRouter` objects that don't show `.path` under naive `.routes` iteration -- confirmed this is a `.routes` inspection quirk, not a registration bug.

## Review findings fixed

- Finding: `/health` used `ORDER BY generated_at ASC LIMIT :row_cap`, so windows large enough to hit the row cap (hours=6/24 at ~1.8k rows/hour) silently classified from the *oldest* slice of the window instead of the newest -- the exact staleness failure mode this feature exists to replace.
  - Fix: `ORDER BY generated_at DESC LIMIT :row_cap`, then reverse in Python before building series.
  - Evidence: new test `test_health_endpoint_reverses_desc_rows_back_to_chronological_order`.
- Finding: 5 channels (`expected_offline_suppression`, `transport_pressure`, `contract_pressure`, `catalog_drift_pressure`, `observer_failure_pressure`) that are genuinely wired but read exactly `0.0` this tick get dropped by `collect_field_channel_pressures()`'s merge gate, and were misclassified `never_produced` (implying broken wiring) instead of `dead` (implying no current signal).
  - Fix: `build_channel_series()` now falls back to checking raw `node_vectors`/`capability_vectors` keys directly when a channel is missing from the merge, recording `0.0` if the key is structurally present; only a channel absent from every row's raw vectors all window is `never_produced`.
  - Evidence: new tests `test_build_channel_series_quiet_zero_channel_is_dead_not_never_produced`, `test_build_channel_series_genuinely_never_produced_when_key_absent_everywhere`.
- Finding: `ratchet_suspect` had no minimum-sample guard -- a 2-point up-step (a coin flip for any noisy-but-healthy channel) could false-positive as a suspected one-way ratchet.
  - Fix: added `RATCHET_MIN_SAMPLES = 4` guard.
  - Evidence: new tests `test_classify_two_point_up_step_is_not_ratchet_suspect`, `test_classify_ratchet_suspect_requires_minimum_sample_count`.
- Finding: malformed/unparsable historical rows were silently discarded with no diagnostic, so "every channel dead" and "100% of rows failed to parse" looked identical in the response.
  - Fix: added `unparsable_count` to the `/health` response and the static page's window-meta line.
  - Evidence: new test `test_build_channel_series_counts_unparsable_rows_separately_from_dead`.

## Restart required

```text
No restart required for review/merge. Hub service restart (or redeploy) needed to serve the new tab/routes in a running environment:
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build orion-hub
```

## Risks / concerns

- Severity: low
- Concern: `services/orion-hub/tests` has a pre-existing, wide `rdflib`-missing gap in the sandbox test venv (`/tmp/orion-hub-test-venv`) unrelated to this change; confirmed identical on unmodified `main`.
- Mitigation: none needed for this PR; separate venv/dependency fix, out of scope here.

- Severity: low
- Concern: `graphify update .` hit the known pre-existing destructive-update bug (2026-07-14 incident) during this session; the `safe_graphify_update.sh` wrapper caught it and auto-restored `graph.json`/`manifest.json`, nothing was committed. A stray regenerated `GRAPH_REPORT.md`/`graph.html` left over from the refused run were reverted/removed before committing so this branch's diff stays scoped to the feature.
- Mitigation: none needed; underlying graphify bug is a separate, already-tracked issue.

## PR link

(created by this command)