### PR TITLE
fix(hub): remove permanently-dead L6 self-state panel from substrate lattice console

### DIFF
--- a/config/substrate-lattice/grammar_producer_registry.v1.yaml
+++ b/config/substrate-lattice/grammar_producer_registry.v1.yaml
@@ -8,7 +8,6 @@ producers:
       - "bus.transport:"
     field_capability_id: "capability:transport"
     attention_target_id: "capability:transport"
-    self_state_dimension_id: transport_integrity
     trusted_channels:
       - bus_health
       - transport_pressure

--- a/services/orion-hub/scripts/substrate_lattice_routes.py
+++ b/services/orion-hub/scripts/substrate_lattice_routes.py
@@ -32,7 +32,6 @@ _LANES: list[dict[str, Any]] = [
         "trace_prefix": "bus.transport:",
         "field_capability_id": "capability:transport",
         "attention_target_id": "capability:transport",
-        "self_state_dimension_id": "transport_integrity",
         "status": "live",
     },
     {
@@ -259,19 +258,6 @@ def _load_transport_proof_chain(freshness_threshold_sec: int = 60) -> dict[str, 
         }
     m5 = _layer_meta(m5_values, "substrate_attention_frames", attn_ts, freshness_threshold_sec)
 
-    # L6 self-state: transport_integrity dimension
-    ss_raw, ss_ts = _first_json_with_ts(engine, "substrate_self_state", "self_state_json", "generated_at")
-    l6_values = None
-    if ss_raw:
-        dims = ss_raw.get("dimensions", {})
-        l6_values = {
-            "self_state_id": ss_raw.get("self_state_id"),
-            "overall_condition": ss_raw.get("overall_condition"),
-            "overall_intensity": ss_raw.get("overall_intensity"),
-            "transport_integrity": dims.get("transport_integrity"),
-        }
-    l6 = _layer_meta(l6_values, "substrate_self_state", ss_ts, freshness_threshold_sec)
-
     # L7 proposals
     prop_raw, prop_ts = _first_json_with_ts(engine, "substrate_proposal_frames", "proposal_frame_json", "generated_at")
     l7_values = None
@@ -346,12 +332,18 @@ def _load_transport_proof_chain(freshness_threshold_sec: int = 60) -> dict[str, 
         }
     l11 = _layer_meta(l11_values, "substrate_consolidation_frames", consol_ts, freshness_threshold_sec)
 
+    # L6 (SelfStateV1 "transport_integrity" dimension) removed 2026-07-22, SelfStateV1
+    # burn: orion-self-state-runtime (the substrate_self_state producer) is deleted, so
+    # this layer had no path to ever be fresh again -- _layer_meta() would have honestly
+    # flagged it "stale" forever rather than fabricating data, but a permanently-dead
+    # layer sitting in an otherwise-live lane's proof chain is exactly the kind of panel
+    # CLAUDE.md's burn spec called out to remove, not leave stale-forever. M5 (attention)
+    # now feeds directly into L7 (proposals) in the chain below.
     transport = {
         "m3": m3,
         "m3_receipts": m3_receipts,
         "m4": m4,
         "m5": m5,
-        "l6": l6,
         "l7": l7,
         "l8": l8,
         "l9": l9,
@@ -384,10 +376,10 @@ def _compute_verdict(chain: dict[str, Any]) -> str:
         return f"Transport lane stale: latest M3 projection is {age_str} old."
 
     # Collect layer statuses
-    layer_order = ["m3", "m3_receipts", "m4", "m5", "l6", "l7", "l8", "l9", "l10", "l11"]
+    layer_order = ["m3", "m3_receipts", "m4", "m5", "l7", "l8", "l9", "l10", "l11"]
     layer_labels = {
         "m3": "M3", "m3_receipts": "M3 receipts", "m4": "M4", "m5": "M5",
-        "l6": "L6", "l7": "L7", "l8": "L8", "l9": "L9", "l10": "L10", "l11": "L11",
+        "l7": "L7", "l8": "L8", "l9": "L9", "l10": "L10", "l11": "L11",
     }
 
     stale_layers = []

--- a/services/orion-hub/static/js/substrate-lattice.js
+++ b/services/orion-hub/static/js/substrate-lattice.js
@@ -213,15 +213,8 @@ function _renderProofChain(chain) {
     `<div class="mb-1">${capTransportHtml}</div>${m5TargetsHtml || '<span class="text-gray-500">no targets</span>'}`
   );
 
-  // L6
-  const l6 = chain.transport?.l6 || {};
-  const ss = l6.values || {};
-  const ti = ss.transport_integrity || {};
-  _setText("l6Status", `${_statusBadge(l6.status)} ${_ts(l6.timestamp)}`);
-  _setText(
-    "l6Body",
-    `condition: <b>${_esc(ss.overall_condition)}</b> &nbsp;|&nbsp; transport_integrity score: <b>${_fmt(ti.score)}</b> confidence: <b>${_fmt(ti.confidence)}</b>`
-  );
+  // L6 (SelfStateV1 "transport_integrity") removed 2026-07-22, SelfStateV1 burn --
+  // its card and chain.transport.l6 no longer exist, see substrate_lattice_routes.py.
 
   // L7
   const l7 = chain.transport?.l7 || {};

--- a/services/orion-hub/static/substrate-lattice.html
+++ b/services/orion-hub/static/substrate-lattice.html
@@ -70,14 +70,9 @@
         <div id="m5Body" class="text-xs text-gray-400">—</div>
       </div>
 
-      <!-- L6: Self-State -->
-      <div id="l6SelfStateCard" class="bg-gray-900 border border-gray-800 rounded-lg p-3 flex flex-col gap-1">
-        <div class="flex items-center justify-between">
-          <span class="text-[10px] font-semibold text-violet-400 uppercase">L6 Self-State · transport_integrity</span>
-          <span id="l6Status" class="text-[10px] text-gray-500">—</span>
-        </div>
-        <div id="l6Body" class="text-xs text-gray-400">—</div>
-      </div>
+      <!-- L6 (SelfStateV1 "transport_integrity") removed 2026-07-22, SelfStateV1 burn:
+           orion-self-state-runtime (its producer) is deleted, so this layer had no path
+           to ever be fresh again. See substrate_lattice_routes.py's matching dated note. -->
 
       <!-- L7: Proposals -->
       <div id="l7ProposalCard" class="bg-gray-900 border border-gray-800 rounded-lg p-3 flex flex-col gap-1">

--- a/services/orion-hub/tests/test_substrate_lattice_routes.py
+++ b/services/orion-hub/tests/test_substrate_lattice_routes.py
@@ -662,7 +662,7 @@ def test_load_chain_fresh_status_when_age_below_threshold(monkeypatch) -> None:
     proj = {"buses": {"bus:athena": {"source_trace_id": "trace:1", "bus_health": 1.0, "contract_pressure": 1.0}}}
     fake = _make_engine_sequence(
         {"projection_json": _json.dumps(proj), "updated_at": fresh_ts},
-        None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None,
     )
     with patch.object(substrate_lattice_routes, "_engine", return_value=fake):
         result = substrate_lattice_routes._load_transport_proof_chain(freshness_threshold_sec=60)
@@ -681,7 +681,7 @@ def test_load_chain_stale_status_when_age_above_threshold(monkeypatch) -> None:
     proj = {"buses": {}}
     fake = _make_engine_sequence(
         {"projection_json": _json.dumps(proj), "updated_at": old_ts},
-        None, None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None, None,
     )
     with patch.object(substrate_lattice_routes, "_engine", return_value=fake):
         result = substrate_lattice_routes._load_transport_proof_chain(freshness_threshold_sec=60)
@@ -700,7 +700,7 @@ def test_load_chain_missing_layer_when_no_row(monkeypatch) -> None:
     proj = {"buses": {}}
     fake = _make_engine_sequence(
         {"projection_json": _json.dumps(proj), "updated_at": fresh_ts},
-        None, None, None, None, None, None, None, None,
+        None, None, None, None, None, None, None,
         None,  # L11 returns None
     )
     with patch.object(substrate_lattice_routes, "_engine", return_value=fake):
@@ -762,7 +762,7 @@ def test_m5_capability_transport_detected_in_capability_targets(monkeypatch) -> 
         None,
         None,
         {"frame_json": _json.dumps(attn_frame), "generated_at": ts},
-        None, None, None, None, None, None,
+        None, None, None, None, None,
     )
     with patch.object(substrate_lattice_routes, "_engine", return_value=fake):
         result = substrate_lattice_routes._load_transport_proof_chain()
@@ -790,7 +790,7 @@ def test_m5_capability_transport_detected_in_suppressed_targets(monkeypatch) -> 
         None,
         None,
         {"frame_json": _json.dumps(attn_frame), "generated_at": ts},
-        None, None, None, None, None, None,
+        None, None, None, None, None,
     )
     with patch.object(substrate_lattice_routes, "_engine", return_value=fake):
         result = substrate_lattice_routes._load_transport_proof_chain()
