### PR TITLE
fix(feedback-runtime): retire schema-incompatible dispatch frames (silent stall, live)

### DIFF
--- a/services/orion-feedback-runtime/app/store.py
+++ b/services/orion-feedback-runtime/app/store.py
@@ -54,17 +54,42 @@ class FeedbackRuntimeStore:
         try:
             return ExecutionDispatchFrameV1.model_validate(payload)
         except ValidationError:
-            # Mirrors load_field_for_tick's guard below: this is the FIFO
-            # lookup (oldest dispatch frame without feedback yet) -- a naive
-            # raise would re-select and fail on this exact row every tick
-            # forever, blocking every dispatch frame queued behind it.
-            # Degrading to None here means this tick does no work for a bad
-            # row instead of crash-looping on it; the row itself isn't
-            # retired (no feedback frame is written for it), which is the
-            # same acknowledged limitation this file's other None-degrades
-            # already accept.
-            logger.warning("dispatch_frame_incompatible_schema fifo_lookup", exc_info=True)
+            # Live incident (2026-07-22, immediately after the SelfStateV1
+            # burn deploy): this is the FIFO lookup (oldest dispatch frame
+            # without feedback yet) -- a bare None-degrade re-selects this
+            # exact row every tick forever (confirmed live: feedback-runtime
+            # sat silently stuck on one legacy dispatch frame for 15+
+            # minutes, producing nothing, while proposal/policy/execution-
+            # dispatch-runtime all correctly drained their own backlogs via
+            # the sibling retirement fix in
+            # orion-policy-runtime/orion-execution-dispatch-runtime's
+            # store.py). Retire the bad row with a stub "unevaluable"
+            # feedback frame so the FIFO actually advances.
+            raw_frame_id = payload.get("frame_id") if isinstance(payload, dict) else None
+            logger.warning(
+                "dispatch_frame_incompatible_schema fifo_lookup frame_id=%s",
+                raw_frame_id,
+                exc_info=True,
+            )
+            if raw_frame_id:
+                self._retire_incompatible_dispatch_frame(raw_frame_id)
             return None
+
+    def _retire_incompatible_dispatch_frame(self, raw_frame_id: str) -> None:
+        """Insert a stub 'unevaluable' feedback_frame for a dispatch frame
+        that failed schema validation, so
+        load_latest_dispatch_frame_without_feedback's FIFO lookup doesn't
+        re-select this exact row forever."""
+        stub = FeedbackFrameV1(
+            frame_id=f"feedback.frame:{raw_frame_id}:schema_incompatible",
+            generated_at=datetime.now(timezone.utc),
+            source_execution_dispatch_frame_id=raw_frame_id,
+            outcome_status="unknown",
+            outcome_score=0.0,
+            confidence_score=0.0,
+            warnings=["source_dispatch_frame_schema_incompatible"],
+        )
+        self.save_feedback_frame(stub)
 
     def load_latest_dispatch_frame(self) -> ExecutionDispatchFrameV1 | None:
         with self._engine.connect() as conn:

--- a/tests/test_feedback_runtime_store.py
+++ b/tests/test_feedback_runtime_store.py
@@ -152,6 +152,61 @@ def test_load_latest_dispatch_frame_without_feedback_degrades_to_none_on_legacy_
     assert store.load_latest_dispatch_frame_without_feedback() is None
 
 
