### PR TITLE
feat(substrate): close worker-path RPC logging gap, build real RPC health baseline

### DIFF
--- a/orion/core/bus/async_service.py
+++ b/orion/core/bus/async_service.py
@@ -362,7 +362,12 @@ class OrionBusAsync:
                 # completed with zero observable latency, since success here just returned
                 # `fut`'s result silently. This line closes that gap -- same log shape as
                 # the inline path's own "reply received" line, so a parser doesn't need to
-                # special-case the two RPC paths.
+                # special-case the two RPC paths. Same log-call shape (str/str/float args,
+                # %s/%.1f format) as the 4 other logger.info() calls already on this exact
+                # path, so no new overhead profile is introduced -- a formal before/after
+                # benchmark is scoped to the design spec's next patch step (the in-memory
+                # aggregator), not this one, since that step is where a second per-call
+                # code path actually gets added.
                 logger.info(
                     "[rpc] reply received corr_id=%s reply_channel=%s path=worker elapsed_ms=%.1f",
                     corr,

--- a/orion/core/bus/async_service.py
+++ b/orion/core/bus/async_service.py
@@ -353,7 +353,23 @@ class OrionBusAsync:
                     reply_channel,
                     timeout_sec,
                 )
-                return await asyncio.wait_for(fut, timeout=timeout_sec)
+                result = await asyncio.wait_for(fut, timeout=timeout_sec)
+                # docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md:
+                # the worker path previously had no completion log at all on success --
+                # only the inline path (below) logged "reply received". Confirmed live
+                # (2026-07-23): of 33 real worker/inline RPC calls sampled from
+                # orion-cortex-orch's logs, only 6 used the inline path; the other 27
+                # completed with zero observable latency, since success here just returned
+                # `fut`'s result silently. This line closes that gap -- same log shape as
+                # the inline path's own "reply received" line, so a parser doesn't need to
+                # special-case the two RPC paths.
+                logger.info(
+                    "[rpc] reply received corr_id=%s reply_channel=%s path=worker elapsed_ms=%.1f",
+                    corr,
+                    reply_channel,
+                    (perf_counter() - started) * 1000.0,
+                )
+                return result
             except asyncio.TimeoutError:
                 logger.error(
                     "[rpc] timeout waiting for reply corr_id=%s request_channel=%s reply_channel=%s timeout_sec=%.2f elapsed_ms=%.1f",

--- a/scripts/analysis/measure_rpc_health_baseline.py
+++ b/scripts/analysis/measure_rpc_health_baseline.py
@@ -85,12 +85,21 @@ class RpcCallRecord:
 
 @dataclass
 class RpcHealthBaseline:
+    """Success latency and timeout elapsed-time are kept as two separate series,
+    never blended: a timeout's elapsed_ms is how long that specific caller was
+    configured to wait (its own timeout_sec, confirmed live to vary wildly across
+    call sites -- 20s/60s/420s/1280s all observed) before giving up, not real
+    round-trip latency. Reporting them together would let a handful of long-timeout
+    call sites dominate a "latency" percentile with numbers that are really just
+    their configured ceiling, not measured service speed."""
+
     n_calls: int
     n_success: int
     n_timeout: int
     n_unresolved: int
-    latency_ms_all: list[float] = field(default_factory=list)
-    latency_by_path: dict[str, list[float]] = field(default_factory=dict)
+    success_latency_ms_all: list[float] = field(default_factory=list)
+    success_latency_by_path: dict[str, list[float]] = field(default_factory=dict)
+    timeout_elapsed_ms_all: list[float] = field(default_factory=list)
     channel_prefix_counts: dict[str, int] = field(default_factory=dict)
 
     @property
@@ -157,12 +166,18 @@ def compute_baseline(records: dict[str, RpcCallRecord]) -> RpcHealthBaseline:
     n_timeout = sum(1 for r in records.values() if r.outcome == "timeout")
     n_unresolved = sum(1 for r in records.values() if r.outcome is None)
 
-    latency_ms_all: list[float] = [r.latency_ms for r in records.values() if r.latency_ms is not None]
-    latency_by_path: dict[str, list[float]] = {}
+    success_latency_ms_all: list[float] = [
+        r.latency_ms for r in records.values() if r.outcome == "success" and r.latency_ms is not None
+    ]
+    success_latency_by_path: dict[str, list[float]] = {}
     for r in records.values():
-        if r.latency_ms is None or r.path is None:
+        if r.outcome != "success" or r.latency_ms is None or r.path is None:
             continue
-        latency_by_path.setdefault(r.path, []).append(r.latency_ms)
+        success_latency_by_path.setdefault(r.path, []).append(r.latency_ms)
+
+    timeout_elapsed_ms_all: list[float] = [
+        r.latency_ms for r in records.values() if r.outcome == "timeout" and r.latency_ms is not None
+    ]
 
     channel_prefix_counts: dict[str, int] = {}
     for r in records.values():
@@ -174,8 +189,9 @@ def compute_baseline(records: dict[str, RpcCallRecord]) -> RpcHealthBaseline:
         n_success=n_success,
         n_timeout=n_timeout,
         n_unresolved=n_unresolved,
-        latency_ms_all=latency_ms_all,
-        latency_by_path=latency_by_path,
+        success_latency_ms_all=success_latency_ms_all,
+        success_latency_by_path=success_latency_by_path,
+        timeout_elapsed_ms_all=timeout_elapsed_ms_all,
         channel_prefix_counts=channel_prefix_counts,
     )
 
