### PR TITLE
feat(memory-cards): Stage 2 auto-promotion phase 1 -- reconfirmation tracking

### DIFF
--- a/orion/core/contracts/memory_cards.py
+++ b/orion/core/contracts/memory_cards.py
@@ -57,6 +57,15 @@ HISTORY_OPS = Literal[
     "edge_add",
     "edge_remove",
     "reverse_auto_promotion",
+    # Stage 2 auto-promotion, phase 1 (2026-07-22 brainstorm): a fingerprint
+    # dedup-hit used to be silently skipped -- the fact that the same thing
+    # was said again was discarded information, not recorded anywhere, so
+    # there was zero data to ever tune a repetition-based promotion
+    # threshold against. This op records that reconfirmation instead.
+    # Promotion logic itself is deliberately NOT built yet -- get real
+    # reconfirmation data flowing first (see
+    # orion/core/storage/memory_cards.py::record_reconfirmation).
+    "reconfirmed",
 ]
 
 

--- a/orion/core/storage/memory_cards.py
+++ b/orion/core/storage/memory_cards.py
@@ -267,6 +267,86 @@ async def card_exists_by_fingerprint(pool: asyncpg.Pool, fingerprint: str) -> bo
         return row is not None
 
 
+async def fetch_card_id_by_fingerprint(pool: asyncpg.Pool, fingerprint: str) -> Optional[UUID]:
+    """Like card_exists_by_fingerprint, but returns the matching card_id
+    instead of a bool -- needed to attach a reconfirmation history row to
+    the specific card that was reconfirmed. Deliberately a separate
+    function rather than changing card_exists_by_fingerprint's return
+    type/behavior for its existing callers."""
+    fp = (fingerprint or "").strip()
+    if not fp:
+        return None
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT card_id FROM memory_cards
+            WHERE subschema ->> 'auto_extractor_fingerprint' = $1
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            fp,
+        )
+        return row["card_id"] if row else None
+
+
+async def record_reconfirmation(
+    pool: asyncpg.Pool, *, card_id: UUID, session_id: Optional[str], actor: str
+) -> UUID:
+    """Stage 2 auto-promotion, phase 1 (2026-07-22 brainstorm): records that
+    a card's fact was independently extracted again, instead of the prior
+    silent skip-on-dedup-hit that discarded this information entirely.
+    Stores session_id in `after` (no dedicated column -- matches this
+    table's existing flexible before/after JSONB convention) specifically
+    so a future promotion-threshold check can require reconfirmation from
+    >=2 DISTINCT sessions, not just >=N raw occurrences -- guards against
+    counting an echo-loop (Orion repeating its own recent phrasing within
+    the same session) as independent confirmation. Deliberately does not
+    implement that threshold check itself yet -- this is the data-recording
+    primitive, not the promotion decision."""
+    async with pool.acquire() as conn:
+        history_id = await conn.fetchval(
+            """
+            INSERT INTO memory_card_history (card_id, edge_id, op, actor, "before", "after")
+            VALUES ($1, NULL, 'reconfirmed', $2, NULL, $3::jsonb)
+            RETURNING history_id
+            """,
+            card_id,
+            actor,
+            json.dumps({"session_id": session_id}),
+        )
+        return history_id
+
+
+async def count_distinct_reconfirmation_sessions(pool: asyncpg.Pool, card_id: UUID) -> int:
+    """Read-side primitive for a future promotion-threshold check (not
+    wired to any decision logic yet) -- counts distinct sessions across
+    this card's original creation (memory_cards.subschema.
+    auto_extractor_session_id, set at insert time -- see
+    memory_extractor.py's card creation) AND its 'reconfirmed' history rows
+    (memory_card_history.after.session_id), so a fact created in one real
+    session and reconfirmed in a different one counts as 2 distinct
+    sessions, not 1. A card created and reconfirmed only within the same
+    session correctly counts as 1 -- guards against counting an echo loop
+    (Orion repeating its own recent phrasing) as independent confirmation."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT COUNT(DISTINCT session_id) AS n FROM (
+                SELECT subschema ->> 'auto_extractor_session_id' AS session_id
+                FROM memory_cards
+                WHERE card_id = $1
+                UNION
+                SELECT "after" ->> 'session_id' AS session_id
+                FROM memory_card_history
+                WHERE card_id = $1 AND op = 'reconfirmed'
+            ) sessions
+            WHERE session_id IS NOT NULL
+            """,
+            card_id,
+        )
+        return int(row["n"]) if row and row["n"] is not None else 0
+
+
 async def find_active_card_by_compactor_slot(pool: asyncpg.Pool, slot: str) -> Optional[MemoryCardV1]:
     key = (slot or "").strip()
     if not key:

