### PR TITLE
feat(substrate): L6 self-model items 3+4 -- Active Inference confidence + predicted_shift

### DIFF
--- a/orion/schemas/attention_self_model.py
+++ b/orion/schemas/attention_self_model.py
@@ -38,10 +38,14 @@ class AttentionSelfModelV1(BaseModel):
       `substrate_attention_broadcast_projection` (confirmed live 2026-07-18:
       PK on `projection_id`, exactly one row at any time) — there is no
       per-tick history for this lane, only the most recent snapshot.
-    - The general field lane (Layer 5/6): `FieldAttentionFrameV1` +
-      `SelfStateV1`, updated on a continuous ~2s tick by
-      `orion-attention-runtime`, with real per-tick history in
-      `substrate_attention_frames` / `substrate_self_state`.
+    - The general field lane (Layer 5/6): `FieldAttentionFrameV1`, updated on
+      a continuous ~2s tick by `orion-attention-runtime`, with real per-tick
+      history in `substrate_attention_frames`. **2026-07-23: this lane's
+      `SelfStateV1` co-input was removed** (that producer no longer exists,
+      PR #1266) and replaced with the five real Active-Inference domains'
+      `prediction_error` signal (`orion/substrate/prediction_error.py`) —
+      see `orion/substrate/attention_self_model.py`'s module docstring for
+      the full account.
 
     This is a read-only measurement artifact (Phase 1 scope). It is not
     published to any bus channel and not consumed by any live decision path —
@@ -86,5 +90,3 @@ class AttentionSelfModelV1(BaseModel):
     # salient" — never silently collapsed into the same output.
     broadcast_lane_stale: bool = True
     broadcast_lane_age_sec: float | None = None
-
-    self_state_present: bool = False

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -1,9 +1,9 @@
 """AST/HOT attention self-model reducer — rung 4 (read-only, Phase 1).
 
-Pure function, no I/O. Takes the three already-parsed real inputs and
-returns one `AttentionSelfModelV1` answering: what's currently salient, what
-was last dispatched, *why* (top-down goal bias vs. pure bottom-up salience —
-the "aboutness" claim AST/HOT instrumentation needs to make honestly), how
+Pure function, no I/O. Takes the already-parsed real inputs and returns one
+`AttentionSelfModelV1` answering: what's currently salient, what was last
+dispatched, *why* (top-down goal bias vs. pure bottom-up salience — the
+"aboutness" claim AST/HOT instrumentation needs to make honestly), how
 confident, and what's predicted to shift next.
 
 Mirrors `scripts/analysis/measure_origination_gate.py`'s separation of a pure
@@ -18,6 +18,25 @@ Phase 1: the reducer must be measured against real historical data
 (`scripts/analysis/measure_ast_hot_reducer.py`) before anything downstream
 consumes it, matching the program charter's own "measure before minting"
 process rule (sec 7).
+
+**2026-07-23: `SelfStateV1` input removed, replaced with Active-Inference
+substrate.** `predicted_shift`/`confidence`'s `self_state` fallback read a
+producer that no longer exists (`orion/self_state/` was deleted, PR #1266;
+`orion-athena-self-state-runtime` was confirmed stopped same-day per
+`docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-
+design.md`'s Missing Question 1). Per that design doc's items 3/4: confidence
+is now the inverse of aggregate prediction-error volatility across the five
+real, live Predictive-Processing domains (execution/transport/biometrics/
+chat/route -- `orion/substrate/prediction_error.py`), and predicted_shift now
+names whichever domain's prediction-error is trending fastest, instead of a
+hand-tuned `SelfStateV1` dimension. Both are supplied by the caller as
+already-computed dicts (`prediction_error_by_domain`,
+`prediction_error_trend_by_domain`) -- this function stays a pure formatter/
+aggregator over them, matching its own "no I/O, no store coupling" design for
+every other input here. `self_state_present`/`self_state` are gone from both
+this signature and `AttentionSelfModelV1` -- not deprecated in place, removed
+(this repo's own "kill means kill" convention: no fallback to the thing being
+killed).
 """
 
 from __future__ import annotations
@@ -27,7 +46,6 @@ from datetime import datetime, timezone
 from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
 from orion.schemas.attention_self_model import AttentionSelfModelV1
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1
-from orion.schemas.self_state import SelfStateV1
 
 # 2x the live ORION_ATTENTION_BROADCAST_INTERVAL_SEC default (30s, confirmed
 # live 2026-07-18 via `docker exec orion-athena-substrate-runtime env`) —
@@ -40,25 +58,65 @@ def _round_or_none(value: float | None, digits: int = 4) -> float | None:
     return None if value is None else round(float(value), digits)
 
 
+def _aggregate_prediction_error_confidence(
+    prediction_error_by_domain: dict[str, float],
+) -> tuple[float, str]:
+    """mean(), not max(): item 1/2 above already surface the single loudest
+    domain via dynamic_pressure-driven attention selection (see
+    `orion/substrate/attention_broadcast.py`), so a max()-based confidence
+    here would be a redundant, same-sensor restatement of what attention
+    selection already answers -- CLAUDE.md's metric-quality-gate
+    independence check. mean() answers a genuinely different question
+    (overall systemic stability across every domain right now, not just the
+    worst one) at the cost of being diluted by domains with little real
+    signal. Confirmed against live data (2026-07-23, 6h window,
+    `substrate_field_state`): biometrics carries almost all the real
+    variance (mean=0.037, max=0.62); execution/chat/route are real but tiny
+    (means ~1e-5); transport reads exactly 0.0 for the entire window (its
+    documented single-queue narrow scope -- see
+    `services/orion-substrate-runtime/README.md`'s "transport domain is one
+    queue" note). This mean() is real and non-degenerate (it visibly moves
+    with biometrics activity) but heavily damped by the other four domains'
+    near-silence -- an honest, disclosed limitation, not a hidden one.
+    """
+    values = list(prediction_error_by_domain.values())
+    mean_error = sum(values) / len(values)
+    # Symmetric clamp: every real producer in prediction_error.py only ever emits
+    # min(1.0, ...) (non-negative), but this is a general-purpose function over an
+    # arbitrary caller-supplied dict -- an out-of-range (e.g. negative) input must
+    # not silently produce confidence > 1.0. Found in code review (live-reproduced:
+    # a single -0.5 domain value produced confidence=1.5, outside
+    # AttentionSelfModelV1.confidence's own declared [0,1] range, which Pydantic v2
+    # does not re-check on plain attribute assignment).
+    mean_error = max(0.0, min(1.0, mean_error))
+    confidence = 1.0 - mean_error
+    domains = ", ".join(sorted(prediction_error_by_domain))
+    basis = (
+        f"1 - mean(prediction_error) across {len(values)} domains ({domains}) "
+        "(broadcast lane stale/absent)"
+    )
+    return confidence, basis
+
+
 def reduce_attention_self_model(
     broadcast: AttentionBroadcastProjectionV1 | None,
     field_frame: FieldAttentionFrameV1 | None,
-    self_state: SelfStateV1 | None,
     *,
     now: datetime | None = None,
     broadcast_stale_threshold_sec: float = DEFAULT_BROADCAST_STALE_THRESHOLD_SEC,
     harness_closure_signal: dict | None = None,
+    prediction_error_by_domain: dict[str, float] | None = None,
+    prediction_error_trend_by_domain: dict[str, float] | None = None,
 ) -> AttentionSelfModelV1:
     """Unify the GWT-dispatch lane and the general field lane into one
-    inspectable AST/HOT self-model. Never raises: any of the three inputs may
-    be `None` (partial data honestly represented, not a crash).
+    inspectable AST/HOT self-model. Never raises: any input may be `None`
+    (partial data honestly represented, not a crash).
 
     `now` is the reference tick this self-model is being generated *for* —
     normally the field-lane tick's own `generated_at` (the highest-frequency
     real signal, so it drives the replay/live cadence per the Phase 1 design).
-    Falls back to `self_state.generated_at`, then `broadcast.generated_at`,
-    then wall-clock `datetime.now(timezone.utc)` if none of the three inputs
-    are present.
+    Falls back to `broadcast.generated_at`, then wall-clock
+    `datetime.now(timezone.utc)` if neither input is present.
 
     `harness_closure_signal` is an optional, intentionally-minimal plain dict
     -- `{"prediction_error": float, "contributing_turn_ids": list[str]}` --
@@ -74,12 +132,31 @@ def reduce_attention_self_model(
     `attention_reason` itself, and every other branch (`top_down_override`,
     `bottom_up_salience`) ignores it entirely. Omitting this argument (the
     default) reproduces today's narrative byte-for-byte.
+
+    `prediction_error_by_domain` is an optional, caller-supplied snapshot of
+    the current raw `prediction_error` value for each of the five real
+    Predictive-Processing domains (`{"execution": 0.0001, "transport": 0.0,
+    "biometrics": 0.0459, "chat": ..., "route": ...}` -- keys are whatever
+    the caller has data for; missing domains are simply absent, not
+    defaulted to 0.0). Drives `confidence` in the `field_salience_only`
+    branch (see `_aggregate_prediction_error_confidence`). Omitting this
+    argument falls back to the pre-existing
+    `field_attention_frame.dominant_targets[].confidence_score` mean.
+
+    `prediction_error_trend_by_domain` is an optional, caller-supplied dict
+    of each domain's recent prediction-error *trend* (already computed
+    upstream -- e.g. mean(recent ticks) - mean(prior ticks); this function
+    does no time-series math of its own, matching its "no I/O, format what's
+    given" design). Drives `predicted_shift`: whichever domain has the
+    largest-magnitude trend is named as the honest candidate for "what
+    surprises me next" -- mirroring the argmax-over-a-delta-dict shape the
+    old `self_state.dimension_trajectory` branch used, just over real
+    Active-Inference domains instead of a dead `SelfStateV1` dimension.
     """
 
     reference_ts = (
         now
         or (field_frame.generated_at if field_frame is not None else None)
-        or (self_state.generated_at if self_state is not None else None)
         or (broadcast.generated_at if broadcast is not None else None)
         or datetime.now(timezone.utc)
     )
@@ -94,26 +171,26 @@ def reduce_attention_self_model(
         model.field_overall_salience = _round_or_none(field_frame.overall_salience)
         model.field_salient_target_ids = [t.target_id for t in field_frame.dominant_targets]
 
-    # --- Self-state: predicted shift + a confidence fallback ---------------
-    if self_state is not None:
-        model.self_state_present = True
-        top_drift_dim: str | None = None
-        top_drift_val = 0.0
-        for dim_id, delta in (self_state.dimension_trajectory or {}).items():
-            if abs(delta) > abs(top_drift_val):
-                top_drift_dim, top_drift_val = dim_id, delta
-        if self_state.trajectory_condition != "unknown":
-            if top_drift_dim is not None:
-                model.predicted_shift = (
-                    f"trajectory={self_state.trajectory_condition}; "
-                    f"largest-moving dimension={top_drift_dim} (delta={top_drift_val:+.3f})"
-                )
-                model.predicted_shift_basis = (
-                    "self_state.trajectory_condition + self_state.dimension_trajectory"
-                )
-            else:
-                model.predicted_shift = f"trajectory={self_state.trajectory_condition}"
-                model.predicted_shift_basis = "self_state.trajectory_condition"
+    # --- Predicted shift: whichever domain's prediction-error is trending --
+    # fastest right now (Active Inference), replacing the dead
+    # self_state.dimension_trajectory fallback. Computed unconditionally
+    # (not gated on which attention_reason branch fires below), matching the
+    # old self_state block's own positioning.
+    if prediction_error_trend_by_domain:
+        top_domain: str | None = None
+        top_trend_val = 0.0
+        for domain, trend in prediction_error_trend_by_domain.items():
+            if abs(trend) > abs(top_trend_val):
+                top_domain, top_trend_val = domain, trend
+        if top_domain is not None and top_trend_val != 0.0:
+            direction = "rising" if top_trend_val > 0 else "falling"
+            model.predicted_shift = (
+                f"{top_domain} prediction-error {direction} "
+                f"(trend={top_trend_val:+.4f} over recent window)"
+            )
+            model.predicted_shift_basis = (
+                "prediction_error_trend_by_domain (Active Inference, argmax by |trend|)"
+            )
 
     # --- Broadcast lane: what was last dispatched + cadence-mismatch state -
     broadcast_age_sec: float | None = None
@@ -181,11 +258,12 @@ def reduce_attention_self_model(
             f"Pure bottom-up dispatch: '{model.broadcast_selected_open_loop_id}' "
             f"selected by salience alone; no active goal override at this tick."
         )
-    elif model.field_lane_present or model.self_state_present:
+    elif model.field_lane_present or prediction_error_by_domain or prediction_error_trend_by_domain:
         model.attention_reason = "field_salience_only"
-        if self_state is not None:
-            model.confidence = _round_or_none(self_state.overall_confidence)
-            model.confidence_basis = "self_state.overall_confidence (broadcast lane stale/absent)"
+        if prediction_error_by_domain:
+            confidence, basis = _aggregate_prediction_error_confidence(prediction_error_by_domain)
+            model.confidence = _round_or_none(confidence)
+            model.confidence_basis = basis
         elif field_frame is not None and field_frame.dominant_targets:
             scores = [t.confidence_score for t in field_frame.dominant_targets]
             model.confidence = _round_or_none(sum(scores) / len(scores))

--- a/orion/substrate/tests/test_attention_self_model.py
+++ b/orion/substrate/tests/test_attention_self_model.py
@@ -10,7 +10,6 @@ from orion.schemas.attention_frame import (
     VoluntaryOverrideV1,
 )
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
-from orion.schemas.self_state import SelfStateV1
 from orion.substrate.attention_self_model import (
     DEFAULT_BROADCAST_STALE_THRESHOLD_SEC,
     reduce_attention_self_model,
@@ -73,27 +72,23 @@ def _field_frame(*, generated_at: datetime = NOW, overall_salience: float = 0.7)
     )
 
 
-def _self_state(*, generated_at: datetime = NOW, overall_confidence: float = 0.55) -> SelfStateV1:
-    return SelfStateV1(
-        self_state_id="self-state-1",
-        generated_at=generated_at,
-        source_field_tick_id="tick-1",
-        source_field_generated_at=generated_at,
-        source_attention_frame_id="field-frame-1",
-        source_attention_generated_at=generated_at,
-        overall_condition="steady",
-        overall_intensity=0.5,
-        overall_confidence=overall_confidence,
-        trajectory_condition="improving",
-        dimension_trajectory={"coherence": 0.12, "uncertainty": -0.04},
-    )
+def _prediction_error_by_domain(**overrides: float) -> dict[str, float]:
+    base = {
+        "execution": 0.0001,
+        "transport": 0.0,
+        "biometrics": 0.0459,
+        "chat": 0.0,
+        "route": 0.0,
+    }
+    base.update(overrides)
+    return base
 
 
 class TestVoluntaryOverridePresent:
     def test_override_present_narrates_top_down_reason(self) -> None:
         override = _override()
         broadcast = _broadcast(override=override)
-        model = reduce_attention_self_model(broadcast, _field_frame(), _self_state(), now=NOW)
+        model = reduce_attention_self_model(broadcast, _field_frame(), now=NOW)
 
         assert model.attention_reason == "top_down_override"
         assert model.voluntary_override is not None
@@ -106,7 +101,7 @@ class TestVoluntaryOverridePresent:
 
     def test_override_absent_narrates_bottom_up_reason(self) -> None:
         broadcast = _broadcast(override=None)
-        model = reduce_attention_self_model(broadcast, _field_frame(), _self_state(), now=NOW)
+        model = reduce_attention_self_model(broadcast, _field_frame(), now=NOW)
 
         assert model.attention_reason == "bottom_up_salience"
         assert model.voluntary_override is None
@@ -117,7 +112,7 @@ class TestVoluntaryOverridePresent:
 class TestCadenceMismatch:
     def test_fresh_broadcast_is_not_stale(self) -> None:
         broadcast = _broadcast(generated_at=NOW - timedelta(seconds=5))
-        model = reduce_attention_self_model(broadcast, _field_frame(), None, now=NOW)
+        model = reduce_attention_self_model(broadcast, _field_frame(), now=NOW)
 
         assert model.broadcast_lane_stale is False
         assert model.broadcast_lane_age_sec == pytest.approx(5.0, abs=0.01)
@@ -126,7 +121,10 @@ class TestCadenceMismatch:
     def test_stale_broadcast_is_distinct_from_nothing_salient(self) -> None:
         stale_age = DEFAULT_BROADCAST_STALE_THRESHOLD_SEC + 30.0
         broadcast = _broadcast(generated_at=NOW - timedelta(seconds=stale_age))
-        model = reduce_attention_self_model(broadcast, _field_frame(), _self_state(), now=NOW)
+        model = reduce_attention_self_model(
+            broadcast, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
 
         assert model.broadcast_lane_stale is True
         assert model.broadcast_lane_age_sec == pytest.approx(stale_age, abs=0.01)
@@ -144,7 +142,7 @@ class TestCadenceMismatch:
         # data for that moment -- must not silently reuse a snapshot from
         # later in time as if it applied retroactively.
         broadcast = _broadcast(generated_at=NOW + timedelta(seconds=10))
-        model = reduce_attention_self_model(broadcast, _field_frame(), None, now=NOW)
+        model = reduce_attention_self_model(broadcast, _field_frame(), now=NOW)
 
         assert model.broadcast_lane_present is False
         assert model.broadcast_lane_age_sec is None
@@ -154,26 +152,24 @@ class TestCadenceMismatch:
 
 class TestPartialData:
     def test_all_none_is_no_data_not_a_crash(self) -> None:
-        model = reduce_attention_self_model(None, None, None)
+        model = reduce_attention_self_model(None, None)
 
         assert model.attention_reason == "no_data"
         assert model.field_lane_present is False
         assert model.broadcast_lane_present is False
-        assert model.self_state_present is False
         assert model.voluntary_override is None
         assert model.reason_narrative == "No attention data available from either lane."
 
     def test_only_broadcast_present(self) -> None:
         broadcast = _broadcast(override=_override())
-        model = reduce_attention_self_model(broadcast, None, None, now=NOW)
+        model = reduce_attention_self_model(broadcast, None, now=NOW)
 
         assert model.field_lane_present is False
-        assert model.self_state_present is False
         assert model.attention_reason == "top_down_override"
-        assert model.predicted_shift is None  # no self_state -> honestly absent, not invented
+        assert model.predicted_shift is None  # no trend data -> honestly absent, not invented
 
     def test_only_field_frame_present(self) -> None:
-        model = reduce_attention_self_model(None, _field_frame(), None, now=NOW)
+        model = reduce_attention_self_model(None, _field_frame(), now=NOW)
 
         assert model.broadcast_lane_present is False
         assert model.field_lane_present is True
@@ -182,45 +178,154 @@ class TestPartialData:
             "mean(field_attention_frame.dominant_targets"
         )
 
-    def test_only_self_state_present(self) -> None:
-        model = reduce_attention_self_model(None, None, _self_state(), now=NOW)
+    def test_only_prediction_error_by_domain_present(self) -> None:
+        model = reduce_attention_self_model(
+            None, None, now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
 
-        assert model.self_state_present is True
+        assert model.field_lane_present is False
         assert model.attention_reason == "field_salience_only"
-        assert model.confidence_basis == "self_state.overall_confidence (broadcast lane stale/absent)"
+        assert model.confidence_basis.startswith("1 - mean(prediction_error)")
+
+    def test_only_prediction_error_trend_present_is_not_no_data(self) -> None:
+        """Regression guard (found in code review): trend-only input used to
+        leave attention_reason == "no_data" (reason_narrative claiming "No
+        attention data available from either lane") while predicted_shift
+        was simultaneously populated with a real, substantive prediction --
+        a self-contradictory output CLAUDE.md's "no empty-shell cognition"
+        rule bans. Must now honestly reflect that real data is present."""
+        model = reduce_attention_self_model(
+            None, None, now=NOW,
+            prediction_error_trend_by_domain={"biometrics": 0.3},
+        )
+
+        assert model.attention_reason != "no_data"
         assert model.predicted_shift is not None
-        assert "coherence" in model.predicted_shift
+        assert "No attention data available" not in model.reason_narrative
+
+
+class TestPredictionErrorConfidence:
+    def test_low_stable_prediction_error_yields_high_confidence(self) -> None:
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        # mean of {0.0001, 0.0, 0.0459, 0.0, 0.0} = 0.0092
+        assert model.confidence == pytest.approx(1.0 - 0.0092, abs=1e-4)
+        assert "5 domains" in model.confidence_basis
+        assert "biometrics" in model.confidence_basis
+
+    def test_several_domains_surprising_at_once_lowers_confidence(self) -> None:
+        calm = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        surprised = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(
+                execution=0.6, chat=0.5, route=0.4,
+            ),
+        )
+        assert surprised.confidence < calm.confidence
+
+    def test_confidence_never_goes_negative_at_extreme_error(self) -> None:
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(
+                execution=5.0, transport=5.0, biometrics=5.0, chat=5.0, route=5.0,
+            ),
+        )
+        assert model.confidence == pytest.approx(0.0)
+
+    def test_empty_prediction_error_dict_falls_back_to_field_frame_confidence(self) -> None:
+        """An empty dict (falsy) must behave exactly like omitting the
+        argument -- no ZeroDivisionError from dividing by len({})."""
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain={},
+        )
+        assert model.confidence_basis.startswith("mean(field_attention_frame.dominant_targets")
+
+    def test_negative_input_does_not_push_confidence_above_one(self) -> None:
+        """Regression guard (found in code review): every real producer in
+        prediction_error.py only ever emits non-negative values, but this
+        function takes an arbitrary caller-supplied dict with no input-range
+        assertion -- a negative value must not silently produce
+        confidence > 1.0 (AttentionSelfModelV1.confidence's own declared
+        range, which Pydantic v2 does not re-check on plain attribute
+        assignment)."""
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(biometrics=-0.5),
+        )
+        assert model.confidence <= 1.0
 
 
 class TestPredictedShift:
