### PR TITLE
fix(graph-compression): retire orion:chat:social from EpisodicFederator

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-social-episodic-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-social-episodic-pr.md
@@ -1,0 +1,81 @@
+# PR report: retire `orion:chat:social` from `EpisodicFederator`
+
+## Summary
+
+- Fourth in today's series of Fuseki-dependency retirements. Scoped narrower than the prior two `orion-graph-compression` PRs: `EpisodicFederator` itself stays live (still reads 8 other graphs), only its `orion:chat:social` graph entry is removed.
+- Live evidence: Fuseki's `orion:chat:social` holds ~154 triples / ~12 `SocialRoomTurn` nodes, metadata-only (no message text). Postgres `social_room_turns` already owns richer content (33 rows, real `prompt`/`response`/`text` columns) with zero other readers of the Fuseki copy anywhere in the repo. The underlying social-chat feature also looks near-dormant (latest Postgres row ~20 days stale relative to today).
+- A separate, already-live 2026-07-18 fix (`orion-meta-tags`) already writes social-turn tags/entities into the same `orion_recall` Falkor graph `episodic_falkor.py` reads -- but live Cypher queries found this thin (2 social-sourced `ChatTurn` nodes, zero tag/entity edges, vs 1,772 for `chat.history`). Disclosed as thin rather than overclaimed as full coverage, both in code comments and in the explicit tradeoff presented before implementing.
+- This was a genuine three-way judgment call (kill now / investigate the thin Falkor write first / leave alone), presented and confirmed explicitly rather than assumed.
+
+## Outcome moved
+
+`EpisodicFederator`'s SPARQL dependency narrows from 9 graphs to 8. Combined with today's other three PRs (`orion-recall`, `orion-vision-scribe`, and the two fully-retired graph-compression federators), the only remaining genuinely-open Fuseki dependency in `orion-graph-compression` is collapse/cognition/metacog content within the still-live `EpisodicFederator` -- cognition/metacog are already dead-writer/frozen-history (killed at the source in an earlier PR), leaving collapse as the one real remaining gap.
+
+## Current architecture
+
+Before this patch: `EpisodicFederator` unconditionally queried 9 named Fuseki graphs via UNION, including `orion:chat:social`.
+
+## Architecture touched
+
+- `services/orion-graph-compression/app/federators/{episodic.py,episodic_falkor.py}`, `app/worker.py`, `.env_example`, `README.md`, `tests/test_federator_episodic.py`
+
+## Files changed
+
+- `services/orion-graph-compression/app/federators/episodic.py`: removed `http://conjourney.net/graph/orion/chat/social` from `EPISODIC_GRAPHS` (9 -> 8 entries), with an explanatory comment citing the live evidence.
+- `services/orion-graph-compression/app/federators/episodic_falkor.py`: docstring correction -- previously claimed `orion:chat:social` "has no Falkor equivalent yet" (implying pending future work); now accurately describes it as retired outright, with the live-verified thin-Falkor-coverage numbers disclosed rather than glossed over.
+- `services/orion-graph-compression/app/worker.py`: review finding -- a comment at the `episodic` scope's Falkor-union call site still lumped "social" in with collapse/cognition/metacog as "no Falkor equivalent yet." Corrected: those three genuinely have none; social was retired, not pending.
+- `services/orion-graph-compression/.env_example`: same review finding, same fix, in `GRAPH_COMPRESSION_EPISODIC_FALKOR_ENABLED`'s comment (which explicitly cross-references the README section this PR already corrected -- was pointing readers at a section that would have contradicted it).
+- `services/orion-graph-compression/tests/test_federator_episodic.py`: generalized a docstring's "9 graphs" reference (the assertions themselves were already graph-count-agnostic, iterating `EPISODIC_GRAPHS` dynamically); added `test_episodic_federator_no_longer_queries_chat_social`, a regression test asserting the URI is absent -- confirmed by review to be the only thing actually pinning the graph count/membership (the pre-existing UNION-count test would still pass with 9 graphs).
+- `services/orion-graph-compression/README.md`: Compression Scopes table (8 graphs, noted the removal) and FalkorDB federators section (expanded explanation, live coverage numbers).
+
+Deliberately not touched (confirmed by review against the live repo state, not just asserted):
+- `orion-rdf-writer`'s own `SocialRoomTurn`/`SocialConceptEvidence` Fuseki write -- still writes there; this PR only stops graph-compression reading it back.
+- `stale_listener.py`'s `orion:chat:social` -> `episodic` mapping -- left in place, since the write itself is untouched and still real (unlike the fully-dead `self_study` mappings removed in an earlier PR today).
+- `orion-meta-tags`' social-turn Falkor tag/entity write -- pre-existing, unrelated to this session's work, untouched.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None (no new/removed/renamed keys -- comment-only edit to `.env_example`).
+
+## Tests run
+
+```text
+ORION_BUS_URL=redis://127.0.0.1:6379/0 PYTHONPATH=.:services/orion-graph-compression venv/bin/python3 -m pytest services/orion-graph-compression/tests -q
+-> 46 passed (45 + 1 new regression test)
+
+git diff --check -> clean
+```
+
+## Evals run
+
+No eval harness exists for this service; the new regression test plus the existing dynamic-count UNION test cover the changed behavior.
+
+## Docker/build/smoke checks
+
+No container rebuild/restart performed. Live evidence backing this decision (Fuseki triple counts, Postgres row counts/recency, live FalkorDB Cypher queries) was gathered directly against the running containers in this same session, prior to writing this diff.
+
+## Review findings fixed
+
+- Finding (should-fix, low): two comments outside the files this diff directly touches (`app/worker.py`'s `_process_scope` Falkor-union call site, `.env_example`'s `GRAPH_COMPRESSION_EPISODIC_FALKOR_ENABLED` comment) still described `orion:chat:social` as lumped with collapse/cognition/metacog under "no Falkor equivalent yet" -- implying it was pending future migration rather than retired outright. The `.env_example` instance was worse: it explicitly cross-referenced the README section this same PR had already rewritten to say the opposite, creating a direct self-contradiction for anyone following that reference.
+  - Fix: both corrected to match the framing already applied in `episodic.py`/`episodic_falkor.py`/`README.md` -- collapse/cognition/metacog genuinely have no Falkor equivalent; social was retired, not pending.
+  - Evidence: commit, same PR.
+- Informational (no fix needed, verified true): all three "deliberately not touched" claims (rdf-writer's write, stale_listener's mapping, meta-tags' Falkor write) confirmed accurate against direct inspection of the current repo state, not just trusted from the diff's own description.
+- Informational (no fix needed): no other file in the repo assumes `EpisodicFederator` covers 9 graphs or specifically covers `orion:chat:social`; no `CompressionRegionV1` consumer assumes episodic-scope clustering includes social-turn content specifically.
+
+## Restart required
+
+No restart required to merge. If `orion-athena-graph-compression` is redeployed from this branch/main, the next `episodic` scope tick will simply query one fewer graph -- no other behavior change.
+
+## Risks / concerns
+
+- Severity: Low.
+- Concern: social-turn clustering signal (already small: ~12 turns' worth of metadata) is now gone from the `episodic` scope entirely, with only the thin, disclosed Falkor coverage (2 nodes, 0 tag/entity edges today) standing in. If social-chat traffic picks back up meaningfully, this thin Falkor coverage may need real attention (either confirming the meta-tags write path fires correctly at volume, or building a dedicated migration) -- not urgent given the current near-dormant traffic pattern, but worth a fresh look if that changes.
+- Mitigation: disclosed explicitly in README.md and inline comments rather than silently assumed equivalent; easy to revisit later since nothing about this change is hard to reverse (Fuseki's `orion:chat:social` graph is untouched, just no longer read).
+
+## PR link
+
+(added after opening)

--- a/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-social-episodic-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-social-episodic-pr.md
@@ -78,4 +78,4 @@ No restart required to merge. If `orion-athena-graph-compression` is redeployed 
 
 ## PR link
 
-(added after opening)
+https://github.com/junebug-junie/Orion-Sapienform/pull/1297

--- a/services/orion-graph-compression/.env_example
+++ b/services/orion-graph-compression/.env_example
@@ -61,8 +61,10 @@ FALKORDB_RECALL_GRAPH=orion_recall
 # this key at all), matching every other Falkor-cutover flag's convention.
 GRAPH_COMPRESSION_SUBSTRATE_FALKOR_ENABLED=true
 # Still additive (unioned with the existing SPARQL EpisodicFederator, never a
-# swap) -- collapse/cognition/metacog/social have no Falkor equivalent yet,
-# see app/worker.py::_process_scope and README.md's federator section.
+# swap) -- collapse/cognition/metacog have no Falkor equivalent at all.
+# orion:chat:social was retired from the SPARQL side entirely 2026-07-23
+# (not "pending Falkor coverage" -- see app/worker.py::_process_scope and
+# README.md's federator section for the live-verified numbers).
 GRAPH_COMPRESSION_EPISODIC_FALKOR_ENABLED=false
 
 # --- LLM Gateway (region summarization) ---

--- a/services/orion-graph-compression/README.md
+++ b/services/orion-graph-compression/README.md
@@ -52,7 +52,7 @@ stale_listener.py   ──► stale_queue (Postgres)
 
 | Scope | Source | Region Kind |
 |-------|--------------|-------------|
-| `episodic` | SPARQL: 9 episodic named graphs (chat, enrichment, collapse, chat/social, autonomy/*). `orion:cognition`/`orion:metacog` are no longer written (2026-07-22: pure Postgres redundancy via orion-sql-writer, see rdf-writer's kill) -- still queried, will just read empty. Additively unioned with Falkor (see below). | `community` |
+| `episodic` | SPARQL: 8 episodic named graphs (chat, enrichment, collapse, autonomy/*). `orion:cognition`/`orion:metacog` are no longer written (2026-07-22: pure Postgres redundancy via orion-sql-writer, see rdf-writer's kill) -- still queried, will just read empty. `orion:chat:social` removed entirely 2026-07-23 (live-verified pure redundancy with Postgres `social_room_turns`, no other reader -- see federator section below). Additively unioned with Falkor (see below). | `community` |
 | `substrate` | FalkorDB only (`orion_substrate` graph). SPARQL `SubstrateFederator` retired 2026-07-23 -- see below. | `hotspot` |
 
 `self_study` was retired 2026-07-23 (previously read `orion:self`,
@@ -80,10 +80,25 @@ no clusters.
 **`GRAPH_COMPRESSION_EPISODIC_FALKOR_ENABLED`** (dark by default, still
 additive): results are **unioned** with the SPARQL `EpisodicFederator`'s
 output in `worker.py::_process_scope`, not swapped -- `episodic_falkor.py`
-covers only the `orion_recall` slice (ChatTurn/Tag/Entity); collapse/social
-have no Falkor writer yet and still depend on the SPARQL federator. Not
-retired -- this scope's SPARQL side is genuinely still load-bearing for
+covers only the `orion_recall` slice (ChatTurn/Tag/Entity); collapse has no
+Falkor writer yet and still depends on the SPARQL federator. Not retired --
+this scope's SPARQL side is genuinely still load-bearing for collapse
 content Falkor doesn't cover, unlike `substrate`/`self_study` above.
+
+`orion:chat:social` (social-turn content) was removed from the SPARQL
+federator's graph list entirely, 2026-07-23 -- not "covered by Falkor
+instead" so much as retired outright (live-verified pure redundancy with
+Postgres `social_room_turns`: richer schema including actual prompt/response
+text the Fuseki copy never had, no other reader anywhere). orion-meta-tags
+does write social-turn tags/entities into the same `orion_recall` graph
+`episodic_falkor.py` reads (unconditional for both `chat.history` and
+`social.turn.stored.v1` since 2026-07-18), but live-verified thin as of this
+writing (2 `social.turn.stored.v1` `ChatTurn` nodes, zero tag/entity edges,
+vs 1,772 for `chat.history`) -- disclosed here rather than overclaimed as
+equivalent coverage. Social-chat volume itself looks near-dormant (Postgres
+`social_room_turns`' most recent row predates this cutover by ~20 days), so
+this was judged low-risk to retire now rather than worth a dedicated
+migration effort.
 
 ## Bus Events
 

--- a/services/orion-graph-compression/app/federators/episodic.py
+++ b/services/orion-graph-compression/app/federators/episodic.py
@@ -13,7 +13,14 @@ EPISODIC_GRAPHS = [
     "http://conjourney.net/graph/orion/collapse",
     "http://conjourney.net/graph/orion/cognition",
     "http://conjourney.net/graph/orion/metacog",
-    "http://conjourney.net/graph/orion/chat/social",
+    # orion/chat/social removed 2026-07-23: live-verified pure redundancy.
+    # Postgres social_room_turns already owns richer content (33 rows,
+    # actual prompt/response/text -- the Fuseki triples were metadata-only,
+    # no text at all). Nothing else read this graph back. Social-turn
+    # tag/entity clustering signal is covered going forward by the
+    # already-live (if currently thin) Falkor write in orion-meta-tags
+    # (unconditional for both chat.history and social.turn.stored.v1 since
+    # 2026-07-18) via FalkorEpisodicFederator.
     # Autonomy graphs are written under graph/autonomy/* (NOT graph/orion/autonomy/*)
     # — see orion/autonomy/constants.py.
     "http://conjourney.net/graph/autonomy/identity",

--- a/services/orion-graph-compression/app/federators/episodic_falkor.py
+++ b/services/orion-graph-compression/app/federators/episodic_falkor.py
@@ -53,11 +53,22 @@ class FalkorEpisodicFederator:
     Covers what has a live Falkor writer today (orion-meta-tags' Entity/
     Tag/ChatTurn/CollapseEvent graph, ``orion_recall``). ``orion:cognition``/
     ``orion:metacog`` (Postgres-owned, no clustering value -- see the
-    rdf-writer kill this ships alongside) and ``orion:chat:social`` have no
-    Falkor equivalent yet and are not covered here -- the SPARQL
-    ``EpisodicFederator`` remains the source for those scopes until they get
-    their own Falkor writer. Degrades to an empty list on any error, matching
-    every other federator's fail-open contract.
+    rdf-writer kill this ships alongside) have no Falkor equivalent and
+    never had one; the SPARQL ``EpisodicFederator`` remains the source for
+    that content, such as it is (it's dead going forward, frozen history).
+
+    ``orion:chat:social`` was removed from the SPARQL federator's graph list
+    entirely 2026-07-23 (live-verified pure redundancy with Postgres
+    ``social_room_turns``, no other reader) -- it is not "covered" by this
+    Falkor federator so much as the whole scope's dependency on it was
+    retired. orion-meta-tags does write social-turn tags/entities into this
+    same query's underlying data (unconditional for both ``chat.history``
+    and ``social.turn.stored.v1`` since 2026-07-18), but live-verified thin
+    as of this writing (2 ``social.turn.stored.v1`` ChatTurn nodes, zero
+    HAS_TAG/MENTIONS_ENTITY edges between them, vs 1,772 for chat.history) --
+    disclosed here rather than overclaimed as equivalent coverage. Degrades
+    to an empty list on any error, matching every other federator's
+    fail-open contract.
     """
 
     def __init__(self, *, client: Optional[Any] = None) -> None:

--- a/services/orion-graph-compression/app/worker.py
+++ b/services/orion-graph-compression/app/worker.py
@@ -118,9 +118,14 @@ class CompressionWorker:
             if s.graph_compression_episodic_falkor_enabled:
                 # Additive, not a swap: FalkorEpisodicFederator only covers
                 # the orion_recall (ChatTurn/Tag/Entity) slice of what the
-                # SPARQL federator reads (collapse/cognition/metacog/social
-                # have no Falkor equivalent yet) -- union so verifying this
-                # live can never regress existing clustering signal.
+                # SPARQL federator reads (collapse/cognition/metacog have no
+                # Falkor equivalent at all). orion:chat:social was retired
+                # from the SPARQL side entirely 2026-07-23 -- not "pending
+                # Falkor coverage," just gone (live-verified pure redundancy
+                # with Postgres social_room_turns); see
+                # episodic_falkor.py's docstring for the live coverage
+                # numbers. Union so verifying the rest of this live can
+                # never regress existing clustering signal.
                 triples = list(set(triples) | set(FalkorEpisodicFederator().fetch()))
             kind = "community"
         elif scope == "substrate":

--- a/services/orion-graph-compression/tests/test_federator_episodic.py
+++ b/services/orion-graph-compression/tests/test_federator_episodic.py
@@ -3,7 +3,7 @@ import pytest
 
 
 def test_episodic_federator_builds_sparql_for_all_graphs():
-    """SPARQL query must reference all 9 episodic named graphs."""
+    """SPARQL query must reference every episodic named graph currently in scope."""
     with patch("httpx.Client") as mock_client_cls:
         from app.federators.episodic import EpisodicFederator, EPISODIC_GRAPHS
 
@@ -31,6 +31,15 @@ def test_episodic_federator_uses_non_orion_autonomy_graphs():
 
     assert "http://conjourney.net/graph/autonomy/identity" in EPISODIC_GRAPHS
     assert "http://conjourney.net/graph/orion/autonomy/identity" not in EPISODIC_GRAPHS
+
+
+def test_episodic_federator_no_longer_queries_chat_social():
+    """Regression for the 2026-07-23 retirement: orion:chat:social was
+    removed (live-verified pure redundancy with Postgres social_room_turns,
+    zero other readers) -- must not silently reappear in the graph list."""
+    from app.federators.episodic import EPISODIC_GRAPHS
+
+    assert "http://conjourney.net/graph/orion/chat/social" not in EPISODIC_GRAPHS
 
 
 def test_episodic_federator_drops_literal_objects():


### PR DESCRIPTION
## Summary

- Live-verified: Fuseki's `orion:chat:social` graph holds ~154 triples / ~12 SocialRoomTurn nodes, metadata-only (no message text at all). Postgres `social_room_turns` already owns richer content (33 rows, real prompt/response text), zero other readers of the Fuseki copy anywhere.
- The underlying feature looks near-dormant (latest Postgres row ~20 days stale).
- A separate already-live meta-tags fix writes social-turn tags/entities to Falkor, but live queries found it thin (2 nodes, 0 tag/entity edges vs 1,772 for chat.history) -- disclosed as such, not overclaimed.
- `EpisodicFederator` itself stays live for its other 8 graphs (collapse/cognition/metacog/autonomy) -- only this one dead graph was removed.
- Review caught 2 stale comments elsewhere in the service still implying social was "pending Falkor migration" rather than retired -- both fixed.

Full report: `docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-social-episodic-pr.md`

## Test plan

- [x] `pytest services/orion-graph-compression/tests -q` -> 46 passed
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)