### PR TITLE
docs(field-digester,mood-arc): fifth training-data cutoff, glossary count fix

### DIFF
--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -157,6 +157,36 @@ python orion/mood_arc/fit_encoder.py train \
   (`floor_ratio`/`ceiling_ratio` don't single out `prediction_error`), just
   carrying one contaminated-but-not-dominant input feature the same way
   `v2` carried `catalog_drift_pressure` before the second cutoff.
+- **Fifth cutoff, `--min-generated-at 2026-07-23T06:10:08Z` (commit `5b1cc0fa`, merged +
+  deployed):** found while checking whether the FCC-motor signal bundle
+  (`docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md`) endangered
+  `v3` — its 5 brand-new channels don't (confirmed: `app/anomaly_scorer.py`'s `score_latest()`
+  selects strictly by `self._manifest.channel_names`, and `build_windows()` defaults any field
+  not present in a row to `0.0` by design — a genuinely new channel name is silently ignored,
+  not a contamination risk). But two of `v3`'s own 15 *trained* channels were live-changed by
+  that same investigation's fix: `execution_load` (`min(1.0, started_step_count/8.0)` over a
+  blended cortex-exec+harness-governor counter, hard-capped) and `reasoning_load` (a boolean
+  `0.35`/`0.05` wearing a magnitude's name) both replaced with real, continuously-varying
+  formulas — see `services/orion-field-digester/README.md`'s entries for the full mechanism.
+  `v3` was trained on the *old* distributions for both. Every score computed since
+  `orion-field-digester`'s `2026-07-23T06:10:08Z` restart compares new-distribution live data
+  against a stale-distribution-trained model — the same contamination class as cutoffs two
+  through four. **Not yet confirmed whether this has produced spurious
+  `field_channel_anomaly.v3` flags** — checked `orion-athena-field-digester`'s logs shortly
+  after the restart, no `field_channel_anomaly_flagged` line yet, but this is inconclusive:
+  `v3`'s `window_size=30` rows may not have filled yet at check time, not evidence of absence.
+  Whoever picks this up next should re-check the logs with more elapsed time before treating it
+  as resolved either way. **Do not retrain yet** — matching every prior cutoff's own caveat,
+  only minutes of clean post-fix data exist as of this writing. `v3` remains the model to keep
+  serving until a `v4` retrain against this cutoff (or whichever is later) is warranted.
+  **Heads-up for whoever eventually renames `transport_pressure`** (flagged as a live
+  scope-honesty issue below, and in that same FCC-motor design doc's appendix, but not yet
+  fixed): `transport_pressure` is also one of `v3`'s 15 trained channels. A rename is a
+  *different* failure mode than this cutoff's distribution shift — the encoder would find the
+  field genuinely absent by name and silently default it to `0.0` (per `build_windows()`'s
+  missing-field convention) rather than see a shifted distribution — but it is still a
+  cutoff-class event for `v3`, not the "safe, no-training-impact" rename it might look like at
+  a glance. Treat it as a sixth cutoff when it ships.
 - **Scope caveat on `prediction_error`'s "transport" contributor (found 2026-07-22, not a new
   cutoff — no code changed, just what the channel actually means):** `prediction_error` is a
   `max()`-merge across five nodes; one of them, `node:substrate.transport`, is fed entirely by

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -485,12 +485,62 @@ meantime** — it is not invalidated on the metrics it actually gates on
 carrying one contaminated-but-not-dominant input channel, the same way
 `v2` carried `catalog_drift_pressure` before the second cutoff.
 
