### PR TITLE
fix(agent-board): scope Stop-hook nag to the current session

### DIFF
--- a/scripts/agent_board.py
+++ b/scripts/agent_board.py
@@ -53,6 +53,7 @@ def main(argv: list[str] | None = None) -> int:
     add.add_argument("--scope-note", default="")
     add.add_argument("--parent")
     add.add_argument("--files", nargs="*", default=[])
+    add.add_argument("--session-id")
 
     heartbeat = sub.add_parser("heartbeat")
     heartbeat.add_argument("--summary")
@@ -86,6 +87,7 @@ def main(argv: list[str] | None = None) -> int:
                 scope_note=args.scope_note,
                 related_files=args.files,
                 parent_id=args.parent,
+                session_id=args.session_id,
             )
             print(f"item: {item_id}")
             return 0
@@ -101,6 +103,12 @@ def main(argv: list[str] | None = None) -> int:
             _print_state(load_state(cfg), worktree=args.worktree)
             return 0
         if args.command == "checkout":
+            # Deliberately unfiltered by session_id, unlike the Stop hook's
+            # nag (see scripts/hooks/session_stop_agent_board.py) -- this is
+            # an explicit, deliberate "give me the full picture before I
+            # leave" query, not a per-turn repeat reminder, so it should
+            # surface every open item in the worktree regardless of who
+            # created it.
             current_worktree = current_worktree_identity()["worktree_path"]
             close_presence(cfg)
             state = load_state(cfg)

--- a/scripts/agent_board_lib.py
+++ b/scripts/agent_board_lib.py
@@ -360,9 +360,11 @@ def add_item(
     scope_note: str = "",
     related_files: list[str] | None = None,
     parent_id: str | None = None,
+    session_id: str | None = None,
 ) -> str:
     identity = current_worktree_identity()
     item_id = _new_item_id()
+    resolved_session_id = session_id if session_id is not None else os.environ.get("CLAUDE_CODE_SESSION_ID")
     payload: dict[str, object] = {
         "id": item_id,
         "kind": kind,
@@ -377,6 +379,8 @@ def add_item(
     }
     if parent_id:
         payload["parent_id"] = parent_id
+    if resolved_session_id:
+        payload["session_id"] = resolved_session_id
     validate_item_payload(payload)
     append_event(config, "item_upserted", payload)
     return item_id

--- a/scripts/hooks/session_stop_agent_board.py
+++ b/scripts/hooks/session_stop_agent_board.py
@@ -31,9 +31,24 @@ def main() -> None:
         cfg = board_config_from_env()
         current = resolve_current_identity(cfg, session_id=session_id)["worktree_path"]
         state = load_state(cfg)
+        # Items are worktree-scoped, not session-scoped, so a shared checkout
+        # can accumulate open items across many past sessions -- without the
+        # session_id check below, a fresh read-only session that added zero
+        # items still gets nagged every Stop about work it never touched.
+        # Items with no session_id (added before this field existed, or by a
+        # plain shell call outside Claude Code) have no session to attribute
+        # them to, so they keep nagging rather than going silently unowned.
+        # If *our own* session_id couldn't be resolved (missing/malformed
+        # stdin payload, or a non-Claude-Code harness whose Stop payload
+        # doesn't carry one), we can't tell "mine" from "someone else's"
+        # either -- fail open (fall back to plain worktree scoping) rather
+        # than silently excluding every item that happens to carry a real
+        # session_id.
         open_items = [
             item for item in state.items.values()
-            if item.get("worktree_path") == current and item.get("status") in {"open", "parked"}
+            if item.get("worktree_path") == current
+            and item.get("status") in {"open", "parked"}
+            and (session_id is None or not item.get("session_id") or item.get("session_id") == session_id)
         ]
     except Exception:
         return

--- a/tests/scripts/test_agent_board_cli.py
+++ b/tests/scripts/test_agent_board_cli.py
@@ -10,7 +10,11 @@ CLI = ROOT / "scripts" / "agent_board.py"
 
 
 def _run(cwd: Path, board_path: Path, *args: str) -> subprocess.CompletedProcess:
+    # Strip the real session id this test process may itself be running
+    # under (e.g. a live Claude Code session) so `add_item`'s automatic
+    # CLAUDE_CODE_SESSION_ID tagging stays deterministic across test runs.
     env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board_path)}
