### PR TITLE
feat(attention): Candidate B -- society-of-mind rank-aggregated salience (shadow, read-only)

### DIFF
--- a/orion/attention/field_attention/candidate_society_of_mind.py
+++ b/orion/attention/field_attention/candidate_society_of_mind.py
@@ -1,0 +1,369 @@
+"""Candidate B: rank-aggregated independent scorers (Global Workspace Theory /
+Society-of-Mind -- Baars 1988 "A Cognitive Theory of Consciousness", Dehaene
+2014 "Consciousness and the Brain", Minsky 1986 "The Society of Mind").
+
+**Shadow candidate. Read-only. Not wired to any live consumer.** Per
+`docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-
+tentative-plan.md`'s "Candidate B" section: this is one of two parallel,
+structurally different replacement candidates for
+`orion/attention/field_attention/scoring.py::compute_salience()`'s hand-typed
+linear weighted sum (`pressure*0.45 + novelty*0.20 + urgency*0.25 +
+confidence*0.10`, zero citation, zero calibration -- see that doc's "Finding:
+the disease is systemic, not one bug"). Candidate A (Friston-style
+precision-weighted prediction error) is a separate, parallel effort; this
+module does not build or depend on it.
+
+**Structural claim**: instead of one formula with N weights to hand-tune,
+three independently-sourced real scorers each rank targets on their own
+terms, and a citable social-choice rank-aggregation method (Borda count,
+de Borda 1770) combines the rankings. No cross-scorer weight is ever
+guessed or calibrated -- each scorer only has to be internally sound, not
+commensurable with the others on a shared numeric scale.
+
+The three scorers are exactly the "smallest probe" triad named in
+`docs/superpowers/specs/2026-07-17-field-native-motivational-substrate-
+design.md`'s blue-sky extension 2 ("Society-of-Mind competition"):
+magnitude, novelty, unresolved-duration (dwell). All three reuse existing,
+already-shipped, already-live real signal sources -- this module adds no new
+producer, only a new *combination* mechanism over data that already exists:
+
+1. `magnitude_scorer` -- passthrough/validation over real prediction-error
+   magnitudes already computed by `orion.substrate.prediction_error`'s five
+   `*_prediction_error()` functions (execution/transport/biometrics/chat/
+   route), each already a real [0,1] surprise score.
+2. `novelty_scorer` -- thin wrapper around the already-live, already-real
+   `orion.attention.field_attention.scoring.novelty_for_target()`, reused
+   here in a genuinely different structural role: an independent
+   rank-aggregation voter, not a weighted-summed term inside
+   `compute_salience()`.
+3. `dwell_scorer` -- real duration-of-unresolved-coalition signal from
+   `AttentionBroadcastProjectionV1.dwell_ticks`/`attended_node_ids`
+   (`orion/substrate/attention_broadcast.py`, already live, already fixed of
+   a prior loop-scoped-vs-global-scalar bug per program history).
+
+**Real live-data finding, load-bearing (2026-07-21)**: as of this build, the magnitude scorer's real target universe
+(`node:substrate.{biometrics,execution,transport,chat,route}`, written by
+`services/orion-substrate-runtime/app/worker.py::_write_prediction_error_node`)
+and the novelty scorer's real target universe (`node:athena`/`node:atlas`/
+`node:circe` plus `capability:*`/`field:recent_perturbations`, drawn from
+`FieldStateV1.node_vectors` as ingested by `orion-field-digester`) do not
+currently overlap at all in live data -- confirmed by direct query, not
+assumed. This does not make the combiner below wrong; it means real
+three-way competition on the *same* target requires either (a) waiting for
+target-universe overlap to occur naturally (e.g. a `substrate.*` domain node
+entering the dwell coalition, which has been observed, rarely) or (b) a
+follow-up patch teaching `orion-field-digester` to ingest the
+prediction-error domain nodes into `FieldStateV1.node_vectors` too -- out of
+scope for this shadow-only patch, named as a real follow-up.
+
+Non-goals of this module:
+- Does not modify `orion/attention/field_attention/scoring.py` or
+  `selectors.py` (the live formula).
+- Does not wire into `compute_salience()`, `select_system_targets`,
+  `orion/self_state/builder.py`, `LinearSalienceCombiner`/`seed-v1`, or any
+  live consumer.
+- Does not invent a fourth scorer or a hand-tuned aggregation formula -- the
+  whole point of this candidate is to have zero cross-factor weights.
+
+## Live-data sanity check status (CLAUDE.md §0A metric-quality-gate step 4) -- disclosed honestly, 2026-07-22
+
+An earlier version of this docstring claimed a "companion replay script" existed for
+this module. It did not -- that was a false, unverified citation, caught in review, not
+a stale reference to something that once existed. Corrected here rather than silently
+dropped, so the gap is visible instead of implied-covered.
+
+**What real data has actually been run through this module, as of this patch**:
+`magnitude_scorer()` only, via `scripts/analysis/measure_society_of_mind_magnitude_probe.py`
+(new, this patch) -- real `substrate_reduction_receipts` history, reusing Candidate A's
+already-proven Postgres-loading code rather than duplicating it. See that script's own
+report for real numbers.
+
+**What has NOT been run against real data**: `novelty_scorer()` (needs real
+`substrate_attention_frames` history), `dwell_scorer()` (needs real
+`substrate_coalition_dwell_log` history), and `aggregate_borda()`'s full three-scorer
+combination -- i.e. the plan doc's own Candidate B acceptance check ("do the three
+scorers ever disagree, and is that disagreement itself informative -- report real
+examples, not a summary claim") is **not yet met**. Only synthetic-fixture unit tests
+exist for those three functions. This is a real, disclosed gap, not a completed
+capability -- treat any claim that this candidate is "live-data validated" as false
+until a real three-scorer replay exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from orion.attention.field_attention.scoring import clamp01, novelty_for_target
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+
+# services/orion-substrate-runtime/app/worker.py::_write_prediction_error_node
+# writes real FalkorDB nodes at this exact id convention for all five
+# producer domains. Exposed here so the replay script and any future caller
+# share one source of truth for the convention instead of re-deriving it.
+PREDICTION_ERROR_TARGET_PREFIX = "node:substrate."
+
+# Dwell-ticks normalization cap for `dwell_scorer`'s [0,1] output. 30s tick
+# cadence (`orion-substrate-runtime`'s broadcast tick, confirmed live via
+# `substrate_coalition_dwell_log` row spacing 2026-07-21) * 120 ticks = ~1h of
+# continuous unresolved dwell before this scorer saturates to 1.0. Chosen as
+# a round, documented number rather than fit to any particular observed
+# distribution -- real dwell_ticks values observed live on 2026-07-21 ranged
+# from single digits up to 4900+ (a multi-day-old un-reset coalition), so
+# *some* cap is required for this scorer's output to stay informative rather
+# than dominated by however long the process has been running since its last
+# restart. Callers needing raw duration for their own reporting should read
+# `dwell_ticks` directly rather than back-deriving it from this score.
+DWELL_TICKS_SATURATION = 120
+
+_NEG_INF = float("-inf")
+
+
+def magnitude_scorer(prediction_errors: dict[str, float]) -> dict[str, float]:
+    """Real prediction-error magnitude per target -- passthrough, not a
+    re-derivation.
+
+    Metric-quality-gate note (CLAUDE.md Sec 0A): `orion.substrate.
+    prediction_error`'s five `*_prediction_error()` functions already
+    produce a real [0,1] surprise score per producer domain (four via
+    `min(1.0, mean(|delta|) / 0.30)`, `route_prediction_error` via a
+    categorical mismatch rate -- see that module's own docstrings for why
+    the two shapes differ). This scorer performs no additional weighting or
+    transform of its own -- it *is* the magnitude vote, taken as-is. The
+    only work done here is defensive: clamp to [0,1] and drop non-finite
+    values, since the caller may be assembling this dict from several
+    real-but-independently-sourced upstream calls (one per producer domain)
+    and a single malformed value must not poison the whole tick's ranking.
+
+    Callers build `prediction_errors` themselves, one key per producer
+    domain, e.g. `{"node:substrate.biometrics": biometrics_prediction_error
+    (prev, curr), ...}` -- see `PREDICTION_ERROR_TARGET_PREFIX` and the
+    companion replay script for the real historical data source (this
+    module does no I/O; `substrate_reduction_receipts` is the only place
+    real history for these values exists, per Candidate A's own established
+    finding, reused here rather than re-derived).
+    """
+    out: dict[str, float] = {}
+    for target_id, value in prediction_errors.items():
+        try:
+            fv = float(value)
+        except (TypeError, ValueError):
+            continue
+        if fv != fv or fv in (float("inf"), float("-inf")):  # NaN/inf guard
+            continue
+        out[target_id] = clamp01(fv)
+    return out
+
+
+def novelty_scorer(
+    target_ids: list[str],
+    current_salience: dict[str, float],
+    previous_frame: FieldAttentionFrameV1 | None,
+) -> dict[str, float]:
+    """Real novelty vote per target -- thin wrapper around the already-live
+    `novelty_for_target()`.
+
+    Metric-quality-gate note: this is the *same* real signal RPT/Lamme
+    already contributes to the live (broken) `compute_salience()` weighted
+    sum -- reused here in a genuinely different structural role (an
+    independent rank-aggregation voter competing on its own terms, not a
+    0.20-weighted addend inside one formula). Per this candidate's own
+    design brief: "a genuinely different structural role for the same real
+    signal." Requires `current_salience[target_id]` -- the target's
+    *pre-novelty* salience for the current tick (mirrors
+    `selectors.py::_build_target`'s own two-pass compute: pressure/urgency/
+    confidence first, then novelty diffs that pre-novelty salience against
+    the same target's *prior* frame -- computing novelty from a
+    salience that already includes this tick's own novelty contribution
+    would be circular). A `target_id` missing from `current_salience`
+    defaults to 0.0 (no observed pressure this tick), the same convention
+    `measure_emergent_clustering_probe.py::extract_target_salience_map`
+    already uses for tick-level absence.
+    """
+    return {
+        target_id: novelty_for_target(
+            target_id, current_salience.get(target_id, 0.0), previous_frame
+        )
+        for target_id in target_ids
+    }
+
+
+def dwell_scorer(
+    attended_node_ids: list[str],
+    dwell_ticks: int,
+    *,
+    saturation_ticks: int = DWELL_TICKS_SATURATION,
+) -> dict[str, float]:
+    """Real unresolved-duration vote: every target currently inside the
+    active broadcast coalition gets the same normalized `dwell_ticks` score;
+    everything else gets no vote at all (empty dict entry, not 0.0 --
+    important for the Borda combiner's partial-ballot handling below: a
+    target this scorer has no opinion about must be treated as "unranked",
+    not "actively scored lowest for a real reason").
+
+    Metric-quality-gate note, load-bearing (2026-07-21 live query against
+    `substrate_coalition_dwell_log`): `attended_node_ids` was the empty list
+    in 2837 of 2840 real rows over the most recent 24h window (99.9%) --
+    the coalition being "dwelt on" is, almost always, the empty coalition
+    (no `selected_action`/`open_loop_id` resolved that tick), not a real
+    target. `dwell_ticks` itself is real and non-degenerate (a genuine,
+    live, monotonically-increasing-with-resets counter, observed ranging
+    from single digits to 4900+ across the same window), but the *target
+    attribution* dimension is almost entirely absent in current live data.
+    This is disclosed here plainly rather than smoothed over: this scorer
+    is real and correctly wired, but in today's live substrate it will
+    almost never cast a real per-target vote. The 2837/2840 figure above is
+    from a one-off live query against `substrate_coalition_dwell_log`, not
+    from a replay script -- no script currently measures this dwell-emptiness
+    fraction (unlike `magnitude_scorer()`, which
+    `scripts/analysis/measure_society_of_mind_magnitude_probe.py` does cover
+    against real data; see that scorer's own docstring above and the module's
+    top-level "Live-data sanity check status" section).
+
+    `attended_node_ids` is de-duplicated (a target should not get inflated
+    influence just because `AttentionBroadcastProjectionV1.attended_node_ids`
+    happens to list it more than once) while preserving first-seen order,
+    though the resulting score is uniform across all attended targets
+    regardless of order -- there is exactly one coalition-wide dwell
+    duration, not a per-target one, per the real schema
+    (`AttentionBroadcastProjectionV1.dwell_ticks` is a single int, not a
+    per-node mapping).
+    """
+    if dwell_ticks <= 0 or not attended_node_ids:
+        return {}
+    cap = max(1, int(saturation_ticks))
+    score = clamp01(float(dwell_ticks) / float(cap))
+    deduped = list(dict.fromkeys(attended_node_ids))
+    return {target_id: score for target_id in deduped}
+
+
+@dataclass(frozen=True)
+class BordaResult:
+    """Output of one tick's rank-aggregation over `universe`."""
+
+    universe: tuple[str, ...]
+    totals: dict[str, float]
+    ranking: tuple[str, ...]
+    winner: str | None
+    per_scorer_top1: dict[str, str | None]
+    disagreement: bool
+
+
+def scorer_top1(scores: dict[str, float]) -> str | None:
+    """The single highest-scored target for one scorer's own ballot.
+    Deterministic tie-break: highest score, then alphabetical target_id --
+    same convention `measure_emergent_clustering_probe.py::top1_winner`
+    already uses, reused here rather than re-invented."""
+    if not scores:
+        return None
+    return sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]
+
+
+def _borda_points_for_scorer(scores: dict[str, float], universe: list[str]) -> dict[str, float]:
+    """Points one scorer's ballot assigns to every target in `universe`.
+
+    Classic Borda count (de Borda 1770): for N candidates, the worst-ranked
+    gets 0 points and the best-ranked gets N-1, with every intervening rank
+    getting one more point than the rank below it.
+
+    Two explicit, documented deviations from the textbook version, both
+    real and necessary here, neither hand-tuned:
+
+    1. **Tied real scores share the average of their tied positions'
+       points**, rather than an arbitrary tiebreak silently favoring one of
+       two identically-scored targets. Standard Borda tie-handling
+       (sometimes called "average rank" or "fractional Borda"), not
+       invented for this module.
+    2. **A target absent from `scores` (this scorer has no real evidence
+       about it) is treated as tied for this scorer's own last place** --
+       ranked at or below every target the scorer actually scored, never
+       above. This is the standard treatment for partial ballots in
+       rank-aggregation (a voter who does not rank a candidate is not
+       silently excluded from affecting that candidate's total, nor is the
+       candidate given a charitable average-of-everyone-else score) --
+       chosen specifically because "no evidence this target matters" should
+       never accidentally out-rank "measured, real evidence this target
+       matters less than something else." Implemented by sorting absent
+       targets to `-inf`, which then naturally tie-groups with each other
+       (not with any real-scored target) and shares the lowest available
+       points via deviation 1 above -- no separate code path needed.
+    """
+    n = len(universe)
+    if n == 0:
+        return {}
+    if n == 1:
+        return {universe[0]: 0.0}
+    keyed = [(t, scores[t] if t in scores else _NEG_INF) for t in universe]
+    ordered = sorted(keyed, key=lambda kv: (kv[1], kv[0]))
+    points: dict[str, float] = {}
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and ordered[j + 1][1] == ordered[i][1]:
+            j += 1
+        avg_points = sum(range(i, j + 1)) / (j - i + 1)
+        for k in range(i, j + 1):
+            points[ordered[k][0]] = avg_points
+        i = j + 1
+    return points
+
+
+def aggregate_borda(
+    scorer_scores: dict[str, dict[str, float]],
+    universe: list[str] | None = None,
+) -> BordaResult:
+    """Combine N independent scorers' rankings into one Borda-count total.
+
+    Why Borda count and not a weighted sum: a weighted sum requires
+    guessing/calibrating a cross-scorer exchange rate (exactly the disease
+    named in this module's own top docstring -- `compute_salience()`'s
+    uncalibrated `0.45/0.20/0.25/0.10` split). Borda count needs no such
+    rate -- each scorer only orders targets on its own internal scale, and
+    the combination step operates purely on rank position, which is
+    commensurable across scorers by construction (rank 1 always means
+    "this scorer's own best pick," regardless of what numeric scale
+    produced it). Why not a Condorcet method (e.g. pairwise majority):
+    Condorcet methods can produce cycles (no single winner) with only 3
+    voters and can leave ties unresolved without an additional tiebreak
+    rule of their own; Borda always produces one complete, total-ordered
+    ranking from any input, which is what a per-tick "who wins this
+    competition" question needs. Both are real, standard, citable social-
+    choice methods -- Borda is chosen for its guaranteed-total-order
+    property, not because it was the only option considered.
+
+    `universe` defaults to the union of every target any scorer actually
+    scored this tick. Passing it explicitly lets a caller widen the
+    universe to include targets not present in any scorer for this specific
+    tick (e.g. to compare against a fixed real target list across many
+    ticks) -- any such target gets `_NEG_INF`-tied-last treatment from every
+    scorer, i.e. total score 0.0, same as any other fully-unscored target.
+
+    `disagreement` is true iff two or more scorers' own top-1 picks (see
+    `scorer_top1`) differ from each other. A scorer that scored nothing this
+    tick (empty dict, `scorer_top1` returns None) does not count toward
+    disagreement either way -- silence is not itself a vote.
+    """
+    if universe is None:
+        resolved_universe = sorted({t for s in scorer_scores.values() for t in s})
+    else:
+        resolved_universe = sorted(set(universe))
+
+    totals: dict[str, float] = {t: 0.0 for t in resolved_universe}
+    per_scorer_top1: dict[str, str | None] = {}
+    for name, scores in scorer_scores.items():
+        per_scorer_top1[name] = scorer_top1(scores)
+        for t, p in _borda_points_for_scorer(scores, resolved_universe).items():
+            totals[t] += p
+
+    ranking = tuple(sorted(resolved_universe, key=lambda t: (-totals[t], t)))
+    winner = ranking[0] if ranking else None
+    real_top1s = {v for v in per_scorer_top1.values() if v is not None}
+    disagreement = len(real_top1s) > 1
+
+    return BordaResult(
+        universe=tuple(resolved_universe),
+        totals=totals,
+        ranking=ranking,
+        winner=winner,
+        per_scorer_top1=per_scorer_top1,
+        disagreement=disagreement,
+    )

