### PR TITLE
feat(hub,field-digester): turn-incompletion liveness signal (Patch B)

### DIFF
--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -108,6 +108,43 @@ async def _publish_unified_turn_chat_grammar(
         logger.warning("unified_turn_chat_grammar_publish_failed corr=%s", correlation_id, exc_info=True)
 
 
+async def _publish_turn_timeout_grammar(
+    *, bus: Any, correlation_id: str, settings: Any
+) -> None:
+    """Orion capability: liveness marker for a turn whose HarnessGovernorClient.run()
+    call did not yield a usable result (the `run is None` case below).
+
+    Most commonly a true harness-governor RPC timeout -- the ONE case in the
+    unified-turn saga where no governor-side grammar event is ever published at all
+    (HarnessGrammarCollector only flushes at the end of a run, a point a true timeout
+    never reaches). `run is None` also covers a rarer reply-failed-to-decode sub-case
+    where the governor's reply did arrive -- see build_turn_timeout_grammar_events'
+    own docstring for the full caveat. Reuses PUBLISH_HUB_CHAT_GRAMMAR (no new env
+    key, see services/orion-hub/README.md's note on this coupling) since this is still
+    Hub-side grammar publishing onto the same channel. Fail-open, same shape as
+    _publish_unified_turn_chat_grammar above.
+    """
+    if bus is None or not getattr(settings, "PUBLISH_HUB_CHAT_GRAMMAR", False):
+        return
+    try:
+        from scripts.grammar_emit import build_turn_timeout_grammar_events
+        from scripts.grammar_publish import publish_hub_chat_grammar_trace
+
+        events = build_turn_timeout_grammar_events(
+            correlation_id=correlation_id,
+            node_id=settings.NODE_NAME,
+        )
+        await publish_hub_chat_grammar_trace(
+            bus,
+            events,
+            correlation_id=correlation_id,
+            channel=settings.GRAMMAR_EVENT_CHANNEL,
+            enabled=True,
+        )
+    except Exception:
+        logger.warning("turn_timeout_grammar_publish_failed corr=%s", correlation_id, exc_info=True)
+
+
 def _thought_deferred_frame(thought: ThoughtEventV1, *, correlation_id: str) -> dict[str, Any]:
     frame: dict[str, Any] = {
         "type": "turn_deferred",
@@ -460,6 +497,7 @@ async def execute_unified_turn(
         if harness_step_relay is not None:
             harness_step_relay.forget(correlation_id)
     if run is None:
+        await _publish_turn_timeout_grammar(bus=bus, correlation_id=correlation_id, settings=cfg)
         return [
             {
                 "type": "turn_error",

--- a/orion/schemas/execution_projection.py
+++ b/orion/schemas/execution_projection.py
@@ -40,6 +40,11 @@ class ExecutionRunStateV1(BaseModel):
     # single end-of-run flush per turn (see HarnessGrammarCollector), so "current
     # streak" and "max streak" are the same observation in practice.
     tool_failure_streak_max: int = 0
+    # Set only by an exec_turn_timeout event (orion-hub-sourced, published from
+    # orion/hub/turn_orchestrator.py when a harness-governor RPC never returns). This
+    # run's other fields will otherwise be entirely at their defaults -- there is no
+    # governor-side data for a turn that never reached the motor's own lifecycle flush.
+    turn_timed_out: bool = False
     recall_observed: bool = False
     final_text_present: bool = False
     reasoning_present: bool = False

--- a/orion/substrate/execution_loop/constants.py
+++ b/orion/substrate/execution_loop/constants.py
@@ -3,6 +3,12 @@ EXECUTION_GRAMMAR_CURSOR_NAME = "execution_grammar_reducer"
 EXECUTION_SOURCE_SERVICES = frozenset({
     "orion-cortex-exec",
     "orion-harness-governor",
+    # Only ever the source of one event kind: exec_turn_timeout, published by
+    # orion/hub/turn_orchestrator.py when a harness-governor RPC never returns (the
+    # one unified-turn failure mode where the governor side publishes nothing at all).
+    # See services/orion-hub/scripts/grammar_emit.py's build_turn_timeout_grammar_events()
+    # and docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md.
+    "orion-hub",
 })
 # Keep EXECUTION_SOURCE_SERVICE for backward compat imports; prefer EXECUTION_SOURCE_SERVICES.
 EXECUTION_SOURCE_SERVICE = "orion-cortex-exec"

--- a/orion/substrate/execution_loop/grammar_extract.py
+++ b/orion/substrate/execution_loop/grammar_extract.py
@@ -88,6 +88,10 @@ def compute_pressure_hints(
     compliance_deficit = (
         _COMPLIANCE_DEFICIT_RANK.get(run.compliance_verdict.strip().lower(), 0) / 3.0
     )
+    # The one case where the governor never responded at all -- distinct severity from
+    # compliance_deficit's worst rank (refused/failed), which still requires the
+    # governor to have replied with *something*.
+    turn_incompletion = 1.0 if run.turn_timed_out else 0.0
     # llm_serving_node is NOT injected here: pressure_hints must stay
     # float-only -- orion/substrate/relational/adapters/execution_ctx.py's
     # map_execution_ctx_to_substrate() does max(hints.values()) over this
@@ -106,6 +110,7 @@ def compute_pressure_hints(
         "tool_failure_streak_pressure": tool_failure_streak_pressure,
         "avg_step_chars_pressure": avg_step_chars_pressure,
         "compliance_deficit": compliance_deficit,
+        "turn_incompletion": turn_incompletion,
     }
 
 
@@ -204,6 +209,8 @@ def extract_execution_state_from_events(
                 pass
         elif role == "exec_result_emitted":
             egress_emitted = True
+        elif role == "exec_turn_timeout":
+            run.turn_timed_out = True
 
     run.pressure_hints = compute_pressure_hints(run, egress_emitted=egress_emitted)
     return run

--- a/orion/substrate/execution_loop/merge.py
+++ b/orion/substrate/execution_loop/merge.py
@@ -80,6 +80,7 @@ def merge_execution_run_state(
     merged.compliance_verdict = _pick_compliance_verdict(
         existing.compliance_verdict, incoming.compliance_verdict
     )
+    merged.turn_timed_out = existing.turn_timed_out or incoming.turn_timed_out
     merged.recall_observed = existing.recall_observed or incoming.recall_observed
     merged.final_text_present = existing.final_text_present or incoming.final_text_present
     merged.reasoning_present = existing.reasoning_present or incoming.reasoning_present

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -942,6 +942,35 @@ subset for the mood-arc windowed-autoencoder spike (see
 - **SelfState dimension fed**: none yet.
 - **Live-data verdict**: not yet live-verified, pending deploy.
 
+#### `turn_incompletion`
+- **Meaning**: did Hub fail to get a usable result back from the harness-governor RPC
+  for this turn? Most commonly a true timeout; occasionally a reply that arrived but
+  failed to decode (see Producer note). A distinct, worse severity than
+  `compliance_deficit`'s worst rank (`refused`/`failed`) — those still require the
+  governor to have replied with *something* Hub could use. `1.0` if the turn hit Hub's
+  `run is None` path, `0.0` otherwise.
+- **Producer**: `execution_run` delta, mode=`replace`. In `NODE_DECAY_CHANNELS`. Sourced
+  from a NEW `orion-hub`-published grammar event (`semantic_role="exec_turn_timeout"`,
+  `services/orion-hub/scripts/grammar_emit.py`'s `build_turn_timeout_grammar_events()`),
+  fired from `orion/hub/turn_orchestrator.py`'s `run is None` branch. For a true timeout
+  this is the ONE unified-turn failure mode where no governor-side grammar event exists
+  at all — `HarnessGrammarCollector` only flushes its buffered lifecycle atoms once, at
+  the end of a run, and a true timeout never reaches that point. For the rarer
+  decode-failure sub-case, the governor's own reply did arrive and may already have
+  flushed real lifecycle grammar on its own trace lane — this channel doesn't
+  distinguish the two sub-cases (both read `run is None` to Hub). Required widening
+  `EXECUTION_SOURCE_SERVICES` (`orion/substrate/execution_loop/constants.py`) to
+  include `orion-hub` — the one real contract-surface touch in this signal's design,
+  since without it the reducer silently no-ops the event.
+- **Node attribution**: Hub's own node (parsed from this event's `hub_turn_timeout`
+  trace lane, under Hub's `NODE_NAME` — Hub cannot reliably know which physical node
+  the governor's own `HarnessGrammarCollector` would have used, since the RPC it was
+  waiting on never returned). This measures **Hub's view of governor
+  unresponsiveness**, not the governor's own node health — the two may run on
+  different physical nodes.
+- **SelfState dimension fed**: none yet.
+- **Live-data verdict**: not yet live-verified, pending deploy.
+
 #### `egress_confidence_deficit`
 - **Meaning**: `1 - confidence` that an execution's output actually reached
   its destination.

--- a/services/orion-field-digester/app/digestion/decay.py
+++ b/services/orion-field-digester/app/digestion/decay.py
@@ -29,6 +29,7 @@ NODE_DECAY_CHANNELS = {
     "tool_failure_streak_pressure",
     "avg_step_chars_pressure",
     "compliance_deficit",
+    "turn_incompletion",
     # transport
     "transport_pressure",
     "contract_pressure",

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -258,6 +258,13 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
             ("tool_failure_streak_pressure", "tool_failure_streak_pressure", node_key),
             ("avg_step_chars_pressure", "avg_step_chars_pressure", node_key),
             ("compliance_deficit", "compliance_deficit", node_key),
+            # Distinct severity from compliance_deficit's worst rank: the governor
+            # never responded at all (orion-hub-sourced exec_turn_timeout event, no
+            # governor-side data ever existed for this run). node_key here resolves to
+            # Hub's own node (parsed from the hub_turn_timeout-laned trace_id), not the
+            # governor's -- this measures "Hub's view of governor unresponsiveness,"
+            # not the governor's own node health, since they may differ.
+            ("turn_incompletion", "turn_incompletion", node_key),
         ):
             if key in hints:
                 out.append(

--- a/services/orion-field-digester/app/tensor/channels.py
+++ b/services/orion-field-digester/app/tensor/channels.py
@@ -17,6 +17,7 @@ NODE_CHANNELS = [
     "tool_failure_streak_pressure",
     "avg_step_chars_pressure",
     "compliance_deficit",
+    "turn_incompletion",
     "conversation_load",
     "transport_pressure",
     "contract_pressure",

--- a/services/orion-field-digester/tests/test_decay_hold.py
+++ b/services/orion-field-digester/tests/test_decay_hold.py
@@ -51,6 +51,7 @@ def test_new_fcc_motor_channels_are_registered_for_decay() -> None:
         "tool_failure_streak_pressure",
         "avg_step_chars_pressure",
         "compliance_deficit",
+        "turn_incompletion",
     ):
         assert channel in NODE_DECAY_CHANNELS
 

--- a/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
@@ -101,6 +101,21 @@ def test_execution_run_new_fcc_channels_attributed_to_orchestrating_node() -> No
     assert by_channel["harness_step_load"].intensity == 0.62
 
 
+def test_execution_run_turn_incompletion_attributed_to_hub_node() -> None:
+    """turn_incompletion comes from an orion-hub-sourced exec_turn_timeout event whose
+    trace_id lane is under Hub's own node identity, not the governor's -- node_key here
+    is Hub's node, distinct from what harness-governor would report for the same
+    correlation_id (there is none, in this failure mode)."""
+    delta = _make_execution_run_delta(
+        node_id="athena",
+        pressure_hints={"turn_incompletion": 1.0},
+    )
+    perturbations = delta_to_perturbations(delta)
+    by_channel = {p.channel: p for p in perturbations}
+    assert by_channel["turn_incompletion"].node_id == "node:athena"
+    assert by_channel["turn_incompletion"].intensity == 1.0
+
+
 def test_execution_run_harness_step_load_stays_bounded_through_apply_perturbations() -> None:
     """Regression test for a code-review finding: apply_perturbations() hard-clamps
     every mode="replace" channel to [0,1] (app/digestion/perturbation.py), which an

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -537,6 +537,9 @@ SUBSTRATE_GRAPHDB_PASS=
 # Emit GrammarEventV1 per chat turn → substrate-runtime chat_grammar_consumer → field lattice.
 # Apply SQL migration before enabling: services/orion-sql-db/manual_migration_chat_substrate_loop.sql
 # Enable substrate-runtime ENABLE_CHAT_GRAMMAR_REDUCER=true first, then flip this on.
+# Also gates the unrelated turn-incompletion liveness marker (README's "Turn-incompletion
+# liveness marker" section) -- no user content, but currently no separate flag to disable
+# one without the other.
 PUBLISH_HUB_CHAT_GRAMMAR=true
 GRAMMAR_EVENT_CHANNEL=orion:grammar:event
 

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -111,6 +111,8 @@ pytest tests/test_pre_turn_appraisal_wiring.py tests/test_handle_chat_request_su
 
 Gated by the existing `PUBLISH_HUB_CHAT_GRAMMAR` flag (default `true`) -- no new env key. Fires once per turn, right after the stance decision resolves, whether or not the turn goes on to the harness governor. Fail-open: a publish failure is logged and swallowed, never raised into the chat response.
 
+**Note:** as of the turn-incompletion liveness marker below, `PUBLISH_HUB_CHAT_GRAMMAR` also gates that unrelated operational signal (no user content, just `correlation_id` + timeout status) -- flipping this flag off for chat-privacy reasons also silences turn-incompletion telemetry, and there is currently no way to control them independently. Flagged in code review as a real (non-blocking) coupling, not yet split into a separate flag.
+
 The stance fields land in `active_chat_session` and go no further today -- `compute_chat_pressure_hints` doesn't read them, so they never reach `SelfStateV1` or phi. Registered `REHEARSAL` in `orion/self_state/inner_state_registry.py` (`chat_stance_disposition`) rather than left implicit; see `docs/superpowers/specs/2026-07-13-stance-disposition-inner-state-path.md` for why the obvious composition route (into `SelfStateV1.social_pressure`) was rejected and what the real paths forward look like.
 
 **Code**
@@ -118,6 +120,35 @@ The stance fields land in `active_chat_session` and go no further today -- `comp
 - `orion/hub/turn_orchestrator.py::_publish_unified_turn_chat_grammar` — call site, builds the stance-aware event set
 - `scripts/grammar_emit.py::build_chat_turn_grammar_events` — pure builder, `stance_disposition`/`stance_disposition_reasons`/`stance_boundary_register` params
 - `orion/substrate/chat_loop/grammar_extract.py::extract_chat_turn_state` — reducer-side parsing into `ChatTurnStateV1.stance_disposition` etc.
+
+#### Turn-incompletion liveness marker
+
+`orion/hub/turn_orchestrator.py::execute_unified_turn`'s `run is None` branch fires when
+`HarnessGovernorClient.run()` doesn't return a decoded `HarnessRunV1` -- most commonly a true
+harness-governor RPC timeout, but this branch also covers a codec decode failure on an
+otherwise-received reply (rare; in that sub-case the governor's own reply did arrive and may
+already have flushed real lifecycle grammar on its own trace lane, so treat the marker as "Hub
+gave up / couldn't use the reply," not strictly "nothing happened on the governor side"). This
+is otherwise the one unified-turn failure mode where no governor-side grammar event exists at
+all -- `HarnessGrammarCollector` only flushes its buffered lifecycle atoms once, at the end of a
+run, and a true timeout never reaches that point.
+
+Publishes a single `GrammarEventV1` (`semantic_role="exec_turn_timeout"`) under its own trace
+lane (`cortex_exec_trace_id(NODE_NAME, correlation_id, lane="hub_turn_timeout")`) rather than the
+governor's `harness_motor` lane -- Hub can't reliably know which physical node the governor's own
+`HarnessGrammarCollector` would have used when its RPC never returned. `correlation_id` is set
+explicitly on the event rather than left to trace-id parsing, avoiding the lane-suffix-pollution
+bug class already fixed once for the harness/cortex-exec producers. Required widening
+`EXECUTION_SOURCE_SERVICES` (`orion/substrate/execution_loop/constants.py`) to include
+`orion-hub`. Consumed by `orion-field-digester`'s `turn_incompletion` channel -- see that
+service's README glossary. Same `PUBLISH_HUB_CHAT_GRAMMAR` gating and fail-open shape as the
+chat-narrative trace above (see the Note in that section).
+
+**Code**
+
+- `orion/hub/turn_orchestrator.py::_publish_turn_timeout_grammar` — call site
+- `scripts/grammar_emit.py::build_turn_timeout_grammar_events` — pure builder
+- `orion/substrate/execution_loop/grammar_extract.py` — reducer-side `exec_turn_timeout` role parsing into `ExecutionRunStateV1.turn_timed_out`
 
 ### 2. Text-to-Speech (TTS)
 

--- a/services/orion-hub/scripts/grammar_emit.py
+++ b/services/orion-hub/scripts/grammar_emit.py
@@ -16,6 +16,7 @@ from orion.schemas.grammar import (
     GrammarEventV1,
     GrammarProvenanceV1,
 )
+from orion.substrate.execution_loop.ids import cortex_exec_trace_id
 
 
 def _dt(value: Any) -> datetime:
@@ -333,3 +334,79 @@ def build_chat_turn_grammar_events(
     )
 
     return events
+
+
+def build_turn_timeout_grammar_events(
+    *,
+    correlation_id: str,
+    node_id: str = "athena",
+    observed_at: datetime | None = None,
+    code_version: str | None = None,
+) -> list[GrammarEventV1]:
+    """Orion capability: liveness marker for a unified Hub turn whose
+    HarnessGovernorClient.run() call did not yield a usable result.
+
+    Fires only from orion/hub/turn_orchestrator.py's `run is None` branch. Most
+    commonly a true harness-governor RPC timeout -- the one case in the unified-turn
+    saga where NO governor-side grammar event is ever published at all
+    (HarnessGrammarCollector buffers every lifecycle atom in-memory and flushes them
+    only once, at the end of a run via orion/harness/runner.py's
+    _publish_motor_lifecycle, a point a true timeout never reaches). But `run is None`
+    also covers a rarer sub-case (services/orion-hub/scripts/harness_governor_client.py):
+    a reply DID arrive but failed to decode -- in that sub-case the governor may already
+    have flushed real lifecycle grammar on its own trace lane, so this marker means "Hub
+    couldn't use the reply," not unconditionally "nothing happened governor-side." See
+    docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md.
+
+    Uses its own trace lane (lane="hub_turn_timeout") under Hub's own node identity,
+    NOT the governor's harness_motor lane -- Hub cannot reliably know which physical
+    node the governor's HarnessGrammarCollector would have used (services/orion-harness-
+    governor/app/settings.py's NODE_NAME) when the RPC it was waiting on never
+    returned, so this can't share that trace_id.
+
+    correlation_id is set explicitly on the returned GrammarEventV1 (not left to
+    orion/substrate/execution_loop/ids.py's parse_execution_trace_id() fallback), which
+    is the fix already applied for the harness/cortex-exec producers after a prior
+    lane-suffix pollution bug -- parsing a lane-suffixed trace_id back into a
+    correlation_id yields "{correlation_id}:{lane}", not the clean value.
+    """
+    observed_at_ = _dt(observed_at)
+    emitted_at = datetime.now(timezone.utc)
+    trace_id = cortex_exec_trace_id(node_id, correlation_id, lane="hub_turn_timeout")
+
+    provenance = GrammarProvenanceV1(
+        source_service="orion-hub",
+        source_component="hub_turn_timeout_grammar_emit",
+        source_event_id=correlation_id,
+        source_trace_id=trace_id,
+        code_version=code_version,
+    )
+    atom = GrammarAtomV1(
+        atom_id=f"{trace_id}:exec_turn_timeout",
+        trace_id=trace_id,
+        atom_type="uncertainty_marker",
+        semantic_role="exec_turn_timeout",
+        layer="execution",
+        dimensions=["execution", "harness", "liveness"],
+        summary=(
+            f"Harness governor RPC did not yield a usable result for corr={correlation_id} "
+            "(most commonly a timeout; occasionally a reply that failed to decode)"
+        ),
+        confidence=1.0,
+        salience=0.9,
+        source_event_id=correlation_id,
+    )
+    return [
+        GrammarEventV1(
+            event_id=_hash_id(trace_id, "exec_turn_timeout", prefix="gev"),
+            event_kind="atom_emitted",
+            trace_id=trace_id,
+            correlation_id=correlation_id,
+            emitted_at=emitted_at,
+            observed_at=observed_at_,
+            layer="execution",
+            dimensions=["execution", "harness", "liveness"],
+            atom=atom,
+            provenance=provenance,
+        )
+    ]

--- a/services/orion-hub/tests/test_hub_grammar_emit.py
+++ b/services/orion-hub/tests/test_hub_grammar_emit.py
@@ -58,6 +58,46 @@ def test_stable_event_ids_same_inputs_same_ids():
     assert ids_a == ids_b
 
 
+def test_turn_timeout_grammar_event_has_own_trace_lane_and_role():
+    from scripts.grammar_emit import build_turn_timeout_grammar_events
+
+    events = build_turn_timeout_grammar_events(correlation_id="corr-1", node_id="athena")
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, GrammarEventV1)
+    assert event.correlation_id == "corr-1"
+    assert event.provenance.source_service == "orion-hub"
+    # Own lane, NOT harness-governor's harness_motor lane -- Hub can't know the
+    # governor's own NODE_NAME when its RPC never returned.
+    assert event.trace_id == "cortex.exec:athena:corr-1:hub_turn_timeout"
+    assert event.atom is not None
+    assert event.atom.semantic_role == "exec_turn_timeout"
+
+
+def test_turn_timeout_grammar_event_correlation_id_survives_trace_id_lane_suffix():
+    """Regression guard for the lane-suffix pollution bug already fixed once for the
+    harness/cortex-exec producers: parsing this event's own (laned) trace_id back into
+    a correlation_id via parse_execution_trace_id() would yield "corr-1:hub_turn_timeout",
+    not "corr-1" -- the event must carry its own clean correlation_id so downstream
+    consumers never need that fallback."""
+    from orion.substrate.execution_loop.ids import parse_execution_trace_id
+    from scripts.grammar_emit import build_turn_timeout_grammar_events
+
+    event = build_turn_timeout_grammar_events(correlation_id="corr-1", node_id="athena")[0]
+    parsed = parse_execution_trace_id(event.trace_id)
+    assert parsed is not None
+    assert parsed[1] != "corr-1"  # confirms the fallback WOULD be wrong
+    assert event.correlation_id == "corr-1"  # confirms the real field is right
+
+
+def test_turn_timeout_grammar_event_stable_id_same_inputs() -> None:
+    from scripts.grammar_emit import build_turn_timeout_grammar_events
+
+    a = build_turn_timeout_grammar_events(correlation_id="corr-x", node_id="athena")
+    b = build_turn_timeout_grammar_events(correlation_id="corr-x", node_id="athena")
+    assert a[0].event_id == b[0].event_id
+
+
 def test_repair_signal_absent_when_flag_false():
     events = _build(has_repair_signal=False)
     roles = [

--- a/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
+++ b/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
@@ -709,3 +709,98 @@ async def test_publish_unified_turn_chat_grammar_fails_open() -> None:
             settings=_settings_stub(publish_chat_grammar=True),
         )
     # No assertion beyond "did not raise" -- that is the whole point of this test.
+
+
+@pytest.mark.asyncio
+async def test_publish_turn_timeout_grammar_noop_when_disabled() -> None:
+    from orion.hub.turn_orchestrator import _publish_turn_timeout_grammar
+
+    _ensure_hub_import_paths()
+    publish_trace = AsyncMock()
+    with patch("scripts.grammar_publish.publish_hub_chat_grammar_trace", publish_trace):
+        await _publish_turn_timeout_grammar(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            settings=_settings_stub(publish_chat_grammar=False),
+        )
+    publish_trace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_turn_timeout_grammar_fires_with_exec_turn_timeout_role() -> None:
+    from orion.hub.turn_orchestrator import _publish_turn_timeout_grammar
+
+    _ensure_hub_import_paths()
+    publish_trace = AsyncMock()
+    with patch("scripts.grammar_publish.publish_hub_chat_grammar_trace", publish_trace):
+        await _publish_turn_timeout_grammar(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            settings=_settings_stub(publish_chat_grammar=True),
+        )
+    publish_trace.assert_awaited_once()
+    _, kwargs = publish_trace.await_args
+    events = publish_trace.await_args.args[1]
+    assert kwargs["correlation_id"] == _CORR_ID
+    assert len(events) == 1
+    assert events[0].atom.semantic_role == "exec_turn_timeout"
+    assert events[0].provenance.source_service == "orion-hub"
+
+
+@pytest.mark.asyncio
+async def test_publish_turn_timeout_grammar_fails_open() -> None:
+    """A publish failure must not raise -- the client-facing turn_error frame must
+    still be returned even if grammar publishing breaks."""
+    from orion.hub.turn_orchestrator import _publish_turn_timeout_grammar
+
+    _ensure_hub_import_paths()
+    with patch(
+        "scripts.grammar_publish.publish_hub_chat_grammar_trace",
+        AsyncMock(side_effect=RuntimeError("bus down")),
+    ):
+        await _publish_turn_timeout_grammar(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            settings=_settings_stub(publish_chat_grammar=True),
+        )
+    # No assertion beyond "did not raise".
+
+
+@pytest.mark.asyncio
+async def test_turn_orchestrator_publishes_timeout_grammar_when_governor_rpc_never_returns() -> None:
+    """End-to-end: when HarnessGovernorClient.run() returns None (the harness_rpc_timeout
+    case), execute_unified_turn must publish the liveness marker before returning the
+    client-facing turn_error frame -- this is the ONE unified-turn failure mode where no
+    governor-side grammar event is ever published at all."""
+    bus = MagicMock()
+    patches = _hub_client_patches(thought=_thought(), harness_run=AsyncMock(return_value=None))
+    publish_trace = AsyncMock()
+    settings_stub = _settings_stub(publish_chat_grammar=True)
+    # A MagicMock's getattr(..., default) never falls back to the default -- it always
+    # returns a truthy child Mock -- so _run_pre_turn_appraisal's
+    # getattr(settings, "ENABLE_PRE_TURN_APPRAISAL", False) check would otherwise read
+    # as enabled and drive this test into an unmocked RPC path unrelated to what's
+    # actually under test here.
+    settings_stub.ENABLE_PRE_TURN_APPRAISAL = False
+    with patches[0], patches[1], patches[2], patch(
+        "scripts.grammar_publish.publish_hub_chat_grammar_trace", publish_trace
+    ):
+        frames = await execute_unified_turn(
+            bus=bus,
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="hello",
+            emit_observation_fn=lambda **_kwargs: None,
+            settings=settings_stub,
+        )
+
+    assert frames[-1]["type"] == "turn_error"
+    assert frames[-1]["error"] == "harness_rpc_timeout"
+    assert publish_trace.await_count >= 1
+    timeout_calls = [
+        call
+        for call in publish_trace.await_args_list
+        if call.args[1] and call.args[1][0].atom is not None
+        and call.args[1][0].atom.semantic_role == "exec_turn_timeout"
+    ]
+    assert len(timeout_calls) == 1

--- a/tests/test_execution_substrate_reducer.py
+++ b/tests/test_execution_substrate_reducer.py
@@ -464,6 +464,64 @@ def _harness_atom(role: str, summary: str, *, event_id: str = "gev_h") -> Gramma
     )
 
 
+def _hub_atom(role: str, summary: str, *, event_id: str = "gev_hub") -> GrammarEventV1:
+    atom = GrammarAtomV1(
+        atom_id=f"{TRACE}:{role}",
+        trace_id=TRACE,
+        atom_type="uncertainty_marker",
+        semantic_role=role,
+        layer="execution",
+        summary=summary,
+    )
+    return GrammarEventV1(
+        event_id=event_id,
+        event_kind="atom_emitted",
+        trace_id=TRACE,
+        emitted_at=FIXED_TS,
+        observed_at=FIXED_TS,
+        atom=atom,
+        provenance=GrammarProvenanceV1(
+            source_service="orion-hub",
+            source_component="hub_turn_timeout_grammar_emit",
+        ),
+        correlation_id="corr-abc",
+    )
+
+
+def test_extract_accepts_orion_hub_turn_timeout_event() -> None:
+    """orion-hub was widened into EXECUTION_SOURCE_SERVICES specifically for
+    exec_turn_timeout -- the one unified-turn failure mode (harness-governor RPC never
+    returns) where no governor-side grammar event exists at all."""
+    run = extract_execution_state_from_events(
+        [_hub_atom("exec_turn_timeout", "Harness governor RPC timed out for corr=corr-abc")],
+        now=FIXED_TS,
+    )
+    assert run.turn_timed_out is True
+    hints = compute_pressure_hints(run, egress_emitted=False)
+    assert hints["turn_incompletion"] == 1.0
+
+
+def test_pressure_hints_turn_incompletion_default_false() -> None:
+    run = extract_execution_state_from_events(
+        [_exec_atom("exec_result_emitted", "Cortex exec result emitted to reply_to=True, status=success")],
+        now=FIXED_TS,
+    )
+    hints = compute_pressure_hints(run, egress_emitted=True)
+    assert hints["turn_incompletion"] == 0.0
+
+
+def test_merge_turn_timed_out_never_downgrades() -> None:
+    full = _run_with_full_egress()
+    assert full.turn_timed_out is False
+    timed_out = extract_execution_state_from_events(
+        [_hub_atom("exec_turn_timeout", "Harness governor RPC timed out for corr=corr-abc")],
+        now=FIXED_TS,
+    )
+    merged = merge_execution_run_state(full, timed_out)
+    assert merged.turn_timed_out is True
+    assert merged.pressure_hints["turn_incompletion"] == 1.0
+
+
 def test_extract_accepts_harness_governor_lifecycle() -> None:
     events = [
         _harness_atom(


### PR DESCRIPTION
## Summary

- New orion-field-digester channel `turn_incompletion`, completing the 5-signal bundle designed in #1283 (Patch A shipped in #1285).
- Covers the one unified-turn failure mode where `HarnessGovernorClient.run()` returns `None` (most commonly a true harness-governor RPC timeout) and, for a true timeout, no governor-side grammar event exists at all -- `HarnessGrammarCollector` only flushes its buffered lifecycle atoms once, at the end of a run that never happens in this failure mode.
- Hub now publishes a liveness marker at the exact moment it gives up waiting, on its own trace lane (not the governor's), before returning the client-facing `turn_error` frame.

## Architecture touched

- `orion/hub/turn_orchestrator.py` -- new `_publish_turn_timeout_grammar()`, called from the `run is None` branch.
- `services/orion-hub/scripts/grammar_emit.py` -- new `build_turn_timeout_grammar_events()` builder.
- `orion/substrate/execution_loop/` (constants.py, grammar_extract.py, merge.py) -- widened `EXECUTION_SOURCE_SERVICES` to include `orion-hub` (the one real contract-surface touch), new `turn_timed_out` field/parsing/merge/pressure-hint.
- `services/orion-field-digester/` (state_deltas.py, channels.py, decay.py, README.md) -- `turn_incompletion` channel wired through the same `execution_run` perturbation path Patch A established.

## Design details worth knowing

- **Own trace lane**: `cortex_exec_trace_id(hub_node, correlation_id, lane="hub_turn_timeout")`, not the governor's `harness_motor` lane -- Hub can't reliably know the governor's own node identity when its RPC never returned. Verified this produces a genuinely distinct `trace_id` (code review traced this through the actual reducer keying logic, not just the code comments).
- **`correlation_id` set explicitly** on the new event, avoiding a lane-suffix-pollution bug class already fixed once for the harness/cortex-exec producers (parsing a laned trace_id back into a correlation_id yields `"{correlation_id}:{lane}"`, not the clean value).
- **No new env key**: reuses `PUBLISH_HUB_CHAT_GRAMMAR`. Code review flagged this as a real (non-blocking) coupling -- an operator can't control chat-narrative grammar and turn-incompletion liveness independently. Documented explicitly in both `.env_example` and `README.md` rather than left silent.
- **Node attribution**: the channel lands on Hub's own node, not the governor's -- documented as "Hub's view of governor unresponsiveness," not the governor's own node health, since they may differ on a multi-node deploy.

## Review findings fixed

- Finding: `run is None` is not purely "RPC never returned" -- it also covers a rarer reply-failed-to-decode sub-case where the governor's reply did arrive and may have already flushed real lifecycle grammar on its own trace lane.
  - Fix: softened the persisted atom summary text, both docstrings, and the field-digester README glossary entry to caveat this rather than assert "no motor lifecycle event was ever observed" unconditionally.
- Finding: `PUBLISH_HUB_CHAT_GRAMMAR` reuse creates a real decoupling gap, undisclosed.
  - Fix: added explicit notes in `services/orion-hub/.env_example` and `services/orion-hub/README.md`.
- Confirmed correct (no fix needed): trace-lane distinctness, `correlation_id` handling, Hub-node attribution in `state_deltas.py`, and that `run is None` is genuinely the only call site needing this treatment -- all traced through the real code by the reviewer, not just asserted from the comments.

## Tests run

```
cd services/orion-hub && pytest tests/test_hub_grammar_emit.py tests/test_turn_orchestrator_ws_frames.py -q
  -> 39 passed

pytest tests/test_execution_substrate_reducer.py -q
  -> 36 passed

cd services/orion-field-digester && pytest tests/ -q
  -> 141 passed

pytest orion/harness/tests tests/test_execution_substrate_reducer.py -q
  -> 204 passed, 3 failed (all 3 confirmed pre-existing on unmodified main, same as
     the Patch A review cycle -- unrelated to this patch)
```

## Evals run

No eval harness exists for this signal-quality question yet. Per the design spec's acceptance checks, a live sanity check (real harness-governor timeout, then confirming `turn_incompletion` is non-degenerate in field-digester's live `node_vectors`) is still open, pending deploy -- documented as such in the README glossary entry.

## Env/config changes

None. No new env keys (deliberately reuses `PUBLISH_HUB_CHAT_GRAMMAR`, documented above), no `.env_example` key additions, no Docker/compose changes.

## Restart required

```
No restart required (no service is deployed with this branch yet).
```

## Risks / concerns

- Severity: low
- Concern: `PUBLISH_HUB_CHAT_GRAMMAR` now gates two semantically unrelated signals (chat narrative + operational liveness) with no independent control.
- Mitigation: documented explicitly; a dedicated flag is the clean follow-up if this proves operationally annoying, not done here to avoid an unnecessary new env key for a first landing.

- Severity: low
- Concern: `turn_incompletion` doesn't distinguish a true RPC timeout from the rarer decode-failure sub-case (both read `run is None` to Hub).
- Mitigation: documented in the glossary/docstrings; the channel still correctly signals "Hub couldn't use the governor's reply" either way, which is the actionable fact.

## PR link

(this PR)