### PR TITLE
feat(orion-equilibrium-service): log every terminal chat_turn gate evaluation

### DIFF
--- a/services/orion-equilibrium-service/app/service.py
+++ b/services/orion-equilibrium-service/app/service.py
@@ -17,6 +17,7 @@ from .telemetry_anomaly_metacog_gate import build_telemetry_anomaly_metacog_trig
 from .chat_turn_metacog_gate import (
     ChatTurnCorrelator,
     build_chat_turn_metacog_trigger,
+    evaluate_chat_turn_gate_conditions,
     is_chat_turn_evidence_terminal,
 )
 from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
@@ -394,6 +395,42 @@ class EquilibriumService(BaseChassis):
             thought_event=merged_thought, run_artifact=merged_run, timed_out=merged_timed_out
         ):
             return
+
+        # Real, always-on evidence of what the gate actually saw and decided --
+        # previously the only info-level output on this path was "Published
+        # metacog trigger" on an actual fire, so a no-fire terminal evaluation
+        # (the common case) was invisible: confirming "the gate correctly saw
+        # this turn and found nothing" vs. "the gate silently never evaluated
+        # it" required reverse-engineering grammar_atoms/harness-governor logs
+        # by hand, live-verified as a real gap post-deploy.
+        fired_conditions = evaluate_chat_turn_gate_conditions(
+            thought_event=merged_thought,
+            run_artifact=merged_run,
+            timed_out=merged_timed_out,
+            timeout_reason=merged_timeout_reason,
+            surprise_threshold=settings.metacog_chat_turn_surprise_threshold,
+        )
+        reflection = (merged_run or {}).get("reflection") or {}
+        substrate_appraisal = (merged_run or {}).get("substrate_appraisal") or {}
+        logger.info(
+            "chat_turn_gate_evaluated corr_id=%s fired=%s fired_conditions=%s "
+            "disposition=%s boundary_register=%s alignment_verdict=%s strain_unresolved=%s "
+            "surprise_level=%s compliance_verdict=%s exit_code=%s finalize_degraded_reason=%s "
+            "timed_out=%s timeout_reason=%s",
+            correlation_id,
+            bool(fired_conditions),
+            fired_conditions,
+            (merged_thought or {}).get("disposition"),
+            (merged_thought or {}).get("boundary_register"),
+            reflection.get("alignment_verdict"),
+            reflection.get("strain_unresolved"),
+            substrate_appraisal.get("surprise_level"),
+            (merged_run or {}).get("compliance_verdict"),
+            (merged_run or {}).get("exit_code"),
+            (merged_run or {}).get("finalize_degraded_reason"),
+            merged_timed_out,
+            merged_timeout_reason,
+        )
 
         trigger = build_chat_turn_metacog_trigger(
             correlation_id=correlation_id,

--- a/services/orion-equilibrium-service/tests/test_chat_turn_gate_evaluation_logging.py
+++ b/services/orion-equilibrium-service/tests/test_chat_turn_gate_evaluation_logging.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.service import EquilibriumService
+
+
+def _thought_event(*, disposition="proceed", boundary_register=False) -> dict:
+    return {
+        "correlation_id": "corr-1",
+        "disposition": disposition,
+        "disposition_reasons": [],
+        "boundary_register": boundary_register,
+        "grounding_capsule": None,
+        "autonomy_slice": None,
+    }
+
+
+def _run_artifact(*, compliance_verdict="completed", exit_code=0) -> dict:
+    return {
+        "correlation_id": "corr-1",
+        "compliance_verdict": compliance_verdict,
+        "grounding_status": "grounded",
+        "exit_code": exit_code,
+        "finalize_degraded_reason": None,
+        "reflection": {"alignment_verdict": "aligned", "strain_unresolved": False},
+        "substrate_appraisal": {"surprise_level": 0.1},
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_fire_terminal_evaluation_is_logged(caplog):
+    """Regression for the live-verification gap found post-deploy: a terminal
+    evaluation that fires nothing must still produce one clear, greppable log
+    line -- not silence indistinguishable from the gate never having run."""
+    svc = EquilibriumService()
+    svc._chat_turn_correlator = AsyncMock()
+    svc._chat_turn_correlator.accumulate.return_value = (
+        _thought_event(),
+        _run_artifact(),
+        False,
+        None,
+    )
+    svc._publish_metacog_trigger = AsyncMock()
+
+    with caplog.at_level("INFO", logger="orion-equilibrium"):
+        await svc._handle_chat_turn_evidence(
+            distress=0.0,
+            zen=1.0,
+            correlation_id="corr-1",
+            run_artifact=_run_artifact(),
+        )
+
+    svc._publish_metacog_trigger.assert_not_called()
+    messages = [r.getMessage() for r in caplog.records]
+    evaluated = [m for m in messages if "chat_turn_gate_evaluated" in m]
+    assert len(evaluated) == 1
+    assert "fired=False" in evaluated[0]
+    assert "corr_id=corr-1" in evaluated[0]
+    assert "disposition=proceed" in evaluated[0]
+    assert "compliance_verdict=completed" in evaluated[0]
+
+
+@pytest.mark.asyncio
+async def test_fire_terminal_evaluation_is_logged_before_publish(caplog):
+    svc = EquilibriumService()
+    svc._chat_turn_correlator = AsyncMock()
+    svc._chat_turn_correlator.accumulate.return_value = (
+        _thought_event(disposition="defer"),
+        None,
+        False,
+        None,
+    )
+    svc._publish_metacog_trigger = AsyncMock()
+
+    with caplog.at_level("INFO", logger="orion-equilibrium"):
+        await svc._handle_chat_turn_evidence(
+            distress=0.0,
+            zen=1.0,
+            correlation_id="corr-1",
+            thought_event=_thought_event(disposition="defer"),
+        )
+
+    svc._publish_metacog_trigger.assert_called_once()
+    messages = [r.getMessage() for r in caplog.records]
+    evaluated = [m for m in messages if "chat_turn_gate_evaluated" in m]
+    assert len(evaluated) == 1
+    assert "fired=True" in evaluated[0]
+    assert "disposition=defer" in evaluated[0]
+
+
+@pytest.mark.asyncio
+async def test_non_terminal_evidence_does_not_log_or_publish(caplog):
+    svc = EquilibriumService()
+    svc._chat_turn_correlator = AsyncMock()
+    svc._chat_turn_correlator.accumulate.return_value = (
+        _thought_event(),
+        None,
+        False,
+        None,
+    )
+    svc._publish_metacog_trigger = AsyncMock()
+
+    with caplog.at_level("INFO", logger="orion-equilibrium"):
+        await svc._handle_chat_turn_evidence(
+            distress=0.0,
+            zen=1.0,
+            correlation_id="corr-1",
+            thought_event=_thought_event(),
+        )
+
+    svc._publish_metacog_trigger.assert_not_called()
+    messages = [r.getMessage() for r in caplog.records]
+    assert not [m for m in messages if "chat_turn_gate_evaluated" in m]


### PR DESCRIPTION
## Summary

- Real gap found during live post-deploy verification of the `chat_turn` metacog trigger (PR #1291, enabled in PR #1298): the only info-level output on this path was "Published metacog trigger", emitted only on an actual fire. A terminal evaluation that fires nothing (the common case) produced zero log output.
- Confirming "the gate correctly evaluated this turn and found no conditions" vs. "the gate silently never processed this turn at all" required reverse-engineering `grammar_atoms`/harness-governor logs by hand and manually re-deriving `finalize.py`'s `surprise_resolved` formula -- not something that should need detective work.
- Adds one `chat_turn_gate_evaluated` log line per terminal evaluation, fired or not, carrying every real field the gate condition table reads.
- Code review (orion-repo-agent) found nothing material -- confirmed no privacy/sensitivity issue (only enum/bool/float values logged, never `grounding_capsule`/`disposition_reasons`/`alignment_notes`), confirmed the double-evaluation of `evaluate_chat_turn_gate_conditions` is safe (no mutation between calls), confirmed the log format string's 13 placeholders match its 13 args exactly, and independently re-ran the full test suite in a scratch venv.

## Outcome moved

Any future live-verification pass on `chat_turn` (like the one that found this gap) can now `docker logs | grep chat_turn_gate_evaluated` and get a direct answer instead of cross-referencing three other services' logs and hand-deriving formulas from source.

## Current architecture

`_handle_chat_turn_evidence` (`services/orion-equilibrium-service/app/service.py`) accumulates evidence via `ChatTurnCorrelator`, checks `is_chat_turn_evidence_terminal`, and on terminal evidence called `build_chat_turn_metacog_trigger` directly -- which internally calls the pure `evaluate_chat_turn_gate_conditions` function but never surfaced its result unless a trigger actually fired.

## Architecture touched

`services/orion-equilibrium-service/app/service.py` only -- calls the already-existing `evaluate_chat_turn_gate_conditions` once more, directly, right after the terminal check, purely to log the result before proceeding exactly as before (build + publish if fired).

## Files changed

- `services/orion-equilibrium-service/app/service.py`: new log line in `_handle_chat_turn_evidence`, imports `evaluate_chat_turn_gate_conditions`.
- `services/orion-equilibrium-service/tests/test_chat_turn_gate_evaluation_logging.py`: new, 3 tests (no-fire logs + no publish, fire logs + publish, non-terminal logs nothing).

## Schema / bus / API changes

None. Logging only, no bus/schema contract touched.

## Env/config changes

None.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/python3 -m pytest services/orion-equilibrium-service/tests/test_chat_turn_gate_evaluation_logging.py -q
3 passed

/mnt/scripts/Orion-Sapienform/.venv/bin/python3 -m pytest services/orion-equilibrium-service/tests -q
69 passed
```

Reviewer independently re-ran both in a separate scratch venv with the service's real `requirements.txt` installed -- same result.

## Evals run

N/A -- logging-only change, no eval harness applicable.

## Docker/build/smoke checks

```text
python3 -c "import ast; ast.parse(open('services/orion-equilibrium-service/app/service.py').read())"
-> OK
```

Not deployed/smoke-tested against a live container as part of this PR -- purely additive logging, verified via unit tests; will be observable on the next real deploy the same way the original gap was found (log grep).

## Review findings fixed

None required a fix -- code review (orion-repo-agent) reported no material findings. Full detail:
- Verified: double-evaluation of `evaluate_chat_turn_gate_conditions` (once for the log, once inside `build_chat_turn_metacog_trigger`) cannot diverge -- no mutation of `merged_thought`/`merged_run` between the two calls, both are pure `.get()` reads.
- Verified: nothing sensitive logged -- only enum/bool/float field values, never the richer `grounding_capsule`/`disposition_reasons`/`alignment_notes` content that already goes out on the bus + into a persisted journal entry on an actual fire.
- Verified: log format string's 13 `%s` placeholders match the 13-arg tuple exactly, field-by-field; traced every logged field's real value space (closed enums / two hardcoded timeout-reason literals / one hardcoded degraded-reason sentence) to rule out any literal-`%`-in-freeform-text risk.
- Verified: constructing a real `EquilibriumService()` in tests is side-effect-free (`BaseChassis`/`OrionBusAsync.__init__` never opens a connection; that only happens later in `.start()`).
- Nit noted, not fixed (cosmetic only): the new test doesn't mock `redis`/`redis.asyncio` in `sys.modules` before import the way two sibling test files do -- confirmed not load-bearing (the real `redis` package is already a service dependency and import-safe either way), so left as-is rather than copying a defensive pattern that isn't actually needed here.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-equilibrium-service/.env \
  -f services/orion-equilibrium-service/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: none
  - Concern: n/a -- observability-only, no behavior change to what fires, when, or what gets published.

## PR link

(filled in by `gh pr create`)