### PR TITLE
fix(memory-extractor): log unparseable annotation text before fail-open

### DIFF
--- a/services/orion-cortex-orch/app/memory_extractor.py
+++ b/services/orion-cortex-orch/app/memory_extractor.py
@@ -199,7 +199,11 @@ async def _rpc_annotation_llm(
     if not text:
         raw = response_payload.get("raw") or {}
         text = str(raw.get("content") or raw.get("text") or "").strip()
-    data = json.loads(text)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("memory_extractor_annotation_unparseable_text snippet=%r", text[:200])
+        raise
     if not isinstance(data, dict):
         raise ValueError("annotation_response_not_object")
     # Hard boundary: CardAnnotationV1 has no sensitivity/visibility_scope


### PR DESCRIPTION
## Summary

- `_rpc_annotation_llm()` in `services/orion-cortex-orch/app/memory_extractor.py` now logs the raw text snippet when `json.loads(text)` fails to parse an LLM-gateway annotation reply, before re-raising.
- Triggered by a real live production failure while spot-checking the just-merged reconfirmation-tracking pipeline (PR #1244): the gateway backend (`circe-worker-1`, Qwen3.6-35B-A3B) generated 94 completion tokens with `finish_reason=stop`, but the text that reached this function was empty/unparseable, and the only log was the exception message -- no way to see what the actual text was.
- Direct reproduction of the same model/prompt/options afterward came back clean (valid JSON, 247 tokens, no reasoning wrapper), ruling out a systemic prompt/model bug. The live failure looks like a one-off transient. This patch doesn't fix that specific failure (it's not reproducible on demand) -- it makes the *next* occurrence diagnosable instead of another round of log archaeology.

## Outcome moved

Diagnosability only. `_annotate_via_llm`'s existing fail-open behavior (catch `json.JSONDecodeError` among others, return `None`, drive the regex-extraction fallback) is completely unchanged -- verified by review and by the full existing test suite passing.

## Current architecture

`memory_extractor.py::_rpc_annotation_llm()` RPCs to the LLM gateway for a per-turn memory-card annotation, extracts `text` from the decoded bus envelope payload (or its `raw` sub-object as a fallback), then calls `json.loads(text)`. On any parse failure the caller (`_annotate_via_llm`) already catches it and falls back to a regex-based extractor -- correct fail-open design -- but the actual `text` that broke parsing was never logged anywhere, only the exception's message.

## Architecture touched

Single function, single service. No schema, bus, contract, or env changes.

## Files changed

- `services/orion-cortex-orch/app/memory_extractor.py`: wrap `json.loads(text)` in `try/except json.JSONDecodeError`, log `logger.warning("memory_extractor_annotation_unparseable_text snippet=%r", text[:200])`, then bare `raise` to preserve the exact original exception and traceback.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-cortex-orch/tests/test_memory_extractor.py -q
26 passed, 16 warnings in 2.82s   (warnings are pre-existing pydantic protected_namespaces deprecations, unrelated to this change)

/mnt/scripts/Orion-Sapienform/.venv/bin/python -m py_compile services/orion-cortex-orch/app/memory_extractor.py
syntax OK
```

## Evals run

None applicable -- this is a logging-only diagnosability patch, not a behavior or quality change.

## Docker/build/smoke checks

Not run for this patch (no runtime/config/dependency change). The underlying failure this addresses was found via live log/DB inspection of the already-running `orion-athena-cortex-orch` container plus a direct reproduction call against the real `circe-worker-1` backend (see Summary) -- both against the currently-deployed image, not this branch.

## Review findings fixed

Reviewed via subagent (orion-repo-agent) against: log level correctness (WARNING required since root logger is `logging.basicConfig(level=logging.INFO)`, consistent with every other fail-open log in this file), control-flow preservation (bare `raise` confirmed to preserve caller's existing `json.JSONDecodeError` handling unmodified), and privacy exposure (200-char snippet of LLM-generated output, less revealing than logging the full prompt, consistent with existing `title[:80]`/`fp[:16]` snippet-logging practice in this file). Verdict: clean, no material findings.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-cortex-orch/.env \
  -f services/orion-cortex-orch/docker-compose.yml \
  up -d --build orion-cortex-orch
```

## Risks / concerns

- Severity: low
- Concern: this only makes the *next* occurrence of the underlying transient diagnosable -- it does not fix or explain the original failure, since it wasn't reproducible on demand.
- Mitigation: none needed beyond merging and waiting for a recurrence to inspect the new log line.

## PR link

(filled in by `gh pr create`)