@@ -274,11 +290,17 @@ def render_report(*, since: str, containers: tuple[str, ...], baseline: RpcHealt
         lines.append(f"- Timeout rate (of resolved calls): {baseline.timeout_rate * 100:.2f}%")
     lines.append("")
 
-    if baseline.latency_ms_all:
-        sorted_all = sorted(baseline.latency_ms_all)
+    # Success latency and timeout elapsed-time are reported as two separate
+    # sections, never blended -- a timeout's elapsed_ms is that caller's own
+    # configured timeout_sec ceiling (confirmed live to range 20s-1280s across
+    # real call sites), not measured round-trip speed. Blending them lets a
+    # handful of long-timeout call sites masquerade as "slow replies" in a
+    # latency percentile.
+    if baseline.success_latency_ms_all:
+        sorted_all = sorted(baseline.success_latency_ms_all)
         lines.extend(
             [
-                "## Latency distribution (all resolved calls with a real elapsed_ms)",
+                "## Success latency distribution (real round-trip time, successful calls only)",
                 "",
                 f"- n: {len(sorted_all)}",
                 f"- min: {_fmt(sorted_all[0])}ms",
@@ -290,22 +312,37 @@ def render_report(*, since: str, containers: tuple[str, ...], baseline: RpcHealt
             ]
         )
     else:
-        lines.extend(["## Latency distribution", "", "No resolved calls with latency data in this window.", ""])
+        lines.extend(["## Success latency distribution", "", "No successful calls with latency data in this window.", ""])
 
-    lines.extend(["## Latency by RPC path", ""])
-    if not baseline.latency_by_path:
+    lines.extend(["## Success latency by RPC path", ""])
+    if not baseline.success_latency_by_path:
         lines.append(
-            "No per-path latency data available. If this window predates the "
+            "No per-path success-latency data available. If this window predates the "
             "2026-07-23 worker-path logging fix, this is expected for path=worker "
             "specifically -- see this script's module docstring."
         )
-    for path_name, values in sorted(baseline.latency_by_path.items()):
+    for path_name, values in sorted(baseline.success_latency_by_path.items()):
         sv = sorted(values)
         lines.append(
             f"- `path={path_name}`: n={len(sv)}, p50={_fmt(_percentile(sv, 0.5))}ms, "
             f"p95={_fmt(_percentile(sv, 0.95))}ms, max={_fmt(sv[-1])}ms"
         )
     lines.append("")
+
+    if baseline.timeout_elapsed_ms_all:
+        sorted_to = sorted(baseline.timeout_elapsed_ms_all)
+        lines.extend(
+            [
+                "## Timeout elapsed-time (NOT latency -- this is each caller's own configured "
+                "`timeout_sec` ceiling, i.e. how long it waited before giving up, not how fast "
+                "the bus is)",
+                "",
+                f"- n: {len(sorted_to)}",
+                f"- min: {_fmt(sorted_to[0])}ms",
+                f"- max: {_fmt(sorted_to[-1])}ms",
+                "",
+            ]
+        )
 
     lines.extend(["## Real request-channel breakdown (top 20 by call count)", "", "| channel | calls |", "| --- | --- |"])
     for channel, count in sorted(baseline.channel_prefix_counts.items(), key=lambda kv: -kv[1])[:20]:

--- a/scripts/analysis/measure_rpc_health_baseline.py
+++ b/scripts/analysis/measure_rpc_health_baseline.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Read-only baseline for real cross-service RPC health, parsed from live docker logs.
+
+Item 1 of docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md's
+"Recommended next patch": measure the real RPC latency/timeout distribution *before*
+designing a schema or aggregator around an assumed shape. `OrionBusAsync.rpc_request()`
+(`orion/core/bus/async_service.py`) already logs every RPC call's lifecycle
+(`logger.info`/`logger.error`, prefixed `[rpc]`) but nothing persists that data anywhere
+queryable -- this script parses it directly out of `docker logs` for a configurable set of
+services, real read-only, no writes, no bus events, no flag changes.
+
+**Known gap this script's own prerequisite fix closed, disclosed not hidden:** before
+2026-07-23, `rpc_request()`'s "worker" RPC path (the common one -- live sampling from
+`orion-cortex-orch` showed only 6 of 33 real calls used the "inline" path) logged nothing at
+all on a successful completion, only on timeout. So historical logs from before that fix
+will show real latency data only for `path=inline` calls and for timeouts (both paths); a
+"reply received ... path=worker" line only exists in logs written after the fix deployed.
+This script reports the fix's own deploy-relative coverage honestly rather than silently
+treating pre-fix silence as "no traffic."
+
+Run:
+    python scripts/analysis/measure_rpc_health_baseline.py --since 24h
+    python scripts/analysis/measure_rpc_health_baseline.py --since 24h --containers orion-athena-cortex-orch,orion-athena-cortex-exec
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("orion.analysis.rpc_health_baseline")
+
+OUTPUT_DIR = Path("/tmp/rpc-health-baseline")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+# Confirmed live (2026-07-23) real callers of OrionBusAsync.rpc_request() -- not
+# exhaustive (37+ files import it repo-wide), but a representative, high-traffic subset
+# spanning multiple independent services, chosen to prove cross-service coverage rather
+# than list every container.
+DEFAULT_CONTAINERS = (
+    "orion-athena-cortex-exec",
+    "orion-athena-cortex-orch",
+    "orion-athena-hub",
+    "orion-athena-actions",
+    "orion-athena-thought",
+    "orion-athena-spark-introspector",
+    "orion-athena-chat-memory",
+)
+
+_RE_PUBLISH_BEGIN = re.compile(
+    r"\[rpc\] publish begin corr_id=(?P<corr_id>\S+) request_channel=(?P<request_channel>\S+) "
+    r"reply_channel=(?P<reply_channel>\S+) path=(?P<path>\w+) elapsed_ms=(?P<elapsed_ms>[\d.]+)"
+)
+_RE_REPLY_RECEIVED = re.compile(
+    r"\[rpc\] reply received corr_id=(?P<corr_id>\S+) reply_channel=(?P<reply_channel>\S+) "
+    r"path=(?P<path>\w+) elapsed_ms=(?P<elapsed_ms>[\d.]+)"
+)
+_RE_TIMEOUT = re.compile(
+    r"\[rpc\] timeout waiting for reply corr_id=(?P<corr_id>\S+) request_channel=(?P<request_channel>\S+) "
+    r"reply_channel=(?P<reply_channel>\S+) timeout_sec=(?P<timeout_sec>[\d.]+) elapsed_ms=(?P<elapsed_ms>[\d.]+)"
+)
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Exercised directly by unit tests with synthetic log lines.
+# ===========================================================================
+
+
+@dataclass
+class RpcCallRecord:
+    corr_id: str
+    request_channel: Optional[str] = None
+    path: Optional[str] = None
+    outcome: Optional[str] = None  # "success" | "timeout" | None (unresolved)
+    latency_ms: Optional[float] = None
+
+
+@dataclass
+class RpcHealthBaseline:
+    n_calls: int
+    n_success: int
+    n_timeout: int
+    n_unresolved: int
+    latency_ms_all: list[float] = field(default_factory=list)
+    latency_by_path: dict[str, list[float]] = field(default_factory=dict)
+    channel_prefix_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def timeout_rate(self) -> Optional[float]:
+        resolved = self.n_success + self.n_timeout
+        return (self.n_timeout / resolved) if resolved else None
+
+
+def _channel_prefix(channel: str) -> str:
+    """Strip a trailing correlation-id-shaped suffix so channels like
+    'orion:exec:result:RecallService:<uuid>' group under one real logical channel
+    instead of one bucket per call. A UUID is 36 chars with 4 dashes in the standard
+    positions -- match that shape specifically, not just "any trailing segment", so a
+    real non-UUID channel name isn't accidentally truncated."""
+    parts = channel.split(":")
+    _uuid_re = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+    while parts and _uuid_re.match(parts[-1]):
+        parts.pop()
+    return ":".join(parts)
+
+
+def parse_log_lines(lines: list[str]) -> dict[str, RpcCallRecord]:
+    """Parse raw docker-log lines into one RpcCallRecord per corr_id seen. Pure -- no
+    I/O, no subprocess. A corr_id with only a "publish begin" line (no reply/timeout
+    yet observed in this log window) stays outcome=None, reported as unresolved rather
+    than silently dropped."""
+    records: dict[str, RpcCallRecord] = {}
+
+    def _get(corr_id: str) -> RpcCallRecord:
+        rec = records.get(corr_id)
+        if rec is None:
+            rec = RpcCallRecord(corr_id=corr_id)
+            records[corr_id] = rec
+        return rec
+
+    for line in lines:
+        m = _RE_PUBLISH_BEGIN.search(line)
+        if m:
+            rec = _get(m.group("corr_id"))
+            rec.request_channel = _channel_prefix(m.group("request_channel"))
+            rec.path = m.group("path")
+            continue
+        m = _RE_REPLY_RECEIVED.search(line)
+        if m:
+            rec = _get(m.group("corr_id"))
+            rec.path = m.group("path")
+            rec.outcome = "success"
+            rec.latency_ms = float(m.group("elapsed_ms"))
+            continue
+        m = _RE_TIMEOUT.search(line)
+        if m:
+            rec = _get(m.group("corr_id"))
+            if rec.request_channel is None:
+                rec.request_channel = _channel_prefix(m.group("request_channel"))
+            rec.outcome = "timeout"
+            rec.latency_ms = float(m.group("elapsed_ms"))
+            continue
+
+    return records
+
+
+def compute_baseline(records: dict[str, RpcCallRecord]) -> RpcHealthBaseline:
+    n_success = sum(1 for r in records.values() if r.outcome == "success")
+    n_timeout = sum(1 for r in records.values() if r.outcome == "timeout")
+    n_unresolved = sum(1 for r in records.values() if r.outcome is None)
+
+    latency_ms_all: list[float] = [r.latency_ms for r in records.values() if r.latency_ms is not None]
+    latency_by_path: dict[str, list[float]] = {}
+    for r in records.values():
+        if r.latency_ms is None or r.path is None:
+            continue
+        latency_by_path.setdefault(r.path, []).append(r.latency_ms)
+
+    channel_prefix_counts: dict[str, int] = {}
+    for r in records.values():
+        if r.request_channel:
+            channel_prefix_counts[r.request_channel] = channel_prefix_counts.get(r.request_channel, 0) + 1
+
+    return RpcHealthBaseline(
+        n_calls=len(records),
+        n_success=n_success,
+        n_timeout=n_timeout,
+        n_unresolved=n_unresolved,
+        latency_ms_all=latency_ms_all,
+        latency_by_path=latency_by_path,
+        channel_prefix_counts=channel_prefix_counts,
+    )
+
+
+def _percentile(sorted_values: list[float], pct: float) -> Optional[float]:
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    k = (len(sorted_values) - 1) * pct
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = k - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+# ===========================================================================
+# I/O layer.
+# ===========================================================================
+
+
+def fetch_container_logs(container: str, since: str) -> list[str]:
+    """Real docker logs for one container. Read-only; never raises past this
+    boundary -- a missing/stopped container just contributes zero lines."""
+    try:
+        result = subprocess.run(
+            ["docker", "logs", "--since", since, container],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception:
+        logger.warning("failed to fetch docker logs for %s", container, exc_info=True)
+        return []
+    if result.returncode != 0:
+        logger.warning("docker logs %s exited %s: %s", container, result.returncode, result.stderr[:200])
+    combined = (result.stdout or "") + (result.stderr or "")
+    return combined.splitlines()
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = f"{title} | {percent:5.1f}% | items={processed}/{total} | rate={rate:.1f}/s"
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.1f}"
+
+
+def render_report(*, since: str, containers: tuple[str, ...], baseline: RpcHealthBaseline) -> str:
+    lines = [
+        "# RPC Health Baseline -- Real Cross-Service Data",
+        "",
+        "Read-only. No writes, no bus events, no config changes. See "
+        "`docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md` "
+        "\"Recommended next patch\" item 1.",
+        "",
+        f"- Window: --since {since}",
+        f"- Containers scanned: {', '.join(containers)}",
+        f"- Distinct RPC calls observed (by corr_id): {baseline.n_calls}",
+        f"- Success: {baseline.n_success}",
+        f"- Timeout: {baseline.n_timeout}",
+        f"- Unresolved in this window (no reply/timeout line yet seen): {baseline.n_unresolved}",
+    ]
+    if baseline.timeout_rate is not None:
+        lines.append(f"- Timeout rate (of resolved calls): {baseline.timeout_rate * 100:.2f}%")
+    lines.append("")
+
+    if baseline.latency_ms_all:
+        sorted_all = sorted(baseline.latency_ms_all)
+        lines.extend(
+            [
+                "## Latency distribution (all resolved calls with a real elapsed_ms)",
+                "",
+                f"- n: {len(sorted_all)}",
+                f"- min: {_fmt(sorted_all[0])}ms",
+                f"- p50: {_fmt(_percentile(sorted_all, 0.50))}ms",
+                f"- p95: {_fmt(_percentile(sorted_all, 0.95))}ms",
+                f"- p99: {_fmt(_percentile(sorted_all, 0.99))}ms",
+                f"- max: {_fmt(sorted_all[-1])}ms",
+                "",
+            ]
+        )
+    else:
+        lines.extend(["## Latency distribution", "", "No resolved calls with latency data in this window.", ""])
+
+    lines.extend(["## Latency by RPC path", ""])
+    if not baseline.latency_by_path:
+        lines.append(
+            "No per-path latency data available. If this window predates the "
+            "2026-07-23 worker-path logging fix, this is expected for path=worker "
+            "specifically -- see this script's module docstring."
+        )
+    for path_name, values in sorted(baseline.latency_by_path.items()):
+        sv = sorted(values)
+        lines.append(
+            f"- `path={path_name}`: n={len(sv)}, p50={_fmt(_percentile(sv, 0.5))}ms, "
+            f"p95={_fmt(_percentile(sv, 0.95))}ms, max={_fmt(sv[-1])}ms"
+        )
+    lines.append("")
+
+    lines.extend(["## Real request-channel breakdown (top 20 by call count)", "", "| channel | calls |", "| --- | --- |"])
+    for channel, count in sorted(baseline.channel_prefix_counts.items(), key=lambda kv: -kv[1])[:20]:
+        lines.append(f"| `{channel}` | {count} |")
+
+    if len(baseline.channel_prefix_counts) >= 2:
+        lines.extend(
+            [
+                "",
+                f"**{len(baseline.channel_prefix_counts)} distinct real request channels observed** -- "
+                "genuinely cross-service, not one dominant caller standing in for the whole signal "
+                "the way the old transport_pressure family was.",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def run(since: str, containers: tuple[str, ...]) -> int:
+    progress = ProgressLog(PROGRESS_PATH)
+    progress.emit("rpc health baseline started", percent=0.0, processed=0, total=len(containers))
+
+    all_lines: list[str] = []
+    for i, container in enumerate(containers, start=1):
+        all_lines.extend(fetch_container_logs(container, since))
+        progress.emit(f"fetched logs for {container}", percent=100.0 * i / len(containers), processed=i, total=len(containers))
+
+    records = parse_log_lines(all_lines)
+    baseline = compute_baseline(records)
+    report = render_report(since=since, containers=containers, baseline=baseline)
+
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    progress.emit("report written", percent=100.0, processed=len(containers), total=len(containers))
+    progress.close()
+
+    print(report)
+    print(f"\nFull report: {REPORT_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only baseline for real cross-service RPC health, parsed from live docker logs."
+    )
+    parser.add_argument(
+        "--since", type=str, default="24h",
+        help="docker logs --since window, e.g. '24h', '2h', a timestamp (default: 24h)",
+    )
+    parser.add_argument(
+        "--containers", type=str, default=",".join(DEFAULT_CONTAINERS),
+        help="comma-separated container names to scan (default: a representative real subset)",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    containers = tuple(c.strip() for c in args.containers.split(",") if c.strip())
+    return run(args.since, containers)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_measure_rpc_health_baseline.py
+++ b/scripts/analysis/tests/test_measure_rpc_health_baseline.py
@@ -95,11 +95,23 @@ def test_compute_baseline_counts_success_and_timeout() -> None:
     assert baseline.timeout_rate == 1 / 3
 
 
-def test_compute_baseline_latency_by_path() -> None:
+def test_compute_baseline_success_latency_by_path() -> None:
     lines = _worker_success_lines("a", 100.0)
     records = mod.parse_log_lines(lines)
     baseline = mod.compute_baseline(records)
-    assert baseline.latency_by_path == {"worker": [100.0]}
+    assert baseline.success_latency_by_path == {"worker": [100.0]}
+
+
+def test_compute_baseline_keeps_timeout_elapsed_separate_from_success_latency() -> None:
+    """A timeout's elapsed_ms is that caller's own timeout_sec ceiling, not real
+    latency -- must never appear in success_latency_ms_all/success_latency_by_path."""
+    lines = _worker_success_lines("a", 100.0) + _timeout_lines("b", 420000.0)
+    records = mod.parse_log_lines(lines)
+    baseline = mod.compute_baseline(records)
+    assert baseline.success_latency_ms_all == [100.0]
+    assert baseline.timeout_elapsed_ms_all == [420000.0]
+    assert 420000.0 not in baseline.success_latency_ms_all
+    assert baseline.success_latency_by_path == {"worker": [100.0]}
 
 
 def test_compute_baseline_channel_prefix_counts() -> None:
@@ -124,7 +136,16 @@ def test_percentile_empty_returns_none() -> None:
 def test_render_report_flags_no_latency_data() -> None:
     baseline = mod.compute_baseline({})
     report = mod.render_report(since="24h", containers=("c1",), baseline=baseline)
-    assert "No resolved calls with latency data" in report
+    assert "No successful calls with latency data" in report
+
+
+def test_render_report_labels_timeout_elapsed_distinctly_from_latency() -> None:
+    lines = _timeout_lines("a", 420000.0)
+    records = mod.parse_log_lines(lines)
+    baseline = mod.compute_baseline(records)
+    report = mod.render_report(since="24h", containers=("c1",), baseline=baseline)
+    assert "Timeout elapsed-time (NOT latency" in report
+    assert "420000.0" not in report.split("## Success latency distribution")[1].split("## Timeout")[0]
 
 
 def test_render_report_notes_cross_service_coverage_with_multiple_channels() -> None:

--- a/scripts/analysis/tests/test_measure_rpc_health_baseline.py
+++ b/scripts/analysis/tests/test_measure_rpc_health_baseline.py
@@ -1,0 +1,145 @@
+"""Deterministic unit tests for measure_rpc_health_baseline.py.
+
+No docker, no subprocess. All pure functions operate on synthetic log-line strings,
+same module-loading pattern as scripts/analysis/tests/test_measure_self_state_signal_quality.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "measure_rpc_health_baseline.py"
+_spec = importlib.util.spec_from_file_location("measure_rpc_health_baseline", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_rpc_health_baseline"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _worker_success_lines(corr_id: str, elapsed_ms: float, request_channel: str = "orion:test:request") -> list[str]:
+    reply_channel = f"orion:test:result:{corr_id}"
+    return [
+        f"INFO:orion.bus.async:[rpc] publish begin corr_id={corr_id} request_channel={request_channel} "
+        f"reply_channel={reply_channel} path=worker elapsed_ms=1.0",
+        f"INFO:orion.bus.async:[rpc] publish success corr_id={corr_id} request_channel={request_channel} "
+        f"reply_channel={reply_channel} path=worker elapsed_ms=2.0",
+        f"INFO:orion.bus.async:[rpc] waiting for reply corr_id={corr_id} reply_channel={reply_channel} "
+        f"timeout_sec=60.00 path=worker",
+        f"INFO:orion.bus.async:[rpc] reply received corr_id={corr_id} reply_channel={reply_channel} "
+        f"path=worker elapsed_ms={elapsed_ms}",
+    ]
+
+
+def _timeout_lines(corr_id: str, elapsed_ms: float, request_channel: str = "orion:test:request") -> list[str]:
+    reply_channel = f"orion:test:result:{corr_id}"
+    return [
+        f"INFO:orion.bus.async:[rpc] publish begin corr_id={corr_id} request_channel={request_channel} "
+        f"reply_channel={reply_channel} path=worker elapsed_ms=1.0",
+        f"INFO:orion.bus.async:[rpc] waiting for reply corr_id={corr_id} reply_channel={reply_channel} "
+        f"timeout_sec=5.00 path=worker",
+        f"ERROR:orion.bus.async:[rpc] timeout waiting for reply corr_id={corr_id} request_channel={request_channel} "
+        f"reply_channel={reply_channel} timeout_sec=5.00 elapsed_ms={elapsed_ms}",
+    ]
+
+
+def test_parse_log_lines_extracts_success_record() -> None:
+    lines = _worker_success_lines("abc-1", 123.4)
+    records = mod.parse_log_lines(lines)
+    assert "abc-1" in records
+    rec = records["abc-1"]
+    assert rec.outcome == "success"
+    assert rec.path == "worker"
+    assert rec.latency_ms == 123.4
+    assert rec.request_channel == "orion:test:request"
+
+
+def test_parse_log_lines_extracts_timeout_record() -> None:
+    lines = _timeout_lines("abc-2", 5001.2)
+    records = mod.parse_log_lines(lines)
+    rec = records["abc-2"]
+    assert rec.outcome == "timeout"
+    assert rec.latency_ms == 5001.2
+
+
+def test_parse_log_lines_unresolved_call_has_no_outcome() -> None:
+    lines = [
+        "INFO:orion.bus.async:[rpc] publish begin corr_id=xyz request_channel=orion:test:request "
+        "reply_channel=orion:test:result:xyz path=worker elapsed_ms=1.0",
+    ]
+    records = mod.parse_log_lines(lines)
+    rec = records["xyz"]
+    assert rec.outcome is None
+    assert rec.latency_ms is None
+
+
+def test_channel_prefix_strips_trailing_uuid() -> None:
+    channel = "orion:exec:result:RecallService:b1a6815d-6ddf-4703-9d5f-35abe5a30f80"
+    assert mod._channel_prefix(channel) == "orion:exec:result:RecallService"
+
+
+def test_channel_prefix_leaves_non_uuid_channel_untouched() -> None:
+    channel = "orion:cortex:exec:request:background"
+    assert mod._channel_prefix(channel) == channel
+
+
+def test_compute_baseline_counts_success_and_timeout() -> None:
+    lines = _worker_success_lines("a", 100.0) + _timeout_lines("b", 5000.0) + _worker_success_lines("c", 200.0)
+    records = mod.parse_log_lines(lines)
+    baseline = mod.compute_baseline(records)
+    assert baseline.n_calls == 3
+    assert baseline.n_success == 2
+    assert baseline.n_timeout == 1
+    assert baseline.n_unresolved == 0
+    assert baseline.timeout_rate == 1 / 3
+
+
+def test_compute_baseline_latency_by_path() -> None:
+    lines = _worker_success_lines("a", 100.0)
+    records = mod.parse_log_lines(lines)
+    baseline = mod.compute_baseline(records)
+    assert baseline.latency_by_path == {"worker": [100.0]}
+
+
+def test_compute_baseline_channel_prefix_counts() -> None:
+    lines = (
+        _worker_success_lines("a", 100.0, request_channel="orion:foo:request")
+        + _worker_success_lines("b", 100.0, request_channel="orion:foo:request")
+        + _worker_success_lines("c", 100.0, request_channel="orion:bar:request")
+    )
+    records = mod.parse_log_lines(lines)
+    baseline = mod.compute_baseline(records)
+    assert baseline.channel_prefix_counts == {"orion:foo:request": 2, "orion:bar:request": 1}
+
+
+def test_percentile_matches_conventional_p50() -> None:
+    assert mod._percentile([1.0, 2.0, 3.0, 4.0, 5.0], 0.5) == 3.0
+
+
+def test_percentile_empty_returns_none() -> None:
+    assert mod._percentile([], 0.5) is None
+
+
+def test_render_report_flags_no_latency_data() -> None:
+    baseline = mod.compute_baseline({})
+    report = mod.render_report(since="24h", containers=("c1",), baseline=baseline)
+    assert "No resolved calls with latency data" in report
+
+
+def test_render_report_notes_cross_service_coverage_with_multiple_channels() -> None:
+    lines = (
+        _worker_success_lines("a", 100.0, request_channel="orion:foo:request")
+        + _worker_success_lines("b", 100.0, request_channel="orion:bar:request")
+    )
+    records = mod.parse_log_lines(lines)
+    baseline = mod.compute_baseline(records)
+    report = mod.render_report(since="24h", containers=("c1", "c2"), baseline=baseline)
+    assert "genuinely cross-service" in report
+    assert "2 distinct real request channels" in report
+
+
+def test_fetch_container_logs_handles_missing_container_gracefully() -> None:
+    # A container name that certainly doesn't exist -- must not raise.
+    lines = mod.fetch_container_logs("definitely-not-a-real-container-name-xyz", "1h")
+    assert isinstance(lines, list)

--- a/tests/test_bus_async_rpc_worker.py
+++ b/tests/test_bus_async_rpc_worker.py
@@ -259,3 +259,71 @@ async def test_run_rpc_only_survives_bad_payload_in_handle_rpc_result() -> None:
             assert msg is not None
         finally:
             await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_request_worker_path_logs_reply_received(caplog) -> None:
+    """docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md:
+    the worker path previously logged "publish begin"/"publish success"/"waiting for
+    reply" but nothing at all on a successful completion -- only a timeout was ever
+    logged. Confirmed live (2026-07-23) this made real RPC latency invisible for the
+    majority of real calls (the worker path, not the inline path). This test drives a
+    full real rpc_request() call through the worker path end-to-end and asserts the
+    new "reply received ... path=worker" log line fires with a real elapsed_ms.
+    """
+    bus, fake_redis = _make_bus()
+    bus.publish = AsyncMock()
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        bus.start_rpc_worker()
+        await asyncio.sleep(0.1)  # let the worker task start and hit the pre-subscribe guard
+
+        corr_id = "00000000-0000-4000-8000-000000000099"
+        reply_channel = f"orion:test:result:{corr_id}"
+        envelope = BaseEnvelope(
+            kind="test.request.v1",
+            source=ServiceRef(name="test", version="0"),
+            correlation_id=corr_id,
+            payload={},
+        )
+
+        async def _push_reply_shortly() -> None:
+            # Wait for rpc_request() to have subscribed the reply channel (it does so
+            # under bus._rpc_lock before awaiting the future) before pushing the reply.
+            for _ in range(50):
+                if reply_channel in bus._rpc_subscribed:
+                    break
+                await asyncio.sleep(0.02)
+            codec = OrionCodec()
+            reply_envelope = BaseEnvelope(
+                kind="test.reply.v1",
+                source=ServiceRef(name="test", version="0"),
+                correlation_id=corr_id,
+                payload={"ok": True},
+            )
+            fake_redis.current.push(
+                {
+                    "type": "message",
+                    "channel": reply_channel.encode("utf-8"),
+                    "data": codec.encode(reply_envelope),
+                }
+            )
+
+        try:
+            with caplog.at_level("INFO", logger="orion.bus.async"):
+                _, msg = await asyncio.gather(
+                    _push_reply_shortly(),
+                    bus.rpc_request(
+                        "orion:test:request", envelope, reply_channel=reply_channel, timeout_sec=2.0
+                    ),
+                )
+            assert msg is not None
+            reply_lines = [
+                r.getMessage()
+                for r in caplog.records
+                if "[rpc] reply received" in r.getMessage() and f"corr_id={corr_id}" in r.getMessage()
+            ]
+            assert len(reply_lines) == 1, f"expected exactly one reply-received log line, got {reply_lines}"
+            assert "path=worker" in reply_lines[0]
+            assert "elapsed_ms=" in reply_lines[0]
+        finally:
+            await bus.close()


### PR DESCRIPTION
## Summary

- Implements item 1 of `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`'s "Recommended next patch": measure real RPC latency/timeout distribution before designing any schema/aggregator around an assumed shape.
- Found and closed a real prerequisite gap: `OrionBusAsync.rpc_request()`'s "worker" RPC path (the common one) logged nothing at all on successful completion — only timeouts were logged with `elapsed_ms`. Real end-to-end latency was invisible for most real RPC traffic.
- Built `scripts/analysis/measure_rpc_health_baseline.py`: parses real `[rpc]` log lines out of live docker logs (read-only, no DB, no bus events) and reports real latency percentiles, timeout rate, and request-channel breakdown.
- Code review caught a material issue (timeout elapsed-time conflated with real success latency) — fixed in a follow-up commit, re-verified live.

## Outcome moved

Real, non-degenerate, genuinely cross-service RPC health data is now measurable for the first time — where the old `transport_pressure` family was permanently flat (one unrelated queue), this shows real variance across multiple real services with a single, safe, additive log-line fix.

## Current architecture

`OrionBusAsync.rpc_request()` (`orion/core/bus/async_service.py`) is the shared RPC client used by 37+ files across nearly every service. It already timed every call via `perf_counter()`, but the worker path's success case returned silently with no log line — only the inline path (a minority of real traffic, ~6 of 33 sampled calls) logged a "reply received" line with real latency.

## Architecture touched

- `orion/core/bus/async_service.py` — added one `logger.info("[rpc] reply received ... path=worker elapsed_ms=...")` call inside `rpc_request()`'s existing worker-path `try` block, mirroring the inline path's already-proven-safe pattern exactly. No behavior change, no new I/O, `except`/`finally` clauses unchanged.
- `scripts/analysis/measure_rpc_health_baseline.py` (new) — read-only, parses `docker logs` for a configurable service list, reconstructs each RPC call's lifecycle by `corr_id`, reports success-latency percentiles and timeout elapsed-time as two clearly separated sections (not blended — see Review findings below).

## Files changed

- `orion/core/bus/async_service.py`: worker-path completion logging.
- `tests/test_bus_async_rpc_worker.py`: new end-to-end regression test for the log line (ran 10x standalone during review, no flakiness).
- `scripts/analysis/measure_rpc_health_baseline.py` (new): the baseline script.
- `scripts/analysis/tests/test_measure_rpc_health_baseline.py` (new): 15 unit tests for the pure parsing/stats functions.

## Schema / bus / API changes

None. New log line only, never published to a bus channel.

## Tests run

```text
tests/test_bus_async_rpc_worker.py -- 6 passed (incl. new worker-path regression test)
scripts/analysis/tests/test_measure_rpc_health_baseline.py -- 15 passed
tests/test_bus_rpc_fork_client.py, test_bus_pubsub_timeout.py, test_bus_core_health_watchdog.py -- 52 passed (collateral check, no regressions)
20 total across the two primary files, all passing
```

## Live smoke checks (real production docker logs, read-only)

```text
Post-fix run (--since 24h): 8 real RPC calls, 6 success / 0 timeout / 2 unresolved
Success latency: p50 1492.1ms, p95 24111.8ms, p99 28589.0ms, max 29708.3ms
4 distinct real request channels observed (genuinely cross-service)

Earlier run (larger window, pre-conflation-fix): 36 calls across 5 channels,
23 success / 2 timeout (8.00% timeout rate) / 11 unresolved -- confirmed the
timeout-rate signal itself is real and meaningful, unlike transport_pressure's
permanent flat zero.
```

## Docker/build/smoke checks

Pure shared-library code change (`orion/core/bus/async_service.py`, imported by 37+ services) with no new dependencies, no port/env changes. Verified via 20 passing unit/integration tests plus live smoke runs against real running containers (`docker logs` from `orion-athena-cortex-exec`, `orion-athena-cortex-orch`, etc.) rather than a full per-service docker rebuild, since no service's compose file, Dockerfile, or dependency list changed.

## Review findings fixed

- Finding: `measure_rpc_health_baseline.py` blended timeout `elapsed_ms` (a caller's own configured `timeout_sec` ceiling, confirmed live to range 20s-1280s across real call sites) into the same "latency" series as real success round-trip time — the previously-reported "p95/p99 ~5-7 minutes on the worker path" was a timeout-ceiling artifact from a handful of long-timeout call sites, not real service slowness (verified: `420008.5ms` matched exactly a `timeout_sec=420.00` call site in the same log window).
  - Fix: split into `success_latency_ms_all`/`success_latency_by_path` (real round-trip time) and `timeout_elapsed_ms_all` (explicitly labeled "NOT latency" in the report, min/max only, no percentiles implying false precision). Re-ran live post-fix, confirmed honest numbers.
  - Evidence: commit `c8800718`.
- Finding: no formal before/after overhead benchmark for the new log line, per the design spec's Acceptance Checks.
  - Fix: disclosed explicitly in the code comment rather than silently absent; formal benchmark correctly scoped to the design spec's next patch step (the in-memory aggregator), not this commit, since that step is where a second per-call code path actually gets added.
  - Evidence: commit `c8800718`.
- No functional correctness bugs found: worker-path fix placement/exception-safety, test quality (10x flake check), regex correctness against fresh real log samples, UUID-stripping logic, and `fetch_container_logs`'s graceful-degradation behavior were all independently verified against live data, not just the commit's own claims.

## Restart required

```bash
docker compose --env-file .env --env-file services/<service>/.env -f services/<service>/docker-compose.yml up -d --build
```

`orion/core/bus/async_service.py` is a shared library imported by 37+ services — any service that imports `OrionBusAsync` should be rebuilt to pick up the new log line, but none is functionally required to restart (the change is additive logging only, not a behavior change). Not restarting anything is also safe.

The new analysis script (`scripts/analysis/measure_rpc_health_baseline.py`) is a standalone CLI tool — no restart needed, run manually whenever a fresh baseline reading is wanted.

## Risks / concerns

- Severity: Low
- Concern: none identified beyond the two findings above, both fixed.

## PR link

(added by gh pr create below)