### PR TITLE
feat(analysis): emergent-clustering probe for O4 (Sentience Striving Program §6 item 5)

### DIFF
--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -239,6 +239,56 @@ first place. Full reasoning and phased detail:
    this program.
 5. **Run the emergent-clustering probe** on real coalition-winning history (not built yet,
    named in the baseline design) — toward O4.
+   **Status (2026-07-21): built and run against real data; the baseline design's acceptance
+   check reads AMBIGUOUS, and the separate monoculture comparison reads NOT MET.**
+   `scripts/analysis/measure_emergent_clustering_probe.py` pulls real, historical
+   `FieldAttentionFrameV1` rows from Postgres `substrate_attention_frames` (verified live
+   table, written by `services/orion-attention-runtime/app/store.py::save_attention_frame()`;
+   127,936 rows spanning ~72h as of the run), splits them into two non-overlapping 24h
+   windows separated by a 12h gap, and runs correlation-based grouping over
+   `dominant_targets`/`capability_targets` salience-score time series — per the baseline
+   design's own non-goal against a from-scratch ML clustering pipeline. Read-only; imports
+   nothing from `orion.spark.concept_induction`.
+   **Real numbers found:** the target universe is small by construction (9 distinct
+   `target_id`s total — `dominant_targets` is a capped union of node/capability/system
+   targets, not an independently-sampled top-N), capping the correlation matrix at 36
+   possible pairs, of which 21 had a real (non-degenerate) value in both windows. Exactly one
+   pair cleared the clustering threshold (`corr >= 0.5`) in either window —
+   `capability:llm_inference` <-> `node:atlas` — and it did so in **both** windows with
+   near-identical magnitude (r=0.9228 window A, r=0.9210 window B; correlation-of-correlations
+   over the 21 common pairs = 0.9940; edge-set Jaccard = 1.0). This is real, stable, recurring,
+   non-random structure — the opposite of noise — but because it is the *only* surviving edge
+   in both windows, the design's literal "not identical" bar can't be cleanly separated from
+   "recognizably similar": the script's own classifier (`classify_similarity`, explicit
+   documented bands) reports **AMBIGUOUS**, not a forced MET or NOT MET, and that is the
+   honest read: a real, non-trivial, cross-window-stable coalition pair was found, but the
+   currently-instrumented target universe is too sparse (1 of 36 possible pairs) to
+   demonstrate the richer, multi-cluster "not identical" case the design anticipated.
+   **Separately, item 5's monoculture-differentiation check reads NOT MET, and is the more
+   load-bearing finding of this patch.** The closest real analog to the drives system's
+   `dominant_drive` — the single highest-salience target per tick — is `field:recent_
+   perturbations` in **99.98%** of all 127,936 real ticks measured (`node:athena` and
+   `capability:transport` split the remaining 0.02%). That is at or above the drives system's
+   own documented *pre-fix* 96% `dominant_drive=relational` monoculture
+   (`orion/autonomy/drives_and_autonomy_retrospective.md` ~line 177), and far above its
+   *post-fix* ~31.65% (~line 267). This is exactly the pathology the baseline design's own
+   Missing Question 1 named as the risk to check for before trusting emergent clustering here
+   ("can we tell a real, meaningful coalition of channels apart from 'resource_pressure always
+   wins because it's noisiest,' the exact 96%-dominant-drive monoculture pathology already
+   found once?") — the answer, measured, is: not yet, with the naive top-1-winner framing.
+   `field:recent_perturbations`' salience formula (`min(1.0, recent_perturbation_count / 10.0)`,
+   `orion/attention/field_attention/selectors.py::select_system_targets`) saturates to ~1.0
+   under the field's real, near-constant perturbation rate, structurally out-competing every
+   other target for top rank almost always — the same "noisiest wins" shape as the pre-fix
+   drives pathology, just on a different signal. Full report, correlation matrices, and
+   per-target membership frequencies: run the script (`--window-hours 24 --gap-hours 12`
+   reproduces this measurement) or see its `/tmp/emergent-clustering-probe/report.md` output.
+   Recommended next step, not taken in this patch: either exclude system-kind targets (whose
+   salience formula is structurally different from node/capability pressure) from the
+   top-1-winner comparison and re-measure, or treat this finding as real evidence that
+   `select_system_targets`' formula itself needs the same delta-gating/normalization
+   discipline the O1-O3 drives fixes applied to `DriveEngine` before this probe's numbers can
+   be trusted as representative of the *node/capability* coalition structure specifically.
 6. **Revisit `capability_policy.py`'s coupling to live salience** — only after item 3 closes
    the `drive_origin` dependency and item 2's field-native attention is proven, not assumed.
    At this point the actual mechanism is a real open choice, not a given: a salience-to-

