### PR TITLE
feat(substrate): in-process RPC health aggregator (step 2 of RPC-health redesign)

### DIFF
--- a/orion/core/bus/async_service.py
+++ b/orion/core/bus/async_service.py
@@ -16,6 +16,7 @@ from orion.schemas.registry import resolve as resolve_schema_id
 from .bus_schemas import BaseEnvelope
 from .codec import OrionCodec
 from .enforce import enforcer
+from .rpc_health import RpcHealthAggregator, RpcHealthSnapshot
 from .velocity_keys import DEFAULT_BUCKET_TTL_SEC, velocity_key
 
 logger = logging.getLogger("orion.bus.async")
@@ -45,6 +46,12 @@ class OrionBusAsync:
         self._rpc_lock = asyncio.Lock()
         self._rpc_subscribed: set[str] = set()
         self._pending_rpc: dict[tuple[str, str], asyncio.Future] = {}
+        # docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md
+        # step 2: in-process only, not shared across fork() children, same as every
+        # other per-instance RPC state above. No periodic self-publish wired yet --
+        # see rpc_health.py's own module docstring for why that's a separate,
+        # deliberately deferred decision.
+        self._rpc_health = RpcHealthAggregator()
         if enforce_catalog is None:
             enforce_catalog = os.getenv("ORION_BUS_ENFORCE_CATALOG", "false").lower() == "true"
         self.enforce_catalog = bool(enforce_catalog)
@@ -101,6 +108,13 @@ class OrionBusAsync:
             await child.connect()
             child.start_rpc_worker()
         return child
+
+    def get_rpc_health_snapshot(self) -> RpcHealthSnapshot:
+        """Drain this instance's accumulated real rpc_request() outcomes since the
+        last call (or since construction). Read-only w.r.t. the bus itself -- no I/O,
+        no publish. No automatic periodic caller exists yet; see rpc_health.py's
+        module docstring for why that's a separate, deliberately deferred decision."""
+        return self._rpc_health.snapshot_and_reset()
 
     def start_rpc_worker(self) -> None:
         if not self.enabled:
@@ -401,22 +415,26 @@ class OrionBusAsync:
                 # benchmark is scoped to the design spec's next patch step (the in-memory
                 # aggregator), not this one, since that step is where a second per-call
                 # code path actually gets added.
+                success_elapsed_ms = (perf_counter() - started) * 1000.0
                 logger.info(
                     "[rpc] reply received corr_id=%s reply_channel=%s path=worker elapsed_ms=%.1f",
                     corr,
                     reply_channel,
-                    (perf_counter() - started) * 1000.0,
+                    success_elapsed_ms,
                 )
+                self._rpc_health.record_success(request_channel=request_channel, latency_ms=success_elapsed_ms)
                 return result
             except asyncio.TimeoutError:
+                timeout_elapsed_ms = (perf_counter() - started) * 1000.0
                 logger.error(
                     "[rpc] timeout waiting for reply corr_id=%s request_channel=%s reply_channel=%s timeout_sec=%.2f elapsed_ms=%.1f",
                     corr,
                     request_channel,
                     reply_channel,
                     timeout_sec,
-                    (perf_counter() - started) * 1000.0,
+                    timeout_elapsed_ms,
                 )
+                self._rpc_health.record_timeout(request_channel=request_channel, elapsed_ms=timeout_elapsed_ms)
                 raise TimeoutError(f"RPC timeout waiting on {reply_channel}")
             finally:
                 self._pending_rpc.pop(key, None)
@@ -441,11 +459,15 @@ class OrionBusAsync:
 
                 async def _wait_one():
                     async for msg in self.iter_messages(pubsub):
+                        success_elapsed_ms = (perf_counter() - started) * 1000.0
                         logger.info(
                             "[rpc] reply received corr_id=%s reply_channel=%s path=inline elapsed_ms=%.1f",
                             corr,
                             reply_channel,
-                            (perf_counter() - started) * 1000.0,
+                            success_elapsed_ms,
+                        )
+                        self._rpc_health.record_success(
+                            request_channel=request_channel, latency_ms=success_elapsed_ms
                         )
                         return msg
 
@@ -458,14 +480,16 @@ class OrionBusAsync:
                 msg = await asyncio.wait_for(_wait_one(), timeout=timeout_sec)
                 return msg
             except asyncio.TimeoutError:
+                timeout_elapsed_ms = (perf_counter() - started) * 1000.0
                 logger.error(
                     "[rpc] timeout waiting for reply corr_id=%s request_channel=%s reply_channel=%s timeout_sec=%.2f elapsed_ms=%.1f",
                     corr,
                     request_channel,
                     reply_channel,
                     timeout_sec,
-                    (perf_counter() - started) * 1000.0,
+                    timeout_elapsed_ms,
                 )
+                self._rpc_health.record_timeout(request_channel=request_channel, elapsed_ms=timeout_elapsed_ms)
                 raise TimeoutError(f"RPC timeout waiting on {reply_channel}")
 
     async def rpc_legacy_dict(

--- a/orion/core/bus/rpc_health.py
+++ b/orion/core/bus/rpc_health.py
@@ -1,0 +1,143 @@
+"""In-process RPC health aggregator for OrionBusAsync.rpc_request().
+
+Step 2 of docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md's
+"Recommended next patch", after step 1 (worker-path logging fix + real baseline
+measurement, PR #1290) and the "gated investigation" (PR #1299: confirmed no silent
+uncaught-exception blind spot in `rpc_request()`'s outcome set, confirmed real
+cross-service volume/variance, formally benchmarked the log line's overhead as
+negligible -- +9.8us/call, 0.0135% of the fastest real observed RPC call).
+
+**Scope of this patch, deliberately narrow:** this builds the in-memory accumulator
+only -- `record_success()`/`record_timeout()` called synchronously inside
+`rpc_request()`'s existing branches, `snapshot_and_reset()` exposed for a future caller
+to drain. It does NOT add a periodic self-publish loop, a new schema/bus channel, or
+any wiring into `orion-substrate-runtime`'s tick loop or any live consumer -- that
+cross-process "how does one service's in-memory counters reach anything else" question
+is a separate, still-open architectural decision (this aggregator is per-process, same
+as every other piece of `OrionBusAsync` instance state -- `_pending_rpc`,
+`_rpc_subscribed`, etc. -- and is NOT shared across `OrionBusAsync.fork()` children,
+consistent with that existing pattern). Building that consumption path before this
+piece is proven in production would be designing around an assumed shape, exactly what
+the "measure before minting" discipline this whole redesign has followed exists to
+avoid.
+
+**Bounded by design, not an afterthought.** This codebase has hit the same
+"unbounded evidence-list" bug class multiple times independently (`evidence_event_ids`,
+execution-merge evidence, others) -- capped collections here from the start rather than
+retrofitted after a live incident.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+# Same cap precedent as evidence_event_ids/execution-merge-evidence elsewhere in this
+# codebase (see feedback_execution_merge_cap.md-class fixes) -- if nothing ever calls
+# snapshot_and_reset(), memory must stay flat regardless of call volume, not grow
+# unboundedly between drains.
+MAX_SAMPLES_PER_BUCKET = 500
+MAX_DISTINCT_CHANNELS = 100
+
+
+@dataclass
+class RpcHealthSnapshot:
+    """One drained window's worth of real RPC call outcomes. Success latency and
+    timeout elapsed-time are kept as separate fields, never blended -- a timeout's
+    elapsed_ms is the caller's own configured timeout_sec ceiling, not real
+    round-trip latency (the exact conflation bug found and fixed in
+    measure_rpc_health_baseline.py during step 1)."""
+
+    window_start: datetime
+    window_end: datetime
+    success_count: int
+    timeout_count: int
+    success_latency_ms_p50: Optional[float]
+    success_latency_ms_p95: Optional[float]
+    success_latency_ms_max: Optional[float]
+    timeout_elapsed_ms_max: Optional[float]
+    channel_counts: dict[str, int]
+    truncated: bool
+
+
+def _percentile(sorted_values: list[float], pct: float) -> Optional[float]:
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    k = (len(sorted_values) - 1) * pct
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = k - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+@dataclass
+class RpcHealthAggregator:
+    """Cheap, in-memory, per-`OrionBusAsync`-instance accumulator. `record_success()`/
+    `record_timeout()` are called synchronously from `rpc_request()`'s existing
+    success/timeout branches -- no I/O, no bus publish, bounded list appends only.
+    asyncio is single-threaded cooperative concurrency, so no lock is needed for these
+    plain dict/list mutations (same assumption already relied on elsewhere in
+    `OrionBusAsync`, e.g. `_pending_rpc`).
+    """
+
+    _window_start: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    _success_latencies_ms: list[float] = field(default_factory=list)
+    _timeout_elapsed_ms: list[float] = field(default_factory=list)
+    _success_count: int = 0
+    _timeout_count: int = 0
+    _channel_counts: dict[str, int] = field(default_factory=dict)
+    _truncated: bool = False
+
+    def record_success(self, *, request_channel: str, latency_ms: float) -> None:
+        self._success_count += 1
+        self._bump_channel(request_channel)
+        if len(self._success_latencies_ms) < MAX_SAMPLES_PER_BUCKET:
+            self._success_latencies_ms.append(latency_ms)
+        else:
+            self._truncated = True
+
+    def record_timeout(self, *, request_channel: str, elapsed_ms: float) -> None:
+        self._timeout_count += 1
+        self._bump_channel(request_channel)
+        if len(self._timeout_elapsed_ms) < MAX_SAMPLES_PER_BUCKET:
+            self._timeout_elapsed_ms.append(elapsed_ms)
+        else:
+            self._truncated = True
+
+    def _bump_channel(self, request_channel: str) -> None:
+        if not request_channel:
+            return
+        if request_channel in self._channel_counts:
+            self._channel_counts[request_channel] += 1
+        elif len(self._channel_counts) < MAX_DISTINCT_CHANNELS:
+            self._channel_counts[request_channel] = 1
+        else:
+            self._truncated = True
+
+    def snapshot_and_reset(self) -> RpcHealthSnapshot:
+        """Atomically read the accumulated window and reset for the next one."""
+        now = datetime.now(timezone.utc)
+        sorted_success = sorted(self._success_latencies_ms)
+        snapshot = RpcHealthSnapshot(
+            window_start=self._window_start,
+            window_end=now,
+            success_count=self._success_count,
+            timeout_count=self._timeout_count,
+            success_latency_ms_p50=_percentile(sorted_success, 0.5),
+            success_latency_ms_p95=_percentile(sorted_success, 0.95),
+            success_latency_ms_max=max(self._success_latencies_ms) if self._success_latencies_ms else None,
+            timeout_elapsed_ms_max=max(self._timeout_elapsed_ms) if self._timeout_elapsed_ms else None,
+            channel_counts=dict(self._channel_counts),
+            truncated=self._truncated,
+        )
+        self._window_start = now
+        self._success_latencies_ms = []
+        self._timeout_elapsed_ms = []
+        self._success_count = 0
+        self._timeout_count = 0
+        self._channel_counts = {}
+        self._truncated = False
+        return snapshot

--- a/orion/core/bus/rpc_health.py
+++ b/orion/core/bus/rpc_health.py
@@ -29,9 +29,12 @@ retrofitted after a live incident.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
+
+logger = logging.getLogger("orion.bus.rpc_health")
 
 # Same cap precedent as evidence_event_ids/execution-merge-evidence elsewhere in this
 # codebase (see feedback_execution_merge_cap.md-class fixes) -- if nothing ever calls
@@ -47,7 +50,17 @@ class RpcHealthSnapshot:
     timeout elapsed-time are kept as separate fields, never blended -- a timeout's
     elapsed_ms is the caller's own configured timeout_sec ceiling, not real
     round-trip latency (the exact conflation bug found and fixed in
-    measure_rpc_health_baseline.py during step 1)."""
+    measure_rpc_health_baseline.py during step 1).
+
+    `truncated=True` means the window's real call *counts* (`success_count`/
+    `timeout_count`) are still accurate, but the sample lists behind
+    `success_latency_ms_*`/`timeout_elapsed_ms_max` are first-N-wins, not a rolling
+    window: once `MAX_SAMPLES_PER_BUCKET` is hit mid-window, every later sample is
+    dropped from the percentile/max computation, not the earliest ones. A future
+    consumer draining a long-lived, high-volume window should not assume
+    `success_latency_ms_max` is the true max of the whole window when `truncated` is
+    set -- a later latency spike could be invisible. Not a concern yet (no periodic
+    drain is wired), but a real caveat for whoever wires the first one."""
 
     window_start: datetime
     window_end: datetime
@@ -92,20 +105,33 @@ class RpcHealthAggregator:
     _truncated: bool = False
 
     def record_success(self, *, request_channel: str, latency_ms: float) -> None:
-        self._success_count += 1
-        self._bump_channel(request_channel)
-        if len(self._success_latencies_ms) < MAX_SAMPLES_PER_BUCKET:
-            self._success_latencies_ms.append(latency_ms)
-        else:
-            self._truncated = True
+        """Never raises past this boundary: this call sits directly in
+        `rpc_request()`'s success path, after the real result is already in hand --
+        a bug in here must never mask or replace that real outcome."""
+        try:
+            self._success_count += 1
+            self._bump_channel(request_channel)
+            if len(self._success_latencies_ms) < MAX_SAMPLES_PER_BUCKET:
+                self._success_latencies_ms.append(latency_ms)
+            else:
+                self._truncated = True
+        except Exception:
+            logger.warning("failed to record RPC success in health aggregator", exc_info=True)
 
     def record_timeout(self, *, request_channel: str, elapsed_ms: float) -> None:
-        self._timeout_count += 1
-        self._bump_channel(request_channel)
-        if len(self._timeout_elapsed_ms) < MAX_SAMPLES_PER_BUCKET:
-            self._timeout_elapsed_ms.append(elapsed_ms)
-        else:
-            self._truncated = True
+        """Never raises past this boundary: this call sits directly in
+        `rpc_request()`'s `except asyncio.TimeoutError` branch, immediately before
+        `raise TimeoutError(...)` -- a bug in here must never substitute a different
+        exception type for the real timeout the caller is about to see."""
+        try:
+            self._timeout_count += 1
+            self._bump_channel(request_channel)
+            if len(self._timeout_elapsed_ms) < MAX_SAMPLES_PER_BUCKET:
+                self._timeout_elapsed_ms.append(elapsed_ms)
+            else:
+                self._truncated = True
+        except Exception:
+            logger.warning("failed to record RPC timeout in health aggregator", exc_info=True)
 
     def _bump_channel(self, request_channel: str) -> None:
         if not request_channel:

--- a/orion/core/bus/tests/test_rpc_health.py
+++ b/orion/core/bus/tests/test_rpc_health.py
@@ -125,3 +125,27 @@ def test_empty_request_channel_ignored_without_crashing() -> None:
     snap = agg.snapshot_and_reset()
     assert snap.success_count == 1
     assert snap.channel_counts == {}
+
+
+def test_record_success_never_raises_past_its_boundary() -> None:
+    """record_success() sits directly in rpc_request()'s success path, after the
+    real result is already in hand -- a bug in here must never propagate and mask
+    that real outcome. An unhashable request_channel (violates the str type hint,
+    but this must degrade gracefully rather than raise) exercises the internal
+    try/except directly."""
+    agg = RpcHealthAggregator()
+    agg.record_success(request_channel=["not", "a", "string"], latency_ms=1.0)  # type: ignore[arg-type]
+    snap = agg.snapshot_and_reset()
+    # success_count still increments -- only the channel bookkeeping (which is what
+    # actually raises on an unhashable key) is swallowed.
+    assert snap.success_count == 1
+
+
+def test_record_timeout_never_raises_past_its_boundary() -> None:
+    """Same guarantee as above, for the timeout path -- a raise here must never
+    substitute a different exception type for the real TimeoutError the caller is
+    about to see."""
+    agg = RpcHealthAggregator()
+    agg.record_timeout(request_channel=["not", "a", "string"], elapsed_ms=1.0)  # type: ignore[arg-type]
+    snap = agg.snapshot_and_reset()
+    assert snap.timeout_count == 1

--- a/orion/core/bus/tests/test_rpc_health.py
+++ b/orion/core/bus/tests/test_rpc_health.py
@@ -1,0 +1,127 @@
+"""Unit tests for RpcHealthAggregator (orion/core/bus/rpc_health.py).
+
+Step 2 of docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md.
+Pure, no asyncio/Redis required.
+"""
+
+from __future__ import annotations
+
+from orion.core.bus.rpc_health import (
+    MAX_DISTINCT_CHANNELS,
+    MAX_SAMPLES_PER_BUCKET,
+    RpcHealthAggregator,
+)
+
+
+def test_empty_snapshot_has_no_data() -> None:
+    agg = RpcHealthAggregator()
+    snap = agg.snapshot_and_reset()
+    assert snap.success_count == 0
+    assert snap.timeout_count == 0
+    assert snap.success_latency_ms_p50 is None
+    assert snap.success_latency_ms_p95 is None
+    assert snap.success_latency_ms_max is None
+    assert snap.timeout_elapsed_ms_max is None
+    assert snap.channel_counts == {}
+    assert snap.truncated is False
+
+
+def test_record_success_counts_and_tracks_latency() -> None:
+    agg = RpcHealthAggregator()
+    agg.record_success(request_channel="orion:test:request", latency_ms=100.0)
+    agg.record_success(request_channel="orion:test:request", latency_ms=200.0)
+    snap = agg.snapshot_and_reset()
+    assert snap.success_count == 2
+    assert snap.timeout_count == 0
+    assert snap.success_latency_ms_max == 200.0
+    assert snap.channel_counts == {"orion:test:request": 2}
+
+
+def test_record_timeout_counts_and_tracks_elapsed_separately_from_success() -> None:
+    """A timeout's elapsed_ms must never leak into success latency stats -- same
+    conflation bug already found and fixed in measure_rpc_health_baseline.py."""
+    agg = RpcHealthAggregator()
+    agg.record_success(request_channel="orion:test:request", latency_ms=100.0)
+    agg.record_timeout(request_channel="orion:test:request", elapsed_ms=420000.0)
+    snap = agg.snapshot_and_reset()
+    assert snap.success_count == 1
+    assert snap.timeout_count == 1
+    assert snap.success_latency_ms_max == 100.0
+    assert snap.timeout_elapsed_ms_max == 420000.0
+    assert snap.channel_counts == {"orion:test:request": 2}
+
+
+def test_snapshot_and_reset_clears_state_for_next_window() -> None:
+    agg = RpcHealthAggregator()
+    agg.record_success(request_channel="c", latency_ms=1.0)
+    first = agg.snapshot_and_reset()
+    assert first.success_count == 1
+
+    second = agg.snapshot_and_reset()
+    assert second.success_count == 0
+    assert second.channel_counts == {}
+
+
+def test_snapshot_window_advances_between_drains() -> None:
+    agg = RpcHealthAggregator()
+    first = agg.snapshot_and_reset()
+    second = agg.snapshot_and_reset()
+    assert second.window_start == first.window_end
+
+
+def test_percentiles_computed_over_success_latencies() -> None:
+    agg = RpcHealthAggregator()
+    for v in [10.0, 20.0, 30.0, 40.0, 50.0]:
+        agg.record_success(request_channel="c", latency_ms=v)
+    snap = agg.snapshot_and_reset()
+    assert snap.success_latency_ms_p50 == 30.0
+    assert snap.success_latency_ms_max == 50.0
+
+
+def test_success_latency_bounded_and_flags_truncation() -> None:
+    agg = RpcHealthAggregator()
+    for i in range(MAX_SAMPLES_PER_BUCKET + 10):
+        agg.record_success(request_channel="c", latency_ms=float(i))
+    snap = agg.snapshot_and_reset()
+    # count is real (not silently dropped), only the raw sample list is capped
+    assert snap.success_count == MAX_SAMPLES_PER_BUCKET + 10
+    assert snap.truncated is True
+
+
+def test_timeout_elapsed_bounded_and_flags_truncation() -> None:
+    agg = RpcHealthAggregator()
+    for i in range(MAX_SAMPLES_PER_BUCKET + 5):
+        agg.record_timeout(request_channel="c", elapsed_ms=float(i))
+    snap = agg.snapshot_and_reset()
+    assert snap.timeout_count == MAX_SAMPLES_PER_BUCKET + 5
+    assert snap.truncated is True
+
+
+def test_distinct_channel_count_bounded_and_flags_truncation() -> None:
+    agg = RpcHealthAggregator()
+    for i in range(MAX_DISTINCT_CHANNELS + 20):
+        agg.record_success(request_channel=f"orion:test:request:{i}", latency_ms=1.0)
+    snap = agg.snapshot_and_reset()
+    assert len(snap.channel_counts) == MAX_DISTINCT_CHANNELS
+    assert snap.truncated is True
+
+
+def test_existing_channel_still_increments_past_distinct_cap() -> None:
+    """Once the distinct-channel cap is hit, an *existing* channel key must still
+    increment correctly -- only brand-new channel names get dropped."""
+    agg = RpcHealthAggregator()
+    for i in range(MAX_DISTINCT_CHANNELS):
+        agg.record_success(request_channel=f"orion:test:request:{i}", latency_ms=1.0)
+    # cap now hit; record more against an already-tracked channel
+    agg.record_success(request_channel="orion:test:request:0", latency_ms=1.0)
+    agg.record_success(request_channel="orion:test:request:0", latency_ms=1.0)
+    snap = agg.snapshot_and_reset()
+    assert snap.channel_counts["orion:test:request:0"] == 3
+
+
+def test_empty_request_channel_ignored_without_crashing() -> None:
+    agg = RpcHealthAggregator()
+    agg.record_success(request_channel="", latency_ms=1.0)
+    snap = agg.snapshot_and_reset()
+    assert snap.success_count == 1
+    assert snap.channel_counts == {}

--- a/tests/test_bus_async_rpc_worker.py
+++ b/tests/test_bus_async_rpc_worker.py
@@ -509,3 +509,26 @@ async def test_rpc_request_inline_path_records_success_in_health_aggregator() ->
         assert snap.success_count == 1
         assert snap.timeout_count == 0
         assert snap.channel_counts == {"orion:real:request:channel": 1}
+
+
+@pytest.mark.asyncio
+async def test_fork_gets_an_independent_rpc_health_aggregator() -> None:
+    """fork() must not share the parent's RpcHealthAggregator -- same non-sharing
+    guarantee already relied on for _pending_rpc/_rpc_subscribed elsewhere in this
+    class. Recording on the parent must not show up in the child's snapshot, and
+    vice versa."""
+    parent = OrionBusAsync("redis://127.0.0.1:6379/0", enabled=True)
+    child = await parent.fork()
+    try:
+        assert child._rpc_health is not parent._rpc_health
+
+        parent._rpc_health.record_success(request_channel="parent:channel", latency_ms=1.0)
+        child_snap = child.get_rpc_health_snapshot()
+        assert child_snap.success_count == 0
+
+        child._rpc_health.record_success(request_channel="child:channel", latency_ms=1.0)
+        parent_snap = parent.get_rpc_health_snapshot()
+        assert parent_snap.success_count == 1  # only the parent's own earlier call
+        assert parent_snap.channel_counts == {"parent:channel": 1}
+    finally:
+        await child.close()

--- a/tests/test_bus_async_rpc_worker.py
+++ b/tests/test_bus_async_rpc_worker.py
@@ -327,3 +327,185 @@ async def test_rpc_request_worker_path_logs_reply_received(caplog) -> None:
             assert "elapsed_ms=" in reply_lines[0]
         finally:
             await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_request_worker_path_records_success_in_health_aggregator() -> None:
+    """Step 2 of docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-
+    redesign.md: a real, successful rpc_request() call through the worker path must
+    show up in get_rpc_health_snapshot(), not just in the log line."""
+    bus, fake_redis = _make_bus()
+    bus.publish = AsyncMock()
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        bus.start_rpc_worker()
+        await asyncio.sleep(0.1)
+
+        corr_id = "00000000-0000-4000-8000-000000000100"
+        reply_channel = f"orion:test:result:{corr_id}"
+        envelope = BaseEnvelope(
+            kind="test.request.v1",
+            source=ServiceRef(name="test", version="0"),
+            correlation_id=corr_id,
+            payload={},
+        )
+
+        async def _push_reply_shortly() -> None:
+            for _ in range(50):
+                if reply_channel in bus._rpc_subscribed:
+                    break
+                await asyncio.sleep(0.02)
+            codec = OrionCodec()
+            reply_envelope = BaseEnvelope(
+                kind="test.reply.v1",
+                source=ServiceRef(name="test", version="0"),
+                correlation_id=corr_id,
+                payload={"ok": True},
+            )
+            fake_redis.current.push(
+                {
+                    "type": "message",
+                    "channel": reply_channel.encode("utf-8"),
+                    "data": codec.encode(reply_envelope),
+                }
+            )
+
+        try:
+            await asyncio.gather(
+                _push_reply_shortly(),
+                bus.rpc_request(
+                    "orion:real:request:channel", envelope, reply_channel=reply_channel, timeout_sec=2.0
+                ),
+            )
+            snap = bus.get_rpc_health_snapshot()
+            assert snap.success_count == 1
+            assert snap.timeout_count == 0
+            assert snap.success_latency_ms_max is not None
+            assert snap.success_latency_ms_max >= 0.0
+            assert snap.channel_counts == {"orion:real:request:channel": 1}
+
+            # snapshot_and_reset() must actually reset -- a second drain with no new
+            # calls should come back empty, not double-count the same call.
+            second = bus.get_rpc_health_snapshot()
+            assert second.success_count == 0
+        finally:
+            await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_request_worker_path_records_timeout_in_health_aggregator() -> None:
+    """A real timeout on the worker path must land in timeout_count/
+    timeout_elapsed_ms_max, never mixed into success_latency stats."""
+    bus, fake_redis = _make_bus()
+    bus.publish = AsyncMock()
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        bus.start_rpc_worker()
+        await asyncio.sleep(0.1)
+
+        corr_id = "00000000-0000-4000-8000-000000000101"
+        reply_channel = f"orion:test:result:{corr_id}"
+        envelope = BaseEnvelope(
+            kind="test.request.v1",
+            source=ServiceRef(name="test", version="0"),
+            correlation_id=corr_id,
+            payload={},
+        )
+
+        try:
+            with pytest.raises(TimeoutError):
+                await bus.rpc_request(
+                    "orion:real:request:channel", envelope, reply_channel=reply_channel, timeout_sec=0.1
+                )
+            snap = bus.get_rpc_health_snapshot()
+            assert snap.success_count == 0
+            assert snap.timeout_count == 1
+            assert snap.timeout_elapsed_ms_max is not None
+            assert snap.success_latency_ms_max is None
+        finally:
+            await bus.close()
+
+
+class _InlinePubSub:
+    """Minimal, self-contained fake for the inline RPC path only -- deliberately
+    separate from _FakePubSub above (which supports get_message(), used by the worker
+    path) since the inline path's iter_messages() calls listen(), an async generator
+    _FakePubSub doesn't implement. Kept isolated so extending it can't affect any
+    existing worker-path test's behavior."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue = asyncio.Queue()
+
+    async def subscribe(self, *channels: str) -> None:
+        return None
+
+    async def unsubscribe(self, *channels: str) -> None:
+        return None
+
+    async def listen(self):
+        while True:
+            msg = await self._queue.get()
+            yield msg
+
+    async def close(self) -> None:
+        return None
+
+    def push(self, msg: dict) -> None:
+        self._queue.put_nowait(msg)
+
+
+class _InlineRedis:
+    def __init__(self, pubsub_instance: _InlinePubSub) -> None:
+        self._pubsub_instance = pubsub_instance
+
+    def pubsub(self) -> _InlinePubSub:
+        return self._pubsub_instance
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_rpc_request_inline_path_records_success_in_health_aggregator() -> None:
+    """Same check as the worker-path test above, for the inline path -- no
+    start_rpc_worker() call here, so rpc_request() falls through to the inline
+    subscribe-per-call branch."""
+    bus = OrionBusAsync("redis://127.0.0.1:6379/0", enabled=True)
+    bus.publish = AsyncMock()
+    inline_pubsub = _InlinePubSub()
+    fake_redis = _InlineRedis(inline_pubsub)
+
+    corr_id = "00000000-0000-4000-8000-000000000102"
+    reply_channel = f"orion:test:result:{corr_id}"
+    envelope = BaseEnvelope(
+        kind="test.request.v1",
+        source=ServiceRef(name="test", version="0"),
+        correlation_id=corr_id,
+        payload={},
+    )
+
+    async def _push_reply_shortly() -> None:
+        await asyncio.sleep(0.05)
+        codec = OrionCodec()
+        reply_envelope = BaseEnvelope(
+            kind="test.reply.v1",
+            source=ServiceRef(name="test", version="0"),
+            correlation_id=corr_id,
+            payload={"ok": True},
+        )
+        inline_pubsub.push(
+            {
+                "type": "message",
+                "channel": reply_channel.encode("utf-8"),
+                "data": codec.encode(reply_envelope),
+            }
+        )
+
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        _, msg = await asyncio.gather(
+            _push_reply_shortly(),
+            bus.rpc_request("orion:real:request:channel", envelope, reply_channel=reply_channel, timeout_sec=2.0),
+        )
+        assert msg is not None
+        snap = bus.get_rpc_health_snapshot()
+        assert snap.success_count == 1
+        assert snap.timeout_count == 0
+        assert snap.channel_counts == {"orion:real:request:channel": 1}


