### PR TITLE
docs: correct dead-consumer misdiagnosis, cross-reference RPC-health redesign

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -165,14 +165,19 @@ python orion/mood_arc/fit_encoder.py train \
   DLQ, **the only two real Redis Streams anywhere in the architecture** (everything else is
   pub/sub, which has no depth/backlog concept to measure). This is not general bus/transport
   health across services, despite the name — it's whether one specific service's result queue
-  backs up. Confirmed live: that queue has sat at a constant 91 unconsumed messages for the
-  entire post-second-cutoff corpus window (zero variance), so this contributor to the merge is
-  essentially always the smallest/least-surprising of the five, structurally, not because
-  transport is calm. See `services/orion-substrate-runtime/README.md`'s "transport domain scope"
-  note for the full trace. Doesn't change any cutoff or training recommendation above — flagged
-  so a future retrain's field-selection results for `prediction_error` aren't misread as "the
-  whole bus is healthy" when they're really "one queue is quiet, structurally the only thing
-  that can ever show up here."
+  backs up. Confirmed live: that queue has sat at a constant 91 messages for the entire
+  post-second-cutoff corpus window (zero variance) — **not** an unconsumed backlog (corrected
+  2026-07-23: `XINFO GROUPS` shows the real consumer group at `pending=0, lag=0`, fully caught
+  up; the Stream is simply never trimmed, so `XLEN` reflects lifetime message count since
+  2026-07-07, not a depth). Either way, this contributor to the merge is essentially always the
+  smallest/least-surprising of the five, structurally, not because transport is calm. See
+  `services/orion-substrate-runtime/README.md`'s "transport domain is one queue" note for the
+  full trace, including this correction and the redesign now in progress
+  (`docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`, PR #1290) —
+  not yet wired to feed `prediction_error` or any mood-arc training channel; flagged here so a
+  future retrain's field-selection results for `prediction_error` aren't misread as "the whole
+  bus is healthy" when they're really "one queue is quiet, structurally the only thing that can
+  ever show up here."
 - **`catalog_drift_pressure` is now a structurally dead channel going forward (found
   2026-07-23):** unlike `prediction_error`, this one is an actual member of `v2`'s (and
   presumably `v3`'s) 15 selected channels. It counts streams the bus-observer watches that

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -1074,6 +1074,13 @@ follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
   same single node channel, `transport_pressure`; `stream_depth_pressure`
   never appears under its own name in the corpus (confirmed `MISSING` in
   every row checked), it is folded into `transport_pressure` at the source.
+  **This is not a documented-and-abandoned problem** — a real replacement is
+  in progress, not a rename: see `services/orion-substrate-runtime/README.md`'s
+  "transport domain is one queue, not the bus" note for the correction to an
+  earlier (wrong) "dead consumer" theory, and
+  `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`
+  (PR #1290 shipped the first measurement step) for the redesign itself. Not
+  yet wired to replace this channel or feed the field-digester corpus.
 
 #### `contract_pressure`
 - **Meaning**: intended to represent pressure from bus/schema "contract"

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -320,10 +320,20 @@ short of it growing to tens of thousands of messages. Checked against the traini
 (2026-07-22T04:35:01Z, PR #1248's `mode="add"` fix), this same value was pinned at ~100,000 for 80%
 of the corpus's history — that saturation was the already-documented accumulation bug, not evidence
 this queue is normally busy. After the fix, it has been *exactly* 90 or 91, with zero movement, for
-the entire ~18h observed post-fix window — consistent with `orion:stream:world_pulse:run:result`
-having 91 messages sitting permanently unconsumed the whole time, not a healthy, actively-drained
-queue. Whether that backlog itself is expected (nobody reads this queue by design) or a dead
-consumer is a separate, not-yet-investigated question.
+the entire ~18h observed post-fix window.
+
+**Correction, 2026-07-23 — the "permanently unconsumed backlog" read above was wrong; do not carry
+it forward.** An earlier draft of this note speculated the constant 91 meant messages sitting
+unconsumed, with a dead consumer as an open question. Checked directly against the real consumer
+group and it's the opposite: `redis-cli -h <bus host> XINFO GROUPS
+orion:stream:world_pulse:run:result` → `cg:concept-induction`, `pending=0`, `lag=0` — every entry
+ever written has been read and acknowledged; the consumer is fully caught up, not stuck. The real
+explanation is simpler and more structural: this Stream has no `MAXLEN`/`XTRIM` policy, so `XLEN`
+returns the *cumulative message count since the stream's creation* (its oldest entry dates to
+2026-07-07), not a backlog depth. A perfectly healthy, zero-lag consumer and a genuinely dead one
+would produce an *identical* `XLEN` reading either way — this instrument cannot distinguish "backed
+up" from "healthy but never trimmed," independent of and in addition to the narrow single-queue
+scope problem above. Two compounding, separate defects, not one.
 
 **Update, 2026-07-23: the same root cause also governs the raw pressure channels, not just
 `prediction_error`.** `transport_pressure` (the raw current-level channel, distinct from
@@ -345,6 +355,21 @@ instruments, `orion/field/pressure.py::collect_field_channel_pressures()`) is al
 `field_channel_corpus.v1`'s trained mood-arc channels — this domain's contribution to that merge
 has the same narrow-scope caveat. See `orion/mood_arc/README.md` and this document's "fourth
 training-data quality cutoff" section for the corpus-facing side of this.
+
+**Redesign in progress, 2026-07-23 — this is not a documented-and-abandoned problem.**
+`docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md` proposes a real
+replacement rather than a rename: `OrionBusAsync.rpc_request()` (`orion/core/bus/async_service.py`)
+already times every RPC round-trip via `perf_counter()` and is called from 37+ files across nearly
+every real service — genuinely cross-service, unlike `BUS_OBSERVER_STREAMS`. First measurement step
+shipped (PR #1290): closed a logging gap where the common "worker" RPC path logged nothing on
+success (only timeouts were ever logged), then built `scripts/analysis/measure_rpc_health_baseline.py`
+to parse real `[rpc]` log lines into a latency/timeout baseline. Live-confirmed real, non-degenerate,
+genuinely cross-service variance (a real 8% timeout rate observed in one run; success-latency p50
+~1.5s, p95 in the tens of seconds, across 4-5 distinct real request channels) — the opposite of
+`transport_pressure`'s permanent flat zero. No schema, aggregator, or live-consumer wiring yet;
+that's explicitly sequenced for a later patch once more baseline data accumulates. The old
+`transport_pressure`/`bus_health`/etc. family's fate (rename vs. deprecate) remains undecided until
+then — do not assume this redesign has already replaced it.
 
 **Reverie semantic lift:** unresolved closures also upsert human referent rows into
 `substrate_turn_referent` via `turn_referent_store.persist_turn_referent`. Apply


### PR DESCRIPTION
## Summary

- Corrects a factual error that had propagated into two READMEs: world_pulse's result queue was documented as having "91 messages sitting permanently unconsumed... dead consumer" — checked directly this session (`XINFO GROUPS`, `pending=0, lag=0`) and found wrong. The real explanation is simpler: the Stream is never trimmed, so `XLEN` reflects lifetime message count, not backlog depth.
- Adds forward-pointers to the RPC-health redesign (docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md + PR #1290) in all three READMEs that document the old `transport_pressure` family's narrow-scope problem — previously none of them mentioned that a real replacement effort exists, making the documentation read like a dead end.

## Outcome moved

The mesh's documentation no longer repeats a disproven "dead consumer" theory, and a reader tracing the transport_pressure narrow-scope finding through any of these three READMEs now finds the active redesign work instead of a stale dead end.

## Files changed

- `services/orion-substrate-runtime/README.md`: corrected the dead-consumer claim (original source of the error), added the redesign cross-reference.
- `orion/mood_arc/README.md`: corrected the propagated copy of the same claim, added the redesign cross-reference.
- `services/orion-field-digester/README.md`: added the redesign cross-reference (this file didn't have the factual error, only the missing forward-pointer).

## Non-goals

No code changes. Does not decide the old `transport_pressure` family's fate (rename vs. deprecate) — still explicitly undecided, stated as such in all three files.

## Tests run

N/A — documentation only.

## Restart required

```text
No restart required.
```

## PR link

(added by gh pr create below)