### PR TITLE
fix(field-digester): mode=replace for the other 5 transport_bus channels

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -61,7 +61,7 @@ python orion/mood_arc/fit_encoder.py train \
   --out /tmp/mood-arc-encoders/v1-candidate
 ```
 
-- `--min-generated-at 2026-07-17T04:32:14Z` is the current data-quality
+- `--min-generated-at 2026-07-17T04:32:14Z` is the first data-quality
   cutoff: rows before this timestamp reflect known-broken channel behavior
   from before a 7-PR fix sprint (PRs #1108-#1113, #1115). Training on the
   full unfiltered corpus produces contaminated field selection and fails the
@@ -69,6 +69,20 @@ python orion/mood_arc/fit_encoder.py train \
   `services/orion-field-digester/README.md`'s "`field_channel_corpus.v1`
   training-data quality cutoff" section; keep the two in sync if it's ever
   revised.
+- **Second cutoff, 2026-07-22 (PR #1248, pending deploy):** `transport_pressure`/
+  `catalog_drift_pressure`/`observer_failure_pressure`/`reliability_pressure`/
+  `contract_pressure` could get permanently stuck at a stale value (an
+  `add`-mode perturbation bug in `services/orion-field-digester/app/ingest/
+  state_deltas.py`, fixed in PR #1248) — confirmed live as the cause of
+  `catalog_drift_pressure` alone driving ~66% of average reconstruction
+  error against `field_channel_anomaly.v2`. Unlike the first cutoff, this
+  contamination window has no known start (a channel only breaks once it
+  picks up a nonzero value and then fails to correct/decay), so **do not
+  train against any corpus data until PR #1248 is merged and deployed, and
+  a second `--min-generated-at` cutoff is set to that deploy timestamp** —
+  see `services/orion-field-digester/README.md`'s "second training-data
+  quality cutoff" section for the exact mechanism to determine it once
+  known. If both cutoffs apply, use whichever is later.
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -237,6 +237,52 @@ conservative-but-not-perfectly-precise, not a scientifically exact boundary;
 a training run right at the edge of it may still carry a small amount of
 pre-fix contamination.
 
+## `field_channel_corpus.v1` second training-data quality cutoff (2026-07-22, PR #1248)
+
+A second, independent contamination window: `transport_pressure`/
+`catalog_drift_pressure`/`observer_failure_pressure`/`reliability_pressure`/
+`contract_pressure` were injected into the field via the default
+`Perturbation` `mode="add"` (`app/ingest/state_deltas.py`'s `transport_bus`
+branch) instead of `mode="replace"`, even though `transport_loop_reducer`
+recomputes all five fresh every reduction (a "current reading," not an
+incremental delta). Combined with `apply_perturbations()` unconditionally
+stamping `node_vector_updated_at` regardless of mode, and `apply_decay()`
+holding a channel flat while "fresh," any of these five channels that ever
+picked up a nonzero value from a real event could get permanently stuck —
+immune to both correction (an `add`-mode `0.0` "no drift" report is a no-op)
+and decay (perpetually re-marked "fresh"). Confirmed live: `catalog_drift_pressure`
+was frozen at exactly `0.13517857261119032` for 10+ minutes across a service
+restart while the real value (read directly from `transport_bus_reducer`'s
+live Postgres receipts) was `0.0` the entire time — traced end to end via
+the `telemetry_anomaly` metacog trigger firing on nearly every tick because
+of it (this one channel accounted for ~66% of the average reconstruction
+error against the trained `field_channel_anomaly.v2` encoder).
+
+Fixed by PR #1248 (`mode="replace"` for all five channels, matching
+`bus_health`/`delivery_confidence`'s existing correct handling). **Rows
+generated before this fix is deployed may carry a stuck value for any of
+the five channels above** — not necessarily contaminated at every timestamp
+(a channel only gets stuck once it has picked up a nonzero value from a real
+event and then failed to decay/correct), but unlike the 2026-07-17 cutoff
+above, this window has no known start — a channel could have been stuck for
+an arbitrarily long time before anyone noticed. Get the exact cutoff once
+PR #1248 is merged and `orion-field-digester` has been restarted with it via
+`gh pr view 1248 --json mergedAt`, cross-checked against the actual
+container restart time (`docker inspect orion-athena-field-digester
+--format '{{.State.StartedAt}}'`) the same way the 2026-07-17 cutoff above
+notes merge-time and restart-time can drift apart. As of this writing PR
+#1248 is open, not yet merged or deployed — **do not train against corpus
+data until it has been, and until the new cutoff below is filled in**:
+
+```bash
+python orion/mood_arc/fit_encoder.py train \
+  --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
+  --min-generated-at <PR #1248 deploy timestamp, TBD> \
+  --out <out-dir>
+```
+
+If both cutoffs apply, use whichever is later.
+
 ## Field channel glossary
 
 This is the consolidated reference for all 29 channels in

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -270,28 +270,46 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
     if delta.target_kind == "transport_bus":
         hints = dict((delta.after or {}).get("pressure_hints") or {})
         node_key = _node_key(str((delta.after or {}).get("node_id") or delta.target_id.replace("bus:", "")))
-        # bus_health / delivery_confidence are fresh-value-per-report readings
-        # (orion/substrate/transport_loop/reducer.py::reduce_transport_trace_events
-        # recomputes them from scratch via extract_transport_bus_state_from_events
-        # every time it reduces new bus-trace events -- not an incremental delta),
-        # the same "here's the current reading" shape already used for
+        # All seven pressure_hints channels below (bus_health,
+        # delivery_confidence, and the five in the loop further down) are
+        # fresh-value-per-report readings (orion/substrate/transport_loop/
+        # reducer.py::reduce_transport_trace_events recomputes them from
+        # scratch via extract_transport_bus_state_from_events every time it
+        # reduces new bus-trace events -- not an incremental delta), the same
+        # "here's the current reading" shape already used for
         # execution_load/execution_friction/reasoning_load/failure_pressure/
-        # egress_confidence_deficit/prediction_error elsewhere in this file, all
-        # of which use mode="replace". Left as default mode="add" here, these two
-        # channels ratchet to 1.0 and stay there (add-mode ceiling, never cleared)
-        # since nothing else in this file wrote a downward value for them.
-        # mode="replace" alone is the fix: worker.py::_transport_tick() only
-        # reduces when fetch_transport_grammar_events() actually returns events
-        # (`if not events: return None`), i.e. bus_health/delivery_confidence
-        # deltas arrive only when there is genuine transport bus trace activity,
-        # not unconditionally every field-digester tick. Deliberately NOT added
-        # to NODE_DECAY_CHANNELS: both are "current health/confidence reading"
-        # scores (0.0-1.0, default 0.5 -- see orion/schemas/transport_projection.py
-        # and extract.py), not pressure accumulators. A health score fading
-        # toward 0.0 between reports, just because the bus went quiet, would
-        # misrepresent a quiet bus as a degrading one; mode="replace" already
-        # guarantees the value reflects the most recent genuine report, and decay
-        # would only distort that between reports rather than bound anything.
+        # egress_confidence_deficit/prediction_error elsewhere in this file,
+        # all of which use mode="replace".
+        #
+        # bus_health/delivery_confidence use mode="replace" and are
+        # deliberately NOT in NODE_DECAY_CHANNELS: both are "current
+        # health/confidence reading" scores (0.0-1.0, default 0.5 -- see
+        # orion/schemas/transport_projection.py and extract.py), not pressure
+        # accumulators, and have no decay story.
+        #
+        # transport_pressure/catalog_drift_pressure/observer_failure_pressure/
+        # reliability_pressure/contract_pressure (the loop below) ARE in
+        # NODE_DECAY_CHANNELS -- decaying toward baseline if the bus-observer
+        # genuinely goes dark is correct for these. But until 2026-07-22 this
+        # loop left mode at its default "add", which combined with
+        # apply_perturbations() unconditionally stamping
+        # node_vector_updated_at on every perturbation regardless of mode
+        # (perturbation.py) to produce a stuck-value bug: a real "no drift"
+        # report (intensity=0.0) is a no-op in add-mode, so it can never
+        # correct a previously-injected nonzero value back down, while
+        # simultaneously re-marking the channel "fresh" every ~10s -- which
+        # makes apply_decay()'s hold-if-fresh logic skip decay too. Net
+        # effect: whatever nonzero value one of these channels last picked up
+        # from a genuine event got permanently frozen, immune to both
+        # correction (add-mode 0.0 no-ops) and decay (perpetually "fresh").
+        # Confirmed live 2026-07-22: catalog_drift_pressure stuck at
+        # 0.13517857261119032 for 10+ minutes across a service restart while
+        # transport_bus_reducer was continuously emitting the real current
+        # value (0.0) every ~10s the whole time -- traced end to end via
+        # docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md's
+        # telemetry_anomaly investigation, which was firing on nearly every
+        # tick because of this exact stale channel. mode="replace" is the
+        # same fix already applied to bus_health/delivery_confidence above.
         if "bus_health" in hints:
             out.append(
                 Perturbation(
@@ -326,26 +344,24 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                         channel=channel,
                         intensity=float(hints[key]),
                         label=delta.delta_id,
+                        mode="replace",
                     )
                 )
-        if "stream_depth_pressure" in hints:
-            out.append(
-                Perturbation(
-                    node_id=node_key,
-                    channel="transport_pressure",
-                    intensity=float(hints["stream_depth_pressure"]),
-                    label=delta.delta_id,
-                )
-            )
-        if "backpressure" in hints:
-            out.append(
-                Perturbation(
-                    node_id=node_key,
-                    channel="transport_pressure",
-                    intensity=float(hints["backpressure"]),
-                    label=delta.delta_id,
-                )
-            )
+        # stream_depth_pressure/backpressure are NOT separately injected here:
+        # extract.py's transport_pressure = max(stream_depth_pressure,
+        # backpressure) already folds both into the "transport_pressure" hint
+        # handled by the loop above. Re-injecting them as their own
+        # mode="add" perturbations against the same channel (as this code did
+        # until 2026-07-22) would fight the replace above -- whichever
+        # Perturbation for "transport_pressure" apply_perturbations() sees
+        # last in this list wins outright (replace) or silently inflates it
+        # past the intended max() (add), depending on ordering. hints always
+        # carries all of bus_health/delivery_confidence/stream_depth_pressure/
+        # backpressure/catalog_drift_pressure/observer_failure_pressure/
+        # transport_pressure/contract_pressure/reliability_pressure together
+        # (single dict returned by compute_transport_pressures()), so
+        # "transport_pressure" is always present whenever
+        # "stream_depth_pressure"/"backpressure" would have been.
 
     if delta.target_kind == "prediction_signal":
         hints = dict((delta.after or {}).get("pressure_hints") or {})

--- a/services/orion-field-digester/tests/test_field_channel_ratchets.py
+++ b/services/orion-field-digester/tests/test_field_channel_ratchets.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.digestion.perturbation import apply_perturbations
 from app.digestion.suppression import apply_suppression
 from app.ingest.state_deltas import Perturbation, delta_to_perturbations
@@ -387,10 +389,14 @@ def test_delivery_confidence_drop_reflected_not_ceiling_clamped() -> None:
     assert state.node_vectors["node:athena"]["delivery_confidence"] == 0.3
 
 
-def test_other_transport_bus_channels_still_default_add_mode() -> None:
-    """Scope check: only bus_health/delivery_confidence changed mode. The other
-    transport_bus channels (out of scope for this fix -- reliability_pressure,
-    transport_pressure, etc.) must remain untouched (default mode="add")."""
+def test_remaining_transport_bus_channels_also_use_replace_mode() -> None:
+    """2026-07-22: closes the gap this test used to document as "out of
+    scope". transport_pressure/catalog_drift_pressure/observer_failure_pressure/
+    reliability_pressure/contract_pressure are fresh-value-per-report readings
+    from the same reducer as bus_health/delivery_confidence -- mode="add"
+    left them stuck (confirmed live: catalog_drift_pressure frozen at
+    0.13517857261119032 for 10+ minutes across a restart while the real
+    value was 0.0 the whole time)."""
     delta = _transport_bus_delta(
         hints={
             "transport_pressure": 0.4,
@@ -402,7 +408,64 @@ def test_other_transport_bus_channels_still_default_add_mode() -> None:
     )
     perturbations = delta_to_perturbations(delta)
     for p in perturbations:
-        assert p.mode == "add", f"{p.channel} unexpectedly changed mode to {p.mode}"
+        assert p.mode == "replace", f"{p.channel} unexpectedly still mode={p.mode}"
+
+
+def test_catalog_drift_pressure_drop_reflected_not_stuck() -> None:
+    """The live regression this fix closes: a real event pushes
+    catalog_drift_pressure up, then the next report says the real current
+    value is back to 0.0. Under the old mode="add" default the 0.0 report
+    was a no-op and the channel stayed stuck at the old value forever."""
+    state = _state()
+
+    up = delta_to_perturbations(_transport_bus_delta(hints={"catalog_drift_pressure": 0.4}))
+    apply_perturbations(state, up)
+    assert state.node_vectors["node:athena"]["catalog_drift_pressure"] == 0.4
+
+    down = delta_to_perturbations(_transport_bus_delta(hints={"catalog_drift_pressure": 0.0}))
+    apply_perturbations(state, down)
+    assert state.node_vectors["node:athena"]["catalog_drift_pressure"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "channel",
+    ["transport_pressure", "observer_failure_pressure", "reliability_pressure", "contract_pressure"],
+)
+def test_remaining_channels_drop_reflected_not_stuck(channel: str) -> None:
+    """Same regression as test_catalog_drift_pressure_drop_reflected_not_stuck,
+    covering the other three channels the review flagged as sharing the
+    identical loop body but lacking their own explicit up-then-down test."""
+    state = _state()
+
+    up = delta_to_perturbations(_transport_bus_delta(hints={channel: 0.4}))
+    apply_perturbations(state, up)
+    assert state.node_vectors["node:athena"][channel] == 0.4
+
+    down = delta_to_perturbations(_transport_bus_delta(hints={channel: 0.0}))
+    apply_perturbations(state, down)
+    assert state.node_vectors["node:athena"][channel] == 0.0
+
+
+def test_stream_depth_pressure_and_backpressure_no_longer_double_inject_transport_pressure() -> None:
+    """transport_pressure = max(stream_depth_pressure, backpressure) is
+    already folded into the "transport_pressure" hint by extract.py. Before
+    this fix, stream_depth_pressure/backpressure were also separately
+    injected as their own mode="add" perturbations against the same
+    "transport_pressure" channel -- redundant with, and conflicting with, the
+    now mode="replace" entry above. Exactly one Perturbation should target
+    transport_pressure per transport_bus delta."""
+    delta = _transport_bus_delta(
+        hints={
+            "transport_pressure": 0.6,
+            "stream_depth_pressure": 0.6,
+            "backpressure": 0.2,
+        }
+    )
+    perturbations = delta_to_perturbations(delta)
+    transport_pressure_perturbations = [p for p in perturbations if p.channel == "transport_pressure"]
+    assert len(transport_pressure_perturbations) == 1
+    assert transport_pressure_perturbations[0].mode == "replace"
+    assert transport_pressure_perturbations[0].intensity == 0.6
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `transport_pressure`/`catalog_drift_pressure`/`observer_failure_pressure`/`reliability_pressure`/`contract_pressure` in `state_deltas.py`'s `transport_bus` ingest branch used the default `Perturbation` `mode="add"` instead of `mode="replace"`, even though `bus_health`/`delivery_confidence` two blocks above already use `mode="replace"` for the identical reason (both are "current reading" values, not incremental deltas).
- `mode="add"` on a 0.0 "no drift" report is a no-op, so a channel that ever picked up a nonzero value from a real event could never be corrected back down. Worse, `apply_perturbations()` stamps `node_vector_updated_at` on every perturbation regardless of mode, so the no-op reports kept marking the channel "fresh" and blocking `apply_decay()`'s hold-if-fresh decay too — a permanent stuck value.
- Also removes two now-redundant/conflicting standalone perturbations (`stream_depth_pressure`, `backpressure`) that both separately targeted the `transport_pressure` channel — `extract.py` already folds both into the `transport_pressure` hint the main loop reads, and leaving them mode="add" after the loop's entry became mode="replace" would corrupt the just-set value.

## Outcome moved

`telemetry_anomaly` metacog trigger was firing on nearly every field-digester tick since `field_channel_anomaly.v2` went live (14 firings in 25 minutes, recon_loss 11-24x over threshold, every time). Traced end to end (live Postgres receipts, live corpus JSONL, direct per-channel reconstruction-error attribution against the trained encoder weights): `catalog_drift_pressure` was frozen at exactly `0.13517857261119032` for 10+ minutes across a service restart while the real value — read directly from `transport_bus_reducer`'s continuous live receipts — was `0.0` the entire time. That one stale channel accounted for ~66% of the average reconstruction error. Not calibration theater, not a real anomaly: a stuck field channel from this exact bug.

## Current architecture

`services/orion-field-digester/app/ingest/state_deltas.py::delta_to_perturbations()` maps `StateDeltaV1` events into `Perturbation` objects consumed by `app/digestion/perturbation.py::apply_perturbations()`, which then feed `app/digestion/decay.py::apply_decay()` each tick. The `target_kind == "transport_bus"` branch handles deltas from `orion/substrate/transport_loop/reducer.py`, which recomputes all 9 `pressure_hints` fields from scratch every reduction via `extract.py::compute_transport_pressures()`.

## Architecture touched

`services/orion-field-digester` only — no schema, bus, or API contract changes. No env changes.

## Files changed

- `services/orion-field-digester/app/ingest/state_deltas.py`: added `mode="replace"` to the 5-channel loop; removed the redundant `stream_depth_pressure`/`backpressure` standalone entries; expanded the explanatory comment to cover all 7 transport_bus channels' shared "current reading" rationale.
- `services/orion-field-digester/tests/test_field_channel_ratchets.py`: replaced the test that explicitly asserted the old (buggy) `mode="add"` behavior with one asserting `mode="replace"`; added an up-then-down regression test for `catalog_drift_pressure` reproducing the exact live bug, parametrized the same regression across the other 4 channels, and added a test confirming `transport_pressure` gets exactly one `Perturbation` (not three).

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
cd services/orion-field-digester && /mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest tests/ -q
130 passed, 6 warnings in 3.27s
```