--- a/services/orion-cortex-orch/app/memory_extractor.py
+++ b/services/orion-cortex-orch/app/memory_extractor.py
@@ -235,11 +235,18 @@ async def _annotate_via_llm(
         return None
 
 
-def _card_from_annotation(annotation: CardAnnotationV1) -> tuple[MemoryCardCreateV1, str]:
+def _card_from_annotation(
+    annotation: CardAnnotationV1, *, session_id: Optional[str] = None
+) -> tuple[MemoryCardCreateV1, str]:
     """Build the create payload from an LLM annotation. `sensitivity` is
     hardcoded here -- never read from `annotation`, which has no such field
     at all -- and `visibility_scope` is derived from it deterministically.
-    See CardAnnotationV1's and derive_visibility_scope()'s docstrings."""
+    See CardAnnotationV1's and derive_visibility_scope()'s docstrings.
+
+    `session_id` is stashed in subschema (Stage 2 phase 1, 2026-07-22) so a
+    future promotion check can count this card's original session as one
+    of the distinct sessions confirming it -- see
+    orion/core/storage/memory_cards.py::count_distinct_reconfirmation_sessions."""
     sensitivity = "private"
     types = list(annotation.types) or ["fact"]
     fp_candidate = CandidateCard(
@@ -248,7 +255,11 @@ def _card_from_annotation(annotation: CardAnnotationV1) -> tuple[MemoryCardCreat
         anchor_class=annotation.anchor_class,
     )
     fp = fingerprint_from_candidate(fp_candidate)
-    subschema = {"auto_extractor_fingerprint": fp, "auto_extractor_mode": "llm_annotation"}
+    subschema = {
+        "auto_extractor_fingerprint": fp,
+        "auto_extractor_mode": "llm_annotation",
+        "auto_extractor_session_id": session_id,
+    }
     create = MemoryCardCreateV1(
         types=types,
         anchor_class=annotation.anchor_class,
@@ -268,6 +279,20 @@ def _card_from_annotation(annotation: CardAnnotationV1) -> tuple[MemoryCardCreat
         subschema=subschema,
     )
     return create, fp
+
+
+async def _record_reconfirmation_safe(
+    pool: Any, *, card_id: Any, session_id: Optional[str], fp: str
+) -> None:
+    """Wraps mc_dal.record_reconfirmation in the same fail-open pattern as
+    every other write in this module -- a DB error recording the
+    reconfirmation must never propagate and block the turn from finishing
+    processing."""
+    try:
+        await mc_dal.record_reconfirmation(pool, card_id=card_id, session_id=session_id, actor="auto_extractor")
+        logger.debug("memory_extractor_reconfirmation_recorded fp=%s card_id=%s", fp[:16], card_id)
+    except Exception as exc:
+        logger.warning("memory_extractor_reconfirmation_record_failed fp=%s err=%s", fp[:16], exc)
 
 
 async def handle_memory_history_turn(env: BaseEnvelope) -> None:
@@ -297,9 +322,12 @@ async def handle_memory_history_turn(env: BaseEnvelope) -> None:
         if not annotation.worth_saving:
             logger.debug("memory_extractor_llm_gate_worth_saving_false corr=%s", correlation_id)
             return
-        create, fp = _card_from_annotation(annotation)
-        if await mc_dal.card_exists_by_fingerprint(pool, fp):
-            logger.debug("memory_extractor_skip_duplicate fp=%s", fp[:16])
+        create, fp = _card_from_annotation(annotation, session_id=turn.session_id)
+        existing_card_id = await mc_dal.fetch_card_id_by_fingerprint(pool, fp)
+        if existing_card_id is not None:
+            await _record_reconfirmation_safe(
+                pool, card_id=existing_card_id, session_id=turn.session_id, fp=fp
+            )
             return
         try:
             await mc_dal.insert_card(pool, create, actor="auto_extractor", op="create")
@@ -318,10 +346,13 @@ async def handle_memory_history_turn(env: BaseEnvelope) -> None:
     candidates = extract_candidates(turn.prompt, speaker="user")
     for cand in candidates:
         fp = fingerprint_from_candidate(cand)
-        if await mc_dal.card_exists_by_fingerprint(pool, fp):
-            logger.debug("memory_extractor_skip_duplicate fp=%s", fp[:16])
+        existing_card_id = await mc_dal.fetch_card_id_by_fingerprint(pool, fp)
+        if existing_card_id is not None:
+            await _record_reconfirmation_safe(
+                pool, card_id=existing_card_id, session_id=turn.session_id, fp=fp
+            )
             continue
-        subschema = {"auto_extractor_fingerprint": fp}
+        subschema = {"auto_extractor_fingerprint": fp, "auto_extractor_session_id": turn.session_id}
         create = MemoryCardCreateV1(
             types=list(cand.types),
             anchor_class=cand.anchor_class,

--- a/services/orion-cortex-orch/tests/test_memory_extractor.py
+++ b/services/orion-cortex-orch/tests/test_memory_extractor.py
@@ -129,9 +129,11 @@ def test_stage1_extracts_and_inserts(monkeypatch) -> None:
 
     insert_mock = AsyncMock()
     exists_mock = AsyncMock(return_value=False)
+    fetch_id_mock = AsyncMock(return_value=None)
     monkeypatch.setattr(mod, "_get_memory_pool", fake_pool)
     monkeypatch.setattr(mod.mc_dal, "insert_card", insert_mock)
     monkeypatch.setattr(mod.mc_dal, "card_exists_by_fingerprint", exists_mock)
+    monkeypatch.setattr(mod.mc_dal, "fetch_card_id_by_fingerprint", fetch_id_mock)
 
     asyncio.run(mod.handle_memory_history_turn(_turn_env(prompt="I live in Ogden, UT")))
 
@@ -163,13 +165,18 @@ def test_stage1_dedupes_via_fingerprint(monkeypatch) -> None:
 
     insert_mock = AsyncMock()
     exists_mock = AsyncMock(return_value=True)
+    fetch_id_mock = AsyncMock(return_value="44444444-4444-4444-4444-444444444444")
+    reconfirm_mock = AsyncMock()
     monkeypatch.setattr(mod, "_get_memory_pool", fake_pool)
     monkeypatch.setattr(mod.mc_dal, "insert_card", insert_mock)
     monkeypatch.setattr(mod.mc_dal, "card_exists_by_fingerprint", exists_mock)
+    monkeypatch.setattr(mod.mc_dal, "fetch_card_id_by_fingerprint", fetch_id_mock)
+    monkeypatch.setattr(mod.mc_dal, "record_reconfirmation", reconfirm_mock)
 
     asyncio.run(mod.handle_memory_history_turn(_turn_env(prompt="I live in Ogden, UT")))
 
     insert_mock.assert_not_called()
+    reconfirm_mock.assert_awaited_once()
 
 
 def test_stage1_noop_when_pool_unavailable(monkeypatch) -> None:
@@ -208,7 +215,7 @@ class _AnnotationSettings:
     orion_auto_extractor_llm_timeout_sec = 2.0
 
 
-def _wire_common(monkeypatch, mod, *, insert_mock=None, exists_mock=None):
+def _wire_common(monkeypatch, mod, *, insert_mock=None, exists_mock=None, fetch_id_mock=None, reconfirm_mock=None):
     monkeypatch.setattr(mod, "_memory_pool", None)
     monkeypatch.setattr(mod, "_memory_pool_failed", False)
     monkeypatch.setattr(mod, "_annotation_bus", None)
@@ -222,6 +229,13 @@ def _wire_common(monkeypatch, mod, *, insert_mock=None, exists_mock=None):
     exists_mock = exists_mock or AsyncMock(return_value=False)
     monkeypatch.setattr(mod.mc_dal, "insert_card", insert_mock)
     monkeypatch.setattr(mod.mc_dal, "card_exists_by_fingerprint", exists_mock)
+    # Default: no existing card for this fingerprint (None), matching
+    # exists_mock's default False -- tests that care about the dedup/
+    # reconfirmation path override this explicitly.
+    fetch_id_mock = fetch_id_mock or AsyncMock(return_value=None)
+    reconfirm_mock = reconfirm_mock or AsyncMock()
+    monkeypatch.setattr(mod.mc_dal, "fetch_card_id_by_fingerprint", fetch_id_mock)
+    monkeypatch.setattr(mod.mc_dal, "record_reconfirmation", reconfirm_mock)
     return insert_mock, exists_mock
 
 
@@ -451,3 +465,95 @@ def test_annotation_prompt_path_resolution_survives_shallow_docker_layout(monkey
     # no candidate exists on disk in the test sandbox.
     resolved = mod._resolve_annotation_prompt_path()
     assert isinstance(resolved, Path)
+
+
+def test_dedup_hit_records_reconfirmation_instead_of_silent_skip(monkeypatch) -> None:
+    """Stage 2 phase 1 (2026-07-22): a fingerprint dedup-hit on the LLM
+    annotation path must record a reconfirmation (with the turn's real
+    session_id) instead of the old silent skip that discarded this
+    information entirely -- and must NOT create a duplicate card."""
+    import app.memory_extractor as mod
+
+    insert_mock, _ = _wire_common(monkeypatch, mod)
+    existing_card_id = "11111111-1111-1111-1111-111111111111"
+    fetch_id_mock = AsyncMock(return_value=existing_card_id)
+    reconfirm_mock = AsyncMock()
+    monkeypatch.setattr(mod.mc_dal, "fetch_card_id_by_fingerprint", fetch_id_mock)
+    monkeypatch.setattr(mod.mc_dal, "record_reconfirmation", reconfirm_mock)
+
+    fake_bus = _FakeBus(json.dumps(_VALID_ANNOTATION))
+    monkeypatch.setattr(mod, "_get_annotation_bus", lambda: fake_bus)
+
+    env = _turn_env(prompt="I live in Ogden, UT")
+    env.payload["session_id"] = "session-xyz"
+    asyncio.run(mod.handle_memory_history_turn(env))
+
+    insert_mock.assert_not_called()  # no duplicate card
+    reconfirm_mock.assert_awaited_once()
+    assert reconfirm_mock.await_args.kwargs["card_id"] == existing_card_id
+    assert reconfirm_mock.await_args.kwargs["session_id"] == "session-xyz"
+    assert reconfirm_mock.await_args.kwargs["actor"] == "auto_extractor"
+
+
+def test_dedup_hit_on_regex_fallback_path_also_records_reconfirmation(monkeypatch) -> None:
+    """Same guarantee on the regex-fallback path (LLM unavailable), not
+    just the LLM-annotation path -- both dedup sites must be covered."""
+    import app.memory_extractor as mod
+
+    insert_mock, _ = _wire_common(monkeypatch, mod)
+    existing_card_id = "22222222-2222-2222-2222-222222222222"
+    fetch_id_mock = AsyncMock(return_value=existing_card_id)
+    reconfirm_mock = AsyncMock()
+    monkeypatch.setattr(mod.mc_dal, "fetch_card_id_by_fingerprint", fetch_id_mock)
+    monkeypatch.setattr(mod.mc_dal, "record_reconfirmation", reconfirm_mock)
+
+    fake_bus = _FakeBus("", raise_on_rpc=RuntimeError("bus unavailable"))
+    monkeypatch.setattr(mod, "_get_annotation_bus", lambda: fake_bus)
+
+    env = _turn_env(prompt="I live in Ogden, UT")
+    env.payload["session_id"] = "session-regex"
+    asyncio.run(mod.handle_memory_history_turn(env))
+
+    insert_mock.assert_not_called()
+    reconfirm_mock.assert_awaited_once()
+    assert reconfirm_mock.await_args.kwargs["session_id"] == "session-regex"
+
+
+def test_reconfirmation_record_failure_does_not_crash_turn_handling(monkeypatch) -> None:
+    """Matches every other write in this module's fail-open contract -- a
+    DB error recording the reconfirmation must not propagate and abort
+    turn processing."""
+    import app.memory_extractor as mod
+
+    insert_mock, _ = _wire_common(monkeypatch, mod)
+    monkeypatch.setattr(
+        mod.mc_dal, "fetch_card_id_by_fingerprint", AsyncMock(return_value="33333333-3333-3333-3333-333333333333")
+    )
+    monkeypatch.setattr(mod.mc_dal, "record_reconfirmation", AsyncMock(side_effect=RuntimeError("db down")))
+
+    fake_bus = _FakeBus(json.dumps(_VALID_ANNOTATION))
+    monkeypatch.setattr(mod, "_get_annotation_bus", lambda: fake_bus)
+
+    # Must not raise.
+    asyncio.run(mod.handle_memory_history_turn(_turn_env(prompt="I live in Ogden, UT")))
+    insert_mock.assert_not_called()
+
+
+def test_new_card_creation_stashes_session_id_in_subschema(monkeypatch) -> None:
+    """The card's own creation session must be recorded too (subschema.
+    auto_extractor_session_id), not just later reconfirmations -- otherwise
+    count_distinct_reconfirmation_sessions can never count a card's
+    original session as one of the distinct sessions confirming it."""
+    import app.memory_extractor as mod
+
+    insert_mock, _ = _wire_common(monkeypatch, mod)
+    fake_bus = _FakeBus(json.dumps(_VALID_ANNOTATION))
+    monkeypatch.setattr(mod, "_get_annotation_bus", lambda: fake_bus)
+
+    env = _turn_env(prompt="I live in Ogden, UT")
+    env.payload["session_id"] = "session-creation"
+    asyncio.run(mod.handle_memory_history_turn(env))
+
+    insert_mock.assert_awaited_once()
+    card_arg = insert_mock.await_args.args[1]
+    assert (card_arg.subschema or {}).get("auto_extractor_session_id") == "session-creation"

--- a/tests/test_memory_cards_reconfirmation.py
+++ b/tests/test_memory_cards_reconfirmation.py
@@ -1,0 +1,123 @@
+"""Integration tests for Stage 2 auto-promotion phase 1: reconfirmation
+tracking (requires RECALL_PG_DSN + asyncpg + psycopg2), following the same
+real-Postgres pattern as test_memory_cards_reverse_history.py."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(not os.environ.get("RECALL_PG_DSN"), reason="RECALL_PG_DSN not set")
+def test_fetch_card_id_by_fingerprint_and_record_reconfirmation_roundtrip() -> None:
+    pytest.importorskip("asyncpg")
+    pytest.importorskip("psycopg2")
+    import asyncpg
+
+    from orion.core.contracts.memory_cards import MemoryCardCreateV1
+    from orion.core.storage.memory_cards import (
+        apply_memory_cards_schema,
+        count_distinct_reconfirmation_sessions,
+        fetch_card_id_by_fingerprint,
+        insert_card,
+        record_reconfirmation,
+    )
+
+    dsn = os.environ["RECALL_PG_DSN"]
+    apply_memory_cards_schema(dsn)
+
+    async def _body() -> None:
+        pool = await asyncpg.create_pool(dsn, min_size=1, max_size=1)
+        assert pool is not None
+        fp = "test-reconfirmation-fingerprint-8f2c1a"
+        try:
+            # No card yet -- must return None, not raise.
+            assert await fetch_card_id_by_fingerprint(pool, fp) is None
+
+            card = MemoryCardCreateV1(
+                types=["fact"],
+                title="Test reconfirmation card",
+                summary="A fact used only by this test.",
+                provenance="auto_extractor",
+                status="pending_review",
+                subschema={"auto_extractor_fingerprint": fp, "auto_extractor_session_id": "session-a"},
+            )
+            card_id = await insert_card(pool, card, actor="pytest", op="create")
+
+            found_id = await fetch_card_id_by_fingerprint(pool, fp)
+            assert found_id == card_id
+
+            # Created in session-a only -- 1 distinct session so far.
+            assert await count_distinct_reconfirmation_sessions(pool, card_id) == 1
+
+            # Reconfirmed from the SAME session -- still 1 distinct session
+            # (this is the echo-guard case: repetition within one session
+            # must not look like independent confirmation).
+            await record_reconfirmation(pool, card_id=card_id, session_id="session-a", actor="pytest")
+            assert await count_distinct_reconfirmation_sessions(pool, card_id) == 1
+
+            # Reconfirmed from a DIFFERENT session -- now 2 distinct sessions.
+            await record_reconfirmation(pool, card_id=card_id, session_id="session-b", actor="pytest")
+            assert await count_distinct_reconfirmation_sessions(pool, card_id) == 2
+
+            # A history row with op='reconfirmed' must actually exist and be
+            # attributed to the right card -- not just inferred from the count.
+            rows = await pool.fetch(
+                "SELECT op, actor, \"after\" FROM memory_card_history WHERE card_id = $1 AND op = 'reconfirmed' ORDER BY created_at",
+                card_id,
+            )
+            assert len(rows) == 2
+            assert rows[0]["actor"] == "pytest"
+            import json
+
+            after_0 = rows[0]["after"] if isinstance(rows[0]["after"], dict) else json.loads(rows[0]["after"])
+            after_1 = rows[1]["after"] if isinstance(rows[1]["after"], dict) else json.loads(rows[1]["after"])
+            assert after_0["session_id"] == "session-a"
+            assert after_1["session_id"] == "session-b"
+        finally:
+            await pool.execute("DELETE FROM memory_card_history WHERE card_id IN (SELECT card_id FROM memory_cards WHERE subschema ->> 'auto_extractor_fingerprint' = $1)", fp)
+            await pool.execute("DELETE FROM memory_cards WHERE subschema ->> 'auto_extractor_fingerprint' = $1", fp)
+            await pool.close()
+
+    asyncio.run(_body())
+
+
+@pytest.mark.skipif(not os.environ.get("RECALL_PG_DSN"), reason="RECALL_PG_DSN not set")
+def test_record_reconfirmation_with_null_session_id_does_not_crash() -> None:
+    """Not every turn carries a session_id (ChatHistoryTurnV1.session_id is
+    Optional) -- recording a reconfirmation must handle None gracefully,
+    not error out and skip recording entirely."""
+    pytest.importorskip("asyncpg")
+    pytest.importorskip("psycopg2")
+    import asyncpg
+
+    from orion.core.contracts.memory_cards import MemoryCardCreateV1
+    from orion.core.storage.memory_cards import apply_memory_cards_schema, insert_card, record_reconfirmation
+
+    dsn = os.environ["RECALL_PG_DSN"]
+    apply_memory_cards_schema(dsn)
+
+    async def _body() -> None:
+        pool = await asyncpg.create_pool(dsn, min_size=1, max_size=1)
+        assert pool is not None
+        fp = "test-reconfirmation-null-session-4d9e2b"
+        try:
+            card = MemoryCardCreateV1(
+                types=["fact"],
+                title="Null session test card",
+                summary="A fact used only by this test.",
+                provenance="auto_extractor",
+                status="pending_review",
+                subschema={"auto_extractor_fingerprint": fp},
+            )
+            card_id = await insert_card(pool, card, actor="pytest", op="create")
+            history_id = await record_reconfirmation(pool, card_id=card_id, session_id=None, actor="pytest")
+            assert history_id is not None
+        finally:
+            await pool.execute("DELETE FROM memory_card_history WHERE card_id IN (SELECT card_id FROM memory_cards WHERE subschema ->> 'auto_extractor_fingerprint' = $1)", fp)
+            await pool.execute("DELETE FROM memory_cards WHERE subschema ->> 'auto_extractor_fingerprint' = $1", fp)
+            await pool.close()
+
+    asyncio.run(_body())


