### PR TITLE
fix(vision-scribe): kill dead Fuseki RDF write, pure redundancy

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-23-vision-scribe-fuseki-write-kill-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-23-vision-scribe-fuseki-write-kill-pr.md
@@ -1,0 +1,99 @@
+# PR report: kill orion-vision-scribe's dead Fuseki RDF write
+
+## Summary
+
+- While auditing what still depends on Fuseki before considering the container/data-store safe to decommission, the live Fuseki container's own request log (checked directly, not assumed) showed a real, current write: `POST .../orion/data?graph=...orion/vision`, from `orion-vision-scribe`.
+- Live audit (matching this repo's established "verify redundant, then kill" pattern used for every other successful Fuseki write removal): Postgres `vision_events` has 33,389 rows, latest row timestamped to the same second as the caught Fuseki write. Postgres's schema (`confidence`/`salience`/`evidence_refs`/`tags` as real structured columns) is strictly richer than the flat RDF literals (`hasNarrative`/`hasType`/`mentionsEntity` strings only). A repo-wide grep found zero readers of Fuseki's `orion:vision` graph anywhere.
+- Removed the RDF write entirely (not migrated -- there was no real signal to preserve, same conclusion as cognition/metacog, identity/goals, and Hub's orionmem in prior PRs).
+
+## Outcome moved
+
+`orion-vision-scribe` no longer depends on Fuseki at all. This closes one of three open dependents identified in a fresh live-audit pass on `orion-recall`'s Falkor cutover (PR #1281/#1286) -- the only one of the three that was a hard write dependency (the other two, `orion-graph-compression`'s SPARQL federators and `orion:chat:social:stored`'s unmigrated SocialRoomTurn/SocialConceptEvidence data, are read-side/fail-open and remain separately open).
+
+## Current architecture
+
+Before this patch: `_write_to_sinks` dual-wrote every vision event -- Postgres (`vision.event.v1` bus message -> `orion-sql-writer` -> `vision_events` table) and Fuseki (`rdf.write.request` bus message -> `orion-rdf-writer` -> `orion:vision` RDF graph, built via `rdflib`). Both writes were independent, not transactional; `ack.ok` required both to succeed.
+
+## Architecture touched
+
+- `services/orion-vision-scribe/app/{main.py,settings.py,.env_example,docker-compose.yml,requirements.txt,README.md}`
+- `scripts/vision_persistence_smoke.py`, `scripts/smoke_vision_persistence_live.sh` (shared smoke-test helper, also used by the pytest suite)
+- `orion/bus/channels.yaml`
+- `docs/vision_services.md`
+
+## Files changed
+
+- `services/orion-vision-scribe/app/main.py`: removed `_build_event_triples`, the `RdfWriteRequest` import + inline fallback stub, `rdflib` imports, the `ORION` namespace constant, and the RDF write branch inside `_write_to_sinks`. `ack.ok` now depends on SQL success alone (previously `sql_ok and rdf_ok` via the `errors` list) -- correct, since RDF failures were a false-negative source for the sink that actually mattered.
+- `services/orion-vision-scribe/app/settings.py`, `.env_example`, `docker-compose.yml`: removed the now-dangling `CHANNEL_RDF_ENQUEUE` key.
+- `services/orion-vision-scribe/requirements.txt`: removed `rdflib==7.0.0` (only used by the removed code).
+- `services/orion-vision-scribe/README.md`: replaced the "RDF write path" section with a note explaining the removal and the live-verification evidence.
+- `services/orion-vision-scribe/tests/test_write_to_sinks.py`: removed RDF-specific tests; added `test_write_to_sinks_makes_exactly_one_publish_call_no_rdf` and `test_write_to_sinks_reports_ok_when_sql_write_succeeds` (regression coverage for both real behavior changes).
+- `services/orion-vision-scribe/tests/test_vision_persistence_smoke_helpers.py`: removed RDF-specific tests, trimmed `test_channel_constants_match_bus_catalog`, added `test_no_rdf_symbols_remain_on_smoke_module`.
+- `scripts/vision_persistence_smoke.py`: removed `rdf_ntriple_markers`/`build_rdf_write_request`, `CHANNEL_RDF_ENQUEUE`/`CHANNEL_RDF_CONFIRM`/`KIND_RDF_WRITE_REQUEST`, `_wait_for_rdf_signals`, and all RDF logic from `run_contract_mode()`/`run_live_mode()` -- including the gate that would have made the live smoke test fail forever once the write it waited for stopped existing.
+- `scripts/smoke_vision_persistence_live.sh`: updated header comments.
+- `orion/bus/channels.yaml`: dropped `orion-vision-scribe` from `orion:rdf:enqueue`'s `producer_services`; dropped it from `orion:rdf:confirm`'s `consumer_services` too (review found this entry was already stale/aspirational -- no `CHANNEL_RDF_CONFIRM` setting ever existed in this service per git history, unrelated to this PR's own change but cleaned up alongside it since both concern the same removed RDF path).
+- `docs/vision_services.md`: corrected the vision-scribe catalog line, which claimed "SQL, RDF, and Vector stores."
+
+## Schema / bus / API changes
+
+- Removed: `orion-vision-scribe` as a producer of `orion:rdf:enqueue`, and as a (stale, never-real) consumer of `orion:rdf:confirm`.
+- Behavior changed: vision events are now Postgres-only. `ack.ok` reflects SQL-write success only.
+- Compatibility notes: `orion-rdf-writer`'s generic `RdfWriteRequest` handler is untouched (it's a passthrough for any graph name, used by other producers) -- confirmed via grep, no vision-specific logic existed there to also remove.
+
+## Env/config changes
+
+- Removed keys: `CHANNEL_RDF_ENQUEUE` (`orion-vision-scribe`).
+- `.env_example` updated: yes.
+- Local `.env` synced: N/A -- this service declares `env_file:` in its own `.env_example`/compose wiring so no key existed to remove from a separate live `.env`; confirmed via `check_service_env_compose_parity.py orion-vision-scribe` -> N/A.
+- Skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+ORION_BUS_URL=redis://127.0.0.1:6379/0 PYTHONPATH=.:services/orion-vision-scribe venv/bin/python3 -m pytest services/orion-vision-scribe/tests -q
+-> 8 passed
+
+python3 scripts/check_service_env_compose_parity.py orion-vision-scribe -> N/A (env_file covers everything)
+ORION_BUS_URL=redis://100.92.216.81:6379/0 python3 scripts/check_single_consumer_channels.py -> OK, 30 channels checked, 3 pre-existing warnings unrelated to this patch
+python3 -c "import app.main" -> imports cleanly, RdfWriteRequest symbol gone
+VISION_PERSISTENCE_SMOKE_MODE=contract python3 -m scripts.vision_persistence_smoke -> PASS (contract mode), reproduced by the review agent independently
+git diff --check -> clean
+```
+
+## Evals run
+
+No eval harness exists for this service; focused deterministic tests plus the existing contract-mode smoke test cover the changed behavior.
+
+## Docker/build/smoke checks
+
+No container rebuild/restart performed as part of this PR. Live Fuseki traffic (the write this PR removes) was directly observed in `orion-athena-fuseki`'s own container log during the investigation that led to this patch -- see Summary.
+
+## Review findings fixed
+
+- Finding (should-fix): `orion/bus/channels.yaml`'s `orion:rdf:confirm` entry still listed `orion-vision-scribe` as a consumer, undermining the diff's own "fully out of the RDF business" claim.
+  - Fix: removed from `consumer_services`; added a comment noting (confirmed via git history) this was already a stale/aspirational entry, not a real subscription this PR broke.
+  - Evidence: commit `7c4b9b1f`.
+- Finding (should-fix): `docs/vision_services.md`'s service catalog still described vision-scribe as persisting to "SQL, RDF, and Vector stores."
+  - Fix: corrected to describe the SQL-only reality and cite the removal.
+  - Evidence: same commit.
+- Informational (no fix needed, pre-existing and out of scope): the review also noted the catalog's "Vector stores" claim was already false before this PR (`CHANNEL_VECTOR_WRITE` is declared but never referenced in `main.py`, old or new code) -- not touched, unrelated to this PR's actual change.
+- Informational (no fix needed): `ack.ok`'s new dependency on `sql_ok` alone was verified by the reviewer to be the correct, intended behavior (removes RDF flakiness as a false-negative source), not a hidden regression -- confirmed by reading the pre-diff file directly rather than trusting the PR's own framing.
+- Informational (no fix needed): `run_live_mode`'s rewrite was hand-traced by the reviewer against the diff and confirmed to have no leftover references to removed queues/constants and no dead-end blocking wait.
+
+## Restart required
+
+No restart required to merge. `orion-athena-vision-scribe` should be rebuilt/redeployed once merged so the running container stops attempting the (already relatively harmless, fail-open) RDF write:
+
+```bash
+docker compose --env-file .env --env-file services/orion-vision-scribe/.env \
+  -f services/orion-vision-scribe/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: Low.
+- Concern: none identified that block merge. The two open, separately-tracked Fuseki dependents from the same audit (`orion-graph-compression`'s SPARQL federators, `orion:chat:social:stored`'s unmigrated data) are unaffected by this PR and remain open questions before the Fuseki container/data store itself can be safely removed.
+
+## PR link
+
+(added after opening)

--- a/docs/vision_services.md
+++ b/docs/vision_services.md
@@ -16,7 +16,7 @@ The vision pipeline is a distributed system using the Titanium Contract Stack ov
 4.  **Vision Retina (`orion-vision-retina`)**: Capture service that publishes frame pointers (legacy/alternate capture path).
 5.  **Vision Window (`orion-vision-window`)**: Aggregates artifacts into time-based windows with evidence tiers.
 6.  **Vision Council (`orion-vision-council`)**: Performs high-level cognitive analysis on windows using LLMs. Council V2 parses `VisionSceneInterpretationV1` internally (strict validation, then salvage/coercion for common malformed nested fields, then legacy fallback), then projects `event_candidates` to the legacy `VisionEventPayload` published on `orion:vision:events` (Scribe contract unchanged).
-7.  **Vision Scribe (`orion-vision-scribe`)**: Persists events to SQL, RDF, and Vector stores.
+7.  **Vision Scribe (`orion-vision-scribe`)**: Persists events to SQL (Postgres `vision_events`). The RDF write was removed 2026-07-23 (live-verified pure redundancy -- see `services/orion-vision-scribe/README.md`).
 
 ## Channels and Kinds
 

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -702,17 +702,27 @@ channels:
   - name: "orion:rdf:enqueue"
     kind: "request"
     schema_id: "RdfWriteRequest"
-    producer_services: ["orion-cortex-exec", "orion-vision-scribe", "orion-spark-concept-induction"]
+    producer_services: ["orion-cortex-exec", "orion-spark-concept-induction"]
     consumer_services: ["orion-rdf-writer", "orion-graph-compression"]
     stability: "experimental"
     since: "2026-01-08"
+    # orion-vision-scribe removed as a producer 2026-07-23: its Fuseki
+    # `orion:vision` write was killed outright (live-verified pure
+    # redundancy with Postgres vision_events -- no migration, nothing to
+    # preserve). See services/orion-vision-scribe/README.md.
 
   - name: "orion:rdf:confirm"
     kind: "result"
     schema_id: "RdfWriteResult"
     producer_services: ["orion-rdf-writer"]
-    consumer_services: ["orion-cortex-exec", "orion-vision-scribe"]
+    consumer_services: ["orion-cortex-exec"]
     stability: "experimental"
+    # orion-vision-scribe removed as a consumer 2026-07-23: it never
+    # actually subscribed to this channel (no CHANNEL_RDF_CONFIRM setting
+    # ever existed in its settings.py, per git history) -- stale/aspirational
+    # entry predating this PR, cleaned up alongside the real orion:rdf:enqueue
+    # producer removal since both concern vision-scribe's now-fully-removed
+    # RDF write.
     since: "2026-01-08"
 
   - name: "orion:rdf:error"

--- a/scripts/smoke_vision_persistence_live.sh
+++ b/scripts/smoke_vision_persistence_live.sh
@@ -2,12 +2,17 @@
 # smoke_vision_persistence_live.sh
 #
 # Verifies the Orion Vision event persistence path:
-#   orion:vision:events -> orion-vision-scribe -> sql-write + rdf enqueue
+#   orion:vision:events -> orion-vision-scribe -> sql-write
+#
+# The RDF/Fuseki write (and this smoke's RDF enqueue/confirm check) was
+# removed 2026-07-23 -- live-verified pure redundancy with Postgres
+# vision_events (see services/orion-vision-scribe/README.md). SQL is the
+# sole sink now.
 #
 # MODES (explicit selection required when deps are missing):
 #   VISION_PERSISTENCE_SMOKE_MODE=live
 #       Requires ORION_BUS_URL and DATABASE_URL (or POSTGRES_URI).
-#       Asserts scribe ack, vision_events row, and RDF enqueue or confirm.
+#       Asserts scribe ack and a matching vision_events row.
 #
 #   VISION_PERSISTENCE_SMOKE_MODE=contract
 #       In-process contract validation (no Redis/Postgres). Does NOT claim live persistence.

--- a/scripts/vision_persistence_smoke.py
+++ b/scripts/vision_persistence_smoke.py
@@ -3,8 +3,12 @@
 Helpers for scripts/smoke_vision_persistence_live.sh.
 
 Live mode exercises the real bus + Postgres mesh. Contract mode validates payload
-shape, SQL coercion, RDF N-Triples, and channel/kind constants without claiming
-live persistence.
+shape, SQL coercion, and channel/kind constants without claiming live persistence.
+
+RDF verification was removed 2026-07-23 along with orion-vision-scribe's Fuseki
+write itself (live-verified pure redundancy with Postgres `vision_events` --
+see services/orion-vision-scribe/README.md). SQL is now the sole sink and the
+sole success criterion.
 """
 from __future__ import annotations
 
@@ -24,7 +28,6 @@ if REPO_ROOT not in sys.path:
 
 from orion.core.bus.async_service import OrionBusAsync  # noqa: E402
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef  # noqa: E402
-from orion.schemas.rdf import RdfWriteRequest  # noqa: E402
 from orion.schemas.vision import (  # noqa: E402
     VisionEventBundleItem,
     VisionEventPayload,
@@ -34,13 +37,10 @@ from orion.schemas.vision import (  # noqa: E402
 CHANNEL_VISION_EVENTS = "orion:vision:events"
 CHANNEL_SCRIBE_PUB = "orion:vision:scribe:pub"
 CHANNEL_SQL_WRITE = "orion:vision:events:sql-write"
-CHANNEL_RDF_ENQUEUE = "orion:rdf:enqueue"
-CHANNEL_RDF_CONFIRM = "orion:rdf:confirm"
 
 KIND_VISION_EVENT_BUNDLE = "vision.event.bundle"
 KIND_VISION_SCRIBE_ACK = "vision.scribe.ack"
 KIND_VISION_EVENT_V1 = "vision.event.v1"
-KIND_RDF_WRITE_REQUEST = "rdf.write.request"
 
 SMOKE_SERVICE = ServiceRef(name="vision-persistence-smoke", version="0.1.0")
 
@@ -104,27 +104,6 @@ def expected_sql_row_fields(
     }
 
 
-def rdf_ntriple_markers(
-    event_id: str,
-    narrative: str,
-    event_type: str,
-    entities: list[str],
-) -> list[str]:
-    uri = f"http://conjourney.net/event/{event_id}"
-    markers = [uri, narrative, event_type]
-    markers.extend(entities)
-    return markers
-
-
-def build_rdf_write_request(event_id: str, nt_content: str) -> RdfWriteRequest:
-    return RdfWriteRequest(
-        id=event_id,
-        source="vision-scribe",
-        graph="orion:vision",
-        triples=nt_content,
-    )
-
-
 def _purge_app_modules() -> None:
     for mod_name in list(sys.modules):
         if mod_name == "app" or mod_name.startswith("app."):
@@ -175,20 +154,10 @@ def _pass(
     event_id: str,
     scribe_ack: bool,
     sql_row: bool,
-    rdf_confirm: bool,
-    rdf_enqueue_observed: bool,
 ) -> int:
     print("VISION PERSISTENCE SMOKE PASS")
     print(f"scribe_ack={str(scribe_ack).lower()}")
     print(f"sql_row={str(sql_row).lower()}")
-    if rdf_confirm:
-        print("rdf_confirm=true")
-    elif rdf_enqueue_observed:
-        print("rdf_enqueue_observed=true")
-        print("rdf_confirm=not_available")
-    else:
-        print("rdf_confirm=false")
-        print("rdf_enqueue_observed=false")
     print(f"event_id={event_id}")
     return 0
 
@@ -204,27 +173,6 @@ def run_contract_mode() -> int:
 
     expected = expected_sql_row_fields(item, correlation_id)
 
-    saved_path = sys.path[:]
-    scribe_root = os.path.join(REPO_ROOT, "services", "orion-vision-scribe")
-    try:
-        if scribe_root not in sys.path:
-            sys.path.insert(0, scribe_root)
-        from app.main import _build_event_triples  # noqa: E402
-
-        nt = _build_event_triples(item)
-    finally:
-        sys.path[:] = saved_path
-        _purge_app_modules()
-
-    for marker in rdf_ntriple_markers(
-        item.event_id, item.narrative, item.event_type, item.entities
-    ):
-        assert marker in nt, f"RDF N-Triples missing marker: {marker!r}"
-
-    rdf_req = build_rdf_write_request(item.event_id, nt)
-    assert rdf_req.id == item.event_id
-    assert isinstance(rdf_req.triples, str)
-
     row = coerce_sql_row(item, correlation_id)
     for key, want in expected.items():
         got = getattr(row, key)
@@ -238,8 +186,6 @@ def run_contract_mode() -> int:
     print(f"intake_kind={KIND_VISION_EVENT_BUNDLE}")
     print(f"sql_write_channel={CHANNEL_SQL_WRITE}")
     print(f"sql_write_kind={KIND_VISION_EVENT_V1}")
-    print(f"rdf_enqueue_channel={CHANNEL_RDF_ENQUEUE}")
-    print(f"rdf_enqueue_kind={KIND_RDF_WRITE_REQUEST}")
     print(f"scribe_ack_channel={CHANNEL_SCRIBE_PUB}")
     print(f"scribe_ack_kind={KIND_VISION_SCRIBE_ACK}")
     return 0
@@ -291,41 +237,6 @@ async def _wait_for_scribe_ack(
             return False, ack.error or ack.message or "ack.ok=false"
         return True, ""
     return False, "timeout waiting for vision.scribe.ack"
-
-
-async def _wait_for_rdf_signals(
-    enqueue_q: asyncio.Queue,
-    confirm_q: asyncio.Queue,
-    *,
-    event_id: str,
-    correlation_id: UUID,
-    timeout_sec: float,
-) -> tuple[bool, bool, str]:
-    deadline = time.monotonic() + timeout_sec
-    enqueue_seen = False
-    confirm_seen = False
-    while time.monotonic() < deadline and not (enqueue_seen and confirm_seen):
-        remaining = deadline - time.monotonic()
-        try:
-            env = await asyncio.wait_for(enqueue_q.get(), timeout=min(remaining, 0.25))
-            if _matches_correlation(env, correlation_id) and env.kind == KIND_RDF_WRITE_REQUEST:
-                payload = _payload_dict(env)
-                if str(payload.get("id")) == event_id:
-                    enqueue_seen = True
-        except asyncio.TimeoutError:
-            pass
-        try:
-            env = await asyncio.wait_for(confirm_q.get(), timeout=min(remaining, 0.25))
-            if env.kind in ("rdf.write.confirm", "rdf.write.result"):
-                payload = _payload_dict(env)
-                if str(payload.get("id")) == event_id and payload.get("ok") is True:
-                    confirm_seen = True
-        except asyncio.TimeoutError:
-            pass
-    err = ""
-    if not enqueue_seen and not confirm_seen:
-        err = "timeout waiting for rdf enqueue or confirm"
-    return enqueue_seen, confirm_seen, err
 
 
 def _query_vision_event_row(
@@ -391,12 +302,8 @@ async def run_live_mode(
     await bus.connect()
 
     scribe_q: asyncio.Queue = asyncio.Queue()
-    rdf_enqueue_q: asyncio.Queue = asyncio.Queue()
-    rdf_confirm_q: asyncio.Queue = asyncio.Queue()
     collectors = [
         asyncio.create_task(_collect_envelopes(bus, CHANNEL_SCRIBE_PUB, scribe_q)),
-        asyncio.create_task(_collect_envelopes(bus, CHANNEL_RDF_ENQUEUE, rdf_enqueue_q)),
-        asyncio.create_task(_collect_envelopes(bus, CHANNEL_RDF_CONFIRM, rdf_confirm_q)),
     ]
     await asyncio.sleep(0.5)
 
@@ -413,22 +320,6 @@ async def run_live_mode(
                 correlation_id=str(correlation_id),
                 channel=CHANNEL_SCRIBE_PUB,
                 last_error=scribe_err,
-            )
-
-        rdf_enqueue, rdf_confirm, rdf_err = await _wait_for_rdf_signals(
-            rdf_enqueue_q,
-            rdf_confirm_q,
-            event_id=event_id,
-            correlation_id=correlation_id,
-            timeout_sec=timeout_sec,
-        )
-        if not rdf_confirm and not rdf_enqueue:
-            return _fail(
-                "rdf_enqueue",
-                event_id=event_id,
-                correlation_id=str(correlation_id),
-                channel=CHANNEL_RDF_ENQUEUE,
-                last_error=rdf_err,
             )
 
         sql_ok, sql_err = await asyncio.to_thread(
@@ -451,8 +342,6 @@ async def run_live_mode(
             event_id=event_id,
             scribe_ack=True,
             sql_row=True,
-            rdf_confirm=rdf_confirm,
-            rdf_enqueue_observed=rdf_enqueue,
         )
     finally:
         for task in collectors:

--- a/services/orion-vision-scribe/.env_example
+++ b/services/orion-vision-scribe/.env_example
@@ -8,7 +8,6 @@ CHANNEL_SCRIBE_PUB=orion:vision:scribe:pub
 CHANNEL_SCRIBE_REQUEST=orion:exec:request:VisionScribeService
 
 CHANNEL_SQL_WRITE=orion:vision:events:sql-write
-CHANNEL_RDF_ENQUEUE=orion:rdf:enqueue
 CHANNEL_VECTOR_WRITE=orion:vector:write
 
 VISION_SCRIBE_HTTP_PORT=8026

--- a/services/orion-vision-scribe/README.md
+++ b/services/orion-vision-scribe/README.md
@@ -1,14 +1,18 @@
 # Orion Vision Scribe
 Records events.
 
-## RDF write path
+## RDF write path: removed 2026-07-23
 
-The RDF write side of `_write_to_sinks` builds real triples via `rdflib`
-(`Graph` + `.serialize(format="nt")`) instead of hand-rolling a list of
-tuples. The resulting N-Triples string is sent as `triples` on
-`orion.schemas.rdf.RdfWriteRequest` (along with required `id`/`source`
-fields), matching the shape the RDF writer's `_handle_write_request`
-consumer expects.
+`_write_to_sinks` used to dual-write every event to Postgres (`vision_events`)
+and Fuseki (`orion:vision` graph, via `orion.schemas.rdf.RdfWriteRequest`).
+Live-verified pure redundancy before removal: Postgres `vision_events` gets
+the same event at the same timestamp with a strictly richer schema
+(`confidence`/`salience`/`evidence_refs`/`tags` as real structured columns,
+not flat RDF literals), and nothing in the codebase ever reads the Fuseki
+`orion:vision` graph back. Same pattern as every other Fuseki write this
+migration killed outright rather than migrated (see
+`docs/superpowers/specs/2026-07-17-recall-rdf-writer-falkor-cutover-phase2-spec.md`'s
+PR #1155 precedent). SQL is now the sole sink.
 
 ## SQL write path
 

--- a/services/orion-vision-scribe/app/main.py
+++ b/services/orion-vision-scribe/app/main.py
@@ -4,8 +4,6 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from loguru import logger
-from rdflib import Graph, Namespace, URIRef, Literal
-from rdflib.namespace import RDF
 
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
@@ -17,34 +15,9 @@ from orion.schemas.vision import (
     VisionScribeResultPayload
 )
 
-try:
-    from orion.schemas.rdf import RdfWriteRequest
-except ImportError:
-    from pydantic import BaseModel, ConfigDict
-    class RdfWriteRequest(BaseModel):
-        model_config = ConfigDict(extra="ignore")
-        id: str
-        source: str
-        graph: Optional[str] = None
-        triples: Optional[str] = None
-    logger.warning("Could not import RdfWriteRequest, using fallback")
-
 from .settings import Settings
 
 settings = Settings()
-
-ORION = Namespace("http://conjourney.net/orion#")
-
-
-def _build_event_triples(evt: VisionEventBundleItem) -> str:
-    g = Graph()
-    subject = URIRef(f"http://conjourney.net/event/{evt.event_id}")
-    g.add((subject, RDF.type, ORION.VisionEvent))
-    g.add((subject, ORION.hasNarrative, Literal(evt.narrative)))
-    g.add((subject, ORION.hasType, Literal(evt.event_type)))
-    for ent in evt.entities:
-        g.add((subject, ORION.mentionsEntity, Literal(ent)))
-    return g.serialize(format="nt")
 
 
 class ScribeService:
@@ -165,8 +138,13 @@ class ScribeService:
         try:
             for evt in payload.events:
                 sql_ok = False
-                rdf_ok = False
-                # 1. SQL Write
+                # SQL Write (sole sink -- the Fuseki RDF write was removed
+                # 2026-07-23: live-verified pure redundancy. Postgres
+                # `vision_events` already receives the same event at the
+                # same timestamp with a richer schema (confidence/salience/
+                # evidence_refs/tags as real structured columns, not flat
+                # RDF literals), and nothing in the codebase ever read the
+                # Fuseki `orion:vision` graph back.)
                 try:
                     await self._send_write(settings.CHANNEL_SQL_WRITE, "vision.event.v1", evt, source_env)
                     sql_ok = True
@@ -179,32 +157,11 @@ class ScribeService:
                     )
                     errors.append(f"SQL:{e}")
 
-                # 2. RDF Write
-                try:
-                    nt_content = _build_event_triples(evt)
-                    rdf_req = RdfWriteRequest(
-                        id=evt.event_id,
-                        source=settings.SERVICE_NAME,
-                        graph="orion:vision",
-                        triples=nt_content,
-                    )
-                    await self._send_write(settings.CHANNEL_RDF_ENQUEUE, "rdf.write.request", rdf_req, source_env)
-                    rdf_ok = True
-                except Exception as e:
-                    logger.error(
-                        "[SCRIBE] RDF Write failed event_id={} channel={}: {}",
-                        evt.event_id,
-                        settings.CHANNEL_RDF_ENQUEUE,
-                        e,
-                    )
-                    errors.append(f"RDF:{e}")
-
                 logger.info(
-                    "[SCRIBE] vision_persist event_id={} sql={} rdf={} ack_ok={}",
+                    "[SCRIBE] vision_persist event_id={} sql={} ack_ok={}",
                     evt.event_id,
                     sql_ok,
-                    rdf_ok,
-                    sql_ok and rdf_ok,
+                    sql_ok,
                 )
 
             if errors:

--- a/services/orion-vision-scribe/app/settings.py
+++ b/services/orion-vision-scribe/app/settings.py
@@ -19,5 +19,4 @@ class Settings(BaseSettings):
     CHANNEL_SCRIBE_REQUEST: str = "orion:exec:request:VisionScribeService"
 
     CHANNEL_SQL_WRITE: str = "orion:vision:events:sql-write"
-    CHANNEL_RDF_ENQUEUE: str = "orion:rdf:enqueue"
     CHANNEL_VECTOR_WRITE: str = "orion:vector:write"

--- a/services/orion-vision-scribe/docker-compose.yml
+++ b/services/orion-vision-scribe/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - CHANNEL_SCRIBE_PUB=${CHANNEL_SCRIBE_PUB:-orion:vision:scribe:pub}
       - CHANNEL_SCRIBE_REQUEST=${CHANNEL_SCRIBE_REQUEST:-orion:exec:request:VisionScribeService}
       - CHANNEL_SQL_WRITE=${CHANNEL_SQL_WRITE:-orion:vision:events:sql-write}
-      - CHANNEL_RDF_ENQUEUE=${CHANNEL_RDF_ENQUEUE:-orion:rdf:enqueue}
       - CHANNEL_VECTOR_WRITE=${CHANNEL_VECTOR_WRITE:-orion:vector:write}
     networks:
       - app-net

--- a/services/orion-vision-scribe/requirements.txt
+++ b/services/orion-vision-scribe/requirements.txt
@@ -4,4 +4,3 @@ redis[hiredis]==5.0.7
 pydantic==2.9.2
 pydantic-settings==2.5.2
 loguru==0.7.2
-rdflib==7.0.0

--- a/services/orion-vision-scribe/tests/test_vision_persistence_smoke_helpers.py
+++ b/services/orion-vision-scribe/tests/test_vision_persistence_smoke_helpers.py
@@ -12,7 +12,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 import scripts.vision_persistence_smoke as smoke  # noqa: E402
-from orion.schemas.vision import VisionEventBundleItem  # noqa: E402
 
 
 def test_build_smoke_bundle_item_and_payload_shape():
@@ -37,17 +36,6 @@ def test_expected_sql_row_fields_match_bundle_item():
     assert expected["entities"] == ["orion", "vision", "smoke"]
 
 
-def test_rdf_ntriple_markers_cover_event_fields():
-    item = smoke.build_smoke_bundle_item("evt-abc", "smoke narrative")
-    markers = smoke.rdf_ntriple_markers(
-        item.event_id, item.narrative, item.event_type, item.entities
-    )
-    assert "http://conjourney.net/event/evt-abc" in markers
-    assert "smoke narrative" in markers
-    assert "smoke_test" in markers
-    assert "orion" in markers
-
-
 def test_coerce_sql_row_uses_vision_event_sql_model():
     event_id, correlation_id, narrative = smoke.new_smoke_ids()
     item = smoke.build_smoke_bundle_item(event_id, narrative)
@@ -62,35 +50,13 @@ def test_channel_constants_match_bus_catalog():
     assert smoke.CHANNEL_VISION_EVENTS == "orion:vision:events"
     assert smoke.CHANNEL_SCRIBE_PUB == "orion:vision:scribe:pub"
     assert smoke.CHANNEL_SQL_WRITE == "orion:vision:events:sql-write"
-    assert smoke.CHANNEL_RDF_ENQUEUE == "orion:rdf:enqueue"
     assert smoke.KIND_VISION_EVENT_V1 == "vision.event.v1"
-    assert smoke.KIND_RDF_WRITE_REQUEST == "rdf.write.request"
 
 
-def test_build_rdf_write_request_accepts_ntriples_string():
-    item = VisionEventBundleItem(
-        event_id="evt-rdf",
-        event_type="smoke_test",
-        narrative="n",
-        entities=["a"],
-        tags=["t"],
-        confidence=0.9,
-        salience=0.5,
-        evidence_refs=["e"],
-    )
-    scribe_root = REPO_ROOT / "services" / "orion-vision-scribe"
-    saved_path = sys.path[:]
-    try:
-        sys.path.insert(0, str(scribe_root))
-        from app.main import _build_event_triples  # noqa: E402
-
-        nt = _build_event_triples(item)
-    finally:
-        sys.path[:] = saved_path
-        for mod_name in list(sys.modules):
-            if mod_name == "app" or mod_name.startswith("app."):
-                sys.modules.pop(mod_name, None)
-
-    req = smoke.build_rdf_write_request(item.event_id, nt)
-    assert req.id == "evt-rdf"
-    assert isinstance(req.triples, str)
+def test_no_rdf_symbols_remain_on_smoke_module():
+    """Regression for the 2026-07-23 RDF-write removal: guards against the
+    RDF verification path silently reappearing on this module."""
+    assert not hasattr(smoke, "CHANNEL_RDF_ENQUEUE")
+    assert not hasattr(smoke, "CHANNEL_RDF_CONFIRM")
+    assert not hasattr(smoke, "rdf_ntriple_markers")
+    assert not hasattr(smoke, "build_rdf_write_request")

--- a/services/orion-vision-scribe/tests/test_write_to_sinks.py
+++ b/services/orion-vision-scribe/tests/test_write_to_sinks.py
@@ -1,12 +1,9 @@
 """
-Regression test for the RDF write payload shape bug in `_write_to_sinks`.
+Regression tests for `_write_to_sinks`.
 
-Before the fix, the RDF branch built a Python list of (subject, predicate,
-object) tuples and fed it into `RdfWriteRequest(graph=..., triples=<list>)`.
-That never matched the real consumer contract at `orion.schemas.rdf.RdfWriteRequest`,
-where `triples` must be a pre-serialized string and `id`/`source` are required.
-This test imports the REAL schema (not any local fallback stub) so it fails
-against the old shape and passes against the fixed one.
+The RDF write side was removed 2026-07-23 (live-verified pure redundancy
+with Postgres `vision_events` -- see README.md's "RDF write path: removed"
+section). SQL is now the sole sink.
 """
 from __future__ import annotations
 
@@ -20,9 +17,11 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 sys.path[:0] = [str(REPO_ROOT), str(SERVICE_ROOT)]
 
-# Real consumer-side contract -- must NOT be the fallback stub in app.main.
-from orion.schemas.rdf import RdfWriteRequest  # noqa: E402
-from app.main import _build_event_triples  # noqa: E402
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef  # noqa: E402
+from orion.schemas.vision import VisionEventBundleItem, VisionEventPayload  # noqa: E402
+
+from app.main import ScribeService  # noqa: E402
+from app.settings import Settings as ScribeSettings  # noqa: E402
 
 
 def _make_event(**overrides):
@@ -40,42 +39,12 @@ def _make_event(**overrides):
     return SimpleNamespace(**defaults)
 
 
-def test_build_event_triples_returns_nonempty_string_with_narrative_and_entity():
-    evt = _make_event()
-
-    nt_content = _build_event_triples(evt)
-
-    assert isinstance(nt_content, str)
-    assert nt_content.strip() != ""
-    assert "walked into the kitchen" in nt_content
-    assert "groceries" in nt_content
-
-
-def test_rdf_write_request_accepts_new_shape_against_real_schema():
-    evt = _make_event()
-    nt_content = _build_event_triples(evt)
-
-    req = RdfWriteRequest(
-        id=evt.event_id,
-        source="vision-scribe",
-        graph="orion:vision",
-        triples=nt_content,
+def _make_source_envelope() -> BaseEnvelope:
+    return BaseEnvelope(
+        kind="vision.event.bundle",
+        source=ServiceRef(name="orion-vision-council", version="0.1.0"),
+        payload={},
     )
-
-    assert isinstance(req.triples, str)
-    assert req.triples == nt_content
-    assert req.id == evt.event_id
-    assert req.source == "vision-scribe"
-    assert req.graph == "orion:vision"
-
-
-def test_old_list_of_tuples_shape_is_rejected_by_real_schema():
-    with pytest.raises(Exception) as exc_info:
-        RdfWriteRequest(graph="vision", triples=[("a", "b", "c")])
-
-    # Confirm it's specifically a pydantic validation failure, not something
-    # unrelated -- guards against silently regressing back to this shape.
-    assert "ValidationError" in type(exc_info.value).__name__
 
 
 # ---------------------------------------------------------------------------
@@ -92,20 +61,6 @@ def test_old_list_of_tuples_shape_is_rejected_by_real_schema():
 # kind `"vision.event.v1"`, matching how `orion-sql-writer` validates
 # `env.payload` against `VisionEventBundleItem` for the `VisionEventSQL` route.
 # ---------------------------------------------------------------------------
-
-from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef  # noqa: E402
-from orion.schemas.vision import VisionEventBundleItem, VisionEventPayload  # noqa: E402
-
-from app.main import ScribeService  # noqa: E402
-from app.settings import Settings as ScribeSettings  # noqa: E402
-
-
-def _make_source_envelope() -> BaseEnvelope:
-    return BaseEnvelope(
-        kind="vision.event.bundle",
-        source=ServiceRef(name="orion-vision-council", version="0.1.0"),
-        payload={},
-    )
 
 
 @pytest.mark.asyncio
@@ -137,3 +92,49 @@ async def test_write_to_sinks_publishes_vision_event_bundle_item_for_sql_write()
     assert not hasattr(sent_payload, "table")
     assert not hasattr(sent_payload, "data")
     assert sent_source_env is source_env
+
+
+@pytest.mark.asyncio
+async def test_write_to_sinks_makes_exactly_one_publish_call_no_rdf():
+    """Regression for the 2026-07-23 RDF-write removal: _write_to_sinks must
+    publish to SQL only -- not to CHANNEL_RDF_ENQUEUE or any 'rdf.write.request'
+    kind. Guards against the RDF branch silently reappearing."""
+    service = ScribeService()
+
+    calls: list[tuple] = []
+
+    async def fake_send_write(channel, kind, payload, source_env):
+        calls.append((channel, kind, payload, source_env))
+
+    service._send_write = fake_send_write
+
+    evt = VisionEventBundleItem(**_make_event().__dict__)
+    payload = VisionEventPayload(events=[evt])
+    source_env = _make_source_envelope()
+
+    await service._write_to_sinks(payload, source_env)
+
+    assert len(calls) == 1
+    assert calls[0][1] == "vision.event.v1"
+    assert not hasattr(ScribeSettings(), "CHANNEL_RDF_ENQUEUE")
+
+
+@pytest.mark.asyncio
+async def test_write_to_sinks_reports_ok_when_sql_write_succeeds():
+    """ack.ok must depend on sql_ok alone now -- previously required
+    sql_ok AND rdf_ok, which would have silently regressed to always-partial
+    once the RDF branch was removed if this line wasn't updated too."""
+    service = ScribeService()
+
+    async def fake_send_write(channel, kind, payload, source_env):
+        pass
+
+    service._send_write = fake_send_write
+
+    evt = VisionEventBundleItem(**_make_event().__dict__)
+    payload = VisionEventPayload(events=[evt])
+    source_env = _make_source_envelope()
+
+    ack = await service._write_to_sinks(payload, source_env)
+
+    assert ack.ok is True


### PR DESCRIPTION
## Summary

- Found via a live audit while checking what still depends on Fuseki before decommissioning it: `orion-vision-scribe` is still actively dual-writing every event to Postgres (`vision_events`) AND Fuseki (`orion:vision` graph).
- Live-verified pure redundancy: Postgres has 33,389 rows, latest timestamp matching to the second a live Fuseki write caught in the container's own log. Postgres's schema is strictly richer. Zero readers of the Fuseki graph found anywhere in the repo.
- Killed the RDF write outright (same pattern as every other confirmed-redundant Fuseki write in this migration). Updated the shared live-smoke-test helper so it no longer waits forever on a signal that will never arrive again.
- Review caught 2 stale-doc findings (channels.yaml, docs/vision_services.md), both fixed in this same PR.

Full report: `docs/superpowers/pr-reports/2026-07-23-vision-scribe-fuseki-write-kill-pr.md`

## Test plan

- [x] `pytest services/orion-vision-scribe/tests -q` -> 8 passed
- [x] `check_service_env_compose_parity.py orion-vision-scribe` -> N/A, clean
- [x] `check_single_consumer_channels.py` -> OK, no new issues
- [x] Contract-mode smoke reproduced independently by review agent -> PASS
- [ ] Redeploy `orion-athena-vision-scribe` from this branch/main to stop the live (fail-open) RDF write attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)