### PR TITLE
fix(biometrics-loop,field-digester): availability one-way ratchet + merge-window dedup no-op

### DIFF
--- a/orion/schemas/biometrics_projection.py
+++ b/orion/schemas/biometrics_projection.py
@@ -53,6 +53,18 @@ class ActiveNodePressureStateV1(BaseModel):
     pressure_score: float = 0.0
     evidence_event_ids: list[str] = Field(default_factory=list)
     last_updated_at: datetime
+    # Per-pressure-kind merge-window bookkeeping (2026-07-22): keyed by
+    # pressure_kind ("strain"/"availability"/etc.), not a single timestamp,
+    # since different pressure kinds on the same node can legitimately be
+    # accepted at different cadences -- a single shared timestamp would
+    # falsely suppress one kind's fresh candidate just because a different
+    # kind was reinforced moments earlier. Lives on the durable projection
+    # (not a reducer-local dict) specifically so DEFAULT_MERGE_WINDOW_SEC
+    # actually holds across separate reduce_node_pressure_candidates() calls
+    # -- confirmed live this was previously a no-op: this reducer runs once
+    # per trigger event (orion/substrate/biometrics_loop/pipeline.py), so a
+    # call-scoped dict could never accumulate dedup history across events.
+    last_accepted_at: dict[str, datetime] = Field(default_factory=dict)
 
 
 class ActiveNodePressureProjectionV1(BaseModel):

--- a/orion/substrate/biometrics_loop/pressure_organ.py
+++ b/orion/substrate/biometrics_loop/pressure_organ.py
@@ -21,6 +21,7 @@ ALLOWED_PRESSURE_ROLES = frozenset(
         "node_pressure_reinforced",
         "node_pressure_decayed",
         "node_availability_concern",
+        "node_availability_recovered",
         "node_pressure_suppressed",
         "node_capability_impact",
     }