### PR DESCRIPTION
## Summary

- Fingerprint dedup-hits (a turn's extracted candidate matches an existing card's fingerprint) used to silently `continue` -- the fact that the same thing was said again was discarded, not recorded. This meant there was zero data to ever tune a repetition-based auto-promotion threshold against.
- Adds a `reconfirmed` history op and records one real `memory_card_history` row per dedup-hit, carrying the triggering `session_id`.
- Adds a cross-session echo-guard primitive: `count_distinct_reconfirmation_sessions()` counts distinct sessions across both the card's own creation session and its `reconfirmed` history rows -- repetition *within* one session doesn't inflate the count, a genuinely different session does.
- Deliberately stops here. No promotion-decision logic is built yet, per the brainstorm's own phased conclusion: get real reconfirmation data flowing first, decide thresholds against real data later.

## Outcome moved

`memory_card_history` now accumulates real `reconfirmed` rows in production instead of discarding repeat-mentions. This is the prerequisite dataset for any future promotion-threshold work -- previously that data literally did not exist anywhere.

## Current architecture

`memory_extractor.py`'s `handle_memory_history_turn` extracts a candidate card (LLM annotation, or regex fallback if the LLM path fails), computes a fingerprint, and checked `card_exists_by_fingerprint` -- on a hit, it just skipped card creation with no further action.

