### PR TITLE
docs(field-digester,mood-arc): document field_channel_anomaly.v3 deploy

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -84,13 +84,10 @@ python orion/mood_arc/fit_encoder.py train \
   post-fix, with the real value correctly reading `0.0`, `v2` (trained on
   the stuck ~`0.135` reading) flipped to flagging the *correct* value as
   anomalous instead: `telemetry_anomaly` still fired 20 times in the 41
-  minutes after the restart, same channel, opposite direction. **`v2` is not
-  a valid baseline and needs a `v3` retrain against
-  `--min-generated-at 2026-07-22T04:35:01Z`** — but as of this writing
-  there's only ~40 minutes of clean data, nowhere near `v2`'s 207K-row/
-  5-day corpus. Do not retrain until meaningfully more clean data has
-  accumulated; see the agent board for the tracked follow-up. If both
-  cutoffs apply, use whichever is later.
+  minutes after the restart, same channel, opposite direction. **`v2` was
+  not a valid baseline** — see the third cutoff below for what actually
+  shipped as its replacement. If both cutoffs apply, use whichever is
+  later.
 - **Third cutoff, `--min-generated-at 2026-07-22T08:29:48Z` (PR #1262,
   merged + deployed):** two bugs in `orion/substrate/biometrics_loop`'s
   active-node-pressure reducer, upstream of this service. (1) `availability`
@@ -108,10 +105,18 @@ python orion/mood_arc/fit_encoder.py train \
   later of the two services this fix spans, and the binding one).
   Confirmed live: `node:atlas`'s `availability` recovered to `1.0`
   immediately post-restart, and its reinforce-delta rate dropped from
