### PR TITLE
docs(field-digester,mood-arc): fourth training-data cutoff for prediction_error

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -17,7 +17,9 @@ it" reference; the docs directory is the "why does it look like this" one.
 
 **Status: dark deployment.** Everything here is an offline, manually-invoked
 CLI. No bus publish, no service process, no container, no cognition consumer.
-Registered `REHEARSAL` in `orion/self_state/inner_state_registry.py`
+Registered `REHEARSAL` in `orion/inner_state_registry.py` (moved from
+`orion/self_state/inner_state_registry.py` during the 2026-07-22 SelfStateV1
+module deletion — path corrected here, no behavior change)
 (`mood_arc_encoder.v1`, `mood_arc_corpus.v1`, `field_channel_corpus.v1`) —
 that status is correct and intentional, not a gap to close as part of this
 patch.
@@ -112,6 +114,33 @@ python orion/mood_arc/fit_encoder.py train \
   cutoff (or the second cutoff, whichever is later — currently this one)**;
   same reasoning as the second cutoff, just for `cpu_pressure` instead of
   `catalog_drift_pressure`.
+- **Fourth cutoff, `--min-generated-at 2026-07-22T19:18:31Z` (commit
+  `a98854a2` + PR #1267, both merged + deployed):** `prediction_error` (one
+  of `v2`'s trained channels — confirmed via `docs/DESIGN.md`'s "15 channels
+  survived selection + pruning" list) is a `max()`-merge across five nodes'
+  shadow prediction-error instruments (`orion/substrate/prediction_error.py`,
+  wired in `services/orion-substrate-runtime`). Two of those five were
+  broken until today: `execution_prediction_error()`/`route_prediction_
+  error()` matched on an exact `trace_id` that structurally never recurs
+  (permanently `0.0`, fixed in `a98854a2`), and `chat_prediction_error()`
+  skipped every brand-new turn (also permanently `0.0` in production despite
+  241 real accumulated chat turns, fixed in PR #1267). Confirmed directly
+  against the training corpus file: its earliest available rows
+  (2026-07-18T20:41Z) already read `prediction_error = 3e-323` — the
+  `apply_decay()` floor a stale `NODE_DECAY_CHANNELS` entry settles to —
+  consistent with this channel sitting at or near that floor for its entire
+  history in this corpus, not carrying real learnable variance the way `v2`'s
+  field selection presumably assumed. `2026-07-22T19:18:31Z` is
+  `orion-substrate-runtime`'s restart time (the later of the two fixes'
+  merges, both landing in that one service — the binding cutoff). Confirmed
+  live post-restart, directly against the corpus file: rows minutes after
+  read `prediction_error = 0.0671`-`0.1171`, varying across ticks rather
+  than stuck at the old floor. See `services/orion-field-digester/README.md`'s
+  "fourth training-data quality cutoff" section for the full detail,
+  including the honest caveat that exact per-node attribution of the new
+  reading hasn't been traced further. **`v4` should train against this
+  cutoff (or whichever prior cutoff is later — currently this one)**; do not
+  retrain yet, only minutes of clean data exist as of this writing.
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -90,6 +90,17 @@ flat).
 `resource_pressure` — attention scoring and any other capability-vector consumer reads the same
 channels and would show the same artifact.
 
