### PR TITLE
feat(substrate): shadow-measure chat and route prediction-error instruments

### DIFF
--- a/docs/superpowers/specs/2026-07-21-chat-route-prediction-error-shadow-design.md
+++ b/docs/superpowers/specs/2026-07-21-chat-route-prediction-error-shadow-design.md
@@ -1,0 +1,335 @@
+# Chat + route prediction-error shadow instruments
+
+Status: design mode + implemented in the same PR (root `CLAUDE.md`'s implementation-mode
+follow-through requirement — this doc captures the decision record, the code lands alongside
+it, not as a separate follow-up). Shadow-measure only, per the Sentience Striving Program
+charter (`orion/sentience_striving_program/README.md`) §6 item 3: "Phased: shadow-measure
+one producer domain before migrating any live."
+
+## Arsonist summary
+
+Charter §9b item 3 (Predictive Processing/Active Inference) named `execution_prediction_
+error()`/`transport_prediction_error()` as the real field-native substrate for this theory
+thread, and (as of the 2026-07-21 biometrics patch) left two of the five named producer
+domains open: "Chat and route remain open — not yet checked, coverage still genuinely
+incomplete for those two." This patch closes both, adding `chat_prediction_error()` and
+`route_prediction_error()` to `orion/substrate/prediction_error.py`, wired into `_chat_tick()`
+and `_route_tick()` in `services/orion-substrate-runtime/app/worker.py`, using the same
+shared `_write_prediction_error_node()` durable writer and the same
+`SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` flag execution/transport/biometrics already use.
+This closes the producer-instrumentation half of charter §6 item 3 for all five named
+domains (execution, transport, biometrics, chat, route) — it does **not** close item 3
+itself, which also requires migrating each domain off `tensions.py`'s bucket-vote layer live
+and proving item 2's reducer as a `dominant_drive` replacement, per the charter's own phased
+language.
+
+## Naming-mistake context (why this matters here)
+
+A prior draft of this same task (see `docs/superpowers/specs/2026-07-21-biometrics-
+prediction-error-shadow-design.md`'s own "Naming-mistake context" section) named a signal
+`coherence_prediction_error`, sourced from `turn_effect` — a `SelfStateV1`/
+`concept_induction`-adjacent field, in direct violation of charter §7's standing rule
+("field-native only — no `SelfStateV1`-anchored substrate for new instrumentation") and §6
+item 3's explicit reframing ("not a port of `tensions.py`'s hand-classified kind vocabulary
+onto field channels"). Both new functions in this patch read only real reducer projections
+(`ChatSessionProjectionV1`, `RouteArbitrationProjectionV1`) built from `orion-cortex-exec`/
+`orion-cortex-orch` grammar events, never `SelfStateV1` or `concept_induction`. Grep of the
+final diff for `concept_induction`, `turn_effect`, `SelfStateV1`, `self_state_id`: zero hits
+(confirmed below).
+
+## Current architecture
+
+- **Chat producer:** `services/orion-substrate-runtime/app/worker.py`'s `_chat_tick()`
+  (`REDUCER_SPECS[3]`, `reducer_key="chat_session"`) — fetches `orion-cortex-exec` chat
+  grammar events, runs `process_chat_grammar_events()`
+  (`orion/substrate/chat_loop/pipeline.py`), saves via `self._store.
+  save_chat_session_projection`, projection type `ChatSessionProjectionV1`
+  (`orion/schemas/chat_projection.py`), `.turns: dict[str, ChatTurnStateV1]`, loaded via a
+  local `_load_chat_projection()` closure keyed on `CHAT_SESSION_PROJECTION_ID`.
+  `reduce_chat_trace_events()` (`orion/substrate/chat_loop/reducer.py` line ~146:
+  `updated.turns[turn_id] = turn`) revises a turn's state in place across ticks as more
+  evidence arrives for the same `turn_id` — create/update, not append-only.
+- **Route producer:** `_route_tick()` (`REDUCER_SPECS[4]`, `reducer_key="route_arbitration"`)
+  — fetches `orion-cortex-orch` route grammar events, runs `process_route_grammar_events()`
+  (`orion/substrate/route_loop/pipeline.py`), saves via `self._store.
+  save_route_arbitration`, projection type `RouteArbitrationProjectionV1`
+  (`orion/schemas/route_projection.py`), `.runs: dict[str, RouteArbitrationRunStateV1]`,
+  loaded via a local `load_projection()` closure keyed on
+  `ROUTE_ARBITRATION_PROJECTION_ID`. `reduce_route_trace_events()`
+  (`orion/substrate/route_loop/reducer.py` line ~146-147) has the same create/update-by-
+  `trace_id` semantics as chat.
+- **Existing pattern (unchanged):** `orion/substrate/prediction_error.py`'s
+  `execution_prediction_error()`/`transport_prediction_error()`/`biometrics_prediction_
+  error()`, wired into `_execution_tick`/`_transport_tick`/`_tick`. All three diff two
+  successive projection snapshots per-entity, average absolute deltas, and scale by
+  `min(1.0, mean/0.30)`. `_write_prediction_error_node()` (`app/worker.py` ~line 715) is the
+  shared durable writer: it internally checks `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES`
+  (`_prediction_error_nodes_enabled()`) and is otherwise fail-open (never raises out of a
+  tick).
+- **Current gap (pre-patch):** no instrument existed for the chat or route reducers.
+
+## Why chat mirrors execution/transport's shape, but route does not
+
+Read `orion/substrate/chat_loop/grammar_extract.py::compute_chat_pressure_hints()` (line
+114) and `orion/schemas/route_projection.py::RouteArbitrationRunStateV1` before deciding
+this — the task's own instruction was not to assume either function's shape transfers.
+
+**Chat**: `compute_chat_pressure_hints(turn: ChatTurnStateV1) -> dict[str, float]` returns
+exactly three keys (`conversation_load`, `repair_pressure`, `topic_coherence`), all derived
+from numeric fields (`word_count`, `repair_pressure_level`) already on `ChatTurnStateV1`. This
+is structurally identical to `execution_prediction_error`'s fixed four-key continuous-
+magnitude diff — the only wrinkle is that the hints are *not* persisted on the projection
+(unlike execution's `pressure_hints` dict, which the reducer itself writes onto each run).
+`compute_chat_pressure_hints()` is a pure function, already tested (see its own test file),
+that only gets called transiently at reduction time to build a receipt's `after` payload. So
+`chat_prediction_error()` calls it directly on both `prev_turn` and `curr_turn` for each
+shared `turn_id`, then diffs the resulting dicts the same way execution diffs its persisted
+`pressure_hints`.
+
+**Route**: `RouteArbitrationRunStateV1`'s fields that describe the actual arbitration
+decision — `lane: str`, `lane_reason: str`, `output_mode: str`, `mind_requested: bool` — are
+categorical/discrete, not continuous. There is no numeric magnitude to subtract between
+`"background"` and `"spark"`. Two options were considered and rejected before landing on a
+mismatch-rate score:
+
+1. **Hand-assign numeric codes to each category** (e.g. `lane: {"background": 0, "chat": 1,
+   "spark": 2}`) and diff those. Rejected: this is exactly the kind of hand-authored
+   taxonomy-on-top-of-taxonomy charter §6 item 3 explicitly warns against ("not a port of
+   `tensions.py`'s hand-classified kind vocabulary onto field channels") — an arbitrary
+   ordinal encoding implies a false distance metric (is `"spark"` "twice as far" from
+   `"background"` as `"chat"` is? no principled answer exists) and would need updating every
+   time a new lane is added.
+2. **Skip route entirely, leave it unmeasured.** Rejected: the task explicitly named route as
+   one of the two remaining domains to close, and a categorical mismatch rate is a real,
+   principled, if different, prediction-error signal — "did the arbitration decision change
+   at all, and how many of its dimensions changed" is itself a meaningful surprise measure
+   for Predictive Processing/Active Inference (see theory anchor below).
+
+`route_prediction_error()` therefore computes a genuinely different-shaped score: for each
+matched run (`trace_id` present in both `prev.runs`/`curr.runs`), compare `lane`,
+`lane_reason`, `output_mode`, `mind_requested` — 1.0 per field if it differs, 0.0 if it
+doesn't — and average across the four fields, then average across matched runs. This is
+disclosed prominently in the function's own docstring (not just this doc), including an
+explicit "do not scale by `_THRESHOLD`" warning, because a mismatch rate is already bounded
+to `[0, 1]` by construction (mean of N values each in `{0.0, 1.0}`) — dividing an
+already-bounded `[0, 1]` value by 0.30 would push most non-zero mismatches to the 1.0 ceiling
+and destroy the very distinction (one field flipped vs. all four) that makes the signal
+informative. `test_route_prediction_error_not_saturated_by_threshold_scaling` is an explicit
+regression guard against a future "fix" that re-applies the `_THRESHOLD` scale here.
+
+**Fields deliberately excluded from route's comparison:** `correlation_id`, `session_id`,
+`turn_id`, `evidence_event_ids`, `last_updated_at` (bookkeeping fields that change on every
+revision by construction — including them would saturate every batch's score to near-1.0,
+making the signal useless), and `mind_skip_reason` (a free-text explanation that is non-null
+only when `mind_requested` is already false — including it would double-count the same
+underlying decision `mind_requested` already captures).
+
+## Metric quality gate (root `CLAUDE.md` §0A) — findings
+
+Run fresh for both new metrics, not inherited from execution/transport/biometrics' prior
+passes.
+
+### `chat_prediction_error()`
+
+1. **Trace provenance to real code.** `chat_prediction_error(prev, curr)` in
+   `orion/substrate/prediction_error.py` (new function). Called from `_chat_tick()` in
+   `services/orion-substrate-runtime/app/worker.py`, which now captures `prev_projection =
+   _load_chat_projection()` before `process_batch` runs and `curr_projection` via the same
+   closure immediately after, when `last_id is not None` (this capture did not exist
+   pre-patch — `_chat_tick()` previously returned immediately after
+   `_process_events_with_poison_isolation`, with no pre/post projection diff). The underlying
+   values are traced one level further: `compute_chat_pressure_hints()`
+   (`orion/substrate/chat_loop/grammar_extract.py:114`) reads `turn.word_count` and
+   `turn.repair_pressure_level`, both populated by `extract_chat_turn_state()`
+   (same file, line 35-111) from real `orion-cortex-exec` chat grammar events (word-count
+   regex over message summaries, repair-pressure-level atoms).
+2. **Independence check.** Not redundant with execution/transport/biometrics: chat's
+   projection is built from an entirely separate event stream (`orion-cortex-exec` chat
+   grammar events specifically tagged with `CHAT_TRACE_PREFIX`, distinct from execution's
+   general trajectory events), a separate reducer (`REDUCER_SPECS[3]`, not `[0]`/`[1]`/`[2]`),
+   and a separate keying scheme (`turn_id`, not `trace_id`/`bus_id`/`node_id`). The causal
+   chain from "conversation got long and repair-heavy" to, say, "execution reasoning_load
+   changed" is indirect at best (mediated by, at minimum, a human/Orion turn triggering a
+   downstream execution run) — not a monotonic transform of an already-included signal. Not
+   redundant with `route_prediction_error()` either: chat measures *how a conversational turn
+   itself is going* (load, repair, coherence), route measures *how the arbitration layer
+   routing that turn behaved* (lane, decision) — different projections, different reducers,
+   different event streams (`orion-cortex-exec` vs `orion-cortex-orch`).
+
+   **Intra-instrument redundancy found on review, disclosed rather than fixed silently.**
+   Code review of this patch caught a redundancy *inside* `chat_prediction_error()` itself,
+   not against another instrument: `compute_chat_pressure_hints()` defines `topic_coherence =
+   max(0.0, 1.0 - repair_pressure_level)`, an affine (monotonic) transform of the same
+   `repair_pressure_level` that also drives `repair_pressure` directly. A change in
+   `repair_pressure_level` therefore moves both `repair_pressure` and `topic_coherence` by
+   the same magnitude, giving that one underlying signal roughly 2x the weight of
+   `conversation_load` in the 3-key mean — a direct instance of CLAUDE.md §0A's own
+   independence-check language ("a monotonic transform of something already included... not
+   independent"). Kept rather than fixed by dropping a key: the three keys diffed are
+   `compute_chat_pressure_hints()`'s full, already-tested output contract, not a subset
+   hand-picked for this instrument — silently dropping `topic_coherence` here would be a
+   second, quieter instance of exactly the "hand-classified vocabulary" problem charter §6
+   item 3 exists to avoid, just one layer down (deciding which of an existing reducer's
+   already-computed signals "count"). Documented explicitly in the function's own docstring.
+   If this weighting proves to be a real problem against live data, the correct fix is
+   upstream in `compute_chat_pressure_hints()` itself (which several other consumers besides
+   this instrument may also read), not a silent key-drop in this diff function.
+3. **Theory anchor.** Same anchor already used for execution/transport/biometrics, charter
+   §9b item 3: Predictive Processing/Active Inference — a 0-1 surprise score computed as the
+   magnitude of change in a reducer's own pressure-hint state between successive
+   observations, written onto `FieldStateV1` nodes so `orion/substrate/dynamics.py::
+   prediction_error_pressure()` can seed activation pressure from real, measured surprise.
+   Chat is a natural fit: a conversation's load/repair/coherence shifting unexpectedly
+   between two observations is exactly the kind of "prediction violated" event the theory
+   anchors to.
+4. **Live-data sanity check.** Queried directly via `psql -h localhost -p 55432 -U postgres -d
+   conjourney` against `substrate_chat_session_projection` (single live row, `generated_at =
+   2026-07-21T03:43:33Z`, `total_turn_count = 230`, 8 distinct sessions). Sampled turn field
+   values: `word_count` ranges 1-587 across turns (not flat), `repair_pressure_level` averages
+   ~0.094 with non-zero spread (not always-zero, not always-saturated). Confirmed
+   non-degenerate. Same singleton-upsert-table limitation as the other three instruments
+   (`projection_id` primary key, one row) — no history table to replay multiple historical
+   deltas against, so this is "current snapshot is real and non-degenerate," not "N
+   historical deltas were replayed."
+5. **Existing-mechanism check.** `grep -rn "chat_prediction_error"` across the repo before
+   this patch: zero hits outside this patch's own new code.
+6. **Reversibility.** Fully reversible: gated behind the existing
+   `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` flag (no new flag), writes to a single fixed
+   `node_id` (`node:substrate.chat`) that collapses on repeat writes, pure diff function with
+   no persisted schema/manifest dependency. Deleting `chat_prediction_error()` and its call
+   site in `_chat_tick()` would leave the other four instruments untouched and would not break
+   any consumer, since `prediction_error_pressure()` reads generically off
+   `node.metadata.get("prediction_error")`.
+
+### `route_prediction_error()`
+
+1. **Trace provenance to real code.** `route_prediction_error(prev, curr)` in
+   `orion/substrate/prediction_error.py` (new function). Called from `_route_tick()`, which
+   now captures `prev_projection = load_projection()` before `process_batch` runs and
+   `curr_projection` after, when `last_id is not None` (same new-capture pattern as chat —
+   `_route_tick()` previously had no pre/post diff either). The underlying field values are
+   traced to `process_route_grammar_events()` (`orion/substrate/route_loop/pipeline.py`),
+   which populates `lane`/`lane_reason`/`output_mode`/`mind_requested` on
+   `RouteArbitrationRunStateV1` from real `orion-cortex-orch` route grammar events (decision
+   router output, `services/orion-cortex-orch/app/decision_router.py`).
+2. **Independence check.** Not redundant with the other four instruments — separate event
+   stream (`orion-cortex-orch`, not `orion-cortex-exec`/`orion-bus`/`orion-biometrics`),
+   separate reducer (`REDUCER_SPECS[4]`), separate keying (`trace_id` for arbitration runs,
+   distinct namespace from execution's `trace_id` — route's is prefixed `orch.route:`,
+   confirmed against live data below). The causal chain from "this turn's lane changed" to
+   any of the other four projections' own state is real (a lane change plausibly follows from
+   or precedes a load/pressure shift) but indirect, mediated by upstream routing logic, not a
+   direct transform.
+3. **Theory anchor.** Same Predictive Processing/Active Inference anchor. A categorical
+   mismatch rate is a legitimate variant of "surprise" under this theory: active inference
+   formalizes surprise as (roughly) the divergence between predicted and observed state:
+   for a discrete decision variable, the natural divergence measure is exactly a mismatch/
+   disagreement rate, not an ill-defined "distance" between category labels. This is not a
+   stretch of the theory to fit the data shape — categorical prediction error is a standard
+   treatment in predictive-coding literature for discrete/symbolic states, distinct from but
+   consistent with the continuous case the other four instruments use.
+4. **Live-data sanity check.** Queried directly via `psql` against
+   `substrate_route_arbitration_projection` (single live row, `generated_at =
+   2026-07-21T04:03:36Z`, 105 runs). Distinct `(lane, lane_reason, output_mode,
+   mind_requested)` combinations observed: `(background, verb_background, direct_answer,
+   false)` ×87, `(spark, explicit_options, direct_answer, false)` ×15, `(chat, mode_chat,
+   direct_answer, false)` ×2, `(chat, verb_chat, direct_answer, false)` ×1. Confirmed
+   non-degenerate: real variation in `lane`/`lane_reason` across the live sample (not a
+   single constant value), even though `mind_requested` and `output_mode` happen to be
+   constant in this particular snapshot (real — `mind_requested` is gated off in the current
+   deployment per `mind_skip_reason: "mind_enabled_not_true"`, not a data-collection bug).
+   This means a *live* prediction-error signal for this domain right now would be driven
+   almost entirely by `lane`/`lane_reason` transitions until mind-escalation is enabled
+   elsewhere — disclosed honestly rather than glossed over. Same singleton-table limitation
+   as the other four instruments.
+5. **Existing-mechanism check.** `grep -rn "route_prediction_error"` across the repo before
+   this patch: zero hits outside this patch's own new code.
+6. **Reversibility.** Fully reversible, same argument as chat: existing flag, single
+   collapsing `node_id` (`node:substrate.route`), pure function, no schema dependency.
+   Deleting it and its call site would not break any consumer.
+
+## Shadow-only confirmation
+
+`orion/substrate/dynamics.py::_compute_pressures()` calls `prediction_error_pressure(node,
+...)` (defined `orion/substrate/pressure.py:36`) for every node in the graph generically —
+confirmed by reading the function body: it reads `node.metadata.get("prediction_error")` and
+`node.temporal.observed_at` off whatever `BaseSubstrateNodeV1` it is handed, with no
+`node_id`-prefix branching anywhere in the function. This means `node:substrate.chat` and
+`node:substrate.route` are automatically picked up by the same already-live mechanism the
+other three instruments use once written — this is the existing wire, not a new consumer
+being added. No change was made to `capability_policy.py`, `top_down.py`, or
+`goal_context.py`, and no new bus consumer was wired.
+
+## Proposed schema / API changes
+
+- `orion/substrate/prediction_error.py`: two new functions, `chat_prediction_error(prev:
+  ChatSessionProjectionV1, curr: ChatSessionProjectionV1) -> float` and
+  `route_prediction_error(prev: RouteArbitrationProjectionV1, curr:
+  RouteArbitrationProjectionV1) -> float`. No schema changes to `ChatTurnStateV1` or
+  `RouteArbitrationRunStateV1` — both new functions read existing fields only.
+- `services/orion-substrate-runtime/app/worker.py`'s `_chat_tick()`/`_route_tick()`: each now
+  captures a `prev_projection` before `process_batch` runs; after a non-`None` `last_id`,
+  reloads `curr_projection`, computes `error`, and on `error > 0.0` saves a
+  `_prediction_error_receipt(...)` and calls `self._write_prediction_error_node(node_id=
+  "node:substrate.chat"|"node:substrate.route", ..., contributing_id=last_id)`. Both
+  functions' return type is unchanged (`str | None`).
+- No new env key. Reuses `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` — the same generic switch
+  execution/transport/biometrics already share.
+
+## Files likely to touch (this patch's actual diff)
+
+- `orion/substrate/prediction_error.py` — new `chat_prediction_error()`,
+  `route_prediction_error()`.
+- `orion/substrate/tests/test_prediction_error.py` — new unit tests for both functions,
+  appended to the existing execution/transport/biometrics test file.
+- `services/orion-substrate-runtime/app/worker.py` — `_chat_tick()`/`_route_tick()` wiring,
+  import update.
+- `services/orion-substrate-runtime/README.md` — document the fourth and fifth instruments
+  alongside execution/transport/biometrics.
+- `orion/sentience_striving_program/README.md` — §6 item 3 status note updated (all five
+  producer domains now shadow-measured, item 3 itself still open pending live migration),
+  §9b item 3's open-question line closed (chat/route no longer unmeasured).
+- This doc.
+
+## Non-goals
+
+- Not migrating any producer off `tensions.py`'s bucket-vote layer — that is a separate,
+  later step in charter §6 item 3, gated on every producer domain first being shadow-measured
+  AND item 2's reducer being proven a `dominant_drive` replacement.
+- Not touching `capability_policy.py`, `top_down.py`, `goal_context.py`, or any bus consumer.
+- Not adding a new env key.
+- Not building a historical-replay script for either instrument (unlike
+  `measure_origination_gate.py`/`measure_ast_hot_reducer.py`) — same singleton-table
+  limitation named in the biometrics design doc.
+- Not claiming charter §6 item 3 itself is complete. Only the producer-instrumentation half
+  is done; the migration-off-bucket-vote half is untouched.
+
+## Acceptance checks
+
+- `pytest orion/substrate/tests/test_prediction_error.py -q` passes — 22 tests (9 pre-existing
+  biometrics tests unchanged, 6 new chat tests, 7 new route tests, including an explicit
+  `test_route_prediction_error_not_saturated_by_threshold_scaling` regression guard for the
+  documented `_THRESHOLD`-scaling deviation).
+- `_chat_tick()`/`_route_tick()`'s existing return signature and poison-isolation behavior
+  are unchanged for callers — confirmed by running the full
+  `services/orion-substrate-runtime/tests/` suite (excluding the always-broken, pre-existing
+  `test_grammar_consumer_integration.py` module-collection error) with this patch applied and
+  with it reverted (`git stash`): both produce the identical `16 failed, 143 passed`. This
+  patch changes zero pre-existing pass/fail outcomes.
+- Grep of the final diff for `concept_induction`, `turn_effect`, `SelfStateV1`,
+  `self_state_id`: zero hits.
+- Live check: both `node:substrate.chat` and `node:substrate.route` writes are gated behind
+  `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` like the other three lanes; no live write was
+  forced as part of this patch (shadow-only). `UNVERIFIED` for end-to-end live durability
+  until a real chat/route batch with a non-zero delta lands post-deploy — same honesty
+  standard the biometrics/harness-closure lanes' own design docs used.
+
+## Recommended next patch
+
+- After deploy, confirm live `node:substrate.chat`/`node:substrate.route` writes via
+  `redis-cli GRAPH.QUERY` against the running FalkorDB backend, the same manual-check
+  pattern used for `node:substrate.biometrics`/`node:substrate.harness_closure`.
+- All five named producer domains (execution, transport, biometrics, chat, route) now have
+  shadow instrumentation. The next real step in charter §6 item 3 is migrating one domain off
+  `tensions.py`'s bucket-vote layer live — gated on item 2's reducer being proven a
+  `dominant_drive` replacement first, per the charter's own phased sequencing.

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -210,6 +210,29 @@ first place. Full reasoning and phased detail:
    biometrics-prediction-error-shadow-design.md`. Shadow-only: no consumer changed, no live
    migration of the bucket-vote layer, `capability_policy.py`/`top_down.py`/`goal_context.py`
    untouched. Chat and route reducers remain unmeasured.
+   **Status (2026-07-21, same-day follow-up): producer-instrumentation sweep closed for all
+   five named domains.** `chat_prediction_error()` and `route_prediction_error()`
+   (`orion/substrate/prediction_error.py`, wired into `_chat_tick()`/`_route_tick()`, writing
+   `node:substrate.chat`/`node:substrate.route` via the same shared writer and flag) close the
+   two remaining domains named in §9b item 3's open question. `chat_prediction_error()`
+   mirrors execution/transport/biometrics' fixed-key continuous-magnitude shape (diffing
+   `compute_chat_pressure_hints()`'s three keys). `route_prediction_error()` is deliberately
+   shaped differently: `RouteArbitrationRunStateV1`'s decision fields (`lane`, `lane_reason`,
+   `output_mode`, `mind_requested`) are categorical, not continuous, so it scores a per-field
+   mismatch rate instead of an absolute-value delta, and does not apply the module's
+   `_THRESHOLD = 0.30` scaling — documented explicitly in the function's own docstring so a
+   future reader doesn't "fix" it into false consistency with the other four. Design record +
+   metric-quality-gate findings for both: `docs/superpowers/specs/2026-07-21-chat-route-
+   prediction-error-shadow-design.md`. **This closes only the producer-instrumentation half
+   of this item** — all five domains (execution, transport, biometrics, chat, route) now have
+   equivalent shadow-measurement instrumentation, answering §9b item 3's open question in
+   full. It does **not** mean item 3 itself is done: retiring the bucket-vote layer still
+   requires migrating each domain's producer live (not just shadow-measuring it) and proving
+   item 2's reducer as a real `dominant_drive` replacement, per this item's own phased
+   language above ("shadow-measure one producer domain before migrating any live; migrate one
+   domain at a time; retire the bucket-vote layer only once every producer has moved and the
+   item-2 reducer is proven"). Shadow-only, same as the biometrics patch: no consumer changed,
+   no live migration, `capability_policy.py`/`top_down.py`/`goal_context.py` untouched.
 4. **Stand up read-only measurement for the remaining consciousness-theory instruments** (§9)
    — RPT/Lamme and predictive processing are already live (items 2-3 build on them directly,
    not duplicate them); IIT continues independently via the mood-arc encoder, not gated by
@@ -381,8 +404,16 @@ fix — see §7.
    route), `biometrics` now has equivalent instrumentation —
    `biometrics_prediction_error()`, writing `node:substrate.biometrics`, same shared
    `_write_prediction_error_node()` writer, same flag. See §6 item 3's status note above and
-   `docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md`. Chat and
-   route remain open — not yet checked, coverage still genuinely incomplete for those two.
+   `docs/superpowers/specs/2026-07-21-biometrics-prediction-error-shadow-design.md`.
+   **Updated 2026-07-21 (same-day follow-up): chat and route now also have equivalent
+   instrumentation.** `chat_prediction_error()` (writing `node:substrate.chat`) and
+   `route_prediction_error()` (writing `node:substrate.route`, categorical mismatch-rate
+   shape rather than a continuous-magnitude diff — see design doc for why) close this
+   question in full: **all five named producer domains (execution, transport, biometrics,
+   chat, route) now have equivalent shadow-measurement instrumentation.** See
+   `docs/superpowers/specs/2026-07-21-chat-route-prediction-error-shadow-design.md`. This
+   answers the coverage question this section originally left open; it does not itself
+   retire the bucket-vote layer (§6 item 3 remains open for that).
    **Attribution durability + consumers (2026-07-18):** the harness-closure variant of this
    same mechanism (`node:substrate.harness_closure`, PR #1205) accumulates per-turn
    attribution in `metadata['contributing_turn_ids']`, but that list was silently dropped on

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from orion.schemas.biometrics_projection import NodeBiometricsProjectionV1
+from orion.schemas.chat_projection import ChatSessionProjectionV1
 from orion.schemas.execution_projection import ExecutionTrajectoryProjectionV1
+from orion.schemas.route_projection import RouteArbitrationProjectionV1
 from orion.schemas.transport_projection import TransportBusProjectionV1
+from orion.substrate.chat_loop.grammar_extract import compute_chat_pressure_hints
 
 _THRESHOLD = 0.30
 
@@ -83,3 +86,120 @@ def biometrics_prediction_error(
                 continue
             deltas.append(abs(cv - pv))
     return min(1.0, _mean(deltas) / _THRESHOLD) if deltas else 0.0
+
+
+def chat_prediction_error(
+    prev: ChatSessionProjectionV1,
+    curr: ChatSessionProjectionV1,
+) -> float:
+    """0-1 surprise score: how much did a chat turn's pressure hints change this batch?
+
+    Mirrors ``execution_prediction_error``'s fixed-key-set shape: ``ChatTurnStateV1``
+    is revised in place per ``turn_id`` (``reduce_chat_trace_events`` at
+    ``orion/substrate/chat_loop/reducer.py`` line ~146 -- ``updated.turns[turn_id] =
+    turn``, a create/update, not append-only), so the same key comparison across two
+    successive projection snapshots is meaningful the same way execution's per-
+    ``trace_id`` comparison is.
+
+    Unlike the other three instruments, the pressure hints themselves are not stored
+    on the projection -- ``compute_chat_pressure_hints()``
+    (``orion/substrate/chat_loop/grammar_extract.py:114``) is a pure function of a
+    ``ChatTurnStateV1`` that only gets called transiently, at reduction time, to build
+    a receipt's ``after`` payload. This function calls it directly on both the
+    previous and current turn state for each shared ``turn_id`` rather than reading a
+    persisted ``pressure_hints`` dict, since none exists on ``ChatTurnStateV1``.
+
+    Known intra-instrument redundancy (CLAUDE.md metric-quality-gate step 2, re-checked
+    against this instrument specifically, not skipped): ``compute_chat_pressure_hints()``
+    defines ``topic_coherence = max(0.0, 1.0 - repair_pressure_level)``, an affine
+    (monotonic) transform of the same ``repair_pressure_level`` that also drives
+    ``repair_pressure`` directly. A change in ``repair_pressure_level`` therefore moves
+    both ``repair_pressure`` and ``topic_coherence`` by the same magnitude, giving that
+    one underlying signal roughly 2x the weight of ``conversation_load`` in the 3-key
+    mean rather than an even 1x/1x/1x split. This is intentional, not an oversight: the
+    three keys diffed here are exactly ``compute_chat_pressure_hints()``'s full, already-
+    tested output contract (not a new subset invented for this instrument), and
+    ``topic_coherence`` is kept rather than dropped so this function stays a literal diff
+    of "the hints this reducer already reports," not a hand-curated reweighting of them --
+    reintroducing the "hand-classified vocabulary" problem charter §6 item 3 was written
+    to avoid, just one layer down. If this weighting becomes a real problem in practice
+    (verified against live data, not asserted), the fix is upstream in
+    ``compute_chat_pressure_hints()`` itself, not a silent key-drop here.
+    """
+    deltas: list[float] = []
+    for turn_id, curr_turn in curr.turns.items():
+        prev_turn = prev.turns.get(turn_id)
+        if prev_turn is None:
+            continue
+        prev_hints = compute_chat_pressure_hints(prev_turn)
+        curr_hints = compute_chat_pressure_hints(curr_turn)
+        for key in ("conversation_load", "repair_pressure", "topic_coherence"):
+            pv = prev_hints.get(key, 0.0)
+            cv = curr_hints.get(key, 0.0)
+            deltas.append(abs(cv - pv))
+    return min(1.0, _mean(deltas) / _THRESHOLD) if deltas else 0.0
+
+
+def route_prediction_error(
+    prev: RouteArbitrationProjectionV1,
+    curr: RouteArbitrationProjectionV1,
+) -> float:
+    """0-1 surprise score: how much did a route arbitration run's *decision* change
+    this batch?
+
+    **Deliberately not a continuous-magnitude diff like the other three instruments
+    in this module.** ``RouteArbitrationRunStateV1``'s fields
+    (``orion/schemas/route_projection.py``) are categorical/discrete -- ``lane``,
+    ``lane_reason``, ``output_mode`` are strings, ``mind_requested`` is a bool -- there
+    is no numeric magnitude to subtract. Applying ``execution_prediction_error``'s
+    ``abs(cv - pv)`` shape here would be meaningless (strings don't subtract) or
+    would require an arbitrary numeric encoding of categories, which is exactly the
+    kind of hand-authored taxonomy-on-top-of-taxonomy this charter's item 3 was
+    written to avoid (see charter §6 item 3: "not a port of ``tensions.py``'s
+    hand-classified kind vocabulary onto field channels").
+
+    Instead this computes a categorical mismatch rate: for each field compared, score
+    ``1.0`` if the value differs between ``prev``/``curr``, else ``0.0``, then average
+    across the compared fields and across matched runs (by ``trace_id``, mirroring
+    ``reduce_route_trace_events``'s create/update-by-``trace_id`` semantics --
+    ``orion/substrate/route_loop/reducer.py`` line ~146-147). The fields compared
+    (``lane``, ``lane_reason``, ``output_mode``, ``mind_requested``) were chosen
+    because together they represent the arbitration *decision* itself -- which lane a
+    turn was routed to, why, what output mode it produced, and whether mind
+    escalation was requested -- as opposed to bookkeeping fields
+    (``correlation_id``, ``session_id``, ``turn_id``, ``evidence_event_ids``,
+    ``last_updated_at``) that change on every revision by construction and would
+    saturate the score at 1.0 for every batch, making it useless as a surprise
+    signal. ``mind_skip_reason`` was left out: it is a free-text explanation that is
+    non-null only when ``mind_requested`` is already false, so including it would
+    double-count the same underlying decision already captured by ``mind_requested``.
+
+    A mismatch rate averaged over four boolean-valued comparisons is already bounded
+    to ``[0, 1]`` by construction (each per-field score is 0.0 or 1.0, so the mean of
+    N such scores is bounded [0, 1] for any N > 0) -- unlike the other three
+    instruments' unbounded absolute deltas, which need ``min(1.0, mean / _THRESHOLD)``
+    to saturate into a [0, 1] surprise score.
+
+    **Do not apply the module's ``_THRESHOLD = 0.30`` scaling here.** That scaling
+    exists to convert an unbounded continuous magnitude into a saturating [0, 1]
+    score; a categorical mismatch rate has no such unboundedness to correct for, and
+    dividing an already-[0, 1] value by 0.30 would push most non-zero mismatches
+    straight to the 1.0 ceiling, destroying the very distinction (one field flipped
+    vs. all four flipped) that makes this signal informative. If a future patch is
+    tempted to "fix" this into consistency with the other three functions by adding
+    the ``_THRESHOLD`` scale here too, that is a regression, not a cleanup -- leave
+    this deviation as-is unless the field types themselves change from categorical to
+    continuous.
+    """
+    fields = ("lane", "lane_reason", "output_mode", "mind_requested")
+    run_scores: list[float] = []
+    for trace_id, curr_run in curr.runs.items():
+        prev_run = prev.runs.get(trace_id)
+        if prev_run is None:
+            continue
+        field_scores = [
+            1.0 if getattr(prev_run, field) != getattr(curr_run, field) else 0.0
+            for field in fields
+        ]
+        run_scores.append(_mean(field_scores))
+    return _mean(run_scores) if run_scores else 0.0

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -13,7 +13,16 @@ from orion.schemas.biometrics_projection import (
     NodeBiometricsProjectionV1,
     NodeBiometricsStateV1,
 )
-from orion.substrate.prediction_error import biometrics_prediction_error
+from orion.schemas.chat_projection import ChatSessionProjectionV1, ChatTurnStateV1
+from orion.schemas.route_projection import (
+    RouteArbitrationProjectionV1,
+    RouteArbitrationRunStateV1,
+)
+from orion.substrate.prediction_error import (
+    biometrics_prediction_error,
+    chat_prediction_error,
+    route_prediction_error,
+)
 
 _NOW = datetime(2026, 7, 21, 0, 0, 0, tzinfo=timezone.utc)
 
@@ -115,3 +124,206 @@ def test_biometrics_prediction_error_fail_open_on_non_numeric_value() -> None:
     )
     # thermal_pressure delta skipped (non-numeric); gpu delta: |0.8-0.5| = 0.3 -> 1.0
     assert biometrics_prediction_error(prev, curr) == pytest.approx(1.0)
+
+
+# -- chat_prediction_error ---------------------------------------------------
+
+
+def _chat_turn(
+    turn_id: str,
+    *,
+    word_count: int = 0,
+    repair_pressure_level: float = 0.0,
+) -> ChatTurnStateV1:
+    return ChatTurnStateV1(
+        trace_id=f"hub.chat:athena:{turn_id}",
+        turn_id=turn_id,
+        session_id="orion_journal",
+        node_id="athena",
+        observed_at=_NOW,
+        word_count=word_count,
+        repair_pressure_level=repair_pressure_level,
+        last_updated_at=_NOW,
+    )
+
+
+def _chat_projection(turns: dict[str, ChatTurnStateV1]) -> ChatSessionProjectionV1:
+    return ChatSessionProjectionV1(
+        projection_id="chat_session_projection",
+        generated_at=_NOW,
+        turns=turns,
+    )
+
+
+def test_chat_prediction_error_zero_when_no_change() -> None:
+    prev = _chat_projection({"t1": _chat_turn("t1", word_count=20, repair_pressure_level=0.1)})
+    curr = _chat_projection({"t1": _chat_turn("t1", word_count=20, repair_pressure_level=0.1)})
+    assert chat_prediction_error(prev, curr) == 0.0
+
+
+def test_chat_prediction_error_zero_when_turn_not_in_prev() -> None:
+    """A brand-new turn_id in curr with no prev counterpart contributes no delta --
+    mirrors execution_prediction_error's ``prev_run is None: continue`` skip."""
+    prev = _chat_projection({})
+    curr = _chat_projection({"t1": _chat_turn("t1", word_count=50)})
+    assert chat_prediction_error(prev, curr) == 0.0
+
+
+def test_chat_prediction_error_zero_when_projections_empty() -> None:
+    prev = _chat_projection({})
+    curr = _chat_projection({})
+    assert chat_prediction_error(prev, curr) == 0.0
+
+
+def test_chat_prediction_error_scales_with_conversation_load_delta() -> None:
+    # word_count 0 -> conversation_load 0.0; word_count 45 -> conversation_load 0.30
+    prev = _chat_turn("t1", word_count=0)
+    curr = _chat_turn("t1", word_count=45)
+    prev_proj = _chat_projection({"t1": prev})
+    curr_proj = _chat_projection({"t1": curr})
+    # conversation_load delta = |0.30 - 0.0| = 0.30; repair_pressure delta = 0.0;
+    # topic_coherence delta = 0.0 (both 1.0). mean(0.30, 0, 0) = 0.10 -> 0.10/0.30 = 1/3
+    assert chat_prediction_error(prev_proj, curr_proj) == pytest.approx(0.30 / 3 / 0.30)
+
+
+def test_chat_prediction_error_scales_with_repair_pressure_delta() -> None:
+    # repair_pressure and topic_coherence both move by the same magnitude when
+    # repair_pressure_level changes (topic_coherence = 1 - repair_pressure_level).
+    prev = _chat_turn("t1", repair_pressure_level=0.0)
+    curr = _chat_turn("t1", repair_pressure_level=0.30)
+    prev_proj = _chat_projection({"t1": prev})
+    curr_proj = _chat_projection({"t1": curr})
+    # conversation_load delta = 0.0; repair_pressure delta = 0.30;
+    # topic_coherence delta = |0.70 - 1.0| = 0.30. mean(0, 0.30, 0.30) = 0.20 -> 0.20/0.30 = 2/3
+    assert chat_prediction_error(prev_proj, curr_proj) == pytest.approx(0.20 / 0.30)
+
+
+def test_chat_prediction_error_averages_across_multiple_turns() -> None:
+    prev = _chat_projection(
+        {
+            "t1": _chat_turn("t1", repair_pressure_level=0.0),
+            "t2": _chat_turn("t2", repair_pressure_level=0.0),
+        }
+    )
+    curr = _chat_projection(
+        {
+            "t1": _chat_turn("t1", repair_pressure_level=0.30),  # non-zero delta alone
+            "t2": _chat_turn("t2", repair_pressure_level=0.0),  # zero delta
+        }
+    )
+    deltas = [0.0, 0.30, 0.30, 0.0, 0.0, 0.0]  # t1: cl/rp/tc, t2: cl/rp/tc
+    expected = min(1.0, (sum(deltas) / len(deltas)) / 0.30)
+    assert chat_prediction_error(prev, curr) == pytest.approx(expected)
+
+
+# -- route_prediction_error ---------------------------------------------------
+
+
+def _route_run(
+    trace_id: str,
+    *,
+    lane: str = "background",
+    lane_reason: str = "verb_background",
+    output_mode: str = "direct_answer",
+    mind_requested: bool = False,
+) -> RouteArbitrationRunStateV1:
+    return RouteArbitrationRunStateV1(
+        trace_id=trace_id,
+        correlation_id=trace_id,
+        session_id="orion_journal",
+        node_id="athena",
+        lane=lane,
+        lane_reason=lane_reason,
+        mind_requested=mind_requested,
+        output_mode=output_mode,
+        last_updated_at=_NOW,
+    )
+
+
+def _route_projection(
+    runs: dict[str, RouteArbitrationRunStateV1],
+) -> RouteArbitrationProjectionV1:
+    return RouteArbitrationProjectionV1(
+        projection_id="route_arbitration_projection",
+        generated_at=_NOW,
+        runs=runs,
+    )
+
+
+def test_route_prediction_error_zero_when_no_change() -> None:
+    prev = _route_projection({"r1": _route_run("r1")})
+    curr = _route_projection({"r1": _route_run("r1")})
+    assert route_prediction_error(prev, curr) == 0.0
+
+
+def test_route_prediction_error_zero_when_run_not_in_prev() -> None:
+    prev = _route_projection({})
+    curr = _route_projection({"r1": _route_run("r1")})
+    assert route_prediction_error(prev, curr) == 0.0
+
+
+def test_route_prediction_error_zero_when_projections_empty() -> None:
+    prev = _route_projection({})
+    curr = _route_projection({})
+    assert route_prediction_error(prev, curr) == 0.0
+
+
+def test_route_prediction_error_one_field_flip_is_quarter() -> None:
+    prev = _route_projection({"r1": _route_run("r1", lane="background")})
+    curr = _route_projection({"r1": _route_run("r1", lane="chat")})
+    # 1 of 4 compared fields differs -> 0.25 (no _THRESHOLD scaling applied)
+    assert route_prediction_error(prev, curr) == pytest.approx(0.25)
+
+
+def test_route_prediction_error_all_fields_flip_is_one() -> None:
+    prev = _route_projection(
+        {
+            "r1": _route_run(
+                "r1",
+                lane="background",
+                lane_reason="verb_background",
+                output_mode="direct_answer",
+                mind_requested=False,
+            )
+        }
+    )
+    curr = _route_projection(
+        {
+            "r1": _route_run(
+                "r1",
+                lane="spark",
+                lane_reason="explicit_options",
+                output_mode="mind_escalation",
+                mind_requested=True,
+            )
+        }
+    )
+    assert route_prediction_error(prev, curr) == pytest.approx(1.0)
+
+
+def test_route_prediction_error_not_saturated_by_threshold_scaling() -> None:
+    """Explicit regression guard for the documented deviation: a single-field flip
+    (mismatch rate 0.25) must NOT be scaled by ``_THRESHOLD`` (0.30) the way the
+    other three instruments scale their deltas -- 0.25 / 0.30 would round up to a
+    different, wrong value. This must equal 0.25 exactly, not min(1.0, 0.25/0.30)."""
+    prev = _route_projection({"r1": _route_run("r1", output_mode="direct_answer")})
+    curr = _route_projection({"r1": _route_run("r1", output_mode="mind_escalation")})
+    result = route_prediction_error(prev, curr)
+    assert result == pytest.approx(0.25)
+    assert result != pytest.approx(min(1.0, 0.25 / 0.30))
+
+
+def test_route_prediction_error_averages_across_multiple_runs() -> None:
+    prev = _route_projection(
+        {
+            "r1": _route_run("r1", lane="background"),
+            "r2": _route_run("r2", lane="background"),
+        }
+    )
+    curr = _route_projection(
+        {
+            "r1": _route_run("r1", lane="chat"),  # 1/4 fields flip -> 0.25
+            "r2": _route_run("r2", lane="background"),  # no flip -> 0.0
+        }
+    )
+    assert route_prediction_error(prev, curr) == pytest.approx(0.125)

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -190,8 +190,8 @@ or `…_skipped` otherwise). Full Task 21 strain reducers are not implemented he
 
 `_write_prediction_error_node()` (`app/worker.py`) writes to a single, fixed `node_id` per
 lane (`node:substrate.execution`, `node:substrate.transport`, `node:substrate.biometrics`,
-`node:substrate.harness_closure` for post-turn closure), so repeat writes collapse instead of
-spawning a new node per event.
+`node:substrate.chat`, `node:substrate.route`, `node:substrate.harness_closure` for post-turn
+closure), so repeat writes collapse instead of spawning a new node per event.
 
 `node:substrate.biometrics` (`biometrics_prediction_error()`, `orion/substrate/
 prediction_error.py`, wired into `_tick()`) is the third instrument in this family, shadow-
@@ -203,6 +203,23 @@ fixed four-key `pressure_hints` diff, biometrics `pressure_hints` keys vary per 
 present on either side of a given node rather than a fixed list. See `docs/superpowers/
 specs/2026-07-21-biometrics-prediction-error-shadow-design.md` for the full metric-quality-
 gate writeup.
+
+`node:substrate.chat` (`chat_prediction_error()`, wired into `_chat_tick()`) and
+`node:substrate.route` (`route_prediction_error()`, wired into `_route_tick()`) are the
+fourth and fifth instruments in this family, shadow-built 2026-07-21, closing charter §6
+item 3's producer-instrumentation sweep across all five named domains. `chat_prediction_
+error()` diffs `compute_chat_pressure_hints()` (`orion/substrate/chat_loop/
+grammar_extract.py:114` — `conversation_load`/`repair_pressure`/`topic_coherence`, computed
+transiently, not persisted on `ChatTurnStateV1`) across successive turn states, same
+fixed-key/`_THRESHOLD`-scaled shape as execution/transport. `route_prediction_error()` is
+**deliberately different in shape**: `RouteArbitrationRunStateV1`'s decision fields
+(`lane`, `lane_reason`, `output_mode`, `mind_requested`) are categorical, not continuous, so
+it scores a per-field mismatch rate (1.0 if a field differs, else 0.0, averaged across
+compared fields and matched runs) instead of an absolute-value delta, and does **not** apply
+the module's `_THRESHOLD = 0.30` scaling — that scaling exists to saturate an unbounded
+continuous delta, and a mismatch rate is already bounded to `[0, 1]` by construction. See
+`docs/superpowers/specs/2026-07-21-chat-route-prediction-error-shadow-design.md` for the
+full metric-quality-gate writeup and the reasoning for route's different scoring shape.
 Repeat writes to the same node accumulate bounded per-event attribution in
 `metadata['contributing_turn_ids']` (capped at 20, deduped, oldest dropped) — this is
 attribution, not the pressure/dormancy state itself, which `DYNAMICS_ENGINE_OWNED_METADATA_

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -40,7 +40,9 @@ from orion.substrate.transport_loop.constants import (
 )
 from orion.substrate.prediction_error import (
     biometrics_prediction_error,
+    chat_prediction_error,
     execution_prediction_error,
+    route_prediction_error,
     transport_prediction_error,
 )
 from orion.substrate.transport_loop.pipeline import (
@@ -1801,6 +1803,8 @@ class BiometricsSubstrateWorker:
         def _save_chat_projection(p: ChatSessionProjectionV1) -> None:
             self._store.save_chat_session_projection(p)
 
+        prev_projection = _load_chat_projection()
+
         def process_batch(batch: list[GrammarEventV1]) -> None:
             process_chat_grammar_events(
                 events=batch,
@@ -1810,11 +1814,33 @@ class BiometricsSubstrateWorker:
                 now=now,
             )
 
-        return self._process_events_with_poison_isolation(
+        last_id = self._process_events_with_poison_isolation(
             spec=spec,
             events=events,
             process_batch=process_batch,
         )
+
+        if last_id is not None:
+            curr_projection = _load_chat_projection()
+            error = chat_prediction_error(prev_projection, curr_projection)
+            if error > 0.0:
+                self._store.save_receipt(
+                    _prediction_error_receipt(
+                        reducer_key="chat_session",
+                        node_id="node:substrate.chat",
+                        prediction_error=error,
+                        now=now,
+                    )
+                )
+                self._write_prediction_error_node(
+                    node_id="node:substrate.chat",
+                    error=error,
+                    now=now,
+                    reducer_key="chat_session",
+                    contributing_id=last_id,
+                )
+
+        return last_id
 
     def _route_tick(self) -> str | None:
         spec = REDUCER_SPECS[4]
@@ -1830,6 +1856,8 @@ class BiometricsSubstrateWorker:
             loaded = self._store.load_route_arbitration(ROUTE_ARBITRATION_PROJECTION_ID)
             return loaded or empty_route_projection(now=now)
 
+        prev_projection = load_projection()
+
         def process_batch(batch: list[GrammarEventV1]) -> None:
             process_route_grammar_events(
                 events=batch,
@@ -1839,11 +1867,33 @@ class BiometricsSubstrateWorker:
                 now=now,
             )
 
-        return self._process_events_with_poison_isolation(
+        last_id = self._process_events_with_poison_isolation(
             spec=spec,
             events=events,
             process_batch=process_batch,
         )
+
+        if last_id is not None:
+            curr_projection = load_projection()
+            error = route_prediction_error(prev_projection, curr_projection)
+            if error > 0.0:
+                self._store.save_receipt(
+                    _prediction_error_receipt(
+                        reducer_key="route_arbitration",
+                        node_id="node:substrate.route",
+                        prediction_error=error,
+                        now=now,
+                    )
+                )
+                self._write_prediction_error_node(
+                    node_id="node:substrate.route",
+                    error=error,
+                    now=now,
+                    reducer_key="route_arbitration",
+                    contributing_id=last_id,
+                )
+
+        return last_id
 
     def _transport_tick(self) -> str | None:
         spec = REDUCER_SPECS[2]


### PR DESCRIPTION
## Summary

- Adds `chat_prediction_error()` and `route_prediction_error()` to `orion/substrate/prediction_error.py`, the fourth and fifth instruments in the field-native prediction-error family (execution, transport, biometrics already live).
- Wires both into `services/orion-substrate-runtime/app/worker.py`'s `_chat_tick()`/`_route_tick()`, reusing the existing shared `_write_prediction_error_node()` writer and `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` flag — no new env key.
- `chat_prediction_error()` mirrors the existing fixed-key continuous-magnitude shape (diffs `compute_chat_pressure_hints()`'s three keys, same `_THRESHOLD=0.30` scaling).
- `route_prediction_error()` is **deliberately shaped differently**: `RouteArbitrationRunStateV1`'s decision fields (`lane`, `lane_reason`, `output_mode`, `mind_requested`) are categorical, not continuous, so it scores a per-field mismatch rate and explicitly does **not** apply the module's `_THRESHOLD` scaling — documented at length in the function's own docstring plus a regression test guarding against a future "fix" that re-applies it.
- Closes charter §6 item 3 / §9b item 3's producer-instrumentation sweep: all five named domains (execution, transport, biometrics, chat, route) now have equivalent shadow instrumentation. Does **not** claim item 3 itself is done — retiring the bucket-vote layer still needs live migration and item 2's reducer proven as a `dominant_drive` replacement.

## Outcome moved

Charter §9b item 3 (Predictive Processing/Active Inference)'s open question — "whether chat and route reducers have equivalent instrumentation" — is now answered yes for both, closing the last gap in the producer-instrumentation sweep started by the same-day prior biometrics patch.

## Current architecture

Before this patch: `_chat_tick()`/`_route_tick()` in `worker.py` ran their reducer batches (`process_chat_grammar_events()`/`process_route_grammar_events()`) with no prediction-error diff — only execution, transport, and biometrics had a prev/curr projection capture and a `_write_prediction_error_node()` call. `ChatSessionProjectionV1`/`RouteArbitrationProjectionV1` already existed and were already being reduced correctly; only the surprise-measurement layer on top was missing.

## Architecture touched

- `orion/substrate/prediction_error.py` (shared library, no service boundary)
- `services/orion-substrate-runtime/app/worker.py` (producer wiring)
- No bus/schema/registry changes — reuses existing projections, existing flag, existing shared writer.

## Files changed

- `orion/substrate/prediction_error.py`: new `chat_prediction_error()`, `route_prediction_error()`.
- `orion/substrate/tests/test_prediction_error.py`: 13 new unit tests (6 chat, 7 route) appended to the existing execution/transport/biometrics test file.
- `services/orion-substrate-runtime/app/worker.py`: `_chat_tick()`/`_route_tick()` now capture prev/curr projections and call the shared writer on non-zero error; import list updated.
- `services/orion-substrate-runtime/README.md`: documents the fourth/fifth instruments alongside the existing three.
- `orion/sentience_striving_program/README.md`: §6 item 3 status note + §9b item 3 open-question line updated — all five domains now covered, item 3 itself explicitly still open.
- `docs/superpowers/specs/2026-07-21-chat-route-prediction-error-shadow-design.md` (new): full design record, metric-quality-gate findings for both instruments (including a should-fix found on review, addressed below), and the reasoning for route's different scoring shape.

## Schema / bus / API changes

- Added: none (no new schema fields, no new bus channels, no registry entries).
- Removed: none.
- Renamed: none.
- Behavior changed: `_chat_tick()`/`_route_tick()` now perform an additional read-only projection diff and, when `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true` and the delta is non-zero, an additional durable node write. Return signature and poison-isolation behavior are unchanged (confirmed by test comparison below).
- Compatibility notes: fully additive, shadow-only. No existing consumer reads `node:substrate.chat`/`node:substrate.route` yet — `orion/substrate/dynamics.py::prediction_error_pressure()` picks them up generically (confirmed by reading the function body, not assumed), which is the same existing wire the other three instruments already use, not a new one.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: not applicable, no env change.
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not applicable, no env change.
- skipped keys requiring operator action: none.

## Tests run

```text
python -m pytest orion/substrate/tests/test_prediction_error.py -q
-> 22 passed (9 pre-existing biometrics tests unchanged, 13 new: 6 chat, 7 route)

python -m pytest services/orion-substrate-runtime/tests -q --ignore=services/orion-substrate-runtime/tests/test_grammar_consumer_integration.py
-> 16 failed, 143 passed  (identical with this patch applied and with it reverted via
   `git stash` -- confirmed byte-for-byte identical failure list both ways, zero
   regressions introduced. test_grammar_consumer_integration.py excluded: pre-existing,
   always-broken module-collection error unrelated to this patch, ModuleNotFoundError
   for app.models in orion/grammar/ledger.py)

python -m pytest services/orion-substrate-runtime/tests/test_chat_session_route_arbitration_endpoints.py -q
-> 4 passed
```

## Evals run

No dedicated eval harness exists for `orion/substrate/prediction_error.py` or this service beyond the unit-test lane above — same gap disclosed in the prior biometrics-instrument PR. Not building a historical-replay eval here either: `substrate_chat_session_projection`/`substrate_route_arbitration_projection` are singleton-upsert tables (confirmed via live Postgres query), so there's no history table to replay multiple deltas against, the same structural limitation the biometrics/AST-HOT reducer design docs already disclosed.

## Docker/build/smoke checks

Not run — this patch touches pure Python (library function + worker tick wiring), no dependency/port/health-check/compose changes. Live-data sanity checks were done directly against Postgres instead (see design doc's metric-quality-gate section):

```text
psql -h localhost -p 55432 -U postgres -d conjourney
  substrate_chat_session_projection: 230 total_turn_count, word_count range 1-587,
    repair_pressure_level mean ~0.094 (non-degenerate)
  substrate_route_arbitration_projection: 105 runs, 4 distinct (lane, lane_reason,
    output_mode, mind_requested) combinations observed (non-degenerate)
```

## Review findings fixed

- Finding: `chat_prediction_error()`'s three diffed keys are not mutually independent — `topic_coherence = max(0.0, 1.0 - repair_pressure_level)` is an affine transform of the same signal driving `repair_pressure` directly, so a `repair_pressure_level` change gets ~2x the weight of `conversation_load` in the 3-key mean. A direct hit on CLAUDE.md §0A's metric-quality-gate independence check, not surfaced in the first draft's independence-check writeup even though a test's own inline comment showed awareness of the mechanism.
  - Fix: kept the redundancy rather than silently dropping a key (the three keys are `compute_chat_pressure_hints()`'s full, already-tested output contract, not a hand-picked subset — dropping one here would just be a quieter instance of the hand-classified-vocabulary problem charter §6 item 3 exists to avoid). Documented explicitly in `chat_prediction_error()`'s own docstring and in the design doc's independence-check section, with an explicit note that the real fix (if this weighting proves to matter against live data) belongs upstream in `compute_chat_pressure_hints()`, not in this diff function.
  - Evidence: `orion/substrate/prediction_error.py` docstring, `docs/superpowers/specs/2026-07-21-chat-route-prediction-error-shadow-design.md`'s "Intra-instrument redundancy found on review" subsection.
- Finding: misleading inline test comment (`# saturates to 1.0 alone`) on `test_chat_prediction_error_averages_across_multiple_turns`'s `t1` fixture — the single-turn delta actually computes to `≈0.667`, not `1.0`; the test's real assertion (derived from the full 6-value delta list) was correct throughout, only the comment was wrong.
  - Fix: corrected the comment to `# non-zero delta alone`.
  - Evidence: `orion/substrate/tests/test_prediction_error.py`.
- Everything else the reviewer checked (route's scoring shape and field selection, worker.py wiring correctness against the existing execution/transport pattern, the four hard-constraint greps, test arithmetic across all 22 tests, doc accuracy) came back clean with no findings.

## Restart required

```text
No restart required for this PR alone -- shadow-only, no live behavior change until
SUBSTRATE_WRITE_PREDICTION_ERROR_NODES is already true in the target environment (it
already is, per the prior biometrics PR's disclosure). If/when a restart of
orion-substrate-runtime happens for any other reason, this code ships with it; no
dedicated restart is required to "activate" this patch beyond the existing flag.
```

## Risks / concerns

- Severity: low
- Concern: `chat_prediction_error()`'s intra-instrument key redundancy (see review findings above) means repair-pressure movement is implicitly weighted ~2x relative to conversation-load movement in the aggregate score. Disclosed and documented, not silently shipped.
- Mitigation: if this proves material against live data, fix upstream in `compute_chat_pressure_hints()` (shared by other consumers), not in this diff function.
- Severity: low
- Concern: no historical-replay eval exists for either new instrument (singleton-upsert-table limitation, same as biometrics).
- Mitigation: live-data sanity check substitutes for replay per the metric-quality-gate's own allowance when replay is structurally impossible; a follow-up append-only history table (same pattern as `substrate_attention_broadcast_log`) would unblock a real replay eval later.
- Severity: informational
- Concern: `scripts/safe_graphify_update.sh` refused to apply (node count would have dropped ~92%, the known 2026-07-14 destructive-update failure mode) and safely restored `graph.json`/`manifest.json` to their pre-update state. `graphify-out/GRAPH_REPORT.md` and a stray `graph.html` were regenerated by the underlying (refused) run and were reverted/removed manually before commit so no destructive graph state was committed.
- Mitigation: none needed for this PR — graph state is unchanged from `main`. The underlying `graphify update .` node-loss bug is a pre-existing, previously-disclosed issue (root-caused as of 2026-07-14 incident but not yet fixed), out of scope for this patch.

## PR link

(filled in after creation)