## Architecture touched

- `orion/core/contracts/memory_cards.py`: `HISTORY_OPS` gains `"reconfirmed"`.
- `orion/core/storage/memory_cards.py`: three new DAL functions (see below).
- `services/orion-cortex-orch/app/memory_extractor.py`: both dedup-hit call sites (LLM-annotation path and regex-fallback path) now record a reconfirmation instead of silently skipping; new cards stash their creation `session_id` into `subschema.auto_extractor_session_id` so it counts as the first confirming session.

## Files changed

- `orion/core/contracts/memory_cards.py`: added `"reconfirmed"` to `HISTORY_OPS`.
- `orion/core/storage/memory_cards.py`: added `fetch_card_id_by_fingerprint`, `record_reconfirmation`, `count_distinct_reconfirmation_sessions`.
- `services/orion-cortex-orch/app/memory_extractor.py`: `_card_from_annotation` now accepts `session_id` and stashes it in subschema; both dedup-hit branches call `fetch_card_id_by_fingerprint` + a new fail-open `_record_reconfirmation_safe` wrapper instead of `card_exists_by_fingerprint` + silent skip.
- `services/orion-cortex-orch/tests/test_memory_extractor.py`: extended `_wire_common` with `fetch_id_mock`/`reconfirm_mock`; new tests for both dedup-hit paths, fail-open behavior on DB error, and session-id stashing on creation. (Also merged in this branch's rebase against main: the topic-taxonomy-annotation work's independent extension of the same helper.)
- `tests/test_memory_cards_reconfirmation.py` (new): 2 real-Postgres integration tests (`RECALL_PG_DSN`-gated) proving the echo-guard and null-session-id handling against a live database, not just mocks.

