### PR TITLE
fix(substrate): predicted_shift was worse than a coin flip -- flip to reversion

### DIFF
--- a/docs/superpowers/specs/2026-07-23-predicted-shift-reversion-finding.md
+++ b/docs/superpowers/specs/2026-07-23-predicted-shift-reversion-finding.md
@@ -1,0 +1,102 @@
+# `predicted_shift` reversion finding — metric-quality-gate exercise on L6 item 5
+
+Status: **finding + shipped fix.** Not a design proposal — this documents a metric-quality-gate
+pass (CLAUDE.md §0A) run against L6 item 4's already-merged `predicted_shift` field (PR #1301)
+while scoping item 5, which surfaced that item 4's trend formula was empirically worse than
+chance. Fixed in the same investigation, before item 5 was started.
+
+## Context
+
+Item 4 (`docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`,
+PR #1276/#1284/#1301) computes `predicted_shift`: whichever of the five Active-Inference domains
+(execution/transport/biometrics/chat/route) has the largest-magnitude `prediction_error` trend
+over a rolling window is named as "what surprises me next." The original formula (PR #1301,
+`scripts/analysis/measure_ast_hot_reducer.py::compute_prediction_error_trend()`) was
+`mean(recent half) - mean(prior half)` — naive continuation: if a domain's error just rose, predict
+it keeps rising.
+
+Item 5 (the higher-order/HOT piece) was proposed to build on whether item 4's own predictions come
+true — a genuine second-order signal (per Rosenthal-style Higher-Order Theory: a representation of
+whether a lower-order representation is accurate). Before building that, CLAUDE.md's
+metric-quality-gate step 4 ("pull real data and look at it") requires checking item 4's predictions
+against reality first — not assumed accurate because the code runs and produces plausible-looking
+strings.
+
+## Finding: naive continuation is worse than a coin flip
+
+Back-tested `compute_prediction_error_trend()`'s original formula against real
+`substrate_field_state` history for `node:substrate.biometrics` — the only domain with enough real
+variance to test against (execution/chat/route are real but tiny; transport reads exactly 0.0 for
+entire multi-hour windows, per the already-documented transport narrow-scope finding). For each
+sampled tick, predicted direction (rising/falling) was checked against the domain's actual value
+~60s later. Final validation run, frozen at a single reference timestamp (`2026-07-23T05:32:00Z`)
+so both windows and both formulas (continuation and reversion) are scored from the identical sample
+set in one pass — not re-queried across separate runs against a live, still-changing table, which
+is why an earlier draft of this doc cited slightly different numbers from the same underlying
+result:
+
+| Window | n | Continuation accuracy | z (vs 50% null) | Reversion accuracy |
+|---|---|---|---|---|
+| A: last 3h | 332 | **37.7%** | -4.50 | **62.3%** |
+| B: 44-48h before that | 454 | **41.0%** | -3.85 | **59.0%** |
+
+Continuation and reversion accuracy sum to exactly 100% in both rows by construction — same
+backtest pass, same sample set, strictly opposite predictions (not two independent runs that
+happen to be close). Both continuation results are far below chance (both `p < 0.001`, two-tailed).
+
+Consistent across every prediction horizon tested on an earlier exploratory pass against Window A
+(2 to 20 field_state ticks / ~4-40s ahead, all 44-48% — below the ~60s headline number's own 37.7%,
+but likewise all below chance). A random coin-flip baseline scored within noise of 50% on the same
+data, confirming the below-chance continuation result isn't a methodology artifact.
+
+**A decay-adjusted formula (compare the current value to what pure exponential continuation of the
+prior half's own trajectory would predict, rather than a flat two-window-mean comparison) was also
+tested in that same earlier exploratory pass and only marginally improved on continuation — 43-45%,
+still well below chance.** The problem isn't the extrapolation *method*, it's the extrapolation
+*direction*: `prediction_error` is spike-and-settle (a burst of real activity is more often
+followed by quiet than by more activity), not momentum-carrying.
+
+## Fix shipped
+
+`compute_prediction_error_trend()` now returns `mean(prior half) - mean(recent half)` — the
+opposite sign of the original formula. `reduce_attention_self_model()`'s own consumption contract
+(positive = predicted rising, negative = predicted falling, argmax by magnitude) is unchanged; only
+the upstream computation that feeds it changed. No behavioral changes to
+`orion/substrate/attention_self_model.py` itself (only an illustrative docstring reference to the
+old formula was corrected there).
+
+**Validated on biometrics only, applied uniformly to all five domains.** No independent back-test
+exists yet for execution/transport/chat/route — too little real variance in the available windows.
+Applying the same reversion sign to them is a reasoned extrapolation (all five domains are computed
+the same way, as deltas between successive states from discrete events), not an independently
+confirmed one. In live replay this mostly matters for biometrics anyway — it wins the cross-domain
+argmax the overwhelming majority of the time — but a future pass should back-test the other four
+domains separately once enough real variance accumulates, rather than assuming this generalizes
+forever.
+
+## Implication for item 5
+
+Item 5 has not been built yet. This finding changes what it should measure: building it directly on
+top of the *original* (continuation) formula would have made item 5's "how often am I wrong"
+signal trivially answer "usually" — a real finding, but a shallow one, mostly just restating this
+bug rather than discovering something new. With item 4 now reversion-corrected and itself
+above-chance (though still wrong ~38-41% of the time), item 5's genuine second-order question (does
+the self-model's own confidence in a prediction track its actual reliability) has a non-trivial,
+non-degenerate baseline to be interesting against.
+
+## Non-goals
+
+- Not implementing item 5 in this patch — that remains separate, per the L6 design's own phasing.
+- Not re-deriving why biometrics specifically shows this spike-and-settle pattern (plausible
+  candidates: individual chat/execution events triggering discrete deltas rather than a smoothly
+  evolving process; not verified further here).
+- Not extending this validation to execution/chat/route (too little real variance in the available
+  windows to test against independently — flagged above, not resolved).
+
+## Acceptance checks
+
+- `pytest orion/substrate/tests/test_attention_self_model.py scripts/analysis/tests/test_measure_ast_hot_reducer.py -q`
+  passes with tests updated to assert the new (validated) direction.
+- Live replay (`measure_ast_hot_reducer.py --window-hours 6`) still shows non-degenerate,
+  cross-domain `predicted_shift` coverage post-fix (not collapsed to a single always-predicted
+  direction).

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -145,9 +145,11 @@ def reduce_attention_self_model(
 
     `prediction_error_trend_by_domain` is an optional, caller-supplied dict
     of each domain's recent prediction-error *trend* (already computed
-    upstream -- e.g. mean(recent ticks) - mean(prior ticks); this function
-    does no time-series math of its own, matching its "no I/O, format what's
-    given" design). Drives `predicted_shift`: whichever domain has the
+    upstream -- see `scripts/analysis/measure_ast_hot_reducer.py::
+    compute_prediction_error_trend()` for the real formula and the live-data
+    validation behind its sign convention; this function does no
+    time-series math of its own, matching its "no I/O, format what's given"
+    design). Drives `predicted_shift`: whichever domain has the
     largest-magnitude trend is named as the honest candidate for "what
     surprises me next" -- mirroring the argmax-over-a-delta-dict shape the
     old `self_state.dimension_trajectory` branch used, just over real

--- a/scripts/analysis/measure_ast_hot_reducer.py
+++ b/scripts/analysis/measure_ast_hot_reducer.py
@@ -17,13 +17,17 @@ replay (it is the highest-frequency real signal, per the Phase 1 design).
 for the full account -- the producer this used to read no longer exists).
 `prediction_error_by_domain` (current-tick snapshot) and
 `prediction_error_trend_by_domain` (this script's own computation --
-mean(recent half) - mean(prior half) over `PREDICTION_ERROR_TREND_WINDOW_
-TICKS` field_state ticks, a starting anchor sized to the live ~2s field_state
-cadence confirmed 2026-07-23 via `substrate_field_state` timestamp diffs, not
-yet independently calibrated -- see Missing Question 3 in the L6 design doc)
-are both derived here, in the pure replay layer, from real
-`substrate_field_state` rows -- the reducer itself does no time-series math
-of its own (see its module docstring).
+mean(prior half) - mean(recent half), a reversion prediction, over
+`PREDICTION_ERROR_TREND_WINDOW_TICKS` field_state ticks -- see
+`compute_prediction_error_trend()`'s own docstring for why this is the
+opposite sign of the naive "continue the recent direction" formula it
+replaced, and `docs/superpowers/specs/2026-07-23-predicted-shift-reversion-
+finding.md` for the validation. Window size is a starting anchor sized to
+the live ~2s field_state cadence confirmed 2026-07-23 via
+`substrate_field_state` timestamp diffs, not yet independently calibrated --
+see Missing Question 3 in the L6 design doc) are both derived here, in the
+pure replay layer, from real `substrate_field_state` rows -- the reducer
+itself does no time-series math of its own (see its module docstring).
 
 **Load-bearing finding, discovered while building this script (2026-07-18):
 `substrate_attention_broadcast_projection` -- the third input,
