### PR TITLE
fix(mood-arc): defer scripts.fit_phi_encoder import, unblock field-digester

### DIFF
--- a/orion/mood_arc/fit_encoder.py
+++ b/orion/mood_arc/fit_encoder.py
@@ -109,14 +109,6 @@ from orion.schemas.telemetry.mood_arc import MoodArcEncoderManifestV1
 from orion.schemas.telemetry.phi_encoder import CorpusStatsV1, TrainingStatsV1
 from orion.telemetry.corpus_rotation import resolve_rotated_corpus_files
 
-# Reused as-is from fit_phi_encoder.py -- these operate on plain np.ndarrays
-# and are genuinely shape-agnostic (percentile-of-a-list, Pearson-of-two-
-# vectors). Everything else in that file (_init_weights/_forward/_losses/
-# _apply_grads) carries phi-specific baggage (a vestigial phi-prediction
-# head, plain-SGD/zero-init) and is deliberately NOT reused -- see module
-# docstring.
-from scripts.fit_phi_encoder import _pearson, _percentile  # noqa: E402
-
 ARCHITECTURE = "mlp_shallow_v1"  # same architecture family as the phi encoder
 
 # Channels excluded from select_fields() by name regardless of variance --
@@ -373,6 +365,17 @@ def prune_correlated_fields(
     not swallowed."""
     if len(fields) < 2:
         return fields
+
+    # Deferred import (2026-07-21, live outage fix): scripts.fit_phi_encoder
+    # is repo-root operator/CLI tooling, not shipped in every service's
+    # Docker image. Module-level import here broke orion-field-digester
+    # (which now imports load_artifacts/score_windows for live anomaly
+    # scoring but has no scripts/ in its container) even though this
+    # training-only function is never called from that path. _pearson/
+    # _percentile operate on plain np.ndarrays and are genuinely shape-
+    # agnostic (see module docstring) -- reused as-is, just imported lazily
+    # so only actual CLI/training use requires scripts/ to be present.
+    from scripts.fit_phi_encoder import _pearson
 
     matrix = _channel_stat_matrix(rows, fields)
     variances = {f: float(np.var(matrix[:, i])) for i, f in enumerate(fields)}
@@ -661,6 +664,9 @@ def train_autoencoder(
 ) -> tuple[dict[str, np.ndarray], TrainingStatsV1]:
     if train_matrix.shape[0] == 0:
         raise SystemExit("train: no training windows after purged temporal split")
+
+    # Deferred import -- see prune_correlated_fields()'s comment above.
+    from scripts.fit_phi_encoder import _percentile
 
     d_in = train_matrix.shape[1]
     data_mean = np.mean(train_matrix, axis=0)

--- a/orion/mood_arc/tests/test_fit_encoder_no_scripts_dependency.py
+++ b/orion/mood_arc/tests/test_fit_encoder_no_scripts_dependency.py
@@ -1,0 +1,89 @@
+"""Regression for a live outage (2026-07-21): orion/mood_arc/fit_encoder.py
+had a module-level `from scripts.fit_phi_encoder import _pearson,
+_percentile`. scripts/ is repo-root operator/CLI tooling, not shipped in
+every service's Docker image -- orion-field-digester's container has no
+scripts/ directory, so importing this module at all (which
+app/anomaly_scorer.py does, for the inference-only load_artifacts/
+score_windows functions) crash-looped the whole service.
+
+_pearson/_percentile are only used inside training-only functions
+(prune_correlated_fields, train_autoencoder) -- neither is reachable from
+load_artifacts()/score_windows(), so the import was moved from module scope
+into those two functions specifically. This test asserts the module-level
+import stays gone by directly checking `scripts` is never touched by the
+inference path, run in a subprocess with `scripts` genuinely unimportable
+(not just "happens to not be imported yet" in this process, which could pass
+even with a bug if pytest's own collection already imported `scripts` for an
+unrelated reason).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_fit_encoder_importable_and_inference_usable_without_scripts_on_path() -> None:
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path[:] = [p for p in sys.path if p]  # drop the implicit '' cwd entry
+        sys.path.insert(0, {repo_root!r})
+
+        import builtins
+        _real_import = builtins.__import__
+
+        def _blocking_import(name, *args, **kwargs):
+            if name == "scripts" or name.startswith("scripts."):
+                raise ImportError(f"simulated missing scripts/ package: {{name}}")
+            return _real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _blocking_import
+
+        import orion.mood_arc.fit_encoder as fe
+
+        assert callable(fe.load_artifacts)
+        assert callable(fe.score_windows)
+        assert "scripts" not in sys.modules
+        print("OK")
+        """
+    ).format(repo_root=str(_REPO_ROOT))
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"importing fit_encoder without scripts/ available must succeed "
+        f"(this is exactly what broke orion-field-digester's container).\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_scripts_import_still_works_lazily_when_available(monkeypatch) -> None:
+    """The flip side: with scripts/ genuinely available (the normal dev/CLI
+    environment), prune_correlated_fields()/train_autoencoder()'s lazy
+    imports must still resolve correctly -- this isn't just a deletion, it's
+    a relocation."""
+    import numpy as np
+
+    from orion.mood_arc.fit_encoder import prune_correlated_fields
+    from orion.schemas.telemetry.field_channel_corpus import FieldChannelCorpusRowV1
+    from datetime import datetime, timezone
+
+    rows = [
+        FieldChannelCorpusRowV1(
+            generated_at=datetime.now(timezone.utc),
+            tick_id=f"t{i}",
+            channels={"a": float(i), "b": float(i)},  # perfectly correlated
+        )
+        for i in range(5)
+    ]
+    kept = prune_correlated_fields(rows, fields=("a", "b"), corr_threshold=0.9)
+    assert len(kept) == 1


### PR DESCRIPTION
## Summary

- **Live outage fix.** `orion-field-digester` has been crash-looping since PR #1224 deployed (confirmed live: container in restart loop, `ModuleNotFoundError: No module named 'scripts'`).
- Root cause: `orion/mood_arc/fit_encoder.py` had a module-level `from scripts.fit_phi_encoder import _pearson, _percentile`. `scripts/` is repo-root operator/CLI tooling — never shipped in `orion-field-digester`'s Docker image (it never needed to import `fit_encoder` before this week).
- `services/orion-field-digester/app/anomaly_scorer.py` (from PR #1224) imports `fit_encoder` for the inference-only `load_artifacts()`/`score_windows()` functions. That pulled the `scripts` dependency in transitively at module-import time, crashing the whole service before FastAPI even starts — not just the anomaly feature, the entire field-digestion pipeline (receipts, biometrics, execution trajectories) has been down since restart.
- `_pearson`/`_percentile` are only used inside two training-only functions (`prune_correlated_fields`, `train_autoencoder`) — neither is reachable from the inference path. Moved the import into those two functions specifically.

## Outcome moved

Unblocks `orion-field-digester` from a crash loop. Once merged and redeployed, the whole substrate field-digestion pipeline resumes (not just telemetry_anomaly).

## Current architecture

`orion/mood_arc/fit_encoder.py` is meant to be usable both as a CLI/training tool (needs `scripts/`) and, since PR #1224, as a library import for live inference-only scoring (should not need `scripts/`). The module-level import didn't distinguish these two uses.

## Files changed

- `orion/mood_arc/fit_encoder.py`: removed the module-level `scripts.fit_phi_encoder` import; added it as a local import inside `prune_correlated_fields()` and `train_autoencoder()`.
- `orion/mood_arc/tests/test_fit_encoder_no_scripts_dependency.py`: new regression test. Verifies in a subprocess with `scripts` genuinely blocked from importing (not just "not yet imported in this process," which could pass even with a bug) that `fit_encoder` imports cleanly and `load_artifacts`/`score_windows` are usable. A second test confirms the lazy imports still resolve correctly when `scripts/` is genuinely available.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
venv/bin/python3 -m pytest orion/mood_arc/tests -q
35 passed (33 pre-existing + 2 new)

venv/bin/python3 -m pytest services/orion-field-digester/tests -q
117 passed
```

## Evals run

None applicable.

## Docker/build/smoke checks

Not run from this worktree (no Docker access in this environment) — the fix is verified via the subprocess-level import-blocking test above, which directly reproduces the failure mode (`ModuleNotFoundError: No module named 'scripts'`) seen in the live container logs. Real container verification still needed post-merge — see Restart required.

## Review findings fixed

N/A — dispatched for review in parallel with opening this PR given the live-outage urgency; will report findings separately if any surface.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build
```

**This is urgent** — `orion-field-digester` is currently down (crash-looping) in production.

## Risks / concerns

- Severity: none identified — this removes a broken dependency, doesn't add new behavior.

## PR link

(filled in by gh pr create)