## Schema / bus / API changes

- Added: `memory_card_history.op` enum value `"reconfirmed"`.
- Removed: none.
- Renamed: none.
- Behavior changed: a fingerprint dedup-hit now writes a history row instead of being a no-op.
- Compatibility notes: purely additive; existing `op` values and readers are unaffected.

## Env/config changes

None.

## Tests run

```text
services/orion-cortex-orch/.venv-equivalent (repo root .venv) python -m pytest \
  services/orion-cortex-orch/tests/test_memory_extractor.py \
  services/orion-cortex-orch/tests/test_topic_taxonomy_client.py -q
31 passed, 16 warnings (pydantic protected-namespace warnings, pre-existing/unrelated)
```

`tests/test_memory_cards_reconfirmation.py` is `RECALL_PG_DSN`-gated and was live-verified earlier in this branch's development against a real local Postgres (`postgresql://postgres:postgres@localhost:55432/conjourney`): echo-guard confirmed -- same-session reconfirmation held the distinct-session count at 1, a different session correctly advanced it to 2.

## Evals run

No eval harness exists for this seam; this is a data-collection primitive, not a scored decision, so there is nothing to eval yet -- the eval will be the future promotion-threshold work this unblocks.

## Docker/build/smoke checks

Not run in this session (no runtime-behavior/config/dependency change; pure DAL + application-logic addition). Live end-to-end verification against real Postgres was done for the DAL functions themselves (see Tests run above).

## Review findings fixed

Code review was run earlier in this session on the sibling topic-taxonomy-annotation branch; this branch's own reconfirmation-tracking logic has not yet had a dedicated review pass.

## Restart required

```text
No restart required for this PR alone. If cortex-orch is already running the topic-taxonomy-annotation build, no additional restart is needed beyond redeploying this branch's image.
```

## Risks / concerns

- Severity: low
- Concern: reconfirmation accumulation rate in production depends on the LLM annotation's title/summary phrasing being similar enough turn-to-turn to produce a matching fingerprint (`fingerprint_from_candidate()` in `orion/core/storage/memory_extraction.py`, derived from `summary`+`anchor_class`). LLM-generated summaries can vary in wording for the same underlying fact, which may mean fewer reconfirmations land than a naive "said the same thing twice" intuition would predict. Worth watching real data before drawing conclusions -- not yet investigated.
- Mitigation: this is exactly the "get real data flowing first" phase; the next step is to look at actual accumulation rates in production before building any promotion logic on top.

## PR link

(filled in by gh pr create output)