### PR TITLE
docs(field-digester,mood-arc): third training-data cutoff for PR #1262

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -91,6 +91,25 @@ python orion/mood_arc/fit_encoder.py train \
   5-day corpus. Do not retrain until meaningfully more clean data has
   accumulated; see the agent board for the tracked follow-up. If both
   cutoffs apply, use whichever is later.
+- **Third cutoff, PR #1262 (pending deploy):** two bugs in
+  `orion/substrate/biometrics_loop`'s active-node-pressure reducer,
+  upstream of this service. (1) `availability` one-way ratchet — a
+  transient staleness blip could permanently flag a node unavailable, with
+  no rule able to clear it; not one of `v2`'s 16 trained channels, but its
+  exclusion from training was itself likely an artifact of this bug
+  (permanently-stuck looks like no-signal). (2) merge-window dedup was a
+  no-op across ticks — `node:atlas` accepted 767 "reinforce" deltas in 2
+  hours instead of the ~24 a working 5-minute window should allow, inflating
+  `pressure_score` and therefore `cpu_pressure` (`mode="add"`, one of `v2`'s
+  16 trained channels) via `active_node_pressure` deltas' `"strain"`
+  pressure kind. See `services/orion-field-digester/README.md`'s "third
+  training-data quality cutoff" section for the full detail and the exact
+  mechanism to determine the real cutoff once PR #1262 is merged and both
+  `orion-field-digester` and `orion-substrate-runtime` (which runs the
+  biometrics_loop reducer) have been restarted. **Do not retrain until this
+  cutoff is known** — same reasoning as the second cutoff, just for
+  `cpu_pressure` instead of `catalog_drift_pressure`. If multiple cutoffs
+  apply, use whichever is latest.
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -291,6 +291,60 @@ as of this writing there are only ~40 minutes of clean post-cutoff data,
 nowhere near `v2`'s 207K-row/5-day corpus. Let clean data accumulate
 first; see the agent board for the tracked follow-up.
 
+## `field_channel_corpus.v1` third training-data quality cutoff (PR #1262, pending deploy)
+
+A third, independent contamination window, found in `orion/substrate/
+biometrics_loop` (upstream of this service, not a field-digester bug
+itself) while re-auditing channels for the work above:
+
+1. **`availability` one-way ratchet.** A transient biometrics staleness
+   blip permanently flagged a node's `availability` pressure — the only
+   removal rule was hardcoded to clear a different pressure kind
+   (`"strain"`), so `availability` could never recover. Confirmed live:
+   `node:atlas` reported `availability=0.0` for hours after its biometrics
+   resumed reporting fresh. `availability` itself is **not** one of `v2`'s
+   16 trained channels (excluded already by field selection, presumably as
+   a near-constant/degenerate signal) — but that exclusion was itself an
+   artifact of this bug: a channel that's permanently stuck at one value
+   looks exactly like a channel with no real signal. Once nodes can
+   actually recover, `availability` may show real variance in future
+   corpus data and could be selected into a future retrain where it
+   previously wasn't.
+2. **Biometrics-pressure merge-window dedup was a no-op across ticks**
+   (a separate bug in the same reducer, unrelated to the ratchet above) —
+   `node:atlas` alone accepted 767 "reinforce" deltas in 2 hours instead of
+   the ~24 a working 5-minute window should have allowed. This inflated
+   `pressure_score`, which feeds `cpu_pressure`/`gpu_pressure` (via
+   `active_node_pressure` deltas' `"strain"` pressure kind, `mode="add"`,
+   `state_deltas.py:36`) — `cpu_pressure` **is** one of `v2`'s 16 trained
+   channels. Corpus rows recorded before this fix reflect artificially
+   inflated reinforcement-flood contamination on `cpu_pressure` (and, for
+   `atlas`/`circe`, `gpu_pressure`); rows after it reflect the
+   `merge_window_sec=300` dedup actually working as designed.
+
+Both fixed by PR #1262 (`orion/substrate/biometrics_loop/pressure_organ.py`
+Rule B' + `pressure_reducer.py`'s `last_accepted_at`-based dedup, plus a
+companion fix in this service's `state_deltas.py` restoring `availability`
+to `1.0` on the recovery transition). As of this writing PR #1262 is open,
+not yet merged or deployed. Once it is, get the exact cutoff the same way
+as the second cutoff above (`gh pr view 1262 --json mergedAt`, cross-checked
+against **both** `orion-field-digester`'s and `orion-substrate-runtime`'s
+container restart times — this fix spans both services, and the earlier
+container to restart is not necessarily the binding cutoff since corpus
+contamination could come from either side):
+
+```bash
+python orion/mood_arc/fit_encoder.py train \
+  --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
+  --min-generated-at <PR #1262 deploy timestamp, TBD> \
+  --out <out-dir>
+```
+
+If multiple cutoffs apply, use whichever is latest. **Do not retrain until
+this cutoff is known and filled in** — same reasoning as the second cutoff:
+retraining against contaminated `cpu_pressure` data would just produce
+another `v2`-shaped problem for a different channel.
+
 ## Field channel glossary
 
 This is the consolidated reference for all 29 channels in


### PR DESCRIPTION
## Summary

- Adds a third training-data quality cutoff section to both READMEs, for PR #1262 (availability one-way ratchet + biometrics-pressure merge-window dedup no-op — both in `orion/substrate/biometrics_loop`, upstream of field-digester).
- `availability` itself isn't one of `field_channel_anomaly.v2`'s 16 trained channels, but its exclusion from field selection was likely an artifact of the same bug (a permanently-stuck value looks exactly like no-signal to a degenerate-channel filter).
- `cpu_pressure` **is** one of the 16 trained channels, and was corrupted by the dedup bug: inflated `pressure_score` from over-accepted "reinforce" deltas feeds `cpu_pressure` via `active_node_pressure`'s `"strain"` pressure kind (`mode="add"`, `state_deltas.py:36`).
- Cutoff timestamp left as `TBD` — PR #1262 isn't merged/deployed yet. Documents the exact mechanism to fill it in once it is (matching the pattern already used for the second cutoff): `gh pr view 1262 --json mergedAt`, cross-checked against **both** `orion-field-digester`'s and `orion-substrate-runtime`'s restart times, since this fix spans both services.

## Files changed

- `services/orion-field-digester/README.md`: new "third training-data quality cutoff" section.
- `orion/mood_arc/README.md`: matching cutoff note in the `--min-generated-at` bullet list.

## Tests run

None applicable (docs only).

## Restart required

No restart required for this docs-only PR.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/docs/telemetry-anomaly-third-cutoff