+    env.pop("CLAUDE_CODE_SESSION_ID", None)
     return subprocess.run(
         [sys.executable, str(CLI), *args],
         cwd=cwd,

--- a/tests/scripts/test_agent_board_lib.py
+++ b/tests/scripts/test_agent_board_lib.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from agent_board_lib import (  # noqa: E402
     BoardConfig,
+    add_item,
     append_event,
     detect_collisions,
     load_state,
@@ -65,6 +66,50 @@ def test_load_state_materializes_last_presence_event(tmp_path: Path) -> None:
 
     assert state.presence["/repo/wt-a"]["thread_summary"] == "Working on the board."
     assert state.presence["/repo/wt-a"]["current_task"] == "Writing tests."
+
+
+def test_add_item_tags_session_id_from_env_var(
+    primary_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """add_item should tag CLAUDE_CODE_SESSION_ID automatically when no
+    explicit session_id kwarg is given -- callers that go through the CLI's
+    `add` command without --session-id (the common case for an interactive
+    agent's own Bash tool calls) still get their items attributed to the
+    real session, since the Bash tool's subprocess inherits this env var."""
+    cfg = _config(tmp_path)
+    monkeypatch.chdir(primary_repo)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "sess-from-env")
+
+    item_id = add_item(cfg, kind="finding", severity="note", summary="test")
+
+    state = load_state(cfg)
+    assert state.items[item_id]["session_id"] == "sess-from-env"
+
+
+def test_add_item_explicit_session_id_overrides_env_var(
+    primary_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _config(tmp_path)
+    monkeypatch.chdir(primary_repo)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "sess-from-env")
+
+    item_id = add_item(cfg, kind="finding", severity="note", summary="test", session_id="sess-explicit")
+
+    state = load_state(cfg)
+    assert state.items[item_id]["session_id"] == "sess-explicit"
+
+
+def test_add_item_has_no_session_id_when_unset(
+    primary_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _config(tmp_path)
+    monkeypatch.chdir(primary_repo)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+    item_id = add_item(cfg, kind="finding", severity="note", summary="test")
+
+    state = load_state(cfg)
+    assert "session_id" not in state.items[item_id]
 
 
 def test_owner_scope_requires_scope_note_when_not_this_worktree() -> None:

--- a/tests/scripts/test_session_agent_board_hooks.py
+++ b/tests/scripts/test_session_agent_board_hooks.py
@@ -14,7 +14,11 @@ STOP_HOOK = ROOT / "scripts" / "hooks" / "session_stop_agent_board.py"
 def _run_hook(
     hook: Path, cwd: Path, board_path: Path, *, stdin_payload: dict | None = None
 ) -> subprocess.CompletedProcess:
+    # Strip the real session id this test process may itself be running
+    # under (e.g. a live Claude Code session) so tests only see the
+    # session_id explicitly passed via stdin_payload, not ambient env.
     env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board_path)}
+    env.pop("CLAUDE_CODE_SESSION_ID", None)
     # Explicit input= regardless of whether a real payload is given -- these
     # hooks now read stdin (for session_id), and relying on however pytest
     # happens to have stdin configured is fragile; an empty string mimics
@@ -73,7 +77,12 @@ def test_hooks_noop_for_fcc_subprocess(primary_repo: Path, tmp_path: Path) -> No
     and add noise to the FCC harness step count. fcc_motor.py tags its
     subprocess env with ORION_FCC_SUBPROCESS=1 for exactly this check."""
     board = tmp_path / "agent-board.jsonl"
+    # Strip the real session id this test process may itself be running
+    # under -- harmless today since the ORION_FCC_SUBPROCESS gate returns
+    # before either hook reads session_id, but kept consistent with the
+    # other helpers in this file so it stays harmless if that changes.
     env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board), "ORION_FCC_SUBPROCESS": "1"}
+    env.pop("CLAUDE_CODE_SESSION_ID", None)
 
     start = subprocess.run(
         [sys.executable, str(START_HOOK)],
@@ -116,6 +125,7 @@ def test_hooks_fail_open_outside_git_repo(tmp_path: Path) -> None:
 
 def _run_board_cli(cwd: Path, board_path: Path, *args: str) -> subprocess.CompletedProcess:
     env = {**os.environ, "ORION_AGENT_BOARD_PATH": str(board_path)}
+    env.pop("CLAUDE_CODE_SESSION_ID", None)
     return subprocess.run(
         [sys.executable, str(ROOT / "scripts" / "agent_board.py"), *args],
         cwd=cwd,
@@ -210,6 +220,118 @@ def test_session_start_hook_resolves_via_session_id_not_fixed_cwd(
     payload = json.loads(proc.stdout)
     context = payload["hookSpecificOutput"]["additionalContext"]
     assert "remember to check X" in context
+
+
+def test_stop_hook_does_not_nag_about_a_different_sessions_items(
+    primary_repo: Path, tmp_path: Path
+) -> None:
+    """Regression test: items are worktree-scoped, not session-scoped, so a
+    shared checkout accumulates open items across every past session that
+    ever worked there. A fresh session that added zero items of its own
+    should not be nagged every Stop about items a *different* session
+    opened -- only about its own open items (or legacy items with no
+    session_id at all, which have no session to attribute them to)."""
+    board = tmp_path / "agent-board.jsonl"
+    other_session = "sess-other-111"
+    add = _run_board_cli(
+        primary_repo,
+        board,
+        "add",
+        "--kind",
+        "finding",
+        "--severity",
+        "note",
+        "--summary",
+        "found by a different session",
+        "--session-id",
+        other_session,
+    )
+    assert add.returncode == 0, add.stderr
+
+    proc = _run_hook(STOP_HOOK, primary_repo, board, stdin_payload={"session_id": "sess-me-222"})
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == ""
+
+
+def test_stop_hook_still_nags_about_this_sessions_own_items(
+    primary_repo: Path, tmp_path: Path
+) -> None:
+    """Items this session itself opened must still surface in the nag --
+    the fix scopes out *other* sessions' items, not all items."""
+    board = tmp_path / "agent-board.jsonl"
+    session_id = "sess-me-333"
+    add = _run_board_cli(
+        primary_repo,
+        board,
+        "add",
+        "--kind",
+        "finding",
+        "--severity",
+        "note",
+        "--summary",
+        "found by me",
+        "--session-id",
+        session_id,
+    )
+    assert add.returncode == 0, add.stderr
+
+    proc = _run_hook(STOP_HOOK, primary_repo, board, stdin_payload={"session_id": session_id})
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert "1 open item" in payload["hookSpecificOutput"]["additionalContext"]
+
+
+def test_stop_hook_still_nags_when_its_own_session_id_is_unresolved(
+    primary_repo: Path, tmp_path: Path
+) -> None:
+    """Regression test for a review-caught bug: if the hook can't resolve
+    its OWN session_id (missing/malformed stdin payload, or a non-Claude-Code
+    harness whose Stop payload doesn't carry one), it can't tell "this
+    session's item" from "some other session's item" either. The fix must
+    fail open (fall back to plain worktree scoping) in that case, not
+    silently treat every session_id-tagged item as belonging to someone
+    else. A naive `item_session_id == session_id` check with session_id=None
+    would incorrectly exclude this item."""
+    board = tmp_path / "agent-board.jsonl"
+    add = _run_board_cli(
+        primary_repo,
+        board,
+        "add",
+        "--kind",
+        "finding",
+        "--severity",
+        "note",
+        "--summary",
+        "tagged item",
+        "--session-id",
+        "sess-real-555",
+    )
+    assert add.returncode == 0, add.stderr
+
+    # No stdin_payload at all -- session_id resolves to None, same as a
+    # malformed/absent Stop payload.
+    proc = _run_hook(STOP_HOOK, primary_repo, board)
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert "1 open item" in payload["hookSpecificOutput"]["additionalContext"]
+
+
+def test_stop_hook_still_nags_about_legacy_items_with_no_session_id(
+    primary_repo: Path, tmp_path: Path
+) -> None:
+    """Items added before this field existed (or via a plain shell call
+    outside Claude Code) have no session_id to attribute them to -- they
+    must keep nagging rather than silently going unowned forever."""
+    board = tmp_path / "agent-board.jsonl"
+    add = _run_board_cli(
+        primary_repo, board, "add", "--kind", "finding", "--severity", "note", "--summary", "legacy item"
+    )
+    assert add.returncode == 0, add.stderr
+
+    proc = _run_hook(STOP_HOOK, primary_repo, board, stdin_payload={"session_id": "sess-me-444"})
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert "1 open item" in payload["hookSpecificOutput"]["additionalContext"]
 
 
 def test_cursor_hooks_file_calls_agent_board_scripts() -> None:


### PR DESCRIPTION
## Summary

- Agent-board items were worktree-scoped only, so the Stop hook's "N open items remain" reminder nagged every session in a shared worktree about items any *past* session left open, even a fresh read-only session that created zero items.
- `add_item()` now tags new items with `CLAUDE_CODE_SESSION_ID` (or an explicit `--session-id` override, mirroring the existing `heartbeat --session-id` flag).
- The Stop hook now only nags about items tagged with a *different* session, or with no session_id at all (legacy items / items added outside Claude Code -- these still nag since there's no session to attribute them to).
- Fail-open safeguard: if the hook can't resolve its own session_id (missing/malformed stdin payload, or a non-Claude-Code harness like Cursor if its Stop payload shape differs), it falls back to the old worktree-only behavior instead of silently excluding every session_id-tagged item.

## Outcome moved

A session that adds zero board items, or only items under its own session_id, is no longer nagged every Stop about unrelated pre-existing open items in a shared worktree (e.g. the main checkout).

## Current architecture

`scripts/hooks/session_stop_agent_board.py` reminded the agent to check out or resolve open board items, filtering purely by `item["worktree_path"] == current_worktree`. `add_item()` in `scripts/agent_board_lib.py` never recorded who created an item, only `worktree_path`/`branch`.

## Architecture touched

- `scripts/agent_board_lib.py`: `add_item()` gains an optional `session_id` kwarg, defaulting to `os.environ.get("CLAUDE_CODE_SESSION_ID")`.
- `scripts/agent_board.py`: `add` subcommand gains `--session-id`.
- `scripts/hooks/session_stop_agent_board.py`: nag filter now session-aware, with a documented fail-open path.

## Files changed

- `scripts/agent_board_lib.py`: `add_item()` now stamps `session_id` on new items.
- `scripts/agent_board.py`: `add` subcommand accepts `--session-id`; documented why `checkout` deliberately stays unfiltered by session.
- `scripts/hooks/session_stop_agent_board.py`: nag filter scoped to current session, with fail-open handling when the hook's own session_id is unresolved.
- `tests/scripts/test_agent_board_lib.py`: unit tests for `add_item`'s session_id resolution (env default, explicit override, unset).
- `tests/scripts/test_session_agent_board_hooks.py`: regression tests for the new filter (own-session nags, other-session doesn't, legacy no-session-id item still nags, unresolved-own-session-id fails open); env-isolation fix so these tests are deterministic regardless of the real session running them.
- `tests/scripts/test_agent_board_cli.py`: same env-isolation fix.

## Schema / bus / API changes

- Added: optional `session_id` field on agent-board items (backward compatible -- absent on items that predate this change, and those are treated as always-nag legacy items).
- Removed: none.
- Renamed: none.
- Behavior changed: Stop hook nag is now session-scoped instead of purely worktree-scoped.
- Compatibility notes: none required; `validate_item_payload` treats `session_id` as unvalidated passthrough metadata, same as `branch`.

## Env/config changes

None. No `.env_example` changes; this repo's `CLAUDE_CODE_SESSION_ID` is set automatically by the Claude Code harness's own Bash tool subprocess environment, not something operators configure.

## Tests run

```text
python3 -m pytest tests/scripts/ -q -k "agent_board"
44 passed
```

## Evals run

No dedicated eval harness for this service; tests above are the full coverage for this seam.

## Docker/build/smoke checks

Not applicable -- pure Python scripts/hooks, no Docker-relevant runtime behavior touched.

## Review findings fixed

- Finding: the Stop-hook filter's boolean logic (`not item.get("session_id") or item.get("session_id") == session_id`) silently excluded items that DO carry a `session_id` whenever the hook's own `session_id` resolved to `None` (malformed/absent stdin payload, or a non-Claude-Code harness like Cursor) -- inverting the intended fail-open design.
  - Fix: added `session_id is None or ...` to the filter so an unresolved own-identity falls back to the old worktree-only (always nag) behavior instead of silently narrowing to untagged items only.
  - Evidence: added `test_stop_hook_still_nags_when_its_own_session_id_is_unresolved`, which reproduces exactly this case and fails without the fix.
- Finding: no regression test covered the above case, so the bug would have shipped invisibly.
  - Fix: added the test above.
  - Evidence: `pytest tests/scripts/test_session_agent_board_hooks.py -q` passes with the new test included.
- Finding: three existing tests (`test_session_stop_hook_emits_checkout_context`, `test_stop_hook_uses_session_id_to_find_the_real_worktree`, plus one new test) failed nondeterministically because the real `CLAUDE_CODE_SESSION_ID` from the live Claude Code session running these tests leaked into subprocess env via `{**os.environ, ...}`.
  - Fix: strip `CLAUDE_CODE_SESSION_ID` in all subprocess-invoking test helpers (`test_agent_board_cli.py::_run`, `test_session_agent_board_hooks.py::_run_hook`/`_run_board_cli`, and the FCC-subprocess test for consistency).
  - Evidence: full suite passes (44/44) regardless of ambient session env.
- Finding (low severity, addressed via comment not code change): `checkout`'s "Open items remain: N" report is intentionally NOT session-scoped (unlike the Stop hook), which could look inconsistent without explanation.
  - Fix: added a comment at the `checkout` call site explaining this is a deliberate "full picture before I leave" query, not a repeat-noise reminder.
  - Evidence: `scripts/agent_board.py` checkout block.

## Restart required

No restart required -- these are hook scripts invoked fresh on every Claude Code Stop/SessionStart event, no long-running process to restart.

## Risks / concerns

- Severity: low
- Concern: items added by a human running `agent_board.py add` directly from a plain shell (no Claude Code session) still have no `session_id` and will keep nagging every session in that worktree until resolved/parked -- this is the accepted, documented tradeoff (no session to attribute unowned items to), not a bug.
- Mitigation: none needed; matches the explicitly agreed design.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/agent-board-stop-hook-session-scope