### PR TITLE
feat(attention): Candidate A -- precision-weighted prediction-error salience (shadow, read-only)

### DIFF
--- a/orion/attention/field_attention/candidate_precision_weighted.py
+++ b/orion/attention/field_attention/candidate_precision_weighted.py
@@ -1,0 +1,179 @@
+"""Candidate A -- precision-weighted prediction-error salience.
+
+**Shadow, read-only candidate instrument. Not wired into any live consumer.**
+
+Sentience Striving Program (`orion/sentience_striving_program/README.md`) §7 ("measure
+before minting", "multi-theory, not single-theory") and
+`docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-tentative-
+plan.md`'s "Candidate A" section. This is one of two parallel candidate replacements for
+the un-calibrated `compute_salience()` formula in
+`orion/attention/field_attention/scoring.py` -- Candidate B (Global Workspace/
+Society-of-Mind rank-aggregation) is being built separately against the same real data
+window. **Do not modify `scoring.py` or `selectors.py` here** -- this module is a parallel
+measurement, not a live change, per the plan doc's non-goals ("Not choosing between
+Candidate A and B here... Both get built as real, replayed, comparable instruments;
+integration is decided from data, later.").
+
+## Theory anchor
+
+Feldman & Friston 2010, "Attention, Uncertainty, and Free-Energy" (confirmed against the
+primary Wikipedia summary of the Free Energy Principle, "Perceptual precision, attention
+and salience" section, 2026-07-21): attention is precision-optimization on prediction
+error. Precision is the inverse variance ("temperature") of a signal's own historical
+fluctuation -- a large prediction error is more salient when it occurs against a
+historically *quiet* (low-variance, high-precision) backdrop than when the same magnitude
+error occurs against a historically noisy one.
+
+    salience(target) = precision(target) x |prediction_error(target)|
+    precision(target) = 1 / variance(target's own real historical prediction-error series)
+
+## Real data source and scoping (2026-07-21, live-verified at build time)
+
+`prediction_error(target)`'s *current* value comes from the five already-shipped
+instruments in `orion/substrate/prediction_error.py` (`execution_prediction_error`,
+`transport_prediction_error`, `biometrics_prediction_error`, `chat_prediction_error`,
+`route_prediction_error`). `precision(target)` needs that same target's own *historical*
+series -- FalkorDB substrate-graph nodes (`node:substrate.*`) hold only a single current
+value with no history (confirmed live via `redis-cli GRAPH.QUERY` against `n.node_id`,
+2026-07-21). The real historical series lives in Postgres
+`substrate_reduction_receipts`, filtered by `reducer_name` (the receipt's
+`state_deltas[0].reducer_id`, written by `_prediction_error_receipt()` in
+`services/orion-substrate-runtime/app/worker.py`), ordered by `created_at`, with the
+error value at `receipt_json->'state_deltas'->0->'after'->'pressure_hints'->>
+'prediction_error'`.
+
+**Honest scoping requirement, re-checked live at build time (not inherited from the
+morning's design-doc numbers, which were already hours stale by the time this was
+built):**
+
+```
+psql -h localhost -p 55432 -U postgres -d conjourney -c "
+  SELECT reducer_name, count(*) FROM substrate_reduction_receipts
+  WHERE reducer_name IN (
+    'substrate.node_biometrics', 'substrate.execution_trajectory',
+    'substrate.transport_bus', 'substrate.chat_session', 'substrate.route_arbitration'
+  ) GROUP BY reducer_name;"
+```
+
+returned exactly one row: `substrate.node_biometrics` (168 receipts, real spread
+0.0000-0.1656, non-degenerate). The other four reducer names -- despite their underlying
+grammar reducers (`execution_trajectory`, `transport_bus`, `chat_grammar`,
+`route_grammar`) all being `enabled=true` in the live `.env` -- had **zero** rows: their
+prediction-error writers (`_tick`'s `if error > 0.0` gate at each of the four call sites
+in `worker.py`) produced no qualifying delta within the live retention window at check
+time. A second, load-bearing finding not in the earlier design doc: `substrate_
+reduction_receipts` retains **success** receipts for only
+`ORION_RECEIPT_RETENTION_SUCCESS_MINUTES=30` minutes (confirmed in
+`services/orion-substrate-runtime/.env` and `app/settings.py`, and empirically: 6,353
+total live rows spanning 2026-07-03 -> now, but all `expires_at` within 30 minutes of
+their own `created_at`, so a background pruner is actively deleting older rows). This
+means the "real historical series" available to this module's `precision_weighted_
+salience()` is *always* bounded to a rolling ~30-minute window, for every target, not
+just for whichever targets happen to be fresh today -- a structural property of the data
+source, not a today-only staleness artifact.
+
+**Scope for this patch: `substrate.node_biometrics` only.** Per the task's explicit
+instruction, this module's precision computation is not silently extended to
+execution/transport/chat/route -- they simply have no real, non-degenerate receipt
+history to compute a meaningful variance from at build time. If/when a future live run of
+one of those four lanes produces enough qualifying receipts, the replay script
+(`scripts/analysis/measure_precision_weighted_salience_probe.py`) will report that
+honestly rather than silently including a reducer this module was never checked against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Precision = 1 / variance diverges as variance -> 0 (a target whose recent error has
+# been almost perfectly constant). This is the "variance-near-zero instability risk"
+# named in the tentative-plan doc's Candidate A section. Floored here at a concrete
+# epsilon so precision saturates at a finite ceiling (1 / PRECISION_VARIANCE_FLOOR)
+# instead of diverging to +inf or raising a ZeroDivisionError.
+PRECISION_VARIANCE_FLOOR: float = 1e-6
+
+
+@dataclass(frozen=True)
+class PrecisionWeightedSalienceResult:
+    """Everything needed to inspect *why* a salience score came out the way it did --
+    not just the final scalar. `variance_floored` in particular is the concrete,
+    inspectable signal for the instability risk named in the design doc: a report can
+    tally how often it fires rather than trusting an unbounded score blindly."""
+
+    salience: float
+    precision: float
+    variance: float
+    current_error: float
+    n_samples: int
+    variance_floored: bool
+
+
+_EMPTY_RESULT = PrecisionWeightedSalienceResult(
+    salience=0.0,
+    precision=0.0,
+    variance=0.0,
+    current_error=0.0,
+    n_samples=0,
+    variance_floored=False,
+)
+
+
+def _population_variance(values: list[float]) -> float:
+    n = len(values)
+    if n == 0:
+        return 0.0
+    mean = sum(values) / n
+    return sum((v - mean) ** 2 for v in values) / n
+
+
+def precision_weighted_salience(
+    error_history: list[float],
+) -> PrecisionWeightedSalienceResult:
+    """Candidate A salience for one target: precision x |current prediction error|.
+
+    ``error_history``: a target's own real historical prediction-error magnitudes,
+    oldest-first (e.g. a window of real rows from `substrate_reduction_receipts` for one
+    `reducer_name`, in `created_at ASC` order -- see module docstring for the exact
+    query shape and the current real scope, `substrate.node_biometrics` only). The last
+    element is treated as the "current" error being weighted; the *entire* list
+    (including that current point) is used to estimate the process's own variance, per
+    Feldman & Friston 2010's framing of precision as a property of the signal's own
+    recent fluctuation, not a leave-one-out estimate of "everything before now."
+
+    Pure function. No I/O. Never raises.
+
+    Edge cases:
+    - Empty history -> zero salience/precision, `n_samples=0`. There is no "current"
+      error to weight in the first place.
+    - Single-sample history -> population variance of one point is exactly 0.0 by
+      definition (no fluctuation observed yet). This is NOT treated as a separate
+      "undefined" case from near-zero variance -- one real observation is real data at
+      the smallest possible sample size, not missing data -- so it floors the same way
+      any other near-zero-variance history does (see below), with `n_samples=1`
+      reported so a caller/report can weight its confidence in the result accordingly.
+    - Near-zero variance (a target whose error has been almost constant across the
+      window) -> precision would otherwise diverge; floored at
+      ``1 / PRECISION_VARIANCE_FLOOR`` (large but finite), and `variance_floored=True`
+      is reported explicitly so a caller can flag the instability risk rather than
+      silently trust an extreme score.
+    """
+    n = len(error_history)
+    if n == 0:
+        return _EMPTY_RESULT
+
+    values = [float(v) for v in error_history]
+    current_error = values[-1]
+    variance = _population_variance(values)
+    variance_floored = variance < PRECISION_VARIANCE_FLOOR
+    effective_variance = max(variance, PRECISION_VARIANCE_FLOOR)
+    precision = 1.0 / effective_variance
+    salience = precision * abs(current_error)
+
+    return PrecisionWeightedSalienceResult(
+        salience=salience,
+        precision=precision,
+        variance=variance,
+        current_error=current_error,
+        n_samples=n,
+        variance_floored=variance_floored,
+    )

--- a/scripts/analysis/measure_precision_weighted_salience_probe.py
+++ b/scripts/analysis/measure_precision_weighted_salience_probe.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python3
+"""Read-only replay of Candidate A (precision-weighted prediction-error salience) over
+real `substrate_reduction_receipts` history.
+
+Sentience Striving Program (`orion/sentience_striving_program/README.md`) §7 ("measure
+before minting") and
+`docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-tentative-
+plan.md`'s "Candidate A" section. Replays
+`orion/attention/field_attention/candidate_precision_weighted.py::
+precision_weighted_salience()` -- a pure function, imported and exercised here, never
+reimplemented -- over real historical prediction-error receipts, the same discipline as
+`measure_emergent_clustering_probe.py` / `measure_origination_gate.py` /
+`measure_ast_hot_reducer.py`.
+
+This performs NO writes, emits NO events, flips NO flags, and imports nothing from
+`orion.spark.concept_induction`.
+
+## Honest scoping, re-verified live at run time, not assumed from a prior check
+
+`orion/substrate/prediction_error.py` has five instruments (execution, transport,
+biometrics, chat, route), each of which -- when `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES`
+is enabled -- writes a `substrate_reduction_receipts` row via `_prediction_error_receipt()`
+(`services/orion-substrate-runtime/app/worker.py`) with `reducer_name` equal to the
+receipt's `state_deltas[0].reducer_id` (`f"substrate.{reducer_key}"`). This script queries
+all five real `reducer_name` values (`REDUCER_NAMES` below) and reports, per reducer,
+whether it has enough real rows (`QUALIFYING_MIN_ROWS`) to run a meaningful replay --
+it does NOT hardcode the assumption that only biometrics qualifies, so a future run
+against a live deployment where execution/transport/chat/route have accumulated real
+history will pick them up automatically, honestly, without a code change here.
+
+**A structural constraint on ALL five reducers, not a today-only staleness note:**
+`substrate_reduction_receipts` retains `success`-kind receipts for only
+`ORION_RECEIPT_RETENTION_SUCCESS_MINUTES` (30 minutes in the live `.env` at time of
+writing) before a background pruner deletes them -- confirmed empirically (6,353 total
+live rows spanning 2026-07-03 -> run time, but every row's `expires_at` within ~30 minutes
+of its own `created_at`). This means the real historical series available to Candidate A
+is *always* bounded to a rolling window on that order, for whichever reducer(s) qualify --
+not a limitation of this script, a property of the live data source it reads from.
+
+## Disclosed scoping decisions
+
+1. **Rolling window, not full-history expanding window, for precision estimation.**
+   Feldman & Friston's "precision" is meant to capture a signal's *current* volatility,
+   which can itself drift over time -- an expanding window that includes very old
+   observations would let stale variance dominate a fresh estimate. Each tick's
+   precision is computed from the `--rolling-window` (default 20) most recent samples
+   up to and including that tick, matching `precision_weighted_salience()`'s own
+   documented contract ("the LAST element is treated as the current error").
+2. **Window-hours/gap-hours CLI flags kept for comparability with Candidate B's probe**
+   (`measure_emergent_clustering_probe.py --window-hours 24 --gap-hours 12`), but this
+   script's own `MIN_WINDOW_HOURS` default (0.05h = 3 minutes) is far smaller than that
+   script's (4h), because the real retention-bounded data volume here is orders of
+   magnitude smaller. If the real available span cannot support even a same-length
+   two-window split at the requested `--window-hours`/`--gap-hours`, this script reports
+   that honestly and falls back to a single full-window analysis -- it does NOT force an
+   artificial split, per the task's explicit instruction not to fabricate alignment with
+   Candidate B's window.
+3. **Qualifying threshold** (`QUALIFYING_MIN_ROWS`, default 20): a reducer needs at least
+   this many real rows before this script treats its precision estimate as meaningful.
+   Below this, the reducer is reported as `NOT_QUALIFIED`, not silently skipped or
+   silently analyzed anyway.
+
+Run:
+    python scripts/analysis/measure_precision_weighted_salience_probe.py \\
+        --window-hours 24 --gap-hours 12 --rolling-window 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import os
+import statistics
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from orion.attention.field_attention.candidate_precision_weighted import (
+    PRECISION_VARIANCE_FLOOR,
+    PrecisionWeightedSalienceResult,
+    precision_weighted_salience,
+)
+
+logger = logging.getLogger("orion.analysis.precision_weighted_salience_probe")
+
+# Real reducer_name values a prediction-error node write can carry -- see
+# `_prediction_error_receipt()`'s `reducer_id=f"substrate.{reducer_key}"` and the
+# `reducer_key=` call sites in `services/orion-substrate-runtime/app/worker.py`.
+REDUCER_NAMES: tuple[str, ...] = (
+    "substrate.node_biometrics",
+    "substrate.execution_trajectory",
+    "substrate.transport_bus",
+    "substrate.chat_session",
+    "substrate.route_arbitration",
+)
+
+DEFAULT_WINDOW_HOURS: float = 24.0
+DEFAULT_GAP_HOURS: float = 12.0
+MIN_WINDOW_HOURS: float = 0.05  # 3 minutes -- see module docstring disclosed decision #2
+DEFAULT_ROLLING_WINDOW: int = 20
+QUALIFYING_MIN_ROWS: int = 20
+MAX_ROWS: int = 50_000
+
+OUTPUT_DIR = Path("/tmp/precision-weighted-salience-probe")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+CSV_DIR = OUTPUT_DIR / "ticks"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Runs the real candidate_precision_weighted module over
+# aligned (timestamp, value) series and summarizes real numbers.
+# ===========================================================================
+
+
+def parse_prediction_error(raw: Any) -> Optional[float]:
+    """Parse a raw `receipt_json->...->>'prediction_error'` value (a JSON text
+    scalar, possibly None/malformed). Never raises."""
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def compute_rolling_results(
+    values: list[float], rolling_window: int
+) -> list[PrecisionWeightedSalienceResult]:
+    """Run the real `precision_weighted_salience()` at each tick, using the
+    `rolling_window` most recent samples up to and including that tick (see module
+    docstring disclosed decision #1). Tick 0 gets a window of size 1."""
+    results: list[PrecisionWeightedSalienceResult] = []
+    for i in range(len(values)):
+        start = max(0, i - rolling_window + 1)
+        results.append(precision_weighted_salience(values[start : i + 1]))
+    return results
+
+
+@dataclass
+class ResultSummary:
+    n: int
+    salience_min: float
+    salience_max: float
+    salience_mean: float
+    salience_median: float
+    salience_stdev: float
+    precision_min: float
+    precision_max: float
+    precision_mean: float
+    variance_floored_count: int
+    variance_floored_pct: float
+    raw_error_min: float
+    raw_error_max: float
+    raw_error_mean: float
+    raw_error_stdev: float
+
+
+def summarize_results(results: list[PrecisionWeightedSalienceResult]) -> Optional[ResultSummary]:
+    if not results:
+        return None
+    saliences = [r.salience for r in results]
+    precisions = [r.precision for r in results]
+    errors = [r.current_error for r in results]
+    n_floored = sum(1 for r in results if r.variance_floored)
+    return ResultSummary(
+        n=len(results),
+        salience_min=min(saliences),
+        salience_max=max(saliences),
+        salience_mean=statistics.fmean(saliences),
+        salience_median=statistics.median(saliences),
+        salience_stdev=statistics.pstdev(saliences) if len(saliences) > 1 else 0.0,
+        precision_min=min(precisions),
+        precision_max=max(precisions),
+        precision_mean=statistics.fmean(precisions),
+        variance_floored_count=n_floored,
+        variance_floored_pct=(n_floored / len(results)) * 100.0,
+        raw_error_min=min(errors),
+        raw_error_max=max(errors),
+        raw_error_mean=statistics.fmean(errors),
+        raw_error_stdev=statistics.pstdev(errors) if len(errors) > 1 else 0.0,
+    )
+
+
+@dataclass
+class WindowSpec:
+    start: datetime
+    end: datetime
+    label: str
+
+
+def choose_windows(
+    min_ts: datetime,
+    max_ts: datetime,
+    window_hours: float = DEFAULT_WINDOW_HOURS,
+    gap_hours: float = DEFAULT_GAP_HOURS,
+    min_window_hours: float = MIN_WINDOW_HOURS,
+) -> Optional[tuple[WindowSpec, WindowSpec]]:
+    """Same anchoring/degradation shape as `measure_emergent_clustering_probe.py`'s
+    `choose_windows`, generic over a plain (min_ts, max_ts) span rather than a target
+    universe. Returns None when even a back-to-back split can't produce two windows of
+    at least `min_window_hours` each -- reported honestly, not fabricated."""
+    if min_ts is None or max_ts is None or max_ts <= min_ts:
+        return None
+    total_hours = (max_ts - min_ts).total_seconds() / 3600.0
+
+    if total_hours >= 2 * window_hours + gap_hours:
+        a_start, a_end = min_ts, min_ts + timedelta(hours=window_hours)
+        b_end = max_ts
+        b_start = b_end - timedelta(hours=window_hours)
+        return (
+            WindowSpec(a_start, a_end, f"{window_hours:g}h (window A, start-anchored)"),
+            WindowSpec(b_start, b_end, f"{window_hours:g}h (window B, end-anchored)"),
+        )
+
+    if total_hours >= 2 * min_window_hours:
+        half_hours = total_hours / 2.0
+        mid = min_ts + timedelta(hours=half_hours)
+        return (
+            WindowSpec(min_ts, mid, f"{half_hours * 60:.1f}min (window A, back-to-back split)"),
+            WindowSpec(mid, max_ts, f"{half_hours * 60:.1f}min (window B, back-to-back split)"),
+        )
+
+    return None
+
+
+def partition_by_window(
+    timestamps: list[datetime],
+    values: list[float],
+    win_a: WindowSpec,
+    win_b: WindowSpec,
+) -> tuple[list[float], list[float]]:
+    a: list[float] = []
+    b: list[float] = []
+    for ts, v in zip(timestamps, values):
+        if win_a.start <= ts < win_a.end:
+            a.append(v)
+        elif win_b.start <= ts <= win_b.end:
+            b.append(v)
+    return a, b
+
+
+# ===========================================================================
+# I/O layer -- psycopg2 read-only. Same connection contract as
+# measure_emergent_clustering_probe.py (refuses a non-read-only session).
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_reducer_rows(
+    conn, reducer_name: str, max_rows: int = MAX_ROWS
+) -> tuple[list[datetime], list[float]]:
+    """Real (timestamp, prediction_error) rows for one reducer_name, ASC by
+    created_at. Skips rows whose value fails to parse (never fatal)."""
+    if conn is None:
+        return [], []
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT created_at,
+                       receipt_json->'state_deltas'->0->'after'->'pressure_hints'
+                         ->>'prediction_error' AS pe
+                FROM substrate_reduction_receipts
+                WHERE reducer_name = %s
+                ORDER BY created_at ASC
+                LIMIT %s
+                """,
+                (reducer_name, max_rows),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch rows for reducer_name=%s", reducer_name, exc_info=True)
+        return [], []
+
+    timestamps: list[datetime] = []
+    values: list[float] = []
+    for ts, raw_pe in rows:
+        pe = parse_prediction_error(raw_pe)
+        if pe is None or ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        timestamps.append(ts)
+        values.append(pe)
+    return timestamps, values
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int, note: str = "") -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+            f"{(' | ' + note) if note else ''}"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def write_ticks_csv(
+    path: Path, timestamps: list[datetime], results: list[PrecisionWeightedSalienceResult]
+) -> None:
+    import csv
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            ["created_at", "current_error", "variance", "precision", "salience", "n_samples", "variance_floored"]
+        )
+        for ts, r in zip(timestamps, results):
+            writer.writerow(
+                [ts.isoformat(), f"{r.current_error:.6f}", f"{r.variance:.8f}", f"{r.precision:.4f}", f"{r.salience:.4f}", r.n_samples, r.variance_floored]
+            )
+
+
+def _fmt(value: Optional[float], nd: int = 4) -> str:
+    return "n/a" if value is None else f"{value:.{nd}f}"
+
+
+def _summary_block(label: str, summary: Optional[ResultSummary]) -> list[str]:
+    if summary is None:
+        return [f"### {label}: no rows", ""]
+    return [
+        f"### {label} ({summary.n} ticks)",
+        "",
+        f"- Raw `|prediction_error|` (current-tick value): min={_fmt(summary.raw_error_min)} "
+        f"max={_fmt(summary.raw_error_max)} mean={_fmt(summary.raw_error_mean)} "
+        f"stdev={_fmt(summary.raw_error_stdev)}",
+        f"- Precision: min={_fmt(summary.precision_min, 2)} max={_fmt(summary.precision_max, 2)} "
+        f"mean={_fmt(summary.precision_mean, 2)}",
+        f"- Salience (precision x |error|): min={_fmt(summary.salience_min, 2)} "
+        f"max={_fmt(summary.salience_max, 2)} mean={_fmt(summary.salience_mean, 2)} "
+        f"median={_fmt(summary.salience_median, 2)} stdev={_fmt(summary.salience_stdev, 2)}",
+        f"- Variance-floor instability rate: {summary.variance_floored_count}/{summary.n} "
+        f"({summary.variance_floored_pct:.1f}%) ticks hit `PRECISION_VARIANCE_FLOOR="
+        f"{PRECISION_VARIANCE_FLOOR:g}` (precision pinned at its ceiling, "
+        f"{1.0 / PRECISION_VARIANCE_FLOOR:g})",
+        "",
+    ]
+
+
+def render_report(
+    *,
+    rolling_window: int,
+    reducer_reports: dict[str, dict[str, Any]],
+    caveats: list[str],
+) -> str:
+    lines = [
+        "# Precision-Weighted Salience Probe (Candidate A) -- Real Prediction-Error Receipt History",
+        "",
+        "Read-only. No writes, no events, no flag/config changes. Replays the real, pure "
+        "`orion/attention/field_attention/candidate_precision_weighted.py::"
+        "precision_weighted_salience()` function over real `substrate_reduction_receipts` "
+        "history, per the Sentience Striving Program §7 ('measure before minting') and "
+        "`docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-"
+        "tentative-plan.md`'s Candidate A section. Imports nothing from "
+        "`orion.spark.concept_induction`.",
+        "",
+        f"- Rolling window for precision estimation: {rolling_window} samples",
+        f"- Reducer names checked (all 5 real `orion/substrate/prediction_error.py` "
+        f"instruments): {', '.join(f'`{r}`' for r in REDUCER_NAMES)}",
+        "",
+        "## Per-reducer results",
+        "",
+    ]
+
+    for reducer_name in REDUCER_NAMES:
+        rep = reducer_reports.get(reducer_name, {})
+        status = rep.get("status", "UNKNOWN")
+        n_rows = rep.get("n_rows", 0)
+        lines.append(f"### `{reducer_name}` -- **{status}**")
+        lines.append("")
+        lines.append(f"- Real rows found (bounded by live receipt retention): {n_rows}")
+        if status == "NOT_QUALIFIED":
+            lines.append(
+                f"- Below `QUALIFYING_MIN_ROWS={QUALIFYING_MIN_ROWS}` -- not enough real "
+                "history to compute a meaningful variance/precision estimate. No analysis "
+                "run for this reducer (honest scoping, not silently extended)."
+            )
+            lines.append("")
+            continue
+        if status == "NO_ROWS":
+            lines.append("- No real receipts at all for this reducer_name at run time.")
+            lines.append("")
+            continue
+
+        real_span = rep.get("real_span_label", "n/a")
+        lines.append(f"- Real data span: {real_span}")
+        lines.append("")
+        lines.extend(_summary_block("Full available window", rep.get("full_summary")))
+
+        window_status = rep.get("window_status")
+        if window_status == "INSUFFICIENT_FOR_TWO_WINDOW_SPLIT":
+            lines.append(
+                "**Two-window comparison (matching Candidate B's `--window-hours`/"
+                "`--gap-hours` convention): not attempted.** The real available span for "
+                f"this reducer ({real_span}) is too short to carve out two non-overlapping "
+                f"windows at the requested size, even with this script's own reduced "
+                f"`MIN_WINDOW_HOURS={MIN_WINDOW_HOURS:g}h` floor (itself far smaller than "
+                "Candidate B's 4h default, given how much smaller the real retention-bounded "
+                "data volume is here). Reported honestly rather than forcing an artificial "
+                "split -- see module docstring disclosed decision #2."
+            )
+            lines.append("")
+        elif window_status == "SPLIT":
+            win_a_label = rep.get("win_a_label", "")
+            win_b_label = rep.get("win_b_label", "")
+            lines.append(f"**Two-window comparison** -- Window A: {win_a_label}; Window B: {win_b_label}")
+            lines.append("")
+            lines.extend(_summary_block("Window A", rep.get("window_a_summary")))
+            lines.extend(_summary_block("Window B", rep.get("window_b_summary")))
+
+    lines.extend(["## Coverage caveats", ""])
+    if caveats:
+        lines.extend(f"- {c}" for c in caveats)
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(
+    window_hours: float = DEFAULT_WINDOW_HOURS,
+    gap_hours: float = DEFAULT_GAP_HOURS,
+    rolling_window: int = DEFAULT_ROLLING_WINDOW,
+) -> int:
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    progress = ProgressLog(PROGRESS_PATH)
+    caveats: list[str] = []
+
+    progress.emit("connect", percent=0.0, processed=0, total=0)
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        caveats.append("postgres unavailable or not read-only; nothing measured")
+        progress.close()
+        print("ERROR: could not open a read-only postgres connection; see log")
+        return 2
+
+    reducer_reports: dict[str, dict[str, Any]] = {}
+    total_reducers = len(REDUCER_NAMES)
+
+    for idx, reducer_name in enumerate(REDUCER_NAMES):
+        percent = (idx / total_reducers) * 90.0
+        progress.emit(f"fetching {reducer_name}", percent=percent, processed=idx, total=total_reducers)
+        timestamps, values = fetch_reducer_rows(conn, reducer_name, MAX_ROWS)
+        n_rows = len(values)
+
+        if n_rows == 0:
+            reducer_reports[reducer_name] = {"status": "NO_ROWS", "n_rows": 0}
+            continue
+        if n_rows < QUALIFYING_MIN_ROWS:
+            reducer_reports[reducer_name] = {"status": "NOT_QUALIFIED", "n_rows": n_rows}
+            continue
+
+        min_ts, max_ts = timestamps[0], timestamps[-1]
+        span_hours = (max_ts - min_ts).total_seconds() / 3600.0
+        real_span_label = f"{min_ts.isoformat()} -> {max_ts.isoformat()} ({span_hours * 60:.1f} min)"
+
+        full_results = compute_rolling_results(values, rolling_window)
+        full_summary = summarize_results(full_results)
+
+        report: dict[str, Any] = {
+            "status": "QUALIFIED",
+            "n_rows": n_rows,
+            "real_span_label": real_span_label,
+            "full_summary": full_summary,
+        }
+
+        windows = choose_windows(min_ts, max_ts, window_hours, gap_hours, MIN_WINDOW_HOURS)
+        if windows is None:
+            report["window_status"] = "INSUFFICIENT_FOR_TWO_WINDOW_SPLIT"
+        else:
+            win_a, win_b = windows
+            vals_a, vals_b = partition_by_window(timestamps, values, win_a, win_b)
+            if len(vals_a) < QUALIFYING_MIN_ROWS or len(vals_b) < QUALIFYING_MIN_ROWS:
+                report["window_status"] = "INSUFFICIENT_FOR_TWO_WINDOW_SPLIT"
+                caveats.append(
+                    f"{reducer_name}: a two-window split was geometrically possible but at "
+                    f"least one window had < QUALIFYING_MIN_ROWS={QUALIFYING_MIN_ROWS} real "
+                    f"rows (A={len(vals_a)}, B={len(vals_b)}) -- reported as insufficient "
+                    "rather than run on too little data."
+                )
+            else:
+                report["window_status"] = "SPLIT"
+                report["win_a_label"] = win_a.label
+                report["win_b_label"] = win_b.label
+                report["window_a_summary"] = summarize_results(compute_rolling_results(vals_a, rolling_window))
+                report["window_b_summary"] = summarize_results(compute_rolling_results(vals_b, rolling_window))
+
+        reducer_reports[reducer_name] = report
+        write_ticks_csv(CSV_DIR / f"{reducer_name.replace('.', '_')}.csv", timestamps, full_results)
+
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+    progress.emit("done", percent=100.0, processed=total_reducers, total=total_reducers)
+    progress.close()
+
+    qualified = [r for r, rep in reducer_reports.items() if rep.get("status") == "QUALIFIED"]
+    if not qualified:
+        caveats.append(
+            "no reducer had enough real receipt history to qualify for analysis at run "
+            "time -- see per-reducer status above"
+        )
+
+    report_md = render_report(rolling_window=rolling_window, reducer_reports=reducer_reports, caveats=caveats)
+    REPORT_PATH.write_text(report_md, encoding="utf-8")
+    print(report_md)
+    print(f"\nartifacts: {REPORT_PATH}, {CSV_DIR}/, {PROGRESS_PATH}")
+    return 0 if qualified else 2
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only replay of Candidate A (precision-weighted salience) over real prediction-error receipt history."
+    )
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"size of each of the two comparison windows in hours, for comparability with "
+             f"Candidate B's probe (default {DEFAULT_WINDOW_HOURS})",
+    )
+    parser.add_argument(
+        "--gap-hours", type=float, default=DEFAULT_GAP_HOURS,
+        help=f"untouched real history between the two windows, in hours (default {DEFAULT_GAP_HOURS})",
+    )
+    parser.add_argument(
+        "--rolling-window", type=int, default=DEFAULT_ROLLING_WINDOW,
+        help=f"number of most-recent real samples used to estimate precision at each tick "
+             f"(default {DEFAULT_ROLLING_WINDOW})",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    return run(args.window_hours, args.gap_hours, args.rolling_window)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_measure_precision_weighted_salience_probe.py
+++ b/scripts/analysis/tests/test_measure_precision_weighted_salience_probe.py
@@ -1,0 +1,187 @@
+"""Deterministic unit tests for measure_precision_weighted_salience_probe.py.
+
+No DB, no network. Everything here is pure: parsing, rolling-window replay (via the
+real `precision_weighted_salience()` import, not a reimplementation), summarization,
+and window selection all operate on plain synthetic data. Same sibling-module-by-
+file-path loading pattern as test_measure_emergent_clustering_probe.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "measure_precision_weighted_salience_probe.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "measure_precision_weighted_salience_probe", _MODULE_PATH
+)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_precision_weighted_salience_probe"] = mod
+_spec.loader.exec_module(mod)
+
+UTC = timezone.utc
+BASE = datetime(2026, 7, 21, 0, 0, 0, tzinfo=UTC)
+
+
+# ===========================================================================
+# parse_prediction_error -- pure scalar parsing, must never raise.
+# ===========================================================================
+
+
+def test_parse_prediction_error_valid_string() -> None:
+    assert mod.parse_prediction_error("0.0429") == 0.0429
+
+
+def test_parse_prediction_error_none_returns_none() -> None:
+    assert mod.parse_prediction_error(None) is None
+
+
+def test_parse_prediction_error_malformed_returns_none() -> None:
+    assert mod.parse_prediction_error("not-a-number") is None
+    assert mod.parse_prediction_error("") is None
+
+
+def test_parse_prediction_error_non_finite_returns_none() -> None:
+    assert mod.parse_prediction_error("nan") is None
+    assert mod.parse_prediction_error("inf") is None
+
+
+# ===========================================================================
+# compute_rolling_results -- exercises the REAL precision_weighted_salience()
+# import, not a local copy.
+# ===========================================================================
+
+
+def test_compute_rolling_results_length_matches_input() -> None:
+    values = [0.01, 0.02, 0.5, 0.03, 0.04]
+    results = mod.compute_rolling_results(values, rolling_window=3)
+    assert len(results) == len(values)
+
+
+def test_compute_rolling_results_first_tick_uses_single_sample_window() -> None:
+    values = [0.05, 0.1, 0.2]
+    results = mod.compute_rolling_results(values, rolling_window=3)
+    assert results[0].n_samples == 1
+    assert results[0].current_error == 0.05
+
+
+def test_compute_rolling_results_window_caps_at_rolling_size() -> None:
+    values = [0.01] * 10 + [0.9]
+    results = mod.compute_rolling_results(values, rolling_window=3)
+    # last tick's window should be the 3 most recent samples: [0.01, 0.01, 0.9]
+    assert results[-1].n_samples == 3
+    assert results[-1].current_error == 0.9
+
+
+# ===========================================================================
+# summarize_results
+# ===========================================================================
+
+
+def test_summarize_results_empty_returns_none() -> None:
+    assert mod.summarize_results([]) is None
+
+
+def test_summarize_results_reports_variance_floored_rate() -> None:
+    values = [0.02] * 10 + [0.5]  # last tick: real change against near-constant history
+    results = mod.compute_rolling_results(values, rolling_window=20)
+    summary = mod.summarize_results(results)
+    assert summary is not None
+    assert summary.n == 11
+    assert summary.variance_floored_count >= 1
+    assert 0.0 <= summary.variance_floored_pct <= 100.0
+
+
+def test_summarize_results_healthy_series_no_floor_hits() -> None:
+    values = [0.01, 0.08, 0.02, 0.12, 0.005, 0.09, 0.02, 0.15, 0.03, 0.11]
+    results = mod.compute_rolling_results(values, rolling_window=20)
+    summary = mod.summarize_results(results)
+    assert summary is not None
+    assert summary.raw_error_min == min(values)
+    assert summary.raw_error_max == max(values)
+
+
+# ===========================================================================
+# choose_windows -- same anchoring/degradation contract as the clustering
+# probe's own choose_windows, but with this script's much smaller
+# MIN_WINDOW_HOURS default (real data volume here is retention-bounded to
+# minutes, not days).
+# ===========================================================================
+
+
+def test_choose_windows_none_when_span_too_short() -> None:
+    min_ts = BASE
+    max_ts = BASE + timedelta(seconds=1)
+    assert mod.choose_windows(min_ts, max_ts, window_hours=24, gap_hours=12) is None
+
+
+def test_choose_windows_back_to_back_split_for_short_real_span() -> None:
+    """Real Candidate A data (~30min retention window) never reaches the 24h/12h
+    ask -- must degrade to a back-to-back split instead of returning None, as long
+    as it clears this script's own MIN_WINDOW_HOURS floor (3 minutes)."""
+    min_ts = BASE
+    max_ts = BASE + timedelta(minutes=30)
+    windows = mod.choose_windows(min_ts, max_ts, window_hours=24, gap_hours=12)
+    assert windows is not None
+    win_a, win_b = windows
+    assert win_a.start == min_ts
+    assert win_b.end == max_ts
+    assert win_a.end == win_b.start  # back-to-back, no gap
+
+
+def test_choose_windows_full_split_when_span_is_ample() -> None:
+    min_ts = BASE
+    max_ts = BASE + timedelta(hours=61)  # >= 2*24 + 12
+    windows = mod.choose_windows(min_ts, max_ts, window_hours=24, gap_hours=12)
+    assert windows is not None
+    win_a, win_b = windows
+    assert win_a.start == min_ts
+    assert win_a.end == min_ts + timedelta(hours=24)
+    assert win_b.end == max_ts
+    assert win_b.start == max_ts - timedelta(hours=24)
+    assert win_a.end < win_b.start  # real gap between the two windows
+
+
+def test_choose_windows_none_min_ts_or_max_ts() -> None:
+    assert mod.choose_windows(None, BASE, 24, 12) is None
+    assert mod.choose_windows(BASE, None, 24, 12) is None
+
+
+def test_choose_windows_none_when_max_before_min() -> None:
+    assert mod.choose_windows(BASE + timedelta(hours=1), BASE, 24, 12) is None
+
+
+# ===========================================================================
+# partition_by_window
+# ===========================================================================
+
+
+def test_partition_by_window_no_row_double_counted_or_dropped() -> None:
+    win_a = mod.WindowSpec(BASE, BASE + timedelta(minutes=5), "a")
+    win_b = mod.WindowSpec(BASE + timedelta(minutes=10), BASE + timedelta(minutes=15), "b")
+    boundary_ts = BASE + timedelta(minutes=5)  # == win_a.end
+    timestamps = [BASE + timedelta(minutes=1), boundary_ts, BASE + timedelta(minutes=14)]
+    values = [1.0, 2.0, 3.0]
+
+    a, b = mod.partition_by_window(timestamps, values, win_a, win_b)
+
+    assert a == [1.0]
+    assert b == [3.0]  # boundary_ts falls in neither window (gap), row 3 in win_b
+    assert len(a) + len(b) + 1 == len(values)  # the boundary row is dropped, not duplicated
+
+
+def test_partition_by_window_last_row_inclusive_of_window_b_end() -> None:
+    win_a = mod.WindowSpec(BASE, BASE + timedelta(minutes=2), "a")
+    win_b = mod.WindowSpec(BASE + timedelta(minutes=8), BASE + timedelta(minutes=10), "b")
+    timestamps = [BASE + timedelta(minutes=10)]  # exactly win_b.end
+    values = [9.0]
+
+    a, b = mod.partition_by_window(timestamps, values, win_a, win_b)
+
+    assert a == []
+    assert b == [9.0]