## Evals run

No eval harness exists for orion-field-digester's ingest layer; this is unit-test-covered only. Live post-deploy verification (recon_loss dropping to near-baseline, telemetry_anomaly firing rate returning to occasional) is the practical eval and is called out under Restart required below.

## Docker/build/smoke checks

Not run from this worktree (deploy requires `scripts/safe_docker_build.sh orion-field-digester ...`, left for Juniper/next session per restart commands below since this worktree doesn't hold prod Docker state). No compose/env/Dockerfile changes in this PR, so a `config` check would be a no-op.

## Review findings fixed

- Finding: only `catalog_drift_pressure` had an explicit up-then-down "not stuck" regression test; the other 4 channels sharing the identical loop body did not.
  - Fix: added `test_remaining_channels_drop_reflected_not_stuck`, parametrized over `transport_pressure`/`observer_failure_pressure`/`reliability_pressure`/`contract_pressure`.
  - Evidence: `130 passed` (was `126` before this addition + the earlier fix's own new tests).
- Reviewed and confirmed safe (no fix needed): no other `target_kind` branch or file writes these 5 channels (verified by grep across `services/orion-field-digester/app/`), so `mode="replace"` can't collide with an additive caller elsewhere; `hints["transport_pressure"]` is always present whenever `stream_depth_pressure`/`backpressure` are (verified against `reducer.py`'s fixed 9-key `pressure_hints` construction), so removing the redundant entries is safe; `decay.py`'s `NODE_DECAY_CHANNELS` membership and staleness-hold logic are untouched, so the decay-to-baseline safety net for a genuinely silent bus-observer still works.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build orion-field-digester
```

Post-restart verification (what to check to confirm this actually fixed it, not just that it compiled):
```bash
# catalog_drift_pressure in the live corpus should track the real value (0.0 right now) instead of staying frozen
docker exec orion-athena-field-digester tail -n 5 /mnt/telemetry/field_channels/corpus/field_channels.jsonl

# telemetry_anomaly firing rate should drop back to occasional, not every tick
docker logs orion-athena-equilibrium --since 10m 2>&1 | grep telemetry_anomaly
```

## Risks / concerns

- Severity: low
- Concern: this doesn't retroactively fix the 14 already-published `telemetry_anomaly` metacog entries from the stuck-value period (2026-07-22 03:34-04:12) sitting in `orion_metacog` — they'll read as real anomalies to any future consumer even though they were a data bug.
- Mitigation: no consumer of `orion_metacog` currently exists (confirmed zero real consumers earlier this session), so no live surface is currently misled by them. Flagging for awareness, not blocking.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/transport-bus-perturbation-replace-mode