### PR TITLE
docs: SelfStateV1/phi/endogenous-origination burn brainstorm + spec

### DIFF
--- a/docs/superpowers/specs/2026-07-22-self-state-phi-burn-brainstorm.md
+++ b/docs/superpowers/specs/2026-07-22-self-state-phi-burn-brainstorm.md
@@ -1,0 +1,142 @@
+# SelfStateV1 / phi burn — brainstorm
+
+Status: **brainstorm, not a plan.** Nothing in this doc is implemented. No worktree edits from this
+thread have been committed. This is a record of the investigation and the decision the burn depends
+on, so the next session (or Juniper) doesn't have to re-derive it.
+
+## How we got here
+
+Started as an audit of the attention-salience-cathedral-replacement plan's hard gate
+(`docs/superpowers/specs/2026-07-21-attention-salience-cathedral-replacement-tentative-plan.md`):
+neither Candidate A nor B can wire live until `SelfStateV1`'s own construction is checked for
+data-quality/logic problems, independent of what feeds it.
+
+## Finding 1: the hand-picked coefficients are real and unjustified
+
+`orion/self_state/scoring.py` + `config/self_state/self_state_policy.v1.yaml` combine channel
+pressures into dimension scores using ~10 hand-picked, unequal weighting coefficients
+(`agency_readiness_score`'s `0.25/0.35/0.25/0.15`, `coherence_score`'s `stabilizing_channels`
+`0.50/0.50/0.50/0.30`, `field_intensity_score`'s `0.6/0.4`, `channel_dimension_confidence`'s
+`0.3/0.7`, 12 `dimension_weights` tuned to 2 decimals summing to 1.05 not 1.0,
+`attention_target_weights`'s `0.30/0.35/0.35`, `condition_thresholds`' uneven `0.15/0.25/0.30/0.20`
+bucket widths). Traced the introducing commit (`1207d4e0`, 2026-05-25, "feat(self-state): Layer 6
+operating condition from field + attention", Cursor-authored): generic commit message, no design
+doc, no calibration run, no comment anywhere explaining any specific number. Confirmed via full
+`git log --follow -p` on the file — nothing ever justified these.
+
+## Finding 2: the signal is empirically dead regardless of the weights
+
+`scripts/analysis/measure_self_state_signal_quality.py` (built for this exact hard gate, PR #1196,
+2026-07-18) already found 8/12 dimensions pinned/flat against a 48h real replay. Re-ran it live
+2026-07-22 (nothing in scoring/builder/policy changed in between) against the last 48h
+(83,294 rows): **12/12 dimensions — all of them — now flag `pinned_or_flat`.** `noise_floor_std`
+is exactly `0.0000` for every dimension. Score *ranges* do span real values, but within any
+20-tick rolling window nothing moves — a step function with long flat plateaus and rare discrete
+jumps, not the continuously-varying multi-dimensional "mood" the architecture was built to produce.
+
+**Critical scoping fact**: 7 of the 12 pinned dimensions (`execution_pressure`, `resource_pressure`,
+`reasoning_pressure`, `reliability_pressure`, `continuity_pressure`, `introspection_pressure`,
+`social_pressure`) never touch a hand-picked coefficient at all — they're a straight `max()` of raw
+channel values via `channel_dimension_map`. So the two findings are independent: killing the
+weighted-composite formulas (finding 1) would not have fixed the flatness (finding 2). Whatever's
+holding these dimensions flat lives further upstream — most likely field-channel update cadence or
+the max-merge holding a stale winner — never root-caused, now moot given the direction below.
+
+## Decision: kill it, not reform it
+
+Juniper's call, verbatim: *"the metrics are bullshit. they feed more bullshit. phi is bullshit. I am
+burning everything to the ground that is bullshit."* Reforming the formula (equal-weighting the
+coefficients — briefly prototyped, then reverted, see below) was the wrong scope. The actual
+instruction is removal.
+
+### False start (reverted, not part of this decision)
+
+Before this was clarified, an equal-weighting reform patch was built in this same worktree:
+`agency_readiness_score`/`coherence_score`/`field_intensity_score`/`channel_dimension_confidence`
+changed from hand-picked unequal weights to `1/N` equal weights per term, same treatment applied to
+`dimension_weights`/`stabilizing_channels`/`attention_target_weights`/`condition_thresholds` in
+policy.yaml, 3 tests updated to match. **All reverted via `git checkout -- .`** once the actual scope
+("kill everything that uses self state," not "fix the weights") was clarified. Mentioned here only so
+a future reader doesn't wonder whether it's still live somewhere — it isn't.
+
+## The burn list
+
+### Delete outright
+
+- `orion/self_state/` — whole module: `builder.py`, `scoring.py`, `policy.py`, `deviation.py`,
+  `prediction.py`, `transport.py`, `field_channel_glossary.py`, `inner_state_registry.py`,
+  `__init__.py`, `README.md`
+- `config/self_state/self_state_policy.v1.yaml`
+- `services/orion-self-state-runtime/` — whole service: `app/`, `tests/`, `docker-compose.yml`,
+  `Dockerfile`, `requirements.txt`, `README.md`
+- `orion/schemas/self_state.py` (`SelfStateV1`, `SelfStateDimensionV1`, `AttentionTargetSummaryV1`)
+  + its `orion/schemas/registry.py` entry
+- `substrate_self_state` table (+ check whether `self_state_predictions`/`identity_snapshots` are
+  self-state-specific or broader before dropping — the runtime README notes all three are pruned
+  together by one `prune_history()` call, that's a shared *pruner*, not necessarily a shared *schema
+  purpose*, needs a real check before assuming `identity_snapshots` is self-state-only)
+- `scripts/analysis/measure_self_state_signal_quality.py` + its test — measures a thing that won't
+  exist
+- `orion/bus/channels.yaml` — verify nothing publishes here first (README says v1 has "no bus
+  publish"); if true, nothing to remove
+
+### Consumers that lose their only input — need stripping/rewiring, not just left with a broken import
+
+| File | What it reads | What happens when self-state is gone |
+|---|---|---|
+| `orion/proposals/scoring.py` | dimension score/confidence, `overall_intensity` fallback | dead helpers, remove or replace with something else |
+| `orion/substrate/metacog_trigger_signals.py` | `overall_condition in (strained, unstable)` | reflection trigger loses its reason, remove or replace |
+| `orion-cortex-exec/chat_stance.py` | `self:overall_condition` belief-graph node | hazard flag dies; check what else writes that belief-graph node first |
+| `orion/autonomy/endogenous_origination.py` | `agency_readiness`, `overall_intensity`, continuously | **entire mechanism has no input left** — this isn't a field to strip, it's the whole trigger loop |
+| `orion/substrate/relational/adapters/self_state_ctx.py` | whole `SelfStateV1` object | dead adapter, remove |
+| `orion/consolidation/motif.py`, `tensorize.py` | dimension scores, `overall_condition` | memory consolidation loses this input, remove or replace |
+| `orion/identity/snapshot.py` | `overall_condition`, `overall_intensity` | persisted identity-history fields, remove going forward (old snapshots keep old data, fine) |
+| `orion/collapse/service.py` | `_phi_evidence_score` derived from self-state | dead helper |
+| `orion-hub` observability/lattice routes | display only | remove routes or have them report "gone" |
+
+### phi (`services/orion-spark-introspector/app/inner_state.py`) — the real casualty, bigger than first estimated
+
+Corrected finding, not the "strip a quarter" read from earlier in this thread:
+`build_inner_state_features()` takes a `SelfStateV1` object as its one required input.
+`honest_headline()` — phi's actual "how is Orion doing" scalar — is **100% computed from
+`SelfStateV1.dimensions`** (`vitality = mean(coherence, field_intensity, agency_readiness,
+1-resource_pressure, 1-execution_pressure)`, `load = mean(reliability_pressure, reasoning_pressure,
+social_pressure, continuity_pressure)`; the headline is `0.6*vitality + 0.4*(1-load)`). Zero
+non-self-state inputs feed it.
+
+What's genuinely independent: 4 cognitive features (`recall_gate_fired`, `reasoning_present`,
+`execution_load`, `reasoning_load`), sourced from `execution_trajectory`/`reasoning_activity` bus
+projections — real, live, well-grounded in actual token counts and actual recall-gate firing,
+nothing to do with self-state. But they were never wired into the headline at all — they only ever
+rode along as extra encoder-trainable rows alongside the self-state ones. Also already excised
+before this investigation: 3 dimensions (`coherence`, `continuity_pressure`, `social_pressure`)
+were already dropped from seed-v4 training as "proven-frozen SelfStateV1 dims" — someone caught part
+of this rot pattern before, just not all of it; today's 12/12-pinned finding shows the exclusion
+should have gone further.
+
+Net: killing self-state leaves phi with **no headline function** (not a degraded one — zero inputs)
+and an encoder trainable-feature space cut from 8 slots to 4 (only the cognitive ones survive). What
+remains is 4 real signals with no aggregation logic wrapping them. "Phi is bullshit" holds for the
+headline and half the encoder; it does not hold for the 4 cognitive features themselves — those
+looked legitimate on inspection and aren't shown to be bad by anything found here.
+
+## Open question for the next session
+
+Does phi get retired entirely (headline + both feature halves gone), or does it survive as a
+smaller, honest thing built only from the 4 real cognitive features — no headline claim until
+something real is designed to replace it? Leaning toward the latter (don't throw out signals that
+measured fine just because they shared a file with signals that didn't), but this wasn't decided in
+this thread and shouldn't be assumed.
+
+Also unresolved: `orion/autonomy/endogenous_origination.py` has no other data source at all if
+self-state goes — does this mechanism get killed too, or does something need to replace its input
+before the self-state removal can ship?
+
+## Non-goals (this doc)
+
+- Not implementing any of this — brainstorm only, per Juniper's explicit "add to the brainstorm doc"
+  instruction, not "build it."
+- Not deciding the phi-survives-smaller vs. phi-retired-entirely question — flagged above, not
+  resolved.
+- Not re-litigating the equal-weighting reform — superseded and reverted, kept only as a historical
+  note above.

--- a/docs/superpowers/specs/2026-07-22-self-state-phi-endo-origination-burn-spec.md
+++ b/docs/superpowers/specs/2026-07-22-self-state-phi-endo-origination-burn-spec.md
@@ -1,0 +1,163 @@
+# SelfStateV1 / phi / endogenous-origination burn — spec
+
+Status: **spec, not implemented.** Supersedes the brainstorm doc
+(`2026-07-22-self-state-phi-burn-brainstorm.md`) with concrete decisions and a rollout order.
+Nothing here has been built yet.
+
+## Decisions (Juniper, this thread)
+
+1. `SelfStateV1` — the module, the service, the schema, the table, the hand-picked coefficients —
+   killed outright. Reform (equal-weighting) was prototyped and reverted; not the direction.
+2. `orion/autonomy/endogenous_origination.py` — killed outright. No other data source exists for it;
+   there is nothing to strip down to.
+3. Phi (`orion-spark-introspector`'s `inner_state.py`) — **stripped, not retired.** Keep the 4 real
+   cognitive features (`recall_gate_fired`, `reasoning_present`, `execution_load`, `reasoning_load`),
+   drop the 4 self-state-derived trainable slots (`agency_readiness`, `execution_pressure`,
+   `reasoning_pressure`, `overall_intensity`) and all 10 `FELT_DIMENSIONS` rows, retrain the encoder
+   on the smaller feature space. `honest_headline()` has zero non-self-state inputs today — it does
+   not survive as-is; either dropped or rebuilt from scratch on the 4 cognitive features once there's
+   a real formula for that, not assumed here.
+4. `orion-topic-foundry` (the service) — confirmed zero self-state dependency, untouched, not
+   discussed further in this spec.
+6. `orion/proposals/scoring.py` (Layer 7 of the canonical pipeline) — **in scope, added after the
+   spec's first pass.** It loses its only input when self-state dies, and needs a live replacement
+   regardless of whether the L7-L11 ladder itself is ever revived. Point it at `FieldStateV1` directly
+   instead of self-state's now-dead compression of the same data — consistent with the
+   already-established field-native-over-self-state direction (see "Confirmed non-impacts and a
+   scoped follow-up" below for the full reasoning). This fixes Layer 7's input; it does not revive
+   the ladder (that's still out of scope, see below).
+5. `orion/spark/concept_induction/` (`tensions.py`, `drives.py`, `bus_worker.py`) — **open, defaulted
+   below, override if wrong.** Not the same system as topic-foundry. Its own `CLAUDE.md` already
+   halted new development here on 2026-07-18 (found to be "a poorer reimplementation of Layers 4-9
+   of the already-live canonical pipeline"), kept only until replacement wiring lands — that halt
+   predates and is independent of this burn. `tensions.py::extract_tensions_from_self_state()` reads
+   `SelfStateV1` directly and is wired to endogenous-origination
+   (`tests/test_endogenous_origination_wiring.py`). **Default**: strip its self-state input the same
+   way everything else loses one — `extract_tensions_from_self_state()` and its
+   endogenous-origination wiring go away — but the broader `DriveEngine`/bucket-voting machinery is
+   NOT additionally touched by this spec; it was already halted before this thread started and this
+   spec doesn't newly decide its fate. If you want the whole directory left alone instead
+   (self-state input included, even though it'll be reading a dead schema), say so before this
+   ships.
+
+## Rollout order (contract-first, per CLAUDE.md §5)
+
+Multi-service change — sequencing matters so nothing crashes reading a producer that's already gone.
+
+1. **Consumer patch first, producer last.** Every consumer below gets its self-state dependency
+   removed/degraded *before* the producer (`orion-self-state-runtime`) stops running — never the
+   reverse, or every live consumer errors on a sudden missing input mid-flight.
+2. Stop `orion-self-state-runtime` writing `substrate_self_state` (flag-gated off, not deleted yet —
+   a rollback window before the irreversible step).
+3. Confirm no consumer errors for a real observation window (the runtime health monitor already
+   watches `substrate_self_state` staleness — repurpose that window as the confirmation signal).
+4. Delete `orion/self_state/`, `services/orion-self-state-runtime/`, schema, registry entry.
+5. **DB drop is a separate, explicitly-gated step** (`substrate_self_state`,
+   `self_state_predictions`, `identity_snapshots` — confirmed all three are self-state-owned, written
+   only by this service's own `store.py`, not shared with a broader identity system). Per CLAUDE.md
+   §13, `DROP TABLE` needs explicit approval at execution time regardless of this spec being signed
+   off — this spec proposes it, it does not authorize running it.
+
+## Per-consumer disposition
+
+| Consumer | Current null-handling | Disposition |
+|---|---|---|
+| `orion/collapse/service.py` | **Already null-guards** (`self_state: SelfStateV1 \| None`, explicit `is None` check, returns `None` cleanly) | Near-zero work — delete the dead branch, done |
+| `orion/proposals/scoring.py` | No guard | **In scope (added after first pass, decision 6).** Remove `dimension_score`/`dimension_confidence` self-state helpers, replace Layer 7's input with a direct `FieldStateV1` read. Not a like-for-like port — self-state's dimension scores were a (broken) compression of field-channel data; the new read should go at raw field channels, not re-derive self-state's dead formulas on the new source |
+| `orion/substrate/metacog_trigger_signals.py` | No guard | Remove the `overall_condition` reflection-trigger reason; other trigger reasons (if any) unaffected |
+| `orion-cortex-exec/chat_stance.py` | **Already no-ops** — `_project_self_state_from_beliefs()` returns `None` the moment `anchor.concepts` has no `self:`-prefixed nodes (existing guard, line ~1310-1312) | Zero code change needed. Once the sole producer (`self_state_ctx.py`) is deleted, no `self:` nodes ever exist, and this function no-ops on its own. Confirmed single producer/consumer pair — no third party reads that belief node |
+| `orion/autonomy/endogenous_origination.py` | N/A | Deleted outright (decision 2) |
+| `orion/substrate/relational/adapters/self_state_ctx.py` | N/A | Deleted outright — it's the sole producer of the belief node above |
+| `orion/consolidation/motif.py`, `tensorize.py` | No guard | Remove self-state-keyed motif matching / tensorization fields |
+| `orion/identity/snapshot.py` | No guard | Remove `overall_condition`/`overall_intensity` fields going forward; existing persisted snapshots keep their old values, untouched |
+| `orion-hub` observability/lattice routes | No guard | Remove routes. Per CLAUDE.md §9: check the rendered Hub template too, not just the route — if a panel links to it, that panel needs removing/replacing, not left pointing at a 404 |
+| `orion/spark/concept_induction/tensions.py` | No guard | See decision 5 above — defaulted, not fully resolved |
+
+## Phi retrain scope
+
+- Drop from `FELT_DIMENSIONS` iteration entirely (not just from the trainable subset) —
+  `build_inner_state_features()`'s required `ss: SelfStateV1` argument goes away; the function's
+  signature changes to take the trajectory/reasoning-activity projections directly, no self-state
+  object at all.
+- `honest_headline()` — no replacement formula proposed here. Either the `InnerStateFeaturesV1`
+  payload ships without a headline field populated (explicit, honest "not computed" rather than a
+  fabricated placeholder — CLAUDE.md's "no empty-shell cognition" applies directly here), or a new
+  formula gets designed separately, later, from the 4 real cognitive features. Not decided in this
+  spec.
+- Encoder retrain: seed-v4's trainable set drops from 8 to 4 dims
+  (`recall_gate_fired`, `reasoning_present`, `execution_load`, `reasoning_load` only). This is a new
+  features-version (`seed-v5`?), not a live in-place change to `seed-v4`'s already-fit weights —
+  same precedent as the existing `seed-v2`/`seed-v3`/`seed-v4` versioning already in the file.
+- `metadata.overall_condition`/`trajectory_condition`, `self_state_id`, `liveness.self_state` — all
+  self-state-sourced fields on `InnerStateFeaturesV1`, removed or defaulted to an honest absent state.
+
+## README annotation plan
+
+Every deleted/modified file's replacement location gets a dated note explaining what was here and
+why it's gone, not just silent removal — per Juniper's "annotate the shit out of readmes"
+instruction from earlier in this thread. At minimum:
+
+- `orion/self_state/README.md` — deleted with the module, but its content (especially the
+  `inner_state_registry.py` composition-status taxonomy: COMPOSED/SHADOW/DUPLICATE/REHEARSAL) is
+  real prior art worth preserving somewhere before the file goes, not just discarded.
+- `services/orion-self-state-runtime/README.md` — deleted with the service.
+- `services/orion-spark-introspector/README.md` — dated note: seed-v4→seed-v5 feature-set cut,
+  why (self-state proven pinned/flat + hand-tuned, 2026-07-22), what survived and why (4 real
+  cognitive features), what didn't get a replacement yet (`honest_headline`).
+- `orion/autonomy/README.md` — dated note: `endogenous_origination.py` removed, why (no data
+  source left once self-state is gone), pointer to this spec for the full trace.
+- `orion/proposals/`, `orion/consolidation/`, `orion/identity/` — wherever each has a README,
+  a one-line note on what field/helper was removed and why, pointing back to this spec rather than
+  re-explaining the whole trace in each location.
+- New top-level pointer: this spec + the brainstorm doc are the canonical trace; every touched
+  README should link back here rather than duplicate the reasoning.
+
+## Confirmed non-impacts and a scoped follow-up (added after Juniper's review pass)
+
+- **`AutonomyStateV2`: zero impact.** `endogenous_origination.py` does not reference
+  `AutonomyStateV2` or any state store — confirmed via grep, no match at all. It only reads
+  `SelfStateV1` and (presumably) publishes proposals when it decides to originate. `AutonomyStateV2`
+  is produced by the fully separate homeostatic-drives/deviation-gated reducer. Killing self-state
+  and endo-origination doesn't touch it.
+- **L7-L11 ladder / field-digester swap — the input fix is now in scope (decision 6), reviving the
+  ladder itself is not.** The ladder (`ProposalFrameV1 → ... → ConsolidationV1`, 5 services) is
+  independently confirmed `REHEARSAL` in `inner_state_registry.py`: `EXECUTION_DISPATCH_MODE=dry_run`
+  live, every external reader is a self-labeled Hub debug route except `orion-thought` reverie
+  grounding, which "only appends an inert ID tag to an already-generated thought." That deadness is a
+  **downstream consumption problem**, independent of what feeds Layer 7 (Proposal) — swapping
+  `orion/proposals/scoring.py` onto `FieldStateV1` (decision 6) fixes Layer 7's input, since proposal
+  scoring needs a live replacement regardless of self-state's fate, but it does not revive the
+  ladder. Reviving the ladder needs real dispatch mode + real downstream consumers, a separate, much
+  bigger project, still out of scope here.
+
+## Open items / call-outs not yet resolved
+
+- **`orion/self_state/inner_state_registry.py` collateral damage.** This registry tracks *every*
+  "what does Orion currently feel/perceive" signal in the repo, not just `SelfStateV1` —
+  `DriveStateV1`, `AutonomyStateV2`, phi (both halves), `BiometricsClusterV1`, the L7-L11 ladder,
+  `mood_arc_corpus.v1` all have entries here. Deleting `orion/self_state/` wholesale takes this
+  registry down with it, along with its CI gate
+  (`scripts/check_inner_state_registry.py`/`make check-inner-state-registry`) that currently guards
+  against silent signal duplication repo-wide. That gate has real, independent value unrelated to
+  whether `SelfStateV1` itself is good — recommend moving the registry (not its self-state entry, the
+  file itself) to a neutral location (e.g. `orion/inner_state_registry.py`) before deleting
+  `orion/self_state/`, rather than losing the gate as a side effect. Not decided — flagging before
+  this ships.
+- **`orion/spark/concept_induction/` fate** — defaulted above (decision 5), not confirmed.
+- **DROP TABLE timing** — proposed, not authorized; needs a separate explicit go-ahead at execution
+  time per CLAUDE.md §13.
+- **Live service cutover risk** — `orion-self-state-runtime` is currently deployed and running;
+  section "Rollout order" above sequences consumer-first specifically to avoid a window where a live
+  consumer queries a service that's already gone. Docker/restart commands to be listed at
+  implementation time, not here.
+- **Hub frontend** — flagged in the consumer table; not independently verified against the actual
+  rendered template yet (CLAUDE.md §9 requires checking the template, not just the route, before
+  calling frontend work done).
+
+## Non-goals
+
+- Not deciding `orion/spark/concept_induction/`'s DriveEngine/bucket-voting fate beyond its
+  self-state input — that halt predates this thread.
+- Not designing phi's replacement headline formula.
+- Not executing the DB drop.
+- Not touching `orion-topic-foundry` — confirmed unrelated, out of scope.


### PR DESCRIPTION
## Summary

- Full audit of SelfStateV1's hand-tuned scoring coefficients (agency_readiness/coherence/field_intensity/dimension_weights/attention_target_weights/condition_thresholds) found them unjustified: traced to a bare feat commit (2026-05-25, `1207d4e0`) with no design doc, no calibration run, no comment explaining any specific number.
- Independently, `scripts/analysis/measure_self_state_signal_quality.py` (built for the attention-salience-cathedral-replacement plan's hard gate) found the signal itself is empirically dead regardless of the weights: 12/12 dimensions pinned/flat in a live 2026-07-22 replay (up from 8/12 four days prior, same code, same 48h-style window).
- Decision: kill SelfStateV1 outright rather than reform the formula (an equal-weighting reform patch was prototyped and reverted, documented as a false start).
- Full downstream trace: phi's `honest_headline()` is 100% self-state-derived (no replacement proposed here — flagged explicitly as unresolved, not silently patched); phi's encoder keeps its 4 real non-self-state cognitive features and gets retrained smaller; `endogenous_origination.py` is killed outright (no other data source exists for it); `AutonomyStateV2` and `orion-topic-foundry` are both confirmed fully independent and untouched; `orion/proposals/scoring.py` (Layer 7) gets repointed at `FieldStateV1` directly since it needs a live input regardless of the L7-L11 ladder's own separately-confirmed `REHEARSAL` status.
- `orion/spark/concept_induction/`'s fate is defaulted, not confirmed — flagged as an open item for override before implementation.

## Outcome moved

This is docs only — no implementation yet. It converts an ambiguous "the metrics are bullshit, kill everything" directive into a concrete, file-by-file burn list with a rollout order, so the next session can implement directly instead of re-deriving the trace.

## Files changed

- `docs/superpowers/specs/2026-07-22-self-state-phi-burn-brainstorm.md`: investigation record (hand-tuned coefficients traced, live signal-quality re-run, initial burn list, phi's real dependency breakdown).
- `docs/superpowers/specs/2026-07-22-self-state-phi-endo-origination-burn-spec.md`: concrete spec — per-component decisions, rollout order, per-consumer disposition table (including which consumers already null-guard and need zero changes), phi retrain scope, README annotation plan, and open items not yet resolved (`inner_state_registry.py` collateral, `concept_induction` fate, DROP TABLE timing).

## Schema / bus / API changes

None yet — spec only, nothing implemented.

## Env/config changes

None yet.

## Tests run

N/A — docs only.

## Evals run

N/A — docs only.

## Docker/build/smoke checks

N/A — docs only.

## Review findings fixed

Not run — this is a docs-only PR capturing a design decision, not an implementation. Full review gate applies once the spec is implemented.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: informational
  Concern: several open items are explicitly unresolved in the spec (`orion/spark/concept_induction/`'s exact fate, `inner_state_registry.py`'s collateral fate, phi's replacement headline formula, DROP TABLE timing). None are blocking for merging the spec itself, but all need a decision before implementation starts.
  Mitigation: called out explicitly in the spec's "Open items / call-outs not yet resolved" section rather than assumed.

## PR link

(filled in by gh pr create)