### PR TITLE
feat(cortex-orch): ground card auto-annotation in orion-topic-foundry…

### DIFF
--- a/orion/cognition/prompts/memory_card_annotation_prompt.j2
+++ b/orion/cognition/prompts/memory_card_annotation_prompt.j2
@@ -26,6 +26,14 @@ Rules:
   "anchor", "preference"). tags/anchors: short lowercase keyword arrays for
   retrieval. still_true: short standalone restatements of facts still true
   after this turn (may be empty).
+{%- if known_categories %}
+- Known categories from Orion's real conversation history (data-driven topic
+  clusters, not invented): {{ known_categories | join(", ") }}. If this fact
+  clearly fits one, prefer reusing it as one of the tags -- keeps related
+  memory grouped together instead of every card inventing its own wording
+  for the same topic. This is a hint, not a constraint: if nothing fits,
+  use your own judgment.
+{%- endif %}
 - Do NOT include "sensitivity" or "visibility_scope" keys in your response.
   Those are decided outside this call, never by you -- any such keys you
   emit will be ignored.

--- a/services/orion-cortex-orch/.env_example
+++ b/services/orion-cortex-orch/.env_example
@@ -101,6 +101,14 @@ ORION_AUTO_EXTRACTOR_AUTO_PROMOTE_THRESHOLD=2
 # substrate spec, Item 1a). Falls back to the regex extractor on timeout.
 ORION_AUTO_EXTRACTOR_LLM_TIMEOUT_SEC=6.0
 
+# Taxonomy grounding for auto-annotation (2026-07-22): pulls orion-topic-foundry's
+# current active-model topic labels as a hint for the annotation call's tags,
+# instead of the LLM inventing categories fresh every time. Empty base_url or
+# any fetch failure degrades to no hint -- never blocks card creation.
+TOPIC_FOUNDRY_BASE_URL=http://orion-athena-topic-foundry:8615
+TOPIC_FOUNDRY_TIMEOUT_SEC=3.0
+TOPIC_FOUNDRY_LABELS_CACHE_TTL_SEC=3600.0
+
 # --- Orion Mind (HTTP to services/orion-mind; Hub enables via context.metadata mind_enabled only through Orch) ---
 # Hostname must match the Mind container on app-net: ${PROJECT:-orion}-mind (e.g. orion-mind or orion-athena-mind).
 ORION_MIND_BASE_URL=http://orion-mind:6611

--- a/services/orion-cortex-orch/app/memory_extractor.py
+++ b/services/orion-cortex-orch/app/memory_extractor.py
@@ -66,8 +66,19 @@ def _annotation_prompt_path_candidates() -> list[Path]:
     here = Path(__file__).resolve()
     if len(here.parents) >= 2:
         _add(here.parents[1])  # Docker layout: /app/app/memory_extractor.py -> /app
-    if len(here.parents) >= 3:
-        _add(here.parents[2])  # local monorepo checkout: services/orion-cortex-orch/app/... -> repo root
+    # Live incident 2026-07-22: this was `here.parents[2]`, which for the
+    # real local layout (services/orion-cortex-orch/app/memory_extractor.py)
+    # resolves to `services/`, not the repo root -- an off-by-one introduced
+    # in the same commit as the Docker-layout fix above. Masked in every
+    # container run because parents[1] (Docker's shape) matches first, so
+    # this branch never got exercised there; only surfaced running tests
+    # from a local worktree checkout, where it silently fell through to the
+    # hardcoded /mnt/scripts/Orion-Sapienform fallback below -- a real path
+    # on this machine, but the PRIMARY checkout, not the worktree actually
+    # being tested, so edits to this file's sibling prompt template in a
+    # worktree were silently invisible instead of loudly missing.
+    if len(here.parents) >= 4:
+        _add(here.parents[3])  # local monorepo checkout: services/orion-cortex-orch/app/... -> repo root
     _add(Path("/app"))
     _add(Path("/repo"))
     _add(Path("/mnt/scripts/Orion-Sapienform"))
@@ -135,9 +146,9 @@ def _coerce_turn(env: BaseEnvelope) -> Optional[ChatHistoryTurnV1]:
         return None
 
 
-def _build_annotation_prompt(turn_text: str) -> str:
+def _build_annotation_prompt(turn_text: str, *, known_categories: Optional[list] = None) -> str:
     template = Template(_resolve_annotation_prompt_path().read_text(encoding="utf-8"))
