### PR TITLE
fix(rpc-health): correct real SERVICE_NAME values in organ_id resolution

### DIFF
--- a/orion/core/bus/tests/test_rpc_health_publish.py
+++ b/orion/core/bus/tests/test_rpc_health_publish.py
@@ -32,11 +32,11 @@ def test_build_envelope_carries_all_snapshot_fields() -> None:
     snapshot = agg.snapshot_and_reset()
 
     env = build_rpc_health_snapshot_envelope(
-        snapshot, service="orion-cortex-exec", node="athena", instance=None, source=_source()
+        snapshot, service="cortex-exec", node="athena", instance=None, source=_source()
     )
 
     assert env.kind == RPC_HEALTH_SNAPSHOT_KIND
-    assert env.payload["service"] == "orion-cortex-exec"
+    assert env.payload["service"] == "cortex-exec"
     assert env.payload["success_count"] == 1
     assert env.payload["timeout_count"] == 1
     assert env.payload["channel_counts"] == {"orion:cortex:exec:request": 2}
@@ -48,7 +48,7 @@ def test_build_envelope_on_empty_snapshot_is_not_degenerate_shaped() -> None:
     agg = RpcHealthAggregator()
     snapshot = agg.snapshot_and_reset()
     env = build_rpc_health_snapshot_envelope(
-        snapshot, service="orion-cortex-orch", node="athena", instance=None, source=_source()
+        snapshot, service="cortex-orch", node="athena", instance=None, source=_source()
     )
     assert env.payload["success_count"] == 0
     assert env.payload["timeout_count"] == 0
