### PR TITLE
docs(field-digester,mood-arc): fill in PR #1248's cutoff timestamp

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -69,20 +69,28 @@ python orion/mood_arc/fit_encoder.py train \
   `services/orion-field-digester/README.md`'s "`field_channel_corpus.v1`
   training-data quality cutoff" section; keep the two in sync if it's ever
   revised.
-- **Second cutoff, 2026-07-22 (PR #1248, pending deploy):** `transport_pressure`/
-  `catalog_drift_pressure`/`observer_failure_pressure`/`reliability_pressure`/
-  `contract_pressure` could get permanently stuck at a stale value (an
-  `add`-mode perturbation bug in `services/orion-field-digester/app/ingest/
-  state_deltas.py`, fixed in PR #1248) — confirmed live as the cause of
+- **Second cutoff, `--min-generated-at 2026-07-22T04:35:01Z` (PR #1248,
+  merged + deployed):** `transport_pressure`/`catalog_drift_pressure`/
+  `observer_failure_pressure`/`reliability_pressure`/`contract_pressure`
+  could get permanently stuck at a stale value (an `add`-mode perturbation
+  bug in `services/orion-field-digester/app/ingest/state_deltas.py`, fixed
+  in PR #1248, merged 2026-07-22T04:32:27Z, `orion-field-digester` restarted
+  2026-07-22T04:35:01Z) — confirmed live as the cause of
   `catalog_drift_pressure` alone driving ~66% of average reconstruction
   error against `field_channel_anomaly.v2`. Unlike the first cutoff, this
-  contamination window has no known start (a channel only breaks once it
-  picks up a nonzero value and then fails to correct/decay), so **do not
-  train against any corpus data until PR #1248 is merged and deployed, and
-  a second `--min-generated-at` cutoff is set to that deploy timestamp** —
-  see `services/orion-field-digester/README.md`'s "second training-data
-  quality cutoff" section for the exact mechanism to determine it once
-  known. If both cutoffs apply, use whichever is later.
+  contamination window has no known start — `catalog_drift_pressure` was in
+  fact stuck for the *entire* span of `v2`'s training corpus
+  (2026-07-17T04:32:14Z-2026-07-22T01:30:24Z), confirmed by the fact that
+  post-fix, with the real value correctly reading `0.0`, `v2` (trained on
+  the stuck ~`0.135` reading) flipped to flagging the *correct* value as
+  anomalous instead: `telemetry_anomaly` still fired 20 times in the 41
+  minutes after the restart, same channel, opposite direction. **`v2` is not
+  a valid baseline and needs a `v3` retrain against
+  `--min-generated-at 2026-07-22T04:35:01Z`** — but as of this writing
+  there's only ~40 minutes of clean data, nowhere near `v2`'s 207K-row/
+  5-day corpus. Do not retrain until meaningfully more clean data has
+  accumulated; see the agent board for the tracked follow-up. If both
+  cutoffs apply, use whichever is later.
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -259,29 +259,37 @@ of it (this one channel accounted for ~66% of the average reconstruction
 error against the trained `field_channel_anomaly.v2` encoder).
 
 Fixed by PR #1248 (`mode="replace"` for all five channels, matching
-`bus_health`/`delivery_confidence`'s existing correct handling). **Rows
-generated before this fix is deployed may carry a stuck value for any of
-the five channels above** — not necessarily contaminated at every timestamp
-(a channel only gets stuck once it has picked up a nonzero value from a real
-event and then failed to decay/correct), but unlike the 2026-07-17 cutoff
-above, this window has no known start — a channel could have been stuck for
-an arbitrarily long time before anyone noticed. Get the exact cutoff once
-PR #1248 is merged and `orion-field-digester` has been restarted with it via
-`gh pr view 1248 --json mergedAt`, cross-checked against the actual
-container restart time (`docker inspect orion-athena-field-digester
---format '{{.State.StartedAt}}'`) the same way the 2026-07-17 cutoff above
-notes merge-time and restart-time can drift apart. As of this writing PR
-#1248 is open, not yet merged or deployed — **do not train against corpus
-data until it has been, and until the new cutoff below is filled in**:
+`bus_health`/`delivery_confidence`'s existing correct handling), merged
+2026-07-22T04:32:27Z, `orion-field-digester` restarted 2026-07-22T04:35:01Z
+(`docker inspect orion-athena-field-digester --format
+'{{.State.StartedAt}}'`). **Rows generated before `2026-07-22T04:35:01Z`
+may carry a stuck value for any of the five channels above** — not
+necessarily contaminated at every timestamp (a channel only gets stuck once
+it has picked up a nonzero value from a real event and then failed to
+decay/correct), but unlike the 2026-07-17 cutoff above, this window has no
+known start — a channel could have been stuck for an arbitrarily long time
+before anyone noticed, and `catalog_drift_pressure` was in fact stuck for
+the entire span of `field_channel_anomaly.v2`'s training corpus
+(2026-07-17T04:32:14Z-2026-07-22T01:30:24Z per that manifest), confirmed
+live post-fix: with the pipeline bug fixed and the real value now correctly
+reading `0.0`, `v2` (trained almost entirely on the stuck ~`0.135` reading)
+started flagging the *correct* value as anomalous instead —
+`telemetry_anomaly` still fired 20 times in the 41 minutes after the
+restart, same channel, opposite direction. The pipeline bug is fixed; the
+deployed model is not yet retrained on clean data and will keep
+misfiring on this channel until it is.
 
 ```bash
 python orion/mood_arc/fit_encoder.py train \
   --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
-  --min-generated-at <PR #1248 deploy timestamp, TBD> \
+  --min-generated-at 2026-07-22T04:35:01Z \
   --out <out-dir>
 ```
 
-If both cutoffs apply, use whichever is later.
+If both cutoffs apply, use whichever is later. **Do not retrain yet** —
+as of this writing there are only ~40 minutes of clean post-cutoff data,
+nowhere near `v2`'s 207K-row/5-day corpus. Let clean data accumulate
+first; see the agent board for the tracked follow-up.
 
 ## Field channel glossary
 


### PR DESCRIPTION
## Summary

- Fills in the `<PR #1248 deploy timestamp, TBD>` placeholder left in both READMEs with the real value: merged 2026-07-22T04:32:27Z, `orion-field-digester` restarted 2026-07-22T04:35:01Z.
- Records a live post-deploy finding: `field_channel_anomaly.v2`'s training corpus was contaminated for its *entire* span, not just part of it. Confirmed because after the pipeline fix, with `catalog_drift_pressure` correctly reading `0.0` live, `v2` (trained on the stuck ~`0.135` reading) flipped to flagging the *correct* value as anomalous — `telemetry_anomaly` fired 20 times in the 41 minutes after restart, same channel, opposite direction.
- States plainly that `v2` is not a valid baseline and a `v3` retrain is needed against the new cutoff, but blocked on data accumulation (~40 minutes of clean data vs `v2`'s 207K-row/5-day corpus) — tracked on the agent board, not this repo.

## Outcome moved

Docs only — no code/schema/env changes. Closes the loop opened by PR #1248, which explicitly left this cutoff as TBD pending merge+deploy.

## Files changed

- `services/orion-field-digester/README.md`: filled in the cutoff timestamp in the "second training-data quality cutoff" section, added the post-deploy contamination-confirmed note.
- `orion/mood_arc/README.md`: same, in the `--min-generated-at` bullet list.

## Tests run

None applicable (docs only).

## Restart required

No restart required.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/docs/telemetry-anomaly-cutoff-timestamp