### PR TITLE
kill(signals): delete chat_stance organ -- producer is dormant

### DIFF
--- a/orion/signals/adapters/chat_stance.py
+++ b/orion/signals/adapters/chat_stance.py
@@ -1,4 +1,37 @@
-"""Chat stance brief → chat_stance OrionSignalV1 (Milestone B3)."""
+"""Chat stance brief -> chat_stance OrionSignalV1 (Milestone B3).
+
+2026-07-22: dropped the ``_TASK_MODE_COHERENCE``/``_SALIENCE_VALENCE`` lookup
+tables. They mapped ``task_mode``/``identity_salience`` enum labels to
+hardcoded constants -- a relabeling, not a measurement. Replaced with:
+
+  - ``confidence``: scored from cortex-exec's own repair/enforcement telemetry
+    (``chat_stance_debug.enforcement`` -- fallback/semantic-fallback/quality-
+    modification/normalization/parse-error flags it already computes per
+    turn). See ``chat_stance_scoring.score_stance_confidence``.
+  - ``coherence``: cosine similarity between this turn's and the previous
+    turn's (same session) stance text embedding, via orion-vector-host's
+    ``/embedding`` endpoint directly (``orion.signals.vector_host_client`` --
+    not concept-induction's embedder, a different subsystem). No prior-turn
+    embedding (first turn in a session) or a failed embed call -> coherence is
+    omitted from the signal, not guessed.
+  - ``valence``: dropped outright. Bucketing ``identity_salience`` into 3
+    constants measured nothing real and no honest replacement was found; see
+    docs/superpowers/specs/2026-07-22-self-state-phi-burn-brainstorm.md.
+
+Real wire shape (confirmed against a live ``orion:cognition:trace`` capture,
+not assumed): cortex-exec's ``executor.py`` writes the real
+``ChatStanceBrief``/``ChatStanceDebug`` (PascalCase) into a *step's*
+``result`` dict (``merged_result["ChatStanceBrief"] = ...``), which lands at
+``payload["steps"][i]["result"]["ChatStanceBrief"]`` on the published
+envelope -- never at the payload's top level, and
+``build_cognition_trace_metadata()`` (services/orion-cortex-exec/app/main.py)
+only ever forwards a boolean ``metadata.chat_stance_debug_present`` flag, not
+the object itself. ``session_id`` similarly lives at
+``payload["metadata"]["session_id"]``, not the payload top level. A prior
+version of this adapter (and, before this rewrite, the original hardcoded-
+lookup-table version) only checked the top level and so never found real data
+in production -- confirmed by tracing the producer and by a live capture.
+"""
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -6,22 +39,15 @@ from typing import Any, Dict, Optional
 
 from orion.schemas.chat_stance import ChatStanceBrief
 from orion.signals.adapters.base import OrionSignalAdapter
+from orion.signals.adapters.chat_stance_scoring import (
+    cosine_similarity_01,
+    score_stance_confidence,
+)
 from orion.signals.models import OrionOrganRegistryEntry, OrionSignalV1
 from orion.signals.normalization import NormalizationContext, clamp01
 from orion.signals.registry import ORGAN_REGISTRY
 from orion.signals.signal_ids import make_signal_id