--- a/scripts/analysis/measure_emergent_clustering_probe.py
+++ b/scripts/analysis/measure_emergent_clustering_probe.py
@@ -205,10 +205,22 @@ def align_series(raw_maps: list[dict[str, float]], target_ids: list[str]) -> dic
 def pearson_correlation(x: list[float], y: list[float]) -> Optional[float]:
     """Plain-Python Pearson correlation, no numpy/scipy dependency (matches
     this patch's constraint against pulling in a clustering/ML library for
-    day one). Returns None if the series lengths mismatch, are too short, or
-    either series is degenerate (near-zero variance -- flat/constant, not
-    real signal; see the metric-quality-gate "not degenerate" check)."""
+    day one). Returns None if the series lengths mismatch, are too short,
+    contain a non-finite value (NaN/inf -- a malformed upstream salience
+    value, not real signal), or either series is degenerate (near-zero
+    variance -- flat/constant, not real signal; see the metric-quality-gate
+    "not degenerate" check).
+
+    Deliberate NaN handling: Python's `min`/`max` do NOT reliably reject NaN
+    (`min(1.0, float("nan"))` returns `1.0`, since NaN comparisons are always
+    False), so a NaN-poisoned series would otherwise silently clamp to a
+    false "perfect correlation" instead of being caught by the variance
+    check above (variance involving NaN is itself NaN, which also fails to
+    trip the `<=` comparison). Checked explicitly, up front, before any
+    arithmetic that could propagate it."""
     if len(x) != len(y) or len(x) < 2:
+        return None
+    if any(not math.isfinite(v) for v in x) or any(not math.isfinite(v) for v in y):
         return None
     n = len(x)
     mean_x = sum(x) / n
@@ -428,6 +440,33 @@ def choose_windows(
     return None
 
 
+def partition_by_window(
+    timestamps: list[datetime],
+    raw_maps: list[dict[str, float]],
+    win_a: WindowSpec,
+    win_b: WindowSpec,
+) -> tuple[list[dict[str, float]], list[dict[str, float]]]:
+    """Split `raw_maps` into (window A, window B) by their aligned
+    `timestamps`, guaranteeing a real, non-overlapping partition even when
+    `win_a.end == win_b.start` exactly -- `choose_windows`' degraded
+    back-to-back path produces exactly that shared boundary instant when the
+    real data span is too short for a real gap. Half-open on window A's
+    upper bound (`win_a.start <= ts < win_a.end`), inclusive on window B's
+    both ends (`win_b.start <= ts <= win_b.end`, so the very last real row,
+    exactly at `max_ts`, is still counted) -- a row landing exactly on the
+    shared boundary goes to B only, never both. Makes no difference in the
+    ample-span case, where `win_a.end < win_b.start` with real daylight
+    between them."""
+    maps_a: list[dict[str, float]] = []
+    maps_b: list[dict[str, float]] = []
+    for ts, m in zip(timestamps, raw_maps):
+        if win_a.start <= ts < win_a.end:
+            maps_a.append(m)
+        elif win_b.start <= ts <= win_b.end:
+            maps_b.append(m)
+    return maps_a, maps_b
+
+
 # ===========================================================================
 # I/O layer -- psycopg2 read-only. Connection contract mirrors
 # measure_ast_hot_reducer.py / measure_capability_salience_coupling.py
@@ -586,13 +625,12 @@ def _corr_matrix_table(target_ids: list[str], corr_matrix: CorrMatrix) -> list[s
 def render_report(
     *,
     global_window_label: str,
-    global_start: Optional[datetime],
-    global_end: Optional[datetime],
     total_rows: int,
     windows: Optional[tuple[WindowSpec, WindowSpec]],
     window_a_n: int,
     window_b_n: int,
     target_ids: list[str],
+    full_target_ids: list[str],
     corr_a: CorrMatrix,
     corr_b: CorrMatrix,
     clusters_a: list[list[str]],
@@ -750,7 +788,11 @@ def render_report(
             "| --- | --- |",
         ]
     )
-    for target_id in target_ids:
+    # Deliberately `full_target_ids`, NOT the window-scoped `target_ids` used
+    # by the correlation matrices above -- this table's own text (just above)
+    # claims full-history scope, so a target seen in full history but never
+    # inside either probe window must still appear here.
+    for target_id in full_target_ids:
         pct = full_history_membership.get(target_id, 0.0) * 100
         lines.append(f"| `{target_id}` | {pct:.2f}% |")
 
@@ -839,8 +881,9 @@ def run(
             pass
         progress.close()
         report = render_report(
-            global_window_label="n/a (insufficient data)", global_start=min_ts, global_end=max_ts,
+            global_window_label="n/a (insufficient data)",
             total_rows=total_rows, windows=None, window_a_n=0, window_b_n=0, target_ids=[],
+            full_target_ids=[],
             corr_a={}, corr_b={}, clusters_a=[], clusters_b=[], edges_a=set(), edges_b=set(),
             jaccard=None, corr_of_corr=None, n_common_pairs=0,
             classification="INCONCLUSIVE_INSUFFICIENT_PAIRS", full_history_top1=Counter(),
@@ -854,7 +897,14 @@ def run(
 
     all_rows, truncated = fetch_target_rows(conn, min_ts, max_ts, MAX_ROWS)
     if truncated:
-        caveats.append(f"full-history rows truncated at MAX_ROWS={MAX_ROWS}")
+        caveats.append(
+            f"full-history rows truncated at MAX_ROWS={MAX_ROWS} -- the fetch is ORDER BY "
+            "generated_at ASC, so truncation keeps the OLDEST rows and drops the newest, "
+            "which would disproportionately starve window B (the end-anchored/'newest' "
+            "window) rather than shrinking both windows evenly. Not triggered at current "
+            "real data volume (well under MAX_ROWS as of this run), but treat window B's "
+            "numbers as suspect if this caveat is ever present."
+        )
     progress.emit("full history fetched", percent=25.0, processed=len(all_rows), total=len(all_rows))
 
     try:
@@ -878,9 +928,10 @@ def run(
         )
         write_ticks_csv(CSV_PATH, all_raw_maps, all_timestamps, full_target_ids)
         report = render_report(
-            global_window_label=global_label, global_start=min_ts, global_end=max_ts,
+            global_window_label=global_label,
             total_rows=total_rows, windows=None, window_a_n=0, window_b_n=0,
-            target_ids=full_target_ids, corr_a={}, corr_b={}, clusters_a=[], clusters_b=[],
+            target_ids=full_target_ids, full_target_ids=full_target_ids,
+            corr_a={}, corr_b={}, clusters_a=[], clusters_b=[],
             edges_a=set(), edges_b=set(), jaccard=None, corr_of_corr=None, n_common_pairs=0,
             classification="INCONCLUSIVE_INSUFFICIENT_PAIRS", full_history_top1=full_history_top1,
             full_history_n=len(all_raw_maps), full_history_membership=full_history_membership,
@@ -892,10 +943,7 @@ def run(
         return 2
 
     win_a, win_b = windows
-    rows_a = [(ts, m) for ts, m in zip(all_timestamps, all_raw_maps) if win_a.start <= ts <= win_a.end]
-    rows_b = [(ts, m) for ts, m in zip(all_timestamps, all_raw_maps) if win_b.start <= ts <= win_b.end]
-    maps_a = [m for _, m in rows_a]
-    maps_b = [m for _, m in rows_b]
+    maps_a, maps_b = partition_by_window(all_timestamps, all_raw_maps, win_a, win_b)
     progress.emit("windows partitioned", percent=55.0, processed=len(maps_a) + len(maps_b), total=len(all_raw_maps))
 
     if len(maps_a) < MIN_WINDOW_ROWS:
@@ -922,9 +970,10 @@ def run(
 
     write_ticks_csv(CSV_PATH, all_raw_maps, all_timestamps, full_target_ids)
     report = render_report(
-        global_window_label=global_label, global_start=min_ts, global_end=max_ts,
+        global_window_label=global_label,
         total_rows=total_rows, windows=windows, window_a_n=len(maps_a), window_b_n=len(maps_b),
-        target_ids=shared_target_ids, corr_a=corr_a, corr_b=corr_b, clusters_a=clusters_a,
+        target_ids=shared_target_ids, full_target_ids=full_target_ids,
+        corr_a=corr_a, corr_b=corr_b, clusters_a=clusters_a,
         clusters_b=clusters_b, edges_a=edges_a, edges_b=edges_b, jaccard=jaccard,
         corr_of_corr=corr_of_corr, n_common_pairs=n_common_pairs, classification=classification,
         full_history_top1=full_history_top1, full_history_n=len(all_raw_maps),

--- a/scripts/analysis/measure_emergent_clustering_probe.py
+++ b/scripts/analysis/measure_emergent_clustering_probe.py
@@ -1,0 +1,966 @@
+#!/usr/bin/env python3
+"""Read-only emergent-clustering probe over real `FieldAttentionFrameV1` history.
+
+Sentience Striving Program (`orion/sentience_striving_program/README.md`) §6
+item 5, toward outcome O4: *"the 'what are Orion's drives' question is
+answered empirically, continuously, not asserted once by a human design
+chat."* This is the "Recommended next patch" from
+`docs/superpowers/specs/2026-07-17-field-native-motivational-substrate-
+design.md`: pull real, historical `FieldAttentionFrameV1` rows already
+produced live by `orion-attention-runtime`, and check with real numbers
+whether `dominant_targets`/`capability_targets` produce (a) recognizably
+similar, non-identical, non-random groupings across two historical windows
+via correlation-based grouping (the baseline design's literal acceptance
+check), and (b) a differentiation profile meaningfully different from the
+drives system's own documented 96%-`dominant_drive`-monoculture pathology.
+
+**Verified table (not assumed):** `orion/attention/field_attention/
+{scoring,selectors,builder}.py` computes `FieldAttentionFrameV1` in-process;
+`services/orion-attention-runtime/app/store.py::save_attention_frame()` is
+the actual write path, persisting to Postgres `substrate_attention_frames`
+(`frame_json` jsonb column). Confirmed live via `\\d substrate_attention_
+frames` and a row-count query (2026-07-21): 127,953+ rows spanning
+~2026-07-18T19:34Z to ~2026-07-21T19:35Z (~72h retention, matching the
+design doc's own "~43k rows/day retained 72h" characterization).
+
+This performs NO writes, emits NO events, flips NO flags, and imports
+NOTHING from `orion.spark.concept_induction` (per this patch's own hard
+constraint) -- the drives-system comparison numbers below are transcribed,
+with citations, from `orion/autonomy/drives_and_autonomy_retrospective.md`
+as plain float constants, not imported code.
+
+## Disclosed scoping decisions (baseline design under-specifies these)
+
+The baseline design names "correlation-based grouping" and "recognizably
+similar (not identical, not random)" but does not specify a concrete
+similarity metric, window size, or classification bands. Decided here,
+stated plainly rather than silently assumed:
+
+1. **Target universe is small by construction.** Live data shows only
+   ~9 distinct `target_id`s ever appear (3 nodes, up to 5 capabilities,
+   1 system target) -- `FieldAttentionFrameV1.dominant_targets` is a
+   *capped union* of `node_targets + capability_targets + system_targets`
+   (confirmed by reading `orion/attention/field_attention/builder.py`), not
+   an independently-sampled top-N out of a large pool. This caps the
+   correlation matrix at C(9,2)=36 possible pairs. That is real, not a
+   defect of this script -- reported honestly, including how many of those
+   36 pairs turn out non-degenerate.
+2. **Absence = 0.0 salience**, same convention as the sibling script
+   `measure_capability_salience_coupling.py::extract_salience_for_target`
+   (a target absent from a tick's list means it fell below the live
+   policy's `min_salience=0.10`, not a missing observation).
+3. **Correlation signal: per-target `salience_score` time series, not
+   binary presence.** Binary co-occurrence is close to degenerate here
+   (several targets are present on >99% of ticks by construction -- see
+   finding below), so the magnitude series carries the real information
+   about which targets rise and fall together.
+4. **Similarity metric, two independent measures, both reported:**
+   - *Correlation-of-correlations*: flatten each window's pairwise
+     correlation matrix (restricted to pairs with a real, non-degenerate
+     value in BOTH windows) into a vector and take the Pearson correlation
+     between the two windows' vectors. This is the standard way to ask "do
+     two correlation structures agree," used the same way a Mantel test or
+     RV-coefficient compares two correlation/distance matrices. Requires
+     >= 3 common non-degenerate pairs to be meaningful (n=1 or n=2 makes
+     "correlation of correlations" undefined in any useful sense -- reported
+     as `INCONCLUSIVE_INSUFFICIENT_PAIRS`, not forced to a number).
+   - *Jaccard overlap of "co-winning" pairs*: the set of pairs whose
+     correlation clears `CORR_CLUSTER_THRESHOLD` (0.5) in each window,
+     compared by Jaccard index. This is the literal "top co-occurring
+     pairs" metric named as an option in the task brief.
+5. **Classification bands** (`classify_similarity`): explicit, documented
+   numeric thresholds -- see that function's docstring for the exact bands
+   and the reasoning for each. Not asserted as universally correct, just
+   disclosed rather than hidden in an if/else.
+6. **Window sizing**: chosen from the real observed data span, not a fixed
+   guess. Default 24h windows with a 12h gap between them (`choose_windows`)
+   -- checked live to fit inside the real ~72h retention window with room
+   to spare (24 + 12 + 24 = 60h <= ~72h available as of 2026-07-21).
+   `choose_windows` degrades gracefully (shrinks the window, drops the gap)
+   if run against a shorter real span, and returns `None` (reported as
+   insufficient data, not a fabricated split) if even that isn't possible.
+
+Run:
+    python scripts/analysis/measure_emergent_clustering_probe.py --window-hours 24 --gap-hours 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import time
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("orion.analysis.emergent_clustering_probe")
+
+DEFAULT_WINDOW_HOURS: float = 24.0
+DEFAULT_GAP_HOURS: float = 12.0
+MIN_WINDOW_HOURS: float = 4.0
+CORR_CLUSTER_THRESHOLD: float = 0.5
+DEGENERATE_VARIANCE_EPS: float = 1e-12
+MIN_COMMON_PAIRS_FOR_CORR_OF_CORR: int = 3
+MIN_TOTAL_ROWS: int = 200
+MIN_WINDOW_ROWS: int = 50
+MAX_ROWS: int = 200_000
+
+# From orion/autonomy/drives_and_autonomy_retrospective.md, transcribed as
+# plain float constants (NOT imported code -- this script imports nothing
+# from orion.spark.concept_induction, per this patch's hard constraint).
+# Line ~177: "producing dominant_drive=relational in 96% of ticks" (the
+# pre-fix pathology this task explicitly names). Line ~267: post O1/O2/O3
+# fix, "top dominant-drive share dropped from the 96% relational monoculture
+# ... down to 31.65%". Line ~487: a later measurement held at "top share
+# 32.05%". Both post-fix numbers are close; 31.65% is used as the primary
+# post-fix reference since it is the first, most-cited post-fix figure.
+DRIVES_DOMINANT_SHARE_PRE_FIX: float = 0.96
+DRIVES_DOMINANT_SHARE_POST_FIX: float = 0.3165
+
+OUTPUT_DIR = Path("/tmp/emergent-clustering-probe")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+CSV_PATH = OUTPUT_DIR / "ticks.csv"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Parses raw frame_json target lists, builds aligned
+# series, computes correlation matrices, clusters, and similarity metrics.
+# Exercised directly by unit tests with synthetic fixtures, no DB.
+# ===========================================================================
+
+
+def _parse_target_list(raw: Any) -> list[dict]:
+    """Parse a raw `frame_json->'dominant_targets'` or `->'capability_targets'`
+    value (possibly a JSON string, possibly malformed, possibly None) into a
+    list of dict entries. Never raises."""
+    try:
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            raw = json.loads(raw)
+        if not isinstance(raw, list):
+            return []
+        return [e for e in raw if isinstance(e, dict)]
+    except Exception:
+        return []
+
+
+def extract_target_salience_map(dominant_raw: Any, capability_raw: Any) -> dict[str, float]:
+    """Merge one tick's `dominant_targets` and `capability_targets` raw JSON
+    into a single {target_id: salience_score} map. `dominant_targets` is
+    authoritative (it is the capped union computed by
+    `orion/attention/field_attention/builder.py::build_attention_frame`);
+    `capability_targets` only fills in a target_id that, for some reason,
+    didn't make it into `dominant_targets` (defensive, not expected on real
+    data -- see module docstring finding #1). Never raises."""
+    result: dict[str, float] = {}
+    for entry in _parse_target_list(dominant_raw):
+        tid = entry.get("target_id")
+        if not isinstance(tid, str):
+            continue
+        try:
+            score = float(entry.get("salience_score", 0.0))
+        except (TypeError, ValueError):
+            score = 0.0
+        result[tid] = score
+    for entry in _parse_target_list(capability_raw):
+        tid = entry.get("target_id")
+        if not isinstance(tid, str) or tid in result:
+            continue
+        try:
+            score = float(entry.get("salience_score", 0.0))
+        except (TypeError, ValueError):
+            score = 0.0
+        result[tid] = score
+    return result
+
+
+def build_target_universe(raw_maps: list[dict[str, float]]) -> list[str]:
+    """Sorted, deduped target_ids observed anywhere in `raw_maps`."""
+    seen: set[str] = set()
+    for m in raw_maps:
+        seen.update(m.keys())
+    return sorted(seen)
+
+
+def align_series(raw_maps: list[dict[str, float]], target_ids: list[str]) -> dict[str, list[float]]:
+    """Per-target salience_score series aligned to `raw_maps`' tick order.
+    Absence in a tick's map -> 0.0 (see module docstring, disclosed decision
+    #2)."""
+    series: dict[str, list[float]] = {t: [] for t in target_ids}
+    for m in raw_maps:
+        for t in target_ids:
+            series[t].append(float(m.get(t, 0.0)))
+    return series
+
+
+def pearson_correlation(x: list[float], y: list[float]) -> Optional[float]:
+    """Plain-Python Pearson correlation, no numpy/scipy dependency (matches
+    this patch's constraint against pulling in a clustering/ML library for
+    day one). Returns None if the series lengths mismatch, are too short, or
+    either series is degenerate (near-zero variance -- flat/constant, not
+    real signal; see the metric-quality-gate "not degenerate" check)."""
+    if len(x) != len(y) or len(x) < 2:
+        return None
+    n = len(x)
+    mean_x = sum(x) / n
+    mean_y = sum(y) / n
+    var_x = sum((xi - mean_x) ** 2 for xi in x)
+    var_y = sum((yi - mean_y) ** 2 for yi in y)
+    if var_x <= DEGENERATE_VARIANCE_EPS or var_y <= DEGENERATE_VARIANCE_EPS:
+        return None
+    cov = sum((xi - mean_x) * (yi - mean_y) for xi, yi in zip(x, y))
+    denom = math.sqrt(var_x * var_y)
+    if denom == 0:
+        return None
+    r = cov / denom
+    return max(-1.0, min(1.0, r))
+
+
+CorrMatrix = dict[tuple[str, str], Optional[float]]
+
+
+def compute_correlation_matrix(target_ids: list[str], series: dict[str, list[float]]) -> CorrMatrix:
+    """Pairwise Pearson correlation over the upper triangle, keyed by
+    (target_a, target_b) with target_a < target_b lexicographically for a
+    deterministic key regardless of `target_ids` order."""
+    matrix: CorrMatrix = {}
+    ordered = sorted(target_ids)
+    for i in range(len(ordered)):
+        for j in range(i + 1, len(ordered)):
+            a, b = ordered[i], ordered[j]
+            matrix[(a, b)] = pearson_correlation(series[a], series[b])
+    return matrix
+
+
+def cluster_by_correlation(
+    target_ids: list[str], corr_matrix: CorrMatrix, threshold: float = CORR_CLUSTER_THRESHOLD
+) -> list[list[str]]:
+    """Union-find grouping: two targets join the same cluster iff their
+    salience correlation is real (non-None) and >= threshold. Unconnected
+    or degenerate targets end up as singleton clusters -- this is the
+    correlation-based grouping the baseline design names as the day-one
+    starting point (not a from-scratch ML clustering pipeline, per its own
+    non-goal)."""
+    parent = {t: t for t in target_ids}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for (a, b), r in corr_matrix.items():
+        if r is not None and r >= threshold:
+            union(a, b)
+
+    groups: dict[str, list[str]] = {}
+    for t in target_ids:
+        groups.setdefault(find(t), []).append(t)
+    clusters = [sorted(g) for g in groups.values()]
+    clusters.sort(key=lambda g: (-len(g), g))
+    return clusters
+
+
+def edge_set_at_threshold(corr_matrix: CorrMatrix, threshold: float = CORR_CLUSTER_THRESHOLD) -> set[tuple[str, str]]:
+    return {pair for pair, r in corr_matrix.items() if r is not None and r >= threshold}
+
+
+def jaccard_similarity(a: set, b: set) -> Optional[float]:
+    """None only when both sets are empty (undefined, not zero -- zero would
+    falsely read as 'maximally dissimilar' when really there was nothing to
+    compare)."""
+    union = a | b
+    if not union:
+        return None
+    return len(a & b) / len(union)
+
+
+def correlation_of_correlations(corr_a: CorrMatrix, corr_b: CorrMatrix) -> tuple[Optional[float], int]:
+    """Pearson correlation between two windows' flattened correlation
+    matrices, restricted to pairs with a real (non-None) value in BOTH.
+    Returns (value, n_common_pairs); value is None if n_common_pairs < 3
+    (too few degrees of freedom for this to mean anything -- see module
+    docstring disclosed decision #4)."""
+    common_pairs = sorted(set(corr_a) & set(corr_b))
+    xs: list[float] = []
+    ys: list[float] = []
+    for p in common_pairs:
+        va, vb = corr_a[p], corr_b[p]
+        if va is None or vb is None:
+            continue
+        xs.append(va)
+        ys.append(vb)
+    n = len(xs)
+    if n < MIN_COMMON_PAIRS_FOR_CORR_OF_CORR:
+        return None, n
+    return pearson_correlation(xs, ys), n
+
+
+def classify_similarity(
+    corr_of_corr: Optional[float], jaccard: Optional[float], n_common_pairs: int
+) -> str:
+    """Explicit classification bands for the baseline design's acceptance
+    check ("recognizably similar, not identical, not random"). These exact
+    numbers are a disclosed scoping decision (see module docstring #5), not
+    handed down by the design doc:
+
+    - `INCONCLUSIVE_INSUFFICIENT_PAIRS`: fewer than
+      MIN_COMMON_PAIRS_FOR_CORR_OF_CORR=3 non-degenerate common pairs, or
+      corr_of_corr could not be computed. Too little real structure to
+      judge either way.
+    - `IDENTICAL_TRIVIAL`: corr_of_corr >= 0.999 AND jaccard == 1.0 -- the
+      two windows agree completely. Given the small (~9-target, <=36-pair)
+      universe here (module docstring #1), this is flagged as possibly
+      trivial rather than celebrated -- a tiny, mostly-fixed target universe
+      can produce perfect agreement without that being evidence of genuine
+      *emergent* recurring structure, since there may be little room for it
+      to differ in the first place.
+    - `RANDOM`: corr_of_corr < 0.3, or jaccard is not None and < 0.15 --
+      the two windows' co-movement structure does not recognizably agree.
+    - `RECOGNIZABLE_SIMILARITY`: corr_of_corr >= 0.5 AND jaccard is not None
+      and 0.15 <= jaccard < 1.0 -- meaningful, non-trivial, non-identical
+      agreement. This is the literal MET case for the acceptance check.
+    - `AMBIGUOUS`: falls in neither band above (e.g. moderate corr_of_corr
+      with an extreme jaccard, or vice versa) -- reported plainly as
+      ambiguous rather than forced into MET or NOT MET.
+    """
+    if n_common_pairs < MIN_COMMON_PAIRS_FOR_CORR_OF_CORR or corr_of_corr is None:
+        return "INCONCLUSIVE_INSUFFICIENT_PAIRS"
+    if corr_of_corr >= 0.999 and jaccard == 1.0:
+        return "IDENTICAL_TRIVIAL"
+    if corr_of_corr < 0.3 or (jaccard is not None and jaccard < 0.15):
+        return "RANDOM"
+    if corr_of_corr >= 0.5 and jaccard is not None and 0.15 <= jaccard < 1.0:
+        return "RECOGNIZABLE_SIMILARITY"
+    return "AMBIGUOUS"
+
+
+def top1_winner(target_map: dict[str, float]) -> Optional[str]:
+    """The single highest-salience target_id for one tick -- the closest
+    real analog to the drives system's `dominant_drive`. Deterministic tie-
+    break: highest score, then alphabetical target_id."""
+    if not target_map:
+        return None
+    return sorted(target_map.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]
+
+
+def top1_winner_distribution(raw_maps: list[dict[str, float]]) -> Counter:
+    counter: Counter = Counter()
+    for m in raw_maps:
+        winner = top1_winner(m)
+        if winner is not None:
+            counter[winner] += 1
+    return counter
+
+
+def membership_frequency(raw_maps: list[dict[str, float]], target_ids: list[str]) -> dict[str, float]:
+    """Fraction of ticks in which each target_id appears at all in the
+    tick's target map (i.e. was salient enough to clear min_salience)."""
+    n = len(raw_maps)
+    if n == 0:
+        return {t: 0.0 for t in target_ids}
+    counts = {t: 0 for t in target_ids}
+    for m in raw_maps:
+        for t in m:
+            if t in counts:
+                counts[t] += 1
+    return {t: counts[t] / n for t in target_ids}
+
+
+@dataclass
+class WindowSpec:
+    start: datetime
+    end: datetime
+    label: str
+
+
+def choose_windows(
+    min_ts: datetime,
+    max_ts: datetime,
+    window_hours: float = DEFAULT_WINDOW_HOURS,
+    gap_hours: float = DEFAULT_GAP_HOURS,
+    min_window_hours: float = MIN_WINDOW_HOURS,
+) -> Optional[tuple[WindowSpec, WindowSpec]]:
+    """Anchor window A at the start of the real available span and window B
+    at the end, with `gap_hours` of untouched history between them (real
+    non-overlapping windows, not just non-identical timestamps). Degrades
+    gracefully if the real span is shorter than requested: shrinks the
+    window size (never below `min_window_hours`) and drops the gap before
+    giving up. Returns None if even a back-to-back split can't produce two
+    windows of at least `min_window_hours` each -- i.e. genuinely
+    insufficient real historical data, not a number to fabricate a verdict
+    from."""
+    if min_ts is None or max_ts is None or max_ts <= min_ts:
+        return None
+    total_hours = (max_ts - min_ts).total_seconds() / 3600.0
+
+    if total_hours >= 2 * window_hours + gap_hours:
+        a_start, a_end = min_ts, min_ts + timedelta(hours=window_hours)
+        b_end = max_ts
+        b_start = b_end - timedelta(hours=window_hours)
+        return (
+            WindowSpec(a_start, a_end, f"{window_hours:g}h (window A, start-anchored)"),
+            WindowSpec(b_start, b_end, f"{window_hours:g}h (window B, end-anchored)"),
+        )
+
+    if total_hours >= 2 * min_window_hours:
+        half_hours = total_hours / 2.0
+        mid = min_ts + timedelta(hours=half_hours)
+        return (
+            WindowSpec(min_ts, mid, f"{half_hours:g}h (window A, back-to-back split, no gap)"),
+            WindowSpec(mid, max_ts, f"{half_hours:g}h (window B, back-to-back split, no gap)"),
+        )
+
+    return None
+
+
+# ===========================================================================
+# I/O layer -- psycopg2 read-only. Connection contract mirrors
+# measure_ast_hot_reducer.py / measure_capability_salience_coupling.py
+# exactly (refuses a non-read-only session).
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_frame_time_range(conn) -> tuple[Optional[datetime], Optional[datetime], int]:
+    if conn is None:
+        return None, None, 0
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT min(generated_at), max(generated_at), count(*) FROM substrate_attention_frames")
+            row = cur.fetchone()
+    except Exception:
+        logger.error("failed to fetch substrate_attention_frames time range", exc_info=True)
+        return None, None, 0
+    if not row:
+        return None, None, 0
+    min_ts, max_ts, count = row
+    if min_ts is not None and min_ts.tzinfo is None:
+        min_ts = min_ts.replace(tzinfo=timezone.utc)
+    if max_ts is not None and max_ts.tzinfo is None:
+        max_ts = max_ts.replace(tzinfo=timezone.utc)
+    return min_ts, max_ts, int(count or 0)
+
+
+def fetch_target_rows(
+    conn, start: datetime, end: datetime, max_rows: int = MAX_ROWS
+) -> tuple[list[tuple[datetime, Any, Any]], bool]:
+    """Real historical rows in [start, end], ASC by generated_at. Each row:
+    (generated_at, dominant_targets_raw, capability_targets_raw)."""
+    if conn is None:
+        return [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT generated_at, frame_json->'dominant_targets', frame_json->'capability_targets'
+                FROM substrate_attention_frames
+                WHERE generated_at >= %s AND generated_at <= %s
+                ORDER BY generated_at ASC
+                LIMIT %s
+                """,
+                (start, end, max_rows),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch substrate_attention_frames rows", exc_info=True)
+        return [], False
+    out: list[tuple[datetime, Any, Any]] = []
+    for ts, dom_raw, cap_raw in rows:
+        if ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        out.append((ts, dom_raw, cap_raw))
+    return out, len(rows) >= max_rows
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def write_ticks_csv(path: Path, raw_maps: list[dict[str, float]], timestamps: list[datetime], target_ids: list[str]) -> None:
+    import csv
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["generated_at"] + target_ids)
+        for ts, m in zip(timestamps, raw_maps):
+            writer.writerow([ts.isoformat()] + [f"{m.get(t, 0.0):.4f}" for t in target_ids])
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.4f}"
+
+
+def _corr_matrix_table(target_ids: list[str], corr_matrix: CorrMatrix) -> list[str]:
+    lines = ["| target A | target B | correlation |", "| --- | --- | --- |"]
+    for a in target_ids:
+        for b in target_ids:
+            if a >= b:
+                continue
+            r = corr_matrix.get((a, b))
+            lines.append(f"| `{a}` | `{b}` | {_fmt(r)} |")
+    return lines
+
+
+def render_report(
+    *,
+    global_window_label: str,
+    global_start: Optional[datetime],
+    global_end: Optional[datetime],
+    total_rows: int,
+    windows: Optional[tuple[WindowSpec, WindowSpec]],
+    window_a_n: int,
+    window_b_n: int,
+    target_ids: list[str],
+    corr_a: CorrMatrix,
+    corr_b: CorrMatrix,
+    clusters_a: list[list[str]],
+    clusters_b: list[list[str]],
+    edges_a: set[tuple[str, str]],
+    edges_b: set[tuple[str, str]],
+    jaccard: Optional[float],
+    corr_of_corr: Optional[float],
+    n_common_pairs: int,
+    classification: str,
+    full_history_top1: Counter,
+    full_history_n: int,
+    full_history_membership: dict[str, float],
+    caveats: list[str],
+) -> str:
+    lines = [
+        "# Emergent-Clustering Probe (O4) -- Field-Attention Coalition History",
+        "",
+        "Read-only. No writes, no events, no flag/config changes. Runs correlation-based "
+        "grouping over real `substrate_attention_frames` history (real "
+        "`FieldAttentionFrameV1.dominant_targets`/`capability_targets` rows), per the "
+        "baseline field-native motivational substrate design's 'Recommended next patch' "
+        "and Sentience Striving Program §6 item 5. Imports nothing from "
+        "`orion.spark.concept_induction`.",
+        "",
+        f"- Real data span: {global_window_label}",
+        f"- Total `substrate_attention_frames` rows in span: {total_rows}",
+        f"- Target universe observed (dominant_targets ∪ capability_targets): {len(target_ids)} "
+        f"({', '.join(f'`{t}`' for t in target_ids)})",
+        "",
+    ]
+
+    if windows is None:
+        lines.extend(
+            [
+                "## Windows: INSUFFICIENT REAL DATA",
+                "",
+                f"The real available span ({global_window_label}) is too short to carve out "
+                f"two non-overlapping windows of at least {MIN_WINDOW_HOURS:g}h each. No "
+                "clustering-similarity check was run. This is reported honestly rather than "
+                "forcing a verdict from too little data.",
+                "",
+            ]
+        )
+    else:
+        win_a, win_b = windows
+        lines.extend(
+            [
+                "## Windows selected (real data, see `choose_windows` for the anchoring rule)",
+                "",
+                f"- Window A: {win_a.label} -- {win_a.start.isoformat()} -> {win_a.end.isoformat()} "
+                f"({window_a_n} rows)",
+                f"- Window B: {win_b.label} -- {win_b.start.isoformat()} -> {win_b.end.isoformat()} "
+                f"({window_b_n} rows)",
+                "",
+            ]
+        )
+
+        if window_a_n < MIN_WINDOW_ROWS or window_b_n < MIN_WINDOW_ROWS:
+            lines.extend(
+                [
+                    "**INSUFFICIENT ROWS IN AT LEAST ONE WINDOW** -- below "
+                    f"MIN_WINDOW_ROWS={MIN_WINDOW_ROWS}. Correlation matrices below may be "
+                    "unreliable; treat the acceptance-check verdict as low-confidence.",
+                    "",
+                ]
+            )
+
+        lines.extend(["### Window A correlation matrix", ""])
+        lines.extend(_corr_matrix_table(target_ids, corr_a))
+        lines.extend(["", "### Window B correlation matrix", ""])
+        lines.extend(_corr_matrix_table(target_ids, corr_b))
+        lines.extend(
+            [
+                "",
+                f"### Clusters at threshold >= {CORR_CLUSTER_THRESHOLD:g}",
+                "",
+                f"- Window A: {clusters_a}",
+                f"- Window B: {clusters_b}",
+                "",
+                "### Similarity metrics",
+                "",
+                f"- Edge set A (`corr >= {CORR_CLUSTER_THRESHOLD:g}`): {sorted(edges_a)}",
+                f"- Edge set B (`corr >= {CORR_CLUSTER_THRESHOLD:g}`): {sorted(edges_b)}",
+                f"- Jaccard(edges_A, edges_B): {_fmt(jaccard)}",
+                f"- Correlation-of-correlations (over {n_common_pairs} common non-degenerate "
+                f"pairs): {_fmt(corr_of_corr)}",
+                "",
+                f"### Classification: **{classification}**",
+                "",
+            ]
+        )
+        lines.extend(
+            {
+                "IDENTICAL_TRIVIAL": [
+                    "Windows A and B agree completely (corr-of-corr >= 0.999, edge-set "
+                    "Jaccard == 1.0). Given the small (~9-target) universe here, this is "
+                    "flagged as possibly trivial rather than treated as strong evidence of "
+                    "genuine emergent recurring structure -- see module docstring "
+                    "disclosed decision #5.",
+                ],
+                "RANDOM": [
+                    "Windows A and B do not recognizably agree (low corr-of-corr and/or low "
+                    "edge-set Jaccard). This does not clear the baseline design's acceptance "
+                    "check.",
+                ],
+                "RECOGNIZABLE_SIMILARITY": [
+                    "Windows A and B show meaningful, non-identical, non-random agreement in "
+                    "which targets co-vary in salience. This is the literal MET case for the "
+                    "baseline design's acceptance check: \"The emergent clustering step, run "
+                    "on two different historical windows, produces recognizably similar (not "
+                    "identical, not random) groupings.\"",
+                ],
+                "INCONCLUSIVE_INSUFFICIENT_PAIRS": [
+                    f"Fewer than {MIN_COMMON_PAIRS_FOR_CORR_OF_CORR} common non-degenerate "
+                    "correlation pairs were available between the two windows -- too little "
+                    "real structure (most targets' salience series were flat/near-constant, "
+                    "or too few targets co-occurred with real variance in both windows) to "
+                    "judge similarity either way.",
+                ],
+                "AMBIGUOUS": [
+                    "The two windows' agreement falls between the defined RANDOM and "
+                    "RECOGNIZABLE_SIMILARITY bands (see `classify_similarity` docstring for "
+                    "the exact numeric thresholds) -- reported plainly rather than forced "
+                    "into either verdict.",
+                ],
+            }.get(classification, ["(no narrative for this classification)"])
+        )
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Item 5: differentiation vs. the drives system's known monoculture",
+            "",
+            "The closest real analog to the drives system's `dominant_drive` is the single "
+            "highest-`salience_score` target per tick (deterministic tie-break: highest "
+            "score, then alphabetical target_id), computed over the FULL available real "
+            "history (not just the two probe windows above).",
+            "",
+            f"- Full-history ticks: {full_history_n}",
+            "",
+            "| target_id | ticks won (top-1) | share |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for target_id, count in full_history_top1.most_common():
+        share = count / full_history_n if full_history_n else 0.0
+        lines.append(f"| `{target_id}` | {count} | {share * 100:.2f}% |")
+    top_share = (full_history_top1.most_common(1)[0][1] / full_history_n) if full_history_n and full_history_top1 else 0.0
+
+    lines.extend(
+        [
+            "",
+            "| target_id | fraction of ticks present in dominant_targets/capability_targets |",
+            "| --- | --- |",
+        ]
+    )
+    for target_id in target_ids:
+        pct = full_history_membership.get(target_id, 0.0) * 100
+        lines.append(f"| `{target_id}` | {pct:.2f}% |")
+
+    lines.extend(
+        [
+            "",
+            "### Comparison to the drives system's documented monoculture",
+            "",
+            f"- Drives system, pre-fix (documented, `orion/autonomy/drives_and_autonomy_"
+            f"retrospective.md` ~line 177): `dominant_drive=relational` in "
+            f"**{DRIVES_DOMINANT_SHARE_PRE_FIX * 100:.0f}%** of ticks.",
+            f"- Drives system, post O1/O2/O3 fix (same file, ~line 267): top dominant-drive "
+            f"share **{DRIVES_DOMINANT_SHARE_POST_FIX * 100:.2f}%**.",
+            f"- Field-attention top-1-winner share over full real history here: "
+            f"**{top_share * 100:.2f}%** (`{full_history_top1.most_common(1)[0][0] if full_history_top1 else 'n/a'}`).",
+            "",
+        ]
+    )
+    if full_history_top1 and top_share >= DRIVES_DOMINANT_SHARE_PRE_FIX:
+        lines.append(
+            "**Honest finding: this is NOT meaningfully different from the drives system's "
+            "known failure pattern -- if anything it is worse.** The single highest-salience "
+            "target wins essentially every tick, at or above the drives system's *pre-fix* "
+            "96% monoculture share, and well above its *post-fix* ~32% share. This is exactly "
+            "the pathology the baseline design's own Missing Question 1 named as the risk to "
+            "check for (\"'resource_pressure always wins because it's noisiest,' the exact "
+            "96%-dominant-drive monoculture pathology already found once\") -- and it is "
+            "present here too, just for a different target (a near-constant-perturbation "
+            "system counter and/or the primary host node/outbound-capability channel, "
+            "depending on which target universe is inspected -- see the per-target table "
+            "above)."
+        )
+    elif full_history_top1 and top_share >= DRIVES_DOMINANT_SHARE_POST_FIX:
+        lines.append(
+            "This is roughly in the same range as the drives system's *post-fix* concentration "
+            "-- not clearly better, not the pre-fix pathology either."
+        )
+    elif full_history_top1:
+        lines.append(
+            "This is meaningfully less concentrated than either drives-system figure -- some "
+            "real evidence of differentiation in which target wins top salience over time."
+        )
+    else:
+        lines.append("No full-history data available to compute this comparison.")
+    lines.append("")
+
+    lines.extend(["## Coverage caveats", ""])
+    if caveats:
+        lines.extend(f"- {c}" for c in caveats)
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(
+    window_hours: float = DEFAULT_WINDOW_HOURS,
+    gap_hours: float = DEFAULT_GAP_HOURS,
+    corr_threshold: float = CORR_CLUSTER_THRESHOLD,
+) -> int:
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    progress = ProgressLog(PROGRESS_PATH)
+    caveats: list[str] = []
+
+    progress.emit("connect", percent=0.0, processed=0, total=0)
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        caveats.append("postgres unavailable or not read-only; nothing measured")
+        progress.close()
+        print("ERROR: could not open a read-only postgres connection; see log")
+        return 2
+
+    min_ts, max_ts, total_rows = fetch_frame_time_range(conn)
+    progress.emit("time range fetched", percent=5.0, processed=total_rows, total=total_rows)
+
+    if min_ts is None or max_ts is None or total_rows < MIN_TOTAL_ROWS:
+        caveats.append(
+            f"insufficient real substrate_attention_frames history (rows={total_rows}, "
+            f"min_required={MIN_TOTAL_ROWS}); cannot run a meaningful probe"
+        )
+        try:
+            conn.close()
+        except Exception:
+            pass
+        progress.close()
+        report = render_report(
+            global_window_label="n/a (insufficient data)", global_start=min_ts, global_end=max_ts,
+            total_rows=total_rows, windows=None, window_a_n=0, window_b_n=0, target_ids=[],
+            corr_a={}, corr_b={}, clusters_a=[], clusters_b=[], edges_a=set(), edges_b=set(),
+            jaccard=None, corr_of_corr=None, n_common_pairs=0,
+            classification="INCONCLUSIVE_INSUFFICIENT_PAIRS", full_history_top1=Counter(),
+            full_history_n=0, full_history_membership={}, caveats=caveats,
+        )
+        REPORT_PATH.write_text(report, encoding="utf-8")
+        print(report)
+        return 2
+
+    global_label = f"{min_ts.isoformat()} -> {max_ts.isoformat()} ({(max_ts - min_ts).total_seconds() / 3600.0:.1f}h)"
+
+    all_rows, truncated = fetch_target_rows(conn, min_ts, max_ts, MAX_ROWS)
+    if truncated:
+        caveats.append(f"full-history rows truncated at MAX_ROWS={MAX_ROWS}")
+    progress.emit("full history fetched", percent=25.0, processed=len(all_rows), total=len(all_rows))
+
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+    all_timestamps = [ts for ts, _, _ in all_rows]
+    all_raw_maps = [extract_target_salience_map(d, c) for _, d, c in all_rows]
+    full_target_ids = build_target_universe(all_raw_maps)
+    full_history_top1 = top1_winner_distribution(all_raw_maps)
+    full_history_membership = membership_frequency(all_raw_maps, full_target_ids)
+    progress.emit("full-history stats computed", percent=40.0, processed=len(all_raw_maps), total=len(all_raw_maps))
+
+    windows = choose_windows(min_ts, max_ts, window_hours, gap_hours)
+
+    if windows is None:
+        caveats.append(
+            f"real data span ({(max_ts - min_ts).total_seconds() / 3600.0:.1f}h) too short "
+            f"for two non-overlapping windows >= {MIN_WINDOW_HOURS:g}h each"
+        )
+        write_ticks_csv(CSV_PATH, all_raw_maps, all_timestamps, full_target_ids)
+        report = render_report(
+            global_window_label=global_label, global_start=min_ts, global_end=max_ts,
+            total_rows=total_rows, windows=None, window_a_n=0, window_b_n=0,
+            target_ids=full_target_ids, corr_a={}, corr_b={}, clusters_a=[], clusters_b=[],
+            edges_a=set(), edges_b=set(), jaccard=None, corr_of_corr=None, n_common_pairs=0,
+            classification="INCONCLUSIVE_INSUFFICIENT_PAIRS", full_history_top1=full_history_top1,
+            full_history_n=len(all_raw_maps), full_history_membership=full_history_membership,
+            caveats=caveats,
+        )
+        REPORT_PATH.write_text(report, encoding="utf-8")
+        progress.close()
+        print(report)
+        return 2
+
+    win_a, win_b = windows
+    rows_a = [(ts, m) for ts, m in zip(all_timestamps, all_raw_maps) if win_a.start <= ts <= win_a.end]
+    rows_b = [(ts, m) for ts, m in zip(all_timestamps, all_raw_maps) if win_b.start <= ts <= win_b.end]
+    maps_a = [m for _, m in rows_a]
+    maps_b = [m for _, m in rows_b]
+    progress.emit("windows partitioned", percent=55.0, processed=len(maps_a) + len(maps_b), total=len(all_raw_maps))
+
+    if len(maps_a) < MIN_WINDOW_ROWS:
+        caveats.append(f"window A has only {len(maps_a)} rows (< MIN_WINDOW_ROWS={MIN_WINDOW_ROWS})")
+    if len(maps_b) < MIN_WINDOW_ROWS:
+        caveats.append(f"window B has only {len(maps_b)} rows (< MIN_WINDOW_ROWS={MIN_WINDOW_ROWS})")
+
+    shared_target_ids = build_target_universe(maps_a + maps_b)
+
+    series_a = align_series(maps_a, shared_target_ids)
+    series_b = align_series(maps_b, shared_target_ids)
+    corr_a = compute_correlation_matrix(shared_target_ids, series_a)
+    corr_b = compute_correlation_matrix(shared_target_ids, series_b)
+    progress.emit("correlation matrices computed", percent=75.0, processed=len(corr_a), total=len(corr_a))
+
+    clusters_a = cluster_by_correlation(shared_target_ids, corr_a, corr_threshold)
+    clusters_b = cluster_by_correlation(shared_target_ids, corr_b, corr_threshold)
+    edges_a = edge_set_at_threshold(corr_a, corr_threshold)
+    edges_b = edge_set_at_threshold(corr_b, corr_threshold)
+    jaccard = jaccard_similarity(edges_a, edges_b)
+    corr_of_corr, n_common_pairs = correlation_of_correlations(corr_a, corr_b)
+    classification = classify_similarity(corr_of_corr, jaccard, n_common_pairs)
+    progress.emit("similarity computed", percent=90.0, processed=1, total=1)
+
+    write_ticks_csv(CSV_PATH, all_raw_maps, all_timestamps, full_target_ids)
+    report = render_report(
+        global_window_label=global_label, global_start=min_ts, global_end=max_ts,
+        total_rows=total_rows, windows=windows, window_a_n=len(maps_a), window_b_n=len(maps_b),
+        target_ids=shared_target_ids, corr_a=corr_a, corr_b=corr_b, clusters_a=clusters_a,
+        clusters_b=clusters_b, edges_a=edges_a, edges_b=edges_b, jaccard=jaccard,
+        corr_of_corr=corr_of_corr, n_common_pairs=n_common_pairs, classification=classification,
+        full_history_top1=full_history_top1, full_history_n=len(all_raw_maps),
+        full_history_membership=full_history_membership, caveats=caveats,
+    )
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    progress.emit("done", percent=100.0, processed=1, total=1)
+    progress.close()
+
+    print(report)
+    print(f"\nartifacts: {REPORT_PATH}, {CSV_PATH}, {PROGRESS_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read-only emergent-clustering probe over real field-attention history.")
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"size of each of the two comparison windows in hours (default {DEFAULT_WINDOW_HOURS})",
+    )
+    parser.add_argument(
+        "--gap-hours", type=float, default=DEFAULT_GAP_HOURS,
+        help=f"untouched real history between the two windows, in hours (default {DEFAULT_GAP_HOURS})",
+    )
+    parser.add_argument(
+        "--corr-threshold", type=float, default=CORR_CLUSTER_THRESHOLD,
+        help=f"correlation threshold for clustering an edge/pair together (default {CORR_CLUSTER_THRESHOLD})",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    return run(args.window_hours, args.gap_hours, args.corr_threshold)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_measure_emergent_clustering_probe.py
+++ b/scripts/analysis/tests/test_measure_emergent_clustering_probe.py
@@ -1,0 +1,349 @@
+"""Deterministic unit tests for measure_emergent_clustering_probe.py.
+
+No DB, no network. Everything here is pure: JSON-target-list parsing,
+series alignment, Pearson correlation, union-find clustering, similarity
+metrics, and window selection all operate on plain synthetic data. Same
+sibling-module-by-file-path loading pattern as
+test_measure_capability_salience_coupling.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "measure_emergent_clustering_probe.py"
+_spec = importlib.util.spec_from_file_location("measure_emergent_clustering_probe", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_emergent_clustering_probe"] = mod
+_spec.loader.exec_module(mod)
+
+UTC = timezone.utc
+BASE = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+
+
+# ===========================================================================
+# extract_target_salience_map -- pure JSON parsing, must never raise.
+# ===========================================================================
+
+
+def test_extract_target_salience_map_merges_dominant_and_capability() -> None:
+    dominant = [
+        {"target_id": "node:athena", "salience_score": 0.7},
+        {"target_id": "capability:transport", "salience_score": 0.5},
+    ]
+    capability = [{"target_id": "capability:transport", "salience_score": 0.5}]
+    result = mod.extract_target_salience_map(dominant, capability)
+    assert result == {"node:athena": 0.7, "capability:transport": 0.5}
+
+
+def test_extract_target_salience_map_capability_fills_gap_not_present_in_dominant() -> None:
+    """Defensive path: a target present in capability_targets but somehow
+    absent from dominant_targets should still be captured."""
+    dominant = [{"target_id": "node:athena", "salience_score": 0.7}]
+    capability = [{"target_id": "capability:transport", "salience_score": 0.3}]
+    result = mod.extract_target_salience_map(dominant, capability)
+    assert result == {"node:athena": 0.7, "capability:transport": 0.3}
+
+
+def test_extract_target_salience_map_handles_json_string() -> None:
+    dominant = '[{"target_id": "node:athena", "salience_score": 0.42}]'
+    result = mod.extract_target_salience_map(dominant, None)
+    assert result == {"node:athena": 0.42}
+
+
+def test_extract_target_salience_map_none_never_raises() -> None:
+    assert mod.extract_target_salience_map(None, None) == {}
+
+
+def test_extract_target_salience_map_malformed_never_raises() -> None:
+    assert mod.extract_target_salience_map("{not valid json", "also not valid") == {}
+    assert mod.extract_target_salience_map({"unexpected": "shape"}, ["not", "a", "dict"]) == {}
+    assert mod.extract_target_salience_map(
+        [{"target_id": "node:athena", "salience_score": "garbage"}], None
+    ) == {"node:athena": 0.0}
+    assert mod.extract_target_salience_map([{"salience_score": 0.9}], None) == {}
+
+
+# ===========================================================================
+# build_target_universe / align_series
+# ===========================================================================
+
+
+def test_build_target_universe_sorted_dedup() -> None:
+    raw_maps = [{"b": 0.1, "a": 0.2}, {"c": 0.3}]
+    assert mod.build_target_universe(raw_maps) == ["a", "b", "c"]
+
+
+def test_align_series_absence_is_zero() -> None:
+    raw_maps = [{"a": 0.5}, {"b": 0.9}, {"a": 0.2, "b": 0.1}]
+    series = mod.align_series(raw_maps, ["a", "b"])
+    assert series["a"] == [0.5, 0.0, 0.2]
+    assert series["b"] == [0.0, 0.9, 0.1]
+
+
+# ===========================================================================
+# pearson_correlation
+# ===========================================================================
+
+
+def test_pearson_correlation_perfect_positive() -> None:
+    x = [0.1, 0.2, 0.3, 0.4, 0.5]
+    y = [0.2, 0.4, 0.6, 0.8, 1.0]
+    r = mod.pearson_correlation(x, y)
+    assert r is not None
+    assert abs(r - 1.0) < 1e-9
+
+
+def test_pearson_correlation_perfect_negative() -> None:
+    x = [0.1, 0.2, 0.3, 0.4, 0.5]
+    y = [0.5, 0.4, 0.3, 0.2, 0.1]
+    r = mod.pearson_correlation(x, y)
+    assert r is not None
+    assert abs(r - (-1.0)) < 1e-9
+
+
+def test_pearson_correlation_degenerate_flat_series_returns_none() -> None:
+    x = [0.5, 0.5, 0.5, 0.5]
+    y = [0.1, 0.2, 0.3, 0.4]
+    assert mod.pearson_correlation(x, y) is None
+
+
+def test_pearson_correlation_too_short_returns_none() -> None:
+    assert mod.pearson_correlation([0.1], [0.2]) is None
+    assert mod.pearson_correlation([], []) is None
+
+
+def test_pearson_correlation_mismatched_lengths_returns_none() -> None:
+    assert mod.pearson_correlation([0.1, 0.2], [0.1]) is None
+
+
+def test_pearson_correlation_clamped_to_valid_range() -> None:
+    x = [0.1, 0.5, 0.2, 0.9, 0.3]
+    y = [0.9, 0.1, 0.8, 0.05, 0.7]
+    r = mod.pearson_correlation(x, y)
+    assert r is not None
+    assert -1.0 <= r <= 1.0
+
+
+# ===========================================================================
+# compute_correlation_matrix / cluster_by_correlation / edge_set_at_threshold
+# ===========================================================================
+
+
+def test_compute_correlation_matrix_deterministic_key_order() -> None:
+    series = {
+        "z": [0.1, 0.2, 0.3, 0.4],
+        "a": [0.1, 0.2, 0.3, 0.4],
+    }
+    matrix = mod.compute_correlation_matrix(["z", "a"], series)
+    assert ("a", "z") in matrix
+    assert ("z", "a") not in matrix
+    assert abs(matrix[("a", "z")] - 1.0) < 1e-9
+
+
+def test_cluster_by_correlation_groups_correlated_targets() -> None:
+    series = {
+        "a": [0.1, 0.5, 0.2, 0.9],
+        "b": [0.1, 0.5, 0.2, 0.9],  # perfectly correlated with a
+        "c": [0.9, 0.1, 0.8, 0.0],  # uncorrelated-ish with a/b
+    }
+    target_ids = ["a", "b", "c"]
+    matrix = mod.compute_correlation_matrix(target_ids, series)
+    clusters = mod.cluster_by_correlation(target_ids, matrix, threshold=0.9)
+    # a and b must land in the same cluster; c should not be forced in.
+    cluster_containing_a = next(c for c in clusters if "a" in c)
+    assert "b" in cluster_containing_a
+
+
+def test_cluster_by_correlation_degenerate_target_is_singleton() -> None:
+    series = {
+        "a": [0.5, 0.5, 0.5, 0.5],  # flat -> degenerate, correlation always None
+        "b": [0.1, 0.9, 0.2, 0.8],
+    }
+    target_ids = ["a", "b"]
+    matrix = mod.compute_correlation_matrix(target_ids, series)
+    clusters = mod.cluster_by_correlation(target_ids, matrix, threshold=0.5)
+    assert ["a"] in clusters
+
+
+def test_edge_set_at_threshold_excludes_none_and_below_threshold() -> None:
+    matrix = {("a", "b"): 0.9, ("a", "c"): 0.2, ("b", "c"): None}
+    edges = mod.edge_set_at_threshold(matrix, threshold=0.5)
+    assert edges == {("a", "b")}
+
+
+# ===========================================================================
+# jaccard_similarity
+# ===========================================================================
+
+
+def test_jaccard_similarity_identical_sets() -> None:
+    a = {("x", "y"), ("y", "z")}
+    assert mod.jaccard_similarity(a, a) == 1.0
+
+
+def test_jaccard_similarity_disjoint_sets() -> None:
+    a = {("x", "y")}
+    b = {("p", "q")}
+    assert mod.jaccard_similarity(a, b) == 0.0
+
+
+def test_jaccard_similarity_partial_overlap() -> None:
+    a = {("x", "y"), ("y", "z")}
+    b = {("x", "y"), ("p", "q")}
+    # intersection = 1, union = 3
+    assert abs(mod.jaccard_similarity(a, b) - (1 / 3)) < 1e-9
+
+
+def test_jaccard_similarity_both_empty_is_none() -> None:
+    assert mod.jaccard_similarity(set(), set()) is None
+
+
+# ===========================================================================
+# correlation_of_correlations
+# ===========================================================================
+
+
+def test_correlation_of_correlations_identical_matrices() -> None:
+    matrix = {("a", "b"): 0.9, ("a", "c"): 0.1, ("b", "c"): -0.3, ("a", "d"): 0.5}
+    value, n = mod.correlation_of_correlations(matrix, dict(matrix))
+    assert n == 4
+    assert value is not None
+    assert abs(value - 1.0) < 1e-9
+
+
+def test_correlation_of_correlations_too_few_common_pairs_is_none() -> None:
+    matrix_a = {("a", "b"): 0.9, ("a", "c"): 0.1}
+    matrix_b = {("a", "b"): 0.9}
+    value, n = mod.correlation_of_correlations(matrix_a, matrix_b)
+    assert value is None
+    assert n == 1
+
+
+def test_correlation_of_correlations_excludes_none_valued_pairs() -> None:
+    matrix_a = {("a", "b"): 0.9, ("a", "c"): None, ("b", "c"): 0.1, ("a", "d"): 0.5}
+    matrix_b = {("a", "b"): 0.8, ("a", "c"): 0.2, ("b", "c"): 0.05, ("a", "d"): 0.4}
+    value, n = mod.correlation_of_correlations(matrix_a, matrix_b)
+    # ("a", "c") is None in matrix_a -> excluded, leaving 3 usable pairs.
+    assert n == 3
+    assert value is not None
+
+
+# ===========================================================================
+# classify_similarity -- explicit documented bands
+# ===========================================================================
+
+
+def test_classify_similarity_insufficient_pairs() -> None:
+    assert mod.classify_similarity(0.9, 0.9, 2) == "INCONCLUSIVE_INSUFFICIENT_PAIRS"
+    assert mod.classify_similarity(None, 0.9, 5) == "INCONCLUSIVE_INSUFFICIENT_PAIRS"
+
+
+def test_classify_similarity_identical_trivial() -> None:
+    assert mod.classify_similarity(1.0, 1.0, 5) == "IDENTICAL_TRIVIAL"
+
+
+def test_classify_similarity_random_low_corr_of_corr() -> None:
+    assert mod.classify_similarity(0.1, 0.5, 5) == "RANDOM"
+
+
+def test_classify_similarity_random_low_jaccard() -> None:
+    assert mod.classify_similarity(0.8, 0.05, 5) == "RANDOM"
+
+
+def test_classify_similarity_recognizable_similarity() -> None:
+    assert mod.classify_similarity(0.7, 0.4, 5) == "RECOGNIZABLE_SIMILARITY"
+
+
+def test_classify_similarity_ambiguous_falls_between_bands() -> None:
+    # corr_of_corr strong but jaccard is a full 1.0 without also clearing the
+    # exact IDENTICAL_TRIVIAL bar (corr_of_corr < 0.999) -> ambiguous, not
+    # forced into either MET or NOT MET band.
+    assert mod.classify_similarity(0.7, 1.0, 5) == "AMBIGUOUS"
+
+
+# ===========================================================================
+# top1_winner / top1_winner_distribution / membership_frequency
+# ===========================================================================
+
+
+def test_top1_winner_picks_highest_score() -> None:
+    assert mod.top1_winner({"a": 0.5, "b": 0.9, "c": 0.3}) == "b"
+
+
+def test_top1_winner_deterministic_tiebreak_alphabetical() -> None:
+    assert mod.top1_winner({"z": 0.5, "a": 0.5}) == "a"
+
+
+def test_top1_winner_empty_map_is_none() -> None:
+    assert mod.top1_winner({}) is None
+
+
+def test_top1_winner_distribution_counts() -> None:
+    raw_maps = [{"a": 0.9}, {"a": 0.8}, {"b": 0.99}]
+    dist = mod.top1_winner_distribution(raw_maps)
+    assert dist["a"] == 2
+    assert dist["b"] == 1
+
+
+def test_membership_frequency_fraction_present() -> None:
+    raw_maps = [{"a": 0.5}, {"a": 0.1, "b": 0.2}, {"b": 0.9}]
+    freq = mod.membership_frequency(raw_maps, ["a", "b"])
+    assert abs(freq["a"] - (2 / 3)) < 1e-9
+    assert abs(freq["b"] - (2 / 3)) < 1e-9
+
+
+def test_membership_frequency_empty_history() -> None:
+    freq = mod.membership_frequency([], ["a"])
+    assert freq == {"a": 0.0}
+
+
+# ===========================================================================
+# choose_windows
+# ===========================================================================
+
+
+def test_choose_windows_ample_span_anchors_start_and_end() -> None:
+    min_ts = BASE
+    max_ts = BASE + timedelta(hours=72)
+    windows = mod.choose_windows(min_ts, max_ts, window_hours=24.0, gap_hours=12.0)
+    assert windows is not None
+    win_a, win_b = windows
+    assert win_a.start == min_ts
+    assert win_a.end == min_ts + timedelta(hours=24)
+    assert win_b.end == max_ts
+    assert win_b.start == max_ts - timedelta(hours=24)
+    # non-overlapping, with the requested gap preserved
+    assert win_a.end <= win_b.start
+
+
+def test_choose_windows_shrinks_gracefully_for_tight_span() -> None:
+    min_ts = BASE
+    max_ts = BASE + timedelta(hours=10)  # too short for 24h+12h+24h
+    windows = mod.choose_windows(min_ts, max_ts, window_hours=24.0, gap_hours=12.0, min_window_hours=4.0)
+    assert windows is not None
+    win_a, win_b = windows
+    assert win_a.start == min_ts
+    assert win_b.end == max_ts
+    assert win_a.end <= win_b.start  # still non-overlapping
+    assert (win_a.end - win_a.start).total_seconds() / 3600.0 >= 4.0
+    assert (win_b.end - win_b.start).total_seconds() / 3600.0 >= 4.0
+
+
+def test_choose_windows_insufficient_span_returns_none() -> None:
+    min_ts = BASE
+    max_ts = BASE + timedelta(hours=2)  # less than 2 * min_window_hours=4.0
+    windows = mod.choose_windows(min_ts, max_ts, window_hours=24.0, gap_hours=12.0, min_window_hours=4.0)
+    assert windows is None
+
+
+def test_choose_windows_none_timestamps_returns_none() -> None:
+    assert mod.choose_windows(None, None) is None
+
+
+def test_choose_windows_inverted_range_returns_none() -> None:
+    assert mod.choose_windows(BASE, BASE - timedelta(hours=1)) is None

--- a/scripts/analysis/tests/test_measure_emergent_clustering_probe.py
+++ b/scripts/analysis/tests/test_measure_emergent_clustering_probe.py
@@ -112,6 +112,23 @@ def test_pearson_correlation_degenerate_flat_series_returns_none() -> None:
     assert mod.pearson_correlation(x, y) is None
 
 
+def test_pearson_correlation_nan_in_either_series_returns_none() -> None:
+    """A NaN-poisoned series must NOT silently clamp to a false "perfect
+    correlation" -- Python's min/max do not reliably reject NaN
+    (min(1.0, float("nan")) == 1.0), so this is checked explicitly up front
+    in pearson_correlation, not left to the variance guard alone."""
+    x = [float("nan"), 0.2, 0.3, 0.4]
+    y = [0.1, 0.2, 0.3, 0.4]
+    assert mod.pearson_correlation(x, y) is None
+    assert mod.pearson_correlation(y, x) is None
+
+
+def test_pearson_correlation_inf_in_either_series_returns_none() -> None:
+    x = [float("inf"), 0.2, 0.3, 0.4]
+    y = [0.1, 0.2, 0.3, 0.4]
+    assert mod.pearson_correlation(x, y) is None
+
+
 def test_pearson_correlation_too_short_returns_none() -> None:
     assert mod.pearson_correlation([0.1], [0.2]) is None
     assert mod.pearson_correlation([], []) is None
@@ -347,3 +364,93 @@ def test_choose_windows_none_timestamps_returns_none() -> None:
 
 def test_choose_windows_inverted_range_returns_none() -> None:
     assert mod.choose_windows(BASE, BASE - timedelta(hours=1)) is None
+
+
+# ===========================================================================
+# partition_by_window -- the fix for a real found bug: choose_windows'
+# degraded back-to-back path can produce win_a.end == win_b.start exactly,
+# and a naive inclusive-inclusive partition on both windows would double-
+# count a row landing on that shared boundary instant into BOTH windows,
+# contradicting the module's own "real non-overlapping windows" claim.
+# ===========================================================================
+
+
+def test_partition_by_window_row_exactly_on_shared_boundary_goes_to_b_only() -> None:
+    win_a = mod.WindowSpec(BASE, BASE + timedelta(hours=5), "a")
+    win_b = mod.WindowSpec(BASE + timedelta(hours=5), BASE + timedelta(hours=10), "b")
+    boundary_ts = BASE + timedelta(hours=5)  # == win_a.end == win_b.start exactly
+    timestamps = [BASE + timedelta(hours=1), boundary_ts, BASE + timedelta(hours=9)]
+    raw_maps = [{"marker": 1.0}, {"marker": 2.0}, {"marker": 3.0}]
+
+    maps_a, maps_b = mod.partition_by_window(timestamps, raw_maps, win_a, win_b)
+
+    assert maps_a == [{"marker": 1.0}]
+    assert maps_b == [{"marker": 2.0}, {"marker": 3.0}]
+    # No row counted twice, and no row silently dropped.
+    assert len(maps_a) + len(maps_b) == len(raw_maps)
+
+
+def test_partition_by_window_last_row_at_max_ts_included_in_window_b() -> None:
+    """win_b.end is inclusive -- the very last real row (exactly at
+    max_ts, which win_b is anchored to) must not be dropped."""
+    win_a = mod.WindowSpec(BASE, BASE + timedelta(hours=2), "a")
+    win_b = mod.WindowSpec(BASE + timedelta(hours=8), BASE + timedelta(hours=10), "b")
+    timestamps = [BASE + timedelta(hours=10)]  # exactly win_b.end
+    raw_maps = [{"marker": 1.0}]
+
+    maps_a, maps_b = mod.partition_by_window(timestamps, raw_maps, win_a, win_b)
+
+    assert maps_a == []
+    assert maps_b == [{"marker": 1.0}]
+
+
+def test_partition_by_window_rows_in_the_gap_are_dropped_from_both() -> None:
+    win_a = mod.WindowSpec(BASE, BASE + timedelta(hours=2), "a")
+    win_b = mod.WindowSpec(BASE + timedelta(hours=8), BASE + timedelta(hours=10), "b")
+    gap_ts = BASE + timedelta(hours=5)  # inside the untouched gap between windows
+    timestamps = [gap_ts]
+    raw_maps = [{"marker": 1.0}]
+
+    maps_a, maps_b = mod.partition_by_window(timestamps, raw_maps, win_a, win_b)
+
+    assert maps_a == []
+    assert maps_b == []
+
+
+# ===========================================================================
+# render_report -- the "Item 5" full-history membership table must use the
+# FULL-history target universe, not the window-scoped one used by the
+# correlation matrices, since the table's own text claims full-history
+# scope. Real found bug: a target seen in full history but never inside
+# either probe window was silently dropped from this table.
+# ===========================================================================
+
+
+def test_render_report_membership_table_uses_full_target_ids_not_window_scoped() -> None:
+    from collections import Counter
+
+    report = mod.render_report(
+        global_window_label="test span",
+        total_rows=100,
+        windows=None,
+        window_a_n=0,
+        window_b_n=0,
+        target_ids=["node:athena"],  # window-scoped: deliberately missing "node:ghost"
+        full_target_ids=["node:athena", "node:ghost"],  # full-history: has both
+        corr_a={},
+        corr_b={},
+        clusters_a=[],
+        clusters_b=[],
+        edges_a=set(),
+        edges_b=set(),
+        jaccard=None,
+        corr_of_corr=None,
+        n_common_pairs=0,
+        classification="INCONCLUSIVE_INSUFFICIENT_PAIRS",
+        full_history_top1=Counter({"node:athena": 100}),
+        full_history_n=100,
+        full_history_membership={"node:athena": 1.0, "node:ghost": 0.02},
+        caveats=[],
+    )
+    assert "node:ghost" in report
+    assert "node:athena" in report


### PR DESCRIPTION
## Summary

- New `scripts/analysis/measure_emergent_clustering_probe.py`: read-only measurement implementing the baseline field-native motivational substrate design's "Recommended next patch" (`docs/superpowers/specs/2026-07-17-field-native-motivational-substrate-design.md`), toward O4 (Sentience Striving Program §5) and §6 item 5.
- Pulls real historical `FieldAttentionFrameV1` rows from the verified live table (Postgres `substrate_attention_frames`, written by `services/orion-attention-runtime/app/store.py::save_attention_frame()`).
- Runs correlation-based grouping (not an ML clustering pipeline, per the design's own non-goal) of `dominant_targets`/`capability_targets` salience across two non-overlapping historical windows, and checks the baseline design's literal acceptance check: "recognizably similar (not identical, not random) groupings."
- Separately computes the closest real analog to the drives system's `dominant_drive` (single top-salience target per tick) over full real history and compares it against the drives system's documented 96% pre-fix / 31.65% post-fix monoculture shares (`orion/autonomy/drives_and_autonomy_retrospective.md`).
- Adds `scripts/analysis/tests/test_measure_emergent_clustering_probe.py` (47 tests, all pure-function, no DB).
- Updates `orion/sentience_striving_program/README.md` §6 item 5 with a dated status note recording the real verdicts found.

## Outcome moved

O4 ("the 'what are Orion's drives' question is answered empirically, continuously") now has a real, re-runnable, read-only instrument with a first live measurement on its own board, instead of being an unmeasured item in a design doc. The measurement also surfaces a genuinely load-bearing finding: the live field-attention system's naive top-1-winner concentration (99.98%) is *not* better than the drives system's own pre-fix 96% monoculture pathology — a real, disclosed, negative result per root `CLAUDE.md`'s "runtime truth beats config truth" and "no empty-shell cognition" mandates, not a claimed win.

## Current architecture

Before this patch, the baseline design's own "Recommended next patch" section named this exact measurement as not-yet-built. `orion/attention/field_attention/{scoring,selectors,builder}.py` already computes `FieldAttentionFrameV1` live via `orion-attention-runtime` (`ENABLE_ATTENTION_RUNTIME=true`, ~2s cadence, ~43k rows/day, 72h retention in Postgres `substrate_attention_frames`), but nothing had ever measured whether its `dominant_targets`/`capability_targets` history produces meaningful, non-random emergent clustering, or how differentiated it is compared to the retired drives system's known monoculture failure.

## Architecture touched

- `scripts/analysis/` (new script + tests only — no service code, no bus, no schema, no config).
- `orion/sentience_striving_program/README.md` (doc-only status note).

Read-only throughout: no writes to `substrate_attention_frames` or any other table, no bus publish, no new schema, no consumer wiring, no changes to `orion-attention-runtime`, `dynamics.py`, or `capability_policy.py`.

## Files changed

- `scripts/analysis/measure_emergent_clustering_probe.py`: new read-only probe (pure math layer: `extract_target_salience_map`, `align_series`, `pearson_correlation`, `compute_correlation_matrix`, `cluster_by_correlation`, `jaccard_similarity`, `correlation_of_correlations`, `classify_similarity`, `top1_winner`/`top1_winner_distribution`, `membership_frequency`, `choose_windows`, `partition_by_window`; I/O layer: `open_readonly_connection` (refuses a non-read-only session), `fetch_frame_time_range`, `fetch_target_rows`; report layer: `render_report`, `run()`).
- `scripts/analysis/tests/test_measure_emergent_clustering_probe.py`: 47 deterministic unit tests, no DB, no network.
- `orion/sentience_striving_program/README.md`: dated status note under §6 item 5 with the real verdicts and numbers.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: none (read-only analysis script; no live consumer, producer, or schema touched).
- Compatibility notes: n/a.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: no (no env keys introduced; script reads `POSTGRES_URI` from the environment with the same fallback-default pattern as its sibling scripts `measure_ast_hot_reducer.py`/`measure_capability_salience_coupling.py`, neither of which is `.env_example`-registered either).
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a, no template changed.
- skipped keys requiring operator action: none.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest scripts/analysis/tests/test_measure_emergent_clustering_probe.py -q
47 passed

/mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest scripts/analysis/tests/ -q
146 passed, 7 warnings (pre-existing pydantic deprecation warnings, unrelated to this patch)

git diff --check
(clean)
```

## Evals run

This is itself the eval/measurement — the script's whole purpose is a real-data replay, run live below. No separate eval harness gap: `scripts/analysis/` has no `evals/` directory convention (its sibling scripts `measure_ast_hot_reducer.py`, `measure_capability_salience_coupling.py`, `measure_origination_gate.py` are themselves the "evals" for this program).

**Live run against real Postgres** (`postgresql://postgres:postgres@localhost:55432/conjourney`, `--window-hours 24 --gap-hours 12`):

```text
Real data span: ~2026-07-18T19:38Z -> ~2026-07-21T20:0XZ (72.0h), 128,077 total rows
Target universe: 9 target_ids (3 nodes, 5 capabilities, 1 system)

Windows: A = first 24h (42,626 rows), B = last 24h (42,639 rows), 24h gap between

Acceptance check ("recognizably similar, not identical, not random" clustering):
  Edge set A == Edge set B == {(capability:llm_inference, node:atlas)}
  r_A = 0.9228, r_B = 0.9210 (near-identical magnitude, real stable structure)
  Correlation-of-correlations (21 common non-degenerate pairs) = 0.9943
  Jaccard(edges_A, edges_B) = 1.0
  Classification: AMBIGUOUS (real, stable, non-random single coalition pair
  recurs across two independent windows -- but it is the ONLY surviving
  pair out of 36 possible, so the design's "not identical" bar can't be
  cleanly separated from "recognizably similar" with the current, sparse
  9-target instrumentation)

Monoculture-differentiation check (item 5):
  Full-history top-1-winner: field:recent_perturbations, 99.98% of 128,077 ticks
  Drives system pre-fix (documented): 96%
  Drives system post-fix (documented): 31.65%
  Verdict: NOT MET -- field-attention's naive top-1-winner concentration is
  AT OR ABOVE the drives system's own pre-fix monoculture pathology, not
  better. Root cause traced to field:recent_perturbations' salience formula
  (min(1.0, recent_perturbation_count / 10.0)) saturating near-permanently
  under the field's real, near-constant perturbation rate -- the same
  "noisiest signal always wins" shape the baseline design's own Missing
  Question 1 named as the exact risk to check for.
```

Full report/CSV/progress artifacts: `/tmp/emergent-clustering-probe/{report.md,ticks.csv,progress.log}` (local to this session, not committed).

## Docker/build/smoke checks

Not applicable — pure read-only Postgres analysis script, no service/container/runtime behavior touched. No Docker build or compose changes.

## Review findings fixed

- Finding: `pearson_correlation` silently returned `1.0` instead of `None` for a NaN-poisoned series (Python's `min`/`max` do not reliably reject NaN comparisons).
  - Fix: explicit `math.isfinite` check on both series before any arithmetic that could propagate NaN.
  - Evidence: new tests `test_pearson_correlation_nan_in_either_series_returns_none`, `test_pearson_correlation_inf_in_either_series_returns_none`; both pass.
- Finding: `choose_windows`' degraded (tight-span) back-to-back path can produce `win_a.end == win_b.start` exactly, and the original inclusive-inclusive row partition in `run()` would double-count a row landing exactly on that boundary into both windows.
  - Fix: extracted `partition_by_window()` as a pure, directly-tested function — half-open on window A's upper bound, inclusive on window B's, guaranteeing a real non-overlapping partition even at the shared boundary.
  - Evidence: new tests `test_partition_by_window_row_exactly_on_shared_boundary_goes_to_b_only`, `test_partition_by_window_last_row_at_max_ts_included_in_window_b`, `test_partition_by_window_rows_in_the_gap_are_dropped_from_both`; all pass.
- Finding: `render_report`'s full-history membership table was scoped by the window-restricted `target_ids`, not the full-history target universe, silently dropping any target seen in full history but absent from both probe windows — contradicting the table's own "computed over the FULL available real history" text.
  - Fix: added a separate `full_target_ids` parameter, used specifically for that table.
  - Evidence: new test `test_render_report_membership_table_uses_full_target_ids_not_window_scoped`; passes.
- Finding (nice-to-have): unused `global_start`/`global_end` parameters threaded through `render_report` but never referenced in its body.
  - Fix: removed.
  - Evidence: `render_report` call sites updated; full test suite still passes (146/146).
- Finding (nice-to-have): `fetch_target_rows`' `ORDER BY generated_at ASC ... LIMIT MAX_ROWS` would, if ever triggered, keep the oldest rows and disproportionately starve window B (the end-anchored/newest window) rather than shrinking both windows evenly.
  - Fix: documented explicitly in the truncation caveat message so a future reader/run knows to distrust window B's numbers specifically if this caveat ever appears; not currently triggered (128,077 rows vs. `MAX_ROWS=200,000`).
  - Evidence: caveat string updated in `run()`.
- Non-issues confirmed by the reviewer (not fixed, no action needed): SQL parameterization is safe (no string interpolation), read-only session enforcement mirrors the two sibling scripts exactly, hard constraints (zero `orion.spark.concept_induction` imports, no numpy/scipy/sklearn, no writes/bus/schema) verified by direct grep, union-find/Jaccard/correlation-of-correlations/`classify_similarity` band logic all check out correct on manual trace.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: low
- Concern: the acceptance-check classification landed on `AMBIGUOUS` rather than a clean MET/NOT MET, because the currently-instrumented target universe is genuinely small (9 targets, 36 possible pairs, only 1 ever clears the clustering threshold). This is an honest measurement outcome, not a script defect — but it means the baseline design's acceptance check is not yet cleanly resolved.
- Mitigation: none needed for this patch (measurement-only, no live wiring). The README status note names two concrete next steps if this program continues: either exclude system-kind targets from the top-1-winner comparison and re-measure specifically among node/capability targets, or treat the `field:recent_perturbations` saturation finding as evidence that `select_system_targets`' salience formula needs the same delta-gating/normalization discipline the O1-O3 drives fixes applied to `DriveEngine`, before this probe's numbers can be trusted as representative of node/capability coalition structure specifically.
- Severity: low
- Concern: `field:recent_perturbations` dominating top-1 wins (99.98%) is itself a finding that could motivate further investment in this measurement or in fixing the underlying salience formula — but per root `CLAUDE.md`'s proposal-mode rule for cognition-loop-adjacent changes, no such change is made in this patch; it is reported, not acted on.
- Mitigation: flagged explicitly in the README status note and this PR description as a "recommended next step, not taken in this patch."

## PR link

(filled in after `gh pr create`)
