### PR TITLE
fix(hub): resolve field-channel-glossary path via ORION_REPO_ROOT in Hub Docker

### DIFF
--- a/orion/self_state/field_channel_glossary.py
+++ b/orion/self_state/field_channel_glossary.py
@@ -23,15 +23,65 @@ reimplementing merge/polarity logic here.
 from __future__ import annotations
 
 import functools
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-_GLOSSARY_PATH = (
-    Path(__file__).resolve().parents[2] / "config" / "field" / "field_channel_glossary.v1.yaml"
-)
+
+def _glossary_path_candidates() -> list[Path]:
+    """Resolve config/field/field_channel_glossary.v1.yaml from a monorepo
+    checkout *or* Hub's Docker image.
+
+    Hub's Dockerfile only `COPY orion /app/orion` -- `config/` (a sibling of
+    `orion/` on disk, not a subdirectory of it) never lands under `/app`, so
+    `Path(__file__).resolve().parents[2]` (repo root in a normal checkout)
+    resolves to `/app` inside the Hub container and the file is genuinely
+    missing there. Compose mounts the full repo read-only at `/repo` (and
+    `/mnt/scripts/Orion-Sapienform`) specifically for cases like this -- same
+    problem, same fix already established in
+    services/orion-hub/scripts/drives_analytics.py's
+    `_repo_root_candidates()`, mirrored here rather than re-derived.
+    """
+    seen: set[str] = set()
+    roots: list[Path] = []
+
+    def _add(root: Path | None) -> None:
+        if root is None:
+            return
+        try:
+            resolved = root.expanduser().resolve()
+        except OSError:
+            resolved = root
+        key = str(resolved)
+        if key in seen:
+            return
+        seen.add(key)
+        roots.append(resolved)
+
+    raw = os.getenv("ORION_REPO_ROOT", "").strip()
+    if raw:
+        _add(Path(raw))
+    here = Path(__file__).resolve()
+    if len(here.parents) >= 3:
+        _add(here.parents[2])  # repo root in a normal monorepo checkout
+    _add(Path("/repo"))
+    _add(Path("/mnt/scripts/Orion-Sapienform"))
+    return [root / "config" / "field" / "field_channel_glossary.v1.yaml" for root in roots]
+
+
+def _resolve_glossary_path() -> Path:
+    for candidate in _glossary_path_candidates():
+        if candidate.is_file():
+            return candidate
+    # Fall back to the monorepo-checkout candidate so the resulting
+    # FileNotFoundError names the expected path, not an arbitrary one.
+    return _glossary_path_candidates()[0]
+
+
+_GLOSSARY_PATH = _resolve_glossary_path()
 
 # Same threshold scripts/analysis/measure_capability_channel_health.py uses:
 # strictly finer-grained than the smallest downstream decision boundary

--- a/tests/test_field_channel_glossary.py
+++ b/tests/test_field_channel_glossary.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from orion.self_state.field_channel_glossary import (
     CLEAN_VERDICTS,
     LIVE_VARIANCE_THRESHOLD,
     SUBNORMAL_CUTOFF,
+    _glossary_path_candidates,
     classify_channel_series,
     load_glossary,
 )
@@ -19,6 +22,25 @@ def test_load_glossary_has_29_channels_matching_field_digester_channels_py():
     # transport_pressure/contract_pressure are the two node+capability overlaps.
     overlap = [e for e in entries if set(e.level) == {"node", "capability"}]
     assert {e.channel for e in overlap} == {"transport_pressure", "contract_pressure"}
