### PR TITLE
chore(bus-mirror): relocate data dir off /mnt/scripts after 98GB runaway recording

### DIFF
--- a/services/orion-bus-mirror/.env_example
+++ b/services/orion-bus-mirror/.env_example
@@ -7,4 +7,11 @@ ORION_BUS_ENFORCE_CATALOG=true
 MIRROR_PATTERN=orion:*
 MIRROR_SQLITE_PATH=/data/bus_mirror.sqlite
 MIRROR_PARQUET_DIR=/data/parquet
-MIRROR_DATA_DIR=./data
+# Was ./data (relative, resolving onto /mnt/scripts) -- moved to the
+# postgres disk 2026-07-24 after the previous location grew to 98GB
+# unnoticed (MIRROR_PATTERN=orion:* matches all 265 registered bus channels,
+# not a narrow debug slice, so an unbounded run records the entire bus
+# firehose). The old 98GB recording was archived to
+# /mnt/postgres/dumps/bus-mirror/bus_mirror.sqlite, not deleted; this path
+# starts fresh and empty. See README.md "Retention" before re-enabling.
+MIRROR_DATA_DIR=/mnt/postgres/bus-mirror/data

--- a/services/orion-bus-mirror/README.md
+++ b/services/orion-bus-mirror/README.md
@@ -4,6 +4,33 @@ A “wiretap + relay” for the Orion Titanium bus. Use it to copy a slice of th
 
 ---
 
+## Status: disabled, ran into exactly the failure mode this README warns about
+
+Live incident, 2026-07-24: this service was left running with
+`MIRROR_PATTERN=orion:*`, which matches all 265 channels registered in
+`orion/bus/channels.yaml` -- the entire bus, not the narrow debug slice this
+README recommends below. With no retention/rotation cap, the recording grew
+to **98GB** before anyone noticed, on the `/mnt/scripts` disk (shared with
+the codebase and all worktrees).
+
+Current state:
+- The container is stopped and excluded from `mesh-utilities/common/
+  exclude_services.txt`'s auto-rebuild list, so it will not restart on its
+  own.
+- The 98GB recording was archived (not deleted) to
+  `/mnt/postgres/dumps/bus-mirror/bus_mirror.sqlite`.
+- `MIRROR_DATA_DIR` now points at `/mnt/postgres/bus-mirror/data` (moved off
+  the `/mnt/scripts` disk entirely) -- if this service is ever re-enabled,
+  it starts fresh and empty there, not resuming the archived recording.
+
+**If you re-enable this service**, use a narrow pattern (see "Recommended
+patterns" below) and set a real retention/rotation limit -- there still
+isn't a `MIRROR_SAMPLE_RATE` or automatic rotation built in (see "Future
+stubs we should add"), so an unbounded pattern will recreate this exact
+failure.
+
+---
+
 ## Quick start (copy/paste)
 
 ### Set your bus URL once


### PR DESCRIPTION
## Summary
- `orion-bus-mirror`'s `MIRROR_DATA_DIR` moved from relative `./data` (resolving onto the `/mnt/scripts` disk) to `/mnt/postgres/bus-mirror/data`.
- Documents a live incident in the service README: `MIRROR_PATTERN=orion:*` matched all 265 registered bus channels (confirmed live), not a narrow debug slice, and with no retention cap grew to 98GB before anyone noticed.
- The 98GB recording itself was archived to `/mnt/postgres/dumps/bus-mirror/bus_mirror.sqlite` on the host directly (not a git-tracked change) — not deleted, just moved off the shared code disk.

## Outcome moved
`/mnt/scripts` (447GB disk shared with the codebase and all worktrees) had ~98GB of unnecessary debug-tap recording on it. That's now on the dedicated postgres disk instead, and any future re-enable of this service starts fresh rather than resuming the runaway recording.

## Files changed
- `services/orion-bus-mirror/.env_example`: `MIRROR_DATA_DIR` updated to the new path, with an inline comment explaining why.
- `services/orion-bus-mirror/README.md`: new "Status" section documenting the incident and current disabled state, pointing at the archived dump location.

## Env/config changes
- `MIRROR_DATA_DIR` changed: `./data` → `/mnt/postgres/bus-mirror/data`.
- `.env_example` updated in this PR.
- Local `.env` synced directly on the host (this key's value, not added/removed) since the service is currently disabled — no `sync_local_env_from_example.py` run needed for a value-only change to an existing key.

## Tests run
N/A — config/docs only, no code changed.

## Docker/build/smoke checks
N/A — service is intentionally disabled (not started as part of this PR).

## Restart required
None — the service isn't running. Whenever it's next re-enabled, it will pick up the new `MIRROR_DATA_DIR` automatically from `.env` (already updated live) and start with a fresh, empty data directory.

## Risks / concerns
- Severity: informational
  Concern: no retention/rotation cap exists on this tool yet ("Future stubs we should add" in the README already flagged `MIRROR_SAMPLE_RATE` and hasn't been built). Re-enabling with a broad pattern will recreate this same failure.
  Mitigation: documented explicitly in the README's new "Status" section as a condition of re-enabling.