-    return template.render(turn_text=turn_text)
+    return template.render(turn_text=turn_text, known_categories=known_categories or [])
 
 
 async def _rpc_annotation_llm(
@@ -215,7 +226,10 @@ async def _annotate_via_llm(
     if bus is None:
         return None
     try:
-        prompt = _build_annotation_prompt(turn_text)
+        from .topic_taxonomy_client import fetch_active_topic_labels
+
+        known_categories = await fetch_active_topic_labels()
+        prompt = _build_annotation_prompt(turn_text, known_categories=known_categories)
         return await asyncio.wait_for(
             _rpc_annotation_llm(
                 bus,

--- a/services/orion-cortex-orch/app/settings.py
+++ b/services/orion-cortex-orch/app/settings.py
@@ -135,6 +135,19 @@ class Settings(BaseSettings):
     # orion_auto_extractor_enabled above, which stays False by default.
     orion_auto_extractor_llm_timeout_sec: float = Field(6.0, alias="ORION_AUTO_EXTRACTOR_LLM_TIMEOUT_SEC")
 
+    # Taxonomy grounding for write-time auto-annotation (2026-07-22): the
+    # annotation call's types/tags were previously invented fresh by the
+    # LLM every time, ungrounded in anything real. orion-topic-foundry now
+    # produces real, data-driven, LLM-labeled topic clusters from actual
+    # conversation history (fixed same session -- stopword/granularity/
+    # labeling bugs, see services/orion-topic-foundry). This fetches its
+    # current active-model labels as a taxonomy hint. Empty base_url or any
+    # fetch failure degrades to no hint (annotation proceeds exactly as
+    # before this feature existed) -- never blocks card creation.
+    topic_foundry_base_url: str = Field("", alias="TOPIC_FOUNDRY_BASE_URL")
+    topic_foundry_timeout_sec: float = Field(3.0, alias="TOPIC_FOUNDRY_TIMEOUT_SEC")
+    topic_foundry_labels_cache_ttl_sec: float = Field(3600.0, alias="TOPIC_FOUNDRY_LABELS_CACHE_TTL_SEC")
+
     api_host: str = Field("0.0.0.0", alias="API_HOST")
     api_port: int = Field(8072, alias="API_PORT")
 

--- a/services/orion-cortex-orch/app/topic_taxonomy_client.py
+++ b/services/orion-cortex-orch/app/topic_taxonomy_client.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Optional
+
+import httpx
+
+from .settings import get_settings
+
+logger = logging.getLogger("orion.cortex.topic_taxonomy")
+
+_cache: Optional[list[str]] = None
+_cache_at: float = 0.0
+
+
+async def _fetch_active_run_id(client: httpx.AsyncClient, base: str) -> Optional[str]:
+    """Wrapped /runs items already carry model.stage (see
+    orion-topic-foundry/app/routers/runs.py's RunListItem), so the first
+    complete run for the active model can be found in one call -- no
+    separate /models/{name}/active round trip needed. Rows are ordered
+    created_at DESC (list_runs_paginated), so the first match is the most
+    recent."""
+    resp = await client.get(
+        f"{base}/runs",
+        params={"model_name": "topic-foundry", "status": "complete", "format": "wrapped", "limit": 20},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    for item in data.get("items") or []:
+        model = item.get("model") or {}
+        if model.get("stage") == "active":
+            return item.get("run_id")
+    return None
+
+
+async def _fetch_topic_labels(client: httpx.AsyncClient, base: str, run_id: str) -> list[str]:
+    resp = await client.get(f"{base}/topics", params={"run_id": run_id, "limit": 200})
+    resp.raise_for_status()
+    data = resp.json()
+    labels = [item.get("label") for item in data.get("items") or [] if item.get("label")]
+    # Dedupe, preserve order.
+    return list(dict.fromkeys(labels))
+
+
+async def fetch_active_topic_labels() -> list[str]:
+    """Current orion-topic-foundry active-model topic labels, for grounding
+    write-time card annotation's types/tags in real, data-driven categories
+    instead of the LLM inventing them fresh every call. In-process cache
+    with a TTL (default 1h, topics.py::TOPIC_FOUNDRY_LABELS_CACHE_TTL_SEC)
+    -- topics don't change turn to turn, and this must not add an extra
+    bus/HTTP round trip to every single chat turn's annotation latency
+    beyond a cache miss. Fails open to [] on any error (empty base_url,
+    timeout, HTTP error, malformed response) -- annotation proceeds exactly
+    as it did before this feature existed, never blocks card creation."""
+    global _cache, _cache_at
+
+    settings = get_settings()
+    ttl = float(settings.topic_foundry_labels_cache_ttl_sec)
+    if _cache is not None and (time.monotonic() - _cache_at) < ttl:
+        return _cache
+
+    base = (settings.topic_foundry_base_url or "").rstrip("/")
+    if not base:
+        return []
+
+    timeout_sec = max(0.5, min(10.0, float(settings.topic_foundry_timeout_sec)))
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_sec)) as client:
+            run_id = await _fetch_active_run_id(client, base)
+            if not run_id:
+                return []
+            labels = await _fetch_topic_labels(client, base, run_id)
+    except httpx.HTTPError as exc:
+        logger.warning("topic_taxonomy_fetch_http_err err=%s", exc)
+        return _cache or []
+    except (ValueError, KeyError, TypeError) as exc:
+        logger.warning("topic_taxonomy_fetch_parse_err err=%s", exc)
+        return _cache or []
+
+    _cache = labels
+    _cache_at = time.monotonic()
+    return labels

--- a/services/orion-cortex-orch/tests/test_memory_extractor.py
+++ b/services/orion-cortex-orch/tests/test_memory_extractor.py
@@ -46,11 +46,13 @@ class _FakeBus:
         self.codec = _FakeCodec(response_text)
         self._raise_on_rpc = raise_on_rpc
         self.connected = False
+        self.last_env = None
 
     async def connect(self) -> None:
         self.connected = True
 
-    async def rpc_request(self, *args, **kwargs):
+    async def rpc_request(self, channel, env, *args, **kwargs):
+        self.last_env = env
         if self._raise_on_rpc is not None:
             raise self._raise_on_rpc
         return {"data": b"fake"}
@@ -208,7 +210,7 @@ class _AnnotationSettings:
     orion_auto_extractor_llm_timeout_sec = 2.0
 
 
-def _wire_common(monkeypatch, mod, *, insert_mock=None, exists_mock=None):
+def _wire_common(monkeypatch, mod, *, insert_mock=None, exists_mock=None, known_categories=None):
     monkeypatch.setattr(mod, "_memory_pool", None)
     monkeypatch.setattr(mod, "_memory_pool_failed", False)
     monkeypatch.setattr(mod, "_annotation_bus", None)
@@ -222,6 +224,17 @@ def _wire_common(monkeypatch, mod, *, insert_mock=None, exists_mock=None):
     exists_mock = exists_mock or AsyncMock(return_value=False)
     monkeypatch.setattr(mod.mc_dal, "insert_card", insert_mock)
     monkeypatch.setattr(mod.mc_dal, "card_exists_by_fingerprint", exists_mock)
+    # _annotate_via_llm does a local `from .topic_taxonomy_client import
+    # fetch_active_topic_labels` inside its own body (not a module-level
+    # import on `mod`), so patching app.topic_taxonomy_client's own
+    # attribute is what the local import actually picks up -- this keeps
+    # every existing test isolated from real network/env behavior
+    # regardless of what TOPIC_FOUNDRY_BASE_URL happens to resolve to in
+    # the test process.
+    monkeypatch.setattr(
+        "app.topic_taxonomy_client.fetch_active_topic_labels",
+        AsyncMock(return_value=known_categories or []),
+    )
     return insert_mock, exists_mock
 
 
@@ -450,4 +463,86 @@ def test_annotation_prompt_path_resolution_survives_shallow_docker_layout(monkey
     # resolve_annotation_prompt_path itself never raises either, even when
     # no candidate exists on disk in the test sandbox.
     resolved = mod._resolve_annotation_prompt_path()
+
+
+def test_annotation_prompt_path_resolution_finds_real_local_checkout_root(monkeypatch) -> None:
+    """Live incident 2026-07-22: the 2026-07-21 fix's local-checkout
+    candidate used here.parents[2], which for the real local layout
+    (services/orion-cortex-orch/app/memory_extractor.py) resolves to
+    `services/`, not the repo root -- an off-by-one that never got caught
+    because every container run matches the Docker-shaped candidate first
+    (parents[1]) and never exercises this branch, and every prior test only
+    simulated the shallow Docker path, never the real local one. This
+    reproduces the actual local file location (not a simulated one) and
+    asserts the resolver finds the REAL prompt template on disk from it --
+    the strongest possible check, since a wrong-but-existing fallback path
+    (this bug's actual failure mode: silently resolving to a DIFFERENT
+    checkout's file) would make a mere "returns some path" assertion pass
+    while still being wrong."""
+    import app.memory_extractor as mod
+
+    real_file = Path(mod.__file__).resolve()
+    monkeypatch.setattr(mod, "__file__", str(real_file))
+    resolved = mod._resolve_annotation_prompt_path()
+    assert resolved.is_file()
+    # Must resolve under THIS checkout (the one real_file lives in), not
+    # fall through to a different one via the hardcoded absolute fallbacks.
+    repo_root = real_file.parents[3]
+    assert str(resolved).startswith(str(repo_root)), (
+        f"resolved {resolved} outside this checkout's repo root {repo_root} -- "
+        "likely fell through to a different checkout's fallback path"
+    )
     assert isinstance(resolved, Path)
+
+
+def test_build_annotation_prompt_includes_known_categories_when_present() -> None:
+    import app.memory_extractor as mod
+
+    prompt = mod._build_annotation_prompt("some turn text", known_categories=["Family Storytime", "Cat Persona"])
+    assert "Family Storytime" in prompt
+    assert "Cat Persona" in prompt
+    assert "Known categories" in prompt
+
+
+def test_build_annotation_prompt_omits_known_categories_section_when_empty() -> None:
+    import app.memory_extractor as mod
+
+    prompt = mod._build_annotation_prompt("some turn text", known_categories=[])
+    assert "Known categories" not in prompt
+
+
+def test_annotate_via_llm_fetches_and_forwards_topic_labels(monkeypatch) -> None:
+    """End-to-end: handle_memory_history_turn's real LLM call must actually
+    include topic-foundry's labels in the prompt it sends, not just accept
+    the parameter in isolation."""
+    import app.memory_extractor as mod
+
+    insert_mock, _ = _wire_common(
+        monkeypatch, mod, known_categories=["Human-AI Conversations", "Family Storytime"]
+    )
+    fake_bus = _FakeBus(json.dumps(_VALID_ANNOTATION))
+    monkeypatch.setattr(mod, "_get_annotation_bus", lambda: fake_bus)
+
+    asyncio.run(mod.handle_memory_history_turn(_turn_env(prompt="I live in Ogden, UT")))
+
+    insert_mock.assert_awaited_once()
+    sent_prompt = fake_bus.last_env.payload["messages"][0]["content"]
+    assert "Human-AI Conversations" in sent_prompt
+    assert "Family Storytime" in sent_prompt
+
+
+def test_annotate_via_llm_proceeds_with_no_hint_when_topic_foundry_unavailable(monkeypatch) -> None:
+    """fetch_active_topic_labels failing/returning [] (topic-foundry down,
+    unconfigured, etc.) must not block card creation -- annotation proceeds
+    exactly as it did before this feature existed."""
+    import app.memory_extractor as mod
+
+    insert_mock, _ = _wire_common(monkeypatch, mod, known_categories=[])
+    fake_bus = _FakeBus(json.dumps(_VALID_ANNOTATION))
+    monkeypatch.setattr(mod, "_get_annotation_bus", lambda: fake_bus)
+
+    asyncio.run(mod.handle_memory_history_turn(_turn_env(prompt="I live in Ogden, UT")))
+
+    insert_mock.assert_awaited_once()
+    sent_prompt = fake_bus.last_env.payload["messages"][0]["content"]
+    assert "Known categories" not in sent_prompt

--- a/services/orion-cortex-orch/tests/test_topic_taxonomy_client.py
+++ b/services/orion-cortex-orch/tests/test_topic_taxonomy_client.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+
+class _Settings:
+    topic_foundry_base_url = "http://topic-foundry:8615"
+    topic_foundry_timeout_sec = 3.0
+    topic_foundry_labels_cache_ttl_sec = 3600.0
+
+
+def _reset_cache(mod) -> None:
+    mod._cache = None
+    mod._cache_at = 0.0
+
+
+def test_fetch_returns_empty_when_base_url_unset(monkeypatch) -> None:
+    import app.topic_taxonomy_client as mod
+
+    _reset_cache(mod)
+
+    class S(_Settings):
+        topic_foundry_base_url = ""
+
+    monkeypatch.setattr(mod, "get_settings", lambda: S())
+    result = asyncio.run(mod.fetch_active_topic_labels())
+    assert result == []
+
+
+def test_fetch_finds_active_model_run_and_returns_labels(monkeypatch) -> None:
+    """End-to-end happy path: /runs items already carry model.stage, so the
+    active model's most recent complete run is found in one call, then
+    /topics is queried for that run's labels."""
+    import app.topic_taxonomy_client as mod
+
+    _reset_cache(mod)
+    monkeypatch.setattr(mod, "get_settings", lambda: _Settings())
+
+    runs_response = {
+        "items": [
+            {"run_id": "run-2", "model": {"stage": "development"}},
+            {"run_id": "run-1", "model": {"stage": "active"}},
+        ]
+    }
+    topics_response = {
+        "items": [
+            {"topic_id": -1, "label": None},
+            {"topic_id": 0, "label": "Human-AI Conversations"},
+            {"topic_id": 1, "label": "Family Storytime"},
+            {"topic_id": 2, "label": None},
+        ]
+    }
+
+    class _FakeResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None):
+            if url.endswith("/runs"):
+                assert params["model_name"] == "topic-foundry"
+                assert params["status"] == "complete"
+                return _FakeResponse(runs_response)
+            if url.endswith("/topics"):
+                assert params["run_id"] == "run-1"  # the active-stage run, not run-2
+                return _FakeResponse(topics_response)
+            raise AssertionError(f"unexpected url {url}")
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda **kw: _FakeClient())
+    result = asyncio.run(mod.fetch_active_topic_labels())
+    assert result == ["Human-AI Conversations", "Family Storytime"]
+
+
+def test_fetch_returns_empty_when_no_active_model_run_found(monkeypatch) -> None:
+    import app.topic_taxonomy_client as mod
+
+    _reset_cache(mod)
+    monkeypatch.setattr(mod, "get_settings", lambda: _Settings())
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"items": [{"run_id": "run-2", "model": {"stage": "development"}}]}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None):
+            return _FakeResponse()
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda **kw: _FakeClient())
+    result = asyncio.run(mod.fetch_active_topic_labels())
+    assert result == []
+
+
+def test_fetch_fails_open_on_http_error(monkeypatch) -> None:
+    import app.topic_taxonomy_client as mod
+
+    _reset_cache(mod)
+    monkeypatch.setattr(mod, "get_settings", lambda: _Settings())
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None):
+            raise httpx.ConnectTimeout("timed out")
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda **kw: _FakeClient())
+    result = asyncio.run(mod.fetch_active_topic_labels())
+    assert result == []
+
+
+def test_fetch_caches_within_ttl(monkeypatch) -> None:
+    import app.topic_taxonomy_client as mod
+
+    _reset_cache(mod)
+    monkeypatch.setattr(mod, "get_settings", lambda: _Settings())
+
+    call_count = 0
+
+    class _FakeResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None):
+            nonlocal call_count
+            call_count += 1
+            if url.endswith("/runs"):
+                return _FakeResponse({"items": [{"run_id": "run-1", "model": {"stage": "active"}}]})
+            return _FakeResponse({"items": [{"topic_id": 0, "label": "Cat Persona"}]})
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda **kw: _FakeClient())
+
+    first = asyncio.run(mod.fetch_active_topic_labels())
+    calls_after_first = call_count
+    second = asyncio.run(mod.fetch_active_topic_labels())
+
+    assert first == second == ["Cat Persona"]
+    assert call_count == calls_after_first, "second call within TTL must not hit the network again"


