### PR TITLE
fix(attention): Candidate A -- cross-target normalization + test-discovery fix

### DIFF
--- a/orion/attention/field_attention/candidate_precision_weighted.py
+++ b/orion/attention/field_attention/candidate_precision_weighted.py
@@ -27,6 +27,20 @@ error occurs against a historically noisy one.
     salience(target) = precision(target) x |prediction_error(target)|
     precision(target) = 1 / variance(target's own real historical prediction-error series)
 
+## Cross-target comparability (added in review, 2026-07-22)
+
+`precision_weighted_salience()`'s raw `salience` is **not directly comparable across
+targets** and is **not a valid drop-in for `FieldAttentionTargetV1.salience_score`**
+(schema-bound to `[0, 1]`) -- it is unbounded (precision saturates at
+`1 / PRECISION_VARIANCE_FLOOR = 1e6`; the real biometrics replay produced raw salience
+ranging 0.00-57,100.00). This was missed in the original build and caught only in a
+later compliance review, not by the original live-data check, which only confirmed
+non-degenerate variance *within one target's own time series* and never checked whether
+the resulting scale was usable for the cross-target *competition* this candidate exists
+to run. Any real comparison across targets/domains must go through
+`normalize_across_targets()` (below) first -- comparing two raw `.salience` values from
+different targets directly is exactly the mistake that function exists to prevent.
+
 ## Real data source and scoping (2026-07-21, live-verified at build time)
 
 `prediction_error(target)`'s *current* value comes from the five already-shipped
@@ -177,3 +191,55 @@ def precision_weighted_salience(
         n_samples=n,
         variance_floored=variance_floored,
     )
+
+
+def normalize_across_targets(raw_scores: dict[str, float]) -> dict[str, float]:
+    """Min-max normalize raw ``precision_weighted_salience().salience`` values across a
+    set of *competing* targets into ``[0, 1]``.
+
+    **Why this exists (found in review, 2026-07-22, not part of the original build):**
+    ``precision_weighted_salience()``'s raw output is unbounded (precision saturates at
+    ``1 / PRECISION_VARIANCE_FLOOR = 1e6``, so raw salience can reach the tens of
+    thousands -- confirmed live: the real biometrics replay produced a range of
+    0.00-57,100.00). The existing system this candidate is meant to replace,
+    `FieldAttentionTargetV1.salience_score`, is schema-constrained to ``[0, 1]``
+    (`orion/schemas/field_attention_frame.py`) -- the raw, unnormalized output is not a
+    valid drop-in for that field. Worse than a schema mismatch: without normalization,
+    cross-target comparison (the entire point of a *competition* score) is dominated by
+    each target's own historical variance scale, not by how surprising its current error
+    actually is -- a target that has always been quiet will structurally out-rank a
+    noisier-but-currently-alarming one purely from scale, independent of real relative
+    importance.
+
+    **Min-max, not softmax, and why**: a softmax-style normalization would need a
+    temperature/scale hyperparameter to decide how sharply it compresses the
+    distribution -- exactly the kind of hand-guessed, uncalibrated weight this whole
+    program exists to eliminate (see charter §7 / the tentative-plan doc's "Finding: the
+    disease is systemic, not one bug"). Min-max has no free parameter: it maps the
+    lowest-scoring real competitor to 0.0 and the highest to 1.0, preserving relative
+    rank exactly, with nothing to calibrate.
+
+    **This is a per-tick, per-competing-set operation, not part of
+    `precision_weighted_salience()` itself** -- that function has no knowledge of what
+    else is competing this tick (it only sees one target's own history), so it cannot
+    self-normalize. Callers must compute raw scores for every real target competing in
+    the same tick, then pass the whole set here before comparing across targets.
+    Comparing two *raw* `precision_weighted_salience().salience` values from different
+    targets without this step is the exact mistake this function exists to prevent.
+
+    Edge cases:
+    - Empty input -> ``{}``.
+    - All-equal raw scores (including a single-target input) -> every target gets
+      ``1.0``, not an arbitrary ``0.0`` floor. There is no real basis to differentiate
+      "tied for most salient" from "least salient" when every real competitor scored
+      identically -- flooring to 0.0 would misrepresent a tie as "nothing here matters,"
+      which is not what the data says.
+    """
+    if not raw_scores:
+        return {}
+    values = list(raw_scores.values())
+    lo, hi = min(values), max(values)
+    if (hi - lo) < 1e-12:
+        return {target_id: 1.0 for target_id in raw_scores}
+    span = hi - lo
+    return {target_id: (v - lo) / span for target_id, v in raw_scores.items()}

--- a/scripts/analysis/measure_precision_weighted_salience_probe.py
+++ b/scripts/analysis/measure_precision_weighted_salience_probe.py
@@ -87,6 +87,7 @@ if str(_REPO_ROOT) not in sys.path:
 from orion.attention.field_attention.candidate_precision_weighted import (
     PRECISION_VARIANCE_FLOOR,
     PrecisionWeightedSalienceResult,
+    normalize_across_targets,
     precision_weighted_salience,
 )
 
@@ -417,6 +418,7 @@ def render_report(
     rolling_window: int,
     reducer_reports: dict[str, dict[str, Any]],
     caveats: list[str],
+    cross_target_normalization: dict[str, Any] | None = None,
 ) -> str:
     lines = [
         "# Precision-Weighted Salience Probe (Candidate A) -- Real Prediction-Error Receipt History",
@@ -483,6 +485,38 @@ def render_report(
             lines.extend(_summary_block("Window A", rep.get("window_a_summary")))
             lines.extend(_summary_block("Window B", rep.get("window_b_summary")))
 
+    lines.extend(["## Cross-target normalization", ""])
+    lines.append(
+        "Raw `precision_weighted_salience().salience` is unbounded and dominated by each "
+        "target's own historical variance scale -- not comparable across reducers, and not "
+        "a valid `FieldAttentionTargetV1.salience_score` ([0,1]) drop-in, without "
+        "`normalize_across_targets()`. This section compares each qualified reducer's most "
+        "recent real tick as the current competing set."
+    )
+    lines.append("")
+    ctn = cross_target_normalization or {}
+    qualified_count = ctn.get("qualified_count", 0)
+    if qualified_count >= 2:
+        raw = ctn.get("raw", {})
+        normalized = ctn.get("normalized", {})
+        lines.append(f"| Reducer | Raw salience (latest tick) | Normalized [0,1] |")
+        lines.append(f"|---|---|---|")
+        for reducer_name in sorted(raw, key=lambda r: -normalized.get(r, 0.0)):
+            lines.append(
+                f"| `{reducer_name}` | {raw[reducer_name]:.2f} | {normalized[reducer_name]:.4f} |"
+            )
+        lines.append("")
+    else:
+        lines.append(
+            f"**Not demonstrated this run** -- only {qualified_count} reducer(s) qualified. "
+            "`normalize_across_targets()` needs at least 2 real competing targets to show a "
+            "meaningful comparison; reported honestly rather than faked against a single-"
+            "target competing set. Re-run once more real receipt history has accumulated "
+            "across multiple domains (e.g. after PR #1239's execution/route fix has been "
+            "live long enough to accumulate real history)."
+        )
+        lines.append("")
+
     lines.extend(["## Coverage caveats", ""])
     if caveats:
         lines.extend(f"- {c}" for c in caveats)
@@ -539,6 +573,10 @@ def run(
             "n_rows": n_rows,
             "real_span_label": real_span_label,
             "full_summary": full_summary,
+            # Most recent real tick's raw (unnormalized) salience -- oldest-first
+            # contract of compute_rolling_results means the last element is the
+            # latest real observation. Used below for cross-target normalization.
+            "latest_raw_salience": full_results[-1].salience,
         }
 
         windows = choose_windows(min_ts, max_ts, window_hours, gap_hours, MIN_WINDOW_HOURS)
@@ -580,7 +618,36 @@ def run(
             "time -- see per-reducer status above"
         )
 
-    report_md = render_report(rolling_window=rolling_window, reducer_reports=reducer_reports, caveats=caveats)
+    # Cross-target normalization (added in review, 2026-07-22): raw
+    # precision_weighted_salience() output is unbounded and dominated by each
+    # target's own historical variance scale -- not directly comparable across
+    # reducers, and not a valid FieldAttentionTargetV1.salience_score ([0,1])
+    # drop-in. Reports each qualified reducer's own most-recent real tick as the
+    # "current competing set" and normalizes across it, honestly, rather than
+    # silently comparing raw magnitudes or fabricating a competition when fewer
+    # than 2 real reducers qualify this run.
+    latest_raw: dict[str, float] = {
+        reducer_name: reducer_reports[reducer_name]["latest_raw_salience"] for reducer_name in qualified
+    }
+    cross_target_normalization: dict[str, Any] = {"qualified_count": len(qualified)}
+    if len(qualified) >= 2:
+        cross_target_normalization["raw"] = latest_raw
+        cross_target_normalization["normalized"] = normalize_across_targets(latest_raw)
+    else:
+        caveats.append(
+            f"cross-target normalization not demonstrated this run: only "
+            f"{len(qualified)} reducer(s) qualified, and normalize_across_targets() "
+            "needs at least 2 real competing targets to show a meaningful "
+            "comparison -- reported honestly rather than faked with a single-target "
+            "competing set."
+        )
+
+    report_md = render_report(
+        rolling_window=rolling_window,
+        reducer_reports=reducer_reports,
+        caveats=caveats,
+        cross_target_normalization=cross_target_normalization,
+    )
     REPORT_PATH.write_text(report_md, encoding="utf-8")
     print(report_md)
     print(f"\nartifacts: {REPORT_PATH}, {CSV_DIR}/, {PROGRESS_PATH}")

--- a/tests/test_attention_candidate_precision_weighted.py
+++ b/tests/test_attention_candidate_precision_weighted.py
@@ -10,6 +10,7 @@ import pytest
 
 from orion.attention.field_attention.candidate_precision_weighted import (
     PRECISION_VARIANCE_FLOOR,
+    normalize_across_targets,
     precision_weighted_salience,
 )
 
@@ -101,3 +102,69 @@ def test_result_is_a_frozen_dataclass_not_mutable() -> None:
     result = precision_weighted_salience([0.1, 0.2])
     with pytest.raises(Exception):
         result.salience = 999.0  # type: ignore[misc]
+
+
+# -- normalize_across_targets --------------------------------------------------
+# Added in review (2026-07-22): precision_weighted_salience()'s raw output is
+# unbounded and dominated by each target's own historical variance scale, which
+# is not a valid drop-in for FieldAttentionTargetV1.salience_score (schema-bound
+# to [0,1]) and is not meaningfully comparable across targets without this step.
+
+
+def test_normalize_across_targets_empty_input() -> None:
+    assert normalize_across_targets({}) == {}
+
+
+def test_normalize_across_targets_maps_min_to_zero_and_max_to_one() -> None:
+    result = normalize_across_targets({"a": 10.0, "b": 400.0, "c": 57100.0})
+    assert result["c"] == pytest.approx(1.0)
+    assert result["a"] == pytest.approx(0.0)
+    assert result["b"] == pytest.approx((400.0 - 10.0) / (57100.0 - 10.0))
+
+
+def test_normalize_across_targets_preserves_relative_rank() -> None:
+    raw = {"low": 5.0, "mid": 500.0, "high": 50000.0}
+    result = normalize_across_targets(raw)
+    assert result["low"] < result["mid"] < result["high"]
+
+
+def test_normalize_across_targets_output_always_in_unit_interval() -> None:
+    raw = {"a": 0.0, "b": 3.3, "c": 1e6, "d": 42.0}
+    result = normalize_across_targets(raw)
+    assert all(0.0 <= v <= 1.0 for v in result.values())
+
+
+def test_normalize_across_targets_all_equal_scores_get_one_not_zero() -> None:
+    """A real tie must not be misrepresented as 'nothing here matters' -- there is
+    no basis to floor a genuine tie to 0.0."""
+    result = normalize_across_targets({"a": 42.0, "b": 42.0, "c": 42.0})
+    assert result == {"a": 1.0, "b": 1.0, "c": 1.0}
+
+
+def test_normalize_across_targets_single_target_gets_one() -> None:
+    """Degenerate case of the tie rule: the only real competitor this tick gets
+    maximal (not zero, not arbitrary) attention -- it's the only real candidate."""
+    assert normalize_across_targets({"only": 12345.6}) == {"only": 1.0}
+
+
+def test_normalize_across_targets_near_equal_scores_within_epsilon_treated_as_tie() -> None:
+    result = normalize_across_targets({"a": 1.0, "b": 1.0 + 1e-13})
+    assert result == {"a": 1.0, "b": 1.0}
+
+
+def test_normalize_across_targets_does_not_mutate_input() -> None:
+    raw = {"a": 1.0, "b": 2.0}
+    normalize_across_targets(raw)
+    assert raw == {"a": 1.0, "b": 2.0}
+
+
+def test_normalize_across_targets_end_to_end_with_real_precision_weighted_salience() -> None:
+    """Integration-shaped: run two targets through the real
+    precision_weighted_salience() pure function, then normalize the raw results --
+    exercises both functions together the way a real caller would, not in isolation."""
+    quiet_target = precision_weighted_salience([0.03, 0.03, 0.03, 0.03, 0.031])
+    noisy_target = precision_weighted_salience([0.01, 0.08, 0.02, 0.12, 0.15])
+    raw = {"quiet": quiet_target.salience, "noisy": noisy_target.salience}
+    normalized = normalize_across_targets(raw)
+    assert set(normalized) == {"quiet", "noisy"}
+    assert all(0.0 <= v <= 1.0 for v in normalized.values())

--- a/tests/test_measure_precision_weighted_salience_probe.py
+++ b/tests/test_measure_precision_weighted_salience_probe.py
@@ -4,6 +4,13 @@ No DB, no network. Everything here is pure: parsing, rolling-window replay (via 
 real `precision_weighted_salience()` import, not a reimplementation), summarization,
 and window selection all operate on plain synthetic data. Same sibling-module-by-
 file-path loading pattern as test_measure_emergent_clustering_probe.py.
+
+Lives in top-level `tests/`, not `scripts/analysis/tests/` (where this file originally
+shipped in PR #1241) -- `scripts` is in `pyproject.toml`'s `norecursedirs`, so a bare
+`pytest` run from repo root never discovered it there. Confirmed the same defect exists
+for every sibling test under `scripts/analysis/tests/` (e.g.
+`test_measure_emergent_clustering_probe.py`) -- out of scope to fix here, flagged
+separately.
 """
 
 from __future__ import annotations
@@ -14,7 +21,10 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 _MODULE_PATH = (
-    Path(__file__).resolve().parents[1] / "measure_precision_weighted_salience_probe.py"
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "analysis"
+    / "measure_precision_weighted_salience_probe.py"
 )
 _spec = importlib.util.spec_from_file_location(
     "measure_precision_weighted_salience_probe", _MODULE_PATH


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1241 (Candidate A: precision-weighted prediction-error salience). PR #1241 shipped before a forest-level compliance audit (program's own metric-quality-gate, not just code review) caught two real gaps. This PR closes them.

- Added `normalize_across_targets()` -- min-max normalization of raw precision-weighted scores across a set of competing targets into `[0,1]`, matching `FieldAttentionTargetV1.salience_score`'s schema bound (`Field(ge=0.0, le=1.0)`). Raw output was previously unbounded and not a valid drop-in for that field (observed 0 to 57,100 against live data).
- Wired the new normalization into `scripts/analysis/measure_precision_weighted_salience_probe.py`'s report (`## Cross-target normalization` section), with an honest "not demonstrated this run" fallback when fewer than 2 reducers qualify.
- Fixed a repo-wide test-discovery bug for this candidate's own replay test: `scripts/analysis/tests/` is excluded from pytest's default collection (`norecursedirs` in `pyproject.toml`, not in `testpaths`), so `test_measure_precision_weighted_salience_probe.py` (34 tests, shipped in #1241) was never actually run by bare `pytest`. Moved to `tests/`.

## Why

A direct challenge from Juniper: does this pass muster by the Sentience Striving Program's own logic (CLAUDE.md §0A metric-quality-gate), not just "tests pass, code reviews clean." Re-running the gate against #1241 as shipped found the raw score was never checked for comparability across targets -- a single-target's own historical variance sets its scale, so two targets' raw scores aren't meaningfully rankable against each other, which is exactly what `salience_score` is supposed to support.

## Files changed

- `orion/attention/field_attention/candidate_precision_weighted.py`: added `normalize_across_targets()`, new "Cross-target comparability" docstring section
- `tests/test_attention_candidate_precision_weighted.py`: 8 new tests for `normalize_across_targets`
- `scripts/analysis/measure_precision_weighted_salience_probe.py`: wired normalization into the report when >=2 reducers qualify
- `scripts/analysis/tests/test_measure_precision_weighted_salience_probe.py` -> `tests/test_measure_precision_weighted_salience_probe.py`: moved to fix test-discovery gap; same defect confirmed present in other pre-existing sibling probe-script tests (e.g. `test_measure_emergent_clustering_probe.py`), flagged not fixed here (out of scope)

## Schema / bus / API changes

None. Still shadow-only, read-only, not imported by any live compute_salience() path (confirmed via repo-wide grep).

## Tests run

```
pytest tests/test_attention_candidate_precision_weighted.py tests/test_measure_precision_weighted_salience_probe.py -q
```
All passing, including the 8 new normalization tests.

## Review findings fixed

- Finding: raw salience score unbounded and not schema-comparable across targets
  - Fix: `normalize_across_targets()` min-max normalization, ties handled as 1.0 (not misrepresented as "nothing matters")
  - Evidence: new unit tests + live replay report's new "Cross-target normalization" section
- Finding: replay test file silently never executed by CI/local pytest
  - Fix: moved to `tests/`, `_MODULE_PATH` sibling-loading path updated
  - Evidence: `pytest tests/ -q` now collects and passes these 34+8 tests; previously 0 were collected from `scripts/analysis/tests/`

## Restart required

No restart required. Shadow-only module, not live-wired.

## Risks / concerns

- Severity: low
- Concern: normalization requires >=2 qualifying reducers (>=20 rows each per the probe's threshold) to demonstrate; current live retention window (30 min) means this may not always be satisfiable in a single run
- Mitigation: report honestly states "Not demonstrated this run" rather than fabricating a result when the condition isn't met