@@ -139,6 +140,28 @@ def invoke_biometrics_pressure(
             build_pressure_candidate_events(
                 node_id=node_id,
                 semantic_role="node_availability_concern",
+                evidence_event_ids=evidence,
+                confidence=max(min_confidence, 0.8),
+                observed_at=clock,
+            )
+        )
+
+    # Rule B': expected online + fresh + a prior availability concern is
+    # still flagged -> recovered. The symmetric counterpart Rule B needed
+    # and never had: "availability" in active_pressures was a one-way
+    # ratchet -- the only removal path (Rule D / node_pressure_decayed) is
+    # hardcoded in pressure_reducer.py's ROLE_TO_PRESSURE_KIND to clear
+    # "strain" only, never "availability". Confirmed live 2026-07-22:
+    # node:atlas had a transient staleness blip set "availability" once,
+    # then stayed permanently flagged (field-digester's availability
+    # channel pinned at 0.0) for hours after biometrics resumed reporting
+    # fresh (last_seen_at continuously current) -- a real node, fully
+    # reachable, misrepresented as unavailable.
+    elif expected_online is True and not stale and "availability" in active_pressures:
+        candidates.append(
+            build_pressure_candidate_events(
+                node_id=node_id,
+                semantic_role="node_availability_recovered",
                 evidence_event_ids=evidence,
                 confidence=max(min_confidence, 0.8),
                 observed_at=clock,

--- a/orion/substrate/biometrics_loop/pressure_reducer.py
+++ b/orion/substrate/biometrics_loop/pressure_reducer.py
@@ -22,6 +22,7 @@ ROLE_TO_PRESSURE_KIND = {
     "node_pressure_reinforced": "strain",
     "node_pressure_decayed": "strain",
     "node_availability_concern": "availability",
+    "node_availability_recovered": "availability",
     "node_pressure_suppressed": "strain",
     "node_capability_impact": "capability",
 }
@@ -31,6 +32,10 @@ ROLE_TO_OPERATION = {
     "node_pressure_reinforced": "reinforce",
     "node_pressure_decayed": "decay",
     "node_availability_concern": "update",
+    # Reuses "decay" (StateDeltaV1.operation is a closed Literal with no
+    # "recover" value) -- semantically this delta is removing a pressure
+    # kind from active_pressures, the same shape as node_pressure_decayed.
+    "node_availability_recovered": "decay",
     "node_pressure_suppressed": "suppress",
     "node_capability_impact": "update",
 }
@@ -124,7 +129,6 @@ def reduce_node_pressure_candidates(
     projection_updates: list[ProjectionUpdateV1] = []
 
     traces = _extract_candidate_traces(candidates)
-    recent_acceptance: dict[tuple[str, str], datetime] = {}
 
     for trace in traces:
         atom_event_id = _atom_event_id(trace)
@@ -159,14 +163,25 @@ def reduce_node_pressure_candidates(
             continue
 
         pressure_kind = ROLE_TO_PRESSURE_KIND.get(role, "strain")
-        merge_key = (canonical_node_id, pressure_kind)
-        if merge_key in recent_acceptance:
-            prior = recent_acceptance[merge_key]
-            if (clock - prior).total_seconds() <= merge_window_sec:
-                merged.append(atom_event_id)
-                continue
-
         existing = updated.nodes.get(canonical_node_id)
+
+        # Merge-window dedup against the projection's own persisted
+        # last_accepted_at (per node+pressure_kind) -- not a function-local
+        # dict. This function is called once per trigger event (see
+        # orion/substrate/biometrics_loop/pipeline.py's per-event loop), so
+        # a call-scoped dict could never accumulate dedup history across
+        # events -- confirmed live 2026-07-22: merge_window_sec=300 was a
+        # complete no-op in production, node:atlas alone accepted 767
+        # "reinforce" deltas in 2 hours (~6.4/min) instead of the ~24 a
+        # working 5-minute window would allow.
+        if existing is not None:
+            prior = existing.last_accepted_at.get(pressure_kind)
+            if prior is not None:
+                prior_aware = prior if prior.tzinfo else prior.replace(tzinfo=timezone.utc)
+                if (clock - prior_aware).total_seconds() <= merge_window_sec:
+                    merged.append(atom_event_id)
+                    continue
+
         before = existing.model_dump(mode="json") if existing else None
         if existing is None:
             node_state = ActiveNodePressureStateV1(
@@ -180,6 +195,7 @@ def reduce_node_pressure_candidates(
             projection_operation = "update"
 
         node_state.last_updated_at = clock
+        node_state.last_accepted_at[pressure_kind] = clock
         # Cap to 200 most-recent IDs — this list is append-only and grows to 400K+ events
         # without a bound, causing deepcopy/serialize to become O(N) per tick.
         all_ids = sorted(set(node_state.evidence_event_ids + evidence))
@@ -200,6 +216,9 @@ def reduce_node_pressure_candidates(
             if "availability" not in node_state.active_pressures:
                 node_state.active_pressures.append("availability")
             node_state.availability_status = "stale"
+        elif role == "node_availability_recovered":
+            node_state.active_pressures = [p for p in node_state.active_pressures if p != pressure_kind]
+            node_state.availability_status = "online"
         elif role == "node_pressure_suppressed":
             for pressure in list(node_state.active_pressures):
                 if pressure == pressure_kind:
@@ -213,7 +232,6 @@ def reduce_node_pressure_candidates(
 
         updated.nodes[canonical_node_id] = node_state
         accepted.append(atom_event_id)
-        recent_acceptance[merge_key] = clock
 
         state_deltas.append(
             StateDeltaV1(

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -32,6 +32,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
     if delta.target_kind == "active_node_pressure":
         score = float(after.get("pressure_score", 0.0))
         pressures = list(after.get("active_pressures") or [])
+        before_pressures = set((delta.before or {}).get("active_pressures") or [])
         if "strain" in pressures:
             channel = "gpu_pressure" if node_id.replace("node:", "") in GPU_NODES else "cpu_pressure"
             out.append(Perturbation(node_id=node_id, channel=channel, intensity=score, label=delta.delta_id))
@@ -59,6 +60,30 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     # with the same shape as expected_offline_suppression's
                     # original bug (PR #1109), just via min()-floor instead of
                     # add-no-decay.
+                    mode="replace",
+                )
+            )
+        elif "availability" in before_pressures:
+            # Recovery transition (2026-07-22, code review finding on the
+            # biometrics_loop "node_availability_recovered" fix): once
+            # pressure_reducer.py can actually clear "availability" from
+            # active_pressures again (previously a one-way ratchet -- see
+            # the comment above), this delta's own after.active_pressures no
+            # longer contains "availability" at all, so the branch above
+            # never fires for it, or for anything after it. Without this,
+            # the "availability" channel would freeze at whatever value it
+            # last held at the moment of recovery instead of being restored
+            # -- the exact same channel, a different (frozen, not
+            # ratcheted) flavor of the same underlying bug. Explicitly
+            # restore to fully-available on the True->False transition,
+            # same "clear wins" pattern already used for
+            # expected_offline_suppression below.
+            out.append(
+                Perturbation(
+                    node_id=node_id,
+                    channel="availability",
+                    intensity=1.0,
+                    label=delta.delta_id,
                     mode="replace",
                 )
             )

--- a/services/orion-field-digester/tests/test_field_channel_ratchets.py
+++ b/services/orion-field-digester/tests/test_field_channel_ratchets.py
@@ -68,15 +68,30 @@ def _transport_bus_delta(*, node_id: str = "athena", hints: dict) -> StateDeltaV
 
 
 def _active_node_pressure_delta(
-    *, node_id: str = "atlas", score: float, delta_id: str = "delta_pressure_1"
+    *,
+    node_id: str = "atlas",
+    score: float,
+    delta_id: str = "delta_pressure_1",
+    active_pressures: list[str] | None = None,
+    before_active_pressures: list[str] | None = None,
 ) -> StateDeltaV1:
-    after = {"node_id": node_id, "pressure_score": score, "active_pressures": ["availability"]}
+    after = {
+        "node_id": node_id,
+        "pressure_score": score,
+        "active_pressures": ["availability"] if active_pressures is None else active_pressures,
+    }
+    before = (
+        {"node_id": node_id, "active_pressures": before_active_pressures}
+        if before_active_pressures is not None
+        else None
+    )
     return StateDeltaV1(
         delta_id=delta_id,
         target_projection="active_node_pressure",
         target_kind="active_node_pressure",
         target_id=f"node:{node_id}",
         operation="update",
+        before=before,
         after=after,
         caused_by_event_ids=["gev_pressure_1"],
         reducer_id="active_node_pressure_reducer",
@@ -514,3 +529,51 @@ def test_availability_can_still_drop_on_a_later_worse_reading() -> None:
     worse_delta = _active_node_pressure_delta(score=0.9, delta_id="delta_worse")
     apply_perturbations(state, delta_to_perturbations(worse_delta), now=NOW)
     assert state.node_vectors["node:atlas"]["availability"] == 0.0
+
+
+def test_availability_recovered_transition_restores_full_availability() -> None:
+    """2026-07-22, code review finding on the biometrics_loop
+    node_availability_recovered fix: once pressure_reducer.py can remove
+    "availability" from active_pressures again (previously a permanent
+    ratchet), the delta that does so has an empty after.active_pressures
+    for "availability" -- the existing `if "availability" in pressures`
+    branch above never fires for it. Without the before/after transition
+    check, the channel would freeze at its last value (still pinned low
+    from a prior high-pressure reading) instead of being explicitly
+    restored -- the same channel, a frozen-not-ratcheted flavor of the
+    same bug. Must land at exactly 1.0 (fully available), not whatever the
+    stale pressure_score happens to be."""
+    state = _state(node_vectors={"node:atlas": {"availability": 1.0}})
+
+    bad_delta = _active_node_pressure_delta(score=0.9, delta_id="delta_bad")
+    apply_perturbations(state, delta_to_perturbations(bad_delta), now=NOW)
+    assert state.node_vectors["node:atlas"]["availability"] == 0.0, "sanity: pinned low first"
+
+    recovered_delta = _active_node_pressure_delta(
+        score=0.9,  # deliberately still-high and stale -- must be ignored;
+        # only the active_pressures transition should drive this delta's
+        # perturbation, not whatever pressure_score happens to be attached.
+        delta_id="delta_recovered",
+        active_pressures=["strain"],  # "availability" no longer present
+        before_active_pressures=["strain", "availability"],
+    )
+    perturbations = delta_to_perturbations(recovered_delta)
+    availability = next(p for p in perturbations if p.channel == "availability")
+    assert availability.intensity == 1.0
+    assert availability.mode == "replace"
+
+    apply_perturbations(state, perturbations, now=NOW)
+    assert state.node_vectors["node:atlas"]["availability"] == 1.0
+
+
+def test_no_availability_perturbation_when_never_flagged_and_still_absent() -> None:
+    """Sanity check: the recovery branch must not fire spuriously for a
+    node that was never in an availability concern to begin with (no
+    "availability" in before or after)."""
+    delta = _active_node_pressure_delta(
+        score=0.9,
+        active_pressures=["strain"],
+        before_active_pressures=["strain"],
+    )
+    perturbations = delta_to_perturbations(delta)
+    assert not any(p.channel == "availability" for p in perturbations)

--- a/tests/test_biometrics_pressure_organ.py
+++ b/tests/test_biometrics_pressure_organ.py
@@ -27,6 +27,7 @@ ALLOWED_ROLES = {
     "node_pressure_reinforced",
     "node_pressure_decayed",
     "node_availability_concern",
+    "node_availability_recovered",
     "node_pressure_suppressed",
     "node_capability_impact",
 }
@@ -152,6 +153,56 @@ def test_missing_expected_atlas_emits_availability_concern(catalog: NodeCatalog)
         if ev.atom
     }
     assert "node_availability_concern" in roles
+
+
+def test_availability_recovers_when_expected_online_and_fresh(catalog: NodeCatalog) -> None:
+    """Rule B' -- the live regression this fix closes. A prior availability
+    concern is still flagged in active_pressures, but biometrics have
+    resumed reporting fresh (last_seen_at within stale_after_sec) and the
+    node is still expected online. Without this rule, "availability" was a
+    permanent, one-way ratchet: the only removal path (node_pressure_decayed)
+    only ever clears "strain" (pressure_reducer.py's ROLE_TO_PRESSURE_KIND),
+    never "availability"."""
+    emission = invoke_biometrics_pressure(
+        trigger_event=_trigger_event("atlas"),
+        node_bio=_node_bio(
+            node_id="atlas",
+            last_seen_at=FIXED_TS,  # fresh, not stale
+            expected_online=True,
+        ),
+        active_pressure=_active_pressure(node_id="atlas", active_pressures=["availability"]),
+        catalog=catalog,
+        stale_after_sec=180,
+        now=FIXED_TS,
+    )
+    roles = {
+        ev.atom.semantic_role
+        for trace in _group_traces(emission.candidate_events)
+        for ev in trace
+        if ev.atom
+    }
+    assert "node_availability_recovered" in roles
+
+
+def test_no_recovery_candidate_when_availability_not_flagged(catalog: NodeCatalog) -> None:
+    """Rule B' must not fire spuriously -- only when "availability" is
+    actually in active_pressures. A node that was never flagged shouldn't
+    emit a recovery event just because it's online and fresh."""
+    emission = invoke_biometrics_pressure(
+        trigger_event=_trigger_event("atlas"),
+        node_bio=_node_bio(node_id="atlas", last_seen_at=FIXED_TS, expected_online=True),
+        active_pressure=_active_pressure(node_id="atlas", active_pressures=[]),
+        catalog=catalog,
+        stale_after_sec=180,
+        now=FIXED_TS,
+    )
+    roles = {
+        ev.atom.semantic_role
+        for trace in _group_traces(emission.candidate_events)
+        for ev in trace
+        if ev.atom
+    }
+    assert "node_availability_recovered" not in roles
 
 
 def test_organ_emits_only_allowlisted_roles(catalog: NodeCatalog) -> None:

--- a/tests/test_node_pressure_reducer.py
+++ b/tests/test_node_pressure_reducer.py
@@ -149,3 +149,138 @@ def test_low_confidence_rejected(
     )
     assert receipt.rejected_event_ids
     assert not receipt.accepted_event_ids
+
+
+def test_availability_recovered_clears_the_flag(
+    catalog: NodeCatalog,
+) -> None:
+    """The actual live bug this fix closes: "availability" was a one-way
+    ratchet before node_availability_recovered existed -- node_pressure_decayed
+    only ever clears "strain" (ROLE_TO_PRESSURE_KIND), never "availability"."""
+    active = ActiveNodePressureProjectionV1(
+        projection_id="proj_active_pressure",
+        generated_at=FIXED_TS,
+        nodes={
+            "atlas": ActiveNodePressureStateV1(
+                node_id="atlas",
+                availability_status="stale",
+                active_pressures=["strain", "availability"],
+                pressure_score=0.8,
+                last_updated_at=FIXED_TS,
+            )
+        },
+    )
+    projection, receipt = reduce_node_pressure_candidates(
+        candidates=[_candidate("node_availability_recovered")],
+        projection=active,
+        catalog=catalog,
+        now=FIXED_TS,
+    )
+    assert receipt.accepted_event_ids
+    state = projection.nodes["atlas"]
+    assert "availability" not in state.active_pressures
+    # "strain" is a separate pressure kind -- recovery must not touch it.
+    assert "strain" in state.active_pressures
+    assert state.availability_status == "online"
+
+
+def test_merge_window_dedup_persists_across_separate_reduce_calls(
+    catalog: NodeCatalog, empty_pressure: ActiveNodePressureProjectionV1
+) -> None:
+    """The actual live bug this fix closes: reduce_node_pressure_candidates()
+    is called once per trigger event (orion/substrate/biometrics_loop/
+    pipeline.py's per-event loop), so a function-local dedup dict could
+    never accumulate history across calls -- merge_window_sec=300 was a
+    complete no-op in production (confirmed live: node:atlas accepted 767
+    "reinforce" deltas in 2 hours instead of the ~24 a working 5-minute
+    window would allow). The dedup must now live on the durable projection
+    (last_accepted_at) so it survives across separate calls, matching how
+    this function is actually invoked."""
+    projection, receipt1 = reduce_node_pressure_candidates(
+        candidates=[_candidate("node_pressure_detected")],
+        projection=empty_pressure,
+        catalog=catalog,
+        merge_window_sec=300,
+        now=FIXED_TS,
+    )
+    assert receipt1.accepted_event_ids
+
+    # A SEPARATE call (not the same batch), 30s later -- well within the
+    # 300s merge window. Must be merged, not accepted again.
+    projection, receipt2 = reduce_node_pressure_candidates(
+        candidates=[_candidate("node_pressure_reinforced")],
+        projection=projection,
+        catalog=catalog,
+        merge_window_sec=300,
+        now=FIXED_TS + timedelta(seconds=30),
+    )
+    assert receipt2.merged_event_ids
+    assert not receipt2.accepted_event_ids
+
+
+def test_merge_window_dedup_expires_after_window_across_separate_calls(
+    catalog: NodeCatalog, empty_pressure: ActiveNodePressureProjectionV1
+) -> None:
+    """Sanity check: the dedup fix must not become a permanent block --
+    a candidate arriving after merge_window_sec has elapsed must still be
+    accepted."""
+    projection, receipt1 = reduce_node_pressure_candidates(
+        candidates=[_candidate("node_pressure_detected")],
+        projection=empty_pressure,
+        catalog=catalog,
+        merge_window_sec=300,
+        now=FIXED_TS,
+    )
+    assert receipt1.accepted_event_ids
+
+    projection, receipt2 = reduce_node_pressure_candidates(
+        candidates=[_candidate("node_pressure_reinforced")],
+        projection=projection,
+        catalog=catalog,
+        merge_window_sec=300,
+        now=FIXED_TS + timedelta(seconds=301),
+    )
+    assert receipt2.accepted_event_ids
+    assert not receipt2.merged_event_ids
+
+
+def test_merge_window_dedup_is_independent_per_pressure_kind(
+    catalog: NodeCatalog,
+) -> None:
+    """last_accepted_at is keyed by pressure_kind, not a single per-node
+    timestamp -- reinforcing "strain" must not suppress a fresh
+    "availability" recovery candidate arriving moments later for the same
+    node (and vice versa). A single shared timestamp would have made this
+    fail even though the two pressure kinds are unrelated."""
+    active = ActiveNodePressureProjectionV1(
+        projection_id="proj_active_pressure",
+        generated_at=FIXED_TS,
+        nodes={
+            "atlas": ActiveNodePressureStateV1(
+                node_id="atlas",
+                availability_status="stale",
+                active_pressures=["strain", "availability"],
+                last_updated_at=FIXED_TS,
+            )
+        },
+    )
+    projection, receipt1 = reduce_node_pressure_candidates(
+        candidates=[_candidate("node_pressure_reinforced")],
+        projection=active,
+        catalog=catalog,
+        merge_window_sec=300,
+        now=FIXED_TS,
+    )
+    assert receipt1.accepted_event_ids
+
+    # Different pressure_kind ("availability"), 5s later -- must NOT be
+    # suppressed by "strain"'s just-set last_accepted_at.
+    projection, receipt2 = reduce_node_pressure_candidates(
+        candidates=[_candidate("node_availability_recovered")],
+        projection=projection,
+        catalog=catalog,
+        merge_window_sec=300,
+        now=FIXED_TS + timedelta(seconds=5),
+    )
+    assert receipt2.accepted_event_ids
+    assert not receipt2.merged_event_ids


### PR DESCRIPTION
## Summary

- **Bug 1 (availability one-way ratchet)**: `pressure_organ.py`'s Rule B adds `"availability"` to a node's `active_pressures` on a transient biometrics staleness blip, but the only removal role (`node_pressure_decayed`) was hardcoded to always target `pressure_kind="strain"` — `"availability"` could never be removed. Confirmed live: `node:atlas` reported `availability=0.0` for hours after biometrics resumed reporting fresh — a real, reachable node misrepresented as unavailable. Fixed with a new Rule B' (`expected_online=True, not stale, "availability" still flagged` → `node_availability_recovered`), clearing the flag and setting `availability_status="online"`.
- **Bug 2 (merge-window dedup was a no-op)**: `reduce_node_pressure_candidates()`'s anti-flood dedup was a function-local dict reinitialized on every call, but the function is called once per individual trigger event in a loop — the dict could never accumulate history across events. Confirmed live: `node:atlas` alone accepted 767 "reinforce" deltas in 2 hours instead of the ~24 a working 5-minute window would allow. Fixed by moving dedup state onto the durable projection (new `last_accepted_at: dict[str, datetime]` field on `ActiveNodePressureStateV1`, keyed by pressure_kind).
- **Companion fix (code review finding)**: `services/orion-field-digester`'s `delta_to_perturbations()` only ever emitted an `"availability"` `Perturbation` when `"availability"` was present in a delta's `after.active_pressures` — once Bug 1's fix lets a recovery delta actually remove it, the channel would've frozen at its last (low) value instead of being restored. Added an explicit before→after transition check that restores the channel to `1.0` on the `True→False` transition, matching the existing "clear wins" pattern already used for `expected_offline_suppression` in the same file.

## Outcome moved

`node:atlas`'s `availability` field-topology channel will stop being permanently pinned at `0.0` once biometrics genuinely recover, and the biometrics pressure reducer's 5-minute merge window will actually rate-limit reinforcement events as designed instead of accepting every single one.

## Current architecture

`orion/substrate/biometrics_loop/pipeline.py`'s `process_biometrics_grammar_events()` calls `invoke_biometrics_pressure()` (organ, emits candidate events) then `reduce_node_pressure_candidates()` (reducer, turns candidates into `StateDeltaV1`s) once per trigger event. `services/orion-field-digester` later ingests `target_kind="active_node_pressure"` deltas and computes the `availability` field-topology channel from `pressure_score`.

## Architecture touched

`orion/substrate/biometrics_loop` (organ + reducer), `orion/schemas/biometrics_projection.py` (new field, backward compatible), `services/orion-field-digester/app/ingest/state_deltas.py`. No bus/API changes, no env changes.

## Files changed

- `orion/schemas/biometrics_projection.py`: new `last_accepted_at: dict[str, datetime] = Field(default_factory=dict)` on `ActiveNodePressureStateV1`.
- `orion/substrate/biometrics_loop/pressure_organ.py`: new Rule B', new role in `ALLOWED_PRESSURE_ROLES`.
- `orion/substrate/biometrics_loop/pressure_reducer.py`: `ROLE_TO_PRESSURE_KIND`/`ROLE_TO_OPERATION` entries for the new role, new role-dispatch branch, merge-window dedup moved from a function-local dict to the persisted `last_accepted_at` field.
- `services/orion-field-digester/app/ingest/state_deltas.py`: before/after transition check restoring `availability` to `1.0` on recovery.
- `services/orion-field-digester/tests/test_field_channel_ratchets.py`: `_active_node_pressure_delta()` extended with `active_pressures`/`before_active_pressures` kwargs; 2 new tests.
- `tests/test_biometrics_pressure_organ.py`, `tests/test_node_pressure_reducer.py`: 6 new tests covering both bugs (recovery role, cross-call dedup persistence, per-pressure-kind independence, dedup expiry).

## Schema / bus / API changes

- Added: `ActiveNodePressureStateV1.last_accepted_at` (backward compatible, defaults to `{}` for pre-existing persisted projections — confirmed via `model_config = ConfigDict(extra="forbid")` only rejecting unexpected extra fields, not missing ones).
- Added: `"node_availability_recovered"` semantic role/pressure_kind value (internal to `orion/substrate/biometrics_loop`, not a bus channel).
- Compatibility notes: `services/orion-sql-writer` stores the projection as opaque JSONB, no migration needed.

## Tests run

```
/mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest tests/test_biometrics_pressure_organ.py tests/test_node_pressure_reducer.py -q
21 passed, 1 warning in 1.15s

cd services/orion-field-digester && /mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest tests/ -q
137 passed, 6 warnings in 3.83s

PYTHONPATH=services/orion-field-digester /mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest tests/test_field_delta_ingest.py tests/test_field_deterministic_replay.py tests/test_substrate_deterministic_ids.py tests/test_substrate_lineage.py -q
10 passed, 1 warning in 1.51s
```

## Evals run

No eval harness for this seam; unit-test-covered only, including two regression tests reproducing the exact live bug shapes.

## Docker/build/smoke checks

Not run from this worktree — no compose/env/Dockerfile changes.

## Review findings fixed

- Finding (first review pass): the biometrics_loop fix alone closes the ratchet inside `orion/substrate/biometrics_loop`, but `services/orion-field-digester`'s `delta_to_perturbations()` never learns about the recovery — the channel would freeze instead of restoring, materially not closing the live symptom.
  - Fix: added the before/after transition check in `state_deltas.py` described above, restoring `availability` to `1.0` explicitly.
  - Evidence: `test_availability_recovered_transition_restores_full_availability` reproduces exactly this (pins low via a real high-score delta, then applies the recovery delta, asserts final applied state is `1.0`).
- Finding (second, follow-up review pass, verifying the companion fix): none — independently traced `delta.before` is always non-`None` for a genuine recovery delta in production (not just the hand-built test), confirmed no other delta shape can trigger the new before/after branch, confirmed no interaction with the adjacent `suppress` block, confirmed `apply_perturbations()`'s `mode="replace"` branch is checked before the `channel=="availability"` floor-only special case so `intensity=1.0` applies directly.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build orion-field-digester
```

This branch also touches `orion/substrate/biometrics_loop`, which is a shared package — check whether any service that imports it (the biometrics pipeline's own runner) also needs a restart to pick up the reducer/organ changes; not verified from this worktree which service owns that runtime.

Post-restart verification:
```bash
# node:atlas's availability should recover to a real value (not permanently 0.0)
# once its biometrics next report fresh, instead of staying pinned.
PGPASSWORD=postgres psql -h localhost -p 55432 -U postgres -d conjourney -c \
  "select field_json->'node_vectors'->'node:atlas'->'availability' from substrate_field_state order by generated_at desc limit 1;"
```

## Risks / concerns

- Severity: low
- Concern: `orion/substrate/biometrics_loop` is a shared package — didn't identify from this worktree which service actually runs `process_biometrics_grammar_events()` in production, so the exact restart target for the biometrics_loop half of this fix isn't listed above with certainty.
- Mitigation: the field-digester restart is confirmed necessary and listed; flagging the biometrics_loop runtime as a follow-up to confirm before considering this fully deployed.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/availability-ratchet-and-merge-window-dedup