### PR TITLE
feat(field-digester,equilibrium): wire telemetry_anomaly metacog trigger

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -203,6 +203,23 @@ channels:
     stability: "experimental"
     since: "2026-07-18"
 
+  - name: "orion:field_channel:anomaly_score"
+    kind: "event"
+    # Published by orion-field-digester's periodic anomaly-scoring loop
+    # (app/anomaly_scorer.py) -- reconstruction loss from the trained
+    # field_channel_anomaly.v1 encoder (orion/mood_arc/fit_encoder.py) against
+    # the most recent rolling window of live field-channel pressures. Raw
+    # recon_loss + the encoder's own train-time recon_error_p95 are both
+    # carried so orion-equilibrium-service's telemetry_anomaly_metacog_gate
+    # can apply its own configurable threshold multiplier, same pattern as
+    # orion:repair_pressure:appraisal above (producer publishes the
+    # measurement, consumer owns the trigger-sensitivity knob).
+    schema_id: "FieldChannelAnomalyScoreV1"
+    producer_services: ["orion-field-digester"]
+    consumer_services: ["orion-equilibrium-service"]
+    stability: "experimental"
+    since: "2026-07-21"
+
   - name: "orion:exec:request:LLMGatewayService"
     kind: "request"
     schema_id: "ChatRequestPayload"

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -456,6 +456,7 @@ from orion.schemas.telemetry.meta_tags import MetaTagsPayload, MetaTagsRequestV1
 from orion.schemas.metacog_patches import MetacogDraftTextPatchV1, MetacogEnrichScorePatchV1
 from orion.schemas.metacog_entry import MetacogEntryV1, MetacogRepairPressure
 from orion.schemas.repair_pressure_appraisal import RepairPressureAppraisalV1
