### PR TITLE
feat(cortex-orch): flip ORION_AUTO_EXTRACTOR_ENABLED live -- Orion writes its own memory cards

### DIFF
--- a/services/orion-cortex-orch/.env_example
+++ b/services/orion-cortex-orch/.env_example
@@ -88,7 +88,13 @@ CONCEPT_PROFILE_PARITY_CRITICAL_MISMATCH_CLASSES=profile_missing_on_graph,profil
 RECALL_PG_DSN=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
 # If orch runs on the host (not Docker) while Postgres is only published to the host port, use instead:
 # RECALL_PG_DSN=postgresql://postgres:postgres@127.0.0.1:55432/conjourney
-ORION_AUTO_EXTRACTOR_ENABLED=false
+# Live 2026-07-21: Stage 1 (extraction + LLM annotation, PR #1232) flipped on
+# at Juniper's explicit direction. Cards land as status=pending_review only --
+# Stage 2 (auto-promote to active) stays false, so nothing an auto-extracted
+# card says becomes authoritative without a human reviewing it first. This is
+# Item 3 of docs/superpowers/specs/2026-07-21-memory-cards-self-authored-substrate-spec.md,
+# greenlit directly rather than going through further proposal-mode discussion.
+ORION_AUTO_EXTRACTOR_ENABLED=true
 ORION_AUTO_EXTRACTOR_STAGE2_ENABLED=false
 ORION_AUTO_EXTRACTOR_AUTO_PROMOTE_THRESHOLD=2
 # Write-time auto-annotation LLM call timeout (2026-07-21 memory-cards

--- a/services/orion-cortex-orch/app/memory_extractor.py
+++ b/services/orion-cortex-orch/app/memory_extractor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
@@ -36,9 +37,52 @@ _memory_pool_failed: bool = False
 # receives `env`, not a bus reference.
 _annotation_bus: Optional[OrionBusAsync] = None
 
-_ANNOTATION_PROMPT_PATH = (
-    Path(__file__).resolve().parents[3] / "orion" / "cognition" / "prompts" / "memory_card_annotation_prompt.j2"
-)
+def _annotation_prompt_path_candidates() -> list[Path]:
+    """Live incident 2026-07-21: a bare `parents[3]` assumed the local monorepo
+    checkout's directory depth (services/orion-cortex-orch/app/memory_extractor.py
+    -> repo root). Docker's actual layout (Dockerfile: `COPY orion /app/orion`,
+    `COPY services/orion-cortex-orch /app`) only has 2 parent levels above this
+    file, so `parents[3]` raised IndexError at import time -- a hard crash loop,
+    not a degraded fallback, since main.py imports this module at startup.
+    Mirrors the multi-candidate/env-override pattern already proven in
+    orion/self_state/field_channel_glossary.py's _glossary_path_candidates()."""
+    roots: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(root: Path) -> None:
+        try:
+            resolved = root.expanduser().resolve()
+        except OSError:
+            return
+        key = str(resolved)
+        if key in seen:
+            return
+        seen.add(key)
+        roots.append(resolved)
+
+    raw = os.getenv("ORION_REPO_ROOT", "").strip()
+    if raw:
+        _add(Path(raw))
+    here = Path(__file__).resolve()
+    if len(here.parents) >= 2:
+        _add(here.parents[1])  # Docker layout: /app/app/memory_extractor.py -> /app
+    if len(here.parents) >= 3:
+        _add(here.parents[2])  # local monorepo checkout: services/orion-cortex-orch/app/... -> repo root
+    _add(Path("/app"))
+    _add(Path("/repo"))
+    _add(Path("/mnt/scripts/Orion-Sapienform"))
+    return [root / "orion" / "cognition" / "prompts" / "memory_card_annotation_prompt.j2" for root in roots]
+
+
+def _resolve_annotation_prompt_path() -> Path:
+    for candidate in _annotation_prompt_path_candidates():
+        if candidate.is_file():
+            return candidate
+    # No candidate exists on disk -- fall back to the monorepo-checkout shape
+    # so the resulting FileNotFoundError (raised lazily, on read, from
+    # _build_annotation_prompt -- never at import time) at least names a
+    # sensible path instead of an empty one.
+    return Path("/mnt/scripts/Orion-Sapienform") / "orion" / "cognition" / "prompts" / "memory_card_annotation_prompt.j2"
 
 
 async def _get_memory_pool() -> Optional[Any]:
@@ -92,7 +136,7 @@ def _coerce_turn(env: BaseEnvelope) -> Optional[ChatHistoryTurnV1]:
 
 
 def _build_annotation_prompt(turn_text: str) -> str:
-    template = Template(_ANNOTATION_PROMPT_PATH.read_text(encoding="utf-8"))
+    template = Template(_resolve_annotation_prompt_path().read_text(encoding="utf-8"))
     return template.render(turn_text=turn_text)
 
 