@@ -88,7 +88,7 @@ async def test_publish_loop_resolves_bus_getter_fresh_each_tick_not_captured_onc
     task = asyncio.create_task(
         rpc_health_publish_loop(
             bus_getter=_bus_getter,
-            service="orion-cortex-exec",
+            service="cortex-exec",
             node="athena",
             instance=None,
             source=_source(),
@@ -120,7 +120,7 @@ async def test_publish_loop_survives_publish_failure_and_keeps_ticking() -> None
     task = asyncio.create_task(
         rpc_health_publish_loop(
             bus_getter=lambda: bus,
-            service="orion-cortex-exec",
+            service="cortex-exec",
             node="athena",
             instance=None,
             source=_source(),
@@ -147,7 +147,7 @@ async def test_publish_loop_stops_promptly_when_stop_event_set_during_sleep() ->
     task = asyncio.create_task(
         rpc_health_publish_loop(
             bus_getter=lambda: bus,
-            service="orion-cortex-exec",
+            service="cortex-exec",
             node="athena",
             instance=None,
             source=_source(),

--- a/orion/core/bus/tests/test_rpc_health_publish.py
+++ b/orion/core/bus/tests/test_rpc_health_publish.py
@@ -22,7 +22,7 @@ from orion.core.bus.rpc_health_publish import (
 
 
 def _source() -> ServiceRef:
-    return ServiceRef(name="orion-cortex-exec", node="athena")
+    return ServiceRef(name="cortex-exec", node="athena")
 
 
 def test_build_envelope_carries_all_snapshot_fields() -> None:

--- a/orion/signals/adapters/rpc_health.py
+++ b/orion/signals/adapters/rpc_health.py
@@ -47,8 +47,14 @@ def _latency_level(payload: dict) -> float:
     return clamp01(1.0 - min(float(p95), 30_000) / 30_000.0)
 
 
+_KNOWN_SERVICE_ORGAN_IDS = {
+    "cortex-exec": "rpc_health_cortex_exec",
+    "cortex-orch": "rpc_health_cortex_orch",
+}
+
+
 def _organ_id_for_service(service: str) -> Optional[str]:
-    """Per-service organ_id, e.g. 'orion-cortex-exec' -> 'rpc_health_cortex_exec'.
+    """Per-service organ_id, e.g. 'cortex-exec' -> 'rpc_health_cortex_exec'.
 
     Deliberately NOT a single shared 'rpc_health' organ_id across every producer:
     orion-signal-gateway's SignalWindow keys its current-state view by organ_id alone
@@ -56,9 +62,17 @@ def _organ_id_for_service(service: str) -> Optional[str]:
     every producer's publish silently overwrite the previous producer's entry -- found
     in review of this step's first cut. Returns None for an unrecognized service so the
     caller can degrade to no signal rather than guess a wrong identity.
+
+    Keys are the real `SERVICE_NAME` values (confirmed live: both services' settings.py
+    default to "cortex-exec"/"cortex-orch", no "orion-" prefix -- NOT
+    "orion-cortex-exec"/"orion-cortex-orch" as this function originally assumed, which
+    made adapt() silently return None on every real call in production, caught only by
+    live verification after deploy, not by review or the unit tests -- the test payloads
+    used the same wrong assumption as the implementation). Normalizes an "orion-" prefix
+    if present, defensively, in case that convention is ever used instead.
     """
-    known = {"orion-cortex-exec": "rpc_health_cortex_exec", "orion-cortex-orch": "rpc_health_cortex_orch"}
-    return known.get(service)
+    normalized = service.removeprefix("orion-") if service else service
+    return _KNOWN_SERVICE_ORGAN_IDS.get(normalized)
 
 
 class RpcHealthAdapter(OrionSignalAdapter):

--- a/orion/signals/adapters/tests/test_rpc_health_adapter.py
+++ b/orion/signals/adapters/tests/test_rpc_health_adapter.py
@@ -21,7 +21,7 @@ def norm_ctx() -> NormalizationContext:
 def _payload(**overrides) -> dict:
     now = datetime.now(timezone.utc)
     base = {
-        "service": "orion-cortex-exec",
+        "service": "cortex-exec",
         "node": "athena",
         "instance": None,
         "window_start": now.isoformat(),
@@ -107,10 +107,10 @@ def test_adapt_uses_distinct_organ_id_per_service(
     overwrite the previous producer's SignalWindow entry. Two different services must
     resolve to two different organ_ids."""
     exec_signal = adapter.adapt(
-        "orion:rpc_health:snapshot", _payload(service="orion-cortex-exec"), ORGAN_REGISTRY, {}, norm_ctx
+        "orion:rpc_health:snapshot", _payload(service="cortex-exec"), ORGAN_REGISTRY, {}, norm_ctx
     )
     orch_signal = adapter.adapt(
-        "orion:rpc_health:snapshot", _payload(service="orion-cortex-orch"), ORGAN_REGISTRY, {}, norm_ctx
+        "orion:rpc_health:snapshot", _payload(service="cortex-orch"), ORGAN_REGISTRY, {}, norm_ctx
     )
     assert exec_signal is not None and orch_signal is not None
     assert exec_signal.organ_id == "rpc_health_cortex_exec"
@@ -118,11 +118,42 @@ def test_adapt_uses_distinct_organ_id_per_service(
     assert exec_signal.organ_id != orch_signal.organ_id
 
 
+def test_adapt_matches_real_live_service_name_values(
+    adapter: RpcHealthAdapter, norm_ctx: NormalizationContext
+) -> None:
+    """Regression guard for a real bug caught only by live deployment, not by review or
+    the original version of this test suite: both services' real SERVICE_NAME setting is
+    "cortex-exec"/"cortex-orch" (confirmed live via `docker exec ... env`), NOT
+    "orion-cortex-exec"/"orion-cortex-orch" -- the wrong value this adapter (and this
+    test file's _payload() default) originally assumed. adapt() returned None on every
+    real production call until this was fixed, silently (no exception, no error log --
+    can_handle() matched and adapt() correctly degraded to "no signal" for what it
+    believed was an unrecognized service). Pin the exact real strings here so a future
+    refactor of _organ_id_for_service can't silently reintroduce the mismatch."""
+    signal = adapter.adapt(
+        "orion:rpc_health:snapshot", _payload(service="cortex-exec"), ORGAN_REGISTRY, {}, norm_ctx
+    )
+    assert signal is not None
+    assert signal.organ_id == "rpc_health_cortex_exec"
+
+
+def test_adapt_normalizes_orion_prefixed_service_name(
+    adapter: RpcHealthAdapter, norm_ctx: NormalizationContext
+) -> None:
+    """Defensive: if some future producer's SERVICE_NAME does use an "orion-" prefix
+    (matching the repo/registry naming convention elsewhere), resolution still works."""
+    signal = adapter.adapt(
+        "orion:rpc_health:snapshot", _payload(service="orion-cortex-exec"), ORGAN_REGISTRY, {}, norm_ctx
+    )
+    assert signal is not None
+    assert signal.organ_id == "rpc_health_cortex_exec"
+
+
 def test_adapt_unknown_service_degrades_to_none(
     adapter: RpcHealthAdapter, norm_ctx: NormalizationContext
 ) -> None:
     signal = adapter.adapt(
-        "orion:rpc_health:snapshot", _payload(service="orion-some-future-service"), ORGAN_REGISTRY, {}, norm_ctx
+        "orion:rpc_health:snapshot", _payload(service="some-future-service"), ORGAN_REGISTRY, {}, norm_ctx
     )
     assert signal is None
 

--- a/services/orion-cortex-exec/tests/conftest.py
+++ b/services/orion-cortex-exec/tests/conftest.py
@@ -39,7 +39,7 @@ def _ensure_cortex_exec_paths() -> None:
 
 _ensure_cortex_exec_paths()
 
-os.environ.setdefault("SERVICE_NAME", "orion-cortex-exec")
+os.environ.setdefault("SERVICE_NAME", "cortex-exec")
 os.environ.setdefault("SERVICE_VERSION", "0.2.0")
 os.environ.setdefault("NODE_NAME", "athena")
 os.environ.setdefault("ORION_BUS_URL", "redis://localhost:6379/0")

--- a/services/orion-signal-gateway/app/tests/test_rpc_health_channel_subscription.py
+++ b/services/orion-signal-gateway/app/tests/test_rpc_health_channel_subscription.py
@@ -57,9 +57,14 @@ async def test_gateway_processor_produces_rpc_health_signal_end_to_end() -> None
     )
     env = BaseEnvelope(
         kind="rpc_health.snapshot.v1",
-        source=ServiceRef(name="orion-cortex-exec", version="0.1.1", node="athena"),
+        # "cortex-exec", not "orion-cortex-exec" -- the real SERVICE_NAME value
+        # (confirmed live). An earlier version of this test used the wrong value here,
+        # which matched this adapter's then-also-wrong _organ_id_for_service mapping and
+        # so didn't catch that adapt() silently returned None on every real production
+        # call; caught only by live deployment, not by this test or review.
+        source=ServiceRef(name="cortex-exec", version="0.1.1", node="athena"),
         correlation_id=UUID("00000000-0000-4000-8000-0000000000a1"),
-        payload=_rpc_health_payload("orion-cortex-exec"),
+        payload=_rpc_health_payload("cortex-exec"),
     )
     await proc.handle_envelope(env)
 
@@ -89,8 +94,8 @@ async def test_gateway_signal_window_does_not_collide_across_producer_services()
         service_ref=ServiceRef(name="orion-signal-gateway", version="0.1.0", node="n"),
     )
     for service, corr in (
-        ("orion-cortex-exec", "00000000-0000-4000-8000-0000000000b1"),
-        ("orion-cortex-orch", "00000000-0000-4000-8000-0000000000b2"),
+        ("cortex-exec", "00000000-0000-4000-8000-0000000000b1"),
+        ("cortex-orch", "00000000-0000-4000-8000-0000000000b2"),
     ):
         env = BaseEnvelope(
             kind="rpc_health.snapshot.v1",


### PR DESCRIPTION
## Summary

- Live production bug, caught only by deploying and flag-flipping PR #1313: `_organ_id_for_service()` in `orion/signals/adapters/rpc_health.py` mapped `"orion-cortex-exec"`/`"orion-cortex-orch"`, but the real `SERVICE_NAME` on both producer services is `"cortex-exec"`/`"cortex-orch"` (confirmed via `docker exec ... env` on the live containers).
- Impact: `adapt()` silently returned `None` on every single real call — `can_handle()` matched, envelopes flowed correctly onto `orion:rpc_health:snapshot`, the gateway received and logged intake for all of them, but zero signals were ever produced. No exception, no error log — the code correctly degraded to "no signal" for what it believed was an unrecognized service, just triggered unconditionally.
- Neither the original unit tests nor the gateway end-to-end test added in PR #1313's review round caught this — both used the same wrong `"orion-cortex-exec"` string in their test payloads, matching the implementation's wrong assumption.
- Two review rounds on this fix: round 1 fixed the core mapping + the two test files that were actually exercising the broken path; round 2 found and fixed two more instances of the identical wrong-literal pattern (the producer-side envelope-builder test, and a pre-existing test conftest default that's the plausible original source of the wrong assumption).

## Outcome moved

`rpc_health` organ signals will actually be produced by the gateway once this deploys — currently deployed and flag-enabled but producing nothing.

## Current architecture

Post-PR #1313: code fully wired (gateway subscribed to `orion:rpc_health:*`, both services publishing every 30s), but `_organ_id_for_service()`'s wrong keys made every real call resolve to "unrecognized service" and return `None`.

## Architecture touched

- `orion/signals/adapters/rpc_health.py`: `_organ_id_for_service()` mapping keys corrected to the real `SERVICE_NAME` values, with defensive `.removeprefix("orion-")` normalization in case a future producer does use that convention.
- Test fidelity fixes across `orion/signals/adapters/tests/test_rpc_health_adapter.py`, `orion/core/bus/tests/test_rpc_health_publish.py`, `services/orion-signal-gateway/app/tests/test_rpc_health_channel_subscription.py`, `services/orion-cortex-exec/tests/conftest.py`.

## Files changed

- `orion/signals/adapters/rpc_health.py`: fixed mapping, added prefix normalization, expanded docstring with the real-world evidence.
- `orion/signals/adapters/tests/test_rpc_health_adapter.py`: fixed `_payload()` default and explicit service args to real values; added `test_adapt_matches_real_live_service_name_values` (regression pin) and `test_adapt_normalizes_orion_prefixed_service_name` (defensive coverage).
- `orion/core/bus/tests/test_rpc_health_publish.py`: fixed all remaining `service=`/`ServiceRef(name=...)` literals (both rounds — round 1 missed 5 occurrences in the producer-side envelope test, caught by round 2 review).
- `services/orion-signal-gateway/app/tests/test_rpc_health_channel_subscription.py`: fixed payload/source literals.
- `services/orion-cortex-exec/tests/conftest.py`: fixed the pre-existing `SERVICE_NAME` test default (`"orion-cortex-exec"` → `"cortex-exec"`), the plausible original source of the wrong assumption; not exercised by any current assertion, so this doesn't change test behavior, just removes a live trap for future tests.

## Schema / bus / API changes

None — pure bugfix, no schema/channel/contract changes.

## Env/config changes

None.

## Tests run

```text
.venv/bin/python -m pytest orion/signals orion/core/bus/tests services/orion-signal-gateway/app/tests -q
138 passed

.venv/bin/python -m pytest services/orion-cortex-exec/tests/test_rpc_bus_fork.py services/orion-cortex-exec/tests/test_ready.py -q
5 passed
```

Also verified directly against the live deployed system: replayed the exact real envelope payload structure (captured live from `orion:rpc_health:snapshot`) through the real running gateway's `RpcHealthAdapter.adapt()` inside the container (`docker exec`, scratch verification only, not a deploy) — confirmed the fix produces a correct signal (`organ_id="rpc_health_cortex_exec"`, non-degenerate dimensions) where the pre-fix code returned `None`.

## Evals run

N/A — same rationale as PR #1313; covered by the unit/integration test suite above plus the live-payload replay verification.

## Docker/build/smoke checks

Not yet redeployed — this PR needs a real rebuild+restart of `orion-cortex-exec` and `orion-cortex-orch` to pick up the fix (the gateway itself doesn't need code changes, only the adapter it already loads).

## Review findings fixed

- Finding (round 1, self-caught via live verification, not by review): `_organ_id_for_service()` used the wrong `SERVICE_NAME` values.
  - Fix: corrected mapping keys + defensive prefix normalization.
  - Evidence: live payload replay against the real running gateway code, before/after.
- Finding (round 2 review): producer-side test file (`test_rpc_health_publish.py`) still hardcoded the wrong value in 5 places — the exact field (`payload["service"]`) that broke in production.
  - Fix: all 5 occurrences corrected.
  - Evidence: reviewer traced both production call sites (`cortex-exec/app/main.py:1018`, `cortex-orch/app/main.py:702`) confirming they pass `settings.service_name` untransformed, and confirmed no test currently exercises the wrong literal against real production code (not a live bug, but a closed trap).
- Finding (round 2 review): `orion-cortex-exec/tests/conftest.py`'s `SERVICE_NAME` test default carried the same wrong prefix, pre-dating this feature (since 2026-03-18) — plausible original source of the wrong assumption.
  - Fix: corrected to match the real deployed default.
  - Evidence: confirmed no test asserts against the old wrong value (`grep -rn "service_name =="` — zero matches).
- Verified correct, no action needed (round 2 review): `OrionOrganRegistryEntry.service` field (still `"orion-cortex-exec"`/`"orion-cortex-orch"`, repo-convention descriptive metadata) — confirmed via exhaustive repo-wide search that no production code ever compares it against a real payload's `service` field; `str.removeprefix()` Python-version compatibility — confirmed all three services run `python:3.12-slim` (feature requires 3.9+).

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-cortex-orch/.env \
  -f services/orion-cortex-orch/docker-compose.yml \
  up -d --build
```

`RPC_HEALTH_PUBLISH_ENABLED` is already `true` live on both — this restart is what makes the publish actually produce signals.

## Risks / concerns

- Severity: low
- Concern: none — pure bugfix, thoroughly re-verified against live data before and after.
- Mitigation: n/a

## PR link

(filled in after `gh pr create`)