--- a/scripts/analysis/measure_society_of_mind_magnitude_probe.py
+++ b/scripts/analysis/measure_society_of_mind_magnitude_probe.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Read-only replay of Candidate B's `magnitude_scorer()` over real
+`substrate_reduction_receipts` history.
+
+Sentience Striving Program (`orion/sentience_striving_program/README.md`) §7 ("measure
+before minting") and
+`docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-tentative-
+plan.md`'s "Candidate B" section. Replays
+`orion/attention/field_attention/candidate_society_of_mind.py::magnitude_scorer()` --
+a pure function, imported and exercised here, never reimplemented -- over real
+historical prediction-error receipts.
+
+This performs NO writes, emits NO events, flips NO flags.
+
+## Scope, disclosed honestly (2026-07-22)
+
+This replay covers **`magnitude_scorer()` only** -- not `novelty_scorer()` (needs real
+`substrate_attention_frames` history), not `dwell_scorer()` (needs real
+`substrate_coalition_dwell_log` history), and not `aggregate_borda()`'s full three-scorer
+combination. Those three remain unvalidated against real data; see the module docstring's
+"Live-data sanity check status" section for the explicit, disclosed gap. This script
+closes the gap for `magnitude_scorer()` specifically -- the one scorer that reuses the
+exact same real Postgres source and target-id convention
+(`node:substrate.{biometrics,execution,transport,chat,route}`) that Candidate A's own
+replay script (`measure_precision_weighted_salience_probe.py`) already proved out, making
+this the cheapest of the three to validate for real.
+
+The Postgres connection/query helpers below intentionally mirror Candidate A's replay
+script rather than importing it -- the two candidates ship on separate, independently
+mergeable branches, so no shared import target exists yet. This is the same
+each-script-owns-its-own-connection-boilerplate pattern already established by
+`measure_emergent_clustering_probe.py` and `measure_precision_weighted_salience_probe.py`,
+not a new one invented here.
+
+## Honest scoping: real target universe, real competing set (2026-07-22, live-checked)
+
+`magnitude_scorer()` takes a `dict[target_id, value]` -- a single tick's votes across
+*whatever real targets have a value that tick*. All five prediction-error reducers write
+into the same `node:substrate.*` id convention (unlike magnitude vs. novelty's disjoint
+universes, noted in the module docstring), so a genuine multi-target magnitude
+*competition* (e.g. `node:substrate.biometrics` vs `node:substrate.execution` voting in
+the same real tick) is possible in principle. Whether it's demonstrable *today* depends
+on how many of the five reducers have qualifying real history at run time -- reported
+honestly below, not assumed. `substrate_reduction_receipts` retains success rows for only
+`ORION_RECEIPT_RETENTION_SUCCESS_MINUTES` (30 minutes in the live `.env` at time of
+writing) before a background pruner deletes them -- the same structural constraint
+Candidate A's replay already found and documented, reused here rather than re-derived.
+
+Run:
+    python scripts/analysis/measure_society_of_mind_magnitude_probe.py
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from orion.attention.field_attention.candidate_society_of_mind import (
+    magnitude_scorer,
+    scorer_top1,
+)
+
+logger = logging.getLogger("orion.analysis.society_of_mind_magnitude_probe")
+
+# Same real reducer_name -> node:substrate.* convention Candidate A's replay already
+# established -- see _prediction_error_receipt()'s reducer_id=f"substrate.{reducer_key}"
+# in services/orion-substrate-runtime/app/worker.py.
+REDUCER_TO_TARGET_ID: dict[str, str] = {
+    "substrate.node_biometrics": "node:substrate.biometrics",
+    "substrate.execution_trajectory": "node:substrate.execution",
+    "substrate.transport_bus": "node:substrate.transport",
+    "substrate.chat_session": "node:substrate.chat",
+    "substrate.route_arbitration": "node:substrate.route",
+}
+
+QUALIFYING_MIN_ROWS: int = 20
+MAX_ROWS: int = 50_000
+
+OUTPUT_DIR = Path("/tmp/society-of-mind-magnitude-probe")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+
+# ===========================================================================
+# Pure layer -- no I/O.
+# ===========================================================================
+
+
+def parse_prediction_error(raw: Any) -> Optional[float]:
+    """Parse a raw `receipt_json->...->>'prediction_error'` value. Never raises."""
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+# ===========================================================================
+# I/O layer -- psycopg2 read-only. Same connection contract as
+# measure_precision_weighted_salience_probe.py / measure_emergent_clustering_probe.py.
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_reducer_rows(
+    conn, reducer_name: str, max_rows: int = MAX_ROWS
+) -> tuple[list[datetime], list[float]]:
+    """Real (timestamp, prediction_error) rows for one reducer_name, ASC by
+    created_at. Skips rows whose value fails to parse (never fatal)."""
+    if conn is None:
+        return [], []
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT created_at,
+                       receipt_json->'state_deltas'->0->'after'->'pressure_hints'
+                         ->>'prediction_error' AS pe
+                FROM substrate_reduction_receipts
+                WHERE reducer_name = %s
+                ORDER BY created_at ASC
+                LIMIT %s
+                """,
+                (reducer_name, max_rows),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch rows for reducer_name=%s", reducer_name, exc_info=True)
+        return [], []
+
+    timestamps: list[datetime] = []
+    values: list[float] = []
+    for ts, raw_pe in rows:
+        pe = parse_prediction_error(raw_pe)
+        if pe is None or ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        timestamps.append(ts)
+        values.append(pe)
+    return timestamps, values
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int, note: str = "") -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+            f"{(' | ' + note) if note else ''}"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def run() -> int:
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    progress = ProgressLog(PROGRESS_PATH)
+    caveats: list[str] = []
+
+    progress.emit("connect", percent=0.0, processed=0, total=0)
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        caveats.append("postgres unavailable or not read-only; nothing measured")
+        progress.close()
+        print("ERROR: could not open a read-only postgres connection; see log")
+        return 2
+
+    reducer_names = list(REDUCER_TO_TARGET_ID)
+    total = len(reducer_names)
+    per_reducer: dict[str, dict[str, Any]] = {}
+
+    for idx, reducer_name in enumerate(reducer_names):
+        progress.emit(
+            f"fetching {reducer_name}", percent=(idx / total) * 80.0, processed=idx, total=total
+        )
+        timestamps, values = fetch_reducer_rows(conn, reducer_name, MAX_ROWS)
+        n_rows = len(values)
+        if n_rows == 0:
+            per_reducer[reducer_name] = {"status": "NO_ROWS", "n_rows": 0}
+            continue
+        if n_rows < QUALIFYING_MIN_ROWS:
+            per_reducer[reducer_name] = {"status": "NOT_QUALIFIED", "n_rows": n_rows}
+            continue
+
+        target_id = REDUCER_TO_TARGET_ID[reducer_name]
+        # Real magnitude_scorer() call, one tick at a time -- each tick is this
+        # reducer's own single-entry real ballot (a genuine multi-reducer vote in
+        # the *same* tick needs overlapping real timestamps across reducers, checked
+        # separately below).
+        per_tick_scores = [magnitude_scorer({target_id: v}) for v in values]
+        non_finite_dropped = sum(1 for s in per_tick_scores if target_id not in s)
+        clamped_any_out_of_range = any(
+            target_id in per_tick_scores[i] and per_tick_scores[i][target_id] != values[i]
+            for i in range(n_rows)
+        )
+        per_reducer[reducer_name] = {
+            "status": "QUALIFIED",
+            "n_rows": n_rows,
+            "target_id": target_id,
+            "min_ts": timestamps[0],
+            "max_ts": timestamps[-1],
+            "raw_min": min(values),
+            "raw_max": max(values),
+            "clamped_any_out_of_range": clamped_any_out_of_range,
+            "non_finite_dropped": non_finite_dropped,
+        }
+
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+    qualified = [r for r, rep in per_reducer.items() if rep.get("status") == "QUALIFIED"]
+
+    # Real multi-target competition check: do any two qualified reducers have
+    # overlapping real timestamps close enough (same second) to build a genuine
+    # multi-entry magnitude_scorer() ballot? Checked honestly rather than assumed.
+    multi_target_tick: dict[str, float] | None = None
+    if len(qualified) >= 2:
+        by_second: dict[int, dict[str, float]] = {}
+        for reducer_name in qualified:
+            rep = per_reducer[reducer_name]
+            target_id = rep["target_id"]
+            # Only the latest tick per reducer is checked -- a full cross-reducer
+            # timestamp join is out of scope for this probe; this answers "is a
+            # real multi-target vote possible right now," not "replay the full
+            # history as one.
+            key = int(rep["max_ts"].timestamp())
+            by_second.setdefault(key, {})[target_id] = rep["raw_max"]
+        best = max(by_second.values(), key=len, default={})
+        if len(best) >= 2:
+            multi_target_tick = magnitude_scorer(best)
+
+    progress.emit("done", percent=100.0, processed=total, total=total)
+    progress.close()
+
+    lines = [
+        "# Society-of-Mind Magnitude Scorer Probe (Candidate B) -- Real Prediction-Error Receipt History",
+        "",
+        "Read-only. No writes, no events, no flag/config changes. Replays the real, pure "
+        "`orion/attention/field_attention/candidate_society_of_mind.py::magnitude_scorer()` "
+        "function over real `substrate_reduction_receipts` history. Covers `magnitude_scorer()` "
+        "only -- see module docstring's 'Live-data sanity check status' section for what "
+        "remains unvalidated (`novelty_scorer`, `dwell_scorer`, `aggregate_borda`).",
+        "",
+        f"- Reducer names checked: {', '.join(f'`{r}`' for r in reducer_names)}",
+        "",
+        "## Per-reducer results",
+        "",
+    ]
+    for reducer_name in reducer_names:
+        rep = per_reducer.get(reducer_name, {})
+        status = rep.get("status", "UNKNOWN")
+        lines.append(f"### `{reducer_name}` -- **{status}**")
+        lines.append("")
+        lines.append(f"- Real rows found: {rep.get('n_rows', 0)}")
+        if status == "QUALIFIED":
+            lines.append(f"- Target id: `{rep['target_id']}`")
+            lines.append(
+                f"- Real span: {rep['min_ts'].isoformat()} -> {rep['max_ts'].isoformat()}"
+            )
+            lines.append(f"- Raw value range: {rep['raw_min']:.4f} - {rep['raw_max']:.4f}")
+            lines.append(
+                f"- `magnitude_scorer()` clamped any real value out of [0,1] this run: "
+                f"{rep['clamped_any_out_of_range']}"
+            )
+            lines.append(
+                f"- Ticks dropped as non-finite/malformed by `magnitude_scorer()`: "
+                f"{rep['non_finite_dropped']}/{rep['n_rows']} (structurally always 0 through "
+                "this script's own path -- `parse_prediction_error()` already filters "
+                "non-finite values upstream before `magnitude_scorer()` ever sees them; "
+                "the non-finite-drop branch itself is exercised only by the synthetic unit "
+                "test, not by this replay)"
+            )
+        lines.append("")
+
+    lines.extend(["## Multi-target competition (real `magnitude_scorer()` vote across reducers)", ""])
+    if multi_target_tick is not None:
+        lines.append(
+            f"**Demonstrated**: a real multi-target ballot was built from "
+            f"{len(multi_target_tick)} reducers with overlapping real timestamps."
+        )
+        lines.append("")
+        lines.append(f"- Ballot: {multi_target_tick}")
+        lines.append(f"- `scorer_top1()`: `{scorer_top1(multi_target_tick)}`")
+        lines.append("")
+    else:
+        caveats.append(
+            f"multi-target magnitude competition not demonstrated this run: "
+            f"{len(qualified)} reducer(s) qualified with real history, but none shared a "
+            "real overlapping timestamp -- reported honestly rather than fabricated. "
+            "magnitude_scorer() was still exercised against real per-reducer single-target "
+            "ballots above."
+        )
+        lines.append(
+            "**Not demonstrated this run** -- see coverage caveats below. "
+            f"{len(qualified)} reducer(s) qualified with real history, but none shared a "
+            "real overlapping timestamp for a genuine multi-target vote."
+        )
+        lines.append("")
+
+    lines.extend(["## Coverage caveats", ""])
+    if not qualified:
+        caveats.append(
+            "no reducer had enough real receipt history to qualify at run time -- see "
+            "per-reducer status above"
+        )
+    lines.extend(f"- {c}" for c in caveats) if caveats else lines.append("- none")
+    lines.append("")
+
+    report_md = "\n".join(lines)
+    REPORT_PATH.write_text(report_md, encoding="utf-8")
+    print(report_md)
+    print(f"\nartifacts: {REPORT_PATH}, {PROGRESS_PATH}")
+    return 0 if qualified else 2
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    return run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_attention_candidate_society_of_mind.py
+++ b/tests/test_attention_candidate_society_of_mind.py
@@ -1,0 +1,260 @@
+"""Deterministic unit tests for Candidate B's rank-aggregation shadow module
+(`orion/attention/field_attention/candidate_society_of_mind.py`).
+
+No DB, no network, no bus. Pure-function tests only: the three scorer
+functions (magnitude/novelty/dwell) and the Borda-count combiner, exercised
+against synthetic fixtures for clean-rank, tie-handling, partial-ballot, and
+disagreement scenarios per this candidate's own task brief.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from orion.attention.field_attention.candidate_society_of_mind import (
+    DWELL_TICKS_SATURATION,
+    BordaResult,
+    aggregate_borda,
+    dwell_scorer,
+    magnitude_scorer,
+    novelty_scorer,
+    scorer_top1,
+)
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
+
+UTC = timezone.utc
+BASE = datetime(2026, 7, 21, 0, 0, 0, tzinfo=UTC)
+
+
+def _target(target_id: str, salience: float, kind: str = "node") -> FieldAttentionTargetV1:
+    return FieldAttentionTargetV1(
+        target_id=target_id,
+        target_kind=kind,
+        salience_score=salience,
+        pressure_score=salience,
+        novelty_score=0.0,
+        urgency_score=0.0,
+        confidence_score=0.0,
+    )
+
+
+def _frame(targets: list[FieldAttentionTargetV1]) -> FieldAttentionFrameV1:
+    return FieldAttentionFrameV1(
+        frame_id="attention.frame:test:policy.v1",
+        generated_at=BASE,
+        source_field_tick_id="tick:test",
+        source_field_generated_at=BASE,
+        overall_salience=max((t.salience_score for t in targets), default=0.0),
+        dominant_targets=targets,
+        node_targets=[t for t in targets if t.target_kind == "node"],
+        capability_targets=[t for t in targets if t.target_kind == "capability"],
+    )
+
+
+# ===========================================================================
+# magnitude_scorer -- real passthrough/validation, no I/O.
+# ===========================================================================
+
+
+def test_magnitude_scorer_passthrough() -> None:
+    result = magnitude_scorer({"node:substrate.biometrics": 0.42, "node:substrate.execution": 0.0})
+    assert result == {"node:substrate.biometrics": 0.42, "node:substrate.execution": 0.0}
+
+
+def test_magnitude_scorer_clamps_out_of_range() -> None:
+    result = magnitude_scorer({"node:substrate.biometrics": 1.5, "node:substrate.execution": -0.3})
+    assert result == {"node:substrate.biometrics": 1.0, "node:substrate.execution": 0.0}
+
+
+def test_magnitude_scorer_drops_non_finite_and_non_numeric() -> None:
+    result = magnitude_scorer(
+        {
+            "node:substrate.biometrics": float("nan"),
+            "node:substrate.execution": float("inf"),
+            "node:substrate.transport": "garbage",  # type: ignore[dict-item]
+            "node:substrate.chat": 0.3,
+        }
+    )
+    assert result == {"node:substrate.chat": 0.3}
+
+
+def test_magnitude_scorer_empty_input() -> None:
+    assert magnitude_scorer({}) == {}
+
+
+# ===========================================================================
+# novelty_scorer -- thin wrapper around the already-live novelty_for_target().
+# ===========================================================================
+
+
+def test_novelty_scorer_diffs_against_previous_frame() -> None:
+    previous = _frame([_target("node:athena", 0.2)])
+    result = novelty_scorer(["node:athena"], {"node:athena": 0.9}, previous)
+    assert result["node:athena"] == pytest.approx(0.7)
+
+
+def test_novelty_scorer_no_previous_frame_is_zero() -> None:
+    result = novelty_scorer(["node:athena"], {"node:athena": 0.9}, None)
+    assert result == {"node:athena": 0.0}
+
+
+def test_novelty_scorer_missing_current_salience_defaults_zero() -> None:
+    previous = _frame([_target("node:athena", 0.5)])
+    result = novelty_scorer(["node:athena"], {}, previous)
+    assert result["node:athena"] == pytest.approx(0.5)
+
+
+def test_novelty_scorer_target_absent_from_previous_frame_is_zero_prior() -> None:
+    previous = _frame([_target("node:athena", 0.5)])
+    result = novelty_scorer(["node:atlas"], {"node:atlas": 0.3}, previous)
+    assert result["node:atlas"] == pytest.approx(0.3)
+
+
+# ===========================================================================
+# dwell_scorer -- real duration signal, disclosed live-degeneracy caveat.
+# ===========================================================================
+
+
+def test_dwell_scorer_scores_all_attended_targets_equally() -> None:
+    result = dwell_scorer(["node:substrate.harness_closure", "node:athena"], dwell_ticks=60)
+    expected = min(1.0, 60.0 / DWELL_TICKS_SATURATION)
+    assert result == {
+        "node:substrate.harness_closure": pytest.approx(expected),
+        "node:athena": pytest.approx(expected),
+    }
+
+
+def test_dwell_scorer_saturates_at_cap() -> None:
+    result = dwell_scorer(["node:athena"], dwell_ticks=4899, saturation_ticks=120)
+    assert result == {"node:athena": 1.0}
+
+
+def test_dwell_scorer_empty_coalition_returns_empty_dict() -> None:
+    """The real, load-bearing 2026-07-21 finding: attended_node_ids is []
+    in 99.9% of live substrate_coalition_dwell_log rows. This must return an
+    empty ballot (no opinion), not a score for a nonexistent target."""
+    assert dwell_scorer([], dwell_ticks=183) == {}
+
+
+def test_dwell_scorer_zero_or_negative_ticks_returns_empty_dict() -> None:
+    assert dwell_scorer(["node:athena"], dwell_ticks=0) == {}
+    assert dwell_scorer(["node:athena"], dwell_ticks=-1) == {}
+
+
+def test_dwell_scorer_deduplicates_attended_ids() -> None:
+    result = dwell_scorer(["node:athena", "node:athena", "node:atlas"], dwell_ticks=30)
+    assert set(result.keys()) == {"node:athena", "node:atlas"}
+    assert result["node:athena"] == result["node:atlas"]
+
+
+# ===========================================================================
+# scorer_top1 -- deterministic tie-break helper.
+# ===========================================================================
+
+
+def test_scorer_top1_highest_score_wins() -> None:
+    assert scorer_top1({"a": 0.2, "b": 0.9, "c": 0.5}) == "b"
+
+
+def test_scorer_top1_tie_break_alphabetical() -> None:
+    assert scorer_top1({"z": 0.5, "a": 0.5}) == "a"
+
+
+def test_scorer_top1_empty_is_none() -> None:
+    assert scorer_top1({}) is None
+
+
+# ===========================================================================
+# aggregate_borda -- the rank-aggregation combiner itself.
+# ===========================================================================
+
+
+def test_aggregate_borda_clean_rank_all_scorers_agree() -> None:
+    """3 targets, all 3 scorers rank them identically A > B > C -- classic
+    Borda: A gets 3*2=6, B gets 3*1=3, C gets 3*0=0."""
+    scores = {"a": 0.9, "b": 0.5, "c": 0.1}
+    result = aggregate_borda({"magnitude": scores, "novelty": scores, "dwell": scores})
+    assert result.totals == {"a": 6.0, "b": 3.0, "c": 0.0}
+    assert result.ranking == ("a", "b", "c")
+    assert result.winner == "a"
+    assert result.disagreement is False
+
+
+def test_aggregate_borda_tie_within_one_scorer_shares_average_points() -> None:
+    """b and c tie for 2nd/3rd place (positions 0 and 1 in ascending order,
+    each worth 0 and 1 point) -> both get the average, 0.5."""
+    scores = {"a": 0.9, "b": 0.4, "c": 0.4}
+    result = aggregate_borda({"only": scores})
+    assert result.totals["a"] == 2.0
+    assert result.totals["b"] == pytest.approx(0.5)
+    assert result.totals["c"] == pytest.approx(0.5)
+
+
+def test_aggregate_borda_disagreement_detected_with_real_examples() -> None:
+    """Each scorer independently prefers a different target -- the direct
+    test for whether rank-aggregation ever disagrees, per the task brief."""
+    magnitude = {"a": 0.9, "b": 0.1, "c": 0.1}
+    novelty = {"a": 0.1, "b": 0.9, "c": 0.1}
+    dwell = {"a": 0.1, "b": 0.1, "c": 0.9}
+    result = aggregate_borda({"magnitude": magnitude, "novelty": novelty, "dwell": dwell})
+    assert result.per_scorer_top1 == {"magnitude": "a", "novelty": "b", "dwell": "c"}
+    assert result.disagreement is True
+    # Fully symmetric 3-way disagreement: each scorer's own bottom two targets
+    # tie at 0.1 (average of positions 0/1 = 0.5 each) and its top pick gets
+    # 2 -- so every target ends up with the same total (2 + 0.5 + 0.5 = 3.0)
+    # -- the deterministic target_id tiebreak decides the reported winner.
+    assert result.totals == {"a": 3.0, "b": 3.0, "c": 3.0}
+    assert result.winner == "a"
+
+
+def test_aggregate_borda_partial_ballot_absent_target_treated_as_last() -> None:
+    """`dwell` only has an opinion about "a" (the rest of the tick's real
+    targets never entered the coalition) -- "b"/"c" must be tied for dwell's
+    own last place, never silently excluded or averaged favorably."""
+    magnitude = {"a": 0.5, "b": 0.9, "c": 0.1}
+    dwell = {"a": 0.8}  # only "a" was ever in a real coalition this tick
+    result = aggregate_borda({"magnitude": magnitude, "dwell": dwell})
+    # magnitude alone: b=2, a=1, c=0. dwell alone: a=2, {b,c} tied last -> 0.5 each.
+    assert result.totals == {"a": 3.0, "b": 2.5, "c": 0.5}
+    assert result.ranking == ("a", "b", "c")
+
+
+def test_aggregate_borda_scorer_with_empty_ballot_does_not_affect_ranking_or_disagreement() -> None:
+    """A scorer with an entirely empty ballot still nominally casts a
+    "everyone tied last" vote (both targets get the same averaged points
+    added), which shifts absolute totals uniformly but never the relative
+    *ranking* -- "a" still wins, and an empty ballot never registers a top1
+    pick, so it cannot contribute to `disagreement` either."""
+    magnitude = {"a": 0.9, "b": 0.1}
+    empty_dwell: dict[str, float] = {}
+    result = aggregate_borda({"magnitude": magnitude, "dwell": empty_dwell})
+    assert result.totals == {"a": 1.5, "b": 0.5}
+    assert result.ranking == ("a", "b")
+    assert result.per_scorer_top1 == {"magnitude": "a", "dwell": None}
+    assert result.disagreement is False
+
+
+def test_aggregate_borda_explicit_universe_includes_unscored_target() -> None:
+    """"z" is in the requested universe but no scorer ever mentioned it --
+    it sorts below every real (even low) score, not merely tied with the
+    scorer's own lowest real pick: -inf < 0.1, so "z" is strictly last."""
+    magnitude = {"a": 0.9, "b": 0.1}
+    result = aggregate_borda({"magnitude": magnitude}, universe=["a", "b", "z"])
+    assert result.universe == ("a", "b", "z")
+    assert result.totals == {"a": 2.0, "b": 1.0, "z": 0.0}
+    assert result.ranking == ("a", "b", "z")
+
+
+def test_aggregate_borda_no_scorers_empty_universe() -> None:
+    result = aggregate_borda({})
+    assert result == BordaResult(
+        universe=(), totals={}, ranking=(), winner=None, per_scorer_top1={}, disagreement=False
+    )
+
+
+def test_aggregate_borda_single_target_universe_gets_zero_points() -> None:
+    result = aggregate_borda({"magnitude": {"a": 0.7}})
+    assert result.totals == {"a": 0.0}
+    assert result.winner == "a"