+
+
+def test_glossary_path_candidates_prefers_orion_repo_root_env_var(monkeypatch):
+    # Regression: Hub's Dockerfile only `COPY orion /app/orion` -- config/
+    # (a sibling of orion/ on disk) never lands under /app, so a naive
+    # Path(__file__).resolve().parents[2] resolves to /app inside the Hub
+    # container and 404s on the real file. ORION_REPO_ROOT (compose default
+    # /repo) must be checked, and checked first, not just the bare-checkout
+    # parents[2] fallback.
+    monkeypatch.setenv("ORION_REPO_ROOT", "/some/mounted/repo")
+    candidates = _glossary_path_candidates()
+    assert candidates[0] == Path("/some/mounted/repo/config/field/field_channel_glossary.v1.yaml")
+
+
+def test_glossary_path_candidates_includes_repo_and_mnt_fallbacks(monkeypatch):
+    monkeypatch.delenv("ORION_REPO_ROOT", raising=False)
+    candidates = [str(c) for c in _glossary_path_candidates()]
+    assert any(c.startswith("/repo/") for c in candidates)
+    assert any(c.startswith("/mnt/scripts/Orion-Sapienform/") for c in candidates)
 
 
 def test_load_glossary_categories_cover_all_seven_semantic_groups():


### PR DESCRIPTION
## Summary

`orion-athena-hub` crashed on startup after PR #1220 merged:

```
FileNotFoundError: [Errno 2] No such file or directory: '/app/config/field/field_channel_glossary.v1.yaml'
```

Root cause: Hub's `Dockerfile` only `COPY orion /app/orion` -- `config/` is a *sibling* of `orion/` on disk, not a subdirectory of it, so it never lands under `/app`. `orion/self_state/field_channel_glossary.py`'s original path resolution (`Path(__file__).resolve().parents[2] / "config" / "field" / ...`) silently resolves to `/app` inside the Hub container instead of the repo root, and the file is genuinely absent there.

## Fix

Mirror the same fix `services/orion-hub/scripts/drives_analytics.py`'s `_repo_root_candidates()` already established for this exact problem class (that module's own docstring even names it: "Hub image layout is `/app/scripts/drives_analytics.py`... Compose mounts the repo at `ORION_REPO_ROOT` (default `/repo`) and `/mnt/scripts/Orion-Sapienform`"). `orion/self_state/field_channel_glossary.py` now checks, in order: `ORION_REPO_ROOT` env var (compose default `/repo`), `/repo`, `/mnt/scripts/Orion-Sapienform`, then the bare-checkout `parents[2]` fallback -- compose already mounts the full repo read-only at `/repo` specifically for cases like this.

## Files changed

- `orion/self_state/field_channel_glossary.py`: path resolution now checks `ORION_REPO_ROOT`/`/repo`/`/mnt/scripts/Orion-Sapienform` before falling back to the bare-checkout `parents[2]` assumption.
- `tests/test_field_channel_glossary.py`: two new regression tests (`ORION_REPO_ROOT` preferred first; `/repo`/`/mnt/scripts/Orion-Sapienform` present as fallback candidates).

## Tests run

```text
/tmp/orion-test-venv/bin/python -m pytest tests/test_field_channel_glossary.py -q
13 passed

/tmp/orion-hub-test-venv/bin/python -m pytest tests/test_field_channel_glossary_routes.py tests/test_field_channel_glossary_hub_tab.py -q
13 passed
```

Also manually verified against a simulated container layout: a fresh directory with only `orion/` copied (no sibling `config/`, matching the real Dockerfile's `COPY orion /app/orion`), `ORION_REPO_ROOT` pointing at the real repo -- `load_glossary()` now resolves the file and returns all 29 entries instead of raising `FileNotFoundError`.

## Env/config changes

None -- reuses the existing `ORION_REPO_ROOT` env var, already set by `services/orion-hub/docker-compose.yml` (`ORION_REPO_ROOT=${ORION_REPO_ROOT:-/repo}`) and already relied on by `drives_analytics.py` for the identical problem.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build orion-hub
```

## Risks / concerns

None -- this is a path-resolution-only fix with no behavior change once the file is found; falls back to the exact same bare-checkout path as before when no container-style env is present, so local/CI dev usage is unaffected.

## PR link

(created by this command)