@@ -820,7 +820,7 @@ def test_m5_capability_transport_not_found(monkeypatch) -> None:
         None,
         None,
         {"frame_json": _json.dumps(attn_frame), "generated_at": ts},
-        None, None, None, None, None, None,
+        None, None, None, None, None,
     )
     with patch.object(substrate_lattice_routes, "_engine", return_value=fake):
         result = substrate_lattice_routes._load_transport_proof_chain()

--- a/services/orion-hub/tests/test_substrate_lattice_routes.py
+++ b/services/orion-hub/tests/test_substrate_lattice_routes.py
@@ -83,7 +83,7 @@ def test_transport_latest_returns_proof_chain(client) -> None:
     assert "freshness_threshold_sec" in body
     assert "verdict" in body
     transport = body["transport"]
-    for key in ("m3", "m3_receipts", "m4", "m5", "l6", "l7", "l8", "l9", "l10", "l11"):
+    for key in ("m3", "m3_receipts", "m4", "m5", "l7", "l8", "l9", "l10", "l11"):
         assert key in transport, f"Missing key: {key}"
         layer = transport[key]
         assert "status" in layer
@@ -155,7 +155,6 @@ def test_load_transport_proof_chain_empty_buses_yields_empty_bus_summary(monkeyp
         None,  # M3 receipts
         None,  # M4 field
         None,  # M5 attention
-        None,  # L6 self-state
         None,  # L7 proposals
         None,  # L8 policy
         None,  # L9 dispatch
@@ -256,13 +255,6 @@ def _sample_proof_chain_for_gates(
                     ] if capability_transport_bucket == "suppressed_targets" else [],
                     "capability_transport_bucket": capability_transport_bucket,
                 },