### PR DESCRIPTION
## Summary

- Implements step 2 of `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`'s "Recommended next patch": a cheap, in-memory, per-`OrionBusAsync`-instance accumulator wired into `rpc_request()`'s existing outcome sites.
- Deliberately narrow scope: no periodic self-publish, no new schema/channel, no live consumer wiring — that cross-process question is a separate, still-open decision, not silently answered here.
- Code review found no blocking bugs; fixed two real robustness gaps and one coverage gap before merge.

## Outcome moved

The redesign now has a real, tested, negligible-overhead place to accumulate RPC health data, ready for a future consumer to drain — without prematurely deciding how that data crosses process boundaries.

## Current architecture

Step 1 (PR #1290) closed a logging gap in the worker RPC path and built a baseline measurement script. The "gated investigation" (PR #1299) confirmed real, non-degenerate, cross-service variance and a negligible logging overhead (~9.8us/call). This step adds the actual counter.

## Architecture touched

- `orion/core/bus/rpc_health.py` (new): `RpcHealthAggregator`/`RpcHealthSnapshot`. Bounded collections (`MAX_SAMPLES_PER_BUCKET=500`, `MAX_DISTINCT_CHANNELS=100`) with an explicit `truncated` flag — same discipline as this codebase's prior `evidence_event_ids`-class fixes.
- `orion/core/bus/async_service.py` — new `_rpc_health` instance attribute, `get_rpc_health_snapshot()` method, and `record_success()`/`record_timeout()` calls at all 4 real outcome sites (worker success/timeout, inline success/timeout).

## Files changed

- `orion/core/bus/rpc_health.py` (new)
- `orion/core/bus/tests/test_rpc_health.py` (new): 13 unit tests
- `orion/core/bus/async_service.py`: wiring
- `tests/test_bus_async_rpc_worker.py`: 4 new integration/isolation tests

## Schema / bus / API changes

None. Purely in-process; nothing published to a bus channel.

## Tests run

```text
tests/test_bus_async_rpc_worker.py -- 9 passed
orion/core/bus/tests/test_rpc_health.py -- 13 passed
Full bus test suite (collateral check: tests/test_bus_rpc_fork_client.py,
test_bus_pubsub_timeout.py, test_bus_core_health_watchdog.py, orion/core/bus/tests/)
-- 79 passed, no regressions
```

## Overhead verification

```text
record_success()/record_timeout() measured directly: ~500-530ns/call in isolation --
~20x smaller than PR #1299's already-accepted logging overhead (~9.8us/call, 0.0135%
of the fastest real observed RPC call). Combined overhead stays in the same
negligible order of magnitude.
```

## Review findings fixed

- Finding: `record_success()`/`record_timeout()` had no exception boundary of their own — a raise inside `_bump_channel()` could have propagated out of `rpc_request()` in place of the real result, or substituted a different exception type for a real `TimeoutError`.
  - Fix: wrapped both methods in their own `try/except`, logging and swallowing. 2 new tests exercise this with an unhashable channel value.
  - Evidence: commit `215775bd`.
- Finding: truncation is first-N-wins (drops later samples), not a rolling window — could hide a late-window latency spike despite `truncated=True`.
  - Fix: documented explicitly on `RpcHealthSnapshot` for the next consumer to know.
  - Evidence: commit `215775bd`.
- Finding: `fork()`'s aggregator non-sharing was correct but untested.
  - Fix: added a direct isolation test.
  - Evidence: commit `215775bd`.
- No blocking correctness issues found: all 4 outcome sites confirmed wired with the correct `request_channel` (not `reply_channel`), boundary logic hand-verified with no off-by-one, no scope creep beyond the stated non-goals.

## Restart required

```bash
docker compose --env-file .env --env-file services/<service>/.env -f services/<service>/docker-compose.yml up -d --build
```

Shared library (`orion/core/bus/async_service.py`) imported by 37+ services — no restart strictly required (purely additive, in-memory only, nothing consumes the new getter yet), but any service can rebuild to pick it up.

## Risks / concerns

- Severity: Low
- Concern: none identified beyond the findings above, all fixed.

## PR link

(added by gh pr create below)