-    def test_uses_real_self_state_trajectory_fields_not_invented(self) -> None:
-        state = _self_state()
-        model = reduce_attention_self_model(None, None, state, now=NOW)
+    def test_uses_real_prediction_error_trend_not_invented(self) -> None:
+        model = reduce_attention_self_model(
+            None, None, now=NOW,
+            prediction_error_trend_by_domain={
+                "execution": 0.001, "biometrics": 0.18, "chat": -0.02,
+            },
+        )
 
         assert model.predicted_shift_basis == (
-            "self_state.trajectory_condition + self_state.dimension_trajectory"
+            "prediction_error_trend_by_domain (Active Inference, argmax by |trend|)"
         )
-        assert "trajectory=improving" in model.predicted_shift
+        assert "biometrics" in model.predicted_shift
+        assert "rising" in model.predicted_shift
 
-    def test_unknown_trajectory_yields_no_prediction(self) -> None:
-        state = _self_state()
-        state = state.model_copy(update={"trajectory_condition": "unknown", "dimension_trajectory": {}})
-        model = reduce_attention_self_model(None, None, state, now=NOW)
+    def test_falling_trend_is_named_as_falling(self) -> None:
+        model = reduce_attention_self_model(
+            None, None, now=NOW,
+            prediction_error_trend_by_domain={"route": -0.3, "execution": 0.01},
+        )
+
+        assert "route" in model.predicted_shift
+        assert "falling" in model.predicted_shift
+
+    def test_no_trend_data_yields_no_prediction(self) -> None:
+        model = reduce_attention_self_model(None, None, now=NOW)
 
         assert model.predicted_shift is None
         assert model.predicted_shift_basis == ""
 
