### PR TITLE
fix(topic-foundry): keyword extraction was fully hardcoded, model_spec.params crashed HDBSCAN

### DIFF
--- a/services/orion-topic-foundry/app/services/training.py
+++ b/services/orion-topic-foundry/app/services/training.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 
 import numpy as np
 from joblib import dump
-from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS, TfidfVectorizer
 try:
     from hdbscan import HDBSCAN
 except ImportError:  # pragma: no cover - exercised in minimal test envs
@@ -123,11 +123,40 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
+def _resolve_keyword_stop_words(model_params: Dict[str, Any]) -> Any:
+    """Live incident 2026-07-21: this function's caller previously hardcoded
+    TfidfVectorizer(stop_words="english", ...) with no override mechanism at
+    all -- a real, separate BERTopic-style vectorizer in app/topic_engine.py
+    DOES support model_spec.params-driven stopword overrides
+    (vectorizer_stop_words/stop_words_extra), but that code path is never
+    invoked by this service's actual /runs/train training flow, so it gave a
+    false impression the feature existed. Confirmed live: sklearn's "english"
+    list does not cover casual chat filler at all (checked "hi", "like",
+    "just", "let", "know", "need" -- none are in ENGLISH_STOP_WORDS), so the
+    real active model's top keywords were dominated by exactly those words.
+    Mirrors topic_engine.py::_build_vectorizer's stop_words_extra convention
+    (comma-separated, lowercased) so a model_spec.params dict written for one
+    code path works for the other too.
+    """
+    stop_words_raw = str(model_params.get("vectorizer_stop_words", "english") or "").strip().lower()
+    if stop_words_raw in {"", "none", "null", "off", "false", "0"}:
+        return None
+    if stop_words_raw != "english":
+        custom = [x.strip().lower() for x in stop_words_raw.split(",") if x.strip()]
+        return custom or None
+    extras_raw = str(model_params.get("stop_words_extra", "") or "")
+    extras = [x.strip().lower() for x in extras_raw.split(",") if x.strip()]
+    if not extras:
+        return "english"
+    return sorted(set(ENGLISH_STOP_WORDS).union(extras))
+
+
 def _compute_topic_artifacts(
     segments: List[RowBlock],
     labels: np.ndarray,
     *,
     max_keywords: int = 12,
+    model_params: Optional[Dict[str, Any]] = None,
 ) -> tuple[List[Dict[str, Any]], Dict[str, List[str]]]:
     summary_counts: Dict[int, int] = {}
     texts_by_topic: Dict[int, List[str]] = {}
