### PR TITLE
fix(backup): notify on backup success too, not just failure

### DIFF
--- a/scripts/backup/README.md
+++ b/scripts/backup/README.md
@@ -232,6 +232,24 @@ systemctl list-timers orion-backup-databases.timer
 Runs at 03:45 local time, offset 30 minutes after the `/mnt/scripts` backup's
 03:15 slot to avoid the two jobs contending for disk I/O at the same moment.
 
+### Notifications
+
+Unlike the `/mnt/scripts` backup above (failure-only), this tool notifies on
+**every run** via `--notify-url`/`ORION_BACKUP_NOTIFY_URL` (same env var
+names, so it can share `/etc/orion-backup-databases.env`) -- a silent
+success and a silent failure otherwise look identical from the outside.
+Failures are `severity: critical` with `require_ack: true`; successes are
+`severity: info` with `require_ack: false`, so a healthy run doesn't demand
+attention, but a real record still lands in Orion Notify's `/attention`
+history either way. Point it at Orion Notify's `/attention/request` endpoint
+(confirmed live on port 7140):
+
+```bash
+sudo tee /etc/orion-backup-databases.env <<'EOF'
+ORION_BACKUP_NOTIFY_URL=http://localhost:7140/attention/request
+EOF
+```
+
 ### Tests
 
 ```bash

--- a/scripts/backup/orion_backup_databases.py
+++ b/scripts/backup/orion_backup_databases.py
@@ -294,21 +294,34 @@ def run_target_backup(
     )
 
 
-def send_failure_notification(
+def send_backup_notification(
     outcome: RunOutcome, *, notify_url: str | None, notify_token: str | None
 ) -> dict[str, Any]:
+    """Notify on every run, not just failures -- a silent success and a
+    silent failure look identical from the outside otherwise. Failures
+    demand an ack (critical); successes are informational only."""
     if not notify_url:
         return {"attempted": False, "ok": False, "reason": "notify_url_not_configured"}
-    failed_summary = "; ".join(
-        f"{t['name']}: {t['error_summary']}" for t in outcome.targets if t["status"] == "failure"
-    )
-    message = f"Database backup failed on {outcome.node_name} (run_id={outcome.run_id}): {failed_summary}"
+    target_names = ", ".join(t["name"] for t in outcome.targets)
+    if outcome.status == "failure":
+        failed_summary = "; ".join(
+            f"{t['name']}: {t['error_summary']}" for t in outcome.targets if t["status"] == "failure"
+        )
+        message = f"Database backup failed on {outcome.node_name} (run_id={outcome.run_id}): {failed_summary}"
+        reason = "db_backup_failed"
+        severity = "critical"
+        require_ack = True
+    else:
+        message = f"Database backup completed on {outcome.node_name} (run_id={outcome.run_id}): {target_names}"
+        reason = "db_backup_succeeded"
+        severity = "info"
+        require_ack = False
     payload = {
         "source_service": "orion-backup",
-        "reason": "db_backup_failed",
-        "severity": "critical",
+        "reason": reason,
+        "severity": severity,
         "message": message,
-        "require_ack": True,
+        "require_ack": require_ack,
         "context": {"run_id": outcome.run_id, "targets": outcome.targets, "manifest_path": outcome.manifest_path},
     }
     data = json.dumps(payload).encode("utf-8")
@@ -365,10 +378,9 @@ def run_backup(
         _write_json_atomic(base_root / "status" / "latest.json", asdict(outcome))
         _write_json_atomic(base_root / "status" / "runs" / f"{run_id}.json", asdict(outcome))
         _write_json_atomic(Path(outcome.manifest_path), asdict(outcome))
-        if outcome.status == "failure":
-            notify_result = send_failure_notification(outcome, notify_url=notify_url, notify_token=notify_token)
-            outcome = RunOutcome(**{**asdict(outcome), "notification_attempt": notify_result})
-            _write_json_atomic(base_root / "status" / "latest.json", asdict(outcome))
+        notify_result = send_backup_notification(outcome, notify_url=notify_url, notify_token=notify_token)
+        outcome = RunOutcome(**{**asdict(outcome), "notification_attempt": notify_result})
+        _write_json_atomic(base_root / "status" / "latest.json", asdict(outcome))
         return outcome
     finally:
         lock_handle.close()

--- a/tests/test_orion_backup_databases.py
+++ b/tests/test_orion_backup_databases.py
@@ -13,6 +13,7 @@ from scripts.backup.orion_backup_databases import (
     capture_stopped_container_tree,
     run_backup,
     run_target_backup,
+    send_backup_notification,
     validate_environment,
 )
 
@@ -178,6 +179,113 @@ def test_capture_stopped_container_tree_restarts_container_even_if_copy_fails(
         )
 
     assert calls[-1] == ["docker", "start", "my-container"]
+
+
+def test_run_backup_notifies_on_success_not_just_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sent_payloads: list[dict] = []
+
+    def fake_send(outcome, *, notify_url, notify_token):
+        sent_payloads.append({"status": outcome.status, "notify_url": notify_url})
+        return {"attempted": True, "ok": True, "status": 200}
+
+    monkeypatch.setattr("scripts.backup.orion_backup_databases.send_backup_notification", fake_send)
+    outcome = run_backup(
+        storage_warm=tmp_path,
+        node_name="node-a",
+        targets=[Target("good", _ok_capture)],
+        notify_url="http://example/attention/request",
+        require_mount=False,
+    )
+    assert len(sent_payloads) == 1
+    assert sent_payloads[0]["status"] == "success"
+    assert outcome.notification_attempt == {"attempted": True, "ok": True, "status": 200}
+
+
+def test_send_backup_notification_marks_success_informational_no_ack(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.backup.orion_backup_databases import RunOutcome
+
+    captured = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(request, timeout):
+        captured["body"] = request.data
+        return FakeResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    outcome = RunOutcome(
+        run_id="run-1",
+        status="success",
+        node_name="node-a",
+        started_at_utc="2026-01-01T00:00:00Z",
+        finished_at_utc="2026-01-01T00:00:01Z",
+        storage_warm_path="/x",
+        targets=[{"name": "good", "status": "success", "snapshot_path": "/x/y", "error_summary": None, "retention_actions": []}],
+        log_path="/x/log",
+        manifest_path="/x/manifest.json",
+        notification_attempt=None,
+    )
+
+    result = send_backup_notification(outcome, notify_url="http://example/attention/request", notify_token=None)
+
+    assert result["ok"] is True
+    import json as _json
+
+    payload = _json.loads(captured["body"])
+    assert payload["reason"] == "db_backup_succeeded"
+    assert payload["severity"] == "info"
+    assert payload["require_ack"] is False
+
+
+def test_send_backup_notification_marks_failure_critical_with_ack(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.backup.orion_backup_databases import RunOutcome
+
+    captured = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(request, timeout):
+        captured["body"] = request.data
+        return FakeResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    outcome = RunOutcome(
+        run_id="run-1",
+        status="failure",
+        node_name="node-a",
+        started_at_utc="2026-01-01T00:00:00Z",
+        finished_at_utc="2026-01-01T00:00:01Z",
+        storage_warm_path="/x",
+        targets=[{"name": "bad", "status": "failure", "snapshot_path": None, "error_summary": "boom", "retention_actions": []}],
+        log_path="/x/log",
+        manifest_path="/x/manifest.json",
+        notification_attempt=None,
+    )
+
+    result = send_backup_notification(outcome, notify_url="http://example/attention/request", notify_token=None)
+
+    assert result["ok"] is True
+    import json as _json
+
+    payload = _json.loads(captured["body"])
+    assert payload["reason"] == "db_backup_failed"
+    assert payload["severity"] == "critical"
+    assert payload["require_ack"] is True
+    assert "boom" in payload["message"]
 
 
 def test_capture_stopped_container_tree_raises_if_host_path_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `send_failure_notification` (only fired on failure) renamed to `send_backup_notification` and called on every run, success or failure.
- Failures stay `severity: critical` / `require_ack: true`. Successes are new: `severity: info` / `require_ack: false` — a real record in Orion Notify's `/attention` history without demanding acknowledgment for a healthy run.
- Both env var names (`--notify-url`/`ORION_BACKUP_NOTIFY_URL`, `--notify-token`/`ORION_BACKUP_NOTIFY_TOKEN`) are unchanged, so this needs no config change if `/etc/orion-backup-databases.env` is already set up from #1316.

## Why this exists
Direct follow-up from wiring this into Hub's notification surface after #1316 merged: a silent success and a silently-broken notify integration looked identical from the outside with failure-only notify. Explicitly asked for "when it runs and when it fails."

## Files changed
- `scripts/backup/orion_backup_databases.py`: renamed/generalized the notify function, call it unconditionally in `run_backup`.
- `tests/test_orion_backup_databases.py`: 3 new tests — notify fires on success (not just failure), success payload shape (info/no-ack), failure payload shape (critical/ack).
- `scripts/backup/README.md`: documents the new always-notify behavior and contrasts it with the sibling `/mnt/scripts` backup's failure-only behavior.

## Tests run
```text
PYTHONPATH=. ./venv/bin/python -m pytest tests/test_orion_backup_databases.py tests/test_orion_backup_mnt_scripts.py -q
37 passed
```

## Restart required
None yet-running — this only affects the next scheduled run of `orion-backup-databases.timer` (enabled, next fires 2026-07-25 03:45 UTC per #1316's install). No service restart needed; the systemd unit re-reads the script fresh each time it fires.

## Risks / concerns
- Severity: informational
  Concern: none identified — this is additive (a new notify path), doesn't change failure behavior at all.