### PR TITLE
feat(hub): provenance badge on memory-card rows -- observability for auto-written cards

### DIFF
--- a/services/orion-hub/static/js/memory.js
+++ b/services/orion-hub/static/js/memory.js
@@ -116,11 +116,31 @@
     }
   }
 
+  // 2026-07-21: memory-cards substrate spec Item 3 flipped ORION_AUTO_EXTRACTOR_ENABLED
+  // live -- Orion now writes its own pending_review cards via a real LLM annotation
+  // call (services/orion-cortex-orch/app/memory_extractor.py). Distinguishing
+  // provenance at a glance in the compact row (not just the detail panel) is the
+  // whole point of an observability surface for this -- without it, self-authored
+  // cards are indistinguishable from operator-curated ones until you open each one.
+  function provenanceBadge(provenance) {
+    const p = String(provenance || "").trim();
+    if (p === "auto_extractor") {
+      return `<span class="text-[9px] px-1.5 py-0.5 rounded-full border border-sky-700 bg-sky-950/60 text-sky-300" title="Written by Orion's auto-extractor, awaiting review">🤖 auto</span>`;
+    }
+    if (p === "chat_compactor" || p === "repo_compactor") {
+      return `<span class="text-[9px] px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-950/60 text-gray-400" title="${escapeHtml(p)}">⚙ ${escapeHtml(p)}</span>`;
+    }
+    if (p === "operator_distiller" || p === "operator_highlight") {
+      return `<span class="text-[9px] px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-950/60 text-gray-400" title="${escapeHtml(p)}">👤 operator</span>`;
+    }
+    return p ? `<span class="text-[9px] px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-950/60 text-gray-500">${escapeHtml(p)}</span>` : "";
+  }
+
   function renderCardRow(card, onOpen) {
     const row = document.createElement("div");
     row.className = "flex justify-between gap-2 border border-gray-800 rounded px-2 py-1 bg-gray-900/60";
-    row.innerHTML = `<div><div class="font-medium text-gray-100">${escapeHtml(card.title || "")}</div>
-      <div class="text-[10px] text-gray-500">${escapeHtml(card.slug || "")} · ${escapeHtml(card.status || "")} · ${escapeHtml(card.priority || "episodic_detail")}</div></div>`;
+    row.innerHTML = `<div><div class="font-medium text-gray-100 flex items-center gap-1.5">${escapeHtml(card.title || "")} ${provenanceBadge(card.provenance)}</div>
+      <div class="text-[10px] text-gray-500">${escapeHtml(card.slug || "")} · ${escapeHtml(card.status || "")} · ${escapeHtml(card.priority || "episodic_detail")} · ${escapeHtml(card.confidence || "likely")}</div></div>`;
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "text-[10px] text-indigo-300 hover:text-indigo-200";


### PR DESCRIPTION
## Summary

- `ORION_AUTO_EXTRACTOR_ENABLED` just flipped live (companion PR #1234) -- Orion now writes its own `pending_review` memory cards via a real LLM annotation call.
- Hub's existing Memory tab (Review Queue / All Cards, `static/js/memory.js`) already surfaces these correctly through `GET /api/memory/cards` -- **no backend gap, this is UI-only**. But the compact row only showed status/priority, so a self-authored card was indistinguishable from an operator-curated one until you opened its detail panel.
- Adds a small provenance badge (🤖 auto / ⚙ compactor / 👤 operator) to `renderCardRow`, covering both call sites (Review Queue, All Cards) since they share the same render function. Also surfaces `confidence` in the row subtitle, matching `priority` which was already shown there.

## Why not a new page

Investigated building a dedicated new observability dashboard first (mirroring `drives-analytics.html`'s standalone-page pattern) before discovering Hub already has a full memory-cards panel -- Review Queue, All Cards, Activity Log, Crystallizations, a graph annotator with Validate/Approve/Suggest -- wired to the same `/api/memory/cards` API this feature writes through. Building a second page would have been redundant. This PR is the actual gap: making the one new field that matters (provenance) visible without a click.

## Files changed

- `services/orion-hub/static/js/memory.js`: `provenanceBadge()` helper + `renderCardRow` update.

## Live verification

```
curl -fsS "http://127.0.0.1:8080/static/js/memory.js" | grep -c "provenanceBadge"
2
```

Confirmed the real test card created in PR #1234's verification (`"Residence in Ogden, Utah"`, `provenance=auto_extractor`) is served correctly by the underlying API and will render with the 🤖 auto badge in Review Queue.

## Docker/build/smoke checks

```
scripts/safe_docker_build.sh orion-hub up -d --build
docker ps --filter name=orion-athena-hub
  orion-athena-hub   Up 10 seconds   (stable)
docker logs orion-athena-hub --since 15s | grep -iE "error|traceback|exception"
  (no output)
```

Already deployed live.

## Restart required

Already applied live. If redeploying from a fresh pull:
```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

## Risks / concerns

- Severity: none -- pure display change, no backend/data-path modification, no new API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)