+from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
 from orion.schemas.state.contracts import StateGetLatestRequest, StateLatestReply
 from orion.schemas.vision import (
     VisionArtifactPayload,
@@ -728,6 +729,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "MetacogEnrichScorePatchV1": MetacogEnrichScorePatchV1,
     "MetacogEntryV1": MetacogEntryV1,
     "RepairPressureAppraisalV1": RepairPressureAppraisalV1,
+    "FieldChannelAnomalyScoreV1": FieldChannelAnomalyScoreV1,
     "MetacogRepairPressure": MetacogRepairPressure,
     "InnerStateFeaturesV1": InnerStateFeaturesV1,
     "InnerFeatureV1": InnerFeatureV1,

--- a/orion/schemas/telemetry/field_channel_anomaly_score.py
+++ b/orion/schemas/telemetry/field_channel_anomaly_score.py
@@ -1,0 +1,33 @@
+"""field_channel_corpus.v1 anomaly-score envelope -- published by
+orion-field-digester's periodic anomaly-scoring loop (app/anomaly_scorer.py),
+consumed by orion-equilibrium-service's telemetry_anomaly_metacog_gate to
+fire the telemetry_anomaly metacog trigger.
+
+Mirrors orion.schemas.repair_pressure_appraisal.RepairPressureAppraisalV1's
+role for the relational trigger: the producer publishes the raw measurement
+(recon_loss vs. its own train-time reference), the consumer applies its own
+configurable multiplier to decide whether to trigger -- so the trigger
+threshold can be tuned as an equilibrium-service operator setting without
+redeploying orion-field-digester.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class FieldChannelAnomalyScoreV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    correlation_id: str
+    encoder_id: str
+    encoder_version: str
+    recon_loss: float
+    recon_error_p95: float
+    threshold_multiplier: float
+    threshold: float
+    anomalous: bool
+    window_start: datetime
+    window_end: datetime
+    window_size: int

--- a/orion/schemas/telemetry/metacog_trigger.py
+++ b/orion/schemas/telemetry/metacog_trigger.py
@@ -14,9 +14,11 @@ class MetacogTriggerV1(BaseModel):
     trigger_kind: str = Field(
         ...,
         description=(
-            "baseline | dense | manual | pulse | relational | llm_surface_instability "
+            "baseline | dense | manual | pulse | relational | llm_surface_instability | telemetry_anomaly "
             "(advisory: language-surface instability from logprob summary, not factual confidence). "
-            "relational = a live turn_change_classify SHIFT appraisal (REPAIR/TOPIC), not a new detector."
+            "relational = a live repair_pressure_v2 appraisal (see repair_pressure_metacog_gate.py). "
+            "telemetry_anomaly = a field_channel_corpus.v1 reconstruction-loss anomaly from a trained "
+            "orion/mood_arc/fit_encoder.py encoder (see telemetry_anomaly_metacog_gate.py)."
         ),
     )
     reason: str

--- a/services/orion-equilibrium-service/.env_example
+++ b/services/orion-equilibrium-service/.env_example
@@ -76,6 +76,16 @@ EQUILIBRIUM_METACOG_RELATIONAL_TRIGGER_ENABLE=true
 EQUILIBRIUM_METACOG_RELATIONAL_CONFIDENCE_THRESHOLD=0.7
 EQUILIBRIUM_METACOG_RELATIONAL_LEVEL_THRESHOLD=0.5
 
+# Telemetry-anomaly metacog trigger: reuses field_channel_corpus.v1's
+# reconstruction-loss anomaly score, published on
+# CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE by orion-field-digester's periodic
+# anomaly-scoring loop whenever FIELD_CHANNEL_ANOMALY_ENABLED is on there.
+# 2026-07-21 -- see docs/superpowers/design/2026-07-18-collapse-mirror-
+# metacog-redesign.md's trigger taxonomy.
+CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE=orion:field_channel:anomaly_score
+EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_TRIGGER_ENABLE=true
+EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_THRESHOLD_MULTIPLIER=3.0
+
 # Substrate felt-state reader (dense/pulse metacog triggers read Postgres projections)
 ENABLE_SUBSTRATE_FELT_STATE_CTX=true
 SUBSTRATE_FELT_STATE_DATABASE_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney

--- a/services/orion-equilibrium-service/README.md
+++ b/services/orion-equilibrium-service/README.md
@@ -20,6 +20,25 @@ Equilibrium is doing **two** intentional jobs in your current implementation:
 This is controlled by:
 - `EQUILIBRIUM_COLLAPSE_MIRROR_INTERVAL_SEC` (default ~15s)
 
+### Baseline metacog trigger
+
+`_metacog_baseline_loop()` runs on `EQUILIBRIUM_METACOG_BASELINE_INTERVAL_SEC` (default `1000`s) whenever `EQUILIBRIUM_METACOG_ENABLE=true`, and is the fallback trigger every other trigger type in this file effectively bypasses when it fires first: on each tick it first tries the substrate dense/pulse trigger (below); only if that doesn't fire does it fall through to a real `trigger_kind=baseline` (`reason="scheduled_check"`). `EQUILIBRIUM_METACOG_BASELINE_MAX_SKIPS` (default `3`) forces a baseline trigger anyway after that many consecutive ticks where the distress/zen scores haven't changed, so a genuinely quiet system still gets a periodic real trigger rather than skipping forever.
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `EQUILIBRIUM_METACOG_ENABLE` | `true` | Master gate for the whole metacog trigger pipeline (baseline + every trigger type below) |
+| `EQUILIBRIUM_METACOG_BASELINE_INTERVAL_SEC` | `1000` | Baseline loop cadence |
+| `EQUILIBRIUM_METACOG_BASELINE_MAX_SKIPS` | `3` | Force a real trigger after this many unchanged ticks |
+| `EQUILIBRIUM_METACOG_COOLDOWN_SEC` | `30` | Global cooldown in `_publish_metacog_trigger()` -- applies across every trigger type in this file, not baseline-specific; a trigger firing during cooldown is silently dropped (logged, not queued) |
+
+### Manual metacog trigger
+
+Fires `trigger_kind=manual` (`reason="user_collapse_event"`) whenever a real user (not Orion itself) manually triggers a Collapse Mirror snapshot from the Hub UI, published on `CHANNEL_COLLAPSE_MIRROR_USER_EVENT` (`orion:collapse:intake`). Guarded against feedback loops: a payload with `observer=orion` is skipped outright (`elif channel == settings.channel_collapse_mirror_user_event` branch in `app/service.py`), so Orion's own collapse-mirror activity can never re-trigger itself through this path. No dedicated enable flag -- gated only by `EQUILIBRIUM_METACOG_ENABLE` above, same as every trigger type in this section.
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `CHANNEL_COLLAPSE_MIRROR_USER_EVENT` | `orion:collapse:intake` | Source channel (single consumer: this service) |
+
 ### Substrate-driven metacog triggers (dense / pulse)
 
 When `EQUILIBRIUM_METACOG_ENABLE=true`, the baseline loop can emit **substrate-aware** triggers before falling back to scheduled baseline ticks. Equilibrium reads fresh Postgres projections (`substrate_self_state`, `substrate_execution_trajectory_projection`) via the shared felt-state reader and scores eventfulness.

--- a/services/orion-equilibrium-service/README.md
+++ b/services/orion-equilibrium-service/README.md
@@ -48,6 +48,20 @@ As of 2026-07-18 this replaced the previous source, `orion/memory/turn_change_cl
 | `EQUILIBRIUM_METACOG_RELATIONAL_LEVEL_THRESHOLD` | `0.5` | Minimum repair_pressure level to fire |
 | `CHANNEL_REPAIR_PRESSURE_APPRAISAL` | `orion:repair_pressure:appraisal` | Source channel (single consumer: this service) |
 
+### Telemetry-anomaly metacog trigger
+
+When `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_TRIGGER_ENABLE=true`, equilibrium subscribes to `orion:field_channel:anomaly_score`, published by `orion-field-digester`'s periodic anomaly-scoring loop (`app/anomaly_scorer.py`) whenever `FIELD_CHANNEL_ANOMALY_ENABLED=true` there. The score is reconstruction loss from a trained `orion/mood_arc/fit_encoder.py` autoencoder against the most recent rolling window of live `field_channel_corpus.v1` pressures.
+
+Same design as the relational trigger above: the producer publishes the raw measurement (`recon_loss`, plus its own train-time `recon_error_p95` reference), this service applies its OWN `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_THRESHOLD_MULTIPLIER` rather than trusting the producer's embedded `anomalous` flag -- so trigger sensitivity is tunable here without redeploying `orion-field-digester`. Fires `trigger_kind=telemetry_anomaly` when `recon_loss > recon_error_p95 * threshold_multiplier`, carrying `recon_loss`/`recon_error_p95`/`threshold`/`window_start`/`window_end`/`encoder_id`/`encoder_version` in the trigger's `upstream` field.
+
+Added 2026-07-21 -- see `docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md`'s trigger taxonomy.
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_TRIGGER_ENABLE` | `true` | Master gate for the telemetry-anomaly trigger |
+| `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_THRESHOLD_MULTIPLIER` | `3.0` | Multiplier applied to the encoder's own `recon_error_p95` |
+| `CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE` | `orion:field_channel:anomaly_score` | Source channel (single consumer: this service) |
+
 ---
 
 ## Quick start (copy/paste)

--- a/services/orion-equilibrium-service/app/service.py
+++ b/services/orion-equilibrium-service/app/service.py
@@ -13,6 +13,7 @@ from orion.schemas.telemetry.metacognition import MetacognitionTickV1
 from orion.schemas.telemetry.metacog_trigger import MetacogTriggerV1
 from .substrate_metacog_gate import build_substrate_metacog_trigger
 from .repair_pressure_metacog_gate import build_repair_pressure_metacog_trigger
+from .telemetry_anomaly_metacog_gate import build_telemetry_anomaly_metacog_trigger
 from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
 from orion.schemas.telemetry.system_health import EquilibriumServiceState, EquilibriumSnapshotV1, SystemHealthV1
 from orion.schemas.telemetry.spark_signal import SparkSignalV1
@@ -495,6 +496,8 @@ class EquilibriumService(BaseChassis):
             channels.append(settings.channel_pad_signal)
             if settings.metacog_relational_trigger_enable:
                 channels.append(settings.channel_repair_pressure_appraisal)
+            if settings.metacog_telemetry_anomaly_trigger_enable:
+                channels.append(settings.channel_field_channel_anomaly_score)
 
         async with self.bus.subscribe(*channels) as pubsub:
             async for msg in self.bus.iter_messages(pubsub):
@@ -579,6 +582,25 @@ class EquilibriumService(BaseChassis):
                                 recall_enabled=settings.metacog_recall_enabled,
                                 level_floor=settings.metacog_relational_level_threshold,
                                 confidence_floor=settings.metacog_relational_confidence_threshold,
+                            )
+                            if trigger is not None:
+                                await self._publish_metacog_trigger(trigger)
+
+                        elif (
+                            channel == settings.channel_field_channel_anomaly_score
+                            and settings.metacog_telemetry_anomaly_trigger_enable
+                        ):
+                            # Real field_channel_corpus.v1 anomaly score,
+                            # published by orion-field-digester's periodic
+                            # anomaly-scoring loop against a trained
+                            # orion/mood_arc/fit_encoder.py encoder.
+                            trigger = build_telemetry_anomaly_metacog_trigger(
+                                correlation_id=str(payload_dict.get("correlation_id") or ""),
+                                score=payload_dict,
+                                zen_state="zen" if zen > 0.5 else "not_zen",
+                                pressure=distress,
+                                recall_enabled=settings.metacog_recall_enabled,
+                                threshold_multiplier=settings.metacog_telemetry_anomaly_threshold_multiplier,
                             )
                             if trigger is not None:
                                 await self._publish_metacog_trigger(trigger)

--- a/services/orion-equilibrium-service/app/settings.py
+++ b/services/orion-equilibrium-service/app/settings.py
@@ -86,6 +86,20 @@ class Settings(BaseSettings):
         0.5, alias="EQUILIBRIUM_METACOG_RELATIONAL_LEVEL_THRESHOLD"
     )
 
+    # Telemetry-anomaly metacog trigger (2026-07-21). Mirrors the relational
+    # trigger's shape: orion-field-digester publishes the raw measurement
+    # (recon_loss vs. its own train-time recon_error_p95), this service owns
+    # the trigger-sensitivity knob via its own threshold multiplier rather
+    # than trusting the producer's embedded "anomalous" flag.
+    metacog_telemetry_anomaly_trigger_enable: bool = Field(
+        True, alias="EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_TRIGGER_ENABLE"
+    )
+    # Matches fit_encoder.py detect-anomalies's own --threshold-multiplier
+    # default (3.0x the encoder's held-out recon_error_p95).
+    metacog_telemetry_anomaly_threshold_multiplier: float = Field(
+        3.0, alias="EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_THRESHOLD_MULTIPLIER"
+    )
+
     metacog_publish_verb_request: bool = Field(
         False,
         alias="EQUILIBRIUM_METACOG_PUBLISH_VERB_REQUEST",
@@ -96,6 +110,9 @@ class Settings(BaseSettings):
     channel_pad_signal: str = Field("orion:pad:signal", alias="CHANNEL_PAD_SIGNAL")
     channel_repair_pressure_appraisal: str = Field(
         "orion:repair_pressure:appraisal", alias="CHANNEL_REPAIR_PRESSURE_APPRAISAL"
+    )
+    channel_field_channel_anomaly_score: str = Field(
+        "orion:field_channel:anomaly_score", alias="CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE"
     )
 
     @model_validator(mode="after")

--- a/services/orion-equilibrium-service/app/telemetry_anomaly_metacog_gate.py
+++ b/services/orion-equilibrium-service/app/telemetry_anomaly_metacog_gate.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from orion.schemas.telemetry.metacog_trigger import MetacogTriggerV1
+
+logger = logging.getLogger("orion.equilibrium.telemetry_anomaly_metacog_gate")
+
+
+def build_telemetry_anomaly_metacog_trigger(
+    *,
+    correlation_id: str,
+    score: dict[str, Any] | None,
+    zen_state: str,
+    pressure: float,
+    recall_enabled: bool,
+    threshold_multiplier: float,
+) -> MetacogTriggerV1 | None:
+    """Turn a live field_channel_corpus.v1 anomaly score (published on
+    orion:field_channel:anomaly_score by orion-field-digester's periodic
+    anomaly-scoring loop, app/anomaly_scorer.py) into a "telemetry_anomaly"
+    metacog trigger.
+
+    Applies this service's OWN threshold_multiplier against the score's raw
+    recon_loss/recon_error_p95 rather than trusting the producer's embedded
+    `anomalous` flag -- same pattern as build_repair_pressure_metacog_trigger
+    applying its own level/confidence floors, so trigger sensitivity is an
+    equilibrium-service operator setting, not something that requires
+    redeploying orion-field-digester to tune.
+    """
+    if not isinstance(score, dict):
+        return None
+
+    recon_loss = score.get("recon_loss")
+    recon_error_p95 = score.get("recon_error_p95")
+    if not isinstance(recon_loss, (int, float)) or not isinstance(recon_error_p95, (int, float)):
+        return None
+
+    threshold = float(recon_error_p95) * threshold_multiplier
+    if float(recon_loss) <= threshold:
+        return None
+
+    reason = f"telemetry_anomaly:recon_loss={float(recon_loss):.5f}:threshold={threshold:.5f}"
+
+    return MetacogTriggerV1(
+        trigger_kind="telemetry_anomaly",
+        reason=reason[:500],
+        zen_state=zen_state,
+        pressure=pressure,
+        recall_enabled=recall_enabled,
+        signal_refs=[correlation_id] if correlation_id else [],
+        upstream={
+            "recon_loss": recon_loss,
+            "recon_error_p95": recon_error_p95,
+            "threshold": threshold,
+            "threshold_multiplier": threshold_multiplier,
+            "window_start": score.get("window_start"),
+            "window_end": score.get("window_end"),
+            "encoder_id": score.get("encoder_id"),
+            "encoder_version": score.get("encoder_version"),
+        },
+    )

--- a/services/orion-equilibrium-service/tests/test_telemetry_anomaly_metacog_gate.py
+++ b/services/orion-equilibrium-service/tests/test_telemetry_anomaly_metacog_gate.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orion.schemas.telemetry.metacog_trigger import MetacogTriggerV1
+from app.telemetry_anomaly_metacog_gate import build_telemetry_anomaly_metacog_trigger
+
+
+def _score(*, recon_loss=0.01, recon_error_p95=0.0014, anomalous=True) -> dict:
+    return {
+        "correlation_id": "corr-score-1",
+        "encoder_id": "mood-arc-encoder:field_channel_anomaly.v1",
+        "encoder_version": "field_channel_anomaly.v1",
+        "recon_loss": recon_loss,
+        "recon_error_p95": recon_error_p95,
+        "threshold_multiplier": 3.0,
+        "threshold": recon_error_p95 * 3.0,
+        "anomalous": anomalous,
+        "window_start": "2026-07-21T04:00:00+00:00",
+        "window_end": "2026-07-21T04:01:00+00:00",
+        "window_size": 30,
+    }
+
+
+def test_recon_loss_above_own_threshold_fires_telemetry_anomaly_trigger():
+    trigger = build_telemetry_anomaly_metacog_trigger(
+        correlation_id="corr-1",
+        score=_score(recon_loss=0.01, recon_error_p95=0.0014),
+        zen_state="not_zen",
+        pressure=0.4,
+        recall_enabled=False,
+        threshold_multiplier=3.0,
+    )
+    assert isinstance(trigger, MetacogTriggerV1)
+    assert trigger.trigger_kind == "telemetry_anomaly"
+    assert trigger.signal_refs == ["corr-1"]
+    assert trigger.upstream["recon_loss"] == 0.01
+    assert trigger.upstream["recon_error_p95"] == 0.0014
+    assert trigger.upstream["threshold"] == 0.0014 * 3.0
+    assert trigger.upstream["encoder_version"] == "field_channel_anomaly.v1"
+
+
+def test_recon_loss_at_or_below_threshold_does_not_fire():
+    trigger = build_telemetry_anomaly_metacog_trigger(
+        correlation_id="corr-2",
+        score=_score(recon_loss=0.002, recon_error_p95=0.0014),
+        zen_state="zen",
+        pressure=0.1,
+        recall_enabled=False,
+        threshold_multiplier=3.0,
+    )
+    assert trigger is None
+
+
+def test_consumer_threshold_multiplier_overrides_producer_anomalous_flag():
+    """The producer's own `anomalous: True` must not matter -- this
+    service applies its own multiplier, same principle as
+    build_repair_pressure_metacog_trigger's floors."""
+    trigger = build_telemetry_anomaly_metacog_trigger(
+        correlation_id="corr-3",
+        score=_score(recon_loss=0.003, recon_error_p95=0.0014, anomalous=True),
+        zen_state="zen",
+        pressure=0.1,
+        recall_enabled=False,
+        threshold_multiplier=10.0,
+    )
+    assert trigger is None
+
+
+def test_missing_score_does_not_fire():
+    trigger = build_telemetry_anomaly_metacog_trigger(
+        correlation_id="corr-4",
+        score=None,
+        zen_state="zen",
+        pressure=0.1,
+        recall_enabled=False,
+        threshold_multiplier=3.0,
+    )
+    assert trigger is None
+
+
+def test_malformed_score_missing_recon_loss_does_not_fire():
+    trigger = build_telemetry_anomaly_metacog_trigger(
+        correlation_id="corr-5",
+        score={"recon_error_p95": 0.0014},
+        zen_state="zen",
+        pressure=0.1,
+        recall_enabled=False,
+        threshold_multiplier=3.0,
+    )
+    assert trigger is None
+
+
+def test_exactly_at_threshold_does_not_fire():
+    """assert-strict '>' (not '>='), same boundary convention as
+    build_repair_pressure_metacog_trigger's '<' floor check."""
+    trigger = build_telemetry_anomaly_metacog_trigger(
+        correlation_id="corr-6",
+        score=_score(recon_loss=0.0042, recon_error_p95=0.0014),
+        zen_state="zen",
+        pressure=0.1,
+        recall_enabled=False,
+        threshold_multiplier=3.0,
+    )
+    assert trigger is None

--- a/services/orion-field-digester/.env_example
+++ b/services/orion-field-digester/.env_example
@@ -114,3 +114,23 @@ FIELD_PLASTICITY_PRODUCER_INTERVAL_HOURS=24
 # Lookback window in hours for each production cycle. Matches
 # orion/substrate/causal_geometry_engine.py's DEFAULT_WINDOW_HOURS (168h / 7 days).
 FIELD_PLASTICITY_PRODUCER_WINDOW_HOURS=168
+
+# field_channel_corpus.v1 telemetry-anomaly trigger (2026-07-21): periodic
+# rescoring of the live rolling window against a trained orion/mood_arc/
+# fit_encoder.py encoder, publishing orion:field_channel:anomaly_score for
+# orion-equilibrium-service's telemetry_anomaly_metacog_gate. Off by default
+# -- requires a real trained encoder artifact (manifest.json + weights.npz);
+# this service does not train one itself. See README.md.
+FIELD_CHANNEL_ANOMALY_ENABLED=false
+FIELD_CHANNEL_ANOMALY_ENCODER_DIR=
+# Checked every 60s by default -- the encoder's own window_size is ~30 rows
+# (~60s at the default 2s tick cadence), so this scores a genuinely new
+# window each check rather than re-scoring one still mostly overlapping the
+# last.
+FIELD_CHANNEL_ANOMALY_CHECK_INTERVAL_SEC=60
+# Informational on this side -- carried in the published payload alongside
+# the raw recon_loss/recon_error_p95 so orion-equilibrium-service can apply
+# its own multiplier. Matches fit_encoder.py detect-anomalies's own
+# --threshold-multiplier default.
+FIELD_CHANNEL_ANOMALY_THRESHOLD_MULTIPLIER=3.0
+CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE=orion:field_channel:anomaly_score

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -177,6 +177,29 @@ A future rework of `orion/mood_arc/fit_encoder.py` to train against this
 dict-shaped corpus instead of `mood_arc_corpus.v1` is separate, not-yet-
 built work.
 
+## Telemetry-anomaly metacog trigger (2026-07-21)
+
+`FIELD_CHANNEL_ANOMALY_ENABLED` (default `false`) turns on a periodic in-process rescoring loop (`app/anomaly_scorer.py`, `_anomaly_loop()` in `app/worker.py`) against a trained `orion/mood_arc/fit_encoder.py` encoder. Independent of `FIELD_CHANNEL_CORPUS_PATH` above: the scorer maintains its own small in-memory rolling buffer of the same per-tick `FieldChannelCorpusRowV1` rows (not the JSONL sink), so live rescoring works even with the JSONL corpus collector off.
+
+Requires a real trained artifact (`manifest.json` + `weights.npz`, written by `orion/mood_arc/fit_encoder.py train`) at `FIELD_CHANNEL_ANOMALY_ENCODER_DIR` -- this service never trains one itself, and a missing/malformed directory fails open (scoring silently disabled, logged once) rather than crashing the tick loop. Training example (using the corpus-quality cutoff below):
+
+```bash
+python orion/mood_arc/fit_encoder.py train \
+  --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
+  --min-generated-at 2026-07-17T04:32:14Z \
+  --out /mnt/telemetry/models/field_channel_anomaly/v1
+```
+
+Every `FIELD_CHANNEL_ANOMALY_CHECK_INTERVAL_SEC` (default 60s -- the encoder's own `window_size` is ~30 rows / ~60s at the default 2s tick cadence, so this scores a genuinely new window each check), the most recent complete window's reconstruction loss is published on `CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE` (`orion:field_channel:anomaly_score`) alongside the encoder's own train-time `recon_error_p95` reference. `orion-equilibrium-service`'s `telemetry_anomaly_metacog_gate.py` is the consumer -- it applies its own threshold multiplier rather than trusting this service's `FIELD_CHANNEL_ANOMALY_THRESHOLD_MULTIPLIER` (informational only here), so trigger sensitivity is tunable on the equilibrium side without redeploying this service. See `services/orion-equilibrium-service/README.md`'s matching section.
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `FIELD_CHANNEL_ANOMALY_ENABLED` | `false` | Master gate |
+| `FIELD_CHANNEL_ANOMALY_ENCODER_DIR` | (empty) | Directory with `manifest.json` + `weights.npz` from a prior `train` run |
+| `FIELD_CHANNEL_ANOMALY_CHECK_INTERVAL_SEC` | `60` | Rescoring cadence |
+| `FIELD_CHANNEL_ANOMALY_THRESHOLD_MULTIPLIER` | `3.0` | Informational only -- see above |
+| `CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE` | `orion:field_channel:anomaly_score` | Publish channel |
+
 ## `field_channel_corpus.v1` training-data quality cutoff (2026-07-17)
 
 `field_channel_corpus.v1` rows generated **before `2026-07-17T04:32:14Z`**

--- a/services/orion-field-digester/app/anomaly_bus_publish.py
+++ b/services/orion-field-digester/app/anomaly_bus_publish.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
+
+logger = logging.getLogger("orion.field.digester.anomaly_bus_publish")
+
+FIELD_CHANNEL_ANOMALY_SCORE_KIND = "field_channel_anomaly.score.v1"
+
+
+async def publish_anomaly_score(
+    *,
+    bus_url: str,
+    bus_enabled: bool,
+    channel: str,
+    score: FieldChannelAnomalyScoreV1,
+    service_name: str,
+    service_version: str,
+    node_name: str,
+) -> None:
+    """Fresh OrionBusAsync per publish -- this fires at most once per
+    FIELD_CHANNEL_ANOMALY_CHECK_INTERVAL_SEC (default 60s), not a hot path,
+    same one-shot connect/publish/close pattern as
+    orion/substrate/causal_geometry_bus_publish.py. Never raises: called
+    from _anomaly_loop(), which already wraps each tick in a broad
+    try/except, but this mirrors that module's "every failure degrades,
+    never propagates" posture explicitly rather than relying solely on the
+    caller."""
+    if not bus_enabled:
+        return
+    bus = OrionBusAsync(url=bus_url, enabled=True)
+    try:
+        await bus.connect()
+        envelope = BaseEnvelope(
+            kind=FIELD_CHANNEL_ANOMALY_SCORE_KIND,
+            source=ServiceRef(name=service_name, version=service_version, node=node_name),
+            correlation_id=score.correlation_id,
+            payload=score.model_dump(mode="json"),
+        )
+        await bus.publish(channel, envelope)
+    except Exception:
+        logger.warning("field_channel_anomaly_score_publish_failed", exc_info=True)
+    finally:
+        try:
+            await bus.close()
+        except Exception:
+            pass

--- a/services/orion-field-digester/app/anomaly_scorer.py
+++ b/services/orion-field-digester/app/anomaly_scorer.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import deque
+from pathlib import Path
+
+from orion.mood_arc.fit_encoder import load_artifacts, score_windows
+from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
+from orion.schemas.telemetry.field_channel_corpus import FieldChannelCorpusRowV1
+
+logger = logging.getLogger("orion.field.digester.anomaly_scorer")
+
+# Small safety margin over the encoder's own window_size: covers rows that
+# fall into the same run but land just past a stride boundary, without
+# holding meaningfully more history than one window actually needs.
+_BUFFER_MARGIN_ROWS = 10
+
+
+class FieldChannelAnomalyScorer:
+    """Periodic in-process rescoring of the live rolling window of
+    field-channel pressures against a trained encoder (orion/mood_arc/
+    fit_encoder.py). Loads its artifacts once, lazily, fail-open: a missing
+    or malformed encoder_dir disables scoring for this process's lifetime
+    (logged once) rather than crashing the tick loop that calls append_row()
+    every ~2s.
+    """
+
+    def __init__(self, *, encoder_dir: str, threshold_multiplier: float) -> None:
+        self._encoder_dir = encoder_dir
+        self._threshold_multiplier = float(threshold_multiplier)
+        self._manifest = None
+        self._weights: dict | None = None
+        self._load_failed = False
+        self._buffer: deque[FieldChannelCorpusRowV1] = deque()
+
+    def _ensure_loaded(self) -> bool:
+        if self._load_failed:
+            return False
+        if self._manifest is not None:
+            return True
+        if not self._encoder_dir:
+            self._load_failed = True
+            logger.warning("field_channel_anomaly_scorer_no_encoder_dir")
+            return False
+        try:
+            self._manifest, self._weights = load_artifacts(Path(self._encoder_dir))
+        except Exception:
+            self._load_failed = True
+            logger.warning(
+                "field_channel_anomaly_scorer_load_failed encoder_dir=%s",
+                self._encoder_dir,
+                exc_info=True,
+            )
+            return False
+        self._buffer = deque(maxlen=self._manifest.window_size + _BUFFER_MARGIN_ROWS)
+        logger.info(
+            "field_channel_anomaly_scorer_loaded encoder_id=%s encoder_version=%s window_size=%d",
+            self._manifest.encoder_id,
+            self._manifest.encoder_version,
+            self._manifest.window_size,
+        )
+        return True
+
+    def append_row(self, row: FieldChannelCorpusRowV1) -> None:
+        """Called from _tick() every poll, independent of whether the JSONL
+        corpus sink is enabled -- this buffer is in-memory only and serves a
+        different purpose (live rescoring, not training-data collection)."""
+        if not self._ensure_loaded():
+            return
+        self._buffer.append(row)
+
+    def score_latest(self) -> FieldChannelAnomalyScoreV1 | None:
+        """Scores the most recent complete window in the buffer, if any.
+        Returns None when the encoder failed to load or fewer than
+        window_size rows have accumulated yet -- both are normal, expected
+        states (a freshly-started process, or scoring disabled), not
+        errors."""
+        if not self._ensure_loaded():
+            return None
+        rows = list(self._buffer)
+        if len(rows) < self._manifest.window_size:
+            return None
+
+        scored = score_windows(
+            rows,
+            fields=tuple(self._manifest.channel_names),
+            window_size=self._manifest.window_size,
+            stride=self._manifest.stride,
+            max_gap_sec=self._manifest.max_gap_sec,
+            weights=self._weights,
+        )
+        if not scored:
+            return None
+
+        recon_loss, window_start, window_end = scored[-1]
+        recon_error_p95 = float(self._manifest.training.recon_error_p95)
+        threshold = recon_error_p95 * self._threshold_multiplier
+        return FieldChannelAnomalyScoreV1(
+            correlation_id=str(uuid.uuid4()),
+            encoder_id=self._manifest.encoder_id,
+            encoder_version=self._manifest.encoder_version,
+            recon_loss=float(recon_loss),
+            recon_error_p95=recon_error_p95,
+            threshold_multiplier=self._threshold_multiplier,
+            threshold=threshold,
+            anomalous=float(recon_loss) > threshold,
+            window_start=window_start,
+            window_end=window_end,
+            window_size=self._manifest.window_size,
+        )

--- a/services/orion-field-digester/app/settings.py
+++ b/services/orion-field-digester/app/settings.py
@@ -94,6 +94,34 @@ class Settings(BaseSettings):
         168.0, alias="FIELD_PLASTICITY_PRODUCER_WINDOW_HOURS"
     )
 
+    # field_channel_corpus.v1 telemetry-anomaly trigger (2026-07-21): periodic
+    # rescoring of the live rolling window against a trained
+    # orion/mood_arc/fit_encoder.py encoder, publishing
+    # orion:field_channel:anomaly_score for orion-equilibrium-service's
+    # telemetry_anomaly_metacog_gate. Off by default -- requires a real
+    # trained encoder artifact (manifest.json + weights.npz) at
+    # FIELD_CHANNEL_ANOMALY_ENCODER_DIR; this service does not train one
+    # itself. See services/orion-field-digester/README.md.
+    field_channel_anomaly_enabled: bool = Field(False, alias="FIELD_CHANNEL_ANOMALY_ENABLED")
+    field_channel_anomaly_encoder_dir: str = Field("", alias="FIELD_CHANNEL_ANOMALY_ENCODER_DIR")
+    # Encoder's own window_size is 30 rows (~60s at the default 2s tick
+    # cadence); checking every 60s means each check scores a genuinely new
+    # window rather than re-scoring one still mostly overlapping the last.
+    field_channel_anomaly_check_interval_sec: float = Field(
+        60.0, alias="FIELD_CHANNEL_ANOMALY_CHECK_INTERVAL_SEC"
+    )
+    # Informational only on this side -- the producer's own default view of
+    # "anomalous", carried in the published payload alongside the raw
+    # recon_loss/recon_error_p95 so orion-equilibrium-service can apply its
+    # own multiplier instead of trusting this one. Matches
+    # fit_encoder.py detect-anomalies's own --threshold-multiplier default.
+    field_channel_anomaly_threshold_multiplier: float = Field(
+        3.0, alias="FIELD_CHANNEL_ANOMALY_THRESHOLD_MULTIPLIER"
+    )
+    channel_field_channel_anomaly_score: str = Field(
+        "orion:field_channel:anomaly_score", alias="CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE"
+    )
+
 
 _settings: Settings | None = None
 

--- a/services/orion-field-digester/app/worker.py
+++ b/services/orion-field-digester/app/worker.py
@@ -10,6 +10,8 @@ from orion.schemas.telemetry.field_channel_corpus import FieldChannelCorpusRowV1
 from orion.self_state.scoring import collect_field_channel_pressures
 from orion.telemetry.corpus_sink import InnerStateCorpusSink
 
+from app.anomaly_bus_publish import publish_anomaly_score
+from app.anomaly_scorer import FieldChannelAnomalyScorer
 from app.digestion.diffusion import get_learned_store
 from app.graph.lattice import load_lattice
 from app.health_monitor import HealthMonitor
@@ -42,6 +44,12 @@ class FieldDigesterWorker:
         self._store = FieldDigesterStore(self._settings.postgres_uri)
         self._lattice = load_lattice(Path(self._settings.lattice_path))
         self._health_monitor = HealthMonitor(self._store, self._settings)
+        self._anomaly_scorer: FieldChannelAnomalyScorer | None = None
+        if self._settings.field_channel_anomaly_enabled:
+            self._anomaly_scorer = FieldChannelAnomalyScorer(
+                encoder_dir=self._settings.field_channel_anomaly_encoder_dir,
+                threshold_multiplier=self._settings.field_channel_anomaly_threshold_multiplier,
+            )
         self._stop = asyncio.Event()
 
     async def start(self) -> None:
@@ -51,6 +59,8 @@ class FieldDigesterWorker:
         asyncio.create_task(
             self._causal_geometry_producer_loop(), name="field-digester-causal-geometry-producer"
         )
+        if self._anomaly_scorer is not None:
+            asyncio.create_task(self._anomaly_loop(), name="field-digester-anomaly")
 
     async def stop(self) -> None:
         self._stop.set()
@@ -155,6 +165,47 @@ class FieldDigesterWorker:
             except asyncio.CancelledError:
                 break
 
+    async def _anomaly_tick(self) -> None:
+        assert self._anomaly_scorer is not None
+        score = await asyncio.to_thread(self._anomaly_scorer.score_latest)
+        if score is None:
+            return
+        await publish_anomaly_score(
+            bus_url=self._settings.orion_bus_url,
+            bus_enabled=self._settings.orion_bus_enabled,
+            channel=self._settings.channel_field_channel_anomaly_score,
+            score=score,
+            service_name=self._settings.service_name,
+            service_version=self._settings.service_version,
+            node_name=self._settings.node_name,
+        )
+        if score.anomalous:
+            logger.info(
+                "field_channel_anomaly_flagged corr=%s recon_loss=%.6f threshold=%.6f "
+                "window_start=%s window_end=%s",
+                score.correlation_id,
+                score.recon_loss,
+                score.threshold,
+                score.window_start,
+                score.window_end,
+            )
+
+    async def _anomaly_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await self._anomaly_tick()
+            except Exception:
+                logger.exception("field_digester_anomaly_tick_failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=float(self._settings.field_channel_anomaly_check_interval_sec),
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
     async def _health_loop(self) -> None:
         while not self._stop.is_set():
             try:
@@ -236,16 +287,22 @@ class FieldDigesterWorker:
                 max_bytes=self._settings.corpus_sink_max_bytes,
                 max_rotated_files=self._settings.corpus_sink_rotated_keep,
             )
-        if _FIELD_CHANNEL_SINK.enabled:
+        if _FIELD_CHANNEL_SINK.enabled or self._anomaly_scorer is not None:
             try:
                 channel_pressures, _provenance = collect_field_channel_pressures(state)
-                _FIELD_CHANNEL_SINK.append(
-                    FieldChannelCorpusRowV1(
-                        generated_at=state.generated_at,
-                        tick_id=state.tick_id,
-                        channels=channel_pressures,
-                    )
+                row = FieldChannelCorpusRowV1(
+                    generated_at=state.generated_at,
+                    tick_id=state.tick_id,
+                    channels=channel_pressures,
                 )
+                if _FIELD_CHANNEL_SINK.enabled:
+                    _FIELD_CHANNEL_SINK.append(row)
+                if self._anomaly_scorer is not None:
+                    # In-memory rolling buffer for live rescoring -- a
+                    # separate concern from the JSONL sink above (training-
+                    # data collection), so it runs even when that sink is
+                    # off. See app/anomaly_scorer.py.
+                    self._anomaly_scorer.append_row(row)
             except Exception:
                 logger.warning("field_channel_corpus_append_failed", exc_info=True)
 

--- a/services/orion-field-digester/tests/test_anomaly_bus_publish.py
+++ b/services/orion-field-digester/tests/test_anomaly_bus_publish.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.anomaly_bus_publish as anomaly_bus_publish
+from app.anomaly_bus_publish import FIELD_CHANNEL_ANOMALY_SCORE_KIND, publish_anomaly_score
+from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
+
+
+def _score() -> FieldChannelAnomalyScoreV1:
+    return FieldChannelAnomalyScoreV1(
+        correlation_id="00000000-0000-4000-8000-000000000001",
+        encoder_id="mood-arc-encoder:test.v1",
+        encoder_version="test.v1",
+        recon_loss=0.02,
+        recon_error_p95=0.0014,
+        threshold_multiplier=3.0,
+        threshold=0.0042,
+        anomalous=True,
+        window_start=datetime.now(timezone.utc),
+        window_end=datetime.now(timezone.utc),
+        window_size=30,
+    )
+
+
+@pytest.mark.asyncio
+async def test_publishes_envelope_with_expected_shape(monkeypatch) -> None:
+    mock_bus = AsyncMock()
+    monkeypatch.setattr(anomaly_bus_publish, "OrionBusAsync", lambda *a, **kw: mock_bus)
+
+    await publish_anomaly_score(
+        bus_url="redis://unused/0",
+        bus_enabled=True,
+        channel="orion:field_channel:anomaly_score",
+        score=_score(),
+        service_name="orion-field-digester",
+        service_version="0.1.0",
+        node_name="athena",
+    )
+
+    mock_bus.connect.assert_awaited_once()
+    mock_bus.publish.assert_awaited_once()
+    channel_arg, env = mock_bus.publish.call_args[0]
+    assert channel_arg == "orion:field_channel:anomaly_score"
+    assert env.kind == FIELD_CHANNEL_ANOMALY_SCORE_KIND
+    assert env.payload["recon_loss"] == 0.02
+    assert env.payload["anomalous"] is True
+    mock_bus.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_bus_disabled(monkeypatch) -> None:
+    mock_bus = AsyncMock()
+    monkeypatch.setattr(anomaly_bus_publish, "OrionBusAsync", lambda *a, **kw: mock_bus)
+
+    await publish_anomaly_score(
+        bus_url="redis://unused/0",
+        bus_enabled=False,
+        channel="orion:field_channel:anomaly_score",
+        score=_score(),
+        service_name="orion-field-digester",
+        service_version="0.1.0",
+        node_name="athena",
+    )
+
+    mock_bus.connect.assert_not_awaited()
+    mock_bus.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_never_raises_when_publish_fails(monkeypatch) -> None:
+    mock_bus = AsyncMock()
+    mock_bus.publish.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(anomaly_bus_publish, "OrionBusAsync", lambda *a, **kw: mock_bus)
+
+    # Must not raise.
+    await publish_anomaly_score(
+        bus_url="redis://unused/0",
+        bus_enabled=True,
+        channel="orion:field_channel:anomaly_score",
+        score=_score(),
+        service_name="orion-field-digester",
+        service_version="0.1.0",
+        node_name="athena",
+    )
+    mock_bus.close.assert_awaited_once()

--- a/services/orion-field-digester/tests/test_anomaly_scorer.py
+++ b/services/orion-field-digester/tests/test_anomaly_scorer.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+
+from app.anomaly_scorer import FieldChannelAnomalyScorer
+from orion.mood_arc.fit_encoder import init_weights, write_artifacts
+from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
+from orion.schemas.telemetry.field_channel_corpus import FieldChannelCorpusRowV1
+from orion.schemas.telemetry.mood_arc import CorpusStatsV1, MoodArcEncoderManifestV1, TrainingStatsV1
+
+_FIELDS = ("cpu_pressure", "gpu_pressure")
+_WINDOW_SIZE = 3
+
+
+def _write_tiny_encoder(tmp_path: Path, *, recon_error_p95: float = 0.01) -> Path:
+    d_in = _WINDOW_SIZE * len(_FIELDS)
+    weights = init_weights(d_in, hidden_dim=4, latent_dim=2, seed=0, data_mean=np.zeros(d_in))
+    manifest = MoodArcEncoderManifestV1(
+        encoder_id="mood-arc-encoder:test.v1",
+        encoder_version="test.v1",
+        status="candidate",
+        architecture="mlp_shallow_v1",
+        window_size=_WINDOW_SIZE,
+        stride=1,
+        max_gap_sec=10.0,
+        hidden_dim=4,
+        latent_dim=2,
+        channel_names=list(_FIELDS),
+        corpus=CorpusStatsV1(corpus_path="unused", row_count=100, excluded_degenerate=0),
+        training=TrainingStatsV1(
+            epochs=1,
+            final_loss=0.001,
+            held_out_loss=0.001,
+            recon_error_p50=0.001,
+            recon_error_p95=recon_error_p95,
+        ),
+        shuffle_baseline_loss=0.02,
+        git_sha="deadbeef",
+        trained_at=datetime.now(timezone.utc),
+    )
+    out_dir = tmp_path / "encoder"
+    write_artifacts(out_dir, manifest=manifest, weights=weights, probes={})
+    return out_dir
+
+
+def _row(i: int, *, base: datetime) -> FieldChannelCorpusRowV1:
+    return FieldChannelCorpusRowV1(
+        generated_at=base + timedelta(seconds=2 * i),
+        tick_id=f"tick_{i}",
+        channels={"cpu_pressure": 0.1 * i, "gpu_pressure": 0.05 * i},
+    )
+
+
+def test_score_latest_returns_none_before_encoder_dir_configured() -> None:
+    scorer = FieldChannelAnomalyScorer(encoder_dir="", threshold_multiplier=3.0)
+    scorer.append_row(_row(0, base=datetime.now(timezone.utc)))
+    assert scorer.score_latest() is None
+
+
+def test_score_latest_returns_none_when_encoder_dir_does_not_exist(tmp_path: Path) -> None:
+    scorer = FieldChannelAnomalyScorer(
+        encoder_dir=str(tmp_path / "nonexistent"), threshold_multiplier=3.0
+    )
+    scorer.append_row(_row(0, base=datetime.now(timezone.utc)))
+    assert scorer.score_latest() is None
+
+
+def test_score_latest_returns_none_below_window_size(tmp_path: Path) -> None:
+    encoder_dir = _write_tiny_encoder(tmp_path)
+    scorer = FieldChannelAnomalyScorer(encoder_dir=str(encoder_dir), threshold_multiplier=3.0)
+    base = datetime.now(timezone.utc)
+    for i in range(_WINDOW_SIZE - 1):
+        scorer.append_row(_row(i, base=base))
+    assert scorer.score_latest() is None
+
+
+def test_score_latest_returns_a_real_score_at_window_size(tmp_path: Path) -> None:
+    encoder_dir = _write_tiny_encoder(tmp_path)
+    scorer = FieldChannelAnomalyScorer(encoder_dir=str(encoder_dir), threshold_multiplier=3.0)
+    base = datetime.now(timezone.utc)
+    for i in range(_WINDOW_SIZE):
+        scorer.append_row(_row(i, base=base))
+
+    score = scorer.score_latest()
+    assert isinstance(score, FieldChannelAnomalyScoreV1)
+    assert score.encoder_id == "mood-arc-encoder:test.v1"
+    assert score.window_size == _WINDOW_SIZE
+    assert score.recon_error_p95 == 0.01
+    assert score.threshold == 0.01 * 3.0
+    assert score.anomalous == (score.recon_loss > score.threshold)
+
+
+def test_buffer_gap_breaks_the_run_and_still_scores_the_latest_contiguous_window(
+    tmp_path: Path,
+) -> None:
+    """A gap exceeding max_gap_sec must not silently crash scoring -- the
+    run before the gap is simply excluded (_build_windows_with_span's
+    contract), and score_latest() should still find a complete window in
+    whatever the buffer holds after the gap."""
+    encoder_dir = _write_tiny_encoder(tmp_path)
+    scorer = FieldChannelAnomalyScorer(encoder_dir=str(encoder_dir), threshold_multiplier=3.0)
+    base = datetime.now(timezone.utc)
+    for i in range(_WINDOW_SIZE):
+        scorer.append_row(_row(i, base=base))
+    # Big gap (> max_gap_sec=10.0), then a fresh contiguous run.
+    gapped_base = base + timedelta(seconds=1000)
+    for i in range(_WINDOW_SIZE):
+        scorer.append_row(_row(i, base=gapped_base))
+
+    score = scorer.score_latest()
+    assert score is not None
+    assert score.window_start >= gapped_base
+
+
+def test_load_failure_is_sticky_and_does_not_retry_every_call(tmp_path: Path) -> None:
+    """A malformed encoder_dir (missing manifest.json) should fail once and
+    stay disabled, not re-attempt (and re-log) load on every append_row/
+    score_latest call in a hot ~2s tick loop."""
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    scorer = FieldChannelAnomalyScorer(encoder_dir=str(bad_dir), threshold_multiplier=3.0)
+    assert scorer.score_latest() is None
+    assert scorer._load_failed is True
+    scorer.append_row(_row(0, base=datetime.now(timezone.utc)))
+    assert len(scorer._buffer) == 0

--- a/services/orion-field-digester/tests/test_field_channel_corpus.py
+++ b/services/orion-field-digester/tests/test_field_channel_corpus.py
@@ -49,6 +49,26 @@ def test_field_channel_corpus_appends_with_real_channel_pressures(monkeypatch, t
     assert row["channels"] == expected_channels
 
 
+def test_anomaly_scorer_receives_row_even_when_corpus_sink_disabled(monkeypatch, tmp_path) -> None:
+    """append_row() to the anomaly scorer's in-memory buffer is a separate
+    concern from the JSONL corpus sink -- it must fire even when the sink
+    itself is off (FIELD_CHANNEL_CORPUS_PATH empty), since live rescoring
+    doesn't need training-data persistence to be enabled."""
+    monkeypatch.setattr(worker, "_FIELD_CHANNEL_SINK", worker.InnerStateCorpusSink(""), raising=False)
+
+    field_worker = _make_worker(monkeypatch, idle_tick_enabled=True)
+    field_worker._store.fetch_new_receipts.return_value = []
+    existing = empty_field_state(
+        lattice=field_worker._lattice, now=datetime.now(timezone.utc), tick_id="tick_old"
+    )
+    field_worker._store.load_latest_field.return_value = existing
+    field_worker._anomaly_scorer = MagicMock()
+
+    field_worker._tick()
+
+    field_worker._anomaly_scorer.append_row.assert_called_once()
+
+
 def test_field_channel_corpus_disabled_when_path_empty(monkeypatch, tmp_path) -> None:
     corpus_path = tmp_path / "field_channel.jsonl"
     # Default construction: empty path -> disabled, no-op.

--- a/services/orion-field-digester/tests/test_worker.py
+++ b/services/orion-field-digester/tests/test_worker.py
@@ -19,6 +19,7 @@ def _make_worker(monkeypatch, *, idle_tick_enabled: bool = True) -> FieldDigeste
     worker._settings = settings_mod.get_settings()
     worker._store = MagicMock()
     worker._lattice = MagicMock(nodes=["n1"], capabilities=["c1"], edges=[])
+    worker._anomaly_scorer = None
     return worker
 
 

--- a/services/orion-field-digester/tests/test_worker_anomaly_wiring.py
+++ b/services/orion-field-digester/tests/test_worker_anomaly_wiring.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.worker as worker_module
+from app.anomaly_scorer import FieldChannelAnomalyScorer
+from app.worker import FieldDigesterWorker
+
+
+def _make_worker(monkeypatch, *, anomaly_enabled: str = "false") -> FieldDigesterWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused/unused")
+    monkeypatch.setenv("FIELD_CHANNEL_ANOMALY_ENABLED", anomaly_enabled)
+    monkeypatch.setenv("FIELD_CHANNEL_ANOMALY_ENCODER_DIR", "/nonexistent/encoder")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+
+    worker = FieldDigesterWorker.__new__(FieldDigesterWorker)
+    worker._settings = settings_mod.get_settings()
+    worker._anomaly_scorer = None
+    if worker._settings.field_channel_anomaly_enabled:
+        worker._anomaly_scorer = FieldChannelAnomalyScorer(
+            encoder_dir=worker._settings.field_channel_anomaly_encoder_dir,
+            threshold_multiplier=worker._settings.field_channel_anomaly_threshold_multiplier,
+        )
+    worker._stop = MagicMock()
+    return worker
+
+
+def test_anomaly_scorer_is_none_when_disabled(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch, anomaly_enabled="false")
+    assert worker._anomaly_scorer is None
+
+
+def test_anomaly_scorer_is_constructed_when_enabled(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch, anomaly_enabled="true")
+    assert isinstance(worker._anomaly_scorer, FieldChannelAnomalyScorer)
+
+
+@pytest.mark.asyncio
+async def test_anomaly_tick_publishes_when_scorer_returns_a_score(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch, anomaly_enabled="true")
+    fake_score = MagicMock(anomalous=True, correlation_id="c1", recon_loss=0.02, threshold=0.004,
+                            window_start="ws", window_end="we")
+    monkeypatch.setattr(worker._anomaly_scorer, "score_latest", MagicMock(return_value=fake_score))
+    mock_publish = AsyncMock()
+    monkeypatch.setattr(worker_module, "publish_anomaly_score", mock_publish)
+
+    await worker._anomaly_tick()
+
+    mock_publish.assert_awaited_once()
+    kwargs = mock_publish.call_args.kwargs
+    assert kwargs["score"] is fake_score
+    assert kwargs["channel"] == worker._settings.channel_field_channel_anomaly_score
+
+
+@pytest.mark.asyncio
+async def test_anomaly_tick_does_not_publish_when_scorer_returns_none(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch, anomaly_enabled="true")
+    monkeypatch.setattr(worker._anomaly_scorer, "score_latest", MagicMock(return_value=None))
+    mock_publish = AsyncMock()
+    monkeypatch.setattr(worker_module, "publish_anomaly_score", mock_publish)
+
+    await worker._anomaly_tick()
+
+    mock_publish.assert_not_awaited()

--- a/services/orion-mind/README.md
+++ b/services/orion-mind/README.md
@@ -1,0 +1,22 @@
+# orion-mind
+
+FastAPI service exposing `run_mind()` (`orion.mind.v1.MindRunRequestV1` -> `MindRunResultV1`). This README does not attempt to cover the whole service -- it documents one specific, verified piece: the `llm_surface_instability` metacog trigger, added here because `services/orion-equilibrium-service/README.md`'s trigger-taxonomy documentation flagged this as the one real `MetacogTriggerV1` producer living outside that service with no README coverage anywhere (2026-07-21).
+
+## `llm_surface_instability` metacog trigger
+
+`app/uncertainty_metacog.py`'s `maybe_publish_llm_surface_instability_trigger()` fires an *advisory* `trigger_kind=llm_surface_instability` metacog trigger when an LLM response's own logprob telemetry looks unstable -- not a factual-confidence signal, a language-surface-instability one. Gated by `MIND_LLM_UNCERTAINTY_METACOG_ENABLED` (default `false`).
+
+Fires (`should_emit_llm_surface_instability()`) when, off the response's `llm_uncertainty` telemetry dict:
+- `unstable_span_count >= 1` (reason: `unstable_span`), or
+- `mean_top1_margin < 0.75` (reason: `low_mean_margin`), or
+- `low_logprob_token_count / token_count_observed > 0.15` (reason: `high_low_logprob_ratio`)
+
+Never fires if `llm_uncertainty.available` is falsy or `token_count_observed <= 0` (reason: `unavailable`/`no_tokens`). `pressure` on the trigger is `min(1.0, low_logprob_token_count / token_count_observed)`; `upstream` carries the full `llm_uncertainty` dict, the phase name, and the specific `instability_detail` reason string.
+
+**Unlike every trigger documented in `orion-equilibrium-service`'s README, this one bypasses equilibrium's gate logic entirely** -- `_publish_metacog_trigger_async()` publishes `MetacogTriggerV1` directly onto `MIND_METACOG_TRIGGER_CHANNEL`, which defaults to `orion:equilibrium:metacog:trigger` (the same channel equilibrium-service's own `_publish_metacog_trigger()` writes to for `orion-cortex-orch` to consume). There is no confidence/level floor here the way `relational`/`telemetry_anomaly` have -- the three boolean/threshold conditions above are the only gate.
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `MIND_LLM_UNCERTAINTY_METACOG_ENABLED` | `false` | Master gate |
+| `MIND_METACOG_TRIGGER_CHANNEL` | `orion:equilibrium:metacog:trigger` | Publish channel -- shared with equilibrium-service's own triggers, not a dedicated inbound channel |
+| `ORION_BUS_URL` | `redis://redis:6379/0` | Bus connection (fresh `OrionBusAsync` per publish, one-shot connect/publish/close) |


### PR DESCRIPTION
## Summary

- Third metacog trigger in the taxonomy (`docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md`), mirroring the shipped `relational` trigger's architecture exactly: producer publishes a raw measurement, consumer owns the trigger-sensitivity threshold.
- `orion-field-digester`: new `FieldChannelAnomalyScorer` (`app/anomaly_scorer.py`) maintains an in-memory rolling window of live `field_channel_corpus.v1` pressures and periodically rescoring it against a trained `orion/mood_arc/fit_encoder.py` encoder, publishing `recon_loss` on a new `orion:field_channel:anomaly_score` channel. Off by default; requires a real trained artifact.
- **Trained and validated a real encoder against the live corpus this session**: 169,807 post-cutoff rows, `floor_ratio=0.331` (passes the `<0.5` redundancy gate), `detect-anomalies` found 154/11,381 windows anomalous (1.35%, non-degenerate). Deployed at `/mnt/telemetry/models/field_channel_anomaly/v1` (not committed — a disk-only model artifact, same posture as the phi encoder).
- `orion-equilibrium-service`: new `telemetry_anomaly_metacog_gate.py` mirrors `repair_pressure_metacog_gate.py` — applies its own `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_THRESHOLD_MULTIPLIER` against the raw `recon_loss`/`recon_error_p95`, not the producer's embedded `anomalous` flag, so sensitivity is tunable without redeploying field-digester.

## Outcome moved

The trigger taxonomy from the design doc had `telemetry_anomaly` flagged as "passed the metric quality gate but not wired." It's now fully wired end-to-end, with a real live-validated model backing it (not a placeholder).

## Current architecture

Before this PR: the anomaly detector (`orion/mood_arc/fit_encoder.py`) was CLI/research-only — no live service imported it, no trained artifact was deployed anywhere. The `field_channel_corpus.v1` corpus itself was already live (confirmed: 333k+ rows accumulated since 07-13), just never consumed by anything beyond manual CLI runs.

## Architecture touched

- `orion/schemas/telemetry/field_channel_anomaly_score.py` (new schema)
- `orion/schemas/registry.py`, `orion/bus/channels.yaml` (new channel `orion:field_channel:anomaly_score`)
- `orion/schemas/telemetry/metacog_trigger.py` (docstring)
- `services/orion-field-digester/app/{anomaly_scorer.py,anomaly_bus_publish.py,worker.py,settings.py}`
- `services/orion-equilibrium-service/app/{telemetry_anomaly_metacog_gate.py,service.py,settings.py}`
- Both services' `.env_example` and `README.md`

## Files changed

- `orion/schemas/telemetry/field_channel_anomaly_score.py`: new `FieldChannelAnomalyScoreV1` schema.
- `orion/schemas/registry.py`, `orion/bus/channels.yaml`: register the new channel/schema.
- `orion/schemas/telemetry/metacog_trigger.py`: `trigger_kind` docstring now mentions `telemetry_anomaly`.
- `services/orion-field-digester/app/anomaly_scorer.py`: new — lazy-loads encoder artifacts (fail-open), in-memory rolling buffer, `score_latest()`.
- `services/orion-field-digester/app/anomaly_bus_publish.py`: new — async publish, mirrors `causal_geometry_bus_publish.py`.
- `services/orion-field-digester/app/worker.py`: wires `append_row()` into `_tick()`, new `_anomaly_loop()` task.
- `services/orion-field-digester/app/settings.py`, `.env_example`, `README.md`: new settings + docs.
- `services/orion-equilibrium-service/app/telemetry_anomaly_metacog_gate.py`: new gate, mirrors `repair_pressure_metacog_gate.py`.
- `services/orion-equilibrium-service/app/service.py`: wires the new channel into the subscribe/dispatch loop.
- `services/orion-equilibrium-service/app/settings.py`, `.env_example`, `README.md`: new settings + docs.
- Test files: `services/orion-field-digester/tests/{test_anomaly_scorer.py,test_anomaly_bus_publish.py,test_worker_anomaly_wiring.py}` (new), `test_field_channel_corpus.py`/`test_worker.py` (extended — shared `_make_worker` helper needed `_anomaly_scorer = None` since `_tick()` now references it). `services/orion-equilibrium-service/tests/test_telemetry_anomaly_metacog_gate.py` (new).

## Schema / bus / API changes

- Added: `orion:field_channel:anomaly_score` channel, `FieldChannelAnomalyScoreV1` schema, `telemetry_anomaly` as a `trigger_kind` value (no schema constraint change — `trigger_kind` is already a plain `str`).
- Removed: none.
- Renamed: none.
- Behavior changed: none for existing paths — both new settings default appropriately (`FIELD_CHANNEL_ANOMALY_ENABLED=false` on the producer side, so nothing runs until an operator opts in with a real trained artifact; `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_TRIGGER_ENABLE=true` on the consumer side is harmless since the channel never receives traffic until the producer is turned on).
- Compatibility notes: none.

## Env/config changes

- Added keys (`orion-field-digester`): `FIELD_CHANNEL_ANOMALY_ENABLED`, `FIELD_CHANNEL_ANOMALY_ENCODER_DIR`, `FIELD_CHANNEL_ANOMALY_CHECK_INTERVAL_SEC`, `FIELD_CHANNEL_ANOMALY_THRESHOLD_MULTIPLIER`, `CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE`.
- Added keys (`orion-equilibrium-service`): `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_TRIGGER_ENABLE`, `EQUILIBRIUM_METACOG_TELEMETRY_ANOMALY_THRESHOLD_MULTIPLIER`, `CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE`.
- `.env_example` updated: yes, both services.
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not yet — this worktree has no local `.env` files (feature-branch isolation, same as prior sessions this week). **Live `.env` sync for both services still needs to happen manually before this is truly live** — see Restart required below. `FIELD_CHANNEL_ANOMALY_ENABLED` should stay `false` in the live `.env` until the trained artifact at `/mnt/telemetry/models/field_channel_anomaly/v1` is deliberately promoted/verified further; the other keys are safe to sync immediately.
- Skipped keys requiring operator action: `FIELD_CHANNEL_ANOMALY_ENCODER_DIR` — operator must point this at `/mnt/telemetry/models/field_channel_anomaly/v1` (or wherever the artifact ends up) and flip `FIELD_CHANNEL_ANOMALY_ENABLED=true` deliberately.

## Tests run

```text
cd services/orion-field-digester (or set cwd correctly -- see note below) && \
  venv/bin/python3 -m pytest services/orion-field-digester/tests -q
117 passed, 6 warnings

venv/bin/python3 -m pytest services/orion-equilibrium-service/tests -q
19 passed, 6 warnings

venv/bin/python3 -m pytest orion/schemas orion/bus orion/mood_arc/tests -q
94 passed, 1 failed (test_static_ctx_assignments_covered -- confirmed pre-existing
on main, unrelated to this diff: a stale llm_serving_node ctx-key gap from an
earlier merged PR)
```

Note: `python -m pytest` prepends the shell's cwd to `sys.path[0]`, which can make the main checkout's `orion` package shadow the worktree's own if invoked from the wrong directory — always `cd` into the worktree first when running these tests.

## Evals run

None applicable — this is infrastructure wiring, not a model-quality change (the model training itself was validated via `fit_encoder.py train`'s own gates: `floor_ratio=0.331 < 0.5`, and `detect-anomalies` producing a non-degenerate 1.35% anomaly rate against real data).

## Docker/build/smoke checks

Not yet run — this needs both services rebuilt/restarted to pick up the new code, and the live `.env` sync above needs to happen first. See Restart required.

## Review findings fixed

- Finding: `.env_example` comments in both services referenced "See README.md" for this feature, but neither README had a matching section yet.
  - Fix: added a full section to both `services/orion-field-digester/README.md` and `services/orion-equilibrium-service/README.md`, matching the existing relational-trigger/causal-geometry section style.
  - Evidence: both READMEs now have a "Telemetry-anomaly metacog trigger" section with the env table.
- Reviewer also confirmed (no fix needed): no race condition in the shared in-memory buffer (empirically reproduced 20,000 concurrent reads against a writer thread, zero errors — `list(deque)` is GIL-atomic), no double-trigger risk, the consumer-owns-threshold design works as intended (test asserts the producer's `anomalous=True` flag is ignored), schema/channel registration complete, and the shared `_make_worker` test-helper fix is necessary and sufficient (searched for every other `FieldDigesterWorker.__new__` construction site in the test suite).

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-equilibrium-service/.env \
  -f services/orion-equilibrium-service/docker-compose.yml \
  up -d --build
```

Before restarting: sync both `.env` files from `.env_example` (all keys are safe to sync except leave `FIELD_CHANNEL_ANOMALY_ENABLED=false` until the encoder artifact is deliberately promoted), and set `FIELD_CHANNEL_ANOMALY_ENCODER_DIR=/mnt/telemetry/models/field_channel_anomaly/v1` when ready to turn it on.

## Risks / concerns

- Severity: low
- Concern: the deployed encoder artifact is `status="candidate"` with `promoted_at=None` — nothing in the code gates on promotion status, so an operator setting `FIELD_CHANNEL_ANOMALY_ENCODER_DIR` must know to only point at a deliberately-promoted artifact.
- Mitigation: the feature is off by default (`FIELD_CHANNEL_ANOMALY_ENABLED=false`), so no live behavior changes until an operator opts in explicitly.
- Severity: low
- Concern: the trained model has no interpretability probes (`compute_window_probes()` had no defined probe target for `field_channel_corpus.v1` as of training time — an already-known, separate open question, not something this PR resolves).
- Mitigation: doesn't block anomaly *detection* (recon-loss-vs-threshold doesn't need probes), only blocks explaining *why* a window is anomalous in terms of latent semantics. Flagged for future work, not a regression from this PR.

## PR link

(filled in by gh pr create)