### PR TITLE
fix(field-digester): gate FCC-motor channels to their own trace lane

### DIFF
--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -872,6 +872,25 @@ subset for the mood-arc windowed-autoencoder spike (see
   sparse-event trio as `execution_friction`, same `2026-07-16T02:15:08Z`
   spike, genuine rare-event signal.
 
+**Cross-lane overwrite fix (live-confirmed 2026-07-23, same day as initial deploy):**
+`harness_step_load`, `tool_failure_streak_pressure`, `avg_step_chars_pressure`,
+`compliance_deficit`, and `turn_incompletion` (the 5 entries below) are now gated in
+`app/ingest/state_deltas.py` to only ever produce a perturbation from their own
+specific trace lane (`:harness_motor` for the first 4, `:hub_turn_timeout` for the
+last). Before this fix, `compute_pressure_hints()` unconditionally included these
+keys in every `execution_run`'s `pressure_hints` dict regardless of source (defaulting
+to `0.0`/`"unknown"` for cortex-exec-only runs), so `key in hints` was always true and
+every execution_run delta targeting the same node -- including the very same turn's
+own `:harness_finalize_reflect`/`:orion_voice_finalize` cortex-exec sub-lanes, and
+every later unrelated cortex-exec-only turn -- emitted a `mode="replace"` perturbation
+that reset the real value. Live-reproduced within hours of the initial deploy: a real
+`harness_step_load=0.6892` was overwritten back to `0.0` within 15 seconds by the same
+turn's own `:harness_finalize_reflect` delta. See
+`docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md`'s
+follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
+`test_execution_run_off_lane_delta_does_not_reset_prior_harness_value`
+(`tests/test_field_execution_run_perturbations.py`) for the regression coverage.
+
 #### `harness_step_load`
 - **Meaning**: FCC-motor-only step-load proxy for one unified Hub turn, split out of
   `execution_load` (which blends cortex-exec + harness-governor step counts and hard-caps

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -249,22 +249,6 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
             ("execution_friction", "execution_friction", node_key),
             ("reasoning_load", "reasoning_load", reasoning_node_key),
             ("failure_pressure", "failure_pressure", node_key),
-            # FCC-motor-process signals (step load, tool-failure streak, verbosity,
-            # compliance) -- attributed to node_key (the orchestrating/governor node),
-            # not reasoning_node_key, since these describe the motor process itself,
-            # not which node served the LLM call. See
-            # docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md.
-            ("harness_step_load", "harness_step_load", node_key),
-            ("tool_failure_streak_pressure", "tool_failure_streak_pressure", node_key),
-            ("avg_step_chars_pressure", "avg_step_chars_pressure", node_key),
-            ("compliance_deficit", "compliance_deficit", node_key),
-            # Distinct severity from compliance_deficit's worst rank: the governor
-            # never responded at all (orion-hub-sourced exec_turn_timeout event, no
-            # governor-side data ever existed for this run). node_key here resolves to
-            # Hub's own node (parsed from the hub_turn_timeout-laned trace_id), not the
-            # governor's -- this measures "Hub's view of governor unresponsiveness,"
-            # not the governor's own node health, since they may differ.
-            ("turn_incompletion", "turn_incompletion", node_key),
         ):
             if key in hints:
                 out.append(
@@ -286,6 +270,66 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     node_id=node_key,
                     channel="egress_confidence_deficit",
                     intensity=max(0.0, min(1.0, 1.0 - egress_raw)),
+                    label=delta.delta_id,
+                    mode="replace",
+                )
+            )
+
+        # FCC-motor-process signals (step load, tool-failure streak, verbosity,
+        # compliance) -- attributed to node_key (the orchestrating/governor node), not
+        # reasoning_node_key, since these describe the motor process itself, not which
+        # node served the LLM call. Gated to ONLY the harness-governor's own trace
+        # lane (":harness_motor", HarnessGrammarCollector's lane -- see
+        # orion/harness/grammar_emit.py).
+        #
+        # LIVE-CONFIRMED BUG (2026-07-23), fixed here: compute_pressure_hints()
+        # unconditionally includes these 4 keys in EVERY execution_run's
+        # pressure_hints dict, including cortex-exec-only runs (defaulting to
+        # 0.0/"unknown" there, since cortex-exec never sets harness_started_step_count/
+        # compliance_verdict/etc.). Before this gate, `key in hints` was always true
+        # regardless of source, so every execution_run delta -- including the SAME
+        # turn's own cortex-exec sub-lanes (":harness_finalize_reflect",
+        # ":orion_voice_finalize") and every later unrelated cortex-exec-only turn's
+        # bare trace -- emitted a mode="replace" perturbation for these channels
+        # targeting the same node_key (always "node:athena" for both producers),
+        # stomping the real value. Confirmed live: a real harness_step_load=0.6892 was
+        # reset to 0.0 within 15 seconds by the same turn's own
+        # :harness_finalize_reflect delta. Un-gated, these channels could never hold a
+        # real value longer than the shortest interval between any two execution_run
+        # deltas system-wide -- effectively always read near-zero. See
+        # docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md.
+        if delta.target_id.endswith(":harness_motor"):
+            for channel, key in (
+                ("harness_step_load", "harness_step_load"),
+                ("tool_failure_streak_pressure", "tool_failure_streak_pressure"),
+                ("avg_step_chars_pressure", "avg_step_chars_pressure"),
+                ("compliance_deficit", "compliance_deficit"),
+            ):
+                if key in hints:
+                    out.append(
+                        Perturbation(
+                            node_id=node_key,
+                            channel=channel,
+                            intensity=float(hints[key]),
+                            label=delta.delta_id,
+                            mode="replace",
+                        )
+                    )
+
+        # Distinct severity from compliance_deficit's worst rank: the governor never
+        # responded at all (orion-hub-sourced exec_turn_timeout event, no
+        # governor-side data ever existed for this run). Gated to Hub's own
+        # ":hub_turn_timeout" trace lane for the same cross-lane-stomp reason as
+        # above. node_key here resolves to Hub's own node (parsed from that lane's
+        # trace_id), not the governor's -- this measures "Hub's view of governor
+        # unresponsiveness," not the governor's own node health, since they may
+        # differ.
+        if delta.target_id.endswith(":hub_turn_timeout") and "turn_incompletion" in hints:
+            out.append(
+                Perturbation(
+                    node_id=node_key,
+                    channel="turn_incompletion",
+                    intensity=float(hints["turn_incompletion"]),
                     label=delta.delta_id,
                     mode="replace",
                 )

--- a/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
@@ -14,15 +14,23 @@ def _make_execution_run_delta(
     node_id: str = "athena",
     pressure_hints: dict | None = None,
     llm_serving_node: str | None = None,
+    lane: str | None = None,
 ) -> StateDeltaV1:
+    """`lane=None` (the default) produces a bare cortex-exec-shaped trace_id -- the
+    realistic shape for the majority of execution_run deltas in production. Pass
+    lane="harness_motor" or lane="hub_turn_timeout" to simulate the specific traces
+    the FCC-motor-only channels are gated on."""
     after: dict = {"node_id": node_id, "pressure_hints": pressure_hints or {}}
     if llm_serving_node is not None:
         after["llm_serving_node"] = llm_serving_node
+    target_id = f"cortex.exec:{node_id}:corr-1"
+    if lane:
+        target_id = f"{target_id}:{lane}"
     return StateDeltaV1(
         delta_id="delta_exec_1",
         target_projection="active_execution_trajectory",
         target_kind="execution_run",
-        target_id=f"cortex.exec:{node_id}:corr-1",
+        target_id=target_id,
         operation="update",
         after=after,
         caused_by_event_ids=["gev_exec_1"],
@@ -79,8 +87,11 @@ def test_execution_run_with_llm_serving_node_routes_reasoning_load_only() -> Non
 def test_execution_run_new_fcc_channels_attributed_to_orchestrating_node() -> None:
     """harness_step_load/tool_failure_streak_pressure/avg_step_chars_pressure/
     compliance_deficit are FCC-motor-process signals, not LLM-serving-node signals --
-    they must stay on node_key even when llm_serving_node is set, unlike reasoning_load."""
+    they must stay on node_key even when llm_serving_node is set, unlike reasoning_load.
+    Requires lane="harness_motor" -- see test_execution_run_fcc_channels_ignored_off_lane
+    below for why."""
     delta = _make_execution_run_delta(
+        lane="harness_motor",
         pressure_hints={
             "harness_step_load": 0.62,
             "tool_failure_streak_pressure": 0.67,
@@ -105,15 +116,50 @@ def test_execution_run_turn_incompletion_attributed_to_hub_node() -> None:
     """turn_incompletion comes from an orion-hub-sourced exec_turn_timeout event whose
     trace_id lane is under Hub's own node identity, not the governor's -- node_key here
     is Hub's node, distinct from what harness-governor would report for the same
-    correlation_id (there is none, in this failure mode)."""
+    correlation_id (there is none, in this failure mode). Requires
+    lane="hub_turn_timeout" -- see test_execution_run_fcc_channels_ignored_off_lane."""
     delta = _make_execution_run_delta(
         node_id="athena",
+        lane="hub_turn_timeout",
         pressure_hints={"turn_incompletion": 1.0},
     )
     perturbations = delta_to_perturbations(delta)
     by_channel = {p.channel: p for p in perturbations}
     assert by_channel["turn_incompletion"].node_id == "node:athena"
     assert by_channel["turn_incompletion"].intensity == 1.0
+
+
+def test_execution_run_fcc_channels_ignored_off_lane() -> None:
+    """LIVE-CONFIRMED BUG regression test (2026-07-23): compute_pressure_hints()
+    unconditionally includes harness_step_load/tool_failure_streak_pressure/
+    avg_step_chars_pressure/compliance_deficit/turn_incompletion in EVERY
+    execution_run's pressure_hints dict, including cortex-exec-only runs. Before this
+    lane gate, ANY execution_run delta -- a bare cortex-exec trace, or even the SAME
+    turn's own :harness_finalize_reflect/:orion_voice_finalize cortex-exec sub-lanes
+    -- emitted a mode="replace" perturbation for these channels targeting the same
+    node_key, silently resetting a real harness-motor value back to whatever that
+    unrelated delta happened to carry (0.0/"unknown" defaults). Confirmed live: a
+    real harness_step_load=0.6892 was reset to 0.0 within 15 seconds by the same
+    turn's own :harness_finalize_reflect delta. These 5 channels must ONLY ever
+    produce perturbations from their own specific lane."""
+    off_lane_deltas = [
+        _make_execution_run_delta(lane=None, pressure_hints={"harness_step_load": 0.5}),
+        _make_execution_run_delta(
+            lane="harness_finalize_reflect", pressure_hints={"harness_step_load": 0.5}
+        ),
+        _make_execution_run_delta(
+            lane="orion_voice_finalize", pressure_hints={"harness_step_load": 0.5}
+        ),
+        _make_execution_run_delta(lane=None, pressure_hints={"turn_incompletion": 1.0}),
+        _make_execution_run_delta(
+            lane="harness_motor", pressure_hints={"turn_incompletion": 1.0}
+        ),
+    ]
+    for delta in off_lane_deltas:
+        perturbations = delta_to_perturbations(delta)
+        channels = {p.channel for p in perturbations}
+        assert "harness_step_load" not in channels
+        assert "turn_incompletion" not in channels
 
 
 def test_execution_run_harness_step_load_stays_bounded_through_apply_perturbations() -> None:
@@ -127,10 +173,32 @@ def test_execution_run_harness_step_load_stays_bounded_through_apply_perturbatio
     from app.digestion.perturbation import apply_perturbations
     from orion.schemas.field_state import FieldStateV1
 
-    delta = _make_execution_run_delta(pressure_hints={"harness_step_load": 0.92})
+    delta = _make_execution_run_delta(lane="harness_motor", pressure_hints={"harness_step_load": 0.92})
     state = FieldStateV1(generated_at=FIXED_TS, tick_id="tick_x", node_vectors={}, edges=[])
     state = apply_perturbations(state, delta_to_perturbations(delta), now=FIXED_TS)
     assert state.node_vectors["node:athena"]["harness_step_load"] == 0.92
+
+
+def test_execution_run_off_lane_delta_does_not_reset_prior_harness_value() -> None:
+    """End-to-end reproduction of the live bug via apply_perturbations(): a real
+    harness_motor value, once set, must survive a subsequent off-lane delta (the
+    same turn's own cortex-exec sub-lane, or any later unrelated cortex-exec-only
+    turn) rather than being reset to that delta's inert default."""
+    from app.digestion.perturbation import apply_perturbations
+    from orion.schemas.field_state import FieldStateV1
+
+    state = FieldStateV1(generated_at=FIXED_TS, tick_id="tick_x", node_vectors={}, edges=[])
+    real_delta = _make_execution_run_delta(
+        lane="harness_motor", pressure_hints={"harness_step_load": 0.6892}
+    )
+    state = apply_perturbations(state, delta_to_perturbations(real_delta), now=FIXED_TS)
+    assert state.node_vectors["node:athena"]["harness_step_load"] == 0.6892
+
+    off_lane_delta = _make_execution_run_delta(
+        lane="harness_finalize_reflect", pressure_hints={"harness_step_load": 0.0}
+    )
+    state = apply_perturbations(state, delta_to_perturbations(off_lane_delta), now=FIXED_TS)
+    assert state.node_vectors["node:athena"]["harness_step_load"] == 0.6892
 
 
 def test_execution_run_noop_delta_skipped() -> None:


### PR DESCRIPTION
## Summary

Live-audit-discovered bug, found within hours of deploying #1285 (Patch A) and #1287 (Patch B) -- the 5 new FCC-motor field-digester channels were silently getting reset to their inert default almost immediately after any real value was set.

## Root cause

`compute_pressure_hints()` (`orion/substrate/execution_loop/grammar_extract.py`) unconditionally includes `harness_step_load`, `tool_failure_streak_pressure`, `avg_step_chars_pressure`, `compliance_deficit`, and `turn_incompletion` in **every** `execution_run`'s `pressure_hints` dict, regardless of which service produced it -- for a cortex-exec-only run they default to `0.0`/`"unknown"`, but the keys are always present.

`services/orion-field-digester/app/ingest/state_deltas.py`'s delta-to-perturbation mapping only checked `if key in hints:`, which was therefore always true. Every `execution_run` delta targeting the same node ("node:athena" for both cortex-exec and harness-governor today) -- including the **same unified turn's own cortex-exec sub-lanes** (`:harness_finalize_reflect`, `:orion_voice_finalize`) and every later, entirely unrelated cortex-exec-only turn -- emitted a `mode="replace"` perturbation that overwrote the real value.

## Live evidence

Queried the actual production Postgres DB (`substrate_reduction_receipts`) and field-digester's live `/api/substrate/field/node/athena` API directly, right after a real deploy + a real Orion-mode Hub turn:

- The real turn's `:harness_motor`-laned receipt correctly computed `harness_step_load=0.6892` (16 real steps, `log1p(16)/log1p(60)`).
- **15 seconds later**, that same turn's own `:harness_finalize_reflect` cortex-exec sub-lane delta reset it to `0.0`.
- Re-checking field-digester's live API minutes later showed exactly `0.0` for all 5 new channels, despite the underlying receipt data being correct the whole time.

## Fix

`state_deltas.py` now gates the 4 harness-motor-specific channels on `delta.target_id.endswith(":harness_motor")`, and `turn_incompletion` on `":hub_turn_timeout"` -- an **allowlist by trace lane**, not a denylist. Chosen because live data found *more* off-lanes than initially known (`:harness_finalize_reflect`, `:orion_voice_finalize` beyond the bare cortex-exec trace), so enumerating "bad" lanes to exclude would be fragile; enumerating the exact 1-2 lanes each channel can *ever* legitimately come from (matching this codebase's existing `HarnessGrammarCollector`/hub grammar-emit lane-naming convention) is the robust, self-documenting approach.

`execution_load`/`execution_friction`/`reasoning_load`/`failure_pressure` are unchanged -- cortex-exec runs legitimately produce real values for those, so they should stay unconditional.

## Tests

Two new regression tests in `services/orion-field-digester/tests/test_field_execution_run_perturbations.py`:
- `test_execution_run_fcc_channels_ignored_off_lane` -- off-lane deltas (bare, `:harness_finalize_reflect`, `:orion_voice_finalize`) must produce zero perturbations for the 5 gated channels.
- `test_execution_run_off_lane_delta_does_not_reset_prior_harness_value` -- end-to-end via `apply_perturbations()`: a real harness-motor value must survive a subsequent off-lane delta.

```
cd services/orion-field-digester && pytest tests/ -q
  -> 143 passed
```

## Review findings

Code review (subagent) confirmed the fix is correct and traced every claim against the real code and live data:
- `.endswith()` lane-suffix matching is safe -- `cortex_exec_trace_id()` always appends the lane as the final colon segment, correlation_ids are `uuid4()` strings that can't coincidentally collide, and `orion-cortex-exec`'s own `CORTEX_EXEC_ISOLATED_TRACE_LANES` already reserves `"harness_motor"` against collision from an unrelated 2026-07-15 fix.
- No blast radius on the 4 unconditional channels -- diff-verified untouched.
- `egress_confidence_deficit` does NOT share this bug -- live-sampled 50 receipts, confirmed `exec_result_emitted` (its source) is genuinely emitted by both cortex-exec and harness-governor's own collectors, unlike the FCC-motor-specific fields which are structural zeros on every cortex-exec lane.
- The one downstream consumer of raw `pressure_hints` (`execution_ctx.py`'s `map_execution_ctx_to_substrate()`) is structurally immune to this bug -- it keeps each trace_id as its own distinct node, unlike field-digester's shared-node collision.

**New finding, NOT fixed in this PR (flagged as a follow-up):** the 4 channels left unconditional here (`execution_load`, `execution_friction`, `reasoning_load`, `failure_pressure`) exhibit the *same* underlying cross-lane flapping mechanism, just with genuinely-computed values instead of defaults -- live-sampled `execution_load` swinging `0.25 -> 1.0 -> 0.25 -> 0.25 -> 1.0 -> 0.125` across one turn's own sub-lanes within 66 seconds. This predates this whole 5-signal effort and is a separate, pre-existing issue affecting long-established channels -- needs its own investigation, not scope-creep into this bug-fix PR.

## Restart required

```
docker compose --env-file .env --env-file services/orion-field-digester/.env -f services/orion-field-digester/docker-compose.yml up -d --build
```

(Only `orion-field-digester` needs a rebuild -- the fix is entirely in that service's own `state_deltas.py`; no other service's code changed.)

## Risks / concerns

- Severity: low
- Concern: the pre-existing cross-lane flapping on `execution_load`/`execution_friction`/`reasoning_load`/`failure_pressure` (finding above) means those 4 channels' live values should not yet be treated as fully trustworthy either.
- Mitigation: documented explicitly as a follow-up, not silently ignored; out of scope for this PR since it predates the 5-signal effort.

## PR link

(this PR)