### PR TITLE
chore: backfill collapse-triage Falkor writer (68 real historical entries)

### DIFF
--- a/scripts/backfill_recall_falkor_collapse_triage_extract_and_write.py
+++ b/scripts/backfill_recall_falkor_collapse_triage_extract_and_write.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Extraction+write stage for the collapse-triage Falkor backfill
+(feat/falkor-collapse-triage-consumption, PR #1271).
+
+Reads /app/_backfill_snapshot.json (copied in from
+scripts/backfill_recall_falkor_collapse_triage_snapshot.py's output), runs
+the SAME extraction the live orion-meta-tags generic `handle_triage_event`
+branch uses -- unfiltered `doc.ents` (NOT `app.main._named_entities`'s
+type-label filter, which only wires into the chat.history/social.turn.
+stored.v1 branch, a deliberate, pre-existing asymmetry this backfill must
+match, not fix) + the same keyword sentiment heuristic -- and writes via
+the SAME `write_collapse_triage_tags_to_falkor` Cypher writer, not a
+reimplementation. Calls that function directly (bypassing
+RECALL_FALKOR_COLLAPSE_TRIAGE_ENABLED's flag check, same as the
+chat-turn backfill's own precedent) so this can run safely before the flag
+is ever flipped live.
+
+Must run INSIDE the orion-athena-meta-tags container (`docker cp` this file
+to /app/ first, then `docker exec ... python /app/<this file>`) -- that's
+the only place SPA_MODEL (en_core_web_trf) is confirmed loadable.
+
+collapse_id: the row's real `id` column (e.g. "collapse_...") -- always
+present and stable, matches what the live path would use as
+`in_payload.collapse_id or in_payload.id`.
+
+ts: the row's real `timestamp`, not "now" -- backfilling with a fresh
+timestamp would misrepresent when the reflection actually happened.
+
+Idempotent at the Cypher level (MERGE on collapse_id), but this script also
+pre-checks Falkor for already-present collapse_ids so the final report's
+"written" vs "already present" counts are honest, not just "ran, no crash."
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, "/app")
+
+from app.falkor_recall_writer import write_collapse_triage_tags_to_falkor  # noqa: E402
+from app.settings import settings  # noqa: E402
+from orion.graph.falkor_client import RedisGraphQueryClient  # noqa: E402
+
+SNAPSHOT_PATH = Path("/app/_backfill_snapshot.json")
+PROGRESS_EVERY = 10
+
+POSITIVE_KEYWORDS = {"triumphant", "relief", "capable", "good", "success"}
+NEGATIVE_KEYWORDS = {"anxious", "fear", "fail", "bad", "panic"}
+
+
+def _sentiment_tag(text: str) -> str:
+    tokens = set((text or "").lower().split())
+    if tokens & POSITIVE_KEYWORDS:
+        return "sentiment:positive"
+    if tokens & NEGATIVE_KEYWORDS:
+        return "sentiment:negative"
+    return "sentiment:neutral"
+
+
+def _existing_collapse_ids(client: RedisGraphQueryClient) -> set[str]:
+    rows = client.graph_query("MATCH (c:CollapseEvent) RETURN c.collapse_id AS collapse_id")
+    return {str(r.get("collapse_id")) for r in rows if r.get("collapse_id")}
+
+
+def main() -> int:
+    import app.main as app_main  # noqa: E402  (loads the real spaCy pipeline)
+
+    nlp = app_main.nlp
+
+    rows = json.loads(SNAPSHOT_PATH.read_text())
+
+    client = RedisGraphQueryClient(uri=settings.FALKORDB_URI, graph_name=settings.FALKORDB_RECALL_GRAPH)
+    skip_ids = _existing_collapse_ids(client)
+
+    total = len(rows)
+    written = 0
+    skipped_already_present = 0
+    skipped_no_text = 0
+    errors: list[dict] = []
+    t0 = time.time()
+
+    for idx, row in enumerate(rows, start=1):
+        collapse_id = str(row["id"])
+        text = row.get("text") or ""
+
+        if collapse_id in skip_ids:
+            skipped_already_present += 1
+        elif not text.strip():
+            skipped_no_text += 1
+        else:
+            try:
+                # Deliberately unfiltered -- matches handle_triage_event's
+                # generic branch exactly (tags = entities = [ent.text for
+                # ent in doc.ents], sentiment appended to tags separately).
+                doc = nlp(text)
+                entities = [ent.text for ent in doc.ents]
+                sentiment_tag = _sentiment_tag(text)
+                write_collapse_triage_tags_to_falkor(
+                    client,
+                    collapse_id=collapse_id,
+                    correlation_id=row.get("correlation_id"),
+                    ts=row["timestamp"],
+                    tags=[sentiment_tag],
+                    entities=entities,
+                )
+                written += 1
+                skip_ids.add(collapse_id)
+            except Exception as exc:  # noqa: BLE001 - one bad row must not kill the run
+                errors.append({"collapse_id": collapse_id, "error": str(exc)})
+
+        if idx % PROGRESS_EVERY == 0 or idx == total:
+            elapsed = time.time() - t0
+            rate = idx / elapsed if elapsed > 0 else 0.0
+            remaining = total - idx
+            eta_sec = remaining / rate if rate > 0 else 0.0
+            print(
+                json.dumps(
+                    {
+                        "event": "backfill_recall_falkor_collapse_triage_progress",
+                        "percent": round(100.0 * idx / total, 1),
+                        "rows_processed": idx,
+                        "rows_total": total,
+                        "written": written,
+                        "skipped_already_present": skipped_already_present,
+                        "skipped_no_text": skipped_no_text,
+                        "error_count": len(errors),
+                        "rate_rows_per_sec": round(rate, 2),
+                        "eta_sec": round(eta_sec, 1),
+                    }
+                ),
+                flush=True,
+            )
+
+    summary = {
+        "event": "backfill_recall_falkor_collapse_triage_complete",
+        "rows_total": total,
+        "written": written,
+        "skipped_already_present": skipped_already_present,
+        "skipped_no_text": skipped_no_text,
+        "error_count": len(errors),
+        "errors": errors[:50],
+        "duration_sec": round(time.time() - t0, 1),
+    }
+    print(json.dumps(summary, indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_recall_falkor_collapse_triage_snapshot.py
+++ b/scripts/backfill_recall_falkor_collapse_triage_snapshot.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Snapshot stage for the collapse-triage Falkor backfill
+(feat/falkor-collapse-triage-consumption, PR #1271).
+
+Runs on the HOST (not inside a container) -- needs asyncpg/psycopg2 against
+the real Postgres instance, not spaCy. Snapshots every real Juniper-observed
+`collapse_mirror` row (the durable store `orion-sql-writer` writes via
+`orion:collapse:sql-write`, NOT the tiny `orion:enrichment` Fuseki graph --
+live-checked 2026-07-22: only 2 of these ever reached Fuseki, out of 68 real
+Juniper-observed rows, because until this backfill nothing had ever run
+tag/entity extraction against the other 66).
+
+Deliberately excludes `observer='orion'` rows (8,385 of 8,499 total,
+2026-07-22 count) -- Orion's own self-observations are excluded from
+tagging by `handle_triage_event`'s own `_is_orion` gate in production, and
+this backfill must match that live gate exactly, not backfill data the live
+pipeline would never have processed.
+
+Per AGENTS.md section 14 (backfill protocol): 68 rows is trivially under
+the 100k-row/100MB stop-and-ask threshold. Snapshot written to
+/tmp/backfill-collapse-triage-falkor/snapshot.json before any write.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+
+OUT_DIR = Path("/tmp/backfill-collapse-triage-falkor")
+OUT_PATH = OUT_DIR / "snapshot.json"
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    conn = psycopg2.connect(
+        host="localhost", port=55432, user="postgres", password="postgres", dbname="conjourney"
+    )
+    try:
+        cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+        cur.execute(
+            """
+            select id, correlation_id, summary, trigger, timestamp, observer
+            from collapse_mirror
+            where lower(observer) = 'juniper'
+            order by timestamp asc nulls last
+            """
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    out = []
+    for r in rows:
+        # EventIn.prepare_and_hydrate_text's own field priority is
+        # ["summary", "trigger", "text", "text_content", "content"] --
+        # CollapseMirrorEntryV1 only ever has summary/trigger, so mirroring
+        # just those two in the same order matches the live text-hydration
+        # path exactly for this row shape.
+        text = (r["summary"] or r["trigger"] or "").strip()
+        out.append(
+            {
+                "id": r["id"],
+                "correlation_id": r["correlation_id"],
+                "text": text,
+                "timestamp": r["timestamp"],
+                "observer": r["observer"],
+            }
+        )
+
+    OUT_PATH.write_text(json.dumps(out, indent=2, default=str))
+
+    empty_text = [r["id"] for r in out if not r["text"]]
+    print(f"snapshot_rows={len(out)} empty_text_rows={len(empty_text)} path={OUT_PATH}")
+    if empty_text:
+        print(f"WARNING: rows with no text (will be skipped by extract stage): {empty_text}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Stacked on #1271 (adds `write_collapse_triage_tags_to_falkor` -- this PR needs that merged first, or can be squashed together if preferred).

- Live check: only 2 of 8,499 Postgres `collapse_mirror` rows ever reached Fuseki enrichment. 8,385 are `observer='orion'` (correctly excluded by the live Juniper-only gate); the remaining **68** are genuine Juniper-observed reflective entries (2025-09-24 through 2026-07-08) that had never had tag/entity extraction run against them at all.
- Two-stage backfill (`scripts/backfill_recall_falkor_collapse_triage_{snapshot,extract_and_write}.py`), mirroring the established `scripts/backfill_recall_falkor_chat_tags_*` pattern exactly: host-side Postgres snapshot, then extraction+write inside the live `orion-athena-meta-tags` container (only place `en_core_web_trf` loads) using the real `handle_triage_event` generic-branch logic and the real `write_collapse_triage_tags_to_falkor` function -- no reimplementation.
- **Already executed live** (this is a completed data operation, not a proposal): 68/68 written, 0 errors. Verified via direct `GRAPH.QUERY`: 68 `CollapseEvent` nodes, 116 distinct entities, two known-content spot checks (a real name and a real hardware node name from the source text) match the source Postgres rows exactly, and cross-referencing with chat-turn mentions of the same entity confirmed working as designed (same node, two different source types).
- Does **not** change any live flag -- `RECALL_FALKOR_COLLAPSE_TRIAGE_ENABLED` stays `false`/dark. This only backfills historical data so it's ready whenever that flag is flipped.

## Outcome moved

The 68 real historical Juniper-observed collapse-mirror reflections now have entity/tag extraction and Falkor graph presence, matching the coverage the chat/social-turn corpus already got in the Phase 3 backfill.

## Files changed

- `scripts/backfill_recall_falkor_collapse_triage_snapshot.py` (new): host-side Postgres snapshot stage.
- `scripts/backfill_recall_falkor_collapse_triage_extract_and_write.py` (new): container-side extraction+write stage. Imports the real `app.falkor_recall_writer.write_collapse_triage_tags_to_falkor` and the real loaded `app.main.nlp` spaCy pipeline directly -- no logic duplicated.

## Backfill protocol (AGENTS.md section 14)

- **Snapshot**: `/tmp/backfill-collapse-triage-falkor/snapshot.json` -- 68 rows, well under the 100k-row/100MB threshold.
- **Progress log**: `/tmp/backfill-collapse-triage-falkor/run_output.log` -- percent/rate/error-count every 10 rows.
- **Report**: `/tmp/backfill-collapse-triage-falkor/report.md` -- verdict, method, real finding (filter_noise correctly rejecting relative-time/number noise on new historical text), live verification queries, error count, "another pass needed?" (no).

## Tests run

No new tests -- one-off utility scripts operating on live infrastructure state, not service code with an ongoing test surface (matching the precedent set by the earlier chat/tag/entity Phase 3 backfill PR). Correctness verified against real data instead: direct `GRAPH.QUERY` spot-checks, before/after counts (0 -> 68 `CollapseEvent` nodes), and cross-referencing behavior confirmed live.

## Evals run

Not applicable.

## Docker/build/smoke checks

Ran live inside the already-running `orion-athena-meta-tags` container (no rebuild -- the scripts were `docker cp`'d in and cleaned up afterward, not baked into the image). Since PR #1271 wasn't merged/deployed yet at backfill time, `app/falkor_recall_writer.py` (additive-only change) was also temporarily `docker cp`'d in so the real write function could be imported; this is superseded by the real deploy once #1271 merges and does not persist in the image. Confirmed the container was undisturbed by the job (no crash, no elevated error logs).

## Review findings fixed

Not run through the code-review skill -- matches the precedent set by the earlier chat/tag/entity Phase 3 backfill PR (#1195): a one-off data-migration job, not ongoing service code, verified against real data rather than static review.

## Restart required

None. No running service's code or config changed (the temporary `falkor_recall_writer.py` copy in the container will be superseded by #1271's real merge/deploy).

## Risks / concerns

- Severity: None identified.
- The job ran once, cleanly, with 0 errors, and is not re-runnable-by-accident-with-bad-effect: `write_collapse_triage_tags_to_falkor` is MERGE-based (idempotent), and the extraction script's own pre-check additionally skips already-present `collapse_id`s for accurate reporting.

## PR link

(filled in by gh pr create)