### PR TITLE
docs: extend transport-domain scope finding to raw pressure channels

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -173,6 +173,16 @@ python orion/mood_arc/fit_encoder.py train \
   so a future retrain's field-selection results for `prediction_error` aren't misread as "the
   whole bus is healthy" when they're really "one queue is quiet, structurally the only thing
   that can ever show up here."
+- **`catalog_drift_pressure` is now a structurally dead channel going forward (found
+  2026-07-23):** unlike `prediction_error`, this one is an actual member of `v2`'s (and
+  presumably `v3`'s) 15 selected channels. It counts streams the bus-observer watches that
+  aren't in `orion/bus/channels.yaml`'s catalog — since the same 2026-07-18 fix above made the
+  observer only ever watch cataloged streams, that count, and this channel, is now permanently
+  `0.0` by construction, not by observation (confirmed `MISSING` from every recent corpus row —
+  the `PRESSURE_CHANNELS`/`value > 0` inclusion gate no longer lets it through at all). A future
+  retrain's field-selection pass will likely drop it outright; worth noting in the retrain
+  writeup as an expected, not anomalous, absence. Full detail:
+  `services/orion-field-digester/README.md`'s `catalog_drift_pressure` channel-catalog entry.
 - `--hidden-dim 128 --latent-dim 64` are the defaults as of this patch
   (`DEFAULT_HIDDEN_DIM`/`DEFAULT_LATENT_DIM` in `fit_encoder.py`) — sized for
   `field_channel_corpus.v1`'s ~16-26-channel width, not the old 4-channel

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -922,16 +922,40 @@ subset for the mood-arc windowed-autoencoder spike (see
 - **SelfState dimension fed**: not in `channel_dimension_map` directly
   (removed 2026-07-12). `evidence_channel_map`: `transport_pressure` →
   `resource_pressure` (evidence-only).
-- **Live-data verdict**: fully unproduced — confirmed absent (key entirely
-  missing, not just `0.0`) from all 123,245+ live rows checked 2026-07-16
-  (`jq -r '.channels.transport_pressure // "MISSING"' ... | sort -u` returns
-  only `MISSING`). More extreme than "folded-away":
-  `collect_field_channel_pressures()` only includes a channel when `channel
-  in PRESSURE_CHANNELS or value > 0` (`scoring.py:70,76`), and
-  `transport_pressure` is not in `PRESSURE_CHANNELS`, so even its
-  reconcile-seeded `0.0` never reaches the corpus — it needs at least one
-  real nonzero perturbation to ever appear at all, and none has occurred in
-  this corpus.
+- **Live-data verdict, corrected 2026-07-23 (the 2026-07-16 "fully
+  unproduced" verdict below is stale — do not carry it forward):**
+  `transport_pressure` is not in `PRESSURE_CHANNELS`, so
+  `collect_field_channel_pressures()` (`scoring.py:70,76`) only includes it
+  when a real nonzero perturbation lands — same gate the 2026-07-16 check
+  found nothing passing. Since then its live history has moved through three
+  distinct phases, all traced to the same producer
+  (`compute_transport_pressures()`'s `transport_pressure = max(stream_depth_
+  pressure, backpressure)`, `orion/substrate/transport_loop/extract.py:105`):
+  (1) **before 2026-07-18** (`BUS_OBSERVER_STREAMS` still pointed at
+  placeholder/never-wired stream names — see `services/orion-bus/README.md`)
+  — genuinely `MISSING`, matching the 2026-07-16 check exactly; (2)
+  **2026-07-18 through the second training-data cutoff (2026-07-22T04:35Z,
+  PR #1248)** — pinned at `1.0` (ceiling-saturated; confirmed directly
+  against the corpus at rows dated 2026-07-18T20:41Z and
+  2026-07-20T17:42Z), the same `mode="add"` accumulation bug documented
+  above for `catalog_drift_pressure`/`observer_failure_pressure`/
+  `reliability_pressure`; (3) **since the fix** — flat and constant at
+  `0.00091` across every row checked (20,000-row window, 2026-07-22T12:50Z
+  through 2026-07-23T00:04Z, zero variance) — the same value, and the same
+  root cause, as `prediction_error`'s transport contribution: `XLEN
+  orion:stream:world_pulse:run:result` (`91`) divided by
+  `BUS_STREAM_DEPTH_CRITICAL` (`100000`). See
+  `services/orion-substrate-runtime/README.md`'s "transport domain is one
+  queue, not the bus" note — this raw channel and `prediction_error`'s
+  transport contribution are two different computations (current level vs.
+  tick-over-tick delta) over the exact same narrowly-scoped input, so both
+  inherit the identical structural ceiling on what they can ever measure.
+  **`stream_depth_pressure` and `backpressure` are not independent corpus
+  channels** — per the Producer note above, all three hint keys
+  (`transport_pressure`, `stream_depth_pressure`, `backpressure`) target the
+  same single node channel, `transport_pressure`; `stream_depth_pressure`
+  never appears under its own name in the corpus (confirmed `MISSING` in
+  every row checked), it is folded into `transport_pressure` at the source.
 
 #### `contract_pressure`
 - **Meaning**: intended to represent pressure from bus/schema "contract"
@@ -975,7 +999,30 @@ subset for the mood-arc windowed-autoencoder spike (see
 - **SelfState dimension fed**: **none** — same verification as
   `contract_pressure` above; absent from all four policy maps.
 - **Live-data verdict**: exact duplicate of `contract_pressure` (see above);
-  open root-cause question, not fixed by this patch.
+  open root-cause question, not fixed by this patch. **Correction
+  (2026-07-23): this channel is one of `v2`'s (and, by field-selection
+  carryover, presumably `v3`'s) 15 trained mood-arc channels
+  (`orion/mood_arc/docs/DESIGN.md`) — worth flagging beyond the byte-
+  identical-duplicate finding above.** Producer:
+  `catalog_drift_pressure = min(state.uncataloged_stream_count / denom,
+  1.0)` (`orion/substrate/transport_loop/extract.py:88`) —
+  `uncataloged_stream_count` counts streams the bus-observer watches
+  (`BUS_OBSERVER_STREAMS`) that are *not* in `orion/bus/channels.yaml`'s
+  catalog. Since the 2026-07-18 fix (`services/orion-bus/README.md`),
+  `BUS_OBSERVER_STREAMS` only ever names the two streams that *are*
+  cataloged (`orion:stream:world_pulse:run:result` + its DLQ) — so
+  `uncataloged_stream_count` is now structurally always `0`, and
+  `catalog_drift_pressure` is now structurally always `0.0` too, going
+  forward, by construction, not by observation. Confirmed against the
+  live corpus: `MISSING` in every one of the last 5,000 rows checked
+  (2026-07-23) — same `PRESSURE_CHANNELS`/`value > 0` gate as
+  `transport_pressure` above, and this channel never clears it anymore.
+  Practically: a channel `v2`/`v3` were trained to expect some real signal
+  from is now permanently silent under the current bus-observer config —
+  worth accounting for if a future retrain's field-selection drops it or
+  treats it as dead. Not a bug to fix (the 2026-07-18 change was correct
+  for its own stated purpose); a downstream side effect worth having on
+  record.
 
 #### `delivery_confidence`
 - **Meaning**: confidence that bus messages are actually being delivered

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -325,6 +325,17 @@ having 91 messages sitting permanently unconsumed the whole time, not a healthy,
 queue. Whether that backlog itself is expected (nobody reads this queue by design) or a dead
 consumer is a separate, not-yet-investigated question.
 
+**Update, 2026-07-23: the same root cause also governs the raw pressure channels, not just
+`prediction_error`.** `transport_pressure` (the raw current-level channel, distinct from
+`prediction_error`'s tick-over-tick delta) now sits flat at the same `0.00091` in the field-digester
+corpus, and `catalog_drift_pressure` — one of mood-arc `v2`/`v3`'s actual 15 trained channels — is
+now structurally pinned to `0.0` (permanently, by construction: it counts uncataloged streams the
+observer watches, and the observer now only ever watches cataloged ones). Full detail, live numbers,
+and history (including a since-fixed ceiling-saturation phase for `transport_pressure` from the same
+`mode="add"` bug already documented for `catalog_drift_pressure`/`observer_failure_pressure`/
+`reliability_pressure`) in `services/orion-field-digester/README.md`'s `transport_pressure` and
+`catalog_drift_pressure` channel-catalog entries.
+
 **Implication for the charter and for `mood-arc`:** Sentience Striving Program charter §9b item 3
 (Predictive Processing/Active Inference) names "transport" as one of five domains with "equivalent
 shadow-measurement instrumentation" to execution/biometrics/chat/route — true in the sense that


### PR DESCRIPTION
## Summary

Follow-up to #1278 (merged): the same root cause documented there (`BUS_OBSERVER_STREAMS` can only ever watch `world_pulse`'s result queue + DLQ) also governs the raw `transport_pressure`/`catalog_drift_pressure` corpus channels, not just `prediction_error`'s derived transport contribution. User asked directly whether the signal is "called transport_pressure / stream_depth_pressure" — verified live against the corpus and found the answer is more nuanced than a yes/no, so documenting it precisely.

- Corrects a stale field-digester README claim (`transport_pressure` "fully unproduced," checked 2026-07-16) with the current live state, traced through 3 phases: genuinely missing pre-2026-07-18, ceiling-saturated at `1.0` during the already-documented `mode="add"` contamination window, flat at `0.00091` since the fix — same value, same root cause, as `prediction_error`'s transport contribution.
- Flags `catalog_drift_pressure` — one of mood-arc `v2`/`v3`'s actual 15 trained channels — as now structurally pinned to `0.0` going forward: it counts uncataloged streams the observer watches, and the observer now only ever watches cataloged ones. Confirmed `MISSING` from the live corpus (last 5,000 rows checked). Not a bug — the 2026-07-18 fix was correct for its own purpose — but a downstream side effect worth having on record before a future retrain's field-selection silently drops it.
- Clarifies `stream_depth_pressure`/`backpressure` are not independent corpus channels — both hint keys target the same `transport_pressure` node channel; `stream_depth_pressure` never appears under its own name.
- Docs-only. No code touched.

## Outcome moved

Every place documenting the transport-domain scope finding now correctly distinguishes the raw pressure-level channels (`transport_pressure`, `catalog_drift_pressure`) from the derived `prediction_error` delta channel, with accurate current-state numbers for both families instead of a stale 2026-07-16 snapshot.

## Current architecture

`transport_pressure` (current level) and `prediction_error`'s transport contribution (tick-over-tick delta) are two different computations over the exact same narrowly-scoped input (`TransportBusStateV1`, built exclusively from `BUS_OBSERVER_STREAMS`). `catalog_drift_pressure` is a third, structurally-unrelated computation (`uncataloged_stream_count`) that happens to share the same observer-config dependency.

## Architecture touched

Docs only.

## Files changed

- `services/orion-field-digester/README.md`: corrected `transport_pressure`'s stale "fully unproduced" verdict with current 3-phase live history; added a correction to `catalog_drift_pressure`'s entry noting its new structurally-dead state.
- `services/orion-substrate-runtime/README.md`: added a short pointer from the existing "transport domain is one queue" section to the raw-channel findings.
- `orion/mood_arc/README.md`: added a bullet flagging `catalog_drift_pressure`'s dead-channel state for future retrains, next to the existing `prediction_error` scope caveat.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

N/A — docs-only change.

## Evals run

N/A — docs-only change.

## Docker/build/smoke checks

N/A — docs-only change.

## Review findings fixed

Not run — documentation-only, correcting/extending factual claims against directly-verified live data (corpus `jq` queries over a 20,000-row window, `PRESSURE_CHANNELS`/`NODE_DECAY_CHANNELS` source inspection), all cited inline with exact commands and row ranges.

## Restart required

No restart required.

## Risks / concerns

- Severity: low
- Concern: none new beyond what #1278 already flagged (world_pulse backlog consumer status still unresolved).

## PR link