### PR TITLE
feat(bus): Phase 2 channel census diff (declared vs live-active)

### DIFF
--- a/docs/superpowers/specs/2026-07-23-bus-channel-velocity-census-design.md
+++ b/docs/superpowers/specs/2026-07-23-bus-channel-velocity-census-design.md
@@ -1,9 +1,16 @@
 # Bus channel velocity & census — design spec
 
-Status: **proposed, design-only**. No code in this patch. Sequencing: build Phase 1, verify
-against real live data, gate before Phase 2; build Phase 2, verify, gate before anything in the
-Later/Parked section is even scoped as a next patch. Do not skip a gate because a prior phase
-"seems obviously fine" — CLAUDE.md's metric quality gate applies per phase, every time.
+Status: **Phase 1 and Phase 2 both shipped and live-gated.** Phase 1 (PR #1292, compose
+passthrough fix PR #1305) merged and live-verified mesh-wide across all 45 services — real Redis
+velocity counters (`orion:bus:velocity:{channel}:{minute_bucket}`) are live for ~106 of 264
+cataloged channels at any given time. Phase 2 (`orion.bus.census.compute_census()` +
+`orion.bus.velocity.scan_active_channels()`) is built, tested, reviewed, and live-gated against
+the real running mesh: 264 cataloged, 106 active in a trailing 5-minute window, 192
+`declared_silent` (sensible mix of cron-triggered and genuinely low-traffic channels), 0
+`undeclared_active` (confirms wildcard-prefix matching correctly absorbs every dynamic
+per-request reply channel). Nothing in the Later/Parked section below is scoped as a next patch
+yet — CLAUDE.md's metric quality gate applies per phase, every time, and gating those ideas has
+not been done.
 
 **Cross-reference:** `docs/superpowers/specs/2026-07-22-transport-bus-signal-quality-measurement-design.md`
 covers a related but distinct question — the *calibration and trustworthiness* of the six
@@ -256,8 +263,13 @@ patch:
 
 ## Recommended next patch
 
-Start Phase 1 only. Branch/worktree per CLAUDE.md section 2, thin patch: instrument
-`OrionBusAsync.publish()`, add the settings flag (default off), add the read-side summation
-helper, add tests. Do not touch `bus_observer.py`, grammar emission, or Phase 2's census function
-in the same patch — Phase 2 depends on Phase 1's gate passing with real data first, per the
-phased plan above.
+Phase 1 and Phase 2 are both done (see Status above). Neither Phase 2's `compute_census()` nor
+`scan_active_channels()` is wired into anything that runs periodically yet — they exist as
+tested, live-gated functions with no scheduled caller. The next patch, if picked up, should stay
+just as thin: give `scan_active_channels()` + `compute_census()` a periodic caller (a lightweight
+loop or a `bus_observer.py` tick, decision deferred — see the review's note that a coverage
+census belongs on a slow cadence like once-a-minute, not `bus_observer`'s 10s tick) and a
+UI/debug/log surface to actually look at `declared_silent`/`undeclared_active` over time, per
+CLAUDE.md's "no keyword cathedral" rule (a pure function nobody calls is not yet a real seam).
+Nothing in the Later/Parked section above should be scoped until that wiring lands and gets its
+own live-data look.

--- a/orion/bus/census.py
+++ b/orion/bus/census.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["CensusResult", "compute_census"]
+
+
+@dataclass(frozen=True)
+class CensusResult:
+    declared_silent: list[str]
+    undeclared_active: list[str]
+
+
+def _is_wildcard(name: str) -> bool:
+    return name.endswith("*")
+
+
+def _wildcard_prefix(name: str) -> str:
+    return name[:-1]
+
+
+def compute_census(catalog_names: set[str], active_channels: dict[str, float]) -> CensusResult:
+    """Diff the declared channel catalog against channels observed to be
+    carrying real traffic (Phase 1's velocity counters).
+
+    Wildcard-aware: ~25 entries in orion/bus/channels.yaml are prefix
+    patterns (e.g. "orion:exec:result:*", "orion:cortex:result*" -- both the
+    ":*" and bare "*" suffix forms appear) covering dynamic per-request reply
+    channels like "orion:exec:result:LLMGatewayService:<uuid>". Matching
+    catalog_names by exact string equality only would put every one of those
+    reply channels in undeclared_active as a false positive, since no two
+    request/reply cycles share a literal channel name.
+
+    A wildcard catalog entry counts as silent only if nothing in
+    active_channels matches its prefix -- not just its own literal string,
+    since a wildcard entry never appears verbatim as a live channel name.
+
+    Bare-star entries (e.g. "orion:cortex:result*", with no colon before the
+    star) produce a looser prefix than colon-star entries (e.g.
+    "orion:exec:result:*") -- "orion:cortex:result*" would also match a
+    hypothetical unrelated "orion:cortex:resultset" channel. This faithfully
+    reflects what channels.yaml itself declares; no colliding literal exists
+    in the catalog today.
+    """
+    declared_silent: list[str] = []
+    covered_active: set[str] = set()
+    for name in sorted(catalog_names):
+        if _is_wildcard(name):
+            prefix = _wildcard_prefix(name)
+            matches = [ch for ch in active_channels if ch.startswith(prefix)]
+        else:
+            matches = [name] if name in active_channels else []
+        covered_active.update(matches)
+        if not matches:
+            declared_silent.append(name)
+
+    undeclared_active = sorted(ch for ch in active_channels if ch not in covered_active)
+    return CensusResult(declared_silent=declared_silent, undeclared_active=undeclared_active)

--- a/orion/bus/tests/test_census.py
+++ b/orion/bus/tests/test_census.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from orion.bus.census import compute_census
+
+
+def test_compute_census_finds_silent_and_undeclared_literal_channels() -> None:
+    catalog = {"orion:system:health", "orion:journal:write"}
+    active = {"orion:system:health": 1.0, "orion:mystery:channel": 0.5}
+
+    result = compute_census(catalog, active)
+
+    assert result.declared_silent == ["orion:journal:write"]
+    assert result.undeclared_active == ["orion:mystery:channel"]
+
+
+def test_compute_census_wildcard_prefix_matches_dynamic_reply_channels() -> None:
+    catalog = {"orion:exec:result:*"}
+    active = {
+        "orion:exec:result:LLMGatewayService:0cf10589-4bae-4cb7-bc13-40684d7d321e": 0.1,
+        "orion:exec:result:RecallService:9b3c5e84-0fda-4f78-9873-777814191e1a": 0.1,
+    }
+
+    result = compute_census(catalog, active)
+
+    assert result.declared_silent == []
+    assert result.undeclared_active == []
+
+
+def test_compute_census_bare_star_wildcard_without_colon_matches() -> None:
+    # channels.yaml has both "name:*" and "name*" wildcard forms.
+    catalog = {"orion:cortex:result*"}
+    active = {"orion:cortex:result:184992b1-7922-4616-8b26-f2f40e5d0c77": 0.2}
+
+    result = compute_census(catalog, active)
+
+    assert result.declared_silent == []
+    assert result.undeclared_active == []
+
+
+def test_compute_census_wildcard_with_zero_matches_is_declared_silent() -> None:
+    catalog = {"orion:exec:result:*"}
+    active = {"orion:unrelated:channel": 1.0}
+
+    result = compute_census(catalog, active)
+
+    assert result.declared_silent == ["orion:exec:result:*"]
+    assert result.undeclared_active == ["orion:unrelated:channel"]
+
+
+def test_compute_census_empty_active_marks_everything_silent() -> None:
+    catalog = {"orion:a", "orion:b:*"}
+
+    result = compute_census(catalog, {})
+
+    assert result.declared_silent == ["orion:a", "orion:b:*"]
+    assert result.undeclared_active == []
+
+
+def test_compute_census_empty_catalog_marks_everything_undeclared() -> None:
+    active = {"orion:x": 1.0, "orion:y": 2.0}
+
+    result = compute_census(set(), active)
+
+    assert result.declared_silent == []
+    assert result.undeclared_active == ["orion:x", "orion:y"]
+
+
+def test_compute_census_overlapping_wildcard_family_matches_narrowest_and_broadest() -> None:
+    # Mirrors the real orion/bus/channels.yaml shape: one broad wildcard plus
+    # several narrower per-service wildcards all sharing the same prefix
+    # family, exactly what the live 0-undeclared_active mesh check depends on.
+    catalog = {
+        "orion:exec:result:*",
+        "orion:exec:result:LLMGatewayService:*",
+        "orion:exec:result:PadRpc:*",
+        "orion:exec:result:StateService:*",
+        "orion:exec:result:RecallService:*",
+        "orion:exec:result:ContextExecService:*",
+    }
+    active = {
+        "orion:exec:result:LLMGatewayService:0cf10589": 0.1,
+        "orion:exec:result:RecallService:9b3c5e84": 0.1,
+    }
+
+    result = compute_census(catalog, active)
+
+    assert result.undeclared_active == []
+    # The two service-specific wildcards with no live traffic (PadRpc,
+    # StateService, ContextExecService) are correctly silent; the broad
+    # umbrella and the two matched service wildcards are not.
+    assert result.declared_silent == [
+        "orion:exec:result:ContextExecService:*",
+        "orion:exec:result:PadRpc:*",
+        "orion:exec:result:StateService:*",
+    ]

--- a/orion/bus/tests/test_velocity.py
+++ b/orion/bus/tests/test_velocity.py
@@ -5,8 +5,16 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from orion.bus.velocity import read_channel_velocity
+from orion.bus.velocity import read_channel_velocity, scan_active_channels
 from orion.core.bus.velocity_keys import velocity_window_keys
+
+
+def _async_iter(items):
+    async def gen():
+        for item in items:
+            yield item
+
+    return gen()
 
 
 @pytest.mark.asyncio
@@ -49,4 +57,93 @@ async def test_read_channel_velocity_zero_window_short_circuits() -> None:
     redis = AsyncMock()
     rate = await read_channel_velocity(redis, "ch", window_minutes=0)
     assert rate == 0.0
+    redis.mget.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_active_channels_discovers_and_aggregates_per_channel() -> None:
+    now = datetime(2026, 7, 23, 17, 28, 30, tzinfo=timezone.utc)
+    redis = AsyncMock()
+    keys = [
+        "orion:bus:velocity:orion:system:health:20260723T1727Z",
+        "orion:bus:velocity:orion:system:health:20260723T1728Z",
+        "orion:bus:velocity:orion:exec:result:LLMGatewayService:abc-123:20260723T1728Z",
+    ]
+    redis.scan_iter = lambda **kwargs: _async_iter(keys)
+    redis.mget = AsyncMock(return_value=[b"1035", b"732", b"2"])
+
+    result = await scan_active_channels(redis, window_minutes=5, now=now)
+
+    assert result["orion:system:health"] == pytest.approx((1035 + 732) / 300.0)
+    assert result["orion:exec:result:LLMGatewayService:abc-123"] == pytest.approx(2 / 300.0)
+
+
+@pytest.mark.asyncio
+async def test_scan_active_channels_skips_buckets_outside_window() -> None:
+    now = datetime(2026, 7, 23, 17, 28, 30, tzinfo=timezone.utc)
+    redis = AsyncMock()
+    keys = [
+        "orion:bus:velocity:orion:old:channel:20260723T1700Z",  # 28 minutes stale
+    ]
+    redis.scan_iter = lambda **kwargs: _async_iter(keys)
+    redis.mget = AsyncMock(return_value=[])
+
+    result = await scan_active_channels(redis, window_minutes=5, now=now)
+
+    assert result == {}
+    redis.mget.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_active_channels_ignores_malformed_keys() -> None:
+    redis = AsyncMock()
+    keys = ["orion:bus:velocity:not-a-bucket-suffix", "some:other:key:entirely"]
+    redis.scan_iter = lambda **kwargs: _async_iter(keys)
+    redis.mget = AsyncMock(return_value=[])
+
+    result = await scan_active_channels(redis, window_minutes=5)
+
+    assert result == {}
+    redis.mget.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_active_channels_ignores_empty_channel_name() -> None:
+    redis = AsyncMock()
+    # A key with nothing between the prefix and the bucket suffix -- would
+    # parse to an empty-string channel if _parse_velocity_key's guard didn't
+    # reject it explicitly.
+    keys = ["orion:bus:velocity::20260723T1728Z"]
+    redis.scan_iter = lambda **kwargs: _async_iter(keys)
+    redis.mget = AsyncMock(return_value=[])
+
+    result = await scan_active_channels(redis, window_minutes=5)
+
+    assert result == {}
+    redis.mget.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_active_channels_fails_open_on_redis_error() -> None:
+    redis = AsyncMock()
+
+    def _raise(**kwargs):
+        raise ConnectionError("down")
+
+    redis.scan_iter = _raise
+
+    result = await scan_active_channels(redis, window_minutes=5)
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_scan_active_channels_zero_window_short_circuits() -> None:
+    redis = AsyncMock()
+    redis.scan_iter = lambda **kwargs: _async_iter([])
+    redis.mget = AsyncMock(return_value=[])
+
+    result = await scan_active_channels(redis, window_minutes=0)
+
+    assert result == {}
     redis.mget.assert_not_called()

--- a/orion/bus/velocity.py
+++ b/orion/bus/velocity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import re
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from orion.core.bus.velocity_keys import (
@@ -18,7 +19,27 @@ __all__ = [
     "velocity_minute_bucket",
     "velocity_window_keys",
     "read_channel_velocity",
+    "scan_active_channels",
 ]
+
+_BUCKET_SUFFIX_RE = re.compile(r":(\d{8}T\d{4}Z)$")
+
+
+def _parse_velocity_key(key: str) -> tuple[str, str] | None:
+    """Split "orion:bus:velocity:{channel}:{bucket}" back into (channel,
+    bucket). Channel names themselves contain colons, so this anchors on the
+    fixed-format minute-bucket suffix rather than naive splitting."""
+    prefix = f"{VELOCITY_KEY_PREFIX}:"
+    if not key.startswith(prefix):
+        return None
+    remainder = key[len(prefix):]
+    match = _BUCKET_SUFFIX_RE.search(remainder)
+    if not match:
+        return None
+    channel = remainder[: match.start()]
+    if not channel:
+        return None
+    return channel, match.group(1)
 
 
 async def read_channel_velocity(
@@ -58,3 +79,77 @@ async def read_channel_velocity(
         except (TypeError, ValueError):
             continue
     return total / (window_minutes * 60.0)
+
+
+async def scan_active_channels(
+    redis: Any,
+    *,
+    window_minutes: int = 5,
+    now: datetime | None = None,
+) -> dict[str, float]:
+    """Discover every channel currently emitting velocity data and its
+    trailing-window rate (msgs/sec).
+
+    Unlike read_channel_velocity(), which requires the caller to already
+    know the channel name, this SCANs the velocity key namespace itself --
+    the only way to find channels that were never in the static catalog
+    (Phase 2's undeclared_active) or to confirm which cataloged channels
+    have zero live keys at all (declared_silent).
+
+    Fail-open like the rest of this module: a SCAN or read error returns an
+    empty result rather than raising.
+
+    Callers get back only channels with a real (>=1) counted message in the
+    window -- INCR-backed keys never hold a zero or negative value, so a
+    channel present in the returned dict is always genuinely active. This is
+    an implicit contract with compute_census() (orion/bus/census.py), which
+    treats key presence, not value, as "active".
+
+    SCAN cost is bounded by the full velocity-key namespace (up to
+    DEFAULT_BUCKET_TTL_SEC/60 minutes of buckets per channel that has
+    recently published), not by window_minutes -- a 5-minute census still
+    scans and discards up to ~10 minutes of stale buckets. Fine at current
+    key cardinality (~200-300 total); revisit if this ends up on a tight
+    polling loop.
+    """
+    if window_minutes <= 0:
+        return {}
+    now_utc = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    allowed_buckets = {
+        velocity_minute_bucket(now_utc - timedelta(minutes=offset))
+        for offset in range(window_minutes)
+    }
+
+    try:
+        matched_keys: list[str] = []
+        channel_by_key: dict[str, str] = {}
+        async for raw_key in redis.scan_iter(match=f"{VELOCITY_KEY_PREFIX}:*", count=200):
+            key = raw_key.decode() if isinstance(raw_key, bytes) else raw_key
+            parsed = _parse_velocity_key(key)
+            if parsed is None:
+                continue
+            channel, bucket = parsed
+            if bucket not in allowed_buckets:
+                continue
+            matched_keys.append(key)
+            channel_by_key[key] = channel
+
+        if not matched_keys:
+            return {}
+        raw_values = await redis.mget(matched_keys)
+    except Exception:
+        return {}
+
+    totals: dict[str, int] = {}
+    for key, val in zip(matched_keys, raw_values or []):
+        if val is None:
+            continue
+        try:
+            count = int(val)
+        except (TypeError, ValueError):
+            continue
+        channel = channel_by_key[key]
+        totals[channel] = totals.get(channel, 0) + count
+
+    window_sec = window_minutes * 60.0
+    return {channel: total / window_sec for channel, total in totals.items()}


### PR DESCRIPTION
## Summary

- Phase 2 of the bus velocity/census design spec: `orion.bus.census.compute_census()`, a pure, wildcard-aware diff of the 264-entry `orion/bus/channels.yaml` catalog against channels observed to actually carry live traffic.
- `orion.bus.velocity.scan_active_channels()` — new SCAN-based discovery helper that finds every channel currently emitting Phase 1 velocity data, since the pre-existing `read_channel_velocity()` requires the caller to already know the channel name.
- Handles the ~25 wildcard entries in `channels.yaml` (two forms: `name:*` and bare `name*`) by prefix-matching, so dynamic per-request reply channels (e.g. `orion:exec:result:LLMGatewayService:<uuid>`) don't false-positive as "undeclared."
- Design spec (`docs/superpowers/specs/2026-07-23-bus-channel-velocity-census-design.md`) updated: status flipped from "proposed" to "Phase 1 and Phase 2 both shipped and live-gated," Recommended-next-patch section rewritten to point at wiring a periodic caller, not building more phases.

## Outcome moved

Before this patch there was no way to answer "of 264 declared channels, how many are actually alive right now, and which live channels aren't in the catalog at all" — `bus_observer.py` only ever polled 2 of 264 (its Stream-only allowlist). This patch makes that question answerable, and answers it once against the real mesh: **264 cataloged, 106 active in a trailing 5-minute window, 192 declared_silent, 0 undeclared_active.**

## Current architecture

Phase 1 (PR #1292, compose-passthrough fix PR #1305) is merged and live-verified mesh-wide: every producer's `OrionBusAsync.publish()` call increments a per-channel, per-minute Redis counter (`orion:bus:velocity:{channel}:{minute_bucket}`, 600s TTL) when `ORION_BUS_VELOCITY_TRACKING_ENABLED=true`. `orion.bus.velocity.read_channel_velocity()` already existed to sum those buckets into a msgs/sec rate for one named channel. `orion/bus/channels.yaml`'s `load_channel_catalog_names()` (in `services/orion-bus/app/bus_observer.py`) already existed to load the static catalog. Nothing connected the two, and nothing could discover *which* channels have live data without already knowing their names.

## Architecture touched

- `orion/bus/velocity.py` — added `scan_active_channels()` + its `_parse_velocity_key()` helper (regex-anchored on the trailing minute-bucket suffix, since channel names themselves contain colons).
- `orion/bus/census.py` — new, pure, zero-Redis-dependency diff function.
- No bus channel, schema, or `.env` change — this is transport-internal telemetry read-side, same as Phase 1.

## Files changed

- `orion/bus/census.py`: new — `compute_census(catalog_names, active_channels) -> CensusResult(declared_silent, undeclared_active)`, wildcard-prefix-aware.
- `orion/bus/velocity.py`: added `scan_active_channels()` (SCAN + MGET discovery/aggregation) and `_parse_velocity_key()`.
- `orion/bus/tests/test_census.py`: new — pure-function tests including an overlapping-wildcard-family fixture mirroring the real `orion:exec:result:*` family.
- `orion/bus/tests/test_velocity.py`: added tests for `scan_active_channels` (discovery+aggregation, window filtering, malformed/empty-channel-name keys, fail-open on Redis error, zero-window short-circuit).
- `docs/superpowers/specs/2026-07-23-bus-channel-velocity-census-design.md`: status + recommended-next-patch sections updated to reflect Phase 1+2 completion.

## Schema / bus / API changes

- Added: nothing on the bus/schema/API surface. `compute_census`/`scan_active_channels` are internal read-side helpers with no wired caller yet (deliberately — see Risks below).
- Removed / Renamed / Behavior changed: none.
- Compatibility notes: none needed.

## Env/config changes

None. No new env keys.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest orion/bus/tests/test_census.py orion/bus/tests/test_velocity.py orion/core/bus/tests/ -q
44 passed, 6 warnings in 2.45s
```

## Evals run

No eval harness exists for `orion/bus/`. This is a pure-function + Redis-adapter patch; the live-data gate below stands in for an eval, per the design spec's own acceptance-check criteria (CLAUDE.md section 11: report the gap explicitly rather than claim eval coverage that didn't run).

## Docker/build/smoke checks

Not applicable — no service, no Docker-affecting change, no runtime config. Live-gate check ran as a one-off script against the real mesh's Redis instance (see below), not via Docker.

## Live-data gate (Phase 2 acceptance check, per the design spec)

Ran `scan_active_channels()` + `load_channel_catalog_names()` + `compute_census()` against the real running mesh (`ORION_BUS_URL`, real `orion/bus/channels.yaml`):

```text
catalog size: 264
active channels (live, 5min window): 106
declared_silent: 192
undeclared_active: 0
```

- `undeclared_active == 0` is the load-bearing result: it proves the wildcard-prefix matching correctly classifies real dynamic reply channels (`orion:exec:result:LLMGatewayService:<uuid>`, `orion:state:reply:<uuid>`, `orion:cortex:result:<uuid>`, etc.) rather than just synthetic test fixtures.
- Sampled `declared_silent`: mostly cron-triggered channels (`orion:actions:trigger:daily_metacog.v1`, `daily_pulse.v1`) and genuinely low-frequency ones (`orion:autonomy:action:outcome`, `orion:bridge:social:*`) — a believable, non-degenerate mix, not noise.

## Review findings fixed

- Finding: `scan_active_channels`'s `redis.scan_iter()` call had no `count=` hint, unlike the repo's one other `scan_iter` caller (`services/orion-context-exec/app/trace_tools.py`), meaning a ~200-300-key sweep would cost ~20-30 round trips at Redis's default SCAN COUNT instead of ~1-2.
  - Fix: added `count=200` to match existing repo convention.
  - Evidence: `orion/bus/velocity.py::scan_active_channels`.
- Finding: missing test coverage for the zero-window short-circuit not asserting `scan_iter`/`mget` were never called, and no test for the empty-channel-name malformed-key edge case that `_parse_velocity_key`'s guard exists for.
  - Fix: added `test_scan_active_channels_zero_window_short_circuits` (now asserts `mget.assert_not_called()`) and `test_scan_active_channels_ignores_empty_channel_name`.
  - Evidence: `orion/bus/tests/test_velocity.py`.
- Finding: `test_census.py` only exercised single-wildcard catalogs, not the real catalog's overlapping-wildcard-family shape (one broad `orion:exec:result:*` plus 4 narrower per-service wildcards) that the live 0-`undeclared_active` result actually depends on.
  - Fix: added `test_compute_census_overlapping_wildcard_family_matches_narrowest_and_broadest`.
  - Evidence: `orion/bus/tests/test_census.py`.
- Non-blocking, informational (not fixed, out of scope per spec's Non-goals): `channels.yaml` has a pre-existing catalog duplicate (`orion:cortex:result` exact + `orion:cortex:result*` wildcard, same schema/producers/consumers) that will show as a duplicate-looking pair in `declared_silent` if that family goes quiet — a catalog cleanup candidate, not a code defect. Also noted: bare-star wildcard forms (no colon before `*`) are structurally looser prefix matches than colon-star forms; documented as a code comment in `census.py` rather than changed, since it faithfully reflects what `channels.yaml` itself declares.

## Restart required

No restart required. No service, container, or env change.

## Risks / concerns

- Severity: low.
- Concern: `compute_census()`/`scan_active_channels()` have no wired periodic caller yet — they exist as tested, live-gated pure functions, not as a running feature. Left this way deliberately per the design spec's phased-gate structure (Phase 2 = "compute and verify the diff is correct," not "wire it into a dashboard").
- Mitigation: design spec's Recommended-next-patch section now says explicitly: give this a periodic caller (once-a-minute cadence recommended, not `bus_observer.py`'s 10s tick) and a debug/log surface before anything downstream depends on it, to avoid CLAUDE.md's "no keyword cathedral" trap (a pure function nobody calls is not yet a real seam).

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1312
