### PR TITLE
fix(graph-compression): add requests dep, bump redis for Falkor federators

### DIFF
--- a/services/orion-graph-compression/requirements.txt
+++ b/services/orion-graph-compression/requirements.txt
@@ -3,10 +3,11 @@ uvicorn[standard]>=0.29.0
 pydantic>=2.6.0
 pydantic-settings>=2.2.0
 httpx>=0.27.0
+requests==2.32.*
 networkx>=3.2.0
 leidenalg>=0.10.2
 igraph>=0.11.4
 sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.9
 pyyaml>=6.0.1
-redis[hiredis]==5.0.7
+redis[hiredis]==5.2.1


### PR DESCRIPTION
## Summary

- Flipped PR #1254's dark Falkor federator flags live for the first time today and found both federators silently failing on every tick.
- Two real dependency bugs, only catchable by testing inside the actual container (local dev venv already has both deps, so pytest never surfaced this):
  1. `from orion.graph.falkor_client import RedisGraphQueryClient` transitively imports `orion/graph/__init__.py` -> `sparql_client.py`, which needs `requests` -- this service never had it (its own SPARQL calls use `httpx`).
  2. After adding `requests`, `redis==5.0.7`'s `redis/commands/graph/query_result.py` does `from distutils.util import strtobool` -- removed from stdlib in Python 3.12 (this image's interpreter). Bumped to `redis==5.2.1`, matching `orion-substrate-runtime`'s already-proven pin for the same `RedisGraphQueryClient` usage.

## Outcome moved

Both Falkor federators now actually work when their flags are on, instead of silently no-op'ing (fail-open, logged but not crashing) every tick.

## Files changed

- `services/orion-graph-compression/requirements.txt`: `+requests==2.32.*`, `redis[hiredis]==5.0.7` -> `redis[hiredis]==5.2.1`.

## Tests run

```text
ORION_BUS_URL=redis://127.0.0.1:6379/0 PYTHONPATH=.:services/orion-graph-compression venv/bin/python3 -m pytest services/orion-graph-compression/tests -q
→ 42 passed
```

Live-verified end to end inside the real container (not just tests): both federators return real triples (19 substrate, 3414 episodic, matching earlier venv-based numbers), a real compression tick (manually triggered via a `stale_queue` insert) unions them with the SPARQL federator output with zero errors, and every resulting region wrote to Fuseki successfully (`fuseki_ok=True`).

## Review findings fixed

- Finding (should-fix, not a blocker, follow-up not done in this PR): `orion-graph-compression` has zero CI coverage -- the repo already has a proven pattern (`orion-sql-writer-tests.yml`: install the service's real `requirements.txt` fresh on Python 3.12, run its pytest suite) that would have caught this exact bug class pre-merge. Worth a small follow-up PR mirroring that pattern.
- Informational (no fix needed, independently verified): the `redis` bump is safe -- no other file in this service imports `redis` directly besides the new federator's `falkor_store.py`, and `orion-substrate-runtime` already runs the same shared `RedisGraphQueryClient` code under `redis==5.2.1` in production.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-graph-compression/.env \
  -f services/orion-graph-compression/docker-compose.yml up -d --build
```

Note: a concurrent session on this shared host appears to have redeployed this container from stale/unmerged state during today's live verification (a known collision pattern -- see AGENTS.md section 2's "Shared checkout Docker deploy collision" note). Re-verify live behavior post-merge rather than trusting whatever's currently running.

## Risks / concerns

- Severity: Low.
- Concern: none beyond the CI-gap follow-up noted above.