+def test_load_latest_dispatch_frame_without_feedback_retires_incompatible_row(monkeypatch) -> None:
+    # Live incident (2026-07-22, immediately after the SelfStateV1 burn
+    # deploy): a bare None-degrade here re-selects the exact same broken
+    # dispatch frame every tick forever -- confirmed live, feedback-runtime
+    # sat silently stuck for 15+ minutes producing nothing while its sibling
+    # services correctly drained their own backlogs via a retirement fix.
+    # This must ALSO write a stub feedback frame so the FIFO advances.
+    store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    insert_calls: list[dict] = []
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_feedback_frames" in sql:
+            insert_calls.append(params or {})
+            result.rowcount = 1
+        else:
+            result.mappings.return_value.first.return_value = {
+                "dispatch_frame_json": _incompatible_self_state_dispatch_frame_payload(),
+            }
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_latest_dispatch_frame_without_feedback()
+
+    assert result is None
+    assert len(insert_calls) == 1
+    assert insert_calls[0]["source_execution_dispatch_frame_id"] == (
+        "execution.dispatch.frame:legacy:execution_dispatch_policy.v1"
+    )
+
+
+def _incompatible_self_state_dispatch_frame_payload() -> dict:
+    # Shaped like a pre-2026-07-22 (SelfStateV1 burn) dispatch frame row --
+    # source_self_state_id no longer exists on ExecutionDispatchFrameV1.
+    return {
+        "schema_version": "execution.dispatch.frame.v1",
+        "frame_id": "execution.dispatch.frame:legacy:execution_dispatch_policy.v1",
+        "generated_at": NOW.isoformat(),
+        "source_policy_frame_id": "policy.frame:legacy:substrate_policy.v1",
+        "source_proposal_frame_id": "proposal.frame:legacy:proposal_policy.v1",
+        "source_self_state_id": "self.state:legacy",
+        "dispatch_mode": "dispatch_read_only",
+    }
+
+
 def test_load_latest_dispatch_frame_degrades_to_none_on_legacy_row(monkeypatch) -> None:
     store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
     fake_engine = MagicMock()


### PR DESCRIPTION
## Summary

Follow-up to PR #1260. That fix stopped 3 of 4 runtime services from crash-looping, but confirmed live (via `docker logs`) that `orion-feedback-runtime` has a related, quieter bug: its FIFO loader (`load_latest_dispatch_frame_without_feedback`) already had a `ValidationError` guard from an earlier incident, but the guard's degrade-to-None path never retires the bad row. It just logs a warning and returns None every tick, re-selecting the identical oldest-without-feedback dispatch frame forever.

Live evidence: after PR #1260 deployed, `substrate_proposal_frames`, `substrate_policy_decision_frames`, and `substrate_execution_dispatch_frames` all started producing new rows again (the latter two visibly draining their pre-migration backlog via the `:schema_incompatible` retirement stubs PR #1260 added). `substrate_feedback_frames` did not move at all -- `docker logs orion-athena-feedback-runtime` showed the same `ValidationError` on the same legacy dispatch frame being caught and logged on every ~3s tick, indefinitely.

## Outcome moved

`load_latest_dispatch_frame_without_feedback` now writes a stub "unevaluable" feedback frame for a schema-incompatible row (mirrors PR #1260's pattern for policy/execution-dispatch-runtime), so the FIFO actually advances instead of stalling.

## Files changed

- `services/orion-feedback-runtime/app/store.py`: `load_latest_dispatch_frame_without_feedback`'s except branch now calls a new `_retire_incompatible_dispatch_frame` helper.
- `tests/test_feedback_runtime_store.py`: new regression test reproducing the exact legacy self-state-shaped payload, asserting the retirement insert fires with the right `source_execution_dispatch_frame_id`.

## Tests run

```
tests/test_feedback_runtime_store.py: 13 passed
```

## Docker/build/smoke checks

Not run from this environment. Live stall confirmed via `docker logs orion-athena-feedback-runtime` before writing the fix.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-feedback-runtime/.env -f services/orion-feedback-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: same as PR #1260's -- the stub retirement rows are diagnostic breadcrumbs (`warnings=["source_dispatch_frame_schema_incompatible"]`), not silent data loss, but worth a quick post-deploy look to confirm the backlog drains and stops.

## Review findings fixed

Not run this session -- shipping the minimal, tested fix given this is a live, ongoing production stall discovered mid-verification of PR #1260's deploy.

## PR link

(created by this command)