### PR TITLE
docs: transport-domain narrow-scope finding, documented everywhere it's consumed

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -157,6 +157,22 @@ python orion/mood_arc/fit_encoder.py train \
   (`floor_ratio`/`ceiling_ratio` don't single out `prediction_error`), just
   carrying one contaminated-but-not-dominant input feature the same way
   `v2` carried `catalog_drift_pressure` before the second cutoff.
+- **Scope caveat on `prediction_error`'s "transport" contributor (found 2026-07-22, not a new
+  cutoff — no code changed, just what the channel actually means):** `prediction_error` is a
+  `max()`-merge across five nodes; one of them, `node:substrate.transport`, is fed entirely by
+  whatever streams `orion-bus`'s bus-observer role watches (`BUS_OBSERVER_STREAMS`,
+  `services/orion-bus/.env_example`) — currently `orion:stream:world_pulse:run:result` and its
+  DLQ, **the only two real Redis Streams anywhere in the architecture** (everything else is
+  pub/sub, which has no depth/backlog concept to measure). This is not general bus/transport
+  health across services, despite the name — it's whether one specific service's result queue
+  backs up. Confirmed live: that queue has sat at a constant 91 unconsumed messages for the
+  entire post-second-cutoff corpus window (zero variance), so this contributor to the merge is
+  essentially always the smallest/least-surprising of the five, structurally, not because
+  transport is calm. See `services/orion-substrate-runtime/README.md`'s "transport domain scope"
+  note for the full trace. Doesn't change any cutoff or training recommendation above — flagged
+  so a future retrain's field-selection results for `prediction_error` aren't misread as "the
+  whole bus is healthy" when they're really "one queue is quiet, structurally the only thing
+  that can ever show up here."
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -464,6 +464,25 @@ fix — see §7.
    `docs/superpowers/specs/2026-07-21-chat-route-prediction-error-shadow-design.md`. This
    answers the coverage question this section originally left open; it does not itself
    retire the bucket-vote layer (§6 item 3 remains open for that).
