### PR TITLE
docs(field-channel-glossary): register 5 FCC-motor channels

### DIFF
--- a/config/field/field_channel_glossary.v1.yaml
+++ b/config/field/field_channel_glossary.v1.yaml
@@ -1,6 +1,9 @@
-# Structured index of FieldStateV1's 29 raw digester channels (23 NODE_CHANNELS
+# Structured index of FieldStateV1's 34 raw digester channels (28 NODE_CHANNELS
 # + 8 CAPABILITY_CHANNELS in services/orion-field-digester/app/tensor/channels.py,
-# overlapping on transport_pressure/contract_pressure).
+# overlapping on transport_pressure/contract_pressure). 28 = 23 original + 5
+# FCC-motor channels added 2026-07-23 (harness_step_load,
+# tool_failure_streak_pressure, avg_step_chars_pressure, compliance_deficit,
+# turn_incompletion).
 #
 # This is the machine-readable companion to
 # services/orion-field-digester/README.md's "Field channel glossary" section,
@@ -106,6 +109,31 @@ channels:
     category: task_execution
     meaning: "1 - confidence that an execution's output actually reached its destination."
     self_state_dimension: introspection_pressure
+
+  - channel: harness_step_load
+    level: [node]
+    category: task_execution
+    meaning: "FCC-motor-only step-load proxy for one unified Hub turn, split out of execution_load (which blends cortex-exec + harness-governor step counts and hard-caps at 8) -- a compute/thermal/power cost proxy for how much processing one turn actually cost on the expensive GPU node running the motor."
+
+  - channel: tool_failure_streak_pressure
+    level: [node]
+    category: task_execution
+    meaning: "Is the FCC motor stuck repeating the same tool failure (e.g. a denied permission) instead of adapting, for one turn."
+
+  - channel: avg_step_chars_pressure
+    level: [node]
+    category: task_execution
+    meaning: "Per-step verbosity of the FCC motor's tool output for one turn."
+
+  - channel: compliance_deficit
+    level: [node]
+    category: task_execution
+    meaning: "Did the FCC motor actually produce a compliant, delivered turn -- HarnessRunV1.compliance_verdict rank (completed/partial/failed/refused), distinct from failure_pressure since a turn can resolve partial with zero individual tool-step failures."
+
+  - channel: turn_incompletion
+    level: [node]
+    category: task_execution
+    meaning: "Did Hub fail to get a usable result back from the harness-governor RPC for this turn at all -- the one unified-turn failure mode where no governor-side grammar event exists. A distinct, worse severity than compliance_deficit's worst rank."
 
   - channel: repair_pressure
     level: [node]

--- a/services/orion-hub/tests/test_field_channel_glossary_routes.py
+++ b/services/orion-hub/tests/test_field_channel_glossary_routes.py
@@ -71,11 +71,11 @@ def _fake_engine_with_rows(field_jsons: list[dict]):
     return fake_engine
 
 
-def test_channels_endpoint_returns_29_entries(client):
+def test_channels_endpoint_returns_34_entries(client):
     r = client.get("/api/field-channel-glossary/channels")
     assert r.status_code == 200
     body = r.json()
-    assert len(body["channels"]) == 29
+    assert len(body["channels"]) == 34
     assert len(body["categories"]) == 7
 
 

--- a/tests/test_field_channel_glossary.py
+++ b/tests/test_field_channel_glossary.py
@@ -12,10 +12,13 @@ from orion.field.channel_glossary import (
 )
 
 
-def test_load_glossary_has_29_channels_matching_field_digester_channels_py():
+def test_load_glossary_has_34_channels_matching_field_digester_channels_py():
+    """29 + the 5 FCC-motor channels added 2026-07-23 (harness_step_load,
+    tool_failure_streak_pressure, avg_step_chars_pressure, compliance_deficit,
+    turn_incompletion -- see docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md)."""
     glossary = load_glossary()
     entries = glossary["entries"]
-    assert len(entries) == 29
+    assert len(entries) == 34
     names = {e.channel for e in entries}
     assert "cpu_pressure" in names
     assert "reliability_pressure" in names


### PR DESCRIPTION
## Summary

Hub's live "Field Channels" tab was silently missing the 5 new FCC-motor channels shipped in #1285/#1287. Found while confirming the live audit's fix (#1289) was fully reflected end to end.

## Root cause

Hub's Field Channels tab (`#field-channel-glossary` in `templates/index.html`) and `services/orion-field-digester/README.md`'s glossary are two independent documentation surfaces. The tab reads from `config/field/field_channel_glossary.v1.yaml` via `GET /api/field-channel-glossary/channels`, not the README. The prior PRs only updated the README, so the live tab has been showing nothing for `harness_step_load`, `tool_failure_streak_pressure`, `avg_step_chars_pressure`, `compliance_deficit`, or `turn_incompletion` since deploy.

## Fix

Registers all 5 in the `task_execution` category (matching `execution_load`/`reasoning_load`/etc.'s existing category), with none of them yet feeding a `self_state_dimension`/`evidence_dimension` -- consistent with the README's "SelfState dimension fed: none yet" for all 5.

Updates two hardcoded channel-count assertions that exist specifically to catch this class of drift:
- `tests/test_field_channel_glossary.py::test_load_glossary_has_29_channels_matching_field_digester_channels_py` -> renamed to `..._has_34_channels...`
- `services/orion-hub/tests/test_field_channel_glossary_routes.py::test_channels_endpoint_returns_29_entries` -> renamed to `..._returns_34_entries`

Both were already correctly failing before this fix (confirmed) -- they exist precisely to catch a `channels.py` change that isn't mirrored in this yaml, which is exactly what happened.

## Tests run

```
pytest tests/test_field_channel_glossary.py -q
  -> 13 passed

cd services/orion-hub && pytest tests/test_field_channel_glossary_routes.py tests/test_field_channel_glossary_hub_tab.py -q
  -> 13 passed
```

## Restart required

```
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
```

(Only `orion-hub` needs a rebuild -- this yaml is read live by that service's route handler.)

## Risks / concerns

None -- pure additive config registration, no behavior change to any channel computation.

## PR link

(this PR)