@@ -177,12 +181,55 @@ def extract_prediction_error_by_domain(field_state_payload: dict) -> dict[str, f
 def compute_prediction_error_trend(
     window: list[dict[str, float]],
 ) -> dict[str, float]:
-    """mean(recent half) - mean(prior half) per domain, over an ordered
-    (oldest-to-newest) window of `extract_prediction_error_by_domain()`
-    outputs. A domain only gets a trend value if it has at least one reading
-    in BOTH halves -- comparing a half with zero real observations would
-    fabricate a trend from nothing, not measure one. Fewer than 2 ticks in
-    the window yields an empty dict (nothing to compare yet).
+    """Reversion-based trend per domain, over an ordered (oldest-to-newest)
+    window of `extract_prediction_error_by_domain()` outputs. Positive =
+    predicted to rise next; negative = predicted to fall next (same
+    contract `reduce_attention_self_model()` already consumes -- only the
+    computation changed here, 2026-07-23).
+
+    **This is deliberately mean(prior half) - mean(recent half) -- the
+    OPPOSITE sign of the naive "continue the recent direction" formula this
+    replaced.** That naive continuation formula (mean(recent) - mean(prior),
+    predicting the recent direction keeps going) was empirically WORSE than
+    a coin flip: back-tested against real `substrate_field_state` biometrics
+    history (the only domain with enough real variance to test against --
+    execution/chat/route are real but tiny, transport reads exactly 0.0 for
+    entire multi-hour windows, per the already-documented transport
+    narrow-scope finding) on two independent, non-overlapping 3-4h windows,
+    checking whether the named domain's value actually moved in the
+    predicted direction ~60s later: 37.7% accuracy (n=332, z=-4.50) and
+    41.0% accuracy (n=454, z=-3.85), both far below chance. A
+    decay-projection formula (compare the current value to what pure
+    exponential continuation of the prior half's own trajectory would
+    predict, before this fix) only marginally improved on that (43-45% on a
+    separate earlier back-test), still well below chance -- the problem
+    isn't the extrapolation method, it's the extrapolation *direction*: this
+    signal is spike-and-settle (a burst of activity is more often followed
+    by quiet than by more activity), not momentum-carrying. Predicting the
+    OPPOSITE of the naive continuation direction scored 62.3% and 59.0% on
+    the same two windows (sums to exactly 100% with continuation by
+    construction -- same backtest pass, same sample set, strictly opposite
+    predictions) -- real, reproducible, above-chance signal. Full validation
+    methodology and numbers:
+    `docs/superpowers/specs/2026-07-23-predicted-shift-reversion-finding.md`.
+
+    **Validated on biometrics only, applied to all five domains.** No
+    independent data exists yet for execution/transport/chat/route --
+    applying the same reversion sign to them is a reasoned extrapolation
+    (all five domains are computed the same way, as deltas between
+    successive states from discrete events -- turns, exec steps, tool
+    calls -- so the same spike-and-settle dynamic is plausible), not an
+    independently confirmed one. In practice this mostly matters for
+    biometrics anyway (it wins the cross-domain argmax the overwhelming
+    majority of the time in live replay -- see the reducer script's own
+    report), but a future pass should back-test the other four domains
+    separately once enough real variance accumulates, rather than assuming
+    this generalizes.
+
+    A domain only gets a trend value if it has at least one reading in BOTH
+    halves -- comparing a half with zero real observations would fabricate
+    a trend from nothing, not measure one. Fewer than 2 ticks in the window
+    yields an empty dict (nothing to compare yet).
     """
     if len(window) < 2:
         return {}
@@ -201,7 +248,7 @@ def compute_prediction_error_trend(
     prior_means = _domain_means(prior_half)
     recent_means = _domain_means(recent_half)
     return {
-        domain: recent_means[domain] - prior_means[domain]
+        domain: prior_means[domain] - recent_means[domain]
         for domain in recent_means
         if domain in prior_means
     }

--- a/scripts/analysis/tests/test_measure_ast_hot_reducer.py
+++ b/scripts/analysis/tests/test_measure_ast_hot_reducer.py
@@ -92,10 +92,23 @@ class TestExtractPredictionErrorByDomain:
 
 
 class TestComputePredictionErrorTrend:
-    def test_rising_trend_detected(self) -> None:
+    def test_reversion_predicted_after_recent_climb(self) -> None:
+        """This is deliberately the OPPOSITE sign of a naive "continue the
+        recent direction" formula -- validated against real historical data
+        to be the empirically correct one (see the function's own
+        docstring). A domain whose recent half climbed above its prior half
+        is predicted to FALL next (negative trend), not keep climbing."""
         window = [
             {"biometrics": 0.01}, {"biometrics": 0.02},
             {"biometrics": 0.3}, {"biometrics": 0.4},
+        ]
+        trend = mod.compute_prediction_error_trend(window)
+        assert trend["biometrics"] < 0
+
+    def test_reversion_predicted_after_recent_drop(self) -> None:
+        window = [
+            {"biometrics": 0.4}, {"biometrics": 0.3},
+            {"biometrics": 0.02}, {"biometrics": 0.01},
         ]
         trend = mod.compute_prediction_error_trend(window)
         assert trend["biometrics"] > 0
@@ -211,7 +224,9 @@ def test_replay_reducer_joins_broadcast_by_nearest_preceding_timestamp_per_tick(
 def test_replay_reducer_predicted_shift_tracks_rolling_trend_window() -> None:
     """A domain whose prediction_error climbs steadily across field_state
     ticks should surface as the named predicted_shift once enough ticks
-    have accumulated to compute a trend (>=2)."""
+    have accumulated to compute a trend (>=2) -- predicting reversion
+    (falling), the empirically-validated direction, not naive continuation.
+    """
     field_state_rows = [
         (BASE + timedelta(seconds=i), _field_state_payload(BASE + timedelta(seconds=i), biometrics=0.01 * i))
         for i in range(1, 6)
@@ -224,7 +239,7 @@ def test_replay_reducer_predicted_shift_tracks_rolling_trend_window() -> None:
     assert len(ticks) == 1
     assert ticks[0].predicted_shift is not None
     assert "biometrics" in ticks[0].predicted_shift
-    assert "rising" in ticks[0].predicted_shift
+    assert "falling" in ticks[0].predicted_shift
 
 
 def test_reason_histogram_counts_each_category() -> None:


### PR DESCRIPTION
## Summary

Metric-quality-gate finding, discovered while scoping L6 item 5 (before building it): item 4's already-merged `predicted_shift` field (PR #1301) was empirically **worse than a coin flip**.

- CLAUDE.md's metric-quality-gate step 4 requires pulling real data and checking a metric isn't degenerate *before* building further on top of it. Before starting item 5 (which was going to check whether item 4's own predictions come true), I ran that check on item 4 itself first.
- The original formula (`mean(recent half) - mean(prior half)`, predicting the recent direction continues) scored **37.7%** and **41.0%** accuracy on two independent, non-overlapping 3-4h windows of real `substrate_field_state` biometrics history (z=-4.50, z=-3.85 vs. a 50% null — both `p < 0.001`). Consistent across every horizon tested.
- Root cause: `prediction_error` is spike-and-settle (a burst of real activity is more often followed by quiet than by more activity), not momentum-carrying. A decay-adjusted continuation formula was also tried and only marginally improved on this (43-45%, still below chance) — the problem is the extrapolation *direction*, not the method.
- **Fix**: flip the sign. Predicting reversion instead of continuation scores **62.3%**/**59.0%** on the same two windows — real, reproducible, above-chance.
- `reduce_attention_self_model()`'s own consumption contract is unchanged; only the upstream trend computation (`compute_prediction_error_trend()`) moved.

## Outcome moved

`predicted_shift` goes from a signal that was actively anti-correlated with reality to one that's genuinely predictive (above chance on two independent validation windows), before item 5 gets built on top of it.

## Current architecture

`scripts/analysis/measure_ast_hot_reducer.py::compute_prediction_error_trend()` computes each domain's trend from a rolling `PREDICTION_ERROR_TREND_WINDOW_TICKS`-tick window of `substrate_field_state` snapshots, feeding `reduce_attention_self_model()`'s `prediction_error_trend_by_domain` argument (PR #1301).

## Architecture touched

- `scripts/analysis/measure_ast_hot_reducer.py`: `compute_prediction_error_trend()` formula sign flipped; docstrings updated with the full validation numbers and an explicit "validated on biometrics only, extrapolated to the other four domains" caveat.
- `orion/substrate/attention_self_model.py`: no behavior change — corrected a now-stale illustrative formula reference in a docstring.
- `docs/superpowers/specs/2026-07-23-predicted-shift-reversion-finding.md` (new): full validation methodology and numbers.
- Tests updated in `scripts/analysis/tests/test_measure_ast_hot_reducer.py` to assert the new (validated) direction, re-derived from the domain data, not mechanically mirrored from the code's output.

## Schema / bus / API changes

None. `reduce_attention_self_model()`'s signature and consumption contract (positive=rising, negative=falling, argmax by magnitude) are unchanged.

## Env/config changes

None.

## Tests run

```text
orion_dev/bin/python -m pytest orion/substrate/tests scripts/analysis/tests -q
610 passed
```

## Evals run

Live replay (`measure_ast_hot_reducer.py --window-hours 6`) post-fix: `predicted_shift` still shows 100% non-null coverage and real cross-domain breakdown (biometrics=10615, execution=27, chat=6, route=1 in the run used to verify this patch) — not collapsed to a single always-predicted direction.

## Docker/build/smoke checks

Not applicable — pure Python logic, no runtime/config/dependency changes, no live bus wiring (this reducer remains shadow-measurement only).

## Review findings fixed

- **Finding**: the module-level docstring (untouched by the first pass) still described the OLD formula (`mean(recent) - mean(prior)`), directly contradicting the corrected function docstring 166 lines below.
  - **Fix**: updated to reference the new formula and point at the spec doc.
- **Finding**: the reversion sign-flip is applied uniformly across all five domains but was only validated on biometrics (the only domain with enough real variance to test) — no code-level caveat carried that limitation forward, only a markdown Non-goals bullet.
  - **Fix**: added an explicit, prominent code comment in `compute_prediction_error_trend()`'s own docstring stating this plainly, with the reasoning for why it's a defensible extrapolation (same computation shape across domains) rather than a confirmed one.
- **Finding**: a stale illustrative formula example (`mean(recent ticks) - mean(prior ticks)`) was left in `attention_self_model.py`'s docstring, now describing the wrong upstream computation.
  - **Fix**: corrected to point at the real formula/validation instead of restating it inline.
- **Finding**: the originally-cited z/p-values and the continuation+reversion percentages (41.7%+58.0%=99.7% on one window, 42.6%+57.4%=100.0% on the other) didn't reconcile with each other or with a from-scratch z-test recomputation — traced to querying a live, still-changing table across multiple exploratory runs.
  - **Fix**: reran with one frozen reference timestamp so both windows and both formulas are scored from an identical sample set in one pass; continuation+reversion now sum to exactly 100% by construction, and z-scores were recomputed and verified by hand.
- **Finding**: the horizon-sweep framing juxtaposed the ~60s headline number against a "44-48%, 2-20 ticks" range it wasn't actually part of.
  - **Fix**: reworded to make clear the headline number and the horizon sweep are separate exploratory results, both below chance but not the same measurement.

## Restart required

```text
No restart required.
```

This reducer is not wired to any live service — it's only invoked by the offline replay script.

## Risks / concerns

- Severity: low
- Concern: the reversion formula is validated on biometrics only; execution/transport/chat/route inherit the same sign by extrapolation, not independent confirmation. Flagged explicitly in code (not just docs) per the review finding above — a future pass should back-test those domains once enough real variance accumulates.
- Item 5 itself remains unbuilt — this PR only fixes the foundation it would have been built on.

## PR link