+## `field_channel_corpus.v1` fifth training-data quality cutoff (2026-07-23)
+
+A fifth contamination window, this one on two more of `v3`'s 15 trained channels:
+`execution_load` and `reasoning_load` (commit `5b1cc0fa`, merged + deployed). Found while
+checking whether the FCC-motor signal bundle
+(`docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md`) endangered
+`v3` — its 5 brand-new channels don't (`app/anomaly_scorer.py`'s `score_latest()` selects
+strictly by the trained `channel_names`; an unknown field is silently defaulted to `0.0` by
+`build_windows()`, not scored). But `execution_load` and `reasoning_load` are two of `v3`'s
+own *trained* channels, and their live formulas changed underneath the already-trained model:
+
+- `execution_load` was `min(1.0, started_step_count / 8.0)` over a counter blending
+  cortex-exec + harness-governor steps together (hard-capped, an 8-step and a 40-step run read
+  identically) — see this doc's `execution_load` glossary entry above for the full fix.
+- `reasoning_load` was a boolean wearing a magnitude's name (`0.35`/`0.05`, from whether any
+  reasoning was present at all, not how much) — see the `reasoning_load` glossary entry above.
+
+Both fixed to real, continuously-varying magnitudes. `v3` was trained on the *old*
+distributions for both, so every score since `orion-field-digester`'s
+`2026-07-23T06:10:08Z` restart (`docker inspect orion-athena-field-digester --format
+'{{.State.StartedAt}}'`) compares new-distribution live data against a
+stale-distribution-trained model — same contamination class as the second/third/fourth
+cutoffs. **Not yet confirmed whether this has produced spurious `field_channel_anomaly.v3`
+flags** — checked logs shortly after the restart, no `field_channel_anomaly_flagged` line yet,
+but `v3`'s `window_size=30` rows may simply not have filled at check time; this is
+inconclusive, not a clean bill of health. Whoever picks this up next should re-check with more
+elapsed time.
+
+```bash
+python orion/mood_arc/fit_encoder.py train \
+  --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
+  --min-generated-at 2026-07-23T06:10:08Z \
+  --out <out-dir>
+```
+
+If multiple cutoffs apply, use whichever is latest (as of this writing, that's this fifth
+cutoff). **Do not retrain yet** — same reasoning as every prior cutoff, only minutes of clean
+post-cutoff data exist as of this writing. `v3` remains the right model to keep serving until a
+`v4` retrain against this cutoff (or whichever is later) is warranted.
+
+**Heads-up for whoever renames `transport_pressure`** (a live scope-honesty issue flagged
+above and in the FCC-motor design doc's appendix, not yet fixed): it is also one of `v3`'s 15
+trained channels. A rename is a *different* failure mode than this cutoff's distribution shift
+— the encoder would find the field genuinely absent by name and silently default it to `0.0`
+rather than see a shifted distribution — but it is still cutoff-class for `v3`, not the "safe,
+no-training-impact" change it might look like. Treat it as a sixth cutoff when it ships. See
+`orion/mood_arc/README.md`'s matching fifth-cutoff entry — keep the two in sync if either is
+ever revised, same convention as the first four.
+
 ## Field channel glossary
 
-This is the consolidated reference for all 29 channels in
+This is the consolidated reference for all 34 channels in
 `field_channel_corpus.v1` (`orion.schemas.telemetry.field_channel_corpus.FieldChannelCorpusRowV1`),
-sourced from `app/tensor/channels.py`'s `NODE_CHANNELS` (23) + `CAPABILITY_CHANNELS`
-(8), overlapping on `transport_pressure`/`contract_pressure` (23+8-2=29). This
+sourced from `app/tensor/channels.py`'s `NODE_CHANNELS` (28) + `CAPABILITY_CHANNELS`
+(8), overlapping on `transport_pressure`/`contract_pressure` (28+8-2=34). 28 = 23 original
++ 5 FCC-motor channels added 2026-07-23 (see the design doc referenced above). This
 corpus is the raw input for a future windowed autoencoder (roadmap item 2,
 not yet trained) — but several of these same channels also feed
 `SelfStateV1`'s live, cognition-facing dimensions today, via


### PR DESCRIPTION
## Summary

- Documents a real, live, newly-found risk: the currently-deployed mood-arc encoder (`v3`) has `execution_load`, `reasoning_load`, and `transport_pressure` in its trained `channel_names` — and `execution_load`/`reasoning_load` just had their live formulas changed by a concurrent fix (commit `5b1cc0fa`).
- Adds a fifth training-data cutoff entry to both `orion/mood_arc/README.md` and `services/orion-field-digester/README.md` (kept in sync, matching the existing 4-cutoff convention).
- Fixes a real leftover gap: the field-digester glossary's intro still said "29 channels" after the 5-channel FCC-motor expansion (PR #1296 updated the yaml/tests but missed this prose line).

## What prompted this

Juniper asked whether the FCC-motor 5-signal bundle put the mood-arc encoder at risk. Checked and confirmed it doesn't -- `app/anomaly_scorer.py` selects strictly by the trained `channel_names`, and `build_windows()` defaults any unrecognized field to `0.0`, so brand-new channel names are silently ignored, not scored.

But following up (checking who's *actually* in `v3`'s trained channel set, via its manifest at `/mnt/telemetry/models/field_channel_anomaly/v3/manifest.json`) found a different, real risk: `execution_load`, `reasoning_load`, and `transport_pressure` are all pre-existing trained channels. A separate concurrent session (commit `5b1cc0fa`, also merged today) independently fixed `execution_load` (dropped the hard cap, split cortex-exec from harness-governor step counts) and `reasoning_load` (replaced a boolean flag with a real `reasoning_char_count`-based magnitude) -- both are exactly the class of change the existing 4 cutoffs already document as contaminating: same channel name, different live distribution underneath an already-trained model.

## Live evidence

- `orion-athena-field-digester` restarted `2026-07-23T06:10:08Z`, an hour after commit `5b1cc0fa` merged (`05:10:21Z`) -- confirmed the container has been running the new formulas.
- Checked logs post-restart for `field_channel_anomaly_flagged` -- none yet, but this is **inconclusive**, not a clean bill of health: `v3`'s `window_size=30` rows may not have filled at check time. Documented explicitly as unresolved, not swept under the rug.

## Files changed

- `orion/mood_arc/README.md` -- new fifth cutoff entry, placed after the fourth (matching the file's own established format), plus a heads-up that a future `transport_pressure` rename would be a sixth cutoff-class event.
- `services/orion-field-digester/README.md` -- matching fifth cutoff section (cross-referenced, "keep in sync" per the file's own existing convention), plus the "29 channels" -> "34 channels" glossary-intro fix.

## Tests run

N/A -- docs only, no code changed.

## Restart required

```
No restart required -- documentation only.
```

## Risks / concerns

- Severity: low-to-moderate (informational, not a code defect)
- Concern: whether `v3` has actually produced spurious anomaly flags since the `execution_load`/`reasoning_load` fix landed is genuinely unresolved -- flagged explicitly for whoever picks this up next to re-check with more elapsed time.
- Mitigation: documented the exact cutoff timestamp needed for a future `v4` retrain now, while the evidence is fresh, rather than leaving it to be re-derived later. Per this doc's own established pattern, no retrain should happen yet -- only minutes of clean post-cutoff data exist.

## PR link

(this PR)