@@ -146,7 +175,8 @@ def _compute_topic_artifacts(
     topic_texts = [(tid, texts) for tid, texts in texts_by_topic.items() if tid != -1 and texts]
     if topic_texts:
         all_texts = [text for _, texts in topic_texts for text in texts]
-        vectorizer = TfidfVectorizer(stop_words="english", max_features=5000)
+        stop_words = _resolve_keyword_stop_words(model_params or {})
+        vectorizer = TfidfVectorizer(stop_words=stop_words, max_features=5000)
         tfidf = vectorizer.fit_transform(all_texts)
         vocab = np.array(vectorizer.get_feature_names_out())
         offset = 0
@@ -387,11 +417,24 @@ _UMAP_RESERVED_PARAM_KEYS = frozenset(
     {"umap_n_neighbors", "umap_n_components", "umap_min_dist", "umap_metric", "random_state"}
 )
 
+# Live incident 2026-07-21: model_spec.params is a shared namespace across
+# three different consumers (UMAP reducer, HDBSCAN clusterer, keyword
+# vectorizer via _resolve_keyword_stop_words above) but only
+# _UMAP_RESERVED_PARAM_KEYS existed to keep UMAP-only keys out of the
+# HDBSCAN(**params) call -- vectorizer keys had no equivalent exclusion, so
+# setting stop_words_extra/vectorizer_stop_words in model_spec.params (the
+# only documented way to reach _resolve_keyword_stop_words) always crashed
+# clusterer construction with TypeError before training could even reach the
+# keyword-computation step. Confirmed live: a real training run with
+# stop_words_extra set failed at HDBSCAN(**params) every time.
+_VECTORIZER_RESERVED_PARAM_KEYS = frozenset({"vectorizer_stop_words", "stop_words_extra"})
+
 
 def _build_clusterer(spec: ModelSpec) -> HDBSCAN:
     _require_hdbscan()
     params = {"min_cluster_size": spec.min_cluster_size, "metric": spec.metric}
-    params.update({k: v for k, v in spec.params.items() if k not in _UMAP_RESERVED_PARAM_KEYS})
+    reserved = _UMAP_RESERVED_PARAM_KEYS | _VECTORIZER_RESERVED_PARAM_KEYS
+    params.update({k: v for k, v in spec.params.items() if k not in reserved})
     params.setdefault("prediction_data", True)
     return HDBSCAN(**params)
 
@@ -562,7 +605,9 @@ def _write_artifacts(
     (run_dir / "stats.json").write_text(json.dumps(stats, indent=2))
     (run_dir / "run_record.json").write_text(json.dumps(run.model_dump(mode="json"), indent=2))
 
-    topics_summary, topics_keywords = _compute_topic_artifacts(segments, labels)
+    topics_summary, topics_keywords = _compute_topic_artifacts(
+        segments, labels, model_params=run.specs.model.params
+    )
     topics_summary_path = run_dir / "topics_summary.json"
     topics_keywords_path = run_dir / "topics_keywords.json"
     topics_summary_path.write_text(json.dumps(topics_summary, indent=2))

--- a/services/orion-topic-foundry/tests/test_training_umap_reduction.py
+++ b/services/orion-topic-foundry/tests/test_training_umap_reduction.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from app.models import ModelSpec
-from app.services.training import _build_clusterer, _build_reducer
+from app.services.training import _build_clusterer, _build_reducer, _resolve_keyword_stop_words
 
 
 def _model_spec(**overrides) -> ModelSpec:
@@ -75,6 +75,52 @@ def test_build_clusterer_excludes_umap_reserved_keys_from_hdbscan_kwargs():
     embeddings = np.random.default_rng(0).normal(size=(30, 8)).astype(np.float32)
     labels = clusterer.fit_predict(embeddings)
     assert len(labels) == 30
+
+
+def test_build_clusterer_excludes_vectorizer_reserved_keys_from_hdbscan_kwargs():
+    """Live incident 2026-07-21: setting stop_words_extra/vectorizer_stop_words
+    in model_spec.params (the only documented way to reach
+    _resolve_keyword_stop_words) crashed HDBSCAN's constructor directly --
+    TypeError: __init__() got an unexpected keyword argument
+    'vectorizer_stop_words' -- unlike the umap_* keys above, which HDBSCAN's
+    constructor silently accepts and only fails on later at fit time. Both
+    failure shapes are covered: this one at construction, the umap one above
+    at fit."""
+    spec = _model_spec(
+        params={
+            "vectorizer_stop_words": "english",
+            "stop_words_extra": "hi,hey,juniper,orion",
+        }
+    )
+    clusterer = _build_clusterer(spec)  # must not raise
+    embeddings = np.random.default_rng(0).normal(size=(30, 8)).astype(np.float32)
+    labels = clusterer.fit_predict(embeddings)
+    assert len(labels) == 30
+
+
+def test_resolve_keyword_stop_words_defaults_to_english():
+    assert _resolve_keyword_stop_words({}) == "english"
+
+
+def test_resolve_keyword_stop_words_none_disables_filtering():
+    for off in ("none", "off", "false", "0", ""):
+        assert _resolve_keyword_stop_words({"vectorizer_stop_words": off}) is None
+
+
+def test_resolve_keyword_stop_words_extends_english_list():
+    """The actual live defect this fixes: sklearn's 'english' list does not
+    cover conversational filler at all -- confirmed live, none of
+    hi/like/just/let/know/need are in ENGLISH_STOP_WORDS."""
+    result = _resolve_keyword_stop_words({"stop_words_extra": "hi, Juniper, orion"})
+    assert isinstance(result, list)
+    assert "hi" in result
+    assert "juniper" in result  # lowercased
+    assert "the" in result  # base english list still present
+
+
+def test_resolve_keyword_stop_words_custom_list_replaces_english():
+    result = _resolve_keyword_stop_words({"vectorizer_stop_words": "foo,bar"})
+    assert result == ["foo", "bar"]
 
 
 def test_reduce_then_cluster_with_umap_param_overrides_does_not_crash():


### PR DESCRIPTION
## Summary

- Live-caught while retraining the active `topic-foundry` model: its top keywords were dominated by conversational filler ("like", "meow", "just", "user", "assistant", "juniper", "let", "hi", "specific", "know", "mind", "need") -- confirmed none of these are in sklearn's `ENGLISH_STOP_WORDS`.
- Root cause was two real, separate bugs:
  1. `_compute_topic_artifacts` (the function actually used by `/runs/train` -- traced the real call graph, `app/topic_engine.py`'s configurable `_build_vectorizer` exists but is dead code as far as this endpoint is concerned) hardcoded `TfidfVectorizer(stop_words="english", max_features=5000)` with **zero override mechanism**. No API surface has ever been able to customize keyword stopwords for a real training run.
  2. `model_spec.params` is a shared namespace across three consumers (UMAP reducer, HDBSCAN clusterer, keyword vectorizer), but only `_UMAP_RESERVED_PARAM_KEYS` existed to keep UMAP-only keys out of `HDBSCAN(**params)`. Trying to set `vectorizer_stop_words`/`stop_words_extra` crashed clusterer construction with `TypeError` -- confirmed live, twice: once at construction time, and a second, subtler failure at fit time deep in sklearn's `KDTree`/`DistanceMetric` code (HDBSCAN's constructor silently absorbs unrecognized kwargs into `_metric_kwargs` instead of rejecting immediately -- root-caused to a stale in-memory Python module, `docker cp` updates a container's filesystem but not an already-running process's already-imported modules; needed a full restart, not just a file copy, for the fix to actually take effect).

## Fix

- `_resolve_keyword_stop_words()` threads `model_spec.params` into the real vectorizer, mirroring `topic_engine.py`'s `stop_words_extra` convention so a params dict written for one code path works for the other.
- `_VECTORIZER_RESERVED_PARAM_KEYS` keeps those keys out of `HDBSCAN(**params)`, matching the existing UMAP exclusion pattern.

## Live verification

Retrained the active model's own dataset with a real `stop_words_extra` list (conversational filler + structural speaker-label tokens like `user`/`assistant`/`orion`/`juniper`, which behave like stopwords for topic-discrimination purposes since they're near-universal across every document):

| | Before | After |
|---|---|---|
| Outlier rate | 63.09% (412/653) | 0.89% (6/676) |
| Cluster count | 2 | 4 |
| Topic keywords | `like, meow, just, user, assistant, juniper, let, hi, specific, know, mind, need` | 4 genuinely distinct, coherent clusters: general chat, capability/status-check, a "cat persona" cluster, a compactor/journal-system cluster |

Promoted the retrained model (`v2-stopword-lift`) to `active` live, replacing `v1-retry3`.

## Files changed

- `services/orion-topic-foundry/app/services/training.py`: `_resolve_keyword_stop_words()`, `_VECTORIZER_RESERVED_PARAM_KEYS`, threaded into `_compute_topic_artifacts`'s call site.
- `services/orion-topic-foundry/tests/test_training_umap_reduction.py`: 5 new regression tests.

## Tests run

```
docker exec orion-athena-topic-foundry python3 -m pytest /tmp/test_training_umap_reduction.py -v
12 passed (7 pre-existing + 5 new)

Full suite:
16 passed, 1 failed (test_chat_corpus_builder_stages.py -- pre-existing, unrelated to training.py/clustering, confirmed no reference to anything touched in this PR)
```

## Docker/build/smoke checks

```
scripts/safe_docker_build.sh orion-topic-foundry up -d --build
docker ps --filter name=orion-athena-topic-foundry
  orion-athena-topic-foundry   Up 42 seconds (healthy)
docker logs orion-athena-topic-foundry --since 15s | grep -iE "error|traceback|exception"
  (no output)
```

Already deployed live and the retrained model promoted to active (see verification above).

## Restart required

Already applied live. If redeploying from a fresh pull:
```bash
scripts/safe_docker_build.sh orion-topic-foundry up -d --build
```

## Risks / concerns

- Severity: low -- the fix is additive (a new optional override path plus a reserved-key exclusion), doesn't change default behavior for any model that doesn't set these params.
- Concern: the `stop_words_extra` list I used for the live retrain (`hi,hey,hello,like,just,know,need,let,think,mean,yeah,yes,no,okay,ok,thanks,thank,please,really,sure,maybe,actually,gonna,wanna,got,get,getting,going,go,said,says,say,tell,told,ask,asked,user,assistant,orion,juniper,thing,things,stuff,kind,lot,bit,way,much,also,ll,ve,re,didn,don,doesn,isn,wasn`) is a reasonable first pass, not exhaustively tuned -- worth revisiting as more runs accumulate.
- Mitigation: it's a per-model config value (`model_spec.params.stop_words_extra`), easy to adjust on the next model registration without another code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)