-
-_TASK_MODE_COHERENCE = {
-    "direct_response": 0.85,
-    "triage": 0.55,
-    "technical_collaboration": 0.75,
-    "identity_dialogue": 0.7,
-    "reflective_dialogue": 0.72,
-    "playful_exchange": 0.65,
-    "mixed": 0.5,
-}
-
-_SALIENCE_VALENCE = {"low": 0.35, "medium": 0.55, "high": 0.75}
+from orion.signals.vector_host_client import embed_text
 
 _FORBIDDEN_TEXT_KEYS = frozenset(
     {
@@ -36,6 +62,37 @@ _FORBIDDEN_TEXT_KEYS = frozenset(
         "operational_context",
     }
 )
+
+# No repair telemetry available at all (bare brief, or a debug-presence flag
+# with no actual debug object) -- an honest "we don't know" placeholder, not a
+# fabricated per-task-mode number. Always paired with a note explaining why.
+NO_TELEMETRY_CONFIDENCE = 0.5
+
+# Bound on distinct sessions tracked for turn-to-turn coherence. A long-running
+# gateway process would otherwise accumulate one embedding vector per session
+# forever; oldest-inserted sessions are evicted once this cap is exceeded
+# (mirrors cortex-exec's own _PRIOR_STANCE_MAX_ENTRIES bound for the same kind
+# of per-session cache).
+_MAX_TRACKED_SESSIONS = 512
+_SESSION_ORDER_KEY = "_session_order"
+
+
+def _find_step_result(payload: dict, *keys: str) -> Optional[dict]:
+    """Return the first step's ``result`` dict that contains any of ``keys``.
+
+    Real cortex-exec envelopes carry ChatStanceBrief/ChatStanceDebug nested at
+    payload["steps"][i]["result"][key], never at the payload top level.
+    """
+    steps = payload.get("steps")
+    if not isinstance(steps, list):
+        return None
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        result = step.get("result")
+        if isinstance(result, dict) and any(k in result for k in keys):
+            return result
+    return None
 
 
 def _extract_brief_dict(payload: dict) -> dict[str, Any] | None:
@@ -55,28 +112,56 @@ def _extract_brief_dict(payload: dict) -> dict[str, Any] | None:
             raw = contract.get("chat_stance_brief")
             if isinstance(raw, dict):
                 return raw
+    step_result = _find_step_result(payload, "ChatStanceBrief")
+    if step_result is not None:
+        raw = step_result.get("ChatStanceBrief")
+        if isinstance(raw, dict):
+            return raw
     return None
 
 
-def _dimensions_from_brief(brief: ChatStanceBrief | dict[str, Any]) -> tuple[dict[str, float], float, list[str]]:
-    notes: list[str] = []
-    if isinstance(brief, ChatStanceBrief):
-        task_mode = brief.task_mode
-        salience = brief.identity_salience
-        confidence = 0.9
-    else:
-        task_mode = str(brief.get("task_mode") or "mixed")
-        salience = str(brief.get("identity_salience") or "medium")
-        confidence = 0.55
-        notes.append("partial chat_stance payload; schema validation skipped")
+def _extract_debug_dict(payload: dict) -> dict[str, Any] | None:
+    debug = payload.get("chat_stance_debug")
+    if isinstance(debug, dict):
+        return debug
+    step_result = _find_step_result(payload, "ChatStanceDebug")
+    if step_result is not None:
+        debug = step_result.get("ChatStanceDebug")
+        if isinstance(debug, dict):
+            return debug
+    return None
 
-    coherence = _TASK_MODE_COHERENCE.get(task_mode, 0.5)
-    valence = _SALIENCE_VALENCE.get(salience, 0.55)
-    return (
-        {"coherence": coherence, "valence": valence, "confidence": confidence},
-        confidence,
-        notes,
-    )
+
+def _extract_session_id(payload: dict) -> str | None:
+    meta = payload.get("metadata")
+    if isinstance(meta, dict) and meta.get("session_id"):
+        return str(meta["session_id"])
+    if payload.get("session_id"):
+        return str(payload["session_id"])
+    return None
+
+
+def _stance_text(brief_raw: dict[str, Any]) -> str:
+    summary = str(brief_raw.get("stance_summary") or "").strip()
+    strategy = str(brief_raw.get("answer_strategy") or "").strip()
+    return f"{summary}\n{strategy}".strip()
+
+
+def _remember_session_embedding(
+    norm_ctx: NormalizationContext, organ_id: str, session_id: str, vector: list[float]
+) -> None:
+    """Store `vector` under a bounded, oldest-evicted set of session keys."""
+    order = norm_ctx.get_value(organ_id, _SESSION_ORDER_KEY)
+    if not isinstance(order, list):
+        order = []
+    if session_id in order:
+        order.remove(session_id)
+    order.append(session_id)
+    while len(order) > _MAX_TRACKED_SESSIONS:
+        stale_session = order.pop(0)
+        norm_ctx.delete_value(organ_id, f"embedding:{stale_session}")
+    norm_ctx.set_value(organ_id, _SESSION_ORDER_KEY, order)
+    norm_ctx.set_value(organ_id, f"embedding:{session_id}", vector)
 
 
 class ChatStanceAdapter(OrionSignalAdapter):
@@ -89,7 +174,7 @@ class ChatStanceAdapter(OrionSignalAdapter):
             return True
         if "cognition:trace" in channel and payload.get("metadata", {}).get("chat_stance_debug_present"):
             return True
-        if payload.get("chat_stance_debug"):
+        if _extract_debug_dict(payload) is not None:
             return True
         return False
 
@@ -108,21 +193,56 @@ class ChatStanceAdapter(OrionSignalAdapter):
         now = datetime.now(timezone.utc)
         brief_raw = _extract_brief_dict(payload)
         notes: list[str] = []
+        debug = _extract_debug_dict(payload)
+        dimensions: dict[str, float] = {}
 
         if brief_raw is None:
             meta = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
-            if meta.get("chat_stance_debug_present"):
-                dimensions = {"coherence": 0.5, "valence": 0.5, "confidence": 0.4}
-                notes.append("stance_debug_only_no_brief")
+            if debug is not None:
+                confidence, reasons = score_stance_confidence(debug)
+                notes.extend(reasons)
+            elif meta.get("chat_stance_debug_present"):
+                confidence = NO_TELEMETRY_CONFIDENCE
+                notes.append("stance_debug_flag_only_no_object")
             else:
                 return None
+            dimensions["confidence"] = confidence
+            notes.append("stance_debug_only_no_brief")
         else:
-            brief: ChatStanceBrief | dict[str, Any]
             try:
-                brief = ChatStanceBrief.model_validate(brief_raw)
+                ChatStanceBrief.model_validate(brief_raw)
             except Exception:
-                brief = brief_raw
-            dimensions, _, notes = _dimensions_from_brief(brief)
+                notes.append("partial_chat_stance_payload_schema_validation_skipped")
+
+            if debug is not None:
+                confidence, reasons = score_stance_confidence(debug)
+                notes.extend(reasons)
+            else:
+                confidence = NO_TELEMETRY_CONFIDENCE
+                notes.append("no_repair_telemetry_available")
+            dimensions["confidence"] = confidence
+
+            text = _stance_text(brief_raw)
+            session_id = _extract_session_id(payload)
+            if text and session_id:
+                current_vec = embed_text(text)
+                if current_vec is not None:
+                    prev_vec = norm_ctx.get_value(self.organ_id, f"embedding:{session_id}")
+                    if prev_vec is not None:
+                        coherence = cosine_similarity_01(prev_vec, current_vec)
+                        if coherence is not None:
+                            dimensions["coherence"] = coherence
+                        else:
+                            notes.append("coherence_unavailable_vector_mismatch")
+                    else:
+                        notes.append("coherence_unavailable_first_turn_in_session")
+                    _remember_session_embedding(norm_ctx, self.organ_id, session_id, current_vec)
+                else:
+                    notes.append("coherence_unavailable_embed_failed")
+            elif not session_id:
+                notes.append("coherence_unavailable_no_session_id")
+            else:
+                notes.append("coherence_unavailable_no_stance_text")
 
         corr = (
             payload.get("correlation_id")

--- a/orion/signals/adapters/chat_stance_scoring.py
+++ b/orion/signals/adapters/chat_stance_scoring.py
@@ -1,0 +1,74 @@
+"""Real scoring helpers for the chat_stance organ signal.
+
+Replaces the old ``_TASK_MODE_COHERENCE``/``_SALIENCE_VALENCE`` lookup tables
+(enum label -> hardcoded constant, measuring nothing). Both functions here are
+grounded in something that actually happened on the turn:
+
+  - ``score_stance_confidence`` reads cortex-exec's own repair/enforcement
+    telemetry (whether the LLM's raw stance brief needed a fallback, semantic
+    rewrite, quality-guard modification, or field normalization to become
+    usable). More correction needed -> lower confidence.
+  - ``cosine_similarity_01`` compares two embedding vectors (this turn's stance
+    text vs. the previous turn's, same session) and rescales cosine similarity
+    from [-1, 1] to [0, 1].
+
+Neither function invents a number when the real input is missing -- callers
+are expected to omit the dimension rather than fabricate a default.
+"""
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from orion.signals.normalization import clamp01
+
+# Each penalty corresponds to a real correction cortex-exec's own
+# `build_chat_stance_debug_payload` / `parse_chat_stance_brief_with_debug`
+# already had to make to the raw LLM output. Weights are ordered by how much
+# the correction changes the brief's content (fallback replaces it wholesale;
+# normalization only compacts/dedupes fields).
+_FALLBACK_PENALTY = 0.40
+_SEMANTIC_FALLBACK_PENALTY = 0.25
+_QUALITY_MODIFIED_PENALTY = 0.15
+_NORMALIZED_PENALTY = 0.05
+_PARSE_ERROR_PENALTY = 0.20
+
+
+def score_stance_confidence(debug: Dict[str, object]) -> Tuple[float, List[str]]:
+    """Derive a real confidence score from ``chat_stance_debug``'s enforcement telemetry."""
+    enforcement = debug.get("enforcement") if isinstance(debug.get("enforcement"), dict) else {}
+    raw = debug.get("raw") if isinstance(debug.get("raw"), dict) else {}
+    raw_enforcement = raw.get("enforcement") if isinstance(raw.get("enforcement"), dict) else {}
+    parse_error = raw_enforcement.get("parse_error")
+
+    score = 1.0
+    reasons: List[str] = []
+    if enforcement.get("fallback_invoked"):
+        score -= _FALLBACK_PENALTY
+        reasons.append("confidence_penalty_fallback_invoked")
+    if enforcement.get("semantic_fallback"):
+        score -= _SEMANTIC_FALLBACK_PENALTY
+        reasons.append("confidence_penalty_semantic_fallback")
+    if enforcement.get("quality_modified"):
+        score -= _QUALITY_MODIFIED_PENALTY
+        reasons.append("confidence_penalty_quality_modified")
+    if enforcement.get("normalized_applied"):
+        score -= _NORMALIZED_PENALTY
+        reasons.append("confidence_penalty_normalized_applied")
+    if parse_error:
+        score -= _PARSE_ERROR_PENALTY
+        reasons.append("confidence_penalty_parse_error")
+    return clamp01(score), reasons
+
+
+def cosine_similarity_01(a: Optional[Sequence[float]], b: Optional[Sequence[float]]) -> Optional[float]:
+    """Cosine similarity between two vectors, rescaled from [-1, 1] to [0, 1]. None if not comparable."""
+    if not a or not b or len(a) != len(b):
+        return None
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return None
+    cosine = dot / (norm_a * norm_b)
+    return clamp01((cosine + 1.0) / 2.0)

--- a/orion/signals/adapters/tests/test_chat_stance_adapter.py
+++ b/orion/signals/adapters/tests/test_chat_stance_adapter.py
@@ -1,5 +1,6 @@
 import pytest
 
+from orion.signals.adapters import chat_stance as chat_stance_module
 from orion.signals.adapters.chat_stance import ChatStanceAdapter
 from orion.signals.models import OrganClass
 from orion.signals.normalization import NormalizationContext
@@ -16,6 +17,44 @@ _BRIEF = {
     "stance_summary": "Direct technical collaboration without generic assistant tone.",
 }
 
+_CLEAN_DEBUG = {
+    "enforcement": {
+        "fallback_invoked": False,
+        "normalized_applied": False,
+        "quality_modified": False,
+        "semantic_fallback": False,
+    },
+    "raw": {"enforcement": {"parse_error": None}},
+}
+
+_DIRTY_DEBUG = {
+    "enforcement": {
+        "fallback_invoked": True,
+        "normalized_applied": True,
+        "quality_modified": False,
+        "semantic_fallback": False,
+    },
+    "raw": {"enforcement": {"parse_error": None}},
+}
+
+
+def _real_wire_payload(*, correlation_id: str, session_id: str, brief: dict, debug: dict) -> dict:
+    """Mirrors the actual production shape confirmed via a live orion:cognition:trace
+    capture: ChatStanceBrief/ChatStanceDebug live nested in a step's result dict
+    (PascalCase), and session_id lives under payload["metadata"]["session_id"] --
+    never at the payload top level in real cortex-exec output."""
+    return {
+        "correlation_id": correlation_id,
+        "metadata": {"session_id": session_id, "chat_stance_debug_present": True},
+        "steps": [
+            {"step_name": "recall_context", "result": {"RecallService": {"count": 1}}},
+            {
+                "step_name": "synthesize_chat_stance_brief",
+                "result": {"ChatStanceBrief": brief, "ChatStanceDebug": debug},
+            },
+        ],
+    }
+
 
 @pytest.fixture
 def adapter() -> ChatStanceAdapter:
@@ -27,19 +66,155 @@ def norm_ctx() -> NormalizationContext:
     return NormalizationContext()
 
 
-def test_chat_stance_adapter_from_brief(adapter: ChatStanceAdapter, norm_ctx: NormalizationContext) -> None:
-    payload = {"correlation_id": "corr-stance-1", "chat_stance_brief": _BRIEF}
+@pytest.fixture(autouse=True)
+def fake_embeddings(monkeypatch):
+    """Deterministic stand-in for vector-host: text -> a small fixed vector keyed by content."""
+
+    def _embed(text: str, **_kwargs):
+        if not text or not text.strip():
+            return None
+        # Two distinct fixed vectors so "same text" -> identical, "different text" -> different.
+        return [1.0, 0.0, 0.0] if "Direct technical" in text else [0.0, 1.0, 0.0]
+
+    monkeypatch.setattr(chat_stance_module, "embed_text", _embed)
+    yield
+
+
+def test_chat_stance_adapter_from_real_wire_shape(adapter: ChatStanceAdapter, norm_ctx: NormalizationContext) -> None:
+    """Real cortex-exec envelopes nest ChatStanceBrief/ChatStanceDebug under
+    payload["steps"][i]["result"] and session_id under payload["metadata"] --
+    confirmed via a live bus capture. The adapter must find data there, not just
+    at a flat top-level shape no real producer emits."""
+    payload = _real_wire_payload(correlation_id="c1", session_id="sess-real", brief=_BRIEF, debug=_CLEAN_DEBUG)
+    assert adapter.can_handle("orion:cognition:trace", payload) is True
+    signal = adapter.adapt("orion:cognition:trace", payload, ORGAN_REGISTRY, {}, norm_ctx)
+    assert signal is not None
+    assert signal.organ_id == "chat_stance"
+    assert signal.dimensions["confidence"] == pytest.approx(1.0)
+    assert "valence" not in signal.dimensions
+    # First turn in this session -> no prior embedding yet.
+    assert "coherence" not in signal.dimensions
+    assert any("coherence_unavailable_first_turn_in_session" in n for n in signal.notes)
+
+    # Second turn, same session, same stance text -> coherence should now be real.
+    payload_2 = _real_wire_payload(correlation_id="c2", session_id="sess-real", brief=_BRIEF, debug=_CLEAN_DEBUG)
+    signal_2 = adapter.adapt("orion:cognition:trace", payload_2, ORGAN_REGISTRY, {}, norm_ctx)
+    assert signal_2.dimensions["coherence"] == pytest.approx(1.0)
+
+
+def test_chat_stance_adapter_from_brief_no_debug(adapter: ChatStanceAdapter, norm_ctx: NormalizationContext) -> None:
+    payload = {
+        "correlation_id": "corr-stance-1",
+        "metadata": {"session_id": "sess-1"},
+        "chat_stance_brief": _BRIEF,
+    }
     signal = adapter.adapt("cortex.exec.request", payload, ORGAN_REGISTRY, {}, norm_ctx)
     assert signal is not None
     assert signal.organ_id == "chat_stance"
     assert signal.organ_class == OrganClass.endogenous
     assert signal.signal_kind == "chat_stance"
-    assert signal.dimensions["coherence"] > 0.5
-    assert "stub adapter" not in " ".join(signal.notes)
+    assert "valence" not in signal.dimensions
+    # No chat_stance_debug on this payload -> honest neutral confidence, not a task_mode lookup.
+    assert signal.dimensions["confidence"] == pytest.approx(0.5)
+    assert "no_repair_telemetry_available" in signal.notes
+    # First turn in the session -> no prior embedding to compare against.
+    assert "coherence" not in signal.dimensions
+    assert any("coherence_unavailable_first_turn_in_session" in n for n in signal.notes)
     blob = f"{signal.summary} {signal.dimensions}"
     assert "stance_summary" not in blob
     assert "Understand mesh" not in blob
     assert "generic assistant" not in blob
+
+
+def test_chat_stance_no_session_id_skips_coherence_without_fallback_bucket(
+    adapter: ChatStanceAdapter, norm_ctx: NormalizationContext
+) -> None:
+    """No session_id anywhere on the payload -> coherence must be omitted, never
+    silently compared via a shared 'global' bucket across unrelated sessions."""
+    payload = {"correlation_id": "c1", "chat_stance_brief": _BRIEF}
+    signal = adapter.adapt("cortex.exec.request", payload, ORGAN_REGISTRY, {}, norm_ctx)
+    assert "coherence" not in signal.dimensions
+    assert any("coherence_unavailable_no_session_id" in n for n in signal.notes)
+
+
+def test_chat_stance_confidence_penalized_by_real_repair_telemetry(
+    adapter: ChatStanceAdapter,
+) -> None:
+    clean_payload = {
+        "correlation_id": "c1",
+        "metadata": {"session_id": "s1"},
+        "chat_stance_brief": _BRIEF,
+        "chat_stance_debug": _CLEAN_DEBUG,
+    }
+    dirty_payload = {
+        "correlation_id": "c2",
+        "metadata": {"session_id": "s2"},
+        "chat_stance_brief": _BRIEF,
+        "chat_stance_debug": _DIRTY_DEBUG,
+    }
+
+    clean_signal = adapter.adapt("cortex.exec.request", clean_payload, ORGAN_REGISTRY, {}, NormalizationContext())
+    dirty_signal = adapter.adapt("cortex.exec.request", dirty_payload, ORGAN_REGISTRY, {}, NormalizationContext())
+
+    assert clean_signal.dimensions["confidence"] == pytest.approx(1.0)
+    assert dirty_signal.dimensions["confidence"] == pytest.approx(1.0 - 0.40 - 0.05)
+    assert any("confidence_penalty_fallback_invoked" in n for n in dirty_signal.notes)
+    assert any("confidence_penalty_normalized_applied" in n for n in dirty_signal.notes)
+
+
+def test_chat_stance_coherence_uses_prior_turn_same_session(
+    adapter: ChatStanceAdapter, norm_ctx: NormalizationContext
+) -> None:
+    session_payload = {"correlation_id": "c1", "metadata": {"session_id": "sess-1"}, "chat_stance_brief": _BRIEF}
+    first = adapter.adapt("cortex.exec.request", session_payload, ORGAN_REGISTRY, {}, norm_ctx)
+    assert "coherence" not in first.dimensions
+
+    same_stance_payload = {"correlation_id": "c2", "metadata": {"session_id": "sess-1"}, "chat_stance_brief": _BRIEF}
+    second = adapter.adapt("cortex.exec.request", same_stance_payload, ORGAN_REGISTRY, {}, norm_ctx)
+    # Same stance text as the prior turn -> identical embedding -> coherence == 1.0.
+    assert second.dimensions["coherence"] == pytest.approx(1.0)
+
+    different_brief = {**_BRIEF, "stance_summary": "Something else entirely.", "answer_strategy": "Different tack."}
+    different_payload = {
+        "correlation_id": "c3",
+        "metadata": {"session_id": "sess-1"},
+        "chat_stance_brief": different_brief,
+    }
+    third = adapter.adapt("cortex.exec.request", different_payload, ORGAN_REGISTRY, {}, norm_ctx)
+    # Orthogonal fixed vector for non-matching text -> cosine 0 -> rescaled to 0.5.
+    assert third.dimensions["coherence"] == pytest.approx(0.5)
+
+
+def test_chat_stance_coherence_scoped_per_session(adapter: ChatStanceAdapter, norm_ctx: NormalizationContext) -> None:
+    payload_a = {"correlation_id": "c1", "metadata": {"session_id": "sess-a"}, "chat_stance_brief": _BRIEF}
+    adapter.adapt("cortex.exec.request", payload_a, ORGAN_REGISTRY, {}, norm_ctx)
+
+    payload_b = {"correlation_id": "c2", "metadata": {"session_id": "sess-b"}, "chat_stance_brief": _BRIEF}
+    signal_b = adapter.adapt("cortex.exec.request", payload_b, ORGAN_REGISTRY, {}, norm_ctx)
+    # A different session has no prior embedding of its own, even though sess-a just ran.
+    assert "coherence" not in signal_b.dimensions
+    assert any("coherence_unavailable_first_turn_in_session" in n for n in signal_b.notes)
+
+
+def test_chat_stance_session_cache_is_bounded(adapter: ChatStanceAdapter, norm_ctx: NormalizationContext) -> None:
+    """A long-running gateway process must not accumulate one embedding per
+    session forever -- oldest sessions get evicted past the tracked cap."""
+    original_cap = chat_stance_module._MAX_TRACKED_SESSIONS
+    chat_stance_module._MAX_TRACKED_SESSIONS = 3
+    try:
+        for i in range(5):
+            payload = {
+                "correlation_id": f"c{i}",
+                "metadata": {"session_id": f"sess-{i}"},
+                "chat_stance_brief": _BRIEF,
+            }
+            adapter.adapt("cortex.exec.request", payload, ORGAN_REGISTRY, {}, norm_ctx)
+        tracked = norm_ctx.get_value("chat_stance", chat_stance_module._SESSION_ORDER_KEY)
+        assert tracked == ["sess-2", "sess-3", "sess-4"]
+        assert norm_ctx.get_value("chat_stance", "embedding:sess-0") is None
+        assert norm_ctx.get_value("chat_stance", "embedding:sess-4") is not None
+    finally:
+        chat_stance_module._MAX_TRACKED_SESSIONS = original_cap
 
 
 def test_chat_stance_debug_only(adapter: ChatStanceAdapter, norm_ctx: NormalizationContext) -> None:
@@ -50,5 +225,16 @@ def test_chat_stance_debug_only(adapter: ChatStanceAdapter, norm_ctx: Normalizat
     }
     signal = adapter.adapt("cognition.trace", payload, ORGAN_REGISTRY, {}, norm_ctx)
     assert signal is not None
-    assert signal.dimensions["confidence"] == 0.4
-    assert any("stance_debug_only" in n for n in signal.notes)
+    assert "valence" not in signal.dimensions
+    assert "coherence" not in signal.dimensions
+    assert signal.dimensions["confidence"] == pytest.approx(0.5)
+    assert any("stance_debug_only_no_brief" in n for n in signal.notes)
+    assert any("stance_debug_flag_only_no_object" in n for n in signal.notes)
+
+
+def test_chat_stance_debug_dict_present_without_brief(adapter: ChatStanceAdapter, norm_ctx: NormalizationContext) -> None:
+    payload = {"correlation_id": "corr-stance-3", "chat_stance_debug": _DIRTY_DEBUG}
+    signal = adapter.adapt("cognition.trace", payload, ORGAN_REGISTRY, {}, norm_ctx)
+    assert signal is not None
+    assert signal.dimensions["confidence"] == pytest.approx(1.0 - 0.40 - 0.05)
+    assert any("confidence_penalty_fallback_invoked" in n for n in signal.notes)

--- a/orion/signals/adapters/tests/test_chat_stance_scoring.py
+++ b/orion/signals/adapters/tests/test_chat_stance_scoring.py
@@ -1,0 +1,70 @@
+import pytest
+
+from orion.signals.adapters.chat_stance_scoring import (
+    cosine_similarity_01,
+    score_stance_confidence,
+)
+
+_CLEAN_ENFORCEMENT = {
+    "enforcement": {
+        "fallback_invoked": False,
+        "normalized_applied": False,
+        "quality_modified": False,
+        "semantic_fallback": False,
+    },
+    "raw": {"enforcement": {"parse_error": None}},
+}
+
+
+def test_score_stance_confidence_clean_is_full_confidence():
+    score, reasons = score_stance_confidence(_CLEAN_ENFORCEMENT)
+    assert score == pytest.approx(1.0)
+    assert reasons == []
+
+
+def test_score_stance_confidence_penalizes_each_real_flag():
+    debug = {
+        "enforcement": {
+            "fallback_invoked": True,
+            "semantic_fallback": True,
+            "quality_modified": True,
+            "normalized_applied": True,
+        },
+        "raw": {"enforcement": {"parse_error": "boom"}},
+    }
+    score, reasons = score_stance_confidence(debug)
+    # 1.0 - 0.40 - 0.25 - 0.15 - 0.05 - 0.20 = -0.05 -> clamped to 0.0
+    assert score == pytest.approx(0.0)
+    assert len(reasons) == 5
+
+
+def test_score_stance_confidence_missing_enforcement_defaults_clean():
+    score, reasons = score_stance_confidence({})
+    assert score == pytest.approx(1.0)
+    assert reasons == []
+
+
+def test_cosine_similarity_01_identical_vectors_is_one():
+    assert cosine_similarity_01([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == pytest.approx(1.0)
+
+
+def test_cosine_similarity_01_orthogonal_vectors_is_half():
+    assert cosine_similarity_01([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.5)
+
+
+def test_cosine_similarity_01_opposite_vectors_is_zero():
+    assert cosine_similarity_01([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        (None, [1.0]),
+        ([1.0], None),
+        ([], [1.0]),
+        ([1.0, 2.0], [1.0]),
+        ([0.0, 0.0], [1.0, 1.0]),
+    ],
+)
+def test_cosine_similarity_01_returns_none_when_not_comparable(a, b):
+    assert cosine_similarity_01(a, b) is None

--- a/orion/signals/normalization.py
+++ b/orion/signals/normalization.py
@@ -8,7 +8,7 @@ compatibility.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 __all__ = [
     "clamp01",
@@ -118,6 +118,17 @@ class NormalizationContext:
     def __init__(self) -> None:
         self._bands: Dict[str, Dict[str, EwmaBand]] = {}
         self._trackers: Dict[str, Dict[str, InductionTracker]] = {}
+        self._values: Dict[str, Dict[str, Any]] = {}
+
+    def get_value(self, organ_id: str, key: str) -> Optional[Any]:
+        """Arbitrary per-organ scratch state (e.g. a previous-turn embedding vector)."""
+        return self._values.get(organ_id, {}).get(key)
+
+    def set_value(self, organ_id: str, key: str, value: Any) -> None:
+        self._values.setdefault(organ_id, {})[key] = value
+
+    def delete_value(self, organ_id: str, key: str) -> None:
+        self._values.get(organ_id, {}).pop(key, None)
 
     def get_band(self, organ_id: str, metric_key: str) -> EwmaBand:
         organ_bands = self._bands.setdefault(organ_id, {})

--- a/orion/signals/registry.py
+++ b/orion/signals/registry.py
@@ -240,7 +240,7 @@ ORGAN_REGISTRY: Dict[str, OrionOrganRegistryEntry] = {
         organ_class=OrganClass.endogenous,
         service="orion-cortex-exec",
         signal_kinds=["chat_stance", "turn_effect", "metacog_residue"],
-        canonical_dimensions=["coherence", "valence", "confidence"],
+        canonical_dimensions=["coherence", "confidence"],
         causal_parent_organs=["recall", "autonomy", "equilibrium", "social_memory", "spark_introspector"],
         bus_channels=[
             "orion:cortex:exec:request",

--- a/orion/signals/tests/test_normalization_values.py
+++ b/orion/signals/tests/test_normalization_values.py
@@ -1,0 +1,32 @@
+from orion.signals.normalization import NormalizationContext
+
+
+def test_get_value_defaults_to_none():
+    ctx = NormalizationContext()
+    assert ctx.get_value("chat_stance", "missing") is None
+
+
+def test_set_then_get_value_roundtrips():
+    ctx = NormalizationContext()
+    ctx.set_value("chat_stance", "embedding:sess-1", [0.1, 0.2])
+    assert ctx.get_value("chat_stance", "embedding:sess-1") == [0.1, 0.2]
+
+
+def test_values_are_scoped_per_organ():
+    ctx = NormalizationContext()
+    ctx.set_value("chat_stance", "k", "a")
+    ctx.set_value("other_organ", "k", "b")
+    assert ctx.get_value("chat_stance", "k") == "a"
+    assert ctx.get_value("other_organ", "k") == "b"
+
+
+def test_delete_value_removes_key():
+    ctx = NormalizationContext()
+    ctx.set_value("chat_stance", "embedding:sess-1", [0.1, 0.2])
+    ctx.delete_value("chat_stance", "embedding:sess-1")
+    assert ctx.get_value("chat_stance", "embedding:sess-1") is None
+
+
+def test_delete_value_on_missing_key_is_a_no_op():
+    ctx = NormalizationContext()
+    ctx.delete_value("chat_stance", "never-set")  # must not raise

--- a/orion/signals/tests/test_vector_host_client.py
+++ b/orion/signals/tests/test_vector_host_client.py
@@ -1,0 +1,66 @@
+import pytest
+
+from orion.signals import vector_host_client
+
+
+class _FakeResponse:
+    def __init__(self, json_data, status: int = 200):
+        self._json = json_data
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+def test_embed_text_returns_none_for_blank_text():
+    assert vector_host_client.embed_text("") is None
+    assert vector_host_client.embed_text("   ") is None
+
+
+def test_embed_text_returns_vector_on_success(monkeypatch):
+    def fake_post(url, json, timeout):
+        assert url.endswith("/embedding")
+        assert json["text"] == "hello"
+        return _FakeResponse({"embedding": [0.1, 0.2, 0.3]})
+
+    monkeypatch.setattr(vector_host_client.requests, "post", fake_post)
+    result = vector_host_client.embed_text("hello", base_url="http://fake-vector-host:8320")
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_text_returns_none_on_http_error(monkeypatch):
+    def fake_post(url, json, timeout):
+        return _FakeResponse({}, status=500)
+
+    monkeypatch.setattr(vector_host_client.requests, "post", fake_post)
+    assert vector_host_client.embed_text("hello", base_url="http://fake-vector-host:8320") is None
+
+
+def test_embed_text_returns_none_on_transport_exception(monkeypatch):
+    def fake_post(url, json, timeout):
+        raise ConnectionError("no route to host")
+
+    monkeypatch.setattr(vector_host_client.requests, "post", fake_post)
+    assert vector_host_client.embed_text("hello", base_url="http://fake-vector-host:8320") is None
+
+
+def test_embed_text_returns_none_on_malformed_embedding(monkeypatch):
+    def fake_post(url, json, timeout):
+        return _FakeResponse({"embedding": "not-a-list"})
+
+    monkeypatch.setattr(vector_host_client.requests, "post", fake_post)
+    assert vector_host_client.embed_text("hello", base_url="http://fake-vector-host:8320") is None
+
+
+def test_vector_host_url_uses_env_override(monkeypatch):
+    monkeypatch.setenv(vector_host_client.ORION_VECTOR_HOST_URL_ENV, "http://custom-host:1234")
+    assert vector_host_client.vector_host_url() == "http://custom-host:1234"
+
+
+def test_vector_host_url_default_when_unset(monkeypatch):
+    monkeypatch.delenv(vector_host_client.ORION_VECTOR_HOST_URL_ENV, raising=False)
+    assert vector_host_client.vector_host_url() == vector_host_client._DEFAULT_VECTOR_HOST_URL

--- a/orion/signals/vector_host_client.py
+++ b/orion/signals/vector_host_client.py
@@ -1,0 +1,61 @@
+"""Minimal synchronous client for orion-vector-host's ``/embedding`` endpoint.
+
+Deliberately standalone -- does not reuse ``orion.spark.concept_induction.embedder``.
+That client belongs to the concept-induction subsystem; borrowing it here would
+couple an unrelated signal-adapter concern to that package's lifecycle and config.
+This module talks to vector-host directly and knows nothing else.
+
+Fails open: any network/parse error returns ``None`` rather than raising, since
+adapters run inline in orion-signal-gateway's single event loop and must never
+block the shared loop for longer than a short bounded timeout, let alone crash it.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Optional
+
+import requests
+
+logger = logging.getLogger("orion.signals.vector_host_client")
+
+ORION_VECTOR_HOST_URL_ENV = "ORION_VECTOR_HOST_URL"
+_DEFAULT_VECTOR_HOST_URL = "http://orion-athena-vector-host:8320"
+DEFAULT_TIMEOUT_SEC = 0.6
+
+
+def vector_host_url() -> str:
+    return os.environ.get(ORION_VECTOR_HOST_URL_ENV) or _DEFAULT_VECTOR_HOST_URL
+
+
+def embed_text(
+    text: str,
+    *,
+    base_url: Optional[str] = None,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+) -> Optional[List[float]]:
+    """Embed ``text`` via vector-host. Returns ``None`` on any failure -- never raises."""
+    if not text or not text.strip():
+        return None
+    url_base = base_url or vector_host_url()
+    if not url_base:
+        return None
+    url = f"{url_base.rstrip('/')}/embedding"
+    try:
+        response = requests.post(
+            url,
+            json={"doc_id": "signal-chat-stance", "text": text, "include_latent": False},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except Exception as exc:
+        logger.warning("vector_host_embed_failed url=%s error=%s", url, exc)
+        return None
+    embedding = data.get("embedding") if isinstance(data, dict) else None
+    if not isinstance(embedding, list) or not embedding:
+        return None
+    try:
+        return [float(v) for v in embedding]
+    except (TypeError, ValueError):
+        return None

--- a/services/orion-signal-gateway/.env_example
+++ b/services/orion-signal-gateway/.env_example
@@ -11,6 +11,11 @@ LOG_LEVEL=INFO
 SIGNAL_WINDOW_SEC=30.0
 SIGNALS_OUTPUT_CHANNEL=orion:signals
 
+# chat_stance adapter: orion-vector-host's /embedding endpoint, called directly
+# (bounded 0.6s timeout, fails open -- a down/slow vector-host just means the
+# chat_stance signal's coherence dimension is omitted for that turn, never a crash).
+ORION_VECTOR_HOST_URL=http://orion-athena-vector-host:8320
+
 # Optional: skip adapter emit when a passthrough for the same (organ_id, source_event_id) was recent.
 SUPPRESS_ADAPTED_WHEN_PASSTHROUGH=false
 PASSTHROUGH_DEDUPE_WINDOW_SEC=30.0

--- a/services/orion-signal-gateway/docker-compose.yml
+++ b/services/orion-signal-gateway/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - ORION_BUS_URL=${ORION_BUS_URL:-redis://orion-redis:6379/0}
       - ORION_BUS_ENABLED=${ORION_BUS_ENABLED:-true}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      # chat_stance adapter's embedding backend (orion/signals/vector_host_client.py)
+      - ORION_VECTOR_HOST_URL=${ORION_VECTOR_HOST_URL:-http://orion-athena-vector-host:8320}
       # OTLP to sidecar collector (Phase 0 wiring — matches .env_example / README)
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
       - OTEL_CONSOLE_EXPORT=${OTEL_CONSOLE_EXPORT:-false}


### PR DESCRIPTION
## Summary

- `orion/signals/adapters/chat_stance.py` previously fabricated `coherence`/`valence`/`confidence` from two hardcoded lookup tables keyed on `task_mode`/`identity_salience` enum labels — no measurement, pure relabeling.
- Live capture of a real `orion:cognition:trace` envelope confirmed this organ's real data was *also* unreachable in production the whole time: cortex-exec publishes `ChatStanceBrief`/`ChatStanceDebug` (PascalCase) nested at `payload.steps[i].result`, never at the payload top level the old extraction checked. So the lookup-table branch was dead code — only the hardcoded fallback (0.5/0.5/0.4) ever fired, for every real chat turn, forever.
- Replaced with real signal: `confidence` scored from cortex-exec's own repair/enforcement telemetry (fallback/semantic-fallback/quality-modification/normalization/parse-error flags it already computes per turn); `coherence` from cosine similarity between this turn's and the previous turn's (same session) stance-text embedding via orion-vector-host's `/embedding` endpoint directly (new minimal client, not concept-induction's embedder — different subsystem); `valence` dropped outright (no honest replacement found).
- Fixed the extraction bug alongside the math fix, since a correct formula reading no real data isn't actually fixed.

## Outcome moved

The `chat_stance` organ signal now reflects something real that happened on the turn, and actually fires for real chat turns for the first time (previously silently dead in production regardless of what the adapter's math did).

## Current architecture

`orion/signals/` is a per-organ signal-fusion library consumed by `orion-signal-gateway` (async event loop, one adapter per organ, synchronous `adapt()` calls). `chat_stance`'s real substance (`ChatStanceBrief` synthesis) lives in `services/orion-cortex-exec/app/chat_stance.py` / `executor.py`; the adapter here only consumes what cortex-exec already publishes onto the bus.

## Architecture touched

- `orion/signals/adapters/chat_stance.py` — rewritten extraction + scoring.
- `orion/signals/adapters/chat_stance_scoring.py` — new, dedicated scoring utilities.
- `orion/signals/vector_host_client.py` — new, minimal sync client for vector-host's `/embedding` endpoint.
- `orion/signals/normalization.py` — added `get_value`/`set_value`/`delete_value` (generic per-organ scratch state, bounded via the adapter's own eviction).
- `orion/signals/registry.py` — `chat_stance` organ's `canonical_dimensions` drops `valence`.
- `services/orion-signal-gateway/.env_example`, `docker-compose.yml` — new `ORION_VECTOR_HOST_URL` dependency.

## Files changed

- `orion/signals/adapters/chat_stance.py`: real extraction (nested wire shape) + real scoring, drop lookup tables and valence.
- `orion/signals/adapters/chat_stance_scoring.py`: new — `score_stance_confidence()`, `cosine_similarity_01()`.
- `orion/signals/vector_host_client.py`: new — minimal sync `/embedding` client, fails open.
- `orion/signals/normalization.py`: new `get_value`/`set_value`/`delete_value` on `NormalizationContext`.
- `orion/signals/registry.py`: drop `valence` from `chat_stance`'s `canonical_dimensions`.
- `services/orion-signal-gateway/.env_example`, `docker-compose.yml`: add `ORION_VECTOR_HOST_URL`.
- `orion/signals/adapters/tests/test_chat_stance_adapter.py`, `test_chat_stance_scoring.py`, `orion/signals/tests/test_vector_host_client.py`, `test_normalization_values.py`: new/updated tests, including one built from the real captured wire shape.

## Schema / bus / API changes

- Added: `ORION_VECTOR_HOST_URL` env key (matches existing convention used by orion-llm-gateway for the same host).
- Removed: `valence` dimension from the `chat_stance` organ signal.
- Behavior changed: `coherence`/`confidence` are now computed from real telemetry instead of static tables; `chat_stance` now actually fires for real chat turns (previously silently dead).
- Compatibility notes: `canonical_dimensions` is documentation-only, not enforced anywhere — confirmed no other code reads `dimensions["valence"]` for this organ specifically.

## Env/config changes

- Added keys: `ORION_VECTOR_HOST_URL` (`services/orion-signal-gateway/.env_example`, default `http://orion-athena-vector-host:8320`).
- `.env_example` updated: yes.
- local `.env` synced: yes (manually, since `sync_local_env_from_example.py` only updates existing `.env` files, doesn't add new keys from a fresh diff without a matching prior key — added directly).
- skipped keys requiring operator action: none.

## Tests run

```
.venv/bin/python -m pytest orion/signals/ -q          -> 90 passed
.venv/bin/python -m pytest services/orion-signal-gateway/ -q  -> 31 passed
.venv/bin/python -m pytest services/orion-cortex-exec/tests/test_chat_stance_brief.py -q  -> 19 passed (1 pre-existing test-order-dependent flake in that file confirmed unrelated to this patch via A/B stash comparison)
```

## Docker/build/smoke checks

```
scripts/safe_docker_build.sh orion-signal-gateway config  -> ORION_VECTOR_HOST_URL resolves correctly
scripts/safe_docker_build.sh orion-signal-gateway build   -> clean build
scripts/safe_docker_build.sh orion-signal-gateway up -d   -> healthy, GET /health 200
Live bus capture (redis psubscribe against the real production Redis) -> zero errors while processing real live traffic; confirmed the real orion:cognition:trace wire shape (steps[i].result.ChatStanceBrief, metadata.session_id) and built a test around it.
```

**Known gap, disclosed not hidden:** no real `chat_general` turn occurred during my observation windows (only background journal/metacog traffic was live), so the fixed code path is verified via live-shape-accurate tests + zero-error live operation, but not yet end-to-end against an actual chat turn producing a real `chat_stance` signal with computed coherence. Worth a spot-check after a real conversation happens.

## Review findings fixed

- Finding (CRITICAL): real `ChatStanceBrief`/`ChatStanceDebug`/`session_id` never reached the adapter in the only shape actually published (nested in `payload.steps[i].result`, not top-level) — confirmed via code trace + a live bus capture.
  - Fix: rewrote extraction to search `payload.steps[i].result` for the real PascalCase keys, and to read `session_id` from `payload.metadata.session_id` (the real location).
  - Evidence: new `test_chat_stance_adapter_from_real_wire_shape` test built directly from a captured live envelope; live redeploy confirmed zero errors.
- Finding (Medium): per-session embedding cache had no cap/eviction — same class of bug this repo has hit and fixed multiple times elsewhere (uncapped `evidence_event_ids`, etc.).
  - Fix: added bounded, oldest-evicted session tracking (512 sessions) plus a proper `NormalizationContext.delete_value`.
  - Evidence: `test_chat_stance_session_cache_is_bounded`.
- Finding (Low): a `"global"` session fallback would have silently merged unrelated sessions once real data started flowing.
  - Fix: coherence is now skipped entirely (with a note) when no real `session_id` is present, never bucketed.
  - Evidence: `test_chat_stance_no_session_id_skips_coherence_without_fallback_bucket`.

## Restart required

```bash
# Already rebuilt/redeployed live during this session's verification:
cd /mnt/scripts/Orion-Sapienform-chat-stance-real-signal
scripts/safe_docker_build.sh orion-signal-gateway build
scripts/safe_docker_build.sh orion-signal-gateway up -d
```

## Risks / concerns

- Severity: Low
- Concern: `adapt()` is called synchronously from `orion-signal-gateway`'s single async event loop; the new embedding call blocks that loop for up to 0.6s per `chat_stance` event.
- Mitigation: chat_stance events are per-turn, not per-tick (low frequency); the client fails open on timeout/error so a slow/down vector-host degrades to "no coherence" rather than hanging or crashing.

## PR link

(filled in by `gh pr create` output below)