--- a/tests/test_measure_society_of_mind_magnitude_probe.py
+++ b/tests/test_measure_society_of_mind_magnitude_probe.py
@@ -1,0 +1,91 @@
+"""Deterministic unit tests for measure_society_of_mind_magnitude_probe.py.
+
+No DB, no network. Same sibling-module-by-file-path loading pattern as
+test_measure_precision_weighted_salience_probe.py / test_measure_emergent_clustering_probe.py.
+
+Lives in top-level `tests/`, not `scripts/analysis/tests/` -- `scripts` is in
+`pyproject.toml`'s `norecursedirs`, so a bare `pytest` run from repo root never
+discovers anything placed there (same defect found and fixed for Candidate A's replay
+test in this same review cycle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "analysis"
+    / "measure_society_of_mind_magnitude_probe.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "measure_society_of_mind_magnitude_probe", _MODULE_PATH
+)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_society_of_mind_magnitude_probe"] = mod
+_spec.loader.exec_module(mod)
+
+
+# ===========================================================================
+# parse_prediction_error -- pure scalar parsing, must never raise.
+# ===========================================================================
+
+
+def test_parse_prediction_error_valid_string() -> None:
+    assert mod.parse_prediction_error("0.0429") == 0.0429
+
+
+def test_parse_prediction_error_none_returns_none() -> None:
+    assert mod.parse_prediction_error(None) is None
+
+
+def test_parse_prediction_error_malformed_returns_none() -> None:
+    assert mod.parse_prediction_error("not-a-number") is None
+    assert mod.parse_prediction_error("") is None
+
+
+def test_parse_prediction_error_non_finite_returns_none() -> None:
+    assert mod.parse_prediction_error("nan") is None
+    assert mod.parse_prediction_error("inf") is None
+
+
+# ===========================================================================
+# REDUCER_TO_TARGET_ID -- must match the real node:substrate.* convention
+# _write_prediction_error_node() uses, one entry per real orion/substrate/
+# prediction_error.py instrument.
+# ===========================================================================
+
+
+def test_reducer_to_target_id_covers_all_five_real_reducers() -> None:
+    assert set(mod.REDUCER_TO_TARGET_ID) == {
+        "substrate.node_biometrics",
+        "substrate.execution_trajectory",
+        "substrate.transport_bus",
+        "substrate.chat_session",
+        "substrate.route_arbitration",
+    }
+
+
+def test_reducer_to_target_id_values_match_node_substrate_convention() -> None:
+    assert mod.REDUCER_TO_TARGET_ID["substrate.node_biometrics"] == "node:substrate.biometrics"
+    assert mod.REDUCER_TO_TARGET_ID["substrate.execution_trajectory"] == "node:substrate.execution"
+    assert mod.REDUCER_TO_TARGET_ID["substrate.route_arbitration"] == "node:substrate.route"
+
+
+# ===========================================================================
+# magnitude_scorer integration -- real import, exercised via the probe's own
+# per-tick call shape (single-entry dict per real historical value).
+# ===========================================================================
+
+
+def test_magnitude_scorer_real_import_clamps_and_drops_like_the_module_promises() -> None:
+    from orion.attention.field_attention.candidate_society_of_mind import magnitude_scorer
+
+    assert magnitude_scorer({"node:substrate.biometrics": 1.5}) == {
+        "node:substrate.biometrics": 1.0
+    }
+    assert magnitude_scorer({"node:substrate.biometrics": float("nan")}) == {}


### PR DESCRIPTION
## Summary
- Candidate B from the attention-salience-cathedral replacement plan: three independent real scorers (magnitude, novelty, dwell) combined by Borda count (de Borda 1770) instead of a hand-weighted formula -- structurally eliminates the cross-factor weight-guessing problem `compute_salience()` has today.
- `magnitude_scorer`/`novelty_scorer`/`dwell_scorer`: thin, faithful wrappers around already-live real signals (`orion/substrate/prediction_error.py`'s five instruments, the already-live `novelty_for_target()`, and `AttentionBroadcastProjectionV1`'s dwell duration) -- no new producer, only a new combination mechanism.
- `aggregate_borda`: documented tie-handling (average-of-tied-positions) and partial-ballot handling (an unranked target ties for that scorer's own last place via a `-inf` sort key, never silently excluded or favorably averaged) -- hand-verified against 4 test cases independently in review.
- Shadow-only: zero imports outside its own tests, not wired into `compute_salience()`/`select_system_targets`/`self_state/builder.py`/anything live. Blocked from live-wiring by the tentative plan's SelfStateV1 hard gate, same as Candidate A.

## Provenance and compliance note
This module was originally built by an earlier, separate agent session and found sitting uncommitted in an abandoned Claude Code isolation worktree, alongside sibling Candidate A. A timeline audit (file mtimes vs. the design doc's actual git commit time) found **both candidates were fully written 10-15 minutes before the design doc that was supposed to gate and scope them was ever committed to git** -- implementation preceded the design artifact, a real process violation of CLAUDE.md's design-mode-first sequence. The substantive CLAUDE.md §0A constraint (no live-wiring without sign-off) held throughout regardless -- independently verified, zero live-consumer imports.

Two real problems were found in that same compliance re-audit and fixed in this patch, not shipped as-is:
1. **False claim**: the module docstring (in two separate locations) claimed a "companion replay script" existed. It didn't, anywhere in the repo. Both instances corrected.
2. **Failed metric-quality-gate step 4**: zero real data had been run through any of the three scorers -- only synthetic-fixture tests existed, which does not satisfy the plan doc's own Candidate B acceptance check ("do the three scorers ever disagree... report real examples, not a summary claim").

## Outcome moved
`magnitude_scorer()` now genuinely clears CLAUDE.md §0A's live-data sanity check (real Postgres data, confirmed non-degenerate). `novelty_scorer`/`dwell_scorer`/`aggregate_borda`'s full three-scorer combination remain honestly disclosed as unvalidated -- not silently implied covered, in both the module docstring and the replay script's own output.

## Files changed
- `orion/attention/field_attention/candidate_society_of_mind.py` (new)
- `tests/test_attention_candidate_society_of_mind.py` (new)
- `scripts/analysis/measure_society_of_mind_magnitude_probe.py` (new) -- magnitude-only real-data replay, reusing (not duplicating differently than) Candidate A's established read-only-connection pattern
- `tests/test_measure_society_of_mind_magnitude_probe.py` (new)

## Tests run
```
.venv/bin/python3 -m pytest tests/test_attention_candidate_society_of_mind.py tests/test_measure_society_of_mind_magnitude_probe.py -q
31 passed
```

## Live replay (read-only, real Postgres)
```
substrate.node_biometrics        QUALIFIED  (155 rows, range 0.0000-0.1089, non-degenerate)
substrate.execution_trajectory   NO_ROWS
substrate.transport_bus          NO_ROWS
substrate.chat_session           NO_ROWS
substrate.route_arbitration      NO_ROWS
Multi-target competition: not demonstrated this run (only 1 domain qualifies)
```
Full report: `/tmp/society-of-mind-magnitude-probe/report.md` (local artifact, not committed).

## Review findings fixed
- Finding: docstring falsely claimed a companion replay script existed (two locations: top-level docstring and `dwell_scorer`'s docstring).
  - Fix: removed/corrected both; `dwell_scorer`'s 2837/2840 live-query figure now correctly attributed to a one-off query, not a script.
  - Evidence: `orion/attention/field_attention/candidate_society_of_mind.py` diff.
- Finding: zero live-data validation, failing metric-quality-gate step 4.
  - Fix: built the magnitude-only replay script against real Postgres data.
  - Evidence: live run output above.
- Finding: replay-script test would never be discovered by bare `pytest` (`scripts/` is in `pyproject.toml`'s `norecursedirs`).
  - Fix: moved to `tests/`, fixed sibling-module path lookup. Confirmed via `pytest --collect-only`.
- Finding (minor): `non_finite_dropped` bookkeeping is structurally tautological given the upstream filter -- always 0 through this script's real-data path, only exercised by the synthetic unit test.
  - Fix: added an explanatory caveat in the report output rather than removing the (still correct) check.

## Restart required
```
No restart required.
```
Shadow/read-only code, no service or config changes.

## Risks / concerns
- Severity: low
- Concern: `novelty_scorer`/`dwell_scorer`/`aggregate_borda`'s full three-scorer combination is not yet validated against real data -- disclosed, not hidden. A future patch teaching `orion-field-digester` to ingest prediction-error domain nodes into `FieldStateV1.node_vectors` (named in the module docstring as a real follow-up) would be needed before magnitude's and novelty's real target universes overlap enough for a genuine three-way vote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DFRKm1HMv5PLWV435JuT1