-            },
-            "l6": {
-                "status": "fresh",
-                "source_table": "substrate_self_state",
-                "timestamp": ts,
-                "age_sec": bus_age_sec,
-                "values": {"transport_integrity": {"score": 0.8}},
             },
             "l7": {
                 "status": "fresh",
@@ -440,7 +432,6 @@ def test_load_transport_proof_chain_with_projection_returns_full_structure(monke
         None,  # M3 receipts (all())
         None,  # M4 field
         None,  # M5 attention
-        None,  # L6 self-state
         None,  # L7 proposals
         None,  # L8 policy
         None,  # L9 dispatch
@@ -741,7 +732,7 @@ def test_m5_capability_transport_detected_in_dominant_targets(monkeypatch) -> No
         None,  # receipts
         None,  # M4 field
         {"frame_json": _json.dumps(attn_frame), "generated_at": ts},  # M5 attention
-        None, None, None, None, None, None,  # L6-L11
+        None, None, None, None, None,  # L7-L11
     )
     with patch.object(substrate_lattice_routes, "_engine", return_value=fake):
         result = substrate_lattice_routes._load_transport_proof_chain()


### PR DESCRIPTION
## Summary

- Removes the Hub's "L6 Self-State · transport_integrity" card from the substrate lattice tuning console (`services/orion-hub`) end to end: route/DB query, transport-chain dict entry, verdict layer ordering, HTML card, JS renderer.
- Follow-up to the completed SelfStateV1 burn (PR #1266) -- this was the one explicitly-flagged, unverified "Hub frontend" item from that burn's spec.
- Fixes 2 review findings on the first pass: incomplete mock-sequence cleanup in the route's test file, and a stale duplicate field in a dead config registry.

## Outcome moved

The lattice console's transport proof chain no longer carries a layer that can never be fresh again. `_layer_meta()` already handled this honestly (flips to `"stale"` once the frozen row ages out, never fakes "fresh"), but a permanently-dead layer sitting inside an otherwise-`"live"` lane's proof chain is exactly the panel the burn spec flagged as unverified against the real rendered template.

## Current architecture

`services/orion-hub/scripts/substrate_lattice_routes.py`'s `_load_transport_proof_chain()` builds a 9-10 layer chain (M3 reducer projection through L11 consolidation motifs) per producer lane by querying the relevant `substrate_*` Postgres table for each layer, wrapping each in `_layer_meta()` (status/timestamp/age/values), and computing an overall freshness verdict. Rendered by `static/substrate-lattice.html` + `static/js/substrate-lattice.js` as a debug console. L6 was the one layer backed by `substrate_self_state`, which lost its only producer (`orion-self-state-runtime`) when PR #1266 deleted that service.

## Architecture touched

- `services/orion-hub/scripts/substrate_lattice_routes.py` -- removed the L6 DB query/values block, its `transport` dict entry, its `_compute_verdict()` layer_order/layer_labels entry, and the `self_state_dimension_id` field on the `_LANES` transport-lane config.
- `services/orion-hub/static/substrate-lattice.html` -- removed the `l6SelfStateCard` markup.
- `services/orion-hub/static/js/substrate-lattice.js` -- removed the `l6Status`/`l6Body` renderer block.
- `services/orion-hub/tests/test_substrate_lattice_routes.py` -- updated all 9 `_make_engine_sequence(...)` mock call sites to match the new 9-call chain (was 10, L6's query no longer happens); fixed key-list assertions.
- `config/substrate-lattice/grammar_producer_registry.v1.yaml` -- dropped a stale duplicate `self_state_dimension_id` field (confirmed dead config, no code loads this file).

## Files changed

- `services/orion-hub/scripts/substrate_lattice_routes.py`
- `services/orion-hub/static/substrate-lattice.html`
- `services/orion-hub/static/js/substrate-lattice.js`
- `services/orion-hub/tests/test_substrate_lattice_routes.py`
- `config/substrate-lattice/grammar_producer_registry.v1.yaml`

## Schema / bus / API changes

- Removed: `l6` key from `GET /api/substrate-lattice/transport/latest` and `.../transport/gates` response payloads.
- Removed: `self_state_dimension_id` field from `GET /api/substrate-lattice/lanes`'s transport lane entry.
- Compatibility notes: no other code (grepped repo-wide) reads `chain.transport.l6` or the removed lane field; `_compute_gates()` never referenced L6/self-state either before or after.

## Env/config changes

None.

## Tests run

```text
services/orion-hub/tests/test_substrate_lattice_routes.py
services/orion-hub/tests/test_substrate_lattice_hub_tab.py
services/orion-hub/tests/test_hub_ui_polish.py
-- 60 passed

services/orion-hub/tests (full suite) -- 30 failed, 951 passed, 5 skipped
  (all 30 failures confirmed pre-existing and unrelated -- reproduced identically
  against unmodified main, e.g. test_memory_graph_routes.py,
  test_substrate_effect_endpoint.py; none touch substrate_lattice)
```

## Evals run

No dedicated eval harness exists for this Hub debug console; none run.

## Docker/build/smoke checks

```text
scripts/safe_docker_build.sh orion-hub config -q -- exit 0
```

## Review findings fixed

- Finding: only 3 of 9 `_make_engine_sequence(...)` call sites in `test_substrate_lattice_routes.py` were updated for the new 9-call chain; the other 6 still carried a trailing `None` sized for the old 10-call (L6-inclusive) chain. Not currently breaking anything (extra slot never consumed, out-of-range calls already return `None`), but one test's comment had drifted onto the wrong index.
  - Fix: updated all 6 remaining sequences to the correct 9-item count; re-ran the 60-test suite to confirm no regression.
  - Evidence: commit `f6ad0b81`.
- Finding: `config/substrate-lattice/grammar_producer_registry.v1.yaml` still had the same `self_state_dimension_id: transport_integrity` field this PR removed from `_LANES` in the route file -- a dead-config duplicate, not wired to any code, but inconsistent with the field it mirrors.
  - Fix: removed.
  - Evidence: commit `f6ad0b81`.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: Low
- Concern: none identified beyond the two findings above, both fixed.

## PR link

(added by gh pr create below)