### PR TITLE
docs(design): note chat_turn implementation shipped as PR #1291

### DIFF
--- a/docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md
+++ b/docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md
@@ -1041,3 +1041,26 @@ The `chat_turn` gate itself is now real, scoped, and only blocked on the cost/fa
 (`orion-actions`' journal path) having a real answer, on top of the pre-existing open questions 1-4
 (TTL, threshold, and the `orion_metacog`-vs-`orion_metacognitive_trace` fate question — question 3
 is now moot). This section is the spec to react to, not yet a green light.
+
+### Implemented (2026-07-23) — PR #1291
+
+Built per this spec, `services/orion-equilibrium-service/app/chat_turn_metacog_gate.py` +
+`service.py` wiring. Ships **disabled** (`EQUILIBRIUM_METACOG_CHAT_TURN_TRIGGER_ENABLE=false`).
+
+One real correction found during implementation that this spec's question 1 didn't fully cover:
+`run_artifact` never arrives on **two** short-circuit paths in `orion/hub/turn_orchestrator.py`, not
+one. The already-discussed one is `thought.disposition in ("defer", "refuse")`. Code review
+(orion-repo-agent) caught a second, earlier one this spec missed entirely: the `if thought is None:`
+branch, when `ThoughtClient.react()` itself never returns to Hub. That path also short-circuits
+before the harness governor is ever called, and it already publishes a real signal this design
+didn't know to read — `orion:grammar:event`, `semantic_role="stance_disposition"`,
+`text_value="stance_timeout"` (same `_publish_unified_turn_chat_grammar` call site as every other
+stance_disposition atom). The shipped gate treats both this and Patch B's `exec_turn_timeout` as
+terminal timeout evidence (`timeout_reason` distinguishes which). Without this fix, a turn where
+Orion's own reasoning step failed to respond in time would have silently expired via the correlator
+TTL with zero `chat_turn` trigger — the single most severe turn outcome this trigger exists to catch.
+
+Acceptance checks from this spec are implemented as unit tests
+(`services/orion-equilibrium-service/tests/test_chat_turn_metacog_gate.py`, 39 tests) except the
+live-data check (`orion_metacog` rows with real, non-degenerate `upstream`), which can't run until
+the flag is enabled. See PR #1291 for the full review trail.


### PR DESCRIPTION
## Summary

- Re-lands a commit that was mistakenly pushed to the already-merged `docs/chat-turn-metacog-trigger-spec` branch (PR #1279) instead of a fresh branch -- GitHub does not reopen a merged PR or auto-create a new one when a branch gets more commits after merge, so that commit sat orphaned, attached to nothing, never actually reviewable or landed on `main`.
- Cherry-picked cleanly (no conflicts) onto a fresh branch off current `main`. Content unchanged from the original commit.
- Appends a short "Implemented (2026-07-23) — PR #1291" note to the `chat_turn` trigger spec section of `docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md`, recording the one real gap found during implementation that the spec's original question 1 didn't cover: `run_artifact` never arrives on a second short-circuit path in `orion/hub/turn_orchestrator.py` (`if thought is None:`, the earlier `ThoughtClient.react()` RPC itself timing out), not just the already-discussed defer/refuse disposition case.

## Outcome moved

Closes the process gap: the design doc now correctly reflects that `chat_turn` shipped, and the note explaining what was found during implementation vs. what the original spec assumed is preserved and reviewable.

## Current architecture

`docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md`'s `chat_turn` spec section ended at "This section is the spec to react to, not yet a green light" with no record that implementation (PR #1291) had actually happened.

## Architecture touched

Docs only.

## Files changed

- `docs/superpowers/design/2026-07-18-collapse-mirror-metacog-redesign.md`: +23 lines, new "Implemented (2026-07-23) — PR #1291" subsection.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

N/A -- docs-only change.

## Evals run

N/A.

## Docker/build/smoke checks

N/A.

## Review findings fixed

N/A -- this PR only re-lands an already-written, small doc commit; no new review needed for a docs-only cherry-pick.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: none
  - Concern: the doc still says "Ships **disabled**" (`EQUILIBRIUM_METACOG_CHAT_TURN_TRIGGER_ENABLE=false`), which was accurate when this note was originally written but is now mid-flip -- PR #1298 changes the default to `true` and is still open.
  - Mitigation: not editing further here to keep this PR a pure re-land of the orphaned commit; PR #1298's own description covers the flag-flip status.

## PR link

(filled in by `gh pr create`)