+   **Correction (2026-07-22): "equivalent shadow-measurement instrumentation" is true in the
+   sense that code runs for all five domains, but `transport`'s real coverage is far narrower
+   than the other four.** `transport_prediction_error()` is fed entirely by `orion-bus`'s
+   bus-observer role (`BUS_OBSERVER_STREAMS`), which can only ever watch
+   `orion:stream:world_pulse:run:result` and its DLQ — **the only two real Redis Streams that
+   exist anywhere in this architecture** (everything else is pub/sub, with no depth/backlog
+   concept to measure). So "transport," despite the name, does not mean general bus/transport
+   stress across services the way execution/biometrics/chat/route each cover their own real
+   domain — it means, specifically, whether one service's (`orion-world-pulse`) result queue
+   is backing up. Confirmed live 2026-07-22: `XLEN orion:stream:world_pulse:run:result` = `91`
+   against `BUS_STREAM_DEPTH_CRITICAL=100000`, a ratio (~0.00091) that has sat exactly flat for
+   the entire ~18h window since the second training-data cutoff (PR #1248) — consistent with
+   those 91 messages sitting permanently unconsumed, not a healthy actively-drained queue.
+   Full trace: `services/orion-bus/README.md`'s "Naming caveat for downstream consumers,"
+   `services/orion-substrate-runtime/README.md`'s "transport domain scope" note, and
+   `orion/mood_arc/README.md`'s matching caveat (since `transport` is also one of the five
+   inputs `max()`-merged into the `prediction_error` field-digester channel). Whether the
+   backlog itself is expected or a dead consumer is a separate, not-yet-investigated
+   question.
    **Attribution durability + consumers (2026-07-18):** the harness-closure variant of this
    same mechanism (`node:substrate.harness_closure`, PR #1205) accumulates per-turn
    attribution in `metadata['contributing_turn_ids']`, but that list was silently dropped on

--- a/services/orion-bus/README.md
+++ b/services/orion-bus/README.md
@@ -231,6 +231,21 @@ Observes transport health (`PING`), stream depth (`XLEN`), backpressure threshol
 | `BUS_OBSERVER_POLL_INTERVAL_SEC` | `10` | Rollup interval |
 | `BUS_OBSERVER_SCHEMA_SAMPLE_COUNT` | `5` | Per-cataloged-stream `XREVRANGE` sample size for the schema-mismatch check |
 
+**Naming caveat for downstream consumers (found 2026-07-22):** the 2026-07-18 fix above correctly
+made `BUS_OBSERVER_STREAMS` only watch real Streams — but since `orion:stream:world_pulse:run:result`
+and its DLQ are the *only* two `kind: "stream"` channels that exist, this sidecar's `transport_pressure`/
+`stream_depth_pressure`/`backpressure` outputs (consumed downstream as
+`orion/substrate/transport_loop/extract.py::compute_transport_pressures()`, then folded into
+`node:substrate.transport` and the `prediction_error` field-digester channel — see
+`services/orion-substrate-runtime/README.md`'s "transport domain scope" note and
+`orion/mood_arc/README.md`'s matching caveat) do not mean general bus/transport health across
+services. They mean, specifically and only, whether `world_pulse`'s result queue is backing up.
+Confirmed live 2026-07-22: `XLEN orion:stream:world_pulse:run:result` = `91`, against
+`BUS_STREAM_DEPTH_CRITICAL=100000` — a value that has sat exactly flat (90-91, zero movement) for
+the entire ~18h post-accumulation-bug-fix window, consistent with those 91 messages being
+permanently unconsumed rather than a healthy, actively-drained queue. Not yet determined whether
+that backlog is expected (no consumer by design) or a dead consumer — flagged, not investigated.
+
 Smoke: `../../scripts/smoke_orion_bus_substrate_trace.sh`
 
 Layer 3 `bus_transport_reducer` is deferred — see `LAYER_PIPELINE_PLAN.md`.

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -420,7 +420,23 @@ were broken until today, upstream of this service, not a field-digester bug:
    written despite 241 real accumulated chat turns. Fixed (PR #1267).
 3. `transport_prediction_error()` was **not** broken — its low reading is a
    real quiet bus, not an instrument defect (see the earlier fix note in
-   this same file).
+   this same file). **Correction (2026-07-22, later same day): "quiet bus"
+   undersold this.** `transport_prediction_error()` is fed entirely by
+   `orion-bus`'s bus-observer role, which structurally can only ever watch
+   `orion:stream:world_pulse:run:result` and its DLQ — the only two real
+   Redis Streams anywhere in the architecture (everything else is pub/sub,
+   with no depth/backlog concept). So this instrument doesn't sample "the
+   bus" and find it quiet; it can only ever see one service's result queue,
+   full stop. Confirmed live: `XLEN orion:stream:world_pulse:run:result` =
+   `91` against `BUS_STREAM_DEPTH_CRITICAL=100000` (ratio ~0.00091), flat
+   with zero movement for the entire ~18h window since the fix above — the
+   contributing `transport` node to this merged channel is not "currently
+   calm," it is structurally incapable of reflecting broader bus/transport
+   stress at all. Full trace: `services/orion-bus/README.md`'s "Naming
+   caveat for downstream consumers," `services/orion-substrate-runtime/
+   README.md`'s "transport domain scope" note, `orion/mood_arc/README.md`'s
+   matching caveat, and `orion/sentience_striving_program/README.md` §9b
+   item 3's matching correction.
 
 Net effect: for as long as those two instruments were broken, the merged
 `prediction_error` channel could only ever reflect `biometrics_prediction_

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -251,7 +251,10 @@ match design (same live one-shot-per-turn shape, sparser sample). **`transport_p
 did not have this bug** — `transport_bus_reducer` genuinely revises the same `bus_id` (`bus:athena`)
 in place every tick, so its trace_id-equivalent match works; its low variance is a real quiet bus
 (confirmed live: `bus_health`/`delivery_confidence` each took exactly 1 distinct value across the
-last 500 live receipts checked), not an instrument bug.
+last 500 live receipts checked), not an instrument bug. **Correction, 2026-07-22 (see the "transport
+domain scope" note below): "quiet bus" is true for `bus_health`/`delivery_confidence` specifically,
+but `transport_pressure`'s own quietness is not about the bus being calm — it's about what this
+instrument is structurally capable of observing at all.**
 
 Fix: when no exact `trace_id` match exists, both functions now fall back to diffing against
 `prev`'s most-recently-updated run (by `last_updated_at`) instead of contributing nothing — the
@@ -290,6 +293,47 @@ pressure.py::prediction_error_pressure()` does **not** explain it (that function
 from `node.metadata['prediction_error']` on every call rather than persisting a decayed value), so
 the actual mechanism is still open — see the audit doc's Missing Questions. Not fixed in this
 patch.
+
+**The "transport domain" is one queue, not the bus (found 2026-07-22, while re-verifying the "quiet
+bus" claim above against real numbers).** `bus_health`/`delivery_confidence`/`transport_pressure`
+(`orion/substrate/transport_loop/extract.py::compute_transport_pressures()`) are computed entirely
+from whatever streams `orion-bus`'s bus-observer role is configured to watch
+(`BUS_OBSERVER_STREAMS`, `services/orion-bus/app/settings.py`/`.env_example`). That config, and its
+own inline comment, are blunt about the scope: *"`orion:evt:gateway`/`orion:bus:out` were
+placeholder names from the original bus-observer commit (`ee810551`, 2026-05-25), never once
+wired [to real streams]... These are the only two real Streams in the current architecture, so
+they are now the entire default"* — `BUS_OBSERVER_STREAMS=orion:stream:world_pulse:run:result,
+orion:stream:world_pulse:run:result:dlq`. Almost all of Orion's actual inter-service traffic runs
+over Redis pub/sub channels, which have no XLEN-style depth/backlog concept the way a Stream does
+— `world_pulse`'s result queue is the *only* thing on the entire bus built as a Stream, so it is
+structurally the only thing this instrument can ever measure. "Transport domain" and "bus health"
+are the wrong names for what this actually is: **whether one specific service's result queue is
+backing up.**
+
+Confirmed live (2026-07-22): `redis-cli -h <bus host> XLEN orion:stream:world_pulse:run:result` →
+`91`; `:dlq` → `0`. `services/orion-bus/.env_example`'s own `BUS_STREAM_DEPTH_CRITICAL=100000`
+divides this 91 down to `0.00091` (`orion/substrate/transport_loop/extract.py:86`,
+`stream_depth_pressure = min(max_stream_depth / critical, 1.0)`) — a ~1,099x ratio between the real
+number and the "critical" threshold, which reads as "quiet" no matter what the real queue is doing,
+short of it growing to tens of thousands of messages. Checked against the training corpus
+(`/mnt/telemetry/field_channels/corpus/field_channels.jsonl`): before the second cutoff
+(2026-07-22T04:35:01Z, PR #1248's `mode="add"` fix), this same value was pinned at ~100,000 for 80%
+of the corpus's history — that saturation was the already-documented accumulation bug, not evidence
+this queue is normally busy. After the fix, it has been *exactly* 90 or 91, with zero movement, for
+the entire ~18h observed post-fix window — consistent with `orion:stream:world_pulse:run:result`
+having 91 messages sitting permanently unconsumed the whole time, not a healthy, actively-drained
+queue. Whether that backlog itself is expected (nobody reads this queue by design) or a dead
+consumer is a separate, not-yet-investigated question.
+
+**Implication for the charter and for `mood-arc`:** Sentience Striving Program charter §9b item 3
+(Predictive Processing/Active Inference) names "transport" as one of five domains with "equivalent
+shadow-measurement instrumentation" to execution/biometrics/chat/route — true in the sense that
+code exists and runs, misleading in the sense that this domain's real coverage is one queue, not
+general bus stress across services. `prediction_error` (the `max()`-merge across all five domains'
+instruments, `orion/field/pressure.py::collect_field_channel_pressures()`) is also one of
+`field_channel_corpus.v1`'s trained mood-arc channels — this domain's contribution to that merge
+has the same narrow-scope caveat. See `orion/mood_arc/README.md` and this document's "fourth
+training-data quality cutoff" section for the corpus-facing side of this.
 
 **Reverie semantic lift:** unresolved closures also upsert human referent rows into
 `substrate_turn_referent` via `turn_referent_store.persist_turn_referent`. Apply


### PR DESCRIPTION
## Summary

- `transport_prediction_error()`/`bus_health`/`transport_pressure` are fed entirely by `orion-bus`'s bus-observer role (`BUS_OBSERVER_STREAMS`), which can only ever watch `orion:stream:world_pulse:run:result` + its DLQ — the only two real Redis Streams anywhere in the architecture (everything else is pub/sub, no depth/backlog concept to measure).
- "Transport"/"bus health" therefore does not mean general bus stress across services, despite the name. It means, specifically, whether `orion-world-pulse`'s result queue is backing up.
- Confirmed live 2026-07-22: `XLEN orion:stream:world_pulse:run:result` = `91` against `BUS_STREAM_DEPTH_CRITICAL=100000` (ratio ~0.00091), flat with zero movement for the entire ~18h window since the second training-data-cutoff fix (PR #1248) — consistent with those 91 messages sitting permanently unconsumed, not a healthy actively-drained queue.
- This corrects an earlier same-day characterization ("not broken, real quiet bus" — see `services/orion-field-digester/README.md`) that was true as far as it went but understated the finding: the low reading isn't evidence of a calm bus, it's evidence the instrument can only ever see one narrow queue.
- Docs-only change. No code touched.

## Outcome moved

Every place that consumes or asserts coverage from this instrument now carries an accurate scope caveat instead of an implied "general transport/bus health" claim:

- `services/orion-substrate-runtime/README.md` — origin of the finding, full trace with live numbers ("The 'transport domain' is one queue, not the bus").
- `services/orion-bus/README.md` — the owning service's own `BUS_OBSERVER_STREAMS` docs now note the downstream naming mismatch.
- `services/orion-field-digester/README.md` — corrects the same-day-earlier "not broken, real quiet bus" note with the deeper structural finding.
- `orion/mood_arc/README.md` — notes the `prediction_error` merged channel's transport contributor is real-but-narrow-scope, alongside the existing fourth-cutoff bullet.
- `orion/sentience_striving_program/README.md` §9b item 3 — corrects the charter's own "all five named producer domains... have equivalent shadow-measurement instrumentation" claim.

## Current architecture

`transport_prediction_error()` writes `node:substrate.transport`, one of five nodes `max()`-merged by `orion/field/pressure.py::collect_field_channel_pressures()` into the single `prediction_error` field-digester channel — which is one of `field_channel_corpus.v1`'s 15 trained mood-arc channels. Upstream of it, `orion/substrate/transport_loop/extract.py::compute_transport_pressures()` derives `bus_health`/`stream_depth_pressure`/`backpressure` entirely from `TransportBusStateV1`, itself built from whatever streams the bus-observer sidecar (`services/orion-bus`) samples via `BUS_OBSERVER_STREAMS`.

## Architecture touched

Docs only — no schema, bus, contract, or runtime code changed.

## Files changed

- `services/orion-substrate-runtime/README.md`: new "transport domain is one queue, not the bus" section + correction to the existing "quiet bus" paragraph.
- `orion/mood_arc/README.md`: new bullet noting the `prediction_error` channel's transport-contributor scope caveat, alongside the existing fourth-cutoff documentation.
- `services/orion-bus/README.md`: new "naming caveat for downstream consumers" note under the bus-observer's `BUS_OBSERVER_STREAMS` table.
- `services/orion-field-digester/README.md`: correction appended to the existing "transport_prediction_error() was not broken" bullet.
- `orion/sentience_striving_program/README.md`: correction appended to §9b item 3's "all five named producer domains" claim.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

N/A — docs-only change.

## Evals run

N/A — docs-only change.

## Docker/build/smoke checks

N/A — docs-only change.

## Review findings fixed

Not run — pure documentation change with no code/behavior modified; correcting factual claims already made in merged READMEs against directly-verified live data (XLEN, corpus file inspection, env var confirmation), all cited inline.

## Restart required

No restart required.

## Risks / concerns

- Severity: low
- Concern: whether `orion:stream:world_pulse:run:result`'s 91-message backlog is expected (no consumer by design) or a dead/broken consumer is flagged in all five docs as unresolved, not yet investigated.
- Mitigation: explicitly called out as a separate follow-up question in each location, not conflated with this PR's documentation-only scope.

## PR link