### PR TITLE
docs(field-digester,mood-arc): fill in PR #1262's third cutoff timestamp

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -91,25 +91,27 @@ python orion/mood_arc/fit_encoder.py train \
   5-day corpus. Do not retrain until meaningfully more clean data has
   accumulated; see the agent board for the tracked follow-up. If both
   cutoffs apply, use whichever is later.
-- **Third cutoff, PR #1262 (pending deploy):** two bugs in
-  `orion/substrate/biometrics_loop`'s active-node-pressure reducer,
-  upstream of this service. (1) `availability` one-way ratchet — a
-  transient staleness blip could permanently flag a node unavailable, with
-  no rule able to clear it; not one of `v2`'s 16 trained channels, but its
-  exclusion from training was itself likely an artifact of this bug
-  (permanently-stuck looks like no-signal). (2) merge-window dedup was a
-  no-op across ticks — `node:atlas` accepted 767 "reinforce" deltas in 2
-  hours instead of the ~24 a working 5-minute window should allow, inflating
-  `pressure_score` and therefore `cpu_pressure` (`mode="add"`, one of `v2`'s
-  16 trained channels) via `active_node_pressure` deltas' `"strain"`
-  pressure kind. See `services/orion-field-digester/README.md`'s "third
-  training-data quality cutoff" section for the full detail and the exact
-  mechanism to determine the real cutoff once PR #1262 is merged and both
-  `orion-field-digester` and `orion-substrate-runtime` (which runs the
-  biometrics_loop reducer) have been restarted. **Do not retrain until this
-  cutoff is known** — same reasoning as the second cutoff, just for
-  `cpu_pressure` instead of `catalog_drift_pressure`. If multiple cutoffs
-  apply, use whichever is latest.
+- **Third cutoff, `--min-generated-at 2026-07-22T08:29:48Z` (PR #1262,
+  merged + deployed):** two bugs in `orion/substrate/biometrics_loop`'s
+  active-node-pressure reducer, upstream of this service. (1) `availability`
+  one-way ratchet — a transient staleness blip could permanently flag a node
+  unavailable, with no rule able to clear it; not one of `v2`'s 16 trained
+  channels, but its exclusion from training was itself likely an artifact of
+  this bug (permanently-stuck looks like no-signal). (2) merge-window dedup
+  was a no-op across ticks — `node:atlas` accepted 767 "reinforce" deltas in
+  2 hours instead of the ~24 a working 5-minute window should allow,
+  inflating `pressure_score` and therefore `cpu_pressure` (`mode="add"`, one
+  of `v2`'s 16 trained channels) via `active_node_pressure` deltas'
+  `"strain"` pressure kind. See `services/orion-field-digester/README.md`'s
+  "third training-data quality cutoff" section for the full detail.
+  `2026-07-22T08:29:48Z` is `orion-substrate-runtime`'s restart time (the
+  later of the two services this fix spans, and the binding one).
+  Confirmed live: `node:atlas`'s `availability` recovered to `1.0`
+  immediately post-restart, and its reinforce-delta rate dropped from
+  ~1/9s to quiet within the first minute. **`v3` should train against this
+  cutoff (or the second cutoff, whichever is later — currently this one)**;
+  same reasoning as the second cutoff, just for `cpu_pressure` instead of
+  `catalog_drift_pressure`.
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -291,7 +291,7 @@ as of this writing there are only ~40 minutes of clean post-cutoff data,
 nowhere near `v2`'s 207K-row/5-day corpus. Let clean data accumulate
 first; see the agent board for the tracked follow-up.
 
-## `field_channel_corpus.v1` third training-data quality cutoff (PR #1262, pending deploy)
+## `field_channel_corpus.v1` third training-data quality cutoff (2026-07-22, PR #1262)
 
 A third, independent contamination window, found in `orion/substrate/
 biometrics_loop` (upstream of this service, not a field-digester bug
@@ -325,25 +325,30 @@ itself) while re-auditing channels for the work above:
 Both fixed by PR #1262 (`orion/substrate/biometrics_loop/pressure_organ.py`
 Rule B' + `pressure_reducer.py`'s `last_accepted_at`-based dedup, plus a
 companion fix in this service's `state_deltas.py` restoring `availability`
-to `1.0` on the recovery transition). As of this writing PR #1262 is open,
-not yet merged or deployed. Once it is, get the exact cutoff the same way
-as the second cutoff above (`gh pr view 1262 --json mergedAt`, cross-checked
-against **both** `orion-field-digester`'s and `orion-substrate-runtime`'s
-container restart times — this fix spans both services, and the earlier
-container to restart is not necessarily the binding cutoff since corpus
-contamination could come from either side):
+to `1.0` on the recovery transition), merged 2026-07-22T08:06:41Z.
+`orion-field-digester` restarted 2026-07-22T08:29:00Z,
+`orion-substrate-runtime` (which runs the biometrics_loop reducer)
+restarted 2026-07-22T08:29:48Z — the later of the two,
+**`2026-07-22T08:29:48Z`, is the binding cutoff** (corpus contamination
+could come from either service, so the cutoff is only safe once both have
+picked up the fix). Confirmed live immediately post-restart:
+`node:atlas`'s `availability` read `1.0` (was permanently `0.0`), and its
+`node_pressure_reducer` receipts dropped to 2 in the first 40 seconds then
+went quiet, consistent with the 5-minute merge window actually holding
+instead of firing every ~9 seconds:
 
 ```bash
 python orion/mood_arc/fit_encoder.py train \
   --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
-  --min-generated-at <PR #1262 deploy timestamp, TBD> \
+  --min-generated-at 2026-07-22T08:29:48Z \
   --out <out-dir>
 ```
 
-If multiple cutoffs apply, use whichever is latest. **Do not retrain until
-this cutoff is known and filled in** — same reasoning as the second cutoff:
-retraining against contaminated `cpu_pressure` data would just produce
-another `v2`-shaped problem for a different channel.
+If multiple cutoffs apply, use whichever is latest (as of this writing,
+that's this third cutoff, `2026-07-22T08:29:48Z`). Same reasoning as the
+second cutoff still applies to any retrain: skip pre-cutoff rows, or the
+run will reproduce a `cpu_pressure`-shaped version of the same
+contaminated-baseline problem `v2` already hit for `catalog_drift_pressure`.
 
 ## Field channel glossary
 


### PR DESCRIPTION
## Summary

- Fills in the `<PR #1262 deploy timestamp, TBD>` placeholder in both READMEs with the real value: PR #1262 merged 2026-07-22T08:06:41Z, `orion-field-digester` restarted 08:29:00Z, `orion-substrate-runtime` (runs the `biometrics_loop` reducer) restarted 08:29:48Z — the later of the two is the binding cutoff.
- Records live post-deploy confirmation of both fixes actually working, not just deployed: `node:atlas`'s `availability` recovered to `1.0` immediately post-restart (was permanently `0.0`), and its reinforce-delta rate dropped from ~1 every 9 seconds to quiet within the first minute.

## Files changed

- `services/orion-field-digester/README.md`: filled in the cutoff timestamp, added live verification note.
- `orion/mood_arc/README.md`: same, in the `--min-generated-at` bullet list.

## Tests run

None applicable (docs only).

## Restart required

No restart required.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/docs/telemetry-anomaly-third-cutoff-timestamp