### PR TITLE
feat(backup): nightly database backups for Postgres, FalkorDB, Chroma, Convex

### DIFF
--- a/deploy/systemd/orion-backup-databases.service
+++ b/deploy/systemd/orion-backup-databases.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Orion nightly database backups (Postgres, FalkorDB, Chroma, Convex)
+Documentation=file:/mnt/scripts/Orion-Sapienform/scripts/backup/README.md
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+# Finite, not infinity: each subprocess call inside the script already has
+# its own timeout, but a wedged docker daemon could still hang the overall
+# run without this, holding db/backup.lock and failing every subsequent
+# night until someone notices. 2h is generous for the current data sizes
+# (~1.2GB Postgres dump, ~20GB Convex copy) with headroom to grow.
+TimeoutStartSec=2h
+UMask=0077
+WorkingDirectory=/mnt/scripts/Orion-Sapienform
+Environment=PYTHONPATH=/mnt/scripts/Orion-Sapienform
+EnvironmentFile=-/etc/orion-backup-databases.env
+ExecStart=/mnt/scripts/Orion-Sapienform/venv/bin/python /mnt/scripts/Orion-Sapienform/scripts/backup/orion_backup_databases.py
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/deploy/systemd/orion-backup-databases.timer
+++ b/deploy/systemd/orion-backup-databases.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly Orion database backups
+
+[Timer]
+OnCalendar=*-*-* 03:45:00
+Persistent=true
+Unit=orion-backup-databases.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/superpowers/pr-reports/2026-07-24-nightly-database-backup-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-24-nightly-database-backup-pr.md
@@ -1,0 +1,196 @@
+# PR report: nightly database backups (Postgres, FalkorDB, Chroma, Convex)
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1316
+Branch: `feat/db-backup-nightly`
+
+## Summary
+
+- New nightly backup tool (`scripts/backup/orion_backup_databases.py`)
+  covering Postgres, FalkorDB, Chroma, and Convex — separate from the
+  existing `/mnt/scripts` rsync backup because a live database data
+  directory isn't safe to rsync.
+- Each target uses a consistency-safe capture instead of a raw copy.
+- Mirrors the existing `/mnt/scripts` backup tool's shape: staged snapshot
+  dir, atomic rename, per-target retention, status/manifest JSON, failure
+  notify.
+- Adds a real mount-existence check and restricts artifact permissions to
+  0600/0700.
+- Systemd timer at 03:45 local (30 min after the existing 03:15 mnt-scripts
+  slot).
+
+## Outcome moved
+
+Before this PR: zero automated backup coverage for any live database in the
+mesh. The only Postgres backup that existed anywhere was a stale, near-empty
+snapshot from months earlier (traced during the same-day NVMe drive failure
+incident — see the drive-failure conversation this same day). After this PR:
+four database backends get a nightly, consistency-safe snapshot with
+retention, once the timer is installed.
+
+## Current architecture
+
+Before this PR, the only backup mechanism in the repo was
+`scripts/backup/orion_backup_mnt_scripts.py`, which rsyncs `/mnt/scripts`
+(source code + worktrees) nightly. It explicitly does not cover
+`/mnt/postgres` or `/mnt/graphdb` — those were never backed up by any
+automated process. This gap is the direct reason a drive failure earlier the
+same day resulted in near-total data loss with only a 9-month-stale manual
+dump to fall back on.
+
+## Architecture touched
+
+- `scripts/backup/` — new sibling script alongside the existing mnt-scripts
+  tool, reusing its lock/retention/atomic-rename/status-JSON helpers directly
+  via import rather than duplicating them.
+- `deploy/systemd/` — new service + timer units, following the exact pattern
+  of the existing `orion-backup-mnt-scripts.{service,timer}`.
+- No changes to any running service, container, or live config — this is
+  purely new tooling, not yet installed as a running timer on any host.
+
+## Files changed
+
+- `scripts/backup/orion_backup_databases.py`: new — the core backup tool.
+- `tests/test_orion_backup_databases.py`: new — 14 tests covering
+  target-level success/failure/retention, mount validation, permission
+  restriction, lock contention, and the stop/copy/restart capture path
+  (mocked at the subprocess boundary).
+- `deploy/systemd/orion-backup-databases.service`: new — oneshot unit, root
+  by default (no `User=` override), `TimeoutStartSec=2h`, `UMask=0077`.
+- `deploy/systemd/orion-backup-databases.timer`: new — daily 03:45 local,
+  `Persistent=true`.
+- `scripts/backup/README.md`: updated — documents the new tool, the
+  per-target capture rationale, and known gaps (Fuseki, bus-mirror
+  intentionally excluded).
+
+## Schema / bus / API changes
+
+None. This is operational tooling, not a service with a bus/schema surface.
+
+## Env/config changes
+
+- Added: optional `/etc/orion-backup-databases.env` (mirrors the existing
+  `/etc/orion-backup-mnt-scripts.env` pattern) for `ORION_BACKUP_NOTIFY_URL`
+  / `ORION_BACKUP_NOTIFY_TOKEN`.
+- No `.env_example` changes — this tool isn't a `services/<name>` service,
+  it's a repo-root `scripts/` utility, same category as the existing
+  mnt-scripts backup which also has no `.env_example` entry.
+
+## Tests run
+
+```text
+PYTHONPATH=. ./venv/bin/python -m pytest tests/test_orion_backup_databases.py -q
+14 passed
+
+PYTHONPATH=. ./venv/bin/python -m pytest tests/test_orion_backup_mnt_scripts.py -q
+20 passed  (sibling tool, unaffected)
+```
+
+## Evals run
+
+No eval harness exists for this category of tooling (operational backup
+scripts); none added. The functional equivalent — live smoke tests against
+the real running containers — is covered below instead.
+
+## Docker/build/smoke checks
+
+```text
+Live smoke test (scratch destination, real running containers, this session
+had no sudo so /mnt/storage-warm itself couldn't be used directly):
+
+--only postgres falkordb chroma
+  postgres: success — real pg_dumpall.sql captured, 1.2GB+ (grew from
+    ~2,000 to ~221,177 live rows during this session), 0600 permissions
+    confirmed
+  falkordb: success — real dump.rdb captured after fixing a baseline-
+    ordering bug in the original BGSAVE-completion check
+  chroma: success — mechanism validated; the real data directory is
+    currently empty (separate finding, not a bug in this tool)
+
+--only convex
+  NOT fully live-tested against the real ~19.5GB volume: the volume
+  mountpoint under /mnt/docker/volumes/orion-ai-town_convex-data/_data
+  requires root, unavailable in this session. The underlying sqlite3
+  .backup mechanism was validated standalone against a throwaway database
+  earlier in the session; the stop/copy/restart capture path itself is
+  covered by mocked unit tests. Recommend one supervised manual run before
+  enabling the timer.
+```
+
+## Review findings fixed
+
+- Finding: Convex/Chroma's non-SQLite files (RocksDB segments, HNSW index
+  files) were being raw-copied even after routing the SQLite file itself
+  through `.backup` — same tear risk the tool exists to prevent, just moved
+  to different files within the same target.
+  - Fix: Switched both targets to stop-container/copy/restart, consistent
+    for the whole directory rather than partially safe.
+  - Evidence: `test_capture_stopped_container_tree_copies_and_restarts`,
+    `test_capture_stopped_container_tree_restarts_container_even_if_copy_fails`.
+- Finding: SQLite `-wal`/`-shm` sidecars would've been raw-copied alongside
+  a `.backup` output, risking restore-time corruption.
+  - Fix: Moot after switching to the stop/copy/restart approach — no live
+    WAL exists once the container is stopped for the copy window.
+- Finding: No mount validation — a missing `/mnt/storage-warm` at run time
+  would silently write to whatever backs the parent directory.
+  - Fix: Added `validate_environment()`, checked before acquiring the lock.
+  - Evidence: `test_validate_environment_requires_existing_mount`,
+    `test_validate_environment_requires_actual_mount_point`,
+    `test_run_backup_rejects_non_mount_storage_warm_by_default`.
+- Finding: `pg_dumpall` output (observed 1.2GB+ live) was buffered entirely
+  in memory.
+  - Fix: Streams directly to the destination file handle.
+- Finding: No subprocess timeouts, and `TimeoutStartSec=infinity` — a single
+  wedged call could hang forever holding the lock.
+  - Fix: 300s default timeout on all subprocess calls; unit changed to
+    `TimeoutStartSec=2h`.
+- Finding: FalkorDB's BGSAVE-completion check had a real bug (baseline
+  captured after issuing BGSAVE, so a fast save's baseline was already
+  post-save) and, once fixed, still relied on a fixed 60s deadline against
+  `LASTSAVE`'s 1-second-resolution timestamp.
+  - Fix: Poll `INFO persistence`'s explicit `rdb_bgsave_in_progress`/
+    `rdb_last_bgsave_status` fields instead.
+- Finding: Backup artifacts would land world-readable under default umask.
+  - Fix: `UMask=0077` on the unit plus explicit `chmod 0600`/`0700` after
+    each successful capture.
+  - Evidence: `test_run_target_backup_restricts_permissions_to_owner_only`.
+- Finding: Failure-notify path reused the sibling tool's function via a
+  hand-rolled duck-typed adapter mirroring every attribute it reads —
+  fragile and untested.
+  - Fix: Wrote a small local `send_failure_notification` instead.
+- Finding: Run-level `log_path` pointed at a file that was never written.
+  - Fix: Now writes a real aggregated run-level log.
+- Finding: Minor — duplicated private helpers instead of importing the
+  sibling's, unused imports.
+  - Fix: Imports the sibling's versions directly; removed dead imports.
+
+## Restart required
+
+```text
+No restart required for any currently-running service.
+```
+
+Installing the new timer (not done as part of this PR — root-required,
+left to the operator) requires:
+
+```bash
+sudo cp deploy/systemd/orion-backup-databases.service /etc/systemd/system/
+sudo cp deploy/systemd/orion-backup-databases.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now orion-backup-databases.timer
+```
+
+## Risks / concerns
+
+- Severity: should-fix before first unattended run
+  Concern: Convex's stop/copy/restart path is untested against the real
+  ~19.5GB volume (root-only in this session).
+  Mitigation: run one supervised manual pass (`sudo ... --only convex`)
+  before enabling the timer.
+- Severity: informational
+  Concern: Fuseki and bus-mirror intentionally excluded (Fuseki is
+  mid-decommission; bus-mirror is a disabled debug tap holding a 98GB
+  runaway recording, not a database worth backing up).
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1316

