### PR TITLE
feat(substrate): implement transport bus signal quality measurement (items 1-4)

### DIFF
--- a/scripts/analysis/measure_transport_biometrics_prediction_error_correlation.py
+++ b/scripts/analysis/measure_transport_biometrics_prediction_error_correlation.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Read-only correlation probe: transport vs. biometrics prediction-error.
+
+Item 4 of docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-measurement-
+design.md. Before recalibrating or composing anything new for transport's currently-flat
+`prediction_error` channel (`node:substrate.transport`, written by
+`services/orion-substrate-runtime/app/worker.py::_write_prediction_error_node`), this
+checks whether the instrument can carry information at all -- does transport's (tiny, real)
+variance ever move together with a domain already confirmed live and non-degenerate
+(`node:substrate.biometrics`: 81% of 48h rows nonzero, max 0.627, per the design spec's
+own live-data table). Reuses the correlation methodology already established in
+`scripts/analysis/measure_emergent_clustering_probe.py` (Pearson over aligned per-tick
+series), applied to two `FieldStateV1.node_vectors` channels instead of attention targets.
+
+This performs NO writes, emits NO events, flips NO flags.
+
+Run:
+    python scripts/analysis/measure_transport_biometrics_prediction_error_correlation.py --window-hours 48
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("orion.analysis.transport_biometrics_prediction_error_correlation")
+
+DEFAULT_WINDOW_HOURS: float = 48.0
+MAX_ROWS: int = 200_000
+DEGENERATE_VARIANCE_EPS: float = 1e-12
+
+OUTPUT_DIR = Path("/tmp/transport-biometrics-prediction-error-correlation")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+TRANSPORT_NODE = "node:substrate.transport"
+BIOMETRICS_NODE = "node:substrate.biometrics"
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Exercised directly by unit tests with synthetic data.
+# ===========================================================================
+
+
+@dataclass
+class CorrelationResult:
+    n: int
+    transport_variance: float
+    biometrics_variance: float
+    correlation: Optional[float]
+    verdict: str
+
+
+def pearson_correlation(x: list[float], y: list[float]) -> Optional[float]:
+    """Same shape as measure_emergent_clustering_probe.py's own implementation --
+    returns None (not 0.0 or NaN) when either series has no real variance, so a
+    degenerate input can never masquerade as "zero correlation" (a real, meaningful
+    claim) rather than "undefined" (the honest one)."""
+    n = len(x)
+    if n < 2 or n != len(y):
+        return None
+    mean_x = sum(x) / n
+    mean_y = sum(y) / n
+    var_x = sum((xi - mean_x) ** 2 for xi in x)
+    var_y = sum((yi - mean_y) ** 2 for yi in y)
+    if var_x < DEGENERATE_VARIANCE_EPS or var_y < DEGENERATE_VARIANCE_EPS:
+        return None
+    cov = sum((xi - mean_x) * (yi - mean_y) for xi, yi in zip(x, y))
+    return cov / ((var_x ** 0.5) * (var_y ** 0.5))
+
+
+def _variance(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    return sum((v - mean) ** 2 for v in values) / len(values)
+
+
+def compute_correlation(transport: list[float], biometrics: list[float]) -> CorrelationResult:
+    n = min(len(transport), len(biometrics))
+    transport = transport[:n]
+    biometrics = biometrics[:n]
+    var_t = _variance(transport)
+    var_b = _variance(biometrics)
+    r = pearson_correlation(transport, biometrics)
+
+    if n < 2:
+        verdict = "INSUFFICIENT DATA: fewer than 2 aligned rows."
+    elif r is None:
+        degenerate = []
+        if var_t < DEGENERATE_VARIANCE_EPS:
+            degenerate.append("transport")
+        if var_b < DEGENERATE_VARIANCE_EPS:
+            degenerate.append("biometrics")
+        verdict = (
+            "NO CORRELATION COMPUTABLE: insufficient real variance in "
+            f"{' and '.join(degenerate)}'s series over this window."
+        )
+    elif abs(r) >= 0.5:
+        verdict = f"Real, non-trivial correlation found (|r|={abs(r):.4f} >= 0.5)."
+    else:
+        verdict = f"No meaningful correlation found (|r|={abs(r):.4f} < 0.5)."
+
+    return CorrelationResult(
+        n=n, transport_variance=var_t, biometrics_variance=var_b, correlation=r, verdict=verdict
+    )
+
+
+# ===========================================================================
+# I/O layer.
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_aligned_prediction_error_series(
+    conn, since: datetime, max_rows: int = MAX_ROWS
+) -> tuple[list[float], list[float], bool]:
+    """Real per-row `prediction_error` values for both nodes from the same
+    `substrate_field_state` rows (so "aligned" means "same tick," not a join on
+    timestamp proximity). Returns (transport_series, biometrics_series, truncated)."""
+    if conn is None:
+        return [], [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    (field_json->'node_vectors'->%s->>'prediction_error')::float,
+                    (field_json->'node_vectors'->%s->>'prediction_error')::float
+                FROM substrate_field_state
+                WHERE generated_at >= %s
+                  AND field_json->'node_vectors' ? %s
+                  AND field_json->'node_vectors' ? %s
+                ORDER BY generated_at ASC
+                LIMIT %s
+                """,
+                (TRANSPORT_NODE, BIOMETRICS_NODE, since, TRANSPORT_NODE, BIOMETRICS_NODE, max_rows),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch substrate_field_state prediction_error series", exc_info=True)
+        return [], [], False
+
+    transport: list[float] = []
+    biometrics: list[float] = []
+    for t_val, b_val in rows:
+        if t_val is None or b_val is None:
+            continue
+        transport.append(float(t_val))
+        biometrics.append(float(b_val))
+    return transport, biometrics, len(rows) >= max_rows
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def render_report(*, window_hours: float, result: CorrelationResult, truncated: bool) -> str:
+    lines = [
+        "# Transport <-> Biometrics Prediction-Error Correlation Probe",
+        "",
+        "Read-only. No writes, no config changes. See "
+        "`docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-measurement-design.md` "
+        "item 4.",
+        "",
+        f"- Requested window: {window_hours:g}h",
+        f"- Aligned rows (both nodes present, same tick): {result.n}",
+    ]
+    if truncated:
+        lines.append(f"- **TRUNCATED at MAX_ROWS={MAX_ROWS}** -- more real rows exist than were fetched.")
+    lines.extend(
+        [
+            f"- `{TRANSPORT_NODE}` variance this window: {result.transport_variance:.10f}",
+            f"- `{BIOMETRICS_NODE}` variance this window: {result.biometrics_variance:.10f}",
+            "",
+            "## Verdict",
+            "",
+            result.verdict,
+        ]
+    )
+    if result.correlation is not None:
+        lines.append(f"\nPearson r = {result.correlation:.4f}")
+    return "\n".join(lines)
+
+
+def run(window_hours: float, postgres_uri: str = DEFAULT_POSTGRES_URI) -> int:
+    progress = ProgressLog(PROGRESS_PATH)
+    progress.emit("correlation probe started", percent=0.0, processed=0, total=0)
+
+    conn = open_readonly_connection(postgres_uri)
+    since = datetime.now(timezone.utc) - timedelta(hours=window_hours)
+    transport, biometrics, truncated = fetch_aligned_prediction_error_series(conn, since)
+    if conn is not None:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    progress.emit("series fetched", percent=70.0, processed=len(transport), total=len(transport))
+    result = compute_correlation(transport, biometrics)
+    report = render_report(window_hours=window_hours, result=result, truncated=truncated)
+
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    progress.emit("report written", percent=100.0, processed=len(transport), total=len(transport))
+    progress.close()
+
+    print(report)
+    print(f"\nFull report: {REPORT_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only correlation probe between transport and biometrics prediction-error channels."
+    )
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"how far back to look in substrate_field_state (default {DEFAULT_WINDOW_HOURS})",
+    )
+    parser.add_argument(
+        "--postgres-uri", type=str, default=DEFAULT_POSTGRES_URI,
+        help="read-only Postgres DSN (default: in-cluster orion-athena-sql-db)",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    return run(args.window_hours, args.postgres_uri)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/measure_transport_bus_signal_history.py
+++ b/scripts/analysis/measure_transport_bus_signal_history.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Read-only historical baseline for the transport bus's six real pressure signals.
+
+Items 2 and 3 of docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-
+measurement-design.md, combined into one script since both read the same
+`transport_bus_reducer` receipts (item 3's reducer-cadence gap analysis reuses item 2's
+fetch rather than querying twice). `transport_prediction_error()` (`orion/substrate/
+prediction_error.py`) reads
+flat `0.0` in production; that spec traced this to two real, disclosed causes rather than
+a bug: `bus_health`/`delivery_confidence` are genuinely stable under normal operation, and
+`stream_depth_pressure`'s threshold (`DEFAULT_STREAM_DEPTH_CRITICAL = 100_000`,
+`orion/substrate/transport_loop/constants.py`) was never checked against real operating
+data -- live data showed `max_stream_depth` sitting at a constant 91 the whole observed
+window. This script establishes the real historical percentile distribution needed before
+that threshold (or any other recalibration) is touched, per the Sentience Striving
+Program's own "measure before minting" rule (`orion/sentience_striving_program/
+README.md` §7).
+
+**Known data-source limitation, disclosed up front, not hidden in a footnote:**
+`substrate_transport_bus_projection` is a **singleton** upsert table (one row, ever --
+`projection_id` is its primary key) with no history at all. `substrate_reduction_receipts`
+is append-only but has a **short retention TTL** -- a 24h query window returned only ~35
+minutes of real rows when this spec was written (2026-07-22). This script reports whatever
+real history the receipts table actually has *right now*, and says so honestly if that
+turns out to be very little -- it does not pad, extrapolate, or fabricate a longer series.
+
+Run:
+    python scripts/analysis/measure_transport_bus_signal_history.py --window-hours 24
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import statistics
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("orion.analysis.transport_bus_signal_history")
+
+DEFAULT_WINDOW_HOURS: float = 24.0
+MAX_ROWS: int = 200_000
+
+OUTPUT_DIR = Path("/tmp/transport-bus-signal-history")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+# The six real signals from orion/substrate/transport_loop/extract.py::
+# compute_transport_pressures(). stream_depth_pressure/max_stream_depth get their own
+# percentile treatment (continuous, structurally near-always-nonzero); the other five
+# are real/rare event counts, reported as simple totals + first/last-seen timestamps.
+_COUNT_FIELDS = (
+    "backpressure_count",
+    "uncataloged_stream_count",
+    "schema_mismatch_stream_count",
+    "observer_failure_count",
+)
+_PRESSURE_FIELDS = (
+    "backpressure",
+    "catalog_drift_pressure",
+    "contract_pressure",
+    "observer_failure_pressure",
+    "reliability_pressure",
+)
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Exercised directly by unit tests with synthetic data.
+# ===========================================================================
+
+
+@dataclass
+class BusTick:
+    observed_at: datetime
+    max_stream_depth: int
+    counts: dict[str, int] = field(default_factory=dict)
+    pressures: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class CadenceStats:
+    """Item 3: real inter-arrival gaps between consecutive transport_bus_reducer
+    receipts -- is the reducer itself keeping pace, independent of what it's
+    observing. See docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-
+    measurement-design.md item 3."""
+
+    n_gaps: int
+    median_gap_sec: Optional[float]
+    p95_gap_sec: Optional[float]
+    max_gap_sec: Optional[float]
+    stall_threshold_sec: Optional[float]
+    stall_count: int
+    worst_stall_at: Optional[str]
+
+
+@dataclass
+class SignalBaseline:
+    n: int
+    depth_min: Optional[int]
+    depth_max: Optional[int]
+    depth_mean: Optional[float]
+    depth_stdev: Optional[float]
+    depth_p50: Optional[float]
+    depth_p95: Optional[float]
+    depth_p99: Optional[float]
+    count_totals: dict[str, int]
+    count_first_nonzero_at: dict[str, Optional[str]]
+    pressure_ever_nonzero: dict[str, bool]
+    earliest: Optional[str]
+    latest: Optional[str]
+
+
+def _percentile(sorted_values: list[float], pct: float) -> Optional[float]:
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    k = (len(sorted_values) - 1) * pct
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = k - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+def compute_baseline(ticks: list[BusTick]) -> SignalBaseline:
+    """Pure aggregation over already-parsed ticks. No DB, no side effects."""
+    if not ticks:
+        return SignalBaseline(
+            n=0,
+            depth_min=None, depth_max=None, depth_mean=None, depth_stdev=None,
+            depth_p50=None, depth_p95=None, depth_p99=None,
+            count_totals={f: 0 for f in _COUNT_FIELDS},
+            count_first_nonzero_at={f: None for f in _COUNT_FIELDS},
+            pressure_ever_nonzero={f: False for f in _PRESSURE_FIELDS},
+            earliest=None, latest=None,
+        )
+
+    ordered = sorted(ticks, key=lambda t: t.observed_at)
+    depths = [float(t.max_stream_depth) for t in ordered]
+    sorted_depths = sorted(depths)
+
+    count_totals: dict[str, int] = {f: 0 for f in _COUNT_FIELDS}
+    count_first_nonzero_at: dict[str, Optional[str]] = {f: None for f in _COUNT_FIELDS}
+    for t in ordered:
+        for f in _COUNT_FIELDS:
+            v = int(t.counts.get(f, 0) or 0)
+            count_totals[f] += v
+            if v > 0 and count_first_nonzero_at[f] is None:
+                count_first_nonzero_at[f] = t.observed_at.isoformat()
+
+    pressure_ever_nonzero: dict[str, bool] = {f: False for f in _PRESSURE_FIELDS}
+    for t in ordered:
+        for f in _PRESSURE_FIELDS:
+            if float(t.pressures.get(f, 0.0) or 0.0) > 0.0:
+                pressure_ever_nonzero[f] = True
+
+    return SignalBaseline(
+        n=len(ordered),
+        depth_min=int(min(depths)),
+        depth_max=int(max(depths)),
+        depth_mean=statistics.fmean(depths),
+        depth_stdev=statistics.pstdev(depths) if len(depths) > 1 else 0.0,
+        depth_p50=_percentile(sorted_depths, 0.50),
+        depth_p95=_percentile(sorted_depths, 0.95),
+        depth_p99=_percentile(sorted_depths, 0.99),
+        count_totals=count_totals,
+        count_first_nonzero_at=count_first_nonzero_at,
+        pressure_ever_nonzero=pressure_ever_nonzero,
+        earliest=ordered[0].observed_at.isoformat(),
+        latest=ordered[-1].observed_at.isoformat(),
+    )
+
+
+def compute_cadence_stats(ticks: list[BusTick], *, stall_multiplier: float = 5.0) -> CadenceStats:
+    """Item 3: real gaps between consecutive receipts. A "stall" is a gap more
+    than `stall_multiplier` times the observed median -- relative to this
+    reducer's own real cadence, not an assumed absolute number, since that
+    cadence has never been measured before this script."""
+    if len(ticks) < 2:
+        return CadenceStats(
+            n_gaps=0, median_gap_sec=None, p95_gap_sec=None, max_gap_sec=None,
+            stall_threshold_sec=None, stall_count=0, worst_stall_at=None,
+        )
+    ordered = sorted(ticks, key=lambda t: t.observed_at)
+    gaps = [
+        (b.observed_at - a.observed_at).total_seconds()
+        for a, b in zip(ordered, ordered[1:])
+    ]
+    sorted_gaps = sorted(gaps)
+    median = statistics.median(sorted_gaps)
+    stall_threshold = median * stall_multiplier if median > 0 else None
+    stall_count = 0
+    worst_stall_at: Optional[str] = None
+    worst_gap = -1.0
+    if stall_threshold is not None:
+        for a, b in zip(ordered, ordered[1:]):
+            gap = (b.observed_at - a.observed_at).total_seconds()
+            if gap > stall_threshold:
+                stall_count += 1
+                if gap > worst_gap:
+                    worst_gap = gap
+                    worst_stall_at = b.observed_at.isoformat()
+    return CadenceStats(
+        n_gaps=len(gaps),
+        median_gap_sec=median,
+        p95_gap_sec=_percentile(sorted_gaps, 0.95),
+        max_gap_sec=max(sorted_gaps),
+        stall_threshold_sec=stall_threshold,
+        stall_count=stall_count,
+        worst_stall_at=worst_stall_at,
+    )
+
+
+# ===========================================================================
+# I/O layer.
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_transport_receipts(conn, since: datetime, max_rows: int = MAX_ROWS) -> tuple[list[BusTick], bool]:
+    """Real `transport_bus_reducer` receipts since `since`, parsed into BusTicks.
+    Returns (ticks, truncated). Read-only; never raises past this boundary."""
+    if conn is None:
+        return [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT created_at, receipt_json
+                FROM substrate_reduction_receipts
+                WHERE reducer_name = 'transport_bus_reducer'
+                  AND created_at >= %s
+                ORDER BY created_at ASC
+                LIMIT %s
+                """,
+                (since, max_rows),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch substrate_reduction_receipts", exc_info=True)
+        return [], False
+
+    ticks: list[BusTick] = []
+    for created_at, receipt_json in rows:
+        if created_at is None:
+            continue
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        try:
+            payload = json.loads(receipt_json) if isinstance(receipt_json, str) else receipt_json
+            deltas = (payload or {}).get("state_deltas") or []
+            if not deltas:
+                continue
+            after = deltas[0].get("after") or {}
+        except Exception:
+            logger.warning("skipping malformed receipt row at %s", created_at, exc_info=True)
+            continue
+        ticks.append(
+            BusTick(
+                observed_at=created_at,
+                max_stream_depth=int(after.get("max_stream_depth", 0) or 0),
+                counts={f: int(after.get(f, 0) or 0) for f in _COUNT_FIELDS},
+                pressures={f: float(after.get(f, 0.0) or 0.0) for f in _PRESSURE_FIELDS},
+            )
+        )
+    return ticks, len(rows) >= max_rows
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def _fmt(value: Any) -> str:
+    return "n/a" if value is None else (f"{value:.4f}" if isinstance(value, float) else str(value))
+
+
+def render_report(
+    *,
+    window_hours: float,
+    baseline: SignalBaseline,
+    truncated: bool,
+    cadence: Optional[CadenceStats] = None,
+) -> str:
+    lines = [
+        "# Transport Bus Signal History -- Real Baseline",
+        "",
+        "Read-only. No writes, no config changes. See "
+        "`docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-measurement-design.md` "
+        "items 2 and 3.",
+        "",
+        f"- Requested window: {window_hours:g}h",
+        f"- Real rows found: {baseline.n}",
+        f"- Real data span: {baseline.earliest or 'n/a'} -> {baseline.latest or 'n/a'}",
+    ]
+    if truncated:
+        lines.append(f"- **TRUNCATED at MAX_ROWS={MAX_ROWS}** -- more real rows exist than were fetched.")
+    lines.append("")
+
+    if baseline.n == 0:
+        lines.extend(
+            [
+                "## INSUFFICIENT REAL DATA",
+                "",
+                "No `transport_bus_reducer` receipts found in the requested window. Given "
+                "`substrate_reduction_receipts`' short retention TTL (confirmed ~35 minutes "
+                "of history survived a 24h query when this script was designed), this is the "
+                "honest, expected result for any window longer than the TTL -- not a query "
+                "bug. Re-run with a shorter `--window-hours`, or re-run this script again "
+                "after real time has passed to accumulate more history.",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            "## `max_stream_depth` real percentile distribution",
+            "",
+            f"- min: {baseline.depth_min}",
+            f"- p50: {_fmt(baseline.depth_p50)}",
+            f"- p95: {_fmt(baseline.depth_p95)}",
+            f"- p99: {_fmt(baseline.depth_p99)}",
+            f"- max: {baseline.depth_max}",
+            f"- mean: {_fmt(baseline.depth_mean)}",
+            f"- stdev: {_fmt(baseline.depth_stdev)}",
+            "",
+            "Compare against `DEFAULT_STREAM_DEPTH_CRITICAL = 100_000` "
+            "(`orion/substrate/transport_loop/constants.py`) -- if p99 sits at a tiny "
+            "fraction of that threshold, `stream_depth_pressure` is structurally incapable "
+            "of registering realistic variation at its current scale.",
+            "",
+            "## Real event counts (backpressure / catalog drift / schema mismatch / observer failure)",
+            "",
+            "| signal | total (sum across window) | first nonzero at |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for f in _COUNT_FIELDS:
+        lines.append(
+            f"| `{f}` | {baseline.count_totals[f]} | {baseline.count_first_nonzero_at[f] or 'never'} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Pressure signals: ever nonzero in this window?",
+            "",
+            "| signal | ever nonzero |",
+            "| --- | --- |",
+        ]
+    )
+    for f in _PRESSURE_FIELDS:
+        lines.append(f"| `{f}` | {baseline.pressure_ever_nonzero[f]} |")
+
+    if not any(baseline.pressure_ever_nonzero.values()) and baseline.depth_stdev == 0.0:
+        lines.extend(
+            [
+                "",
+                "**Every signal read as flat/zero for the entire observed window.** This "
+                "matches the live spot-check in the design spec (2026-07-22) and is reported "
+                "here as the honest finding it is, not smoothed over -- it means either the "
+                "bus has genuinely had no incident in this window, or the window itself is "
+                "too short to have caught one (see the TTL caveat above). It is not, by "
+                "itself, evidence of a bug in this script or in `compute_transport_pressures()`.",
+            ]
+        )
+
+    if cadence is not None:
+        lines.extend(
+            [
+                "",
+                "## Reducer cadence (item 3: is the reducer itself keeping pace)",
+                "",
+                f"- gaps measured: {cadence.n_gaps}",
+                f"- median gap: {_fmt(cadence.median_gap_sec)}s",
+                f"- p95 gap: {_fmt(cadence.p95_gap_sec)}s",
+                f"- max gap: {_fmt(cadence.max_gap_sec)}s",
+            ]
+        )
+        if cadence.stall_threshold_sec is not None:
+            lines.extend(
+                [
+                    f"- stall threshold (5x median): {_fmt(cadence.stall_threshold_sec)}s",
+                    f"- stalls observed: {cadence.stall_count}"
+                    + (f" (worst at {cadence.worst_stall_at})" if cadence.worst_stall_at else ""),
+                ]
+            )
+        else:
+            lines.append(
+                "- stall threshold: n/a (fewer than 2 gaps observed, or zero median gap)"
+            )
+
+    return "\n".join(lines)
+
+
+def run(window_hours: float, postgres_uri: str = DEFAULT_POSTGRES_URI) -> int:
+    progress = ProgressLog(PROGRESS_PATH)
+    progress.emit("transport_bus_signal_history started", percent=0.0, processed=0, total=0)
+
+    conn = open_readonly_connection(postgres_uri)
+    since = datetime.now(timezone.utc) - timedelta(hours=window_hours)
+    ticks, truncated = fetch_transport_receipts(conn, since)
+    if conn is not None:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    progress.emit("receipts fetched", percent=60.0, processed=len(ticks), total=len(ticks))
+    baseline = compute_baseline(ticks)
+    cadence = compute_cadence_stats(ticks)
+    report = render_report(window_hours=window_hours, baseline=baseline, truncated=truncated, cadence=cadence)
+
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    progress.emit("report written", percent=100.0, processed=len(ticks), total=len(ticks))
+    progress.close()
+
+    print(report)
+    print(f"\nFull report: {REPORT_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only historical baseline for the transport bus's six real pressure signals."
+    )
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"how far back to look for real transport_bus_reducer receipts (default {DEFAULT_WINDOW_HOURS})",
+    )
+    parser.add_argument(
+        "--postgres-uri", type=str, default=DEFAULT_POSTGRES_URI,
+        help="read-only Postgres DSN (default: in-cluster orion-athena-sql-db)",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    return run(args.window_hours, args.postgres_uri)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/measure_transport_bus_signal_history.py
+++ b/scripts/analysis/measure_transport_bus_signal_history.py
@@ -181,7 +181,14 @@ def compute_cadence_stats(ticks: list[BusTick], *, stall_multiplier: float = 5.0
     """Item 3: real gaps between consecutive receipts. A "stall" is a gap more
     than `stall_multiplier` times the observed median -- relative to this
     reducer's own real cadence, not an assumed absolute number, since that
-    cadence has never been measured before this script."""
+    cadence has never been measured before this script.
+
+    Known limitation at small `n`, not fixed here: the median itself is
+    computed from very few gaps when `n_gaps` is small (e.g. 2 gaps
+    `[10, 1000]` -> median 505 -> a 100x jump to 1000 sits *under* a
+    5x-median threshold of 2525 and goes unflagged). Reported honestly via
+    `n_gaps` in the output rather than silently trusted -- treat stall
+    counts as low-confidence whenever `n_gaps` is small (single digits)."""
     if len(ticks) < 2:
         return CadenceStats(
             n_gaps=0, median_gap_sec=None, p95_gap_sec=None, max_gap_sec=None,
@@ -255,7 +262,15 @@ def open_readonly_connection(dsn: str):
 
 def fetch_transport_receipts(conn, since: datetime, max_rows: int = MAX_ROWS) -> tuple[list[BusTick], bool]:
     """Real `transport_bus_reducer` receipts since `since`, parsed into BusTicks.
-    Returns (ticks, truncated). Read-only; never raises past this boundary."""
+    Returns (ticks, truncated). Read-only; never raises past this boundary.
+
+    Single-bus assumption, not enforced here: this reducer emits one receipt
+    per distinct bus per tick, and this deployment currently has exactly one
+    (`BUS_OBSERVER_NODE_ID`, `services/orion-bus/app/settings.py`, defaults to
+    a single node). If more than one bus were ever observed, this function
+    would blend their depth/cadence series into one, undetected -- not
+    currently a real risk (single-bus deployment, confirmed live), but worth
+    an explicit per-`target_id` split if that ever changes."""
     if conn is None:
         return [], False
     try:

--- a/scripts/analysis/tests/test_measure_transport_biometrics_prediction_error_correlation.py
+++ b/scripts/analysis/tests/test_measure_transport_biometrics_prediction_error_correlation.py
@@ -1,0 +1,86 @@
+"""Deterministic unit tests for measure_transport_biometrics_prediction_error_correlation.py.
+
+No DB. All pure functions operate on synthetic float series.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "measure_transport_biometrics_prediction_error_correlation.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "measure_transport_biometrics_prediction_error_correlation", _MODULE_PATH
+)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_transport_biometrics_prediction_error_correlation"] = mod
+_spec.loader.exec_module(mod)
+
+
+def test_pearson_correlation_perfect_positive() -> None:
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y = [2.0, 4.0, 6.0, 8.0, 10.0]
+    assert mod.pearson_correlation(x, y) == pytest.approx(1.0)
+
+
+def test_pearson_correlation_none_when_x_constant() -> None:
+    x = [1.0, 1.0, 1.0, 1.0]
+    y = [1.0, 2.0, 3.0, 4.0]
+    assert mod.pearson_correlation(x, y) is None
+
+
+def test_pearson_correlation_none_when_both_constant() -> None:
+    assert mod.pearson_correlation([0.0, 0.0, 0.0], [0.0, 0.0, 0.0]) is None
+
+
+def test_pearson_correlation_none_for_fewer_than_two_points() -> None:
+    assert mod.pearson_correlation([1.0], [2.0]) is None
+
+
+def test_pearson_correlation_none_for_mismatched_lengths() -> None:
+    assert mod.pearson_correlation([1.0, 2.0], [1.0]) is None
+
+
+def test_compute_correlation_degenerate_transport_reports_which_series() -> None:
+    """Matches the real, currently-observed shape: transport flat, biometrics real."""
+    transport = [0.0] * 50
+    biometrics = [0.01 * i for i in range(50)]
+    result = mod.compute_correlation(transport, biometrics)
+    assert result.correlation is None
+    assert result.transport_variance == 0.0
+    assert result.biometrics_variance > 0.0
+    assert "transport" in result.verdict
+
+
+def test_compute_correlation_both_degenerate() -> None:
+    result = mod.compute_correlation([0.0] * 10, [0.0] * 10)
+    assert result.correlation is None
+    assert "transport" in result.verdict
+    assert "biometrics" in result.verdict
+
+
+def test_compute_correlation_insufficient_data() -> None:
+    result = mod.compute_correlation([0.1], [0.2])
+    assert result.n == 1
+    assert "INSUFFICIENT DATA" in result.verdict
+
+
+def test_compute_correlation_real_correlation_found() -> None:
+    transport = [0.01 * i for i in range(30)]
+    biometrics = [0.02 * i for i in range(30)]
+    result = mod.compute_correlation(transport, biometrics)
+    assert result.correlation == pytest.approx(1.0)
+    assert "Real, non-trivial correlation found" in result.verdict
+
+
+def test_compute_correlation_truncates_to_shorter_series() -> None:
+    transport = [0.01 * i for i in range(10)]
+    biometrics = [0.02 * i for i in range(30)]
+    result = mod.compute_correlation(transport, biometrics)
+    assert result.n == 10

--- a/scripts/analysis/tests/test_measure_transport_bus_signal_history.py
+++ b/scripts/analysis/tests/test_measure_transport_bus_signal_history.py
@@ -1,0 +1,160 @@
+"""Deterministic unit tests for measure_transport_bus_signal_history.py.
+
+No DB. All pure functions operate on synthetic BusTick lists, same
+module-loading pattern as scripts/analysis/tests/test_measure_self_state_signal_quality.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "measure_transport_bus_signal_history.py"
+_spec = importlib.util.spec_from_file_location("measure_transport_bus_signal_history", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_transport_bus_signal_history"] = mod
+_spec.loader.exec_module(mod)
+
+UTC = timezone.utc
+BASE = datetime(2026, 7, 22, 0, 0, 0, tzinfo=UTC)
+
+
+def _tick(i: int, *, depth: int = 91, counts=None, pressures=None) -> "mod.BusTick":
+    return mod.BusTick(
+        observed_at=BASE + timedelta(seconds=i * 10),
+        max_stream_depth=depth,
+        counts=counts or {},
+        pressures=pressures or {},
+    )
+
+
+def test_compute_baseline_empty_returns_n_zero() -> None:
+    baseline = mod.compute_baseline([])
+    assert baseline.n == 0
+    assert baseline.earliest is None
+    assert all(v == 0 for v in baseline.count_totals.values())
+    assert all(v is False for v in baseline.pressure_ever_nonzero.values())
+
+
+def test_compute_baseline_flat_series_reports_zero_stdev_and_no_incidents() -> None:
+    ticks = [_tick(i, depth=91) for i in range(10)]
+    baseline = mod.compute_baseline(ticks)
+    assert baseline.n == 10
+    assert baseline.depth_min == 91
+    assert baseline.depth_max == 91
+    assert baseline.depth_stdev == 0.0
+    assert all(v is False for v in baseline.pressure_ever_nonzero.values())
+    assert all(v == 0 for v in baseline.count_totals.values())
+
+
+def test_compute_baseline_detects_varying_depth() -> None:
+    depths = [50, 100, 150, 200, 90]
+    ticks = [_tick(i, depth=d) for i, d in enumerate(depths)]
+    baseline = mod.compute_baseline(ticks)
+    assert baseline.depth_min == 50
+    assert baseline.depth_max == 200
+    assert baseline.depth_stdev > 0.0
+    assert baseline.depth_p50 is not None
+
+
+def test_compute_baseline_tracks_first_nonzero_count() -> None:
+    ticks = [
+        _tick(0, counts={"backpressure_count": 0}),
+        _tick(1, counts={"backpressure_count": 0}),
+        _tick(2, counts={"backpressure_count": 3}),
+        _tick(3, counts={"backpressure_count": 2}),
+    ]
+    baseline = mod.compute_baseline(ticks)
+    assert baseline.count_totals["backpressure_count"] == 5
+    assert baseline.count_first_nonzero_at["backpressure_count"] == ticks[2].observed_at.isoformat()
+    # untouched counters stay at their default
+    assert baseline.count_totals["observer_failure_count"] == 0
+    assert baseline.count_first_nonzero_at["observer_failure_count"] is None
+
+
+def test_compute_baseline_pressure_ever_nonzero_flag() -> None:
+    ticks = [
+        _tick(0, pressures={"contract_pressure": 0.0}),
+        _tick(1, pressures={"contract_pressure": 0.4}),
+    ]
+    baseline = mod.compute_baseline(ticks)
+    assert baseline.pressure_ever_nonzero["contract_pressure"] is True
+    assert baseline.pressure_ever_nonzero["backpressure"] is False
+
+
+def test_percentile_single_value() -> None:
+    assert mod._percentile([5.0], 0.99) == 5.0
+
+
+def test_percentile_empty_returns_none() -> None:
+    assert mod._percentile([], 0.5) is None
+
+
+def test_percentile_p50_of_sorted_list() -> None:
+    values = sorted([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert mod._percentile(values, 0.5) == 3.0
+
+
+def test_render_report_insufficient_data_when_no_ticks() -> None:
+    baseline = mod.compute_baseline([])
+    report = mod.render_report(window_hours=24.0, baseline=baseline, truncated=False)
+    assert "INSUFFICIENT REAL DATA" in report
+
+
+def test_render_report_flags_all_flat_finding() -> None:
+    ticks = [_tick(i, depth=91) for i in range(5)]
+    baseline = mod.compute_baseline(ticks)
+    report = mod.render_report(window_hours=1.0, baseline=baseline, truncated=False)
+    assert "Every signal read as flat/zero" in report
+
+
+def test_render_report_does_not_flag_flat_finding_when_a_signal_fired() -> None:
+    ticks = [
+        _tick(0, depth=91),
+        _tick(1, depth=91, pressures={"backpressure": 0.5}),
+    ]
+    baseline = mod.compute_baseline(ticks)
+    report = mod.render_report(window_hours=1.0, baseline=baseline, truncated=False)
+    assert "Every signal read as flat/zero" not in report
+
+
+def _tick_at(seconds_from_base: float) -> "mod.BusTick":
+    return mod.BusTick(
+        observed_at=BASE + timedelta(seconds=seconds_from_base),
+        max_stream_depth=91,
+    )
+
+
+def test_compute_cadence_stats_empty_for_fewer_than_two_ticks() -> None:
+    stats = mod.compute_cadence_stats([_tick_at(0)])
+    assert stats.n_gaps == 0
+    assert stats.median_gap_sec is None
+    assert stats.stall_count == 0
+
+
+def test_compute_cadence_stats_regular_cadence_no_stalls() -> None:
+    ticks = [_tick_at(i * 10.0) for i in range(20)]
+    stats = mod.compute_cadence_stats(ticks)
+    assert stats.n_gaps == 19
+    assert stats.median_gap_sec == pytest.approx(10.0)
+    assert stats.stall_count == 0
+
+
+def test_compute_cadence_stats_detects_a_real_stall() -> None:
+    # Regular 10s cadence, then one 200s gap (a real reducer stall), then regular again.
+    ticks = [_tick_at(i * 10.0) for i in range(10)]
+    last = ticks[-1].observed_at
+    ticks.append(mod.BusTick(observed_at=last + timedelta(seconds=200.0), max_stream_depth=91))
+    ticks.extend(
+        mod.BusTick(observed_at=ticks[-1].observed_at + timedelta(seconds=i * 10.0), max_stream_depth=91)
+        for i in range(1, 5)
+    )
+    stats = mod.compute_cadence_stats(ticks)
+    assert stats.stall_count == 1
+    assert stats.max_gap_sec == pytest.approx(200.0)
+    assert stats.worst_stall_at is not None

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -91,6 +91,49 @@ def _prediction_error_nodes_enabled() -> bool:
     return os.getenv(_PREDICTION_ERROR_NODE_FLAG, "false").strip().lower() in _TRUTHY
 
 
+# docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-measurement-design.md
+# item 1: five of the six real transport-bus pressure signals have read as
+# exactly zero in every window checked so far -- honestly, not from a bug (see
+# that spec's "Current architecture" section) -- with the practical effect that
+# a real incident could occur and pass unnoticed, since nothing currently logs
+# it. `stream_depth_pressure` (the sixth) is deliberately excluded from this
+# trigger set: it is structurally nonzero on almost every real tick (any
+# nonzero queue depth divides through DEFAULT_STREAM_DEPTH_CRITICAL to a small
+# positive number), so an ">0" check on it would fire constantly rather than
+# flagging a genuine incident. `max_stream_depth` (its raw input) is still
+# surfaced as context below whenever one of the other five signals fires.
+_TRANSPORT_INCIDENT_FIELDS = (
+    "backpressure",
+    "catalog_drift_pressure",
+    "contract_pressure",
+    "observer_failure_pressure",
+    "reliability_pressure",
+)
+
+
+def _log_transport_incident_signals(projection: Any) -> None:
+    """Log (INFO) any bus whose pressure/count signals are non-trivially nonzero
+    this tick -- see docs/superpowers/specs/2026-07-22-transport-bus-signal-
+    quality-measurement-design.md item 1. Read-only w.r.t. the projection;
+    never raises, so a malformed row can't take down the transport tick."""
+    try:
+        for bus_id, bus in (projection.buses or {}).items():
+            nonzero = {
+                field: value
+                for field in _TRANSPORT_INCIDENT_FIELDS
+                if (value := getattr(bus, field, 0.0)) > 0.0
+            }
+            if nonzero:
+                logger.info(
+                    "transport_incident_signal bus=%s nonzero=%s max_stream_depth=%s",
+                    bus_id,
+                    nonzero,
+                    getattr(bus, "max_stream_depth", None),
+                )
+    except Exception:
+        logger.warning("failed to check transport incident signals", exc_info=True)
+
+
 def _prediction_error_receipt(
     *,
     reducer_key: str,
@@ -1929,6 +1972,7 @@ class BiometricsSubstrateWorker:
 
         if last_id is not None:
             curr_projection = load_projection()
+            _log_transport_incident_signals(curr_projection)
             error = transport_prediction_error(prev_projection, curr_projection)
             if error > 0.0:
                 self._store.save_receipt(

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -97,11 +97,17 @@ def _prediction_error_nodes_enabled() -> bool:
 # that spec's "Current architecture" section) -- with the practical effect that
 # a real incident could occur and pass unnoticed, since nothing currently logs
 # it. `stream_depth_pressure` (the sixth) is deliberately excluded from this
-# trigger set: it is structurally nonzero on almost every real tick (any
-# nonzero queue depth divides through DEFAULT_STREAM_DEPTH_CRITICAL to a small
-# positive number), so an ">0" check on it would fire constantly rather than
-# flagging a genuine incident. `max_stream_depth` (its raw input) is still
-# surfaced as context below whenever one of the other five signals fires.
+# trigger set for two compounding reasons, not just one: (a) it is structurally
+# nonzero on almost every real tick (any nonzero queue depth divides through
+# DEFAULT_STREAM_DEPTH_CRITICAL=100_000 to a small positive number), so an
+# ">0" check on it would fire constantly rather than flagging a genuine
+# incident; and (b) any depth spike large enough to be worth flagging already
+# trips `backpressure_count > 0` first -- services/orion-bus's own observer
+# (bus_observer.py) marks a stream "backpressure" once its length crosses
+# BUS_STREAM_DEPTH_WARNING (default 25,000 -- 25% of the critical threshold
+# above), and `backpressure` IS in this trigger set. `max_stream_depth` (its
+# raw input) is still surfaced as context below whenever one of the other
+# five signals fires.
 _TRANSPORT_INCIDENT_FIELDS = (
     "backpressure",
     "catalog_drift_pressure",

--- a/services/orion-substrate-runtime/tests/test_transport_incident_signal_logging.py
+++ b/services/orion-substrate-runtime/tests/test_transport_incident_signal_logging.py
@@ -1,0 +1,89 @@
+"""Unit tests for _log_transport_incident_signals (docs/superpowers/specs/
+2026-07-22-transport-bus-signal-quality-measurement-design.md item 1).
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+_SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _SUBSTRATE_ROOT.parents[1]
+for _p in (str(_REPO_ROOT), str(_SUBSTRATE_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from app.worker import _log_transport_incident_signals  # noqa: E402
+from orion.schemas.transport_projection import TransportBusProjectionV1, TransportBusStateV1  # noqa: E402
+
+
+def _bus(**overrides) -> TransportBusStateV1:
+    defaults = dict(
+        target_id="bus:athena",
+        node_id="athena",
+        sample_window_id="w1",
+        source_trace_id="bus.transport:athena:w1",
+    )
+    defaults.update(overrides)
+    return TransportBusStateV1(**defaults)
+
+
+def _projection(**buses: TransportBusStateV1) -> TransportBusProjectionV1:
+    from datetime import datetime, timezone
+
+    return TransportBusProjectionV1(updated_at=datetime.now(timezone.utc), buses=buses)
+
+
+def test_logs_nothing_when_all_signals_quiet(caplog) -> None:
+    projection = _projection(**{"bus:athena": _bus(max_stream_depth=91, stream_depth_pressure=0.00091)})
+    with caplog.at_level(logging.INFO, logger="orion.substrate.runtime"):
+        _log_transport_incident_signals(projection)
+    assert "transport_incident_signal" not in caplog.text
+
+
+def test_logs_when_backpressure_nonzero(caplog) -> None:
+    projection = _projection(**{"bus:athena": _bus(backpressure=0.5, backpressure_count=3)})
+    with caplog.at_level(logging.INFO, logger="orion.substrate.runtime"):
+        _log_transport_incident_signals(projection)
+    assert "transport_incident_signal" in caplog.text
+    assert "bus:athena" in caplog.text
+    assert "backpressure" in caplog.text
+
+
+def test_does_not_fire_on_stream_depth_pressure_alone() -> None:
+    """stream_depth_pressure is structurally nonzero on almost every real tick
+    (any nonzero queue depth divides through DEFAULT_STREAM_DEPTH_CRITICAL to a
+    small positive number) -- it must not, by itself, count as an incident."""
+    projection = _projection(
+        **{"bus:athena": _bus(max_stream_depth=91, stream_depth_pressure=0.00091)}
+    )
+    logger = logging.getLogger("orion.substrate.runtime")
+    records: list[str] = []
+    handler = logging.Handler()
+    handler.emit = lambda record: records.append(record.getMessage())
+    logger.addHandler(handler)
+    try:
+        _log_transport_incident_signals(projection)
+    finally:
+        logger.removeHandler(handler)
+    assert not any("transport_incident_signal" in r for r in records)
+
+
+def test_multiple_buses_each_checked_independently(caplog) -> None:
+    projection = _projection(
+        **{
+            "bus:athena": _bus(node_id="athena", target_id="bus:athena"),
+            "bus:atlas": _bus(node_id="atlas", target_id="bus:atlas", observer_failure_pressure=1.0, observer_failure_count=1),
+        }
+    )
+    with caplog.at_level(logging.INFO, logger="orion.substrate.runtime"):
+        _log_transport_incident_signals(projection)
+    assert "bus:atlas" in caplog.text
+    assert "bus:athena" not in caplog.text
+
+
+def test_never_raises_on_malformed_input() -> None:
+    class _Bad:
+        buses = None
+
+    _log_transport_incident_signals(_Bad())  # must not raise


### PR DESCRIPTION
## Summary

- Implements all 4 read-only measurement steps proposed by `docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-measurement-design.md` (PR #1275, merged): incident-capture logging, historical baseline + reducer cadence (combined into one script), and a correlation probe against a known-live domain.
- Purely measurement — no threshold recalibration, no new composite formula, no wiring into the Hub lattice console or any live consumer, per that spec's own non-goals.
- Live-ran all three new pieces against real production Postgres data; results match the spec's own predictions.

## Outcome moved

The transport bus's real signal quality is now measured with real numbers instead of a single live spot-check: percentile baseline for `max_stream_depth`, real event-counter totals, reducer-cadence health, and a correlation check against biometrics (a domain already confirmed non-degenerate). The next real transport incident, whenever it occurs, will now get logged instead of passing unnoticed.

## Current architecture

Before this PR: `transport_prediction_error()` read flat `0.0` in production with no instrumentation to say why, and no historical baseline existed for `stream_depth_pressure`'s `DEFAULT_STREAM_DEPTH_CRITICAL = 100_000` threshold.

## Architecture touched

- `services/orion-substrate-runtime/app/worker.py` — new `_log_transport_incident_signals()`, called from `_transport_tick()` after `curr_projection` is loaded. Logs (INFO) when any of 5 real incident signals (backpressure, catalog_drift_pressure, contract_pressure, observer_failure_pressure, reliability_pressure) goes nonzero on any bus. `stream_depth_pressure` deliberately excluded (documented why); `max_stream_depth` still shown as context.
- `scripts/analysis/measure_transport_bus_signal_history.py` (new) — items 2+3 combined (same underlying `substrate_reduction_receipts` fetch). Real percentile stats for `max_stream_depth`, totals + first-seen timestamps for 4 real event counters, reducer-cadence gap analysis with stall detection.
- `scripts/analysis/measure_transport_biometrics_prediction_error_correlation.py` (new) — item 4. Pearson correlation between `node:substrate.transport` and `node:substrate.biometrics` prediction-error channels, returning `None` (not a fabricated `0.0`) when either series is degenerate.

## Files changed

- `services/orion-substrate-runtime/app/worker.py`: new incident-signal logging.
- `services/orion-substrate-runtime/tests/test_transport_incident_signal_logging.py` (new): 5 tests.
- `scripts/analysis/measure_transport_bus_signal_history.py` (new): items 2+3.
- `scripts/analysis/tests/test_measure_transport_bus_signal_history.py` (new): 14 tests.
- `scripts/analysis/measure_transport_biometrics_prediction_error_correlation.py` (new): item 4.
- `scripts/analysis/tests/test_measure_transport_biometrics_prediction_error_correlation.py` (new): 10 tests.

## Schema / bus / API changes

None. The new log line is INFO-only, never published to a bus channel. No schema changes.

## Env/config changes

None.

## Tests run

```text
services/orion-substrate-runtime/tests/test_transport_incident_signal_logging.py -- 5 passed
scripts/analysis/tests/test_measure_transport_bus_signal_history.py -- 14 passed
scripts/analysis/tests/test_measure_transport_biometrics_prediction_error_correlation.py -- 10 passed
(29 total, all passing)

services/orion-substrate-runtime/tests/test_worker_independent_reducers.py,
test_worker_falkor_routed_store.py -- 2 pre-existing failures, confirmed
identical on unmodified main (unrelated to this patch)
```

## Live smoke checks (real production Postgres, read-only)

```text
measure_transport_bus_signal_history.py --window-hours 24:
  193 real rows, ~35min real history (receipts table's short TTL, as predicted)
  max_stream_depth: flat at 91 (min=p50=p95=p99=max=91, stdev=0)
  all 5 incident signals: never nonzero
  cadence: median 10.5s gap, p95 11.6s, 0 stalls

measure_transport_biometrics_prediction_error_correlation.py --window-hours 48:
  75,036 aligned rows
  transport variance: exactly 0.0000000000
  biometrics variance: 0.0019809933 (real, confirmed non-degenerate)
  verdict: NO CORRELATION COMPUTABLE (correctly refuses to fabricate a coefficient)
```

## Docker/build/smoke checks

```text
scripts/safe_docker_build.sh orion-substrate-runtime config -q -- exit 0
```

## Review findings fixed

- Finding: the `stream_depth_pressure` exclusion's code comment stated one real reason but missed a stronger one — any depth spike large enough to matter already trips `backpressure_count` first (`orion-bus`'s observer flags backpressure at `BUS_STREAM_DEPTH_WARNING=25,000`, 25% of the critical threshold), and `backpressure` is already in the trigger set.
  - Fix: comment strengthened with the traced reasoning.
  - Evidence: commit `e3ad4f24`.
- Finding: `compute_cadence_stats()`'s 5x-median stall threshold has a real blind spot at small `n` (a 100x jump can sit under threshold with only 2 gaps to compute a median from).
  - Fix: disclosed as a known limitation in the function's docstring; not fixed (inert at current real `n_gaps=192`).
  - Evidence: commit `e3ad4f24`.
- Finding: `fetch_transport_receipts()` assumes a single bus (true today) but would silently blend multiple buses' series if that ever changed.
  - Fix: disclosed in the function's docstring.
  - Evidence: commit `e3ad4f24`.
- Finding: prior commit's message claimed "35 new unit tests" — actual count is 29.
  - Fix: corrected in this PR description and the follow-up commit message.
  - Evidence: commit `e3ad4f24`.
- No functional correctness bugs found: item-1 placement/null-safety, field selection completeness, `_percentile()`'s even-length behavior, and the SQL `?` jsonb-operator/psycopg2 interaction were all independently traced and confirmed correct.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env -f services/orion-substrate-runtime/docker-compose.yml up -d --build
```

The two new analysis scripts (`scripts/analysis/measure_transport_bus_signal_history.py`, `scripts/analysis/measure_transport_biometrics_prediction_error_correlation.py`) are standalone CLI tools — no restart needed for them; run manually whenever a fresh reading is wanted.

## Risks / concerns

- Severity: Low
- Concern: reducer-cadence stall detection is unreliable at small sample sizes (see review findings above).
- Mitigation: disclosed in the function's docstring; currently inert given real `n_gaps` in the hundreds.

## PR link

(added by gh pr create below)