-  ~1/9s to quiet within the first minute. **`v3` should train against this
-  cutoff (or the second cutoff, whichever is later — currently this one)**;
-  same reasoning as the second cutoff, just for `cpu_pressure` instead of
-  `catalog_drift_pressure`.
+  ~1/9s to quiet within the first minute.
+
+  **`v3` (currently deployed) trained against exactly this cutoff**:
+  18,377 rows / 10.3h clean data, `floor_ratio=0.210` (pass, CI
+  0.174-0.231), `ceiling_ratio=0.190` — within 0.001 of `v2`'s 0.189
+  despite the much smaller/different corpus (an early n=2 signal this
+  number may be stable, not yet the full multi-seed calibration the
+  roadmap wants). `availability` survived field selection for the first
+  time (`std=0.0398`), confirming its prior exclusion was the ratchet bug,
+  not a real absence of signal. See `services/orion-field-digester/
+  README.md`'s "Deployed model history" table for the full `v1`/`v2`/`v3`
+  comparison.
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -200,6 +200,24 @@ Every `FIELD_CHANNEL_ANOMALY_CHECK_INTERVAL_SEC` (default 60s -- the encoder's o
 | `FIELD_CHANNEL_ANOMALY_THRESHOLD_MULTIPLIER` | `3.0` | Informational only -- see above |
 | `CHANNEL_FIELD_CHANNEL_ANOMALY_SCORE` | `orion:field_channel:anomaly_score` | Publish channel |
 
+**Deployed model history** (live `FIELD_CHANNEL_ANOMALY_ENCODER_DIR`, disk artifacts kept, not
+deleted, on supersession):
+
+| Version | Trained against | Rows | `floor_ratio` | `ceiling_ratio` | Why superseded |
+|---|---|---|---|---|---|
+| `v1` | full corpus, no cutoff | — | — | 0.240 | Contaminated by the 2026-07-17 channel-behavior fix sprint (PRs #1108-#1113/#1115) |
+| `v2` | `--min-generated-at 2026-07-17T04:32:14Z` | 207,415 / 5 days | 0.282 (CI 0.266-0.304) | 0.189 | `catalog_drift_pressure` stuck the *entire* corpus span (PR #1248's mode=`add`→`replace` fix, second cutoff below) |
+| `v3` (current) | `--min-generated-at 2026-07-22T08:29:48Z` | 18,377 / 10.3h | 0.210 (CI 0.174-0.231) | 0.190 | n/a — current live model, deployed after PR #1262's availability-ratchet + merge-window-dedup fix (third cutoff below) |
+
+`v3` trained on a much smaller corpus than `v2` (10.3h of clean data vs. 5 days) — it's a
+calibration-quality run on what was available at the time, not a full-corpus retrain. Notably its
+`ceiling_ratio` (0.190) landed within 0.001 of `v2`'s (0.189) despite the different corpus size and
+composition — an early (n=2) signal this number may be more stable than the "one uncalibrated run"
+framing this doc used to carry, though the roadmap's full multi-seed calibration (5+ seeds against
+one fixed corpus) hasn't been run yet. Field selection also picked up `availability` for the first
+time (`std=0.0398`) — excluded from `v1`/`v2` as degenerate, which in hindsight was itself a symptom
+of the ratchet bug PR #1262 fixed, not a real absence of signal.
+
 ## `field_channel_corpus.v1` training-data quality cutoff (2026-07-17)
 
 `field_channel_corpus.v1` rows generated **before `2026-07-17T04:32:14Z`**
@@ -275,9 +293,9 @@ live post-fix: with the pipeline bug fixed and the real value now correctly
 reading `0.0`, `v2` (trained almost entirely on the stuck ~`0.135` reading)
 started flagging the *correct* value as anomalous instead —
 `telemetry_anomaly` still fired 20 times in the 41 minutes after the
-restart, same channel, opposite direction. The pipeline bug is fixed; the
-deployed model is not yet retrained on clean data and will keep
-misfiring on this channel until it is.
+restart, same channel, opposite direction. **Resolved by `v3`** (see
+"Deployed model history" above and the third cutoff below) — `v2` is no
+longer deployed.
 
 ```bash
 python orion/mood_arc/fit_encoder.py train \
@@ -286,10 +304,14 @@ python orion/mood_arc/fit_encoder.py train \
   --out <out-dir>
 ```
 
-If both cutoffs apply, use whichever is later. **Do not retrain yet** —
-as of this writing there are only ~40 minutes of clean post-cutoff data,
-nowhere near `v2`'s 207K-row/5-day corpus. Let clean data accumulate
-first; see the agent board for the tracked follow-up.
+If both cutoffs apply, use whichever is later. **Superseded by the third
+cutoff below as of `v3`** — the retrain against this cutoff alone was
+skipped; by the time enough clean data existed to retrain at all, PR #1262
+had also merged, so `v3` trained directly against the third (later)
+cutoff instead. Kept here for the historical record and in case a future
+retrain ever needs to reason about this cutoff specifically (e.g. scoring
+a slice that only needs to exclude the second contamination window, not
+the third).
 
 ## `field_channel_corpus.v1` third training-data quality cutoff (2026-07-22, PR #1262)
 
@@ -346,9 +368,18 @@ python orion/mood_arc/fit_encoder.py train \
 
 If multiple cutoffs apply, use whichever is latest (as of this writing,
 that's this third cutoff, `2026-07-22T08:29:48Z`). Same reasoning as the
-second cutoff still applies to any retrain: skip pre-cutoff rows, or the
-run will reproduce a `cpu_pressure`-shaped version of the same
+second cutoff still applies to any future retrain: skip pre-cutoff rows,
+or the run will reproduce a `cpu_pressure`-shaped version of the same
 contaminated-baseline problem `v2` already hit for `catalog_drift_pressure`.
+
+**`v3` trained against exactly this cutoff** (18,377 rows / 10.3h clean
+data — much smaller than `v2`'s 207K-row/5-day corpus, since this cutoff
+had only just landed) and is the currently deployed
+`FIELD_CHANNEL_ANOMALY_ENCODER_DIR`. See "Deployed model history" above
+for the real gate results. A future retrain against a fuller corpus once
+more clean data accumulates past this cutoff would still be worthwhile
+(more data, tighter confidence intervals) but is not blocking — `v3` is a
+real, gate-passing, currently-serving model, not a placeholder.
 
 ## Field channel glossary
 


### PR DESCRIPTION
## Summary

- `v3` trained and deployed — live `.env`'s `FIELD_CHANNEL_ANOMALY_ENCODER_DIR` now points at `/mnt/telemetry/models/field_channel_anomaly/v3`. Real results: `floor_ratio=0.210` (pass, CI 0.174-0.231), `ceiling_ratio=0.190` — within 0.001 of `v2`'s `0.189` despite a much smaller/different corpus (18,377 rows / 10.3h vs. `v2`'s 207K/5 days).
- Added a "Deployed model history" table to `services/orion-field-digester/README.md` summarizing `v1`/`v2`/`v3` lineage and gate results in one place.
- Corrected several passages in both READMEs that had gone stale narrating `v2` as still-deployed and still-misfiring `telemetry_anomaly` — that's resolved now that `v3` shipped.
- Noted `availability` survived field selection for the first time (`std=0.0398`) — its exclusion from `v1`/`v2` was itself a symptom of the ratchet bug PR #1262 fixed, not a real absence of signal.

## Files changed

- `services/orion-field-digester/README.md`: new "Deployed model history" table; updated the second-cutoff and third-cutoff sections to reflect `v3`'s actual deployment instead of "not yet retrained."
- `orion/mood_arc/README.md`: matching updates in the cutoff bullet list.

## Tests run

None applicable (docs only).

## Restart required

No restart required (docs only — the actual `.env` change and deploy already happened; this PR just documents it).

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/docs/field-channel-anomaly-v3-deploy