### PR TITLE
fix(field-digester): bus_health/delivery_confidence are single-observer, not per-node

### DIFF
--- a/config/field/field_channel_glossary.v1.yaml
+++ b/config/field/field_channel_glossary.v1.yaml
@@ -138,13 +138,13 @@ channels:
   - channel: delivery_confidence
     level: [node]
     category: sensor_trust_liveness
-    meaning: "Confidence that bus messages are actually being delivered end-to-end."
+    meaning: "Confidence that bus messages are actually being delivered end-to-end. Single-observer channel (2026-07-22): only node:athena's bus-observer ever reports this -- atlas/circe/prometheus have no code path that could produce a real reading and are excluded from the merge entirely (SINGLE_OBSERVER_NODE_CHANNELS, services/orion-field-digester/app/tensor/channels.py), not defaulted to a placeholder value."
     evidence_dimension: coherence
 
   - channel: bus_health
     level: [node]
     category: sensor_trust_liveness
-    meaning: "Overall bus/transport subsystem health signal."
+    meaning: "Overall bus/transport subsystem health signal. Single-observer channel (2026-07-22): only node:athena's bus-observer ever reports this -- atlas/circe/prometheus have no code path that could produce a real reading and are excluded from the merge entirely (SINGLE_OBSERVER_NODE_CHANNELS, services/orion-field-digester/app/tensor/channels.py), not defaulted to a placeholder value."
     evidence_dimension: coherence
 
   - channel: observer_failure_pressure

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -778,34 +778,54 @@ subset for the mood-arc windowed-autoencoder spike (see
 - **Meaning**: confidence that bus messages are actually being delivered
   end-to-end.
 - **Producer**: `transport_bus` delta, `hints["delivery_confidence"]`,
-  mode=`add` (default). **Not** in `NODE_DECAY_CHANNELS` — one-way ratchet
-  mechanism. Diffuses into `capability:transport`'s `"confidence"` field
-  (weight `0.85`, from `node:athena`) — the only capability with a direct
-  diffusion edge into `confidence`.
+  mode=`replace` (fixed prior to this session — the mode=`add` one-way
+  ratchet described below in the 2026-07-16 verdict no longer applies; see
+  `bus_health`/`delivery_confidence`'s existing correct handling" in the
+  cutoff section above). **Not** in `NODE_DECAY_CHANNELS` — a "current
+  reading" score with no decay story, same as `availability`. Diffuses into
+  `capability:transport`'s `"confidence"` field (weight `0.85`, from
+  `node:athena`) — the only capability with a direct diffusion edge into
+  `confidence`.
+- **Single-observer node channel (2026-07-22)**: only `node:athena`'s
+  bus-observer can ever produce a real reading for this channel —
+  atlas/circe/prometheus run llamacpp-host + biometrics only, with no code
+  path that could ever legitimately report bus/delivery state.
+  `collect_field_channel_pressures()` merges `delivery_confidence` across
+  all 4 lattice nodes via `min()` (it's a `HIGHER_IS_BETTER_CHANNELS`
+  entry), and a stale pre-2026-07-17 `0.0` already persisted on a
+  non-reporting node could never self-correct (reconcile only fills in
+  *missing* channels, it doesn't overwrite an already-present stale value).
+  Confirmed live: `node:athena` reported a real, fresh `1.0` continuously
+  while the merged corpus/`SelfStateV1` `coherence` dimension read `0.0`,
+  masked by `node:atlas`'s stale, never-updated entry.
+  `SINGLE_OBSERVER_NODE_CHANNELS` (`app/tensor/channels.py`) now makes this
+  explicit: `reconcile.py`'s `_ensure_node_vector()` prunes this channel
+  from every node except its owner on every tick — self-healing, no manual
+  data migration needed. `orion/self_state/transport.py`'s
+  `transport_channel_hints()` already read this channel from `node:athena`
+  directly (never merged) and was unaffected by the bug.
 - **SelfState dimension fed**: not in `channel_dimension_map` directly (the
   capability-level `confidence` field it feeds is the one mapped — see
   `confidence` below). `evidence_channel_map`: `delivery_confidence` →
-  `coherence` (evidence-only).
-- **Live-data verdict**: one-way ratchet — same mechanism as
-  `expected_offline_suppression` (mode=`add`, missing from
-  `NODE_DECAY_CHANNELS`); currently benign since the bus is genuinely
-  stable, but structurally could never show a real dip. Confirmed live
-  2026-07-16.
+  `coherence` (evidence-only) — this is the dimension the stale-mask bug
+  above was corrupting.
 
 #### `bus_health`
 - **Meaning**: overall bus/transport subsystem health signal.
-- **Producer**: `transport_bus` delta, `hints["bus_health"]`, mode=`add`.
-  **Not** in `NODE_DECAY_CHANNELS` — same one-way-ratchet mechanism.
+- **Producer**: `transport_bus` delta, `hints["bus_health"]`, mode=`replace`
+  (fixed prior to this session — see `delivery_confidence` above). **Not**
+  in `NODE_DECAY_CHANNELS` — same "current reading, no decay" reasoning.
   Diffuses into `capability:transport`'s `"available_capacity"` field
   (weight `0.85`, from `node:athena`) — the only capability with a direct
   diffusion edge into `available_capacity`.
+- **Single-observer node channel (2026-07-22)**: identical fix and
+  rationale as `delivery_confidence` above — see that entry.
+  `SINGLE_OBSERVER_NODE_CHANNELS` covers both channels together.
 - **SelfState dimension fed**: not in `channel_dimension_map` directly (the
   capability-level `available_capacity` field it feeds is the one mapped —
   see `available_capacity` below). `evidence_channel_map`: `bus_health` →
-  `coherence` (evidence-only).
-- **Live-data verdict**: one-way ratchet, same mechanism as
-  `delivery_confidence`/`expected_offline_suppression` — currently benign,
-  structurally could never dip. Confirmed live 2026-07-16.
+  `coherence` (evidence-only) — this is the dimension the stale-mask bug
+  above was corrupting.
 
 #### `observer_failure_pressure`
 - **Meaning**: pressure from failures of the bus "observer" role

--- a/services/orion-field-digester/app/tensor/channels.py
+++ b/services/orion-field-digester/app/tensor/channels.py
@@ -36,23 +36,63 @@ CAPABILITY_CHANNELS = [
 
 DEFAULT_NODE_VECTOR = {ch: 0.0 for ch in NODE_CHANNELS}
 DEFAULT_NODE_VECTOR["availability"] = 1.0
-# Merge-polarity fix follow-up (2026-07-17, live post-deploy verification).
-# bus_health/delivery_confidence are HIGHER_IS_BETTER_CHANNELS
-# (orion/self_state/scoring.py) -- collect_field_channel_pressures() merges
-# them via min() (worst node wins), same as availability above. Only
-# node:athena (the transport-bus observer node) ever actually reports these;
-# every other lattice node inherited the blanket 0.0 default every other
-# channel in NODE_CHANNELS gets. Under the OLD max()-merge this was inert (a
-# real report always beat 0.0). Under min()-merge it's actively wrong: any
-# untouched node's meaningless 0.0 always wins over athena's real 1.0,
-# permanently masking real bus-health data with a false "unhealthy" reading
-# -- confirmed live: substrate_transport_bus_projection showed
-# bus_health=1.0/delivery_confidence=1.0 for node:athena while the merged
-# field_channel_corpus.v1 row read 0.0 for both, 100% of rows, for the
-# entire post-deploy window. Match availability's existing precedent: a node
-# that has never reported is "presumed healthy," not "worst possible."
+# Kept at 1.0 (see SINGLE_OBSERVER_NODE_CHANNELS below): this is the
+# "presumed healthy until first real report" default for node:athena itself
+# the very first time it reconciles, before its own bus-observer has ever
+# reported. It's no longer reached by any other node -- see below.
 DEFAULT_NODE_VECTOR["bus_health"] = 1.0
 DEFAULT_NODE_VECTOR["delivery_confidence"] = 1.0
+
+# Design correction (2026-07-22): bus_health/delivery_confidence were
+# modeled as ordinary per-node NODE_CHANNELS, merged across every lattice
+# node via min() (orion/self_state/scoring.py's HIGHER_IS_BETTER_CHANNELS
+# handling -- worst node wins). But there is exactly one bus, it runs on
+# athena, and only athena's bus-observer service (BUS_OBSERVER_NODE_ID)
+# ever produces a real reading -- atlas/circe run llamacpp-host + biometrics
+# only, prometheus likewise, none of them have any code path that could
+# ever legitimately report bus health. They aren't "nodes with an
+# unreported bus health," they have no standing to have an opinion on it at
+# all. The 2026-07-17 fix (default 0.0 -> 1.0, see git history) treated
+# this as a data problem -- pick a less-wrong default for the non-reporting
+# nodes -- and it was live-verified to work for *newly* reconciled nodes.
+# But reconcile's _ensure_node_vector() preserves any already-persisted
+# value over the template default, so pre-fix-era stale 0.0 entries already
+# sitting in atlas/circe/prometheus's node_vectors from before that patch
+# deployed could never self-correct -- confirmed live 2026-07-22: athena's
+# real, fresh transport_bus_reducer report was bus_health=1.0/
+# delivery_confidence=1.0, but atlas's persisted entry was a still-0.0
+# value from before the fix with node_vector_updated_at=None (never once
+# perturbed), and the min()-merge let that meaningless stale reading
+# permanently mask athena's real, healthy one -- feeding a false
+# "unhealthy"/coherence-degrading signal into every SelfStateV1 coherence
+# score (config/self_state/self_state_policy.v1.yaml maps both channels to
+# `coherence`) for as long as field-digester has been running this schema.
+#
+# The real fix: stop treating this as a 4-way merge at all.
+# SINGLE_OBSERVER_NODE_CHANNELS below is consulted by reconcile.py's
+# _ensure_node_vector() to (a) never seed these two channels onto any node
+# but their owner, and (b) actively prune them from any other node's
+# vector every reconcile tick -- self-healing, no manual data migration
+# needed. orion/self_state/transport.py's transport_channel_hints() already
+# reads bus_health/delivery_confidence from node:athena directly (never
+# merged across nodes) and was unaffected by this bug; this fix brings
+# collect_field_channel_pressures()'s merge in line with that same
+# single-observer assumption instead of leaving two different mental
+# models of the same two channels live in the codebase at once.
+#
+# "node:athena" is hardcoded, same as orion/self_state/transport.py's
+# existing precedent -- not derived from BUS_OBSERVER_NODE_ID (services/
+# orion-bus/app/settings.py, default "athena"). If that env var is ever
+# changed on a real deployment, a genuinely different node would start
+# producing real transport_bus deltas and this map would silently prune
+# them every reconcile tick instead of masking a stale value -- a
+# resurrection of this same bug class in a new shape. Pre-existing risk
+# (not introduced by this fix), flagged here since this is now the second
+# place carrying the assumption.
+SINGLE_OBSERVER_NODE_CHANNELS: dict[str, str] = {
+    "bus_health": "node:athena",
+    "delivery_confidence": "node:athena",
+}
 
 DEFAULT_CAPABILITY_VECTOR = {ch: 0.0 for ch in CAPABILITY_CHANNELS}
 DEFAULT_CAPABILITY_VECTOR["confidence"] = 1.0

--- a/services/orion-field-digester/app/tensor/reconcile.py
+++ b/services/orion-field-digester/app/tensor/reconcile.py
@@ -10,6 +10,7 @@ from app.tensor.channels import (
     DEFAULT_CAPABILITY_VECTOR,
     DEFAULT_NODE_VECTOR,
     NODE_CHANNELS,
+    SINGLE_OBSERVER_NODE_CHANNELS,
 )
 
 
@@ -26,6 +27,17 @@ def _ensure_node_vector(
     for key, val in existing.items():
         if key not in NODE_CHANNELS:
             merged[key] = val
+    # SINGLE_OBSERVER_NODE_CHANNELS (channels.py): some channels can only
+    # ever be legitimately reported by one specific node (bus_health/
+    # delivery_confidence -> node:athena, the only bus-observer). Every
+    # other node gets the key pruned here, every tick -- not just skipped
+    # at seed time -- so a stale value already persisted on a non-owner
+    # node from before this channel was added to this set (or from before
+    # its owner was assigned) self-heals on the next reconcile instead of
+    # living forever via the "preserve any existing key" loop above.
+    for channel, owner_node_id in SINGLE_OBSERVER_NODE_CHANNELS.items():
+        if node_id != owner_node_id:
+            merged.pop(channel, None)
     node_vectors[node_id] = merged
     return merged
 

--- a/services/orion-field-digester/tests/test_reconcile_single_observer_channels.py
+++ b/services/orion-field-digester/tests/test_reconcile_single_observer_channels.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.graph.lattice import LatticeGraph
+from app.tensor.channels import SINGLE_OBSERVER_NODE_CHANNELS
+from app.tensor.reconcile import _ensure_node_vector, reconcile_field_state_with_lattice
+
+from orion.schemas.field_state import FieldStateV1
+
+NOW = datetime(2026, 7, 22, tzinfo=timezone.utc)
+
+
+def _lattice(nodes: list[str]) -> LatticeGraph:
+    return LatticeGraph(nodes=nodes, capabilities=[], edges=[])
+
+
+def _state(node_vectors: dict[str, dict[str, float]] | None = None) -> FieldStateV1:
+    return FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_reconcile_test",
+        node_vectors=node_vectors or {},
+        edges=[],
+    )
+
+
+def test_owner_node_gets_seeded_with_single_observer_channels() -> None:
+    vec = _ensure_node_vector({}, "node:athena")
+    for channel in SINGLE_OBSERVER_NODE_CHANNELS:
+        assert channel in vec
+
+
+def test_non_owner_node_never_gets_single_observer_channels_seeded() -> None:
+    vec = _ensure_node_vector({}, "node:atlas")
+    for channel in SINGLE_OBSERVER_NODE_CHANNELS:
+        assert channel not in vec
+
+
+def test_stale_pre_fix_value_on_non_owner_node_self_heals_on_reconcile() -> None:
+    """The live bug this fix closes: a non-owner node (atlas) already had a
+    stale bus_health=0.0/delivery_confidence=0.0 persisted from before this
+    fix existed. reconcile must actively prune it, not just stop adding it
+    to new nodes -- the pre-existing "preserve any existing key" behavior
+    would otherwise carry it forward forever."""
+    node_vectors = {
+        "node:atlas": {"bus_health": 0.0, "delivery_confidence": 0.0, "cpu_pressure": 0.3},
+    }
+    vec = _ensure_node_vector(node_vectors, "node:atlas")
+    assert "bus_health" not in vec
+    assert "delivery_confidence" not in vec
+    # Unrelated, legitimately-per-node channels are untouched.
+    assert vec["cpu_pressure"] == 0.3
+
+
+def test_owner_nodes_real_value_is_preserved_across_reconcile() -> None:
+    node_vectors = {
+        "node:athena": {"bus_health": 1.0, "delivery_confidence": 1.0},
+    }
+    vec = _ensure_node_vector(node_vectors, "node:athena")
+    assert vec["bus_health"] == 1.0
+    assert vec["delivery_confidence"] == 1.0
+
+
+def test_full_reconcile_prunes_stale_values_across_the_whole_lattice() -> None:
+    """End-to-end: reconcile_field_state_with_lattice() over a 4-node
+    lattice (matching the real athena/atlas/circe/prometheus topology)
+    leaves only node:athena carrying bus_health/delivery_confidence."""
+    state = _state(
+        node_vectors={
+            "node:atlas": {"bus_health": 0.0, "delivery_confidence": 0.0},
+            "node:circe": {"bus_health": 0.0, "delivery_confidence": 0.0},
+            "node:athena": {"bus_health": 1.0, "delivery_confidence": 1.0},
+            "node:prometheus": {"bus_health": 0.0, "delivery_confidence": 0.0},
+        }
+    )
+    lattice = _lattice(["node:atlas", "node:circe", "node:athena", "node:prometheus"])
+    updated = reconcile_field_state_with_lattice(state, lattice=lattice)
+
+    for node_id in ["node:atlas", "node:circe", "node:prometheus"]:
+        assert "bus_health" not in updated.node_vectors[node_id]
+        assert "delivery_confidence" not in updated.node_vectors[node_id]
+    assert updated.node_vectors["node:athena"]["bus_health"] == 1.0
+    assert updated.node_vectors["node:athena"]["delivery_confidence"] == 1.0

--- a/tests/test_field_topology_reconciliation.py
+++ b/tests/test_field_topology_reconciliation.py
@@ -95,34 +95,46 @@ def test_reconciled_state_validates() -> None:
     assert roundtrip.tick_id == "tick_stale"
 
 
-def test_reconcile_seeds_bus_health_and_delivery_confidence_to_one_not_zero() -> None:
-    # Regression guard, live post-deploy finding (2026-07-17): bus_health/
-    # delivery_confidence are HIGHER_IS_BETTER_CHANNELS (min()-wins merge,
-    # orion/self_state/scoring.py) but were missing from DEFAULT_NODE_VECTOR's
-    # per-channel override table -- every node got the generic 0.0 default
-    # from `{ch: 0.0 for ch in NODE_CHANNELS}`. Only node:athena (the
-    # transport-bus observer) ever reports a real value for these two
-    # channels; every other lattice node's untouched 0.0 always won the
-    # min()-merge, permanently masking athena's real reading regardless of
-    # actual bus health. Confirmed live: substrate_transport_bus_projection
-    # showed bus_health=1.0 for node:athena while the merged
-    # field_channel_corpus.v1 row read 0.0, 100% of rows, for the entire
-    # post-deploy window -- this test reproduces that exact shape.
+def test_reconcile_scopes_bus_health_and_delivery_confidence_to_node_athena_only() -> None:
+    # Design correction (2026-07-22), superseding the 2026-07-17 fix this
+    # test used to guard. That fix (default 0.0 -> 1.0 for non-reporting
+    # nodes) treated the symptom as a data problem, but it only helped
+    # *newly* reconciled nodes -- reconcile's "preserve any existing value"
+    # behavior meant a node with an already-persisted stale 0.0 from before
+    # that patch deployed could never self-correct. Confirmed live: athena's
+    # real, fresh report was bus_health=1.0, but atlas's persisted 0.0 (never
+    # once perturbed, from before the fix) still won the min()-merge and
+    # permanently masked it in field_channel_corpus.v1 and every SelfStateV1
+    # coherence score (self_state_policy.v1.yaml maps both channels to
+    # `coherence`).
+    #
+    # The real fix: there is exactly one bus, it runs on athena, and only
+    # athena's bus-observer ever produces a real reading -- atlas/circe/
+    # prometheus have no standing to have an opinion on bus health at all.
+    # SINGLE_OBSERVER_NODE_CHANNELS (app/tensor/channels.py) makes this
+    # explicit: only node:athena ever gets these two channels seeded, and
+    # they're actively pruned from every other node on every reconcile tick
+    # -- self-healing for exactly the stale-persisted-value case above,
+    # without needing a manual data migration.
     lattice = load_lattice(LATTICE_PATH)
     state = FieldStateV1(
         generated_at=FIXED_TS,
         tick_id="tick_bus_health_default",
-        node_vectors={"node:athena": {"bus_health": 1.0, "delivery_confidence": 1.0}},
+        node_vectors={
+            "node:athena": {"bus_health": 1.0, "delivery_confidence": 1.0},
+            # Simulates the live bug: a stale pre-fix 0.0 already persisted
+            # on a non-owner node.
+            "node:atlas": {"bus_health": 0.0, "delivery_confidence": 0.0},
+        },
     )
     reconciled = reconcile_field_state_with_lattice(state, lattice=lattice)
-    # Every other lattice node must be seeded to 1.0 (presumed healthy until
-    # reported otherwise), matching `availability`'s existing precedent --
-    # not the generic 0.0 every other untouched channel gets.
+    # Every other lattice node must have no opinion at all -- not a default
+    # value, an absent key -- so it can never win (or lose) the min()-merge.
     for node_id, vec in reconciled.node_vectors.items():
         if node_id == "node:athena":
             continue
-        assert vec.get("bus_health") == 1.0, f"{node_id} bus_health should default to 1.0, not mask a real report"
-        assert vec.get("delivery_confidence") == 1.0, f"{node_id} delivery_confidence should default to 1.0"
+        assert "bus_health" not in vec, f"{node_id} should have no bus_health entry at all"
+        assert "delivery_confidence" not in vec, f"{node_id} should have no delivery_confidence entry at all"
 
     channels, _ = collect_field_channel_pressures(reconciled)
     assert channels["bus_health"] == 1.0


### PR DESCRIPTION
## Summary

- Re-auditing the 16 `field_channel_anomaly.v2` trained channels against live post-PR#1248 data surfaced a separate bug outside the trained set: `bus_health`/`delivery_confidence` were modeled as ordinary per-node `NODE_CHANNELS`, merged across all 4 lattice nodes via `min()` (worst node wins). But there's exactly one bus, running on athena, and only athena's bus-observer ever produces a real reading — atlas/circe run llamacpp-host + biometrics only, prometheus likewise, none have a code path that could ever legitimately report bus health.
- A 2026-07-17 fix already changed the non-reporting-node default from `0.0` to `1.0`, but `reconcile.py`'s `_ensure_node_vector()` preserves any already-persisted value over the template default — nodes with a stale pre-fix `0.0` could never self-correct.
- Confirmed live: `node:athena` reported a real, fresh `1.0` continuously (from live `transport_bus_reducer` receipts) while `node:atlas`'s persisted entry was still `0.0` with `node_vector_updated_at=None` (never once perturbed), and the `min()`-merge let that stale, meaningless reading permanently mask athena's real healthy one — feeding a false "unhealthy" signal into `SelfStateV1`'s `coherence` dimension the entire time (`self_state_policy.v1.yaml` maps both channels to `coherence`).
- Real fix: `SINGLE_OBSERVER_NODE_CHANNELS` (new constant in `channels.py`) makes the single-observer assumption explicit. `reconcile.py`'s `_ensure_node_vector()` now actively prunes these two channels from every node but their owner on every reconcile tick — self-healing, no manual data migration needed — instead of patching the symptom with a better default.

## Outcome moved

`SelfStateV1`'s `coherence` dimension was being permanently dragged down by a stale, meaningless reading from nodes that structurally can't produce this signal — a live, currently-active cognition-facing bug, not a dormant data-quality issue. After this fix, `coherence` reflects athena's real bus health instead of atlas's frozen stale default.

## Current architecture

`collect_field_channel_pressures()` (`orion/self_state/scoring.py`) merges `field.node_vectors` across all lattice nodes into one channel-keyed dict, using `min()` for `HIGHER_IS_BETTER_CHANNELS` (worst node wins) and `max()` for pressure-type channels. `reconcile_field_state_with_lattice()` (`services/orion-field-digester/app/tensor/reconcile.py`) seeds every node with a full `NODE_CHANNELS` template on every tick, preserving any already-persisted value over the template default.

## Architecture touched

`services/orion-field-digester` only (`app/tensor/channels.py`, `app/tensor/reconcile.py`), plus docs (`config/field/field_channel_glossary.v1.yaml`, `services/orion-field-digester/README.md`) and a root-level test (`tests/test_field_topology_reconciliation.py`). No schema/bus/API/env changes.

## Files changed

- `services/orion-field-digester/app/tensor/channels.py`: added `SINGLE_OBSERVER_NODE_CHANNELS = {"bus_health": "node:athena", "delivery_confidence": "node:athena"}`, replaced the now-superseded 2026-07-17-fix comment with the corrected design rationale.
- `services/orion-field-digester/app/tensor/reconcile.py`: `_ensure_node_vector()` now prunes `SINGLE_OBSERVER_NODE_CHANNELS` entries from any non-owner node, every tick.
- `services/orion-field-digester/tests/test_reconcile_single_observer_channels.py` (new): owner-seeding, non-owner-never-seeded, stale-value self-heal (the actual live bug), owner-value-preserved, and a full 4-node end-to-end reconcile.
- `tests/test_field_topology_reconciliation.py`: rewrote `test_reconcile_seeds_bus_health_and_delivery_confidence_to_one_not_zero` (asserted the now-incorrect "defaults to 1.0" behavior) into `test_reconcile_scopes_bus_health_and_delivery_confidence_to_node_athena_only` (asserts key-absence on non-owner nodes, including a simulated stale pre-fix value that must self-heal).
- `config/field/field_channel_glossary.v1.yaml`: documented the single-observer scoping for both channels (feeds Hub's live "Field Channels" tab).
- `services/orion-field-digester/README.md`: updated the `bus_health`/`delivery_confidence` glossary entries with the single-observer fix; also corrected two stale claims found while editing (both channels' producer mode was documented as `add`, the pre-2026-07-17 state — both were already fixed to `replace` before this session).

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
cd services/orion-field-digester && /mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest tests/ -q
135 passed, 6 warnings in 3.93s

PYTHONPATH=services/orion-field-digester /mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest tests/test_field_topology_reconciliation.py -q
6 passed in 0.27s

/mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest tests/test_self_state_deviation.py tests/test_field_channel_glossary.py tests/test_field_channel_corpus_schema.py tests/test_self_state_transport_dimension.py tests/test_self_state_builder.py tests/test_self_state_reliability_decontamination.py tests/test_self_state_prediction.py tests/test_self_state_policy_loader.py tests/test_self_state_builder_hardening.py tests/test_self_state_runtime_store.py tests/test_self_state_scoring.py tests/test_self_state_schemas.py -q
78 passed, 1 warning in 1.91s
```

## Evals run

No eval harness for this seam; unit-test-covered only. Live post-deploy verification (re-pull `substrate_field_state`'s `node_vectors`, confirm atlas/circe/prometheus no longer carry `bus_health`/`delivery_confidence` keys and the merged corpus reflects athena's real value) is the practical eval, called out under Restart required below.

## Docker/build/smoke checks

Not run from this worktree — no compose/env/Dockerfile changes in this PR, so a `config` check would be a no-op. Restart is required for the runtime fix (reconcile logic) to take effect.

## Review findings fixed

- Finding: `SINGLE_OBSERVER_NODE_CHANNELS`'s hardcoded `"node:athena"` could drift out of sync with `BUS_OBSERVER_NODE_ID` if that env var is ever changed on a real deployment.
  - Fix: not code-fixed (pre-existing pattern — `orion/self_state/transport.py` already hardcodes `"node:athena"` the same way) — documented as a known, pre-existing risk in a comment in `channels.py` rather than silently left unflagged.
  - Evidence: comment added, reviewed and confirmed as the correct call given the existing precedent.
- Reviewed and confirmed safe (no fix needed): `transport_channel_hints()`'s fallback chain still works correctly if `node:athena` itself ever lacks the key; no other module direct-indexes `node_vectors[...]["bus_health"]` (all use `.get()`); no other `target_kind` branch or test fixture writes these channels onto a non-athena node, so nothing else needed updating to match the new pruning behavior.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build orion-field-digester
```

Post-restart verification:
```bash
# Confirm atlas/circe/prometheus no longer carry bus_health/delivery_confidence at all
PGPASSWORD=postgres psql -h localhost -p 55432 -U postgres -d conjourney -c \
  "select field_json->'node_vectors' from substrate_field_state order by generated_at desc limit 1;"
```

## Risks / concerns

- Severity: low
- Concern: `SINGLE_OBSERVER_NODE_CHANNELS`'s owner is hardcoded to `"node:athena"` rather than derived from `BUS_OBSERVER_NODE_ID`.
- Mitigation: matches existing precedent (`orion/self_state/transport.py`), not a regression introduced by this patch; flagged in a code comment for future reference if `BUS_OBSERVER_NODE_ID` is ever changed on a real deployment.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/bus-health-single-observer-node