--- a/services/orion-cortex-orch/tests/test_memory_extractor.py
+++ b/services/orion-cortex-orch/tests/test_memory_extractor.py
@@ -416,3 +416,38 @@ def test_fallback_to_regex_when_llm_response_fails_anchor_class_validation(monke
     insert_mock.assert_awaited_once()
     card_arg = insert_mock.await_args.args[1]
     assert "Ogden" in (card_arg.summary or "")
+
+
+def test_annotation_prompt_path_resolution_survives_shallow_docker_layout(monkeypatch) -> None:
+    """Live incident 2026-07-21: a bare `Path(__file__).resolve().parents[3]`
+    assumed the local monorepo checkout's depth. Docker's real layout
+    (Dockerfile: `COPY orion /app/orion`, `COPY services/orion-cortex-orch /app`)
+    only has 2 parent levels above this file inside the container
+    (/app/app/memory_extractor.py), so parents[3] raised IndexError at
+    IMPORT time -- main.py imports this module at startup, so the whole
+    service crash-looped, not just this feature. This asserts the fix's
+    candidate-generation never raises regardless of how shallow __file__'s
+    parent chain is, and that the container-shaped root actually gets
+    tried."""
+    import app.memory_extractor as mod
+
+    # Simulate the container's real, shallow file location.
+    shallow = Path("/app/app/memory_extractor.py")
+    monkeypatch.setattr(mod, "__file__", str(shallow))
+
+    candidates = mod._annotation_prompt_path_candidates()
+    assert candidates, "must produce at least one candidate, never raise"
+    assert all(c.name == "memory_card_annotation_prompt.j2" for c in candidates)
+    # The container-shaped root (one parent above __file__) must be among
+    # the candidates -- this is the exact root the live incident needed.
+    assert any(str(c).startswith("/app/orion/") for c in candidates)
+
+    # Never raises even with an absurdly shallow path (no parents at all).
+    monkeypatch.setattr(mod, "__file__", "memory_extractor.py")
+    candidates_shallow = mod._annotation_prompt_path_candidates()
+    assert isinstance(candidates_shallow, list)
+
+    # resolve_annotation_prompt_path itself never raises either, even when
+    # no candidate exists on disk in the test sandbox.
+    resolved = mod._resolve_annotation_prompt_path()
+    assert isinstance(resolved, Path)


### PR DESCRIPTION
## Summary

- Item 3 of `docs/superpowers/specs/2026-07-21-memory-cards-self-authored-substrate-spec.md`, greenlit directly by Juniper.
- `ORION_AUTO_EXTRACTOR_ENABLED` flipped `true`. Stage 2 (`ORION_AUTO_EXTRACTOR_STAGE2_ENABLED`, auto-promote to `active`) stays `false` -- every auto-extracted card lands as `status=pending_review`, reviewed by a human before it's authoritative.
- **Depends on PR #1233** (memory_extractor's Docker-path crash-loop fix). Confirmed live during this deploy: flipping the flag and rebuilding `orion-cortex-orch` from `main` (without #1233's fix) crash-loops the entire service, not just this feature -- redeployed with #1233's fix merged in, now stable.

## Live verification

Published a real `orion:chat:history:turn` bus event (`"I live in Ogden, Utah, near the mountains."`). Confirmed via container logs and direct Postgres query:

```
INFO:orion.cortex.memory_extractor:memory_extractor_card_created fp=fd73dc5c197c58b0 title='Residence in Ogden, Utah' mode=llm_annotation
```

```
title: Residence in Ogden, Utah
summary: The user lives in Ogden, Utah, located near the mountains.
confidence: certain
priority: high_recall
status: pending_review
sensitivity: private   (hardcoded, never LLM-influenced -- confirmed)
subschema.auto_extractor_mode: llm_annotation   (real LLM path, not the regex fallback)
```

Also confirmed visible live through Hub's existing Memory tab -> Review Queue (`GET /api/memory/cards?status=pending_review`) -- no backend gap there, see companion PR for a small provenance-badge UI enhancement to make these visually distinct from operator-authored cards.

## Files changed

- `services/orion-cortex-orch/.env_example`: `ORION_AUTO_EXTRACTOR_ENABLED` `false` -> `true`, with a comment documenting the decision and the PR #1233 dependency.
- Live `.env` in the primary checkout synced directly (same key, plus `ORION_AUTO_EXTRACTOR_LLM_TIMEOUT_SEC` which was missing from it entirely -- PR #1232 added that key to `.env_example` but it never got synced to live `.env` until now).

## Docker/build/smoke checks

```
scripts/safe_docker_build.sh orion-cortex-orch up -d --build
docker ps --filter name=orion-athena-cortex-orch
  orion-athena-cortex-orch   Up 31 seconds   (stable)
docker exec orion-athena-cortex-orch printenv ORION_AUTO_EXTRACTOR_ENABLED ORION_AUTO_EXTRACTOR_STAGE2_ENABLED
  true
  false
```

Already deployed live (see verification above).

## Restart required

Already applied live. If redeploying from a fresh pull:
```bash
scripts/safe_docker_build.sh orion-cortex-orch up -d --build
```

## Risks / concerns

- Severity: low-medium -- this is genuinely new autonomous behavior (Orion writing its own memory), but bounded by `pending_review` gating (nothing is authoritative without human review) and the hardcoded `sensitivity=private` boundary (no path for the LLM to mark something public).
- Concern: extraction currently only fires on messages matching whatever `orion:chat:history:turn` traffic exists -- volume/quality over time is unproven beyond this one live test.
- Mitigation: `status=pending_review` means nothing ships to `active` without review; watch via Hub's Review Queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)