--- a/tests/test_attention_candidate_precision_weighted.py
+++ b/tests/test_attention_candidate_precision_weighted.py
@@ -1,0 +1,103 @@
+"""Unit tests for Candidate A (`orion/attention/field_attention/
+candidate_precision_weighted.py`) -- precision-weighted prediction-error salience,
+Feldman & Friston 2010. Shadow-only pure function; see the module docstring and
+`docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-tentative-
+plan.md` for the design record. No I/O, no fixtures needed."""
+
+from __future__ import annotations
+
+import pytest
+
+from orion.attention.field_attention.candidate_precision_weighted import (
+    PRECISION_VARIANCE_FLOOR,
+    precision_weighted_salience,
+)
+
+
+def test_empty_history_yields_zero_everything() -> None:
+    result = precision_weighted_salience([])
+    assert result.salience == 0.0
+    assert result.precision == 0.0
+    assert result.variance == 0.0
+    assert result.current_error == 0.0
+    assert result.n_samples == 0
+    assert result.variance_floored is False
+
+
+def test_single_sample_history_floors_variance_and_uses_that_sample_as_current() -> None:
+    """One real observation has zero variance by definition -- treated as the
+    smallest-possible-sample-size floor case, not a separate undefined case."""
+    result = precision_weighted_salience([0.05])
+    assert result.n_samples == 1
+    assert result.current_error == pytest.approx(0.05)
+    assert result.variance == 0.0
+    assert result.variance_floored is True
+    assert result.precision == pytest.approx(1.0 / PRECISION_VARIANCE_FLOOR)
+    assert result.salience == pytest.approx(0.05 / PRECISION_VARIANCE_FLOOR)
+
+
+def test_near_zero_variance_edge_case_floors_precision_not_diverges() -> None:
+    """A target whose error has been almost perfectly constant -- the concrete
+    'variance-near-zero instability risk' named in the design doc. Must not raise
+    ZeroDivisionError or produce +inf."""
+    history = [0.03, 0.03, 0.03, 0.03, 0.0300001]
+    result = precision_weighted_salience(history)
+    assert result.n_samples == 5
+    assert result.variance == pytest.approx(0.0, abs=1e-9)
+    assert result.variance_floored is True
+    assert result.precision == pytest.approx(1.0 / PRECISION_VARIANCE_FLOOR)
+    assert result.salience == pytest.approx(
+        (1.0 / PRECISION_VARIANCE_FLOOR) * abs(0.0300001)
+    )
+    import math
+
+    assert math.isfinite(result.precision)
+    assert math.isfinite(result.salience)
+
+
+def test_healthy_variance_produces_finite_bounded_precision() -> None:
+    """A real, non-degenerate history (modeled on the live biometrics spread found
+    2026-07-21: real values roughly in [0.0, 0.17]) should NOT trip the variance
+    floor, and should produce a precision that is large but not floor-ceiling-pinned."""
+    history = [0.001, 0.08, 0.003, 0.12, 0.0005, 0.09, 0.002, 0.15]
+    result = precision_weighted_salience(history)
+    assert result.n_samples == 8
+    assert result.variance > PRECISION_VARIANCE_FLOOR
+    assert result.variance_floored is False
+    assert result.current_error == pytest.approx(0.15)
+    expected_precision = 1.0 / result.variance
+    assert result.precision == pytest.approx(expected_precision)
+    assert result.salience == pytest.approx(expected_precision * 0.15)
+    # Sanity: precision should be well below the floor-ceiling for a healthy series.
+    assert result.precision < 1.0 / PRECISION_VARIANCE_FLOOR
+
+
+def test_current_error_is_the_last_element_not_the_max_or_mean() -> None:
+    history = [0.5, 0.5, 0.01]
+    result = precision_weighted_salience(history)
+    assert result.current_error == pytest.approx(0.01)
+
+
+def test_zero_current_error_yields_zero_salience_regardless_of_precision() -> None:
+    history = [0.02, 0.03, 0.0]
+    result = precision_weighted_salience(history)
+    assert result.current_error == 0.0
+    assert result.salience == 0.0
+    assert result.precision > 0.0  # precision itself is unaffected by the current value
+
+
+def test_negative_values_are_handled_via_absolute_value_of_current_error() -> None:
+    """prediction_error instruments in orion/substrate/prediction_error.py are all
+    non-negative by construction (min(1.0, mean/threshold) or a [0,1] mismatch rate),
+    but this function does not assume that -- abs() is applied defensively."""
+    history = [0.1, -0.2, 0.15, -0.3]
+    result = precision_weighted_salience(history)
+    assert result.current_error == pytest.approx(-0.3)
+    assert result.salience == pytest.approx(result.precision * 0.3)
+    assert result.salience >= 0.0
+
+
+def test_result_is_a_frozen_dataclass_not_mutable() -> None:
+    result = precision_weighted_salience([0.1, 0.2])
+    with pytest.raises(Exception):
+        result.salience = 999.0  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Candidate A from the attention-salience-cathedral replacement plan: `salience(target) = precision(target) x |prediction_error(target)|`, `precision = 1/variance` of the target's own real historical error. Theory anchor: Feldman & Friston 2010, "Attention, Uncertainty, and Free-Energy".
- `orion/attention/field_attention/candidate_precision_weighted.py`: pure function, variance floored at `1e-6` to avoid divide-by-zero/blowup, reports `variance_floored` explicitly.
- `scripts/analysis/measure_precision_weighted_salience_probe.py`: read-only replay against real `substrate_reduction_receipts` (refuses to run unless the DB session is `default_transaction_read_only=on`). Checks all 5 real reducer names live rather than hardcoding which qualify.
- Discovered and documented a structural finding: `substrate_reduction_receipts` retains success rows for only ~30 minutes before pruning, bounding *every* domain's available history to that window — not a today-only staleness artifact.
- Shadow-only: zero imports outside its own tests, not wired into `compute_salience()`/`select_system_targets`/`self_state/builder.py`/anything live. Blocked from live-wiring by the tentative plan's SelfStateV1 hard gate, same as Candidate B.