+**Audited 2026-07-22: `"prediction_error"` (one of `NODE_DECAY_CHANNELS`) confirmed working
+correctly, not another instance of this bug class.** `node:substrate.route`'s prediction_error
+was observed as a subnormal float (~3e-323) and initially suspected as a decay-mechanism defect.
+Traced instead to a real quiet period — route arbitration hadn't produced a `lane`/`mind_
+requested` mismatch recently, and the write path (`app/ingest/state_deltas.py`'s
+`prediction_signal` branch, `mode="replace"`) correctly stamps `node_vector_updated_at` through
+the normal `apply_perturbations()` path, so the hold-then-decay logic above applies to it exactly
+as designed. See the "fourth training-data quality cutoff" section below for the related (and
+real) finding: three of the five nodes contributing to this channel's `max()`-merge were
+themselves broken upstream (in `orion-substrate-runtime`, not here) until today.
+
 **Fixed 2026-07-17** (`docs/superpowers/specs/2026-07-17-field-digester-decay-hold-fix-design.md`).
 `FieldStateV1.node_vector_updated_at` (new field) tracks the wall-clock timestamp of each
 `(node_id, channel)`'s last real write from `apply_perturbations()`. `apply_decay()` now holds a
@@ -349,6 +360,72 @@ that's this third cutoff, `2026-07-22T08:29:48Z`). Same reasoning as the
 second cutoff still applies to any retrain: skip pre-cutoff rows, or the
 run will reproduce a `cpu_pressure`-shaped version of the same
 contaminated-baseline problem `v2` already hit for `catalog_drift_pressure`.
+
+## `field_channel_corpus.v1` fourth training-data quality cutoff (2026-07-22)
+
+A fourth contamination window, this one on `prediction_error` — one of the
+15 channels `v2` actually trained on (`orion/mood_arc/docs/DESIGN.md`).
+`prediction_error` is a `max()`-merge across five nodes (`orion/field/
+pressure.py::collect_field_channel_pressures()`, `PRESSURE_CHANNELS`) —
+`node:substrate.{biometrics,execution,transport,chat,route}`, each written
+by `services/orion-substrate-runtime`'s five shadow prediction-error
+instruments (`orion/substrate/prediction_error.py`). Three of those five
+were broken until today, upstream of this service, not a field-digester bug:
+
+1. `execution_prediction_error()`/`route_prediction_error()` diffed a
+   `curr` run against `prev`'s exact `trace_id` match, which structurally
+   never occurred (real runs are single-shot creates) — permanently `0.0`
+   regardless of activity. Fixed (commit `a98854a2`).
+2. `chat_prediction_error()` skipped every brand-new `turn_id` (the only
+   kind that ever appears in a fresh tick), also permanently `0.0` in
+   production — confirmed live, `node:substrate.chat` had never been
+   written despite 241 real accumulated chat turns. Fixed (PR #1267).
+3. `transport_prediction_error()` was **not** broken — its low reading is a
+   real quiet bus, not an instrument defect (see the earlier fix note in
+   this same file).
+
+Net effect: for as long as those two instruments were broken, the merged
+`prediction_error` channel could only ever reflect `biometrics_prediction_
+error()` (introduced 2026-07-21) or `transport_prediction_error()` (always
+near-zero) — confirmed directly against the training corpus file itself
+(`/mnt/telemetry/field_channels/corpus/field_channels.jsonl`): its earliest
+available rows (2026-07-18T20:41Z, predating even the biometrics/chat/
+route instruments' 2026-07-21 introduction) already read `prediction_error
+= 3e-323` — the decay floor `apply_decay()` (`NODE_DECAY_CHANNELS` includes
+`"prediction_error"`) settles a stale channel to. This is consistent with
+`prediction_error` having been at or near that floor for its entire history
+in this corpus, not a channel with real learnable variance — the opposite
+of what `v2`'s field-selection pass presumably assumed when it kept this
+channel.
+
+Fixed by `a98854a2` (merged earlier 2026-07-22) and PR #1267 (merged
+2026-07-22T19:16:01Z); `orion-substrate-runtime` restarted
+2026-07-22T19:18:31Z (`docker inspect orion-athena-substrate-runtime
+--format '{{.State.StartedAt}}'`) — the later of the two, and the binding
+cutoff since both fixes live in that one service. Confirmed live
+post-restart directly against the corpus file: rows minutes after the
+restart read `prediction_error = 0.0671`-`0.1171` (varying across
+consecutive ticks, not stuck) — a qualitatively different, real signal
+compared to the pre-cutoff decay-floor constant. Exact per-node
+attribution of this specific post-restart value has not been traced
+further in this pass (worth a follow-up if a `v4` retrain's field-selection
+behaves unexpectedly for this channel) — the corpus-level before/after
+contrast is the confirmed finding here, not a claim about which of the
+three now-real instruments produced it.
+
+```bash
+python orion/mood_arc/fit_encoder.py train \
+  --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
+  --min-generated-at 2026-07-22T19:18:31Z \
+  --out <out-dir>
+```
+
+If multiple cutoffs apply, use whichever is latest (as of this writing,
+that's this fourth cutoff, `2026-07-22T19:18:31Z`). Same reasoning as the
+second/third cutoffs: **do not retrain yet** — there are only minutes of
+clean post-cutoff data as of this writing, nowhere near `v2`'s 207K-row/
+5-day corpus. Let clean data accumulate first; see the agent board for the
+tracked follow-up.
 
 ## Field channel glossary
 


### PR DESCRIPTION
## Summary

Answers two follow-up questions from the chat/route prediction-error audit (PRs #1267, #1269):

1. **Did the README notes get updated?** Yes for `orion-substrate-runtime` (in #1267). This PR adds the missing piece: a confirming note in `services/orion-field-digester/README.md`'s existing "Decay vs. injection-interval mismatch" section that `prediction_error` (one of `NODE_DECAY_CHANNELS`) was specifically audited and confirmed NOT another instance of that bug class.
2. **Does the mood-arc-encoder retrain cutoff need to change?** Yes. `prediction_error` is confirmed as one of `v2`'s 15 trained channels (`orion/mood_arc/docs/DESIGN.md`'s field-selection list). It's a `max()`-merge across 5 nodes' shadow prediction-error instruments, two of which (`execution`/`route`, `chat`) were structurally always `0.0` in production until today's fixes. This is a fourth, real training-data-quality-cutoff, following this repo's established 3-cutoff pattern for this exact corpus.

## Outcome moved

Documents the fourth cutoff (`2026-07-22T19:18:31Z`) in both `services/orion-field-digester/README.md` and `orion/mood_arc/README.md`, kept in sync per the existing convention from cutoff #1. No retrain triggered — explicitly flagged "do not retrain yet," same as cutoffs #2/#3, since only minutes of clean data exist.

## Current architecture

`prediction_error` channel = `max()` across `node:substrate.{biometrics,execution,transport,chat,route}`, each written by one of `orion/substrate/prediction_error.py`'s five shadow instruments. Two were broken:
- `execution_prediction_error()`/`route_prediction_error()`: exact-`trace_id`-match bug, permanently `0.0` (fixed commit `a98854a2`).
- `chat_prediction_error()`: skipped every brand-new turn, permanently `0.0` (fixed PR #1267).
- `transport_prediction_error()` was never broken (real quiet bus, already documented).

## Files changed

- `services/orion-field-digester/README.md`: new "fourth training-data quality cutoff" section + a confirming note added to the existing decay-mismatch section.
- `orion/mood_arc/README.md`: matching fourth-cutoff bullet (kept in sync per the file's own stated convention); also fixed a stale path reference (`orion/self_state/inner_state_registry.py` → `orion/inner_state_registry.py`, moved during the 2026-07-22 SelfStateV1 module deletion, unrelated but found while editing this file).

## Evidence

Checked directly against the actual training corpus file (`/mnt/telemetry/field_channels/corpus/field_channels.jsonl`), not just the live DB:
- Earliest available row (2026-07-18T20:41Z): `prediction_error = 3e-323` (the `apply_decay()` floor).
- Rows minutes after `orion-substrate-runtime`'s 19:18:31Z restart: `prediction_error = 0.0671`-`0.1171`, varying across ticks — a real signal.

Exact per-node attribution of the new post-restart reading is disclosed as not fully traced in this pass (flagged honestly rather than guessed).

## Tests run

None — docs-only change.

## Review findings fixed

Not run — docs-only, no code touched.

## Restart required

```text
No restart required.
```

## Risks / concerns

None — documentation only. Explicitly does not trigger a retrain (per the doc's own "do not retrain yet" note, consistent with cutoffs #2/#3).

## PR link

(created by this command)