### PR TITLE
fix(graph-compression): retire orion:collapse from EpisodicFederator

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-collapse-episodic-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-collapse-episodic-pr.md
@@ -1,0 +1,81 @@
+# PR report: retire `orion:collapse` from `EpisodicFederator`
+
+## Summary
+
+- Fifth in today's series of Fuseki-dependency retirements in `orion-graph-compression`. Same pattern as the prior `orion:chat:social` removal: `EpisodicFederator` stays live, one more dead graph drops out of its list (8 -> 7 graphs).
+- Live SPARQL `COUNT` against the running Fuseki container confirmed `orion:collapse` has exactly **0** triples, ever -- not low, zero.
+- Traced the real reason, correcting an initial incomplete theory (see Review findings below): `orion-rdf-writer`'s `collapse.mirror.entry` write handler has its own observer/dense gate, but that gate is unreachable -- `orion-rdf-writer` only subscribes to `orion:collapse:intake`, which carries a different `kind` (`collapse.mirror.intake`, from `orion-cortex-exec`). The only real producer of `kind="collapse.mirror.entry"` (`orion-collapse-mirror`) publishes it to a different channel, `orion:collapse:triage`, whose registered consumers (`channels.yaml`) don't include `orion-rdf-writer` at all. This dispatch branch has never received a matching envelope, period -- a real channel/kind mismatch bug in `orion-rdf-writer`, flagged for its own follow-up, not fixed here.
+
+## Outcome moved
+
+`EpisodicFederator`'s SPARQL dependency narrows to 7 graphs: chat, enrichment, cognition, metacog (all dead writers / frozen history at this point), and the 3 autonomy graphs. Collapse tag/entity clustering signal (a separate concern from this raw-entry graph) has a real, if currently dark-by-default, Falkor path already built (`RECALL_FALKOR_COLLAPSE_TRIAGE_ENABLED` in `orion-meta-tags`).
+
+## Current architecture
+
+Before this patch: `EpisodicFederator` queried 8 named Fuseki graphs via UNION, including `orion:collapse`, which has provably never held any content.
+
+## Architecture touched
+
+- `services/orion-graph-compression/app/federators/episodic.py`, `app/worker.py`, `app/stale_listener.py`, `.env_example`, `README.md`, `tests/test_federator_episodic.py`
+
+## Files changed
+
+- `services/orion-graph-compression/app/federators/episodic.py`: removed `http://conjourney.net/graph/orion/collapse` from `EPISODIC_GRAPHS`, with a comment explaining the verified channel/kind mismatch root cause (corrected mid-review, see below).
+- `services/orion-graph-compression/app/worker.py`, `.env_example`: comment updates at the Falkor-union call site, now reflecting both retirements (social + collapse).
+- `services/orion-graph-compression/app/stale_listener.py`: added a comment on the now-fully-inert `orion:collapse` -> `episodic` mapping (left in place, harmless, matching the review's suggestion for consistency with how `orion:chat:social`'s equivalent mapping was documented).
+- `services/orion-graph-compression/README.md`: Compression Scopes table (8 -> 7 graphs) and a new FalkorDB federators paragraph explaining the collapse removal with the corrected root-cause chain and an accurate "dark by default" disclosure for the collapse-triage Falkor writer (review finding -- see below).
+- `services/orion-graph-compression/tests/test_federator_episodic.py`: added `test_episodic_federator_no_longer_queries_collapse`.
+
+Deliberately not touched (confirmed by review against live repo state):
+- `orion-rdf-writer`'s `collapse.mirror.entry` handler and its observer/dense gate -- untouched; this PR only stops reading the (structurally guaranteed empty) result.
+- The channel/kind mismatch itself (`orion-rdf-writer` not subscribed to `orion:collapse:triage`) -- a real bug, out of scope for a series about retiring Fuseki reads, not reviving Fuseki writes. Flagged for its own follow-up if anyone ever wants this write path alive.
+- `orion-meta-tags`' collapse-triage Falkor writer -- pre-existing, unrelated to this session, untouched.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None (comment-only `.env_example` edit).
+
+## Tests run
+
+```text
+ORION_BUS_URL=redis://127.0.0.1:6379/0 PYTHONPATH=.:services/orion-graph-compression venv/bin/python3 -m pytest services/orion-graph-compression/tests -q
+-> 47 passed (46 + 1 new regression test)
+
+git diff --check -> clean
+```
+
+## Evals run
+
+No eval harness exists for this service; the existing dynamic-count UNION test plus the new membership regression test cover the changed behavior.
+
+## Docker/build/smoke checks
+
+No container rebuild/restart performed. Live evidence (Fuseki triple count, channel/kind tracing against `channels.yaml` and the actual producer/subscriber code) gathered directly against the running system in this same session.
+
+## Review findings fixed
+
+- Finding (HIGH, causal-narrative accuracy): the diff's first-pass comments and README paragraph attributed the empty `orion:collapse` graph solely to `_build_raw_collapse_graph`'s Juniper/dense observer gate. Review traced deeper and found that gate is unreachable: `orion-rdf-writer` isn't even subscribed to the channel (`orion:collapse:triage`) that ever carries a `collapse.mirror.entry`-kind envelope -- it only listens on `orion:collapse:intake`, which carries a different kind entirely. The conclusion (safe to remove) survives, and is if anything more solidly justified -- but the causal claim was wrong and needed correcting before being committed as established fact for future readers.
+  - Fix: rewrote both the code comment and the README paragraph to state the verified channel/kind mismatch as the root cause, with the observer/dense gate noted as real-but-unreachable rather than the primary explanation. Independently re-verified the channel/kind mismatch myself against `channels.yaml` and the actual producer code before committing the correction.
+  - Evidence: commit, this same PR.
+- Finding (LOW): the README's Falkor-coverage claim for collapse tag/entity content didn't disclose that `RECALL_FALKOR_COLLAPSE_TRIAGE_ENABLED` ships dark by default in `orion-meta-tags`, unlike the adjacent `chat:social` paragraph's already-careful "live-verified thin" disclosure.
+  - Fix: added the same disclosure standard to the collapse paragraph.
+- Finding (informational, hygiene): `stale_listener.py`'s now-fully-inert `orion:collapse` mapping had no comment explaining why it's safe to leave (unlike `self_study`'s fully-removed mappings, which got one).
+  - Fix: added a comment.
+- Informational (no fix needed, verified): the `EPISODIC_GRAPHS` removal itself, the UNION-count construction, and the new regression test were all confirmed correct and non-vacuous by hand-tracing `_build_sparql()` against the new 7-item list.
+
+## Restart required
+
+No restart required to merge. If `orion-athena-graph-compression` is redeployed, the `episodic` scope simply queries one fewer graph.
+
+## Risks / concerns
+
+- Severity: Low.
+- Concern: none blocking. The real channel/kind mismatch bug in `orion-rdf-writer` (flagged, not fixed) means nobody should assume fixing the observer/dense gate alone would ever make this write path work -- worth a follow-up ticket if collapse-mirror raw content in Fuseki is ever wanted again (unlikely, given the whole point of this migration).
+
+## PR link
+
+(added after opening)

--- a/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-collapse-episodic-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-collapse-episodic-pr.md
@@ -78,4 +78,4 @@ No restart required to merge. If `orion-athena-graph-compression` is redeployed,
 
 ## PR link
 
-(added after opening)
+https://github.com/junebug-junie/Orion-Sapienform/pull/1302

--- a/services/orion-graph-compression/.env_example
+++ b/services/orion-graph-compression/.env_example
@@ -61,10 +61,11 @@ FALKORDB_RECALL_GRAPH=orion_recall
 # this key at all), matching every other Falkor-cutover flag's convention.
 GRAPH_COMPRESSION_SUBSTRATE_FALKOR_ENABLED=true
 # Still additive (unioned with the existing SPARQL EpisodicFederator, never a
-# swap) -- collapse/cognition/metacog have no Falkor equivalent at all.
-# orion:chat:social was retired from the SPARQL side entirely 2026-07-23
-# (not "pending Falkor coverage" -- see app/worker.py::_process_scope and
-# README.md's federator section for the live-verified numbers).
+# swap) -- cognition/metacog have no Falkor equivalent at all (dead writers,
+# frozen history). orion:chat:social and orion:collapse were both retired
+# from the SPARQL side entirely, 2026-07-23 (not "pending Falkor coverage" --
+# see app/worker.py::_process_scope and README.md's federator section for
+# the live-verified numbers).
 GRAPH_COMPRESSION_EPISODIC_FALKOR_ENABLED=false
 
 # --- LLM Gateway (region summarization) ---

--- a/services/orion-graph-compression/README.md
+++ b/services/orion-graph-compression/README.md
@@ -52,7 +52,7 @@ stale_listener.py   ──► stale_queue (Postgres)
 
 | Scope | Source | Region Kind |
 |-------|--------------|-------------|
-| `episodic` | SPARQL: 8 episodic named graphs (chat, enrichment, collapse, autonomy/*). `orion:cognition`/`orion:metacog` are no longer written (2026-07-22: pure Postgres redundancy via orion-sql-writer, see rdf-writer's kill) -- still queried, will just read empty. `orion:chat:social` removed entirely 2026-07-23 (live-verified pure redundancy with Postgres `social_room_turns`, no other reader -- see federator section below). Additively unioned with Falkor (see below). | `community` |
+| `episodic` | SPARQL: 7 episodic named graphs (chat, enrichment, autonomy/*). `orion:cognition`/`orion:metacog` are no longer written (2026-07-22: pure Postgres redundancy via orion-sql-writer, see rdf-writer's kill) -- still queried, will just read empty (frozen historical content only). `orion:chat:social` and `orion:collapse` both removed entirely 2026-07-23 -- see federator section below. Additively unioned with Falkor (see below). | `community` |
 | `substrate` | FalkorDB only (`orion_substrate` graph). SPARQL `SubstrateFederator` retired 2026-07-23 -- see below. | `hotspot` |
 
 `self_study` was retired 2026-07-23 (previously read `orion:self`,
@@ -80,16 +80,21 @@ no clusters.
 **`GRAPH_COMPRESSION_EPISODIC_FALKOR_ENABLED`** (dark by default, still
 additive): results are **unioned** with the SPARQL `EpisodicFederator`'s
 output in `worker.py::_process_scope`, not swapped -- `episodic_falkor.py`
-covers only the `orion_recall` slice (ChatTurn/Tag/Entity); collapse has no
-Falkor writer yet and still depends on the SPARQL federator. Not retired --
-this scope's SPARQL side is genuinely still load-bearing for collapse
-content Falkor doesn't cover, unlike `substrate`/`self_study` above.
+covers the `orion_recall` slice (ChatTurn/Tag/Entity, plus CollapseEvent via
+the collapse-triage Falkor writer, `RECALL_FALKOR_COLLAPSE_TRIAGE_ENABLED`
+in orion-meta-tags). Cognition/metacog have no Falkor equivalent at all
+(dead writers, frozen history) and remain genuinely SPARQL-only -- not
+retired, that scope's SPARQL side is still load-bearing for that content,
+unlike `substrate`/`self_study`/`chat:social`/`collapse` above.
 
-`orion:chat:social` (social-turn content) was removed from the SPARQL
+`orion:chat:social` (social-turn content) and `orion:collapse` (raw
+collapse-mirror-entry content) were both removed from the SPARQL
 federator's graph list entirely, 2026-07-23 -- not "covered by Falkor
-instead" so much as retired outright (live-verified pure redundancy with
-Postgres `social_room_turns`: richer schema including actual prompt/response
-text the Fuseki copy never had, no other reader anywhere). orion-meta-tags
+instead" so much as retired outright.
+
+`orion:chat:social`: live-verified pure redundancy with Postgres
+`social_room_turns` (richer schema including actual prompt/response text
+the Fuseki copy never had, no other reader anywhere). orion-meta-tags
 does write social-turn tags/entities into the same `orion_recall` graph
 `episodic_falkor.py` reads (unconditional for both `chat.history` and
 `social.turn.stored.v1` since 2026-07-18), but live-verified thin as of this
@@ -99,6 +104,30 @@ equivalent coverage. Social-chat volume itself looks near-dormant (Postgres
 `social_room_turns`' most recent row predates this cutover by ~20 days), so
 this was judged low-risk to retire now rather than worth a dedicated
 migration effort.
+
+`orion:collapse`: live SPARQL `COUNT` confirmed exactly **0** triples, ever
+-- not low, zero, and structurally guaranteed to stay that way. `orion-rdf-
+writer`'s `collapse.mirror.entry` handler (`_build_raw_collapse_graph`) has
+its own `observer==Juniper`/dense gate, but that gate is unreachable: rdf-
+writer only subscribes to `orion:collapse:intake`, which carries
+`kind="collapse.mirror.intake"` from `orion-cortex-exec`. The only real
+producer of `kind="collapse.mirror.entry"` is `orion-collapse-mirror`,
+which publishes it to a *different* channel, `orion:collapse:triage` --
+registered in `channels.yaml` with `orion-rdf-writer` absent from its
+consumer list. So this dispatch branch never receives a matching envelope
+at all, independent of the observer/dense gate -- a real channel/kind
+mismatch bug in `orion-rdf-writer`, not fixed here (out of scope for a
+series about retiring Fuseki *reads*, not reviving Fuseki *writes*), but
+worth its own follow-up if anyone ever wants this path alive. Graph-name
+resolution confirmed correct separately (`rdf_store.py::normalize_graph_name`
+maps `"orion:collapse"` to the exact URI queried) -- not a naming-mismatch
+bug either. Since it's provably always been empty, removing it from
+`EpisodicFederator` changes nothing about any cluster ever formed. Collapse
+tag/entity content (a separate concern from this raw-entry graph) has
+*potential* Falkor coverage via the collapse-triage writer noted above, but
+that flag (`RECALL_FALKOR_COLLAPSE_TRIAGE_ENABLED`) ships dark by default
+in `orion-meta-tags` -- not claimed as active coverage here, just noted as
+the mechanism that exists if/when it's flipped on.
 
 ## Bus Events
 

--- a/services/orion-graph-compression/app/federators/episodic.py
+++ b/services/orion-graph-compression/app/federators/episodic.py
@@ -10,9 +10,32 @@ logger = logging.getLogger("orion.graph-compression.federator.episodic")
 EPISODIC_GRAPHS = [
     "http://conjourney.net/graph/orion/chat",
     "http://conjourney.net/graph/orion/enrichment",
-    "http://conjourney.net/graph/orion/collapse",
     "http://conjourney.net/graph/orion/cognition",
     "http://conjourney.net/graph/orion/metacog",
+    # orion/collapse removed 2026-07-23: live SPARQL COUNT confirmed exactly
+    # 0 triples, ever -- not "low," zero, and structurally guaranteed to
+    # stay that way, not just rare. orion-rdf-writer's collapse.mirror.entry
+    # handler (_build_raw_collapse_graph) exists and has its own
+    # observer==Juniper/dense gate, but that gate is unreachable: rdf-writer
+    # only subscribes to orion:collapse:intake (CHANNEL_EVENTS_COLLAPSE),
+    # which carries kind="collapse.mirror.intake" from orion-cortex-exec.
+    # The only real producer of kind="collapse.mirror.entry" is
+    # orion-collapse-mirror/app/bus_runtime.py, which publishes it to a
+    # DIFFERENT channel, orion:collapse:triage -- registered in
+    # channels.yaml with consumer_services orion-meta-tags/orion-vector-
+    # writer/orion-sql-writer/orion-actions, NOT orion-rdf-writer. So the
+    # dispatch branch that would write this graph never actually receives
+    # a matching envelope at all, independent of the observer/dense gate.
+    # Graph-name resolution confirmed correct separately
+    # (rdf_store.py::normalize_graph_name maps "orion:collapse" to this
+    # exact URI) -- not a naming-mismatch bug either. Since it's provably
+    # always been empty, EpisodicFederator's read of it has never
+    # contributed any clustering signal; removing it changes nothing about
+    # today's real clusters. (The channel/kind mismatch itself is a
+    # separate, real bug in orion-rdf-writer worth its own follow-up if
+    # anyone ever wants this write path alive -- not fixed here, since the
+    # whole point of this series is retiring Fuseki reads, not reviving
+    # Fuseki writes.)
     # orion/chat/social removed 2026-07-23: live-verified pure redundancy.
     # Postgres social_room_turns already owns richer content (33 rows,
     # actual prompt/response/text -- the Fuseki triples were metadata-only,

--- a/services/orion-graph-compression/app/stale_listener.py
+++ b/services/orion-graph-compression/app/stale_listener.py
@@ -13,6 +13,12 @@ logger = logging.getLogger("orion.graph-compression.stale_listener")
 _GRAPH_TO_SCOPE = {
     "orion:chat": "episodic",
     "orion:enrichment": "episodic",
+    # orion:collapse: EpisodicFederator no longer reads this graph (retired
+    # 2026-07-23, see episodic.py) -- this mapping is fully inert, not just
+    # wastefully conservative like orion:chat:social's, since no rdf:enqueue
+    # event naming this graph is even reachable (confirmed: orion-rdf-writer
+    # isn't subscribed to the channel that ever carries collapse.mirror.entry).
+    # Left in place rather than removed since it's harmless either way.
     "orion:collapse": "episodic",
     "orion:cognition": "episodic",
     "orion:metacog": "episodic",

--- a/services/orion-graph-compression/app/worker.py
+++ b/services/orion-graph-compression/app/worker.py
@@ -117,14 +117,17 @@ class CompressionWorker:
             triples = EpisodicFederator(**federator_kwargs).fetch()
             if s.graph_compression_episodic_falkor_enabled:
                 # Additive, not a swap: FalkorEpisodicFederator only covers
-                # the orion_recall (ChatTurn/Tag/Entity) slice of what the
-                # SPARQL federator reads (collapse/cognition/metacog have no
-                # Falkor equivalent at all). orion:chat:social was retired
-                # from the SPARQL side entirely 2026-07-23 -- not "pending
-                # Falkor coverage," just gone (live-verified pure redundancy
-                # with Postgres social_room_turns); see
-                # episodic_falkor.py's docstring for the live coverage
-                # numbers. Union so verifying the rest of this live can
+                # the orion_recall (ChatTurn/Tag/Entity/CollapseEvent) slice
+                # of what the SPARQL federator reads. cognition/metacog have
+                # no Falkor equivalent at all (dead writers, frozen history).
+                # orion:chat:social and orion:collapse were both retired from
+                # the SPARQL side entirely, 2026-07-23 -- not "pending Falkor
+                # coverage," just gone (social: live-verified pure redundancy
+                # with Postgres social_room_turns; collapse: live-verified
+                # exactly 0 triples ever, a real producer's write path that
+                # simply never fired -- see episodic.py's own comment for the
+                # gate it traced). See episodic_falkor.py's docstring for the
+                # live coverage numbers. Union so verifying the rest of this live can
                 # never regress existing clustering signal.
                 triples = list(set(triples) | set(FalkorEpisodicFederator().fetch()))
             kind = "community"

--- a/services/orion-graph-compression/tests/test_federator_episodic.py
+++ b/services/orion-graph-compression/tests/test_federator_episodic.py
@@ -42,6 +42,16 @@ def test_episodic_federator_no_longer_queries_chat_social():
     assert "http://conjourney.net/graph/orion/chat/social" not in EPISODIC_GRAPHS
 
 
+def test_episodic_federator_no_longer_queries_collapse():
+    """Regression for the 2026-07-23 retirement: orion:collapse was removed
+    (live-verified exactly 0 triples ever -- a real producer's write path
+    that simply never fired) -- must not silently reappear in the graph
+    list."""
+    from app.federators.episodic import EPISODIC_GRAPHS
+
+    assert "http://conjourney.net/graph/orion/collapse" not in EPISODIC_GRAPHS
+
+
 def test_episodic_federator_drops_literal_objects():
     """Literal objects are not graph nodes and must be filtered out."""
     sparql_response = {


### PR DESCRIPTION
## Summary

- Live SPARQL COUNT confirmed exactly 0 triples, ever, in orion:collapse.
- Root cause (review-corrected from an initial incomplete theory): orion-rdf-writer isn't even subscribed to the channel that ever carries collapse.mirror.entry envelopes -- a real channel/kind mismatch bug, flagged for its own follow-up, not fixed here.
- EpisodicFederator stays live for its other 7 graphs -- only this dead one removed.
- Review caught my first-pass comments attributing the empty graph to the wrong mechanism (a gate that's real but unreachable) -- corrected before merge.

Full report: `docs/superpowers/pr-reports/2026-07-23-graph-compression-drop-collapse-episodic-pr.md`

## Test plan

- [x] `pytest services/orion-graph-compression/tests -q` -> 47 passed
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)