### PR TITLE
URGENT: guard frame loaders against pre-migration rows (live outage)

### DIFF
--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -49,7 +49,46 @@ class ExecutionDispatchRuntimeStore:
         payload = row["policy_decision_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return PolicyDecisionFrameV1.model_validate(payload)
+        try:
+            return PolicyDecisionFrameV1.model_validate(payload)
+        except ValidationError:
+            # This is the FIFO "oldest undispatched policy frame" lookup --
+            # a naive None-degrade would re-select this exact row forever
+            # (it can never validate), permanently blocking every policy
+            # frame queued behind it. A schema migration (e.g. 2026-07-22's
+            # SelfStateV1 burn) can leave historical rows like this
+            # incompatible with the currently-running PolicyDecisionFrameV1.
+            # Retire it with a stub, unattempted dispatch frame so the FIFO
+            # advances past it.
+            raw_frame_id = payload.get("frame_id") if isinstance(payload, dict) else None
+            raw_proposal_frame_id = (
+                payload.get("source_proposal_frame_id") if isinstance(payload, dict) else None
+            )
+            logger.warning(
+                "policy_decision_frame_incompatible_schema fifo_lookup frame_id=%s",
+                raw_frame_id,
+                exc_info=True,
+            )
+            if raw_frame_id:
+                self._retire_incompatible_policy_frame(raw_frame_id, raw_proposal_frame_id)
+            return None
+
+    def _retire_incompatible_policy_frame(
+        self, raw_frame_id: str, raw_proposal_frame_id: str | None
+    ) -> None:
+        """Insert a stub, unattempted execution_dispatch_frame for a policy
+        frame that failed schema validation, so
+        load_latest_policy_frame_without_dispatch's FIFO lookup doesn't
+        re-select this exact row forever."""
+        stub = ExecutionDispatchFrameV1(
+            frame_id=f"execution.dispatch.frame:{raw_frame_id}:schema_incompatible",
+            generated_at=datetime.now(timezone.utc),
+            source_policy_frame_id=raw_frame_id,
+            source_proposal_frame_id=raw_proposal_frame_id or "unknown",
+            dispatch_attempted=False,
+            warnings=["source_policy_frame_schema_incompatible"],
+        )
+        self.save_dispatch_frame(stub)
 
     def load_proposal_frame(self, frame_id: str) -> ProposalFrameV1 | None:
         with self._engine.connect() as conn:
@@ -72,7 +111,13 @@ class ExecutionDispatchRuntimeStore:
         payload = row["proposal_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ProposalFrameV1.model_validate(payload)
+        try:
+            return ProposalFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning(
+                "proposal_frame_incompatible_schema frame_id=%s", frame_id, exc_info=True
+            )
+            return None
 
     def load_dispatch_frame_for_policy_frame(
         self, policy_frame_id: str

--- a/services/orion-feedback-runtime/app/store.py
+++ b/services/orion-feedback-runtime/app/store.py
@@ -115,7 +115,13 @@ class FeedbackRuntimeStore:
         payload = row["policy_decision_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return PolicyDecisionFrameV1.model_validate(payload)
+        try:
+            return PolicyDecisionFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning(
+                "policy_decision_frame_incompatible_schema frame_id=%s", frame_id, exc_info=True
+            )
+            return None
 
     def load_proposal_frame(self, frame_id: str) -> ProposalFrameV1 | None:
         with self._engine.connect() as conn:
@@ -139,7 +145,11 @@ class FeedbackRuntimeStore:
         payload = row["proposal_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ProposalFrameV1.model_validate(payload)
+        try:
+            return ProposalFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning("proposal_frame_incompatible_schema frame_id=%s", frame_id, exc_info=True)
+            return None
 
     def load_field_for_tick(self, tick_id: str) -> FieldStateV1 | None:
         """2026-07-22 (SelfStateV1 burn): replaces load_self_state. Looks up
@@ -233,7 +243,11 @@ class FeedbackRuntimeStore:
         payload = row["feedback_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return FeedbackFrameV1.model_validate(payload)
+        try:
+            return FeedbackFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning("feedback_frame_incompatible_schema latest_lookup", exc_info=True)
+            return None
 
     def load_feedback_frame_for_dispatch(self, dispatch_frame_id: str) -> FeedbackFrameV1 | None:
         with self._engine.connect() as conn:
@@ -258,7 +272,15 @@ class FeedbackRuntimeStore:
         payload = row["feedback_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return FeedbackFrameV1.model_validate(payload)
+        try:
+            return FeedbackFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning(
+                "feedback_frame_incompatible_schema dispatch_frame_id=%s",
+                dispatch_frame_id,
+                exc_info=True,
+            )
+            return None
 
     def load_cortex_result_evidence(
         self, dispatch_frame: ExecutionDispatchFrameV1

--- a/services/orion-hub/scripts/substrate_feedback_routes.py
+++ b/services/orion-hub/scripts/substrate_feedback_routes.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 
 from orion.schemas.feedback_frame import FeedbackFrameV1
@@ -38,7 +39,13 @@ def _load_latest_feedback_frame() -> FeedbackFrameV1 | None:
     payload = row["feedback_frame_json"]
     if isinstance(payload, str):
         payload = json.loads(payload)
-    return FeedbackFrameV1.model_validate(payload)
+    try:
+        return FeedbackFrameV1.model_validate(payload)
+    except ValidationError:
+        # A pre-migration row (e.g. 2026-07-22's SelfStateV1 burn) can be
+        # incompatible with the currently-running FeedbackFrameV1 -- degrade
+        # to "not found" instead of 500ing this debug endpoint.
+        return None
 
 
 @router.get("/latest")

--- a/services/orion-hub/scripts/substrate_policy_routes.py
+++ b/services/orion-hub/scripts/substrate_policy_routes.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
@@ -38,7 +39,13 @@ def _load_latest_policy_frame() -> PolicyDecisionFrameV1 | None:
     payload = row["policy_decision_frame_json"]
     if isinstance(payload, str):
         payload = json.loads(payload)
-    return PolicyDecisionFrameV1.model_validate(payload)
+    try:
+        return PolicyDecisionFrameV1.model_validate(payload)
+    except ValidationError:
+        # A pre-migration row (e.g. 2026-07-22's SelfStateV1 burn) can be
+        # incompatible with the currently-running PolicyDecisionFrameV1 --
+        # degrade to "not found" instead of 500ing this debug endpoint.
+        return None
 
 
 @router.get("/latest")

--- a/services/orion-hub/scripts/substrate_proposal_routes.py
+++ b/services/orion-hub/scripts/substrate_proposal_routes.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 
 from orion.schemas.proposal_frame import ProposalFrameV1
@@ -37,7 +38,13 @@ def _load_latest_proposal_frame() -> ProposalFrameV1 | None:
     payload = row["proposal_frame_json"]
     if isinstance(payload, str):
         payload = json.loads(payload)
-    return ProposalFrameV1.model_validate(payload)
+    try:
+        return ProposalFrameV1.model_validate(payload)
+    except ValidationError:
+        # A pre-migration row (e.g. 2026-07-22's SelfStateV1 burn) can be
+        # incompatible with the currently-running ProposalFrameV1 -- degrade
+        # to "not found" instead of 500ing this debug endpoint.
+        return None
 
 
 @router.get("/latest")

--- a/services/orion-policy-runtime/app/store.py
+++ b/services/orion-policy-runtime/app/store.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timezone
 
 from psycopg2.extras import Json
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
@@ -47,7 +48,44 @@ class PolicyRuntimeStore:
         payload = row["proposal_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ProposalFrameV1.model_validate(payload)
+        try:
+            return ProposalFrameV1.model_validate(payload)
+        except ValidationError:
+            # This is the FIFO "oldest proposal without a policy frame"
+            # lookup -- a naive None-degrade would re-select this exact row
+            # forever (it can never validate), permanently blocking every
+            # proposal queued behind it. A schema migration (e.g. 2026-07-22's
+            # SelfStateV1 burn) can leave historical rows like this
+            # incompatible with the currently-running ProposalFrameV1.
+            # Retire it with a stub "unevaluable" decision frame so the FIFO
+            # advances past it, mirroring the pre-burn
+            # build_unevaluable_policy_decision_frame pattern.
+            raw_frame_id = payload.get("frame_id") if isinstance(payload, dict) else None
+            logger.warning(
+                "proposal_frame_incompatible_schema fifo_lookup frame_id=%s",
+                raw_frame_id,
+                exc_info=True,
+            )
+            if raw_frame_id:
+                self._retire_incompatible_proposal_frame(raw_frame_id)
+            return None
+
+    def _retire_incompatible_proposal_frame(self, raw_frame_id: str) -> None:
+        """Insert a stub 'unevaluable' policy_decision_frame for a proposal
+        frame that failed schema validation, so
+        load_next_proposal_without_policy_frame's FIFO lookup doesn't
+        re-select this exact row forever."""
+        stub = PolicyDecisionFrameV1(
+            frame_id=f"policy.frame:{raw_frame_id}:schema_incompatible",
+            generated_at=datetime.now(timezone.utc),
+            source_proposal_frame_id=raw_frame_id,
+            decisions=[],
+            overall_risk=0.0,
+            operator_review_required=True,
+            execution_allowed=False,
+            warnings=["source_proposal_frame_schema_incompatible"],
+        )
+        self.save_policy_decision_frame(stub)
 
     def load_latest_proposal_frame(self) -> ProposalFrameV1 | None:
         with self._engine.connect() as conn:
@@ -69,7 +107,11 @@ class PolicyRuntimeStore:
         payload = row["proposal_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ProposalFrameV1.model_validate(payload)
+        try:
+            return ProposalFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning("proposal_frame_incompatible_schema latest_lookup", exc_info=True)
+            return None
 
     def load_policy_frame_for_proposal(self, proposal_frame_id: str) -> PolicyDecisionFrameV1 | None:
         with self._engine.connect() as conn:
@@ -94,7 +136,15 @@ class PolicyRuntimeStore:
         payload = row["policy_decision_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return PolicyDecisionFrameV1.model_validate(payload)
+        try:
+            return PolicyDecisionFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning(
+                "policy_decision_frame_incompatible_schema proposal_frame_id=%s",
+                proposal_frame_id,
+                exc_info=True,
+            )
+            return None
 
     def load_latest_policy_decision_frame(self) -> PolicyDecisionFrameV1 | None:
         with self._engine.connect() as conn:
@@ -117,7 +167,11 @@ class PolicyRuntimeStore:
         payload = row["policy_decision_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return PolicyDecisionFrameV1.model_validate(payload)
+        try:
+            return PolicyDecisionFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning("policy_decision_frame_incompatible_schema latest_lookup", exc_info=True)
+            return None
 
     def save_policy_decision_frame(self, frame: PolicyDecisionFrameV1) -> None:
         now = datetime.now(timezone.utc)

--- a/services/orion-proposal-runtime/app/store.py
+++ b/services/orion-proposal-runtime/app/store.py
@@ -171,7 +171,17 @@ class ProposalRuntimeStore:
         payload = row["proposal_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ProposalFrameV1.model_validate(payload)
+        try:
+            return ProposalFrameV1.model_validate(payload)
+        except ValidationError:
+            # Looked up as "latest", not a fixed id -- can't stall a FIFO
+            # queue the way a fixed-id lookup could, but a schema migration
+            # (e.g. 2026-07-22's SelfStateV1 burn, which removed
+            # source_self_state_id/added a required source_field_generated_at)
+            # can still leave the single latest row incompatible with the
+            # currently-running code. Degrade instead of crash-looping.
+            logger.warning("proposal_frame_incompatible_schema latest_lookup", exc_info=True)
+            return None
 
     def load_proposal_frame_for_field_tick(self, field_tick_id: str) -> ProposalFrameV1 | None:
         """2026-07-22 (SelfStateV1 burn): replaces load_proposal_frame_for_self_state.
@@ -198,7 +208,17 @@ class ProposalRuntimeStore:
         payload = row["proposal_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ProposalFrameV1.model_validate(payload)
+        try:
+            return ProposalFrameV1.model_validate(payload)
+        except ValidationError:
+            # Dedup lookup keyed by field_tick_id, which pre-migration rows
+            # can also carry (source_field_tick_id predates the SelfStateV1
+            # burn) -- a schema-incompatible match here must not crash-loop
+            # the tick; treat as "no existing frame for this tick" instead.
+            logger.warning(
+                "proposal_frame_incompatible_schema field_tick_id=%s", field_tick_id, exc_info=True
+            )
+            return None
 
     def save_proposal_frame(self, frame: ProposalFrameV1) -> None:
         now = datetime.now(timezone.utc)

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -71,6 +71,60 @@ def test_save_and_load_latest(monkeypatch) -> None:
     assert loaded.frame_id == _frame().frame_id
 
 
+def _legacy_self_state_policy_payload() -> dict:
+    # Shaped like a pre-2026-07-22 (SelfStateV1 burn) policy decision frame
+    # row -- source_self_state_id no longer exists on PolicyDecisionFrameV1.
+    return {
+        "schema_version": "policy.decision.frame.v1",
+        "frame_id": "policy.frame:legacy:substrate_policy.v1",
+        "generated_at": NOW.isoformat(),
+        "source_proposal_frame_id": "proposal.frame:legacy:proposal_policy.v1",
+        "source_self_state_id": "self.state:legacy",
+        "decisions": [],
+        "overall_risk": 0.0,
+    }
+
+
+def test_load_latest_policy_frame_without_dispatch_retires_incompatible_row(monkeypatch) -> None:
+    # Live incident (2026-07-22): the SelfStateV1 burn removed
+    # source_self_state_id from PolicyDecisionFrameV1. This is the FIFO
+    # "oldest undispatched policy frame" lookup -- a naive raise here
+    # crash-loops the whole worker forever (confirmed live). It must
+    # degrade to None AND write a stub, unattempted dispatch frame so the
+    # FIFO advances past the bad row.
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    insert_calls: list[dict] = []
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_execution_dispatch_frames" in sql:
+            insert_calls.append(params or {})
+            result.rowcount = 1
+        else:
+            result.mappings.return_value.first.return_value = {
+                "policy_decision_frame_json": _legacy_self_state_policy_payload(),
+            }
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_latest_policy_frame_without_dispatch()
+
+    assert result is None
+    assert len(insert_calls) == 1
+    assert insert_calls[0]["source_policy_frame_id"] == "policy.frame:legacy:substrate_policy.v1"
+    assert insert_calls[0]["source_proposal_frame_id"] == "proposal.frame:legacy:proposal_policy.v1"
+
+
 def test_load_by_policy_frame_id(monkeypatch) -> None:
     payload = _frame().model_dump(mode="json")
     store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")

--- a/tests/test_policy_runtime_store.py
+++ b/tests/test_policy_runtime_store.py
@@ -109,6 +109,64 @@ def test_load_by_proposal_frame_id(monkeypatch) -> None:
     assert loaded.source_proposal_frame_id == "proposal.frame:test:proposal_policy.v1"
 
 
+def _legacy_self_state_proposal_payload() -> dict:
+    # Shaped like a pre-2026-07-22 (SelfStateV1 burn) proposal frame row --
+    # source_self_state_id/source_self_state_generated_at no longer exist on
+    # ProposalFrameV1, and source_field_generated_at is now required.
+    return {
+        "schema_version": "proposal.frame.v1",
+        "frame_id": "proposal.frame:legacy:proposal_policy.v1",
+        "generated_at": NOW.isoformat(),
+        "source_self_state_id": "self.state:legacy",
+        "source_self_state_generated_at": NOW.isoformat(),
+        "source_attention_frame_id": "attention.frame:legacy",
+        "source_field_tick_id": "tick:legacy",
+        "overall_action_pressure": 0.5,
+        "overall_risk": 0.1,
+        "candidates": [],
+    }
+
+
+def test_load_next_proposal_without_policy_frame_retires_incompatible_row(monkeypatch) -> None:
+    # Live incident (2026-07-22): the SelfStateV1 burn removed
+    # source_self_state_id from ProposalFrameV1. This is the FIFO "oldest
+    # proposal without a policy frame" lookup -- a naive raise here
+    # crash-loops the whole worker forever (confirmed live), since this
+    # exact row is always "the oldest unresolved" until a policy frame
+    # exists for it. It must degrade to None AND write a stub decision
+    # frame so the FIFO advances past the bad row.
+    store = PolicyRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    insert_calls: list[dict] = []
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_policy_decision_frames" in sql:
+            insert_calls.append(params or {})
+            result.rowcount = 1
+        else:
+            result.mappings.return_value.first.return_value = {
+                "proposal_frame_json": _legacy_self_state_proposal_payload(),
+            }
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_next_proposal_without_policy_frame()
+
+    assert result is None
+    assert len(insert_calls) == 1
+    assert insert_calls[0]["source_proposal_frame_id"] == "proposal.frame:legacy:proposal_policy.v1"
+
+
 def test_save_idempotent_by_frame_id(monkeypatch) -> None:
     store = PolicyRuntimeStore("postgresql://test:test@localhost/test")
     fake_engine = MagicMock()

--- a/tests/test_proposal_runtime_store.py
+++ b/tests/test_proposal_runtime_store.py
@@ -72,6 +72,57 @@ def test_save_and_load_latest(monkeypatch) -> None:
     assert loaded.frame_id == _frame().frame_id
 
 
+def _legacy_self_state_proposal_payload() -> dict:
+    # Shaped like a pre-2026-07-22 (SelfStateV1 burn) proposal frame row --
+    # source_self_state_id/source_self_state_generated_at no longer exist on
+    # ProposalFrameV1, and source_field_generated_at is now required.
+    return {
+        "schema_version": "proposal.frame.v1",
+        "frame_id": "proposal.frame:legacy:proposal_policy.v1",
+        "generated_at": NOW.isoformat(),
+        "source_self_state_id": "self.state:legacy",
+        "source_self_state_generated_at": NOW.isoformat(),
+        "source_attention_frame_id": "attention.frame:legacy",
+        "source_field_tick_id": "tick:legacy",
+        "overall_action_pressure": 0.5,
+        "overall_risk": 0.1,
+        "candidates": [],
+    }
+
+
+def test_load_latest_proposal_frame_degrades_to_none_on_legacy_row(monkeypatch) -> None:
+    # Live incident (2026-07-22): the SelfStateV1 burn removed
+    # source_self_state_id from ProposalFrameV1 and added a required
+    # source_field_generated_at. A pre-migration row is the single latest
+    # row until the poll loop successfully writes a new one -- a naive
+    # raise here crash-loops the whole worker forever (confirmed live).
+    store = ProposalRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "proposal_frame_json": _legacy_self_state_proposal_payload(),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_latest_proposal_frame() is None
+
+
+def test_load_by_field_tick_id_degrades_to_none_on_legacy_row(monkeypatch) -> None:
+    store = ProposalRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "proposal_frame_json": _legacy_self_state_proposal_payload(),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_proposal_frame_for_field_tick("tick:legacy") is None
+
+
 def test_load_by_field_tick_id(monkeypatch) -> None:
     payload = _frame().model_dump(mode="json")
     store = ProposalRuntimeStore("postgresql://test:test@localhost/test")


### PR DESCRIPTION
## Summary

**Live production outage**, immediately following PR #1257's SelfStateV1 burn merge + mesh deploy. All 4 downstream runtime services -- `orion-proposal-runtime`, `orion-policy-runtime`, `orion-execution-dispatch-runtime`, `orion-feedback-runtime` -- have been crash-looping since redeploy. Confirmed live via `docker logs`.

Root cause: several frame loaders in each service's `store.py` called `{Proposal,PolicyDecision,ExecutionDispatch,Feedback}FrameV1.model_validate()` with no `ValidationError` guard. PR #1257 removed `source_self_state_id` from these 4 schemas (added `source_field_tick_id`/`source_field_generated_at` instead). Every one of these unguarded loaders can select a row written by the pre-burn code -- and at the moment of cutover, that's exactly the single latest row (or, for the FIFO "oldest without a downstream frame" lookups, the permanently-oldest row) every one of these services queries on every tick.

## Outcome moved

All 4 services' crash-loop root cause fixed. Verified against real crash-loop log output pulled from the live containers before writing the fix (not guessed).

## Current architecture

Some loaders in these same files already had a `try/except ValidationError -> None` guard from an earlier, unrelated incident (2026-07-12/13, schema-incompatible historical rows). The loaders that changed schema in PR #1257 did not get this guard added at the same time -- that gap is what's live right now.

## Files changed

- `services/orion-proposal-runtime/app/store.py`: guard `load_latest_proposal_frame`, `load_proposal_frame_for_field_tick`.
- `services/orion-policy-runtime/app/store.py`: guard `load_next_proposal_without_policy_frame` (FIFO -- also retires the bad row via a stub decision frame so the queue advances), `load_latest_proposal_frame`, `load_policy_frame_for_proposal`, `load_latest_policy_decision_frame`.
- `services/orion-execution-dispatch-runtime/app/store.py`: guard `load_latest_policy_frame_without_dispatch` (FIFO -- retires via a stub dispatch frame), `load_proposal_frame`.
- `services/orion-feedback-runtime/app/store.py`: guard `load_policy_frame`, `load_proposal_frame`, `load_latest_feedback_frame`, `load_feedback_frame_for_dispatch`.
- `services/orion-hub/scripts/substrate_{proposal,policy,feedback}_routes.py`: same guard on the read-only debug `/latest` endpoints (404 instead of 500 against a legacy row). `substrate_execution_dispatch_routes.py` already had this guard.

## Schema / bus / API changes

None -- this is a pure defensive-guard fix, no schema/contract change. The two FIFO loaders now also write a stub, honestly-marked "unevaluable" downstream frame when they retire a bad row (mirrors the pre-burn `build_unevaluable_*` pattern PR #1257 removed for policy, reasoning it was unreachable -- it turned out to still be reachable during a migration cutover window).

## Tests run

```
tests/test_policy_runtime_store.py, tests/test_execution_dispatch_runtime_store.py,
tests/test_feedback_runtime_store.py, tests/test_proposal_runtime_store.py: 35 passed
tests/test_policy_runtime_worker.py: 2 passed
tests/test_execution_dispatch_runtime_worker.py: 19 passed
tests/test_proposal_runtime_worker.py: 2 passed
services/orion-hub/tests/test_substrate_{proposal,policy,feedback,execution_dispatch}_debug_api.py: 10 passed
```

4 new regression tests reproduce a legacy self-state-shaped payload (the exact shape confirmed live in `docker logs`) and assert graceful degradation, including the two FIFO cases' stub-frame retirement.

## Docker/build/smoke checks

Not run from this environment (no local Docker access to the live mesh from this worktree). Live crash-loop confirmed via `docker logs orion-athena-{proposal,policy,execution-dispatch,feedback}-runtime` before writing the fix; live DB queried directly (`psql -h localhost -p 55432`) to confirm the exact malformed row shape.

## Review findings fixed

Code-review skill not dispatched this session given the active-outage timeline -- shipping the minimal, tested fix first. Recommend a review pass regardless before/after merge.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-proposal-runtime/.env -f services/orion-proposal-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-policy-runtime/.env -f services/orion-policy-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-execution-dispatch-runtime/.env -f services/orion-execution-dispatch-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-feedback-runtime/.env -f services/orion-feedback-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: the two "retire with a stub frame" paths (policy, execution-dispatch) create real DB rows for frames that will now show up as `operator_review_required=True`/`dispatch_attempted=False` with a `*_schema_incompatible` warning -- these are diagnostic breadcrumbs, not silent data loss, but worth a quick look post-deploy to confirm the retirement count matches the known bad-row backlog and doesn't runaway.
- Mitigation: `warnings` field on each stub frame makes them greppable; this only fires for rows written before the PR #1257 cutover, so the backlog is finite and should stop appearing once the queue catches up.

## PR link

(created by this command)