+    def test_all_zero_trend_yields_no_prediction(self) -> None:
+        model = reduce_attention_self_model(
+            None, None, now=NOW,
+            prediction_error_trend_by_domain={"execution": 0.0, "chat": 0.0},
+        )
+
+        assert model.predicted_shift is None
+
+    def test_predicted_shift_computed_independent_of_attention_reason_branch(self) -> None:
+        """The old self_state-driven predicted_shift was computed
+        unconditionally, before the attention_reason branching -- the new
+        trend-based version must preserve that positioning: it should be set
+        even when a top_down_override wins the reason branch."""
+        broadcast = _broadcast(override=_override())
+        model = reduce_attention_self_model(
+            broadcast, _field_frame(), now=NOW,
+            prediction_error_trend_by_domain={"biometrics": 0.2},
+        )
+
+        assert model.attention_reason == "top_down_override"
+        assert model.predicted_shift is not None
+        assert "biometrics" in model.predicted_shift
+
 
 def test_reference_tick_defaults_to_field_frame_generated_at() -> None:
     field_frame = _field_frame(generated_at=NOW)
-    model = reduce_attention_self_model(None, field_frame, None)
+    model = reduce_attention_self_model(None, field_frame)
 
     assert model.generated_at == NOW
 
 
-def test_reference_tick_falls_back_to_self_state_when_no_field_frame() -> None:
-    state = _self_state(generated_at=NOW)
-    model = reduce_attention_self_model(None, None, state)
+def test_reference_tick_falls_back_to_broadcast_when_no_field_frame() -> None:
+    broadcast = _broadcast(generated_at=NOW)
+    model = reduce_attention_self_model(broadcast, None)
 
     assert model.generated_at == NOW
 