--- a/scripts/backup/README.md
+++ b/scripts/backup/README.md
@@ -1,4 +1,4 @@
-# Local `/mnt/scripts` backup
+# Local `/mnt/scripts` backup and nightly database backups
 
 Nightly hard-linked snapshots of `/mnt/scripts` into `/mnt/storage-warm`, with
 local evidence and optional Orion failure alerts.
@@ -174,3 +174,76 @@ destination node’s own disk IDs, then restore files.
 ```bash
 PYTHONPATH=. ./venv/bin/python -m pytest tests/test_orion_backup_mnt_scripts.py -q
 ```
+
+---
+
+## Nightly database backups (Postgres, FalkorDB, Chroma, Convex)
+
+`orion_backup_databases.py` -- a separate tool from the `/mnt/scripts` backup
+above, because a live database data directory is not safe to `rsync`: files
+mutate mid-copy (confirmed live 2026-07-24 -- a plain tar of Convex's
+`db.sqlite3` failed with "file changed as we read it" while the backend was
+running). Each target uses its own consistency-safe capture instead of a raw
+file copy:
+
+| Target | Capture method | Why |
+|--------|-----------------|-----|
+| Postgres | `docker exec ... pg_dumpall`, streamed straight to the destination file | Logical dump, always consistent regardless of concurrent writes; streamed rather than buffered in memory since a full cluster dump has been observed at 1.2GB+ live and only grows |
+| FalkorDB | `redis-cli BGSAVE`, poll `INFO persistence` for `rdb_bgsave_in_progress`/`rdb_last_bgsave_status`, then copy the resulting `dump.rdb` | Atomic point-in-time RDB snapshot; polling the explicit status fields (not just watching `LASTSAVE` change) avoids both false-negatives from `LASTSAVE`'s 1-second resolution and false-failures on a save that legitimately takes longer than a short fixed timeout |
+| Chroma | `docker stop`, plain copy of the host bind-mount path, `docker start` | Chroma's per-collection index segments mutate on write with no CLI-accessible checkpoint API available here; an earlier version of this tool tried a live `sqlite3 .backup` for the metadata file only and left the segment files raw-copied, which doesn't actually solve the consistency problem for those files (and can leave a stale `-wal`/`-shm` sidecar next to a `.backup` output, corrupting restore) -- stopping for the copy window is simple and actually consistent |
+| Convex | Same stop/copy/start treatment, against the resolved Docker volume mountpoint (`docker volume inspect ... --format '{{.Mountpoint}}'`) | Same reason -- confirmed live that a raw copy of Convex's `db.sqlite3` tears mid-write ("file changed as we read it"), and its data directory also mixes in live RocksDB-style segment files that have no safe online-backup API exposed to this tool either |
+
+Chroma and Convex are non-critical services (an internal vector store and an
+AI-town simulation backend, not user-facing production data paths), so a few
+seconds of downtime during the 03:45 backup window is an acceptable trade for
+actual consistency -- unlike Postgres/FalkorDB above, which stay fully up via
+their own online-backup mechanisms.
+
+Layout mirrors the `/mnt/scripts` backup, one level down per target:
+`/mnt/storage-warm/backups/<node-name>/db/<target>/{snapshots,latest,status,logs,manifests}`,
+plus a shared `db/backup.lock` and `db/status/latest.json` for the whole run.
+Each target has its own retention count (`Target.keep_successful`, default 14)
+and is pruned independently, since a text SQL dump and a ~20GB Convex copy
+have very different reasonable retention windows.
+
+### Manual run
+
+```bash
+sudo PYTHONPATH=. ./venv/bin/python scripts/backup/orion_backup_databases.py
+sudo PYTHONPATH=. ./venv/bin/python scripts/backup/orion_backup_databases.py --only postgres falkordb
+```
+
+Root is required for the real run: the backup root under `/mnt/storage-warm`
+is root-owned (same as the `/mnt/scripts` backup above), and Convex's volume
+mountpoint under `/mnt/docker/volumes/.../_data` is only host-readable as
+root. The systemd service below runs as root by default (no `User=` override),
+matching this.
+
+### Install the nightly timer
+
+```bash
+sudo cp deploy/systemd/orion-backup-databases.service /etc/systemd/system/
+sudo cp deploy/systemd/orion-backup-databases.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now orion-backup-databases.timer
+systemctl list-timers orion-backup-databases.timer
+```
+
+Runs at 03:45 local time, offset 30 minutes after the `/mnt/scripts` backup's
+03:15 slot to avoid the two jobs contending for disk I/O at the same moment.
+
+### Tests
+
+```bash
+PYTHONPATH=. ./venv/bin/python -m pytest tests/test_orion_backup_databases.py -q
+```
+
+### Known gaps (not yet covered)
+
+- **Fuseki**: intentionally not included -- it's mid-decommission (see the
+  Fuseki removal campaign), so a recurring nightly backup of a store being
+  actively killed didn't seem worth building. A one-off manual archival
+  snapshot before final teardown is a `docker exec ... tar` away if wanted,
+  but isn't wired into this tool.
+- **bus-mirror**: not a backup target -- it's a disabled debug tap, not a
+  database (see `services/orion-bus-mirror/README.md`).

--- a/scripts/backup/orion_backup_databases.py
+++ b/scripts/backup/orion_backup_databases.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Nightly backups for the live database backends (Postgres, FalkorDB, Chroma,
+Convex).
+
+Reuses the same shape as orion_backup_mnt_scripts.py (staged snapshot dir,
+atomic rename on success, retention, status/manifest JSON, failure notify)
+but each target has its own consistency-safe capture method instead of a
+single rsync, because a live database data directory is not safe to rsync
+while it is being written -- confirmed live: a plain tar of Convex's
+db.sqlite3 failed with "file changed as we read it" while the backend was
+running. See scripts/backup/README.md for the full per-target rationale.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from scripts.backup.orion_backup_mnt_scripts import (
+    _update_latest_symlink,
+    _utc_iso,
+    _write_json_atomic,
+    acquire_lock,
+    cleanup_incomplete_snapshots,
+    prune_successful_snapshots,
+    snapshot_timestamp,
+)
+
+DEFAULT_STORAGE_WARM = Path("/mnt/storage-warm")
+DEFAULT_KEEP_SUCCESSFUL = 14
+DEFAULT_SUBPROCESS_TIMEOUT_SEC = 300
+
+
+@dataclass(frozen=True)
+class TargetOutcome:
+    name: str
+    status: str
+    snapshot_path: str | None
+    error_summary: str | None
+    retention_actions: list[str]
+
+
+@dataclass(frozen=True)
+class RunOutcome:
+    run_id: str
+    status: str
+    node_name: str
+    started_at_utc: str
+    finished_at_utc: str
+    storage_warm_path: str
+    targets: list[dict[str, Any]]
+    log_path: str
+    manifest_path: str
+    notification_attempt: dict[str, Any] | None
+
+
+def _target_root(storage_warm: Path, node_name: str, target_name: str) -> Path:
+    return storage_warm / "backups" / node_name / "db" / target_name
+
+
+def _run(
+    cmd: list[str], *, log: list[str], timeout: int = DEFAULT_SUBPROCESS_TIMEOUT_SEC
+) -> subprocess.CompletedProcess:
+    log.append("$ " + " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, timeout=timeout)
+
+
+def validate_environment(storage_warm: Path, *, require_mount: bool = True) -> None:
+    """Fail loudly before writing anything if storage-warm isn't actually
+    mounted -- otherwise a missing mount silently falls through to whatever
+    filesystem backs the parent directory (root, in production), which is
+    exactly the phantom-mount failure mode this whole backup system exists
+    to protect against."""
+    if not storage_warm.exists():
+        raise RuntimeError(f"storage-warm path does not exist: {storage_warm}")
+    if require_mount and not storage_warm.is_mount():
+        raise RuntimeError(f"storage-warm path must be a mount point: {storage_warm}")
+    if not os.access(storage_warm, os.W_OK | os.X_OK):
+        raise RuntimeError(f"storage-warm path is not writable: {storage_warm}")
+
+
+def _chmod_tree_owner_only(root: Path) -> None:
+    """Backup artifacts (a full Postgres cluster dump, in plaintext) must not
+    be world- or group-readable by default -- restrict after writing rather
+    than relying on umask alone, since this runs as root and the resulting
+    files would otherwise inherit whatever the process umask happens to be."""
+    for path in root.rglob("*"):
+        if path.is_dir():
+            path.chmod(0o700)
+        else:
+            path.chmod(0o600)
+    root.chmod(0o700)
+
+
+# --- per-target capture -----------------------------------------------------
+
+def capture_postgres(dest_dir: Path, *, container: str, pg_user: str, log: list[str]) -> None:
+    """pg_dumpall inside the running container -- logical dump, always
+    consistent regardless of concurrent writes, unlike a raw data-dir copy.
+
+    Streams stdout straight to the destination file instead of buffering it
+    in memory: a full cluster dump has been observed at 1.2GB+ live and only
+    grows, so capturing it as a Python bytes object first would double peak
+    memory for no reason.
+    """
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "pg_dumpall.sql"
+    cmd = ["docker", "exec", container, "pg_dumpall", "-U", pg_user]
+    log.append("$ " + " ".join(cmd) + f" > {dest_file}")
+    with dest_file.open("wb") as fh:
+        proc = subprocess.run(cmd, stdout=fh, stderr=subprocess.PIPE, timeout=DEFAULT_SUBPROCESS_TIMEOUT_SEC)
+    if proc.returncode != 0:
+        dest_file.unlink(missing_ok=True)
+        raise RuntimeError(f"pg_dumpall failed ({proc.returncode}): {proc.stderr.decode(errors='replace')[:500]}")
+
+
+def capture_falkordb(
+    dest_dir: Path,
+    *,
+    container: str,
+    data_dir_in_container: str,
+    log: list[str],
+    bgsave_deadline_sec: int = 300,
+) -> None:
+    """BGSAVE first for an atomic point-in-time RDB snapshot, then copy the
+    resulting dump.rdb out -- do not rsync/cp a live RDB file mid-write.
+
+    Polls `INFO persistence` for rdb_bgsave_in_progress/rdb_last_bgsave_status
+    rather than just watching LASTSAVE change: LASTSAVE has 1-second
+    resolution and BGSAVE always updates it on completion (even with zero
+    dirty keys), but INFO's explicit in-progress/status fields remove any
+    ambiguity and let a large save run past a short fixed timeout.
+    """
+    dest_dir.mkdir(parents=True)
+    proc = _run(["docker", "exec", container, "redis-cli", "BGSAVE"], log=log)
+    if proc.returncode != 0:
+        raise RuntimeError(f"BGSAVE failed: {proc.stderr.decode(errors='replace')[:500]}")
+    deadline = time.monotonic() + bgsave_deadline_sec
+    while True:
+        info = _run(["docker", "exec", container, "redis-cli", "INFO", "persistence"], log=log).stdout.decode(
+            errors="replace"
+        )
+        fields = dict(
+            line.split(":", 1) for line in info.splitlines() if ":" in line and not line.startswith("#")
+        )
+        if fields.get("rdb_bgsave_in_progress") == "0":
+            if fields.get("rdb_last_bgsave_status") != "ok":
+                raise RuntimeError(f"BGSAVE finished with status={fields.get('rdb_last_bgsave_status')!r}")
+            break
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"BGSAVE did not complete within {bgsave_deadline_sec}s")
+        time.sleep(1)
+    proc = _run(
+        ["docker", "cp", f"{container}:{data_dir_in_container}/dump.rdb", str(dest_dir / "dump.rdb")],
+        log=log,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"docker cp of dump.rdb failed: {proc.stderr.decode(errors='replace')[:500]}")
+
+
+def capture_stopped_container_tree(
+    dest_dir: Path, *, container: str, host_path: Path, log: list[str], stop_timeout_sec: int = 30
+) -> None:
+    """Stop the container, plain-copy its data directory, restart it.
+
+    Used for stores with no safe online-backup mechanism available to this
+    tool (Convex's data dir mixes a SQLite file with live RocksDB-style
+    segment files that have no CLI-accessible checkpoint API here; Chroma
+    similarly has per-collection index segments that mutate on write).
+    Copying any of that raw while the process is live risks tearing exactly
+    like the sqlite-only case already confirmed live for Convex. Stopping
+    for the copy window is the simple, actually-consistent alternative --
+    both of these are non-critical services where a few seconds of downtime
+    during the 03:45 backup window is an acceptable trade, unlike Postgres/
+    FalkorDB above which stay up via their own online-backup mechanisms.
+    """
+    dest_dir.mkdir(parents=True)
+    if not host_path.exists():
+        raise RuntimeError(f"host path does not exist: {host_path}")
+    stop_proc = _run(["docker", "stop", "-t", str(stop_timeout_sec), container], log=log)
+    if stop_proc.returncode != 0:
+        raise RuntimeError(f"docker stop failed: {stop_proc.stderr.decode(errors='replace')[:500]}")
+    try:
+        shutil.copytree(host_path, dest_dir, dirs_exist_ok=True)
+    finally:
+        start_proc = _run(["docker", "start", container], log=log)
+        if start_proc.returncode != 0:
+            # Surface this loudly rather than swallowing it under whatever
+            # copytree exception (if any) is already propagating -- a
+            # container that didn't come back up is worse than a failed
+            # backup.
+            log.append(f"WARNING: docker start failed to restart {container} after backup")
+
+
+@dataclass(frozen=True)
+class Target:
+    name: str
+    capture: Callable[[Path, list[str]], None]
+    keep_successful: int = DEFAULT_KEEP_SUCCESSFUL
+
+
+def default_targets() -> list[Target]:
+    return [
+        Target(
+            "postgres",
+            lambda dest, log: capture_postgres(
+                dest, container="orion-athena-sql-db", pg_user="postgres", log=log
+            ),
+        ),
+        Target(
+            "falkordb",
+            lambda dest, log: capture_falkordb(
+                dest,
+                container="orion-athena-falkordb",
+                data_dir_in_container="/var/lib/falkordb/data",
+                log=log,
+            ),
+        ),
+        Target(
+            "chroma",
+            lambda dest, log: capture_stopped_container_tree(
+                dest,
+                container="orion-athena-vector-db",
+                host_path=Path("/mnt/postgres/collapse-mirrors/chroma"),
+                log=log,
+            ),
+        ),
+        Target(
+            "convex",
+            lambda dest, log: capture_stopped_container_tree(
+                dest,
+                container="orion-ai-town-backend-1",
+                host_path=Path("/mnt/docker/volumes/orion-ai-town_convex-data/_data"),
+                log=log,
+            ),
+        ),
+    ]
+
+
+def run_target_backup(
+    target: Target,
+    *,
+    storage_warm: Path,
+    node_name: str,
+    run_id: str,
+) -> tuple[TargetOutcome, list[str]]:
+    root = _target_root(storage_warm, node_name, target.name)
+    snapshots_dir = root / "snapshots"
+    incomplete = snapshots_dir / f".incomplete-{run_id}"
+    final = snapshots_dir / run_id
+    latest = root / "latest"
+    log: list[str] = []
+    try:
+        snapshots_dir.mkdir(parents=True, exist_ok=True)
+        cleanup_incomplete_snapshots(snapshots_dir)
+        if final.exists():
+            raise RuntimeError(f"snapshot already exists: {final}")
+        target.capture(incomplete, log)
+        _chmod_tree_owner_only(incomplete)
+        incomplete.replace(final)
+        _update_latest_symlink(latest, final)
+        retention_actions = prune_successful_snapshots(snapshots_dir, keep=target.keep_successful)
+        status = "success"
+        snapshot_path: str | None = str(final)
+        error_summary = None
+    except Exception as exc:  # noqa: BLE001 - captured into evidence, not swallowed
+        status = "failure"
+        snapshot_path = None
+        error_summary = str(exc)
+        retention_actions = []
+        if incomplete.exists():
+            shutil.rmtree(incomplete, ignore_errors=True)
+    log_path = root / "logs" / f"{run_id}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("\n".join(log) + "\n")
+    return (
+        TargetOutcome(
+            name=target.name,
+            status=status,
+            snapshot_path=snapshot_path,
+            error_summary=error_summary,
+            retention_actions=retention_actions,
+        ),
+        log,
+    )
+
+
+def send_failure_notification(
+    outcome: RunOutcome, *, notify_url: str | None, notify_token: str | None
+) -> dict[str, Any]:
+    if not notify_url:
+        return {"attempted": False, "ok": False, "reason": "notify_url_not_configured"}
+    failed_summary = "; ".join(
+        f"{t['name']}: {t['error_summary']}" for t in outcome.targets if t["status"] == "failure"
+    )
+    message = f"Database backup failed on {outcome.node_name} (run_id={outcome.run_id}): {failed_summary}"
+    payload = {
+        "source_service": "orion-backup",
+        "reason": "db_backup_failed",
+        "severity": "critical",
+        "message": message,
+        "require_ack": True,
+        "context": {"run_id": outcome.run_id, "targets": outcome.targets, "manifest_path": outcome.manifest_path},
+    }
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(notify_url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+    if notify_token:
+        request.add_header("X-Orion-Notify-Token", notify_token)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return {"attempted": True, "ok": 200 <= response.status < 300, "status": response.status}
+    except (urllib.error.URLError, TimeoutError) as exc:
+        return {"attempted": True, "ok": False, "error": str(exc)}
+
+
+def run_backup(
+    *,
+    storage_warm: Path = DEFAULT_STORAGE_WARM,
+    node_name: str | None = None,
+    targets: list[Target] | None = None,
+    notify_url: str | None = None,
+    notify_token: str | None = None,
+    require_mount: bool = True,
+) -> RunOutcome:
+    node_name = node_name or socket.gethostname()
+    targets = targets if targets is not None else default_targets()
+    validate_environment(storage_warm, require_mount=require_mount)
+    started = _utc_iso(None)
+    run_id = f"{snapshot_timestamp(None)}-{os.getpid()}"
+    base_root = storage_warm / "backups" / node_name / "db"
+    lock_handle = acquire_lock(base_root / "backup.lock")
+    try:
+        run_log: list[str] = []
+        outcomes: list[TargetOutcome] = []
+        for t in targets:
+            outcome, target_log = run_target_backup(t, storage_warm=storage_warm, node_name=node_name, run_id=run_id)
+            outcomes.append(outcome)
+            run_log.append(f"=== {t.name} ===")
+            run_log.extend(target_log)
+        log_path = base_root / "logs" / f"{run_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("\n".join(run_log) + "\n")
+        overall_status = "success" if all(o.status == "success" for o in outcomes) else "failure"
+        outcome = RunOutcome(
+            run_id=run_id,
+            status=overall_status,
+            node_name=node_name,
+            started_at_utc=started,
+            finished_at_utc=_utc_iso(None),
+            storage_warm_path=str(storage_warm),
+            targets=[asdict(o) for o in outcomes],
+            log_path=str(log_path),
+            manifest_path=str(base_root / "manifests" / f"{run_id}.json"),
+            notification_attempt=None,
+        )
+        _write_json_atomic(base_root / "status" / "latest.json", asdict(outcome))
+        _write_json_atomic(base_root / "status" / "runs" / f"{run_id}.json", asdict(outcome))
+        _write_json_atomic(Path(outcome.manifest_path), asdict(outcome))
+        if outcome.status == "failure":
+            notify_result = send_failure_notification(outcome, notify_url=notify_url, notify_token=notify_token)
+            outcome = RunOutcome(**{**asdict(outcome), "notification_attempt": notify_result})
+            _write_json_atomic(base_root / "status" / "latest.json", asdict(outcome))
+        return outcome
+    finally:
+        lock_handle.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Nightly logical backups of Orion's live database backends.")
+    parser.add_argument("--storage-warm", type=Path, default=DEFAULT_STORAGE_WARM)
+    parser.add_argument("--node-name", default=socket.gethostname())
+    parser.add_argument("--notify-url", default=os.environ.get("ORION_BACKUP_NOTIFY_URL"))
+    parser.add_argument("--notify-token", default=os.environ.get("ORION_BACKUP_NOTIFY_TOKEN"))
+    parser.add_argument("--no-require-mount", action="store_true")
+    parser.add_argument(
+        "--only", nargs="*", default=None, help="Restrict to these target names (default: all)"
+    )
+    args = parser.parse_args(argv)
+    targets = default_targets()
+    if args.only:
+        targets = [t for t in targets if t.name in args.only]
+    outcome = run_backup(
+        storage_warm=args.storage_warm,
+        node_name=args.node_name,
+        targets=targets,
+        notify_url=args.notify_url,
+        notify_token=args.notify_token,
+        require_mount=not args.no_require_mount,
+    )
+    print(json.dumps(asdict(outcome), sort_keys=True))
+    return 0 if outcome.status == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_orion_backup_databases.py
+++ b/tests/test_orion_backup_databases.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import fcntl
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.backup.orion_backup_databases import (
+    Target,
+    capture_stopped_container_tree,
+    run_backup,
+    run_target_backup,
+    validate_environment,
+)
+
+
+def _ok_capture(dest: Path, log: list[str]) -> None:
+    dest.mkdir(parents=True)
+    (dest / "payload.txt").write_text("ok")
+
+
+def _failing_capture(dest: Path, log: list[str]) -> None:
+    raise RuntimeError("boom")
+
+
+def test_run_target_backup_success_updates_latest_and_prunes(tmp_path: Path) -> None:
+    outcome, _log = run_target_backup(
+        Target("widget", _ok_capture, keep_successful=2),
+        storage_warm=tmp_path,
+        node_name="node-a",
+        run_id="run-1",
+    )
+
+    assert outcome.status == "success"
+    assert outcome.snapshot_path is not None
+    snapshot = Path(outcome.snapshot_path)
+    assert snapshot.is_dir()
+    assert (snapshot / "payload.txt").read_text() == "ok"
+    latest = tmp_path / "backups" / "node-a" / "db" / "widget" / "latest"
+    assert latest.resolve() == snapshot.resolve()
+
+
+def test_run_target_backup_restricts_permissions_to_owner_only(tmp_path: Path) -> None:
+    outcome, _log = run_target_backup(
+        Target("widget", _ok_capture), storage_warm=tmp_path, node_name="node-a", run_id="run-1"
+    )
+    snapshot = Path(outcome.snapshot_path)
+    assert (snapshot.stat().st_mode & 0o777) == 0o700
+    assert ((snapshot / "payload.txt").stat().st_mode & 0o777) == 0o600
+
+
+def test_run_target_backup_failure_cleans_incomplete_dir(tmp_path: Path) -> None:
+    outcome, _log = run_target_backup(
+        Target("widget", _failing_capture), storage_warm=tmp_path, node_name="node-a", run_id="run-1"
+    )
+
+    assert outcome.status == "failure"
+    assert outcome.snapshot_path is None
+    assert "boom" in outcome.error_summary
+    snapshots_dir = tmp_path / "backups" / "node-a" / "db" / "widget" / "snapshots"
+    assert list(snapshots_dir.glob(".incomplete-*")) == []
+    assert list(snapshots_dir.glob("run-1")) == []
+
+
+def test_run_target_backup_prunes_old_snapshots_beyond_keep(tmp_path: Path) -> None:
+    for i in range(3):
+        run_target_backup(
+            Target("widget", _ok_capture, keep_successful=2),
+            storage_warm=tmp_path,
+            node_name="node-a",
+            run_id=f"run-{i}",
+        )
+    snapshots_dir = tmp_path / "backups" / "node-a" / "db" / "widget" / "snapshots"
+    remaining = sorted(p.name for p in snapshots_dir.iterdir())
+    assert remaining == ["run-1", "run-2"]
+
+
+def test_validate_environment_requires_existing_mount(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(RuntimeError, match="does not exist"):
+        validate_environment(missing)
+
+
+def test_validate_environment_requires_actual_mount_point(tmp_path: Path) -> None:
+    # tmp_path is a plain directory, not a mount point -- this is exactly the
+    # case that must be rejected so a missing storage-warm mount can't
+    # silently fall through to writing on root.
+    with pytest.raises(RuntimeError, match="mount point"):
+        validate_environment(tmp_path, require_mount=True)
+
+
+def test_validate_environment_allows_non_mount_when_not_required(tmp_path: Path) -> None:
+    validate_environment(tmp_path, require_mount=False)
+
+
+def test_run_backup_rejects_non_mount_storage_warm_by_default(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="mount point"):
+        run_backup(storage_warm=tmp_path, node_name="node-a", targets=[Target("good", _ok_capture)])
+
+
+def test_run_backup_overall_status_is_failure_if_any_target_fails(tmp_path: Path) -> None:
+    outcome = run_backup(
+        storage_warm=tmp_path,
+        node_name="node-a",
+        targets=[Target("good", _ok_capture), Target("bad", _failing_capture)],
+        require_mount=False,
+    )
+
+    assert outcome.status == "failure"
+    names_by_status = {t["name"]: t["status"] for t in outcome.targets}
+    assert names_by_status == {"good": "success", "bad": "failure"}
+
+
+def test_run_backup_writes_status_and_manifest_json(tmp_path: Path) -> None:
+    outcome = run_backup(
+        storage_warm=tmp_path, node_name="node-a", targets=[Target("good", _ok_capture)], require_mount=False
+    )
+
+    status_latest = tmp_path / "backups" / "node-a" / "db" / "status" / "latest.json"
+    assert status_latest.exists()
+    assert Path(outcome.manifest_path).exists()
+    assert Path(outcome.log_path).exists()
+
+
+def test_run_backup_lock_prevents_concurrent_runs(tmp_path: Path) -> None:
+    lock_path = tmp_path / "backups" / "node-a" / "db" / "backup.lock"
+    lock_path.parent.mkdir(parents=True)
+    handle = lock_path.open("w")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            run_backup(
+                storage_warm=tmp_path, node_name="node-a", targets=[Target("good", _ok_capture)], require_mount=False
+            )
+    finally:
+        handle.close()
+
+
+def test_capture_stopped_container_tree_copies_and_restarts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "data.bin").write_bytes(b"segment-contents")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], capture_output: bool, timeout: int) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    dest = tmp_path / "dest"
+    capture_stopped_container_tree(dest, container="my-container", host_path=source, log=[])
+
+    assert (dest / "data.bin").read_bytes() == b"segment-contents"
+    assert calls[0][:2] == ["docker", "stop"]
+    assert calls[-1] == ["docker", "start", "my-container"]
+
+
+def test_capture_stopped_container_tree_restarts_container_even_if_copy_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], capture_output: bool, timeout: int) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(shutil, "copytree", MagicMock(side_effect=OSError("disk full")))
+
+    with pytest.raises(OSError, match="disk full"):
+        capture_stopped_container_tree(
+            tmp_path / "dest", container="my-container", host_path=tmp_path, log=[]
+        )
+
+    assert calls[-1] == ["docker", "start", "my-container"]
+
+
+def test_capture_stopped_container_tree_raises_if_host_path_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def fake_run(cmd: list[str], capture_output: bool, timeout: int) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="does not exist"):
+        capture_stopped_container_tree(
+            tmp_path / "dest", container="my-container", host_path=tmp_path / "missing", log=[]
+        )


### PR DESCRIPTION
## Summary
- New nightly backup tool (`scripts/backup/orion_backup_databases.py`) covering Postgres, FalkorDB, Chroma, and Convex — separate from the existing `/mnt/scripts` rsync backup because a live database data directory isn't safe to rsync (confirmed live: a plain tar of Convex's `db.sqlite3` failed with "file changed as we read it" while the backend was running).
- Each target uses a consistency-safe capture instead of a raw copy: Postgres via streamed `pg_dumpall`, FalkorDB via `BGSAVE` + `INFO persistence` status polling, Chroma/Convex via stop-container/copy/restart (no safe online-backup API available for either's live-mutated binary segment files).
- Mirrors the existing `/mnt/scripts` backup tool's shape: staged snapshot dir, atomic rename on success, per-target retention, status/manifest JSON, failure notify.
- Adds a real mount-existence check before writing anything, and restricts backup artifacts to 0600/0700 (a full Postgres dump is plaintext and shouldn't be world-readable).
- Systemd timer at 03:45 local (30 min after the existing 03:15 mnt-scripts slot, to avoid I/O contention).

## Why this exists
Direct outcome of a live NVMe drive failure that took out `/mnt/postgres` and `/mnt/graphdb` with no working database backup in place — only a stale, near-empty Postgres snapshot from months earlier existed. Building this now so the same class of loss doesn't happen again.

## Test plan
- [x] `pytest tests/test_orion_backup_databases.py -q` — 14/14 passing
- [x] `pytest tests/test_orion_backup_mnt_scripts.py -q` — 20/20 passing (unaffected sibling tool)
- [x] Live smoke test of Postgres + FalkorDB capture against the real running containers (scratch destination) — both succeeded, verified real dump content (1.2GB+ `pg_dumpall.sql`, real `dump.rdb`), verified 0600 permissions applied
- [x] Live smoke test of the Chroma capture path (currently empty, mechanism validated)
- [ ] Convex's stop/copy/restart path could not be fully live-tested against the real ~19.5GB volume in this session (the volume mountpoint under `/mnt/docker/volumes/...` requires root, and this session had no sudo) — the stop/copy/restart logic itself is covered by mocked unit tests (verifies `docker stop` runs before the copy, `docker start` runs after including on failure), and the mechanism matches exactly how Postgres/FalkorDB were validated live. Recommend one supervised manual run (`sudo ... --only convex`) before enabling the timer.
- [ ] Systemd timer/service not yet installed on any real host — units are ready under `deploy/systemd/`, install step is a manual `sudo` operation per the README, not run as part of this PR.

## Review findings fixed
- **Finding:** Convex/Chroma's non-SQLite files (RocksDB segments, HNSW index files) were being raw-copied even after switching the SQLite file itself to `.backup` — same tear risk the tool exists to prevent, just moved to different files.
  - **Fix:** Switched both targets to stop-container/copy/restart, which is actually consistent for the whole directory rather than partially safe.
  - **Evidence:** New tests `test_capture_stopped_container_tree_copies_and_restarts` / `..._restarts_container_even_if_copy_fails`.
- **Finding:** SQLite `-wal`/`-shm` sidecar files would've been raw-copied alongside a `.backup` output, risking restore-time corruption (stale WAL replayed against an already-consistent backup).
  - **Fix:** Moot now that the whole tree is copied consistently while the container is stopped — no live WAL to worry about.
- **Finding:** No mount validation — a missing `/mnt/storage-warm` at run time would silently write to whatever backs the parent directory (root, in production).
  - **Fix:** Added `validate_environment()`, checked before acquiring the lock. Tests: `test_validate_environment_*`, `test_run_backup_rejects_non_mount_storage_warm_by_default`.
- **Finding:** `pg_dumpall` output (observed 1.2GB+ live) was buffered entirely in memory via `subprocess.run(capture_output=True)`.
  - **Fix:** Streams directly to the destination file handle instead.
- **Finding:** No subprocess timeouts, and `TimeoutStartSec=infinity` in the systemd unit — a single wedged `docker exec` could hang forever holding the lock, failing every subsequent night.
  - **Fix:** Added a default 300s timeout to all subprocess calls, changed the unit to `TimeoutStartSec=2h`.
- **Finding:** FalkorDB's `BGSAVE` completion check watched a fixed 60s deadline against `LASTSAVE` changing, with a since-fixed baseline-ordering bug (captured the "before" value after issuing `BGSAVE`, so a small/fast save's baseline was already post-save and the loop waited the full deadline before failing).
  - **Fix:** Poll `INFO persistence`'s explicit `rdb_bgsave_in_progress`/`rdb_last_bgsave_status` fields instead, which removes the ambiguity and lets a large save legitimately run longer than a short fixed window.
- **Finding:** Backup artifacts (a full Postgres cluster dump, in plaintext) would land world-readable under default umask.
  - **Fix:** `UMask=0077` on the systemd unit plus explicit `chmod 0600`/`0700` on written files/dirs after each successful target capture. Test: `test_run_target_backup_restricts_permissions_to_owner_only`.
- **Finding:** Failure-notify path reused the sibling tool's `send_failure_notification` via a hand-rolled duck-typed adapter class mirroring every attribute it reads — fragile (an `AttributeError` at the one moment an alert must fire if the sibling ever adds a field) and completely untested.
  - **Fix:** Wrote a small local `send_failure_notification` instead of adapting to the sibling's shape.
- **Finding:** Run-level `RunOutcome.log_path` pointed at a file that was never written (only per-target logs existed).
  - **Fix:** Now writes a real aggregated run-level log combining every target's log.
- **Finding:** Minor — duplicated private helpers (`_write_json_atomic`, `_update_latest_symlink`) instead of importing the sibling's, unused imports.
  - **Fix:** Imports the sibling's versions directly; removed unused `datetime`/`dataclasses.field` imports, moved `import time` to module top.

## Restart required
No restart of any currently-running service — this only adds new files and a not-yet-installed systemd unit. Installing the timer (separate, manual, root-required step per the README) is left to the operator:
```bash
sudo cp deploy/systemd/orion-backup-databases.service /etc/systemd/system/
sudo cp deploy/systemd/orion-backup-databases.timer /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now orion-backup-databases.timer
```

## Risks / concerns
- **Severity:** should-fix before first unattended run — **Concern:** Convex's stop/copy/restart path is untested against the real ~19.5GB volume (root-only in this session). **Mitigation:** run one supervised manual pass (`sudo ... --only convex`) before enabling the timer.
- **Severity:** informational — **Concern:** Fuseki and bus-mirror are intentionally excluded (Fuseki is mid-decommission; bus-mirror is a disabled debug tap, not a database — see README "Known gaps").