## Provenance note
This was originally built by an earlier, separate agent session and found sitting uncommitted (fully built, fully tested, never reviewed or merged) in an abandoned Claude Code isolation worktree. Independently inspected, judged high quality, and adopted verbatim into this clean branch after separating out unrelated stale changes that had been mixed into that same abandoned worktree (an old, already-superseded topic-foundry diff — not touched here).

## Dependency note
The module and replay-script docstrings cite `docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-tentative-plan.md`, which lives on a separate branch (#1240, not yet merged). Not a code dependency (nothing imports the doc) — just a dangling citation until #1240 lands. No merge-order requirement, but worth landing #1240 around the same time.

## Outcome moved
A real, replayable, theory-grounded salience candidate now exists as measurable shadow infrastructure, alongside a live-verified structural fact (30-min retention window) that any future replay work (this candidate, Candidate B, or anything else reading `substrate_reduction_receipts` history) needs to account for.

## Files changed
- `orion/attention/field_attention/candidate_precision_weighted.py` (new)
- `tests/test_attention_candidate_precision_weighted.py` (new)
- `scripts/analysis/measure_precision_weighted_salience_probe.py` (new)
- `scripts/analysis/tests/test_measure_precision_weighted_salience_probe.py` (new)

## Tests run
```
.venv/bin/python3 -m pytest tests/test_attention_candidate_precision_weighted.py scripts/analysis/tests/test_measure_precision_weighted_salience_probe.py -q
25 passed
```

## Live replay (read-only, real Postgres)
```
substrate.node_biometrics        QUALIFIED  (162 rows, span ~33min, mean salience 400.39, 0.6% variance-floor rate)
substrate.execution_trajectory   NO_ROWS    (expected -- PR #1239's fix not yet deployed to the live container)
substrate.transport_bus          NO_ROWS    (expected -- bus genuinely idle, see PR #1239's investigation)
substrate.chat_session           NO_ROWS
substrate.route_arbitration      NO_ROWS    (expected -- same as execution, PR #1239 not yet deployed)
```
Full report: `/tmp/precision-weighted-salience-probe/report.md` (local artifact, not committed).

## Review findings fixed
- No material findings. Reviewer independently re-ran the live replay and full test suite, grepped the repo for any live-consumer import (found none), and confirmed read-only DB enforcement matches the established sibling-script pattern (`measure_emergent_clustering_probe.py`). Two non-blocking notes acknowledged, not fixed: (1) the #1240 doc-citation dependency above, (2) variance is estimated including the current point itself, which is intentional and already disclosed in the docstring per Feldman & Friston's framing.

## Restart required
```
No restart required.
```
Shadow/read-only code, no service or config changes.

## Risks / concerns
- Severity: low
- Concern: none material. This is read-only measurement infrastructure with no live consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DFRKm1HMv5PLWV435JuT1