@@ -235,7 +340,6 @@ class TestHarnessClosureSignal:
         model = reduce_attention_self_model(
             None,
             _field_frame(),
-            None,
             now=NOW,
             harness_closure_signal={
                 "prediction_error": 0.42,
@@ -252,9 +356,9 @@ class TestHarnessClosureSignal:
     def test_harness_closure_signal_absent_is_byte_identical_to_default(self) -> None:
         """Regression guard: omitting harness_closure_signal (the default,
         every existing caller) must reproduce today's narrative exactly."""
-        baseline = reduce_attention_self_model(None, _field_frame(), None, now=NOW)
+        baseline = reduce_attention_self_model(None, _field_frame(), now=NOW)
         with_none = reduce_attention_self_model(
-            None, _field_frame(), None, now=NOW, harness_closure_signal=None
+            None, _field_frame(), now=NOW, harness_closure_signal=None
         )
 
         assert baseline.reason_narrative == with_none.reason_narrative
@@ -264,7 +368,6 @@ class TestHarnessClosureSignal:
         model = reduce_attention_self_model(
             None,
             _field_frame(),
-            None,
             now=NOW,
             harness_closure_signal={
                 "prediction_error": 0.0,
@@ -278,7 +381,6 @@ class TestHarnessClosureSignal:
         model = reduce_attention_self_model(
             None,
             _field_frame(),
-            None,
             now=NOW,
             harness_closure_signal={
                 "prediction_error": 0.75,
@@ -296,7 +398,6 @@ class TestHarnessClosureSignal:
         model = reduce_attention_self_model(
             broadcast,
             _field_frame(),
-            _self_state(),
             now=NOW,
             harness_closure_signal={
                 "prediction_error": 0.9,

--- a/scripts/analysis/measure_ast_hot_reducer.py
+++ b/scripts/analysis/measure_ast_hot_reducer.py
@@ -4,12 +4,26 @@
 Phase 1 of `docs/superpowers/specs/2026-07-18-objective-3-consciousness-
 scaffolded-roadmap-design.md`. Replays the REAL, pure production reducer
 (`reduce_attention_self_model`, `orion/substrate/attention_self_model.py`)
-over real historical Postgres data for all three of its inputs
-(`substrate_attention_frames` -> `FieldAttentionFrameV1`, `substrate_
-self_state` -> `SelfStateV1`, `substrate_attention_broadcast_log` ->
-`AttentionBroadcastProjectionV1`), joined by nearest-preceding timestamp with
-the field lane's own tick cadence driving the replay (it is the highest-
-frequency real signal, per the Phase 1 design).
+over real historical Postgres data for its inputs (`substrate_attention_
+frames` -> `FieldAttentionFrameV1`, `substrate_attention_broadcast_log` ->
+`AttentionBroadcastProjectionV1`, `substrate_field_state` -> the five
+Active-Inference domains' raw `prediction_error`), joined by nearest-
+preceding timestamp with the field lane's own tick cadence driving the
+replay (it is the highest-frequency real signal, per the Phase 1 design).
+
+**2026-07-23: `substrate_self_state` input removed, replaced with
+`substrate_field_state`.** Mirrors `attention_self_model.py`'s own
+`SelfStateV1` -> Active-Inference substrate swap (see that module's docstring
+for the full account -- the producer this used to read no longer exists).
+`prediction_error_by_domain` (current-tick snapshot) and
+`prediction_error_trend_by_domain` (this script's own computation --
+mean(recent half) - mean(prior half) over `PREDICTION_ERROR_TREND_WINDOW_
+TICKS` field_state ticks, a starting anchor sized to the live ~2s field_state
+cadence confirmed 2026-07-23 via `substrate_field_state` timestamp diffs, not
+yet independently calibrated -- see Missing Question 3 in the L6 design doc)
+are both derived here, in the pure replay layer, from real
+`substrate_field_state` rows -- the reducer itself does no time-series math
+of its own (see its module docstring).
 
 **Load-bearing finding, discovered while building this script (2026-07-18):
 `substrate_attention_broadcast_projection` -- the third input,
@@ -28,7 +42,7 @@ singleton by `save_attention_broadcast_history()`
 (`services/orion-substrate-runtime/app/store.py`) from
 `_attention_broadcast_tick()` (`services/orion-substrate-runtime/app/
 worker.py`). This script now joins broadcast rows by nearest-preceding
-timestamp the same two-pointer way it already joins `self_state_rows`,
+timestamp the same two-pointer way it joins `field_state_rows` (see below),
 instead of passing one static row to every call. The old singleton table,
 its writer (`save_attention_broadcast`), and `AttentionBroadcastProjectionV1`
 itself are untouched.
@@ -57,6 +71,11 @@ This performs NO writes, emits NO events, flips NO flags. It reports:
      immediately post-deploy while the log is still young -- that is
      reported as NOT MET via Postgres replay, with the reasoning above,
      rather than asserted as passing.
+  4. Live-data sanity check (CLAUDE.md's metric-quality-gate) for the
+     Active-Inference confidence/predicted_shift signals: per-domain
+     prediction_error coverage in the window, and whether `confidence`/
+     `predicted_shift` show real, non-degenerate variance -- not flat/
+     always-null/always-saturated.
 
 Run:
     python scripts/analysis/measure_ast_hot_reducer.py --window-hours 48
@@ -69,7 +88,7 @@ import json
 import logging
 import os
 import time
-from collections import Counter
+from collections import Counter, deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -79,6 +98,31 @@ logger = logging.getLogger("orion.analysis.ast_hot_reducer")
 
 DEFAULT_WINDOW_HOURS: float = 48.0
 MAX_ROWS: int = 200_000
+
+# The five real, live Predictive-Processing domains
+# (`orion/substrate/prediction_error.py`), keyed by their FieldStateV1 node
+# id. `node:substrate.transport` is included despite its documented
+# structurally-narrow scope (`services/orion-substrate-runtime/README.md`'s
+# "transport domain is one queue" note) -- excluding it would be an
+# undisclosed thumb on the scale, not a fix; its near-permanent 0.0 is
+# reported honestly in `_aggregate_prediction_error_confidence`'s own basis
+# string instead.
+PREDICTION_ERROR_DOMAIN_NODES: dict[str, str] = {
+    "execution": "node:substrate.execution",
+    "transport": "node:substrate.transport",
+    "biometrics": "node:substrate.biometrics",
+    "chat": "node:substrate.chat",
+    "route": "node:substrate.route",
+}
+
+# Trend window, in field_state ticks, split into two equal halves (recent vs
+# prior) for the mean-delta trend computation. Sized to the live ~2s
+# field_state cadence confirmed 2026-07-23 (30 ticks =~ 60s) -- a starting
+# anchor, not yet independently calibrated against how fast a genuine rising
+# trend distinguishes itself from tick noise (L6 design doc's Missing
+# Question 3). Deliberately small enough to stay a real "what's happening
+# right now" window, not a long-run average.
+PREDICTION_ERROR_TREND_WINDOW_TICKS: int = 30
 
 OUTPUT_DIR = Path("/tmp/ast-hot-reducer")
 REPORT_PATH = OUTPUT_DIR / "report.md"
@@ -105,37 +149,82 @@ class ReplayTick:
     broadcast_lane_stale: bool
     broadcast_lane_age_sec: Optional[float]
     field_lane_present: bool
-    self_state_present: bool
+    predicted_shift: Optional[str]
     has_voluntary_override: bool
     reason_narrative: str
 
 
+def extract_prediction_error_by_domain(field_state_payload: dict) -> dict[str, float]:
+    """Pull the current raw `prediction_error` value for each of the five
+    real domains out of one `FieldStateV1.node_vectors` payload. Only
+    includes a domain if its node and channel are actually present in this
+    payload -- missing, not defaulted to 0.0, so a genuinely absent domain
+    doesn't silently masquerade as "confirmed calm" in the aggregate.
+    """
+    node_vectors = field_state_payload.get("node_vectors") or {}
+    out: dict[str, float] = {}
+    for domain, node_id in PREDICTION_ERROR_DOMAIN_NODES.items():
+        vector = node_vectors.get(node_id)
+        if not isinstance(vector, dict) or "prediction_error" not in vector:
+            continue
+        try:
+            out[domain] = float(vector["prediction_error"])
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def compute_prediction_error_trend(
+    window: list[dict[str, float]],
+) -> dict[str, float]:
+    """mean(recent half) - mean(prior half) per domain, over an ordered
+    (oldest-to-newest) window of `extract_prediction_error_by_domain()`
+    outputs. A domain only gets a trend value if it has at least one reading
+    in BOTH halves -- comparing a half with zero real observations would
+    fabricate a trend from nothing, not measure one. Fewer than 2 ticks in
+    the window yields an empty dict (nothing to compare yet).
+    """
+    if len(window) < 2:
+        return {}
+    mid = len(window) // 2
+    prior_half, recent_half = window[:mid], window[mid:]
+
+    def _domain_means(half: list[dict[str, float]]) -> dict[str, float]:
+        sums: dict[str, float] = {}
+        counts: dict[str, int] = {}
+        for snapshot in half:
+            for domain, value in snapshot.items():
+                sums[domain] = sums.get(domain, 0.0) + value
+                counts[domain] = counts.get(domain, 0) + 1
+        return {d: sums[d] / counts[d] for d in sums}
+
+    prior_means = _domain_means(prior_half)
+    recent_means = _domain_means(recent_half)
+    return {
+        domain: recent_means[domain] - prior_means[domain]
+        for domain in recent_means
+        if domain in prior_means
+    }
+
+
 def replay_reducer(
     field_rows: list[tuple[datetime, dict]],
-    self_state_rows: list[tuple[datetime, dict]],
     broadcast_rows: list[tuple[datetime, dict]],
+    field_state_rows: list[tuple[datetime, dict]],
 ) -> tuple[list[ReplayTick], int, int, int]:
     """Replay the real `reduce_attention_self_model` over ordered field-lane
     ticks (the highest-frequency real signal -- drives replay cadence),
-    joining both `self_state_rows` and `broadcast_rows` by nearest-preceding
-    timestamp -- same two-pointer pattern for both, now that
-    `substrate_attention_broadcast_log` gives the broadcast lane real
-    per-tick history instead of a single static snapshot (see module
-    docstring). Returns (ticks, field_rows_skipped, self_state_rows_skipped,
-    broadcast_rows_skipped).
+    joining `broadcast_rows` by nearest-preceding timestamp (same two-pointer
+    pattern `substrate_attention_broadcast_log` already used -- see module
+    docstring) and `field_state_rows` the same way, additionally maintaining
+    a rolling `PREDICTION_ERROR_TREND_WINDOW_TICKS`-sized window of
+    per-domain `prediction_error` snapshots to feed
+    `compute_prediction_error_trend`. Returns (ticks, field_rows_skipped,
+    field_state_rows_skipped, broadcast_rows_skipped).
     """
     from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
     from orion.schemas.field_attention_frame import FieldAttentionFrameV1
-    from orion.schemas.self_state import SelfStateV1
     from orion.substrate.attention_self_model import reduce_attention_self_model
-
-    self_states: list[tuple[datetime, SelfStateV1]] = []
-    self_state_skipped = 0
-    for ts, payload in self_state_rows:
-        try:
-            self_states.append((ts, SelfStateV1.model_validate(payload)))
-        except Exception:
-            self_state_skipped += 1
 
     broadcasts: list[tuple[datetime, AttentionBroadcastProjectionV1]] = []
     broadcast_skipped = 0
@@ -145,12 +234,21 @@ def replay_reducer(
         except Exception:
             broadcast_skipped += 1
 
+    field_states: list[tuple[datetime, dict[str, float]]] = []
+    field_state_skipped = 0
+    for ts, payload in field_state_rows:
+        try:
+            field_states.append((ts, extract_prediction_error_by_domain(payload)))
+        except Exception:
+            field_state_skipped += 1
+
     ticks: list[ReplayTick] = []
     field_skipped = 0
-    ss_idx = 0  # two-pointer: field_rows, self_states, broadcasts are all ASC-sorted
+    fs_idx = 0  # two-pointer: field_rows, broadcasts, field_states are all ASC-sorted
     bc_idx = 0
-    current_self_state: Optional[SelfStateV1] = None
     current_broadcast: Optional[AttentionBroadcastProjectionV1] = None
+    current_prediction_error_by_domain: dict[str, float] = {}
+    trend_window: deque[dict[str, float]] = deque(maxlen=PREDICTION_ERROR_TREND_WINDOW_TICKS)
 
     for ts, payload in field_rows:
         try:
@@ -159,16 +257,22 @@ def replay_reducer(
             field_skipped += 1
             continue
 
-        while ss_idx < len(self_states) and self_states[ss_idx][0] <= ts:
-            current_self_state = self_states[ss_idx][1]
-            ss_idx += 1
-
         while bc_idx < len(broadcasts) and broadcasts[bc_idx][0] <= ts:
             current_broadcast = broadcasts[bc_idx][1]
             bc_idx += 1
 
+        while fs_idx < len(field_states) and field_states[fs_idx][0] <= ts:
+            current_prediction_error_by_domain = field_states[fs_idx][1]
+            if current_prediction_error_by_domain:
+                trend_window.append(current_prediction_error_by_domain)
+            fs_idx += 1
+
         model = reduce_attention_self_model(
-            current_broadcast, field_model, current_self_state, now=ts
+            current_broadcast,
+            field_model,
+            now=ts,
+            prediction_error_by_domain=current_prediction_error_by_domain or None,
+            prediction_error_trend_by_domain=compute_prediction_error_trend(list(trend_window)) or None,
         )
         ticks.append(
             ReplayTick(
@@ -179,12 +283,12 @@ def replay_reducer(
                 broadcast_lane_stale=model.broadcast_lane_stale,
                 broadcast_lane_age_sec=model.broadcast_lane_age_sec,
                 field_lane_present=model.field_lane_present,
-                self_state_present=model.self_state_present,
+                predicted_shift=model.predicted_shift,
                 has_voluntary_override=model.voluntary_override is not None,
                 reason_narrative=model.reason_narrative,
             )
         )
-    return ticks, field_skipped, self_state_skipped, broadcast_skipped
+    return ticks, field_skipped, field_state_skipped, broadcast_skipped
 
 
 def reason_histogram(ticks: list[ReplayTick]) -> Counter:
@@ -283,15 +387,20 @@ def fetch_field_attention_rows(conn, since: datetime) -> tuple[list[tuple[dateti
     return _rows_to_payload_list(rows)
 
 
-def fetch_self_state_rows(conn, since: datetime) -> tuple[list[tuple[datetime, dict]], bool]:
+def fetch_field_state_rows(conn, since: datetime) -> tuple[list[tuple[datetime, dict]], bool]:
+    """Raw `FieldStateV1` snapshots -- the source of the five Active-
+    Inference domains' `prediction_error` (see `PREDICTION_ERROR_DOMAIN_
+    NODES`/`extract_prediction_error_by_domain`). Replaces
+    `fetch_self_state_rows` (removed 2026-07-23, same producer-killed reason
+    as `attention_self_model.py`'s own swap)."""
     if conn is None:
         return [], False
     try:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT self_state_json, generated_at
-                FROM substrate_self_state
+                SELECT field_json, generated_at
+                FROM substrate_field_state
                 WHERE generated_at >= %s
                 ORDER BY generated_at ASC
                 LIMIT %s
@@ -300,7 +409,7 @@ def fetch_self_state_rows(conn, since: datetime) -> tuple[list[tuple[datetime, d
             )
             rows = cur.fetchall()
     except Exception:
-        logger.error("failed to fetch substrate_self_state", exc_info=True)
+        logger.error("failed to fetch substrate_field_state", exc_info=True)
         return [], False
     return _rows_to_payload_list(rows)
 
@@ -421,7 +530,7 @@ def write_ticks_csv(path: Path, ticks: list[ReplayTick]) -> None:
             [
                 "generated_at", "attention_reason", "confidence",
                 "broadcast_lane_present", "broadcast_lane_stale", "broadcast_lane_age_sec",
-                "field_lane_present", "self_state_present", "has_voluntary_override",
+                "field_lane_present", "predicted_shift", "has_voluntary_override",
             ]
         )
         for t in ticks:
@@ -431,7 +540,7 @@ def write_ticks_csv(path: Path, ticks: list[ReplayTick]) -> None:
                     "" if t.confidence is None else f"{t.confidence:.4f}",
                     t.broadcast_lane_present, t.broadcast_lane_stale,
                     "" if t.broadcast_lane_age_sec is None else f"{t.broadcast_lane_age_sec:.3f}",
-                    t.field_lane_present, t.self_state_present, t.has_voluntary_override,
+                    t.field_lane_present, t.predicted_shift or "", t.has_voluntary_override,
                 ]
             )
 
@@ -448,7 +557,8 @@ def render_report(
     ticks: list[ReplayTick],
     field_rows_truncated: bool,
     field_rows_skipped: int,
-    self_state_rows_skipped: int,
+    field_state_rows_skipped: int,
+    field_state_rows_replayed: int,
     broadcast_rows_replayed: int,
     broadcast_rows_skipped: int,
     broadcast_row_count: Optional[int],
@@ -471,6 +581,34 @@ def render_report(
     n_broadcast_fresh = sum(1 for t in ticks if t.broadcast_lane_present and not t.broadcast_lane_stale)
     n_broadcast_stale = sum(1 for t in ticks if t.broadcast_lane_present and t.broadcast_lane_stale)
 
+    confidences = [t.confidence for t in ticks if t.confidence is not None]
+    n_confidence = len(confidences)
+    confidence_min = min(confidences) if confidences else None
+    confidence_max = max(confidences) if confidences else None
+    confidence_mean = (sum(confidences) / n_confidence) if confidences else None
+    confidence_degenerate = (
+        n_confidence > 0 and confidence_min is not None and confidence_max is not None
+        and (confidence_max - confidence_min) < 1e-6
+    )
+    # confidence is populated on every attention_reason branch, but the new
+    # prediction_error-based formula (_aggregate_prediction_error_confidence)
+    # only ever fires in field_salience_only -- top_down_override/
+    # bottom_up_salience use broadcast.coalition_stability_score instead, and
+    # dominate whenever the broadcast lane is fresh. Reporting the aggregate
+    # confidence stats above alone would misleadingly imply broad coverage of
+    # the *new* formula specifically -- break it out on its own.
+    aid_confidences = [
+        t.confidence for t in ticks
+        if t.confidence is not None and t.attention_reason == "field_salience_only"
+    ]
+    n_aid_confidence = len(aid_confidences)
+    aid_confidence_min = min(aid_confidences) if aid_confidences else None
+    aid_confidence_max = max(aid_confidences) if aid_confidences else None
+
+    predicted_shifts = [t.predicted_shift for t in ticks if t.predicted_shift]
+    n_predicted_shift = len(predicted_shifts)
+    predicted_shift_domains = Counter(s.split(" prediction-error", 1)[0] for s in predicted_shifts)
+
     broadcast_singleton_line = (
         "n/a (query failed)" if broadcast_row_count is None
         else f"{broadcast_row_count} row(s) (still a singleton, by design -- "
@@ -488,14 +626,16 @@ def render_report(
         "Read-only. No writes, no events, no flag/config changes. Replays the real "
         "`reduce_attention_self_model` production function over historical "
         "`substrate_attention_frames` (field lane, drives cadence), "
-        "`substrate_self_state`, and `substrate_attention_broadcast_log` rows, all "
-        "joined by nearest-preceding timestamp.",
+        "`substrate_field_state` (five Active-Inference domains' `prediction_error`), "
+        "and `substrate_attention_broadcast_log` rows, all joined by nearest-preceding "
+        "timestamp.",
         "",
         f"- Window: last {window_label} ({window_start.isoformat()} -> {window_end.isoformat()})",
         f"- Field-lane (FieldAttentionFrameV1) ticks replayed: {n}",
         f"- Field-lane rows truncated at MAX_ROWS={MAX_ROWS}: {field_rows_truncated}",
         f"- Field-lane rows skipped (failed to parse): {field_rows_skipped}",
-        f"- Self-state rows skipped (failed to parse): {self_state_rows_skipped}",
+        f"- Field-state rows in window: {field_state_rows_replayed} "
+        f"(skipped/failed to parse: {field_state_rows_skipped})",
         f"- Broadcast-log rows in window: {broadcast_rows_replayed} "
         f"(skipped/failed to parse: {broadcast_rows_skipped})",
         "",
@@ -525,6 +665,28 @@ def render_report(
         "rows were overwritten in place and are not recoverable, so history only exists "
         "from deploy time forward. A run shortly after deploy will show low or zero "
         "broadcast-log coverage for that reason, not because the join is broken.",
+        "",
+        "## Active-Inference confidence / predicted_shift live-data sanity check",
+        "",
+        "CLAUDE.md's metric-quality-gate requirement: confirm these two signals are not "
+        "degenerate (flat, always-null, always-saturated) before treating them as usable.",
+        "",
+        f"- Ticks with a non-null `confidence` (any branch): {n_confidence} / {n} ({pct(n_confidence)})",
+        f"  - min={_fmt(confidence_min)} max={_fmt(confidence_max)} mean={_fmt(confidence_mean)}",
+        f"  - **DEGENERATE (flat within 1e-6)**" if confidence_degenerate else "  - real variance observed, not flat",
+        f"  - **caveat**: this mixes two different formulas -- `broadcast.coalition_"
+        f"stability_score` (top_down_override/bottom_up_salience branches) and the "
+        f"new prediction_error-based formula (field_salience_only only). Broken out "
+        f"below.",
+        f"- Ticks using the NEW prediction_error-based confidence specifically "
+        f"(field_salience_only branch): {n_aid_confidence} / {n} ({pct(n_aid_confidence)})",
+        f"  - min={_fmt(aid_confidence_min)} max={_fmt(aid_confidence_max)}",
+        f"- Ticks with a non-null `predicted_shift`: {n_predicted_shift} / {n} ({pct(n_predicted_shift)})",
+        "  - domain breakdown: "
+        + (
+            ", ".join(f"{d}={c}" for d, c in predicted_shift_domains.most_common())
+            if predicted_shift_domains else "none"
+        ),
         "",
         "## attention_reason distribution",
         "",
@@ -647,10 +809,10 @@ def run(window: timedelta, window_label: str) -> int:
         caveats.append(f"field-attention rows truncated at MAX_ROWS={MAX_ROWS}")
     progress.emit("field_attention loaded", percent=25.0, processed=len(field_rows), total=len(field_rows))
 
-    self_state_rows, self_state_truncated = fetch_self_state_rows(conn, window_start)
-    if self_state_truncated:
-        caveats.append(f"self-state rows truncated at MAX_ROWS={MAX_ROWS}")
-    progress.emit("self_state loaded", percent=45.0, processed=len(self_state_rows), total=len(self_state_rows))
+    field_state_rows, field_state_truncated = fetch_field_state_rows(conn, window_start)
+    if field_state_truncated:
+        caveats.append(f"field-state rows truncated at MAX_ROWS={MAX_ROWS}")
+    progress.emit("field_state loaded", percent=45.0, processed=len(field_state_rows), total=len(field_state_rows))
 
     broadcast_rows, broadcast_truncated = fetch_broadcast_history_rows(conn, window_start)
     if broadcast_truncated:
@@ -675,7 +837,8 @@ def run(window: timedelta, window_label: str) -> int:
         report = render_report(
             window_label=window_label, window_start=window_start, window_end=now,
             ticks=[], field_rows_truncated=field_truncated, field_rows_skipped=0,
-            self_state_rows_skipped=0, broadcast_rows_replayed=len(broadcast_rows),
+            field_state_rows_skipped=0, field_state_rows_replayed=len(field_state_rows),
+            broadcast_rows_replayed=len(broadcast_rows),
             broadcast_rows_skipped=0, broadcast_row_count=broadcast_row_count,
             broadcast_row=broadcast_row, override_examples=[], caveats=caveats,
         )
@@ -684,8 +847,8 @@ def run(window: timedelta, window_label: str) -> int:
         return 2
 
     progress.emit("replaying", percent=60.0, processed=0, total=len(field_rows))
-    ticks, field_skipped, self_state_skipped, broadcast_skipped = replay_reducer(
-        field_rows, self_state_rows, broadcast_rows
+    ticks, field_skipped, field_state_skipped, broadcast_skipped = replay_reducer(
+        field_rows, broadcast_rows, field_state_rows
     )
     progress.emit("replay done", percent=95.0, processed=len(ticks), total=len(field_rows))
 
@@ -699,7 +862,8 @@ def run(window: timedelta, window_label: str) -> int:
         ticks=ticks,
         field_rows_truncated=field_truncated,
         field_rows_skipped=field_skipped,
-        self_state_rows_skipped=self_state_skipped,
+        field_state_rows_skipped=field_state_skipped,
+        field_state_rows_replayed=len(field_state_rows),
         broadcast_rows_replayed=len(broadcast_rows),
         broadcast_rows_skipped=broadcast_skipped,
         broadcast_row_count=broadcast_row_count,

--- a/scripts/analysis/tests/test_measure_ast_hot_reducer.py
+++ b/scripts/analysis/tests/test_measure_ast_hot_reducer.py
@@ -2,7 +2,7 @@
 
 No DB. The replay layer calls the REAL `reduce_attention_self_model`
 (pure, no I/O -- see orion/substrate/attention_self_model.py), so it is
-exercised directly with synthetic field/self-state/broadcast payload dicts,
+exercised directly with synthetic field/field-state/broadcast payload dicts,
 same fixture-loading pattern as
 scripts/analysis/tests/test_measure_origination_gate.py.
 """
@@ -27,7 +27,6 @@ from orion.schemas.attention_frame import (  # noqa: E402
     VoluntaryOverrideV1,
 )
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1  # noqa: E402
-from orion.schemas.self_state import SelfStateV1  # noqa: E402
 
 UTC = timezone.utc
 BASE = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
@@ -50,14 +49,17 @@ def _field_payload(ts: datetime) -> dict:
     return frame.model_dump(mode="json")
 
 
-def _self_state_payload(ts: datetime) -> dict:
-    state = SelfStateV1(
-        self_state_id=f"ss-{ts.isoformat()}", generated_at=ts,
-        source_field_tick_id="tick", source_field_generated_at=ts,
-        source_attention_frame_id="frame", source_attention_generated_at=ts,
-        overall_intensity=0.5, overall_confidence=0.5,
-    )
-    return state.model_dump(mode="json")
+def _field_state_payload(ts: datetime, **prediction_errors: float) -> dict:
+    """Minimal FieldStateV1-shaped dict -- only the node_vectors keys this
+    script's extract_prediction_error_by_domain() actually reads, since the
+    full schema isn't needed to exercise this pure extraction/parsing logic.
+    """
+    domain_nodes = mod.PREDICTION_ERROR_DOMAIN_NODES
+    node_vectors = {
+        domain_nodes[domain]: {"prediction_error": value}
+        for domain, value in prediction_errors.items()
+    }
+    return {"generated_at": ts.isoformat(), "node_vectors": node_vectors}
 
 
 def _broadcast_payload(ts: datetime, *, override: VoluntaryOverrideV1 | None = None) -> dict:
@@ -69,29 +71,74 @@ def _broadcast_payload(ts: datetime, *, override: VoluntaryOverrideV1 | None = N
     return projection.model_dump(mode="json")
 
 
-def test_replay_reducer_joins_self_state_by_nearest_preceding_timestamp() -> None:
+class TestExtractPredictionErrorByDomain:
+    def test_extracts_present_domains_only(self) -> None:
+        payload = _field_state_payload(BASE, execution=0.1, biometrics=0.5)
+        out = mod.extract_prediction_error_by_domain(payload)
+        assert out == {"execution": 0.1, "biometrics": 0.5}
+
+    def test_missing_node_vectors_yields_empty_dict(self) -> None:
+        assert mod.extract_prediction_error_by_domain({}) == {}
+
+    def test_malformed_value_is_skipped_not_raised(self) -> None:
+        payload = {
+            "node_vectors": {
+                "node:substrate.execution": {"prediction_error": "not-a-number"},
+                "node:substrate.biometrics": {"prediction_error": 0.3},
+            }
+        }
+        out = mod.extract_prediction_error_by_domain(payload)
+        assert out == {"biometrics": 0.3}
+
+
+class TestComputePredictionErrorTrend:
+    def test_rising_trend_detected(self) -> None:
+        window = [
+            {"biometrics": 0.01}, {"biometrics": 0.02},
+            {"biometrics": 0.3}, {"biometrics": 0.4},
+        ]
+        trend = mod.compute_prediction_error_trend(window)
+        assert trend["biometrics"] > 0
+
+    def test_domain_missing_from_either_half_is_excluded(self) -> None:
+        window = [
+            {"biometrics": 0.1}, {"execution": 0.1},
+            {"biometrics": 0.2}, {"biometrics": 0.3},
+        ]
+        trend = mod.compute_prediction_error_trend(window)
+        assert "execution" not in trend
+        assert "biometrics" in trend
+
+    def test_fewer_than_two_ticks_yields_empty_dict(self) -> None:
+        assert mod.compute_prediction_error_trend([]) == {}
+        assert mod.compute_prediction_error_trend([{"biometrics": 0.1}]) == {}
+
+
+def test_replay_reducer_joins_field_state_by_nearest_preceding_timestamp() -> None:
     field_rows = [
         (BASE, _field_payload(BASE)),
         (BASE + timedelta(seconds=10), _field_payload(BASE + timedelta(seconds=10))),
     ]
-    self_state_rows = [(BASE - timedelta(seconds=1), _self_state_payload(BASE - timedelta(seconds=1)))]
+    field_state_rows = [
+        (BASE - timedelta(seconds=1), _field_state_payload(BASE - timedelta(seconds=1), biometrics=0.2)),
+    ]
 
-    ticks, field_skipped, ss_skipped, bc_skipped = mod.replay_reducer(field_rows, self_state_rows, [])
+    ticks, field_skipped, fs_skipped, bc_skipped = mod.replay_reducer(field_rows, [], field_state_rows)
 
     assert field_skipped == 0
-    assert ss_skipped == 0
+    assert fs_skipped == 0
     assert bc_skipped == 0
     assert len(ticks) == 2
-    assert all(t.self_state_present for t in ticks)
+    assert all(t.confidence is not None for t in ticks)
 
 
 def test_replay_reducer_skips_unparseable_rows_without_raising() -> None:
     field_rows = [(BASE, {"not": "a valid frame"})]
-    ticks, field_skipped, ss_skipped, bc_skipped = mod.replay_reducer(field_rows, [], [])
+    ticks, field_skipped, fs_skipped, bc_skipped = mod.replay_reducer(field_rows, [], [])
 
     assert ticks == []
     assert field_skipped == 1
-    assert ss_skipped == 0
+    assert fs_skipped == 0
     assert bc_skipped == 0
 
 
@@ -104,7 +151,7 @@ def test_replay_reducer_surfaces_real_voluntary_override() -> None:
     broadcast_rows = [(BASE, _broadcast_payload(BASE, override=override))]
     field_rows = [(BASE + timedelta(seconds=1), _field_payload(BASE + timedelta(seconds=1)))]
 
-    ticks, _, _, bc_skipped = mod.replay_reducer(field_rows, [], broadcast_rows)
+    ticks, _, _, bc_skipped = mod.replay_reducer(field_rows, broadcast_rows, [])
 
     assert bc_skipped == 0
     assert len(ticks) == 1
@@ -121,7 +168,7 @@ def test_replay_reducer_honestly_absent_when_broadcast_predates_nothing_referenc
     broadcast_rows = [(BASE + timedelta(hours=1), _broadcast_payload(BASE + timedelta(hours=1)))]
     field_rows = [(BASE, _field_payload(BASE))]
 
-    ticks, _, _, _ = mod.replay_reducer(field_rows, [], broadcast_rows)
+    ticks, _, _, _ = mod.replay_reducer(field_rows, broadcast_rows, [])
 
     assert len(ticks) == 1
     assert ticks[0].broadcast_lane_present is False
@@ -153,7 +200,7 @@ def test_replay_reducer_joins_broadcast_by_nearest_preceding_timestamp_per_tick(
         (BASE + timedelta(seconds=25), _field_payload(BASE + timedelta(seconds=25))),
     ]
 
-    ticks, _, _, bc_skipped = mod.replay_reducer(field_rows, [], broadcast_rows)
+    ticks, _, _, bc_skipped = mod.replay_reducer(field_rows, broadcast_rows, [])
 
     assert bc_skipped == 0
     assert len(ticks) == 2
@@ -161,11 +208,30 @@ def test_replay_reducer_joins_broadcast_by_nearest_preceding_timestamp_per_tick(
     assert "loop-late" in ticks[1].reason_narrative
 
 
+def test_replay_reducer_predicted_shift_tracks_rolling_trend_window() -> None:
+    """A domain whose prediction_error climbs steadily across field_state
+    ticks should surface as the named predicted_shift once enough ticks
+    have accumulated to compute a trend (>=2)."""
+    field_state_rows = [
+        (BASE + timedelta(seconds=i), _field_state_payload(BASE + timedelta(seconds=i), biometrics=0.01 * i))
+        for i in range(1, 6)
+    ]
+    field_rows = [(BASE + timedelta(seconds=6), _field_payload(BASE + timedelta(seconds=6)))]
+
+    ticks, _, fs_skipped, _ = mod.replay_reducer(field_rows, [], field_state_rows)
+
+    assert fs_skipped == 0
+    assert len(ticks) == 1
+    assert ticks[0].predicted_shift is not None
+    assert "biometrics" in ticks[0].predicted_shift
+    assert "rising" in ticks[0].predicted_shift
+
+
 def test_reason_histogram_counts_each_category() -> None:
     ticks = [
-        mod.ReplayTick(BASE, "top_down_override", 0.5, True, False, 1.0, True, True, True, ""),
-        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, True, False, ""),
-        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, True, False, ""),
+        mod.ReplayTick(BASE, "top_down_override", 0.5, True, False, 1.0, True, None, True, ""),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, None, False, ""),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, None, False, ""),
     ]
     hist = mod.reason_histogram(ticks)
     assert hist["top_down_override"] == 1
@@ -174,9 +240,9 @@ def test_reason_histogram_counts_each_category() -> None:
 
 def test_find_override_examples_returns_context_window() -> None:
     ticks = [
-        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, True, False, "a"),
-        mod.ReplayTick(BASE, "top_down_override", 0.9, True, False, 1.0, True, True, True, "override!"),
-        mod.ReplayTick(BASE, "bottom_up_salience", 0.7, True, False, 1.0, True, True, False, "c"),
+        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, None, False, "a"),
+        mod.ReplayTick(BASE, "top_down_override", 0.9, True, False, 1.0, True, None, True, "override!"),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.7, True, False, 1.0, True, None, False, "c"),
     ]
     examples = mod.find_override_examples(ticks, context=1)
     assert len(examples) == 1
@@ -186,6 +252,6 @@ def test_find_override_examples_returns_context_window() -> None:
 
 def test_find_override_examples_empty_when_no_override_present() -> None:
     ticks = [
-        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, True, False, "a"),
+        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, None, False, "a"),
     ]
     assert mod.find_override_examples(ticks) == []


### PR DESCRIPTION
## Summary

Implements items 3/4 of the merged L6 design (`docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`, PR #1276, revised in #1284) — real Active-Inference grounding for `orion/substrate/attention_self_model.py`'s `confidence`/`predicted_shift` fields, replacing the dead `SelfStateV1` producer entirely.

- **Removed `self_state` from `reduce_attention_self_model()`'s signature entirely** — not deprecated in place. `orion/self_state/` was deleted in PR #1266 and `orion-athena-self-state-runtime` was confirmed stopped (per #1276's own comment thread). This repo's "kill means kill" convention: no fallback to the thing being killed. `AttentionSelfModelV1.self_state_present` field also removed.
- **Item 3 (confidence)**: `1 - mean(prediction_error)` across the five real Active-Inference domains (execution/transport/biometrics/chat/route, `orion/substrate/prediction_error.py`), replacing `self_state.overall_confidence`. `mean()`, not `max()`, deliberately — a `max()`-based confidence would be a redundant, same-sensor restatement of what attention selection already answers via `dynamic_pressure`. Documented against live data in the function's own docstring.
- **Item 4 (predicted_shift)**: argmax-by-trend over a caller-supplied `prediction_error_trend_by_domain` dict, replacing `self_state.dimension_trajectory`. Mirrors the exact argmax-over-a-delta-dict shape the old `self_state` code already used, just over real domains instead of a dead schema.
- `scripts/analysis/measure_ast_hot_reducer.py` (the reducer's read-only Postgres replay/measurement script) now computes both new inputs from real `substrate_field_state` rows instead of `substrate_self_state`.

## Outcome moved

L6's confidence/predicted_shift fields are now backed by real, live, non-degenerate Active-Inference substrate instead of a dead producer's frozen last values. Live-verified (not just unit-tested) against real Postgres data.

## Current architecture

`reduce_attention_self_model()` is a pure function (no I/O, no bus wiring — still explicitly shadow-measurement only, per the charter's §7 "measure before minting" rule) called only by `measure_ast_hot_reducer.py`'s replay harness and its own test suite. Confirmed via repo-wide grep: no other consumer exists, so this signature change is contained.

## Live-data sanity check (CLAUDE.md metric-quality-gate)

Ran `scripts/analysis/measure_ast_hot_reducer.py --window-hours 6` against real Postgres (10,656 real ticks):

- `confidence`: 100% non-null coverage. When the new prediction_error-based formula is actually active (`field_salience_only` branch, 15/10656 ticks — most ticks take `bottom_up_salience` since the broadcast lane has excellent fresh coverage), min=0.3667 max=0.9998 — real variance, not flat.
- `predicted_shift`: 100% non-null coverage (10654/10656), real cross-domain breakdown: biometrics=10600, execution=27, route=21, chat=6. Not saturated to a single always-winning domain.
- The report's own new "Active-Inference confidence / predicted_shift live-data sanity check" section reports this honestly, including the caveat that the aggregate `confidence` stat mixes two different formulas (broadcast-based vs. the new one) so it can't be misread as broader coverage of the new formula than it actually has.

## Architecture touched

- `orion/schemas/attention_self_model.py`: removed `self_state_present` field, updated module docstring.
- `orion/substrate/attention_self_model.py`: removed `self_state` param; added `_aggregate_prediction_error_confidence()`; new `prediction_error_by_domain`/`prediction_error_trend_by_domain` kwargs drive items 3/4.
- `scripts/analysis/measure_ast_hot_reducer.py`: `fetch_self_state_rows`/`substrate_self_state` → `fetch_field_state_rows`/`substrate_field_state`; new `extract_prediction_error_by_domain()`/`compute_prediction_error_trend()` pure helpers; `replay_reducer()` maintains a rolling `PREDICTION_ERROR_TREND_WINDOW_TICKS=30`-tick window via `collections.deque`; new report section.
- Tests updated/added in both reducer test files (`orion/substrate/tests/test_attention_self_model.py`, `scripts/analysis/tests/test_measure_ast_hot_reducer.py`).

## Schema / bus / API changes

- Removed: `AttentionSelfModelV1.self_state_present`; `reduce_attention_self_model()`'s positional `self_state` parameter.
- Added: `reduce_attention_self_model(..., prediction_error_by_domain=..., prediction_error_trend_by_domain=...)` keyword-only params (both optional, default `None`, fully backward-compatible for any future caller that omits them).
- No bus/channel changes — this reducer remains unwired, per its own docstring.

## Env/config changes

None.

## Tests run

```text
orion_dev/bin/python -m pytest orion/substrate/tests scripts/analysis/tests -q
603 passed
```

## Evals run

`scripts/analysis/measure_ast_hot_reducer.py --window-hours 6` against real production Postgres — see "Live-data sanity check" above. This *is* the eval harness for this reducer (per the L6 design doc's own Acceptance checks), not a separate suite.

## Docker/build/smoke checks

Not applicable — pure Python logic, no runtime/config/dependency changes, no live bus wiring.

## Review findings fixed

- **Finding**: `predicted_shift` could be populated (a real, substantive prediction) while `attention_reason == "no_data"` and `reason_narrative` claimed "No attention data available from either lane" — a self-contradictory output, if a caller supplied only `prediction_error_trend_by_domain` with no other inputs. Not reachable via the one real caller today (its trend/current-value data are populated in lockstep), but a genuine break in the pure reducer's own honesty contract.
  - **Fix**: folded `prediction_error_trend_by_domain` into the branch-selection condition, so `attention_reason` honestly reflects that trend data is present.
  - **Evidence**: new test `test_only_prediction_error_trend_present_is_not_no_data`.
- **Finding**: `_aggregate_prediction_error_confidence`'s clamp (`max(0.0, 1.0 - min(1.0, mean_error))`) only bounded the upper end of `mean_error` — a negative input (live-reproduced: a single `-0.5` domain value) produced `confidence=1.5`, outside `AttentionSelfModelV1.confidence`'s own declared `[0,1]` range (Pydantic v2 does not re-validate on plain attribute assignment). Every real producer in `prediction_error.py` is non-negative, but this is a general-purpose function over an arbitrary caller-supplied dict.
  - **Fix**: symmetric clamp (`mean_error = max(0.0, min(1.0, mean_error))`) before computing confidence.
  - **Evidence**: new test `test_negative_input_does_not_push_confidence_above_one`.

## Restart required

```text
No restart required.
```

This reducer is not wired to any live service — it's only invoked by the offline replay script.

## Risks / concerns

- Severity: low
- Concern: item 4's trend window (`PREDICTION_ERROR_TREND_WINDOW_TICKS=30`, ~60s at the live ~2s field_state cadence) is a starting anchor, not independently calibrated against how fast a genuine rising trend distinguishes itself from tick noise — flagged as a starting point in both the code comment and the original L6 design doc's Missing Question 3, not a blocker for this patch.
- Item 5 (the higher-order piece) is explicitly not in this patch — a separate shadow-measurement task per the design doc's own phasing (item 3/4 first, item 5 shadow-measured separately before any consumer is wired).

## PR link