### PR DESCRIPTION
…'s real categories

Closes the loop this session's topic-foundry investigation was actually for: write-time card annotation's types/tags were invented fresh by the LLM every call, ungrounded in anything real. orion-topic-foundry now produces real, data-driven, LLM-labeled topic clusters from actual conversation history (stopword/granularity/labeling bugs fixed earlier this session, PR #1236) -- this fetches its current active-model labels and threads them into the annotation prompt as a hint, so a card's tags can reuse an existing real category ("Human-AI Conversations", "Family Storytime") instead of every card inventing its own wording for the same topic.

New: app/topic_taxonomy_client.py -- fetch_active_topic_labels(), 2 HTTP calls (GET /runs?model_name=topic-foundry&status=complete&format=wrapped to find the active model's most recent complete run via the wrapped response's model.stage field, then GET /topics?run_id=... for labels), in-process cached with a 1h TTL (topics don't change turn to turn). Fails open to [] on empty base_url, any HTTP error, or malformed response -- annotation proceeds exactly as before this feature existed, never blocks card creation.

Also fixes a real off-by-one bug found while testing this from a local checkout, in the PREVIOUS session commit's Docker-path fix (memory_extractor.py's _annotation_prompt_path_candidates): the "local monorepo checkout" candidate used here.parents[2], which for the real local layout (services/orion-cortex-orch/app/memory_extractor.py) resolves to `services/`, not the repo root. Never caught because every container run matches the Docker-shaped candidate (parents[1]) first and never exercises this branch; every prior test only simulated the shallow Docker case, never the real local one. Silently fell through to the hardcoded /mnt/scripts/Orion-Sapienform fallback -- a real path on this machine, but the PRIMARY checkout, not whatever worktree is actually being tested, so edits to the sibling prompt template were silently invisible instead of loudly missing. Fixed to parents[3], with a new regression test asserting the resolved path stays under the checkout __file__ actually lives in, not a coincidentally-real fallback elsewhere.