### PR TITLE
feat(harness,field-digester): real motor reasoning tokens + context_gathering_ratio

### DIFF
--- a/config/field/field_channel_glossary.v1.yaml
+++ b/config/field/field_channel_glossary.v1.yaml
@@ -1,9 +1,11 @@
-# Structured index of FieldStateV1's 34 raw digester channels (28 NODE_CHANNELS
+# Structured index of FieldStateV1's 35 raw digester channels (29 NODE_CHANNELS
 # + 8 CAPABILITY_CHANNELS in services/orion-field-digester/app/tensor/channels.py,
-# overlapping on transport_pressure/contract_pressure). 28 = 23 original + 5
+# overlapping on transport_pressure/contract_pressure). 29 = 23 original + 5
 # FCC-motor channels added 2026-07-23 (harness_step_load,
 # tool_failure_streak_pressure, avg_step_chars_pressure, compliance_deficit,
-# turn_incompletion).
+# turn_incompletion) + 1 FCC-motor channel added 2026-07-24
+# (context_gathering_ratio; reasoning_load also gained a real motor-side
+# magnitude the same day but is not a new channel).
 #
 # This is the machine-readable companion to
 # services/orion-field-digester/README.md's "Field channel glossary" section,
@@ -95,7 +97,11 @@ channels:
   - channel: reasoning_load
     level: [node]
     category: task_execution
-    meaning: "How much active LLM-reasoning work a node is doing."
+    meaning: "How much active LLM-reasoning work a node is doing. Real magnitude
+      since 2026-07-24: cortex-exec-sourced runs use reasoning_char_count (chars);
+      harness-motor-sourced runs use reasoning_output_tokens (real provider-computed
+      tokens from the FCC CLI's own result-event usage object, confirmed live). Falls
+      back to a 0.35/0.05 presence-only flag only when neither magnitude is set."
     evidence_dimension: reasoning_pressure
 
   - channel: failure_pressure
@@ -134,6 +140,17 @@ channels:
     level: [node]
     category: task_execution
     meaning: "Did Hub fail to get a usable result back from the harness-governor RPC for this turn at all -- the one unified-turn failure mode where no governor-side grammar event exists. A distinct, worse severity than compliance_deficit's worst rank."
+
+  - channel: context_gathering_ratio
+    level: [node]
+    category: task_execution
+    meaning: "What fraction of one FCC-motor turn's classified tool calls were
+      read-only research/context tools (Read, Grep, WebSearch, mcp__gitnexus__*,
+      mcp__firecrawl__*, ...) vs action/mutation tools (Bash, Edit, Write, other MCP
+      tools) -- composition, not volume (harness_step_load already covers volume). A
+      fixed, deterministic tool-name allowlist, not a taxonomy: an unmatched tool
+      name increments neither bucket, so 0.0 can mean either all-execution or
+      zero-classified-calls."
 
   - channel: repair_pressure
     level: [node]

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -263,6 +263,51 @@ def _extract_tool_result_errors(step: Dict[str, Any]) -> List[str]:
     return errors
 
 
+# Fixed allowlist for context_gathering_ratio (2026-07-24) -- a deterministic
+# tool-name match, NOT a taxonomy service. Any tool name not listed here is
+# uncounted (neither bucket), rather than guessed into one. MCP prefixes are
+# limited to servers this codebase has confirmed are read-only-by-construction
+# (gitnexus: graph queries only; firecrawl: search/scrape only) -- an unlisted MCP
+# server defaults to uncounted since there's no way to verify it can't mutate state.
+_CONTEXT_GATHERING_TOOLS = frozenset({"Read", "Grep", "Glob", "WebSearch", "WebFetch", "ToolSearch"})
+_CONTEXT_GATHERING_MCP_PREFIXES = ("mcp__gitnexus__", "mcp__firecrawl__")
+_EXECUTION_TOOLS = frozenset({"Bash", "Edit", "Write", "MultiEdit", "NotebookEdit"})
+
+
+def classify_step_tool_kind(tool_name: str | None) -> str | None:
+    """"context_gathering", "execution", or None (uncounted) for one tool_use call."""
+    name = str(tool_name or "")
+    if not name:
+        return None
+    if name in _CONTEXT_GATHERING_TOOLS:
+        return "context_gathering"
+    if name in _EXECUTION_TOOLS:
+        return "execution"
+    if name.startswith(_CONTEXT_GATHERING_MCP_PREFIXES):
+        return "context_gathering"
+    return None
+
+
+def extract_result_output_tokens(step: Dict[str, Any]) -> Optional[int]:
+    """Real output_tokens from the harness CLI's own end-of-turn result event.
+
+    Confirmed live 2026-07-24: Claude Code's stream-json `result` message carries a
+    top-level `usage` object with real provider-computed token counts (input_tokens,
+    output_tokens, cache_read_input_tokens, ...) -- exactly one per FCC-motor
+    invocation (the CLI's own cumulative-run summary), not one per step.
+    """
+    raw = step.get("raw") if isinstance(step.get("raw"), dict) else step
+    if not isinstance(raw, dict) or str(raw.get("type") or "") != "result":
+        return None
+    usage = raw.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    tokens = usage.get("output_tokens")
+    if isinstance(tokens, bool) or not isinstance(tokens, int):
+        return None
+    return max(0, tokens)
+
+
 def expand_env_path(raw: str) -> Path:
     return Path(os.path.expanduser(str(raw or "").strip() or "~/.fcc/.env"))
 

--- a/orion/harness/grammar_emit.py
+++ b/orion/harness/grammar_emit.py
@@ -367,6 +367,9 @@ class HarnessGrammarCollector:
         step_char_sum: int = 0,
         step_char_max: int = 0,
         tool_failure_streak_max: int = 0,
+        reasoning_output_tokens: int = 0,
+        context_gathering_step_count: int = 0,
+        execution_step_count: int = 0,
     ) -> None:
         reasoning_present = compute_harness_reasoning_present(
             step_count=step_count,
@@ -397,7 +400,10 @@ class HarnessGrammarCollector:
                     f"compliance_verdict={compliance_verdict}, "
                     f"step_char_sum={step_char_sum}, "
                     f"step_char_max={step_char_max}, "
-                    f"tool_failure_streak_max={tool_failure_streak_max}"
+                    f"tool_failure_streak_max={tool_failure_streak_max}, "
+                    f"reasoning_output_tokens={reasoning_output_tokens}, "
+                    f"context_gathering_step_count={context_gathering_step_count}, "
+                    f"execution_step_count={execution_step_count}"
                 ),
                 confidence=0.95,
                 salience=0.95,

--- a/orion/harness/runner.py
+++ b/orion/harness/runner.py
@@ -15,7 +15,9 @@ from orion.fcc.context_budget import (
 from orion.harness.fcc_motor import (
     _extract_tool_name,
     _extract_tool_result_errors,
+    classify_step_tool_kind,
     expand_env_path,
+    extract_result_output_tokens,
     load_fcc_env,
     resolve_auth_token,
     run_fcc_turn,
@@ -67,6 +69,14 @@ class HarnessMotorResult:
     step_char_sum: int = 0
     step_char_max: int = 0
     tool_failure_streak_max: int = 0
+    # Real output_tokens from the harness CLI's own result-event usage object, and a
+    # deterministic tool-name step-kind split (see fcc_motor.py's
+    # extract_result_output_tokens/classify_step_tool_kind) -- same carry-through
+    # reason as step_char_sum above (bus_listener.py re-invokes record_result_assembled
+    # on this same collector).
+    reasoning_output_tokens: int = 0
+    context_gathering_step_count: int = 0
+    execution_step_count: int = 0
     # Distinct from grounding_status: that field is an overloaded error/
     # overflow code already surfaced as a user-visible error by downstream
     # consumers (orion/hub/turn_orchestrator.py, orion-harness-governor).
@@ -266,6 +276,9 @@ class HarnessRunner:
         step_char_max = 0
         tool_failure_streak = 0
         tool_failure_streak_max = 0
+        reasoning_output_tokens = 0
+        context_gathering_step_count = 0
+        execution_step_count = 0
         # Only updated inside the is_error loop below -- a step with zero tool_result
         # errors doesn't touch this state at all, so a streak persists across an
         # intervening clean step (e.g. fail/success/fail on the same error kind still
@@ -305,6 +318,14 @@ class HarnessRunner:
                 summary = summarize_harness_step(step, index=step_count)
                 collector.record_step_started(order=step_count + 1, summary=summary)
                 tool_name = _extract_tool_name(step)
+                step_kind = classify_step_tool_kind(tool_name)
+                if step_kind == "context_gathering":
+                    context_gathering_step_count += 1
+                elif step_kind == "execution":
+                    execution_step_count += 1
+                result_tokens = extract_result_output_tokens(step)
+                if result_tokens is not None:
+                    reasoning_output_tokens = max(reasoning_output_tokens, result_tokens)
                 receipt = await publish_harness_step_grammar(
                     self.bus,
                     correlation_id=request.correlation_id,
@@ -396,6 +417,9 @@ class HarnessRunner:
                 step_char_sum=step_char_sum,
                 step_char_max=step_char_max,
                 tool_failure_streak_max=tool_failure_streak_max,
+                reasoning_output_tokens=reasoning_output_tokens,
+                context_gathering_step_count=context_gathering_step_count,
+                execution_step_count=execution_step_count,
             )
             events = build_harness_grammar_events(collector)
             logger.info(
@@ -448,6 +472,9 @@ class HarnessRunner:
                 step_char_sum=step_char_sum,
                 step_char_max=step_char_max,
                 tool_failure_streak_max=tool_failure_streak_max,
+                reasoning_output_tokens=reasoning_output_tokens,
+                context_gathering_step_count=context_gathering_step_count,
+                execution_step_count=execution_step_count,
             )
 
         await _publish_motor_lifecycle(
@@ -502,4 +529,7 @@ class HarnessRunner:
             step_char_sum=step_char_sum,
             step_char_max=step_char_max,
             tool_failure_streak_max=tool_failure_streak_max,
+            reasoning_output_tokens=reasoning_output_tokens,
+            context_gathering_step_count=context_gathering_step_count,
+            execution_step_count=execution_step_count,
         )

--- a/orion/harness/tests/test_harness_runner.py
+++ b/orion/harness/tests/test_harness_runner.py
@@ -212,6 +212,92 @@ async def test_harness_runner_error_path_does_not_use_tool_result_streak() -> No
     assert result.compliance_verdict == "failed"
 
 
+def _result_step(*, output_tokens: int) -> dict[str, Any]:
+    return {
+        "type": "result",
+        "raw": {
+            "type": "result",
+            "usage": {"input_tokens": 10, "output_tokens": output_tokens},
+            "result": "done",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_captures_real_output_tokens_from_result_event() -> None:
+    async def _tokened_runner(**_: Any) -> AsyncIterator[dict[str, Any]]:
+        yield {"type": "step", "step": _step_with_tool_result(is_error=False, text="ok")}
+        yield {"type": "step", "step": _result_step(output_tokens=42)}
+        yield {"type": "final", "llm_response": "done", "metadata": {"exit_code": 0}}
+
+    request = HarnessRunRequestV1(
+        correlation_id="c-tokens",
+        thought_event=make_thought(),
+        user_message="hello",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    result = await HarnessRunner(AsyncMock(), fcc_runner=_tokened_runner).run(request)
+    assert result.reasoning_output_tokens == 42
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_ignores_non_result_step_for_output_tokens() -> None:
+    """A "step"-type event (not "result") must never be mistaken for the CLI's own
+    end-of-turn usage summary, even if it happened to carry a similarly-shaped dict."""
+
+    async def _decoy_runner(**_: Any) -> AsyncIterator[dict[str, Any]]:
+        yield {
+            "type": "step",
+            "step": {
+                "type": "assistant",
+                "raw": {"type": "assistant", "usage": {"output_tokens": 999}},
+            },
+        }
+        yield {"type": "final", "llm_response": "done", "metadata": {"exit_code": 0}}
+
+    request = HarnessRunRequestV1(
+        correlation_id="c-decoy",
+        thought_event=make_thought(),
+        user_message="hello",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    result = await HarnessRunner(AsyncMock(), fcc_runner=_decoy_runner).run(request)
+    assert result.reasoning_output_tokens == 0
+
+
+def _tool_use_step(tool_name: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "raw": {
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "name": tool_name, "input": {}}]},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_harness_runner_classifies_step_tool_kinds() -> None:
+    async def _mixed_runner(**_: Any) -> AsyncIterator[dict[str, Any]]:
+        yield {"type": "step", "step": _tool_use_step("Read")}
+        yield {"type": "step", "step": _tool_use_step("mcp__gitnexus__cypher")}
+        yield {"type": "step", "step": _tool_use_step("Bash")}
+        yield {"type": "step", "step": _tool_use_step("SomeUnlistedMcpTool")}
+        yield {"type": "final", "llm_response": "done", "metadata": {"exit_code": 0}}
+
+    request = HarnessRunRequestV1(
+        correlation_id="c-mixed",
+        thought_event=make_thought(),
+        user_message="hello",
+        permissions=ContextExecPermissionV1(),
+        answer_contract=AnswerContract(),
+    )
+    result = await HarnessRunner(AsyncMock(), fcc_runner=_mixed_runner).run(request)
+    assert result.context_gathering_step_count == 2
+    assert result.execution_step_count == 1
+
+
 async def _mock_fcc_runner_fetch_then_confabulate(**_: Any) -> AsyncIterator[dict[str, Any]]:
     yield {
         "type": "step",

--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -171,14 +171,20 @@ python orion/mood_arc/fit_encoder.py train \
   `v3` was trained on the *old* distributions for both. Every score computed since
   `orion-field-digester`'s `2026-07-23T06:10:08Z` restart compares new-distribution live data
   against a stale-distribution-trained model — the same contamination class as cutoffs two
-  through four. **Not yet confirmed whether this has produced spurious
-  `field_channel_anomaly.v3` flags** — checked `orion-athena-field-digester`'s logs shortly
-  after the restart, no `field_channel_anomaly_flagged` line yet, but this is inconclusive:
-  `v3`'s `window_size=30` rows may not have filled yet at check time, not evidence of absence.
-  Whoever picks this up next should re-check the logs with more elapsed time before treating it
-  as resolved either way. **Do not retrain yet** — matching every prior cutoff's own caveat,
-  only minutes of clean post-fix data exist as of this writing. `v3` remains the model to keep
-  serving until a `v4` retrain against this cutoff (or whichever is later) is warranted.
+  through four. **Resolved 2026-07-24**: exactly 2 `field_channel_anomaly_flagged` events
+  fired, both 11-14 minutes post-restart, none since (re-checked at 11+ hours post-restart).
+  Timing matches `app/anomaly_scorer.py`'s own documented cold-start artifact (reconcile-seeded
+  defaults still in the buffer right after a restart), not a sustained distribution-shift
+  problem — a real shift would keep firing as the new formulas kept flowing, not fire twice and
+  go silent. Read as noise. **Second shift on `reasoning_load` the same day (2026-07-24)**:
+  the FCC-motor/harness-governor path gained its own real magnitude too
+  (`reasoning_output_tokens`, real provider token counts from the FCC CLI's own result-event
+  usage object — previously that path had no magnitude at all, always the `0.35`/`0.05` flag).
+  Same cutoff timestamp already covers it (no new cutoff needed), but noted here since it's a
+  second, later change to an already-cutoff channel, not just the one `5b1cc0fa` fix. **Do not
+  retrain yet** — matching every prior cutoff's own caveat, only minutes of clean post-fix data
+  exist as of this writing. `v3` remains the model to keep serving until a `v4` retrain against
+  this cutoff (or whichever is later) is warranted.
   **Heads-up for whoever eventually renames `transport_pressure`** (flagged as a live
   scope-honesty issue below, and in that same FCC-motor design doc's appendix, but not yet
   fixed): `transport_pressure` is also one of `v3`'s 15 trained channels. A rename is a

--- a/orion/schemas/execution_projection.py
+++ b/orion/schemas/execution_projection.py
@@ -67,7 +67,21 @@ class ExecutionRunStateV1(BaseModel):
     # boolean wearing a magnitude's name -- every turn that used any reasoning at all
     # read identically regardless of how much. See NODE_CHANNELS "reasoning_load".
     reasoning_char_count: int = 0
+    # FCC-motor-only reasoning magnitude: output_tokens from the harness CLI's own
+    # result-event usage object (real provider-computed tokens, not a char
+    # approximation). Takes priority over reasoning_char_count in reasoning_load's
+    # formula when present -- see grammar_extract.py. cortex-exec has no equivalent
+    # field today; this is harness-governor-sourced only.
+    reasoning_output_tokens: int = 0
     thinking_source: str = "none"
+    # Deterministic tool-name-classified step composition for one FCC-motor turn:
+    # how many tool_use calls were read-only research/context tools (Read, Grep,
+    # WebSearch, mcp__gitnexus__*, mcp__firecrawl__*, ...) vs action/mutation tools
+    # (Bash, Edit, Write, other MCP tools). A fixed allowlist match, NOT a taxonomy
+    # service -- an unmatched tool name increments neither counter. See NODE_CHANNELS
+    # "context_gathering_ratio".
+    context_gathering_step_count: int = 0
+    execution_step_count: int = 0
     llm_serving_node: str | None = None
     pressure_hints: dict[str, float] = Field(default_factory=dict)
     evidence_event_ids: list[str] = Field(default_factory=list)

--- a/orion/substrate/execution_loop/grammar_extract.py
+++ b/orion/substrate/execution_loop/grammar_extract.py
@@ -45,6 +45,12 @@ _EXECUTION_LOAD_SATURATION_STEPS = _HARNESS_STEP_LOAD_SATURATION_STEPS
 # magnitude, and neither has been sampled against live data yet.
 _REASONING_LOAD_SATURATION_CHARS = 4000
 
+# FCC-motor reasoning_load anchor when a real output_tokens count is available (2026-07-24).
+# Derived from _REASONING_LOAD_SATURATION_CHARS via the same rough ~4 chars/token ratio
+# used elsewhere in this codebase's token-estimation code, not independently calibrated --
+# keeps the two paths reading comparably instead of introducing a second unrelated guess.
+_REASONING_LOAD_SATURATION_TOKENS = 1000
+
 
 def _utc_now(now: datetime | None) -> datetime:
     if now is None:
@@ -101,7 +107,19 @@ def compute_pressure_hints(
     # back to the old boolean-derived anchor only when reasoning_present is true but
     # the char count is still 0 -- covers in-flight runs mid-rollout whose earlier
     # events predate this kv existing. Fixed 2026-07-23, see the same Appendix, item 2.
-    if run.reasoning_char_count > 0:
+    # reasoning_output_tokens (FCC-motor only, 2026-07-24) takes priority when present:
+    # real provider-computed tokens from the harness CLI's own result-event usage
+    # object, a strictly better unit than a char count could ever approximate. Falls
+    # through to reasoning_char_count (cortex-exec's path) then the old boolean, since
+    # a given run only ever populates one of the two magnitude fields depending on
+    # which producer emitted it.
+    if run.reasoning_output_tokens > 0:
+        reasoning_load = min(
+            1.0,
+            math.log1p(run.reasoning_output_tokens)
+            / math.log1p(_REASONING_LOAD_SATURATION_TOKENS),
+        )
+    elif run.reasoning_char_count > 0:
         reasoning_load = min(
             1.0,
             math.log1p(run.reasoning_char_count) / math.log1p(_REASONING_LOAD_SATURATION_CHARS),
@@ -142,6 +160,16 @@ def compute_pressure_hints(
     # compliance_deficit's worst rank (refused/failed), which still requires the
     # governor to have replied with *something*.
     turn_incompletion = 1.0 if run.turn_timed_out else 0.0
+    # Composition, not volume: what fraction of this turn's *classified* tool calls
+    # were read-only research/context tools vs action/mutation tools. Unmatched tool
+    # names increment neither counter (see fcc_motor.py's classify_step_tool_kind()),
+    # so a turn with zero classified calls reports 0.0 here rather than a misleading
+    # extreme -- distinct from harness_step_load, which measures how much work
+    # happened, not what kind.
+    classified_steps = run.context_gathering_step_count + run.execution_step_count
+    context_gathering_ratio = (
+        run.context_gathering_step_count / classified_steps if classified_steps > 0 else 0.0
+    )
     # llm_serving_node is NOT injected here: pressure_hints must stay
     # float-only -- orion/substrate/relational/adapters/execution_ctx.py's
     # map_execution_ctx_to_substrate() does max(hints.values()) over this
@@ -161,6 +189,7 @@ def compute_pressure_hints(
         "avg_step_chars_pressure": avg_step_chars_pressure,
         "compliance_deficit": compliance_deficit,
         "turn_incompletion": turn_incompletion,
+        "context_gathering_ratio": context_gathering_ratio,
     }
 
 
@@ -260,6 +289,18 @@ def extract_execution_state_from_events(
                 run.reasoning_char_count = int(
                     kv.get("reasoning_char_count", run.reasoning_char_count)
                     or run.reasoning_char_count
+                )
+                run.reasoning_output_tokens = int(
+                    kv.get("reasoning_output_tokens", run.reasoning_output_tokens)
+                    or run.reasoning_output_tokens
+                )
+                run.context_gathering_step_count = int(
+                    kv.get("context_gathering_step_count", run.context_gathering_step_count)
+                    or run.context_gathering_step_count
+                )
+                run.execution_step_count = int(
+                    kv.get("execution_step_count", run.execution_step_count)
+                    or run.execution_step_count
                 )
             except ValueError:
                 pass

--- a/orion/substrate/execution_loop/merge.py
+++ b/orion/substrate/execution_loop/merge.py
@@ -88,6 +88,13 @@ def merge_execution_run_state(
     merged.final_text_present = existing.final_text_present or incoming.final_text_present
     merged.reasoning_present = existing.reasoning_present or incoming.reasoning_present
     merged.reasoning_char_count = max(existing.reasoning_char_count, incoming.reasoning_char_count)
+    merged.reasoning_output_tokens = max(
+        existing.reasoning_output_tokens, incoming.reasoning_output_tokens
+    )
+    merged.context_gathering_step_count = max(
+        existing.context_gathering_step_count, incoming.context_gathering_step_count
+    )
+    merged.execution_step_count = max(existing.execution_step_count, incoming.execution_step_count)
     merged.thinking_source = _pick_thinking_source(existing.thinking_source, incoming.thinking_source)
     if incoming.llm_serving_node:
         merged.llm_serving_node = incoming.llm_serving_node

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -507,11 +507,25 @@ distributions for both, so every score since `orion-field-digester`'s
 `2026-07-23T06:10:08Z` restart (`docker inspect orion-athena-field-digester --format
 '{{.State.StartedAt}}'`) compares new-distribution live data against a
 stale-distribution-trained model — same contamination class as the second/third/fourth
-cutoffs. **Not yet confirmed whether this has produced spurious `field_channel_anomaly.v3`
-flags** — checked logs shortly after the restart, no `field_channel_anomaly_flagged` line yet,
-but `v3`'s `window_size=30` rows may simply not have filled at check time; this is
-inconclusive, not a clean bill of health. Whoever picks this up next should re-check with more
-elapsed time.
+cutoffs.
+
+**Resolved 2026-07-24**: exactly 2 `field_channel_anomaly_flagged` events fired, both
+11-14 minutes post-restart (`06:21`-`06:24Z`), none since (checked again at 11+ hours
+post-restart). That timing matches `app/anomaly_scorer.py`'s own documented cold-start
+artifact ("reconcile-seeded defaults still in the buffer right after a restart"), not a
+sustained distribution-shift problem — a real shift would keep firing as
+`execution_load`/`reasoning_load` kept flowing on their new formulas, not fire twice and
+go silent. Read as noise, not confirmation of the fifth-cutoff risk materializing.
+
+**`reasoning_load`'s distribution shifted again the same day** (2026-07-24, this
+session): the FCC-motor/harness-governor path now sources a real `reasoning_output_tokens`
+magnitude (see the `reasoning_load` glossary entry below) where it previously fell back to
+the `0.35`/`0.05` presence-only flag entirely (harness-governor never emitted
+`reasoning_char_count`). This is a second, later shift on the same already-cutoff channel —
+the `2026-07-23T06:10:08Z` cutoff above still covers it (any retrain against that cutoff or
+later already excludes both the `5b1cc0fa` and this session's contaminated windows), but
+worth naming explicitly rather than leaving the impression only one fix touched this
+channel.
 
 ```bash
 python orion/mood_arc/fit_encoder.py train \
@@ -536,11 +550,14 @@ ever revised, same convention as the first four.
 
 ## Field channel glossary
 
-This is the consolidated reference for all 34 channels in
+This is the consolidated reference for all 35 channels in
 `field_channel_corpus.v1` (`orion.schemas.telemetry.field_channel_corpus.FieldChannelCorpusRowV1`),
-sourced from `app/tensor/channels.py`'s `NODE_CHANNELS` (28) + `CAPABILITY_CHANNELS`
-(8), overlapping on `transport_pressure`/`contract_pressure` (28+8-2=34). 28 = 23 original
-+ 5 FCC-motor channels added 2026-07-23 (see the design doc referenced above). This
+sourced from `app/tensor/channels.py`'s `NODE_CHANNELS` (29) + `CAPABILITY_CHANNELS`
+(8), overlapping on `transport_pressure`/`contract_pressure` (29+8-2=35). 29 = 23 original
++ 5 FCC-motor channels added 2026-07-23 (see the design doc referenced above) + 1
+FCC-motor channel added 2026-07-24 (`context_gathering_ratio`; `reasoning_load` also
+gained a real motor-side token magnitude the same day, see its entry below, but is not
+a new channel). This
 corpus is the raw input for a future windowed autoencoder (roadmap item 2,
 not yet trained) — but several of these same channels also feed
 `SelfStateV1`'s live, cognition-facing dimensions today, via
@@ -925,12 +942,47 @@ subset for the mood-arc windowed-autoencoder spike (see
   derived from whether `reasoning_content`/`reasoning_trace`/`metacog_traces` were
   present at all, not how much reasoning occurred. Every turn that used any
   reasoning at all read identically regardless of volume. Fixed: a new
-  `reasoning_char_count` field (char length of `reasoning_content` +
-  `reasoning_trace`, computed once at `orion-cortex-exec/app/router.py`'s
-  `record_assembled_grammar()` call site and threaded through as a grammar-stream
-  kv) now drives a real log-ratio magnitude, falling back to the old boolean split
-  only when `reasoning_present` is true but the char count is still `0` (covers
-  in-flight runs mid-rollout). See the same Appendix, item 2.
+  `reasoning_char_count` field (char length of `reasoning_content` **only** —
+  `reasoning_trace` is a dict at `router.py`'s call site, and an earlier version
+  of this fix that also counted it added ~340 chars of structural repr noise plus
+  double-counted text `reasoning_content` already carries, found live in code
+  review — fixed to `reasoning_content` only, computed once at
+  `orion-cortex-exec/app/router.py`'s `record_assembled_grammar()` call site and
+  threaded through as a grammar-stream kv) now drives a real log-ratio magnitude,
+  falling back to the old boolean split only when `reasoning_present` is true but
+  the char count is still `0` (covers in-flight runs mid-rollout). See the same
+  Appendix, item 2.
+  **Update 2026-07-24 — real magnitude for the FCC-motor path too:** the fix above
+  only ever applied to cortex-exec-sourced runs; harness-governor/FCC-motor-sourced
+  runs (`orion/harness/grammar_emit.py` never emitted `reasoning_char_count`) still
+  fell back to the `0.35`/`0.05` flag regardless of turn size. Fixed with a new
+  `reasoning_output_tokens` field — real, provider-computed `output_tokens` from the
+  FCC CLI's own end-of-turn `result` stream-json event's `usage` object (confirmed
+  live 2026-07-24 by subscribing to `orion:harness:run:step` during a real turn:
+  `usage: {input_tokens, output_tokens, cache_read_input_tokens, ...}` is already
+  present on every turn, previously read by nothing). Takes priority over
+  `reasoning_char_count` in the formula when present (real tokens beat a char
+  approximation); log-scaled against `_REASONING_LOAD_SATURATION_TOKENS=1000`
+  (derived from the char anchor via this codebase's existing ~4-chars/token estimate,
+  `orion/fcc/context_budget.py`'s `DEFAULT_CHARS_PER_TOKEN`). Deliberately NOT
+  built from assistant text-block chars instead: `ENABLE_MODEL_THINKING=false` is
+  the FCC motor's default (no real extended-thinking content flows through it
+  today), and the harness pipeline has no parser for a `thinking` content-block type
+  even when enabled — assistant text-block chars are already counted by
+  `avg_step_chars_pressure`, so reusing them here would just be a redundant
+  restatement, not new signal. **Also fixed a real cross-lane collision this change
+  would otherwise have introduced**: `reasoning_load`'s perturbation used to fire
+  unconditionally from every `execution_run` delta regardless of lane (the same
+  `key in hints` always-true shape PR #1289 fixed for the 4 harness-only channels,
+  just never audited for this channel specifically) — harmless before, since only
+  cortex-exec's lane ever carried a real value and every other lane just restomped
+  the boring `0.05` fallback. Adding a second real value source on the
+  `:harness_motor` lane would have made that pre-existing race actually matter
+  (last-write-wins between two *real* competing values). Fixed by excluding
+  `reasoning_load` from the unconditional per-lane loop specifically for
+  `:harness_motor`-suffixed deltas and re-emitting it from the same gated block as
+  `harness_step_load` et al. — every other lane's existing (unaudited,
+  out-of-scope-for-this-patch) behavior is untouched.
 
 #### `failure_pressure`
 - **Meaning**: recent execution failure rate/severity on a node.
@@ -1062,6 +1114,34 @@ follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
   different physical nodes.
 - **SelfState dimension fed**: none yet.
 - **Live-data verdict**: not yet live-verified, pending deploy.
+
+#### `context_gathering_ratio`
+- **Meaning**: what fraction of one FCC-motor turn's *classified* tool calls were
+  read-only research/context tools vs action/mutation tools — composition, not
+  volume (`harness_step_load` already covers volume). Added 2026-07-24, prompted by
+  Juniper asking for a "kind of reasoning" category grounded in real motor step data
+  rather than an open-ended taxonomy.
+- **Producer**: `execution_run` delta, mode=`replace`. In `NODE_DECAY_CHANNELS`.
+  Gated to the `:harness_motor` trace lane, same cross-lane-stomp reason as
+  `harness_step_load` et al. Classified deterministically per tool call by
+  `orion/harness/fcc_motor.py`'s `classify_step_tool_kind()`, a fixed allowlist —
+  `Read`/`Grep`/`Glob`/`WebSearch`/`WebFetch`/`ToolSearch` and any
+  `mcp__gitnexus__*`/`mcp__firecrawl__*` tool count as `context_gathering`;
+  `Bash`/`Edit`/`Write`/`MultiEdit`/`NotebookEdit` count as `execution`. A tool name
+  not on the list increments **neither** counter — this is a narrow, auditable
+  allowlist, not a taxonomy service, and an unmatched MCP tool defaults to
+  uncounted rather than guessed, since an arbitrary MCP server can expose action
+  tools this list has no way to verify as read-only. `context_gathering_ratio =
+  context_gathering_step_count / (context_gathering_step_count +
+  execution_step_count)`, `0.0` when no calls were classified — meaning `0.0` can
+  mean either "all-execution" or "nothing classified," a known ambiguity shared
+  with `avg_step_chars_pressure`'s zero-steps case.
+- **SelfState dimension fed**: none yet.
+- **Live-data verdict**: not yet live-verified, pending deploy. Grounded in one
+  real 90-step research turn during development (gitnexus graph queries, file
+  reads, `Bash find`, firecrawl web search) — every classified call in that turn
+  was `context_gathering`, zero `execution`, matching the turn's actual
+  research-only character.
 
 #### `egress_confidence_deficit`
 - **Meaning**: `1 - confidence` that an execution's output actually reached

--- a/services/orion-field-digester/app/digestion/decay.py
+++ b/services/orion-field-digester/app/digestion/decay.py
@@ -30,6 +30,7 @@ NODE_DECAY_CHANNELS = {
     "avg_step_chars_pressure",
     "compliance_deficit",
     "turn_incompletion",
+    "context_gathering_ratio",
     # transport
     "transport_pressure",
     "contract_pressure",

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -250,6 +250,19 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
             ("reasoning_load", "reasoning_load", reasoning_node_key),
             ("failure_pressure", "failure_pressure", node_key),
         ):
+            # reasoning_load is re-emitted below, gated to the harness_motor lane, when
+            # this delta carries a real reasoning_output_tokens-derived value (2026-07-24).
+            # Without this exclusion, the harness_motor lane's real token-based value and
+            # this unconditional per-lane emission (every execution_run delta already
+            # carries a reasoning_load key -- compute_pressure_hints() always returns it,
+            # same "key in hints always true" shape as the bug PR #1289 fixed for the 4
+            # harness-only channels) would race last-write-wins on the same
+            # reasoning_node_key, exactly the cross-lane stomp that fix addressed. Every
+            # OTHER lane's reasoning_load emission is deliberately left untouched here --
+            # not expanding scope to audit lanes this patch doesn't add a new data source
+            # to.
+            if channel == "reasoning_load" and delta.target_id.endswith(":harness_motor"):
+                continue
             if key in hints:
                 out.append(
                     Perturbation(
@@ -304,6 +317,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                 ("tool_failure_streak_pressure", "tool_failure_streak_pressure"),
                 ("avg_step_chars_pressure", "avg_step_chars_pressure"),
                 ("compliance_deficit", "compliance_deficit"),
+                ("context_gathering_ratio", "context_gathering_ratio"),
             ):
                 if key in hints:
                     out.append(
@@ -315,6 +329,22 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                             mode="replace",
                         )
                     )
+            # reasoning_load, re-emitted here (excluded from the unconditional loop
+            # above) so the harness_motor lane's own real reasoning_output_tokens-driven
+            # value doesn't race that loop's per-lane emission. Targets
+            # reasoning_node_key, same attribution as the top-level emission -- this is
+            # the same channel, just gated to the one lane that can carry a real
+            # motor-side magnitude.
+            if "reasoning_load" in hints:
+                out.append(
+                    Perturbation(
+                        node_id=reasoning_node_key,
+                        channel="reasoning_load",
+                        intensity=float(hints["reasoning_load"]),
+                        label=delta.delta_id,
+                        mode="replace",
+                    )
+                )
 
         # Distinct severity from compliance_deficit's worst rank: the governor never
         # responded at all (orion-hub-sourced exec_turn_timeout event, no

--- a/services/orion-field-digester/app/tensor/channels.py
+++ b/services/orion-field-digester/app/tensor/channels.py
@@ -18,6 +18,7 @@ NODE_CHANNELS = [
     "avg_step_chars_pressure",
     "compliance_deficit",
     "turn_incompletion",
+    "context_gathering_ratio",
     "conversation_load",
     "transport_pressure",
     "contract_pressure",

--- a/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
@@ -97,6 +97,7 @@ def test_execution_run_new_fcc_channels_attributed_to_orchestrating_node() -> No
             "tool_failure_streak_pressure": 0.67,
             "avg_step_chars_pressure": 0.3,
             "compliance_deficit": 0.333,
+            "context_gathering_ratio": 0.8,
         },
         llm_serving_node="atlas",
     )
@@ -107,9 +108,56 @@ def test_execution_run_new_fcc_channels_attributed_to_orchestrating_node() -> No
         "tool_failure_streak_pressure",
         "avg_step_chars_pressure",
         "compliance_deficit",
+        "context_gathering_ratio",
     ):
         assert by_channel[channel].node_id == "node:athena"
     assert by_channel["harness_step_load"].intensity == 0.62
+    assert by_channel["context_gathering_ratio"].intensity == 0.8
+
+
+def test_execution_run_reasoning_load_from_harness_motor_lane_routes_to_reasoning_node() -> None:
+    """reasoning_load driven by the harness_motor lane's real reasoning_output_tokens
+    magnitude must still route via llm_serving_node like the cortex-exec path does,
+    and must fire exactly once -- not once from the unconditional top-level loop AND
+    again from the harness_motor-gated block (2026-07-24 fix, see state_deltas.py's
+    comment on why reasoning_load is excluded from that loop for this one lane)."""
+    delta = _make_execution_run_delta(
+        lane="harness_motor",
+        pressure_hints={"reasoning_load": 0.42, "harness_step_load": 0.1},
+        llm_serving_node="circe",
+    )
+    perturbations = delta_to_perturbations(delta)
+    reasoning_perturbations = [p for p in perturbations if p.channel == "reasoning_load"]
+    assert len(reasoning_perturbations) == 1
+    assert reasoning_perturbations[0].node_id == "node:circe"
+    assert reasoning_perturbations[0].intensity == 0.42
+
+
+def test_execution_run_reasoning_load_bare_trace_still_overwrites_harness_motor_value() -> None:
+    """Documents a deliberately out-of-scope limitation, not a fix: this patch only
+    excludes the harness_motor lane from the unconditional top-level loop (so its own
+    real reasoning_output_tokens value doesn't collide with itself); a bare-trace
+    (cortex-exec) delta's own reasoning_load still fires from that same unconditional
+    loop exactly as it always has, and can still overwrite a harness_motor-set value.
+    Auditing/fixing that pre-existing (unaudited before this patch, per
+    state_deltas.py's comment) cross-lane exposure for every other lane is explicitly
+    not this patch's scope -- see the reasoning_load glossary entry's 2026-07-24
+    update in services/orion-field-digester/README.md."""
+    from app.digestion.perturbation import apply_perturbations
+    from orion.schemas.field_state import FieldStateV1
+
+    state = FieldStateV1(generated_at=FIXED_TS, tick_id="tick_x", node_vectors={}, edges=[])
+    real_delta = _make_execution_run_delta(
+        lane="harness_motor", pressure_hints={"reasoning_load": 0.55}
+    )
+    state = apply_perturbations(state, delta_to_perturbations(real_delta), now=FIXED_TS)
+    assert state.node_vectors["node:athena"]["reasoning_load"] == 0.55
+
+    off_lane_delta = _make_execution_run_delta(
+        lane=None, pressure_hints={"reasoning_load": 0.05}
+    )
+    state = apply_perturbations(state, delta_to_perturbations(off_lane_delta), now=FIXED_TS)
+    assert state.node_vectors["node:athena"]["reasoning_load"] == 0.05
 
 
 def test_execution_run_turn_incompletion_attributed_to_hub_node() -> None:
@@ -143,12 +191,17 @@ def test_execution_run_fcc_channels_ignored_off_lane() -> None:
     turn's own :harness_finalize_reflect delta. These 5 channels must ONLY ever
     produce perturbations from their own specific lane."""
     off_lane_deltas = [
-        _make_execution_run_delta(lane=None, pressure_hints={"harness_step_load": 0.5}),
         _make_execution_run_delta(
-            lane="harness_finalize_reflect", pressure_hints={"harness_step_load": 0.5}
+            lane=None,
+            pressure_hints={"harness_step_load": 0.5, "context_gathering_ratio": 0.9},
         ),
         _make_execution_run_delta(
-            lane="orion_voice_finalize", pressure_hints={"harness_step_load": 0.5}
+            lane="harness_finalize_reflect",
+            pressure_hints={"harness_step_load": 0.5, "context_gathering_ratio": 0.9},
+        ),
+        _make_execution_run_delta(
+            lane="orion_voice_finalize",
+            pressure_hints={"harness_step_load": 0.5, "context_gathering_ratio": 0.9},
         ),
         _make_execution_run_delta(lane=None, pressure_hints={"turn_incompletion": 1.0}),
         _make_execution_run_delta(
@@ -160,6 +213,7 @@ def test_execution_run_fcc_channels_ignored_off_lane() -> None:
         channels = {p.channel for p in perturbations}
         assert "harness_step_load" not in channels
         assert "turn_incompletion" not in channels
+        assert "context_gathering_ratio" not in channels
 
 
 def test_execution_run_harness_step_load_stays_bounded_through_apply_perturbations() -> None:

--- a/services/orion-harness-governor/app/bus_listener.py
+++ b/services/orion-harness-governor/app/bus_listener.py
@@ -138,6 +138,9 @@ async def _emit_finalize_lifecycle_grammar(
     step_char_sum: int = 0,
     step_char_max: int = 0,
     tool_failure_streak_max: int = 0,
+    reasoning_output_tokens: int = 0,
+    context_gathering_step_count: int = 0,
+    execution_step_count: int = 0,
     emit_result: bool = True,
 ) -> None:
     # record_result_assembled() is idempotent per atom_id (same collector -> same
@@ -157,6 +160,9 @@ async def _emit_finalize_lifecycle_grammar(
         step_char_sum=step_char_sum,
         step_char_max=step_char_max,
         tool_failure_streak_max=tool_failure_streak_max,
+        reasoning_output_tokens=reasoning_output_tokens,
+        context_gathering_step_count=context_gathering_step_count,
+        execution_step_count=execution_step_count,
     )
     if emit_result:
         collector.record_result_emitted(reply_present=True, status=status)
@@ -374,6 +380,9 @@ async def handle_harness_run_request(
                 step_char_sum=motor.step_char_sum,
                 step_char_max=motor.step_char_max,
                 tool_failure_streak_max=motor.tool_failure_streak_max,
+                reasoning_output_tokens=motor.reasoning_output_tokens,
+                context_gathering_step_count=motor.context_gathering_step_count,
+                execution_step_count=motor.execution_step_count,
             )
         run = HarnessRunV1(
             correlation_id=corr,
@@ -445,6 +454,9 @@ async def handle_harness_run_request(
             step_char_sum=motor.step_char_sum,
             step_char_max=motor.step_char_max,
             tool_failure_streak_max=motor.tool_failure_streak_max,
+            reasoning_output_tokens=motor.reasoning_output_tokens,
+            context_gathering_step_count=motor.context_gathering_step_count,
+            execution_step_count=motor.execution_step_count,
         )
     await _reply_and_artifact(bus, run, reply_to=reply_to, corr=corr, causality=causality)
 

--- a/services/orion-hub/tests/test_field_channel_glossary_routes.py
+++ b/services/orion-hub/tests/test_field_channel_glossary_routes.py
@@ -71,11 +71,11 @@ def _fake_engine_with_rows(field_jsons: list[dict]):
     return fake_engine
 
 
-def test_channels_endpoint_returns_34_entries(client):
+def test_channels_endpoint_returns_35_entries(client):
     r = client.get("/api/field-channel-glossary/channels")
     assert r.status_code == 200
     body = r.json()
-    assert len(body["channels"]) == 34
+    assert len(body["channels"]) == 35
     assert len(body["categories"]) == 7
 
 

--- a/tests/test_execution_substrate_reducer.py
+++ b/tests/test_execution_substrate_reducer.py
@@ -326,6 +326,70 @@ def test_pressure_hints_reasoning_load_falls_back_when_char_count_absent() -> No
     assert hints["reasoning_load"] == 0.35
 
 
+def test_pressure_hints_reasoning_load_prioritizes_output_tokens_over_char_count() -> None:
+    """reasoning_output_tokens (FCC-motor's real provider-computed magnitude) must
+    win over reasoning_char_count when both are somehow present on the same run --
+    real tokens beat a char approximation."""
+    run = extract_execution_state_from_events(
+        [
+            _exec_atom(
+                "exec_result_assembled",
+                "Final result assembled: status=success, final_text_present=True, "
+                "reasoning_present=True, reasoning_char_count=4000, "
+                "reasoning_output_tokens=1, thinking_source=provider_reasoning",
+            )
+        ],
+        now=FIXED_TS,
+    )
+    hints = compute_pressure_hints(run, egress_emitted=False)
+    # 1 output token, log-scaled against a 1000-token anchor, must read far below
+    # 4000 chars scaled against a 4000-char anchor (which alone would be ~1.0).
+    assert hints["reasoning_load"] < 0.2
+
+
+def test_pressure_hints_reasoning_load_uses_output_tokens_when_char_count_absent() -> None:
+    run = extract_execution_state_from_events(
+        [
+            _exec_atom(
+                "exec_result_assembled",
+                "Final result assembled: status=success, final_text_present=True, "
+                "reasoning_present=True, reasoning_output_tokens=500, "
+                "thinking_source=harness_fcc",
+            )
+        ],
+        now=FIXED_TS,
+    )
+    assert run.reasoning_output_tokens == 500
+    assert run.reasoning_char_count == 0
+    hints = compute_pressure_hints(run, egress_emitted=False)
+    assert 0.0 < hints["reasoning_load"] < 1.0
+    assert hints["reasoning_load"] != 0.35
+
+
+def test_pressure_hints_context_gathering_ratio() -> None:
+    run = ExecutionRunStateV1(
+        trace_id=TRACE,
+        correlation_id="corr-abc",
+        node_id="athena",
+        context_gathering_step_count=3,
+        execution_step_count=1,
+        last_updated_at=FIXED_TS,
+    )
+    hints = compute_pressure_hints(run, egress_emitted=False)
+    assert hints["context_gathering_ratio"] == pytest.approx(0.75)
+
+
+def test_pressure_hints_context_gathering_ratio_zero_when_nothing_classified() -> None:
+    run = ExecutionRunStateV1(
+        trace_id=TRACE,
+        correlation_id="corr-abc",
+        node_id="athena",
+        last_updated_at=FIXED_TS,
+    )
+    hints = compute_pressure_hints(run, egress_emitted=False)
+    assert hints["context_gathering_ratio"] == 0.0
+
+
 def test_pressure_hints_tool_failure_streak_and_verbosity_and_compliance() -> None:
     run = ExecutionRunStateV1(
         trace_id=TRACE,
@@ -559,6 +623,9 @@ def test_merge_takes_max_of_new_scalar_fields() -> None:
     full.step_char_max = 200
     full.tool_failure_streak_max = 1
     full.reasoning_char_count = 100
+    full.reasoning_output_tokens = 10
+    full.context_gathering_step_count = 2
+    full.execution_step_count = 5
     incoming = extract_execution_state_from_events(_partial_batch_no_egress(), now=FIXED_TS)
     incoming.harness_started_step_count = 5
     incoming.cortex_exec_started_step_count = 3
@@ -566,6 +633,9 @@ def test_merge_takes_max_of_new_scalar_fields() -> None:
     incoming.step_char_max = 250
     incoming.tool_failure_streak_max = 3
     incoming.reasoning_char_count = 400
+    incoming.reasoning_output_tokens = 60
+    incoming.context_gathering_step_count = 1
+    incoming.execution_step_count = 8
     merged = merge_execution_run_state(full, incoming)
     assert merged.harness_started_step_count == 5
     assert merged.cortex_exec_started_step_count == 3
@@ -573,6 +643,9 @@ def test_merge_takes_max_of_new_scalar_fields() -> None:
     assert merged.step_char_max == 250
     assert merged.tool_failure_streak_max == 3
     assert merged.reasoning_char_count == 400
+    assert merged.reasoning_output_tokens == 60
+    assert merged.context_gathering_step_count == 2
+    assert merged.execution_step_count == 8
     assert merged.pressure_hints["harness_step_load"] == pytest.approx(
         math.log1p(5) / math.log1p(60)
     )

--- a/tests/test_field_channel_glossary.py
+++ b/tests/test_field_channel_glossary.py
@@ -12,13 +12,14 @@ from orion.field.channel_glossary import (
 )
 
 
-def test_load_glossary_has_34_channels_matching_field_digester_channels_py():
+def test_load_glossary_has_35_channels_matching_field_digester_channels_py():
     """29 + the 5 FCC-motor channels added 2026-07-23 (harness_step_load,
     tool_failure_streak_pressure, avg_step_chars_pressure, compliance_deficit,
-    turn_incompletion -- see docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md)."""
+    turn_incompletion -- see docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md)
+    + context_gathering_ratio added 2026-07-24."""
     glossary = load_glossary()
     entries = glossary["entries"]
-    assert len(entries) == 34
+    assert len(entries) == 35
     names = {e.channel for e in entries}
     assert "cpu_pressure" in names
     assert "reliability_pressure" in names

--- a/tests/test_field_channel_glossary.py
+++ b/tests/test_field_channel_glossary.py
@@ -13,7 +13,7 @@ from orion.field.channel_glossary import (
 
 
 def test_load_glossary_has_35_channels_matching_field_digester_channels_py():
-    """29 + the 5 FCC-motor channels added 2026-07-23 (harness_step_load,
+    """23 + the 5 FCC-motor channels added 2026-07-23 (harness_step_load,
     tool_failure_streak_pressure, avg_step_chars_pressure, compliance_deficit,
     turn_incompletion -- see docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md)
     + context_gathering_ratio added 2026-07-24."""


### PR DESCRIPTION
## Summary

- `reasoning_load`'s FCC-motor path (harness-governor) never had a real magnitude — always fell back to the `0.35`/`0.05` presence-only flag, since only cortex-exec threaded `reasoning_char_count` through. Fixed by extracting real `output_tokens` from the FCC CLI's own end-of-turn `result` stream-json event's `usage` object (confirmed live by subscribing to `orion:harness:run:step` during a real turn), threaded through as a new `reasoning_output_tokens` field, prioritized over `reasoning_char_count` in the formula.
- New `context_gathering_ratio` channel: a deterministic tool-name classifier (`context_gathering` vs `execution`, fixed allowlist, unmatched tools count toward neither) grounded in one real 90-step research turn during development.
- Found and fixed a real cross-lane collision this change would otherwise have introduced in `reasoning_load`'s emission (same class of bug PR #1289 fixed for 4 other FCC-motor channels, never previously audited for this specific channel).
- Updated field-digester + mood-arc README glossaries and `field_channel_glossary.v1.yaml` (34 -> 35 channels), and resolved the fifth training-data cutoff's open anomaly-flag question from a prior PR (2 flags, both cold-start artifacts, none in 11+ hours since).

## Outcome moved

`reasoning_load` is now an honest, real-magnitude signal for both producers (cortex-exec via chars, harness-motor via tokens) instead of being real for one and a boolean flag for the other. A new, independent signal (`context_gathering_ratio`) surfaces motor step *composition* (research vs action), which no existing channel measured.

## Current architecture

`orion/harness/grammar_emit.py`'s `record_result_assembled()` already threaded `step_char_sum`/`step_char_max`/`tool_failure_streak_max`/`compliance_verdict` through from `HarnessMotorResult` (PR #1285/#1289). `reasoning_load`'s formula (`orion/substrate/execution_loop/grammar_extract.py`) only had a real-magnitude path for cortex-exec (`reasoning_char_count`); harness-governor runs always used the boolean fallback. No step-composition signal existed at all.

## Architecture touched

- `orion/harness/fcc_motor.py`: new `classify_step_tool_kind()`, `extract_result_output_tokens()`.
- `orion/harness/runner.py`: `HarnessMotorResult` gains 3 new fields, step loop classifies/extracts, both return sites + `_publish_motor_lifecycle` thread them through.
- `orion/harness/grammar_emit.py`: `record_result_assembled()` signature + summary kv extended.
- `services/orion-harness-governor/app/bus_listener.py`: both `_emit_finalize_lifecycle_grammar()` call sites re-pass the new fields (avoids the known idempotent-collector reset bug).
- `orion/schemas/execution_projection.py`: `ExecutionRunStateV1` gains `reasoning_output_tokens`, `context_gathering_step_count`, `execution_step_count`.
- `orion/substrate/execution_loop/grammar_extract.py`: kv parsing, formula priority, new `context_gathering_ratio` computation.
- `orion/substrate/execution_loop/merge.py`: max()-merge for the 3 new fields.
- `services/orion-field-digester/app/ingest/state_deltas.py`: `context_gathering_ratio` added to the `:harness_motor`-gated block; `reasoning_load` excluded from the unconditional per-lane loop for that same lane and re-emitted from the gated block instead (the cross-lane fix).
- `services/orion-field-digester/app/tensor/channels.py`, `app/digestion/decay.py`: new channel registered.

## Files changed

- `orion/harness/fcc_motor.py`: new classifier + token extractor
- `orion/harness/runner.py`: thread new fields through the motor result
- `orion/harness/grammar_emit.py`: kv threading
- `services/orion-harness-governor/app/bus_listener.py`: re-pass new fields at both lifecycle-emit call sites
- `orion/schemas/execution_projection.py`: 3 new fields
- `orion/substrate/execution_loop/grammar_extract.py`: formula priority + new ratio computation
- `orion/substrate/execution_loop/merge.py`: max()-merge
- `services/orion-field-digester/app/ingest/state_deltas.py`: new channel wiring + cross-lane fix
- `services/orion-field-digester/app/tensor/channels.py`, `app/digestion/decay.py`: channel registration
- `config/field/field_channel_glossary.v1.yaml`, `services/orion-field-digester/README.md`, `orion/mood_arc/README.md`: docs (34->35 channels, glossary entries, resolved anomaly-flag question)
- Tests: `orion/harness/tests/test_harness_runner.py`, `tests/test_execution_substrate_reducer.py`, `services/orion-field-digester/tests/test_field_execution_run_perturbations.py`, `tests/test_field_channel_glossary.py`, `services/orion-hub/tests/test_field_channel_glossary_routes.py`

## Schema / bus / API changes

- Added: `ExecutionRunStateV1.reasoning_output_tokens`, `.context_gathering_step_count`, `.execution_step_count`; `NODE_CHANNELS`/`NODE_DECAY_CHANNELS` gain `context_gathering_ratio`.
- Removed: none.
- Renamed: none.
- Behavior changed: `reasoning_load`'s formula now checks `reasoning_output_tokens` before `reasoning_char_count`; its perturbation emission is now lane-gated for `:harness_motor` specifically (was unconditional for every lane before).
- Compatibility notes: additive only, no consumer of the old `reasoning_load`/`execution_load`/etc. shape breaks — same channel name, better-grounded value.

## Env/config changes

None.

## Tests run

```
pytest orion/harness/tests -q                                    # 171 passed, 3 pre-existing failures (unrelated, verified against origin/main)
pytest tests/test_execution_substrate_reducer.py -q               # 45 passed
pytest tests/test_field_channel_glossary.py -q                    # 2 passed (part of above run)
pytest services/orion-field-digester/tests -q                     # 145 passed
pytest services/orion-harness-governor/tests -q                   # 14 passed
pytest services/orion-hub/tests/test_field_channel_glossary_routes.py -q   # 8 passed
```

## Evals run

None — no eval harness exists for this signal family beyond the live-data sanity checks below (mirrors the precedent set by the FCC-motor signals design doc).

## Docker/build/smoke checks

Not run from this branch (no runtime code path changed beyond the pipeline already covered by tests; live-verification of `reasoning_output_tokens` was done directly against the running production `orion-harness-governor`/`orion-field-digester` mesh during development by subscribing to `orion:harness:run:step` on the real bus during two real Hub turns, confirming `usage.output_tokens` is genuinely present on the CLI's `result` event).

## Review findings fixed

- Finding: No material issues found (orion-repo-agent subagent review, full trace of every field through all call sites).
  - Fix: N/A
  - Evidence: Review confirmed the cross-lane exclusion condition is airtight (only `:harness_motor` matches the `.endswith()` check), correctly targets `reasoning_node_key`, and fires exactly once per delta — directly tested by `test_execution_run_reasoning_load_from_harness_motor_lane_routes_to_reasoning_node`.
- Finding: Pre-existing (not introduced by this branch) docstring arithmetic typo in `tests/test_field_channel_glossary.py` ("29 +" should be "23 +").
  - Fix: Corrected while already touching the adjacent line.
  - Evidence: Commit `d28c27b0`.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-harness-governor/.env \
  -f services/orion-harness-governor/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: low
- Concern: `_REASONING_LOAD_SATURATION_TOKENS=1000` is a derived-not-measured anchor (same caveat as every other saturation constant shipped in this signal family so far — `harness_step_load`, `avg_step_chars_pressure`, etc.), not yet calibrated against live output_tokens distributions.
- Mitigation: Documented in the code comment and glossary; matches this repo's established pattern of shipping a reasonable starting anchor and recalibrating once live data accumulates.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/chore/unfsck-execution-reasoning-transport-channels