### PR TITLE
docs+feat(substrate): confirm field_salience_only branch starvation, not a bug

### DIFF
--- a/docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md
+++ b/docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md
@@ -1,0 +1,75 @@
+# `field_salience_only` branch starvation — finding, 2026-07-24
+
+Read-only measurement, per Sentience Striving Program charter section 7 ("measure before
+minting"). Follow-up to a live harness-turn + reducer-replay sanity check run the same day
+against real post-Postgres-rebuild data (8h window, 9208 ticks,
+`scripts/analysis/measure_ast_hot_reducer.py`), which found the new Active-Inference
+confidence formula (`_aggregate_prediction_error_confidence`, PR #1301/#1304) fired on only
+4 of 9208 ticks (0.04%).
+
+## Question
+
+Is that 0.04% a bug (the new formula silently failing to run) or a structural consequence of
+how `reduce_attention_self_model()` (`orion/substrate/attention_self_model.py`) branches?
+
+## Method
+
+`scripts/analysis/measure_attention_reason_branch_starvation.py` (new, this patch) — a pure,
+unit-tested function (`analyze_branch_starvation`) reading the real per-tick
+`attention_reason`/`broadcast_lane_present`/`broadcast_lane_stale` columns already written by
+`measure_ast_hot_reducer.py`'s `ticks.csv` artifact. No new DB access — this is a secondary
+analysis pass over that script's own real-data replay output, not a duplicate pipeline.
+
+## Finding
+
+**Structural, not a bug.** The reducer's `attention_reason` branches in strict elif order:
+`top_down_override` > `bottom_up_salience` > `field_salience_only` > `no_data`
+(`attention_self_model.py:242-303`). `field_salience_only` — the only branch that computes
+the new Active-Inference confidence — is only reached when the broadcast/GWT-dispatch lane is
+absent or stale (>60s old). On the real 8h window measured:
+
+- Broadcast lane fresh (present and not stale): **9204/9208 ticks (99.9566%)**.
+- `bottom_up_salience` fired on 9204 ticks (99.96%) — every tick where the broadcast lane was
+  fresh, with zero exceptions (0 elif-ordering contradictions, confirmed against the real data).
+- `field_salience_only` fired on exactly the 4 remaining ticks.
+
+The broadcast lane runs on a 30s cadence and is essentially always fresh in the live system —
+so the older `broadcast.coalition_stability_score`-based confidence wins the branch nearly
+every time, and the new prediction-error-based confidence formula is almost never the one
+actually driving `AttentionSelfModelV1.confidence` in production, even though it is correct
+whenever it does run (unit-tested; live-verified this session against real data).
+
+## Why this matters
+
+Sentience Striving Program charter, section 6, objective 2 (the AST/HOT reducer) is gated as
+"proven" before objective 3 can retire the drives bucket-vote layer. "Proven" has been checked
+in the sense of "computed correctly when exercised" (unit tests, live replay) but not in the
+sense of "actually exercised by live traffic at any meaningful rate." This finding closes that
+second gap: the new confidence formula is real but functionally dormant today, shadowed by an
+older branch that almost always wins first.
+
+This is not presented as something to fix in this patch — no behavior changes here, this is
+measurement only, per charter section 7's own discipline (a new signal doesn't get built on
+until it's measured, and measuring first here means being honest that it's barely running,
+not assuming it's fine because it passed a unit test).
+
+## Non-goals
+
+- Not deciding whether to reorder the elif branches, blend both confidence sources, or change
+  the broadcast-staleness threshold — that's a real design choice affecting
+  `AttentionSelfModelV1`'s live semantics and needs its own sign-off per this repo's proposal-
+  mode rule for cognition-loop-adjacent changes.
+- Not re-running the paused predicted_shift TEST-set validation (separate, already-tracked
+  open item, blocked on insufficient post-Postgres-rebuild history).
+
+## Artifacts
+
+- `scripts/analysis/measure_attention_reason_branch_starvation.py` (new)
+- `scripts/analysis/tests/test_measure_attention_reason_branch_starvation.py` (new, 7 tests)
+- Source data: `/tmp/ast-hot-reducer/ticks.csv` (from the 2026-07-24 live replay run)
+
+## Related
+
+- `docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`
+- `orion/sentience_striving_program/README.md` section 6, objective 2
+- PR #1301 (confidence/predicted_shift implementation), PR #1304 (predicted_shift reversion fix)

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -190,6 +190,31 @@ first place. Full reasoning and phased detail:
    this PR's report for the decision record and a live-data caveat (no
    `node:substrate.harness_closure` write has occurred yet post-deploy to prove the
    end-to-end durability live, confirmed via manual FalkorDB query).
+   **Active-Inference confidence/predicted_shift, live-verified 2026-07-23/24:** PR #1301
+   implemented items 3/4 (confidence = `1 - mean(prediction_error)` across the five real
+   domains; `predicted_shift` = argmax-by-trend), fully removing the dead `SelfStateV1`
+   fallback. PR #1304, a metric-quality-gate catch run *before* building item 5 on top of
+   item 4, found `predicted_shift`'s original continuation formula was empirically worse
+   than a coin flip (37.7%/41.0% on two real windows, p<0.001) — fixed by flipping to
+   reversion (62.3%/59.0%, validated on biometrics only, extrapolated to the other four
+   domains). A follow-up "hit it all" improvement pass (train/test split, window tuning,
+   spike segmentation, domain-specific validation, logistic regression) found a strong
+   window=2 lead (77% vs. window=30's ~55%) but never reached TEST-set validation before
+   the 2026-07-23 Postgres disk death wiped the history and scratchpad caches it depended
+   on — **paused, not resolved**, blocked on ~48-96h of fresh history re-accumulating.
+   **New finding, 2026-07-24 (`docs/notes/2026-07-24-attention-reason-branch-starvation-
+   finding.md`, `scripts/analysis/measure_attention_reason_branch_starvation.py`):** a live
+   harness-turn + reducer replay (real post-rebuild data, 9208 ticks) found the new
+   confidence formula only actually drives `AttentionSelfModelV1.confidence` on 0.04% of
+   ticks — structurally starved, not broken, because `attention_reason`'s elif order lets
+   `bottom_up_salience` (the older `broadcast.coalition_stability_score` path) win on every
+   tick where the broadcast/GWT-dispatch lane is fresh (99.96% of real ticks; 30s cadence,
+   essentially always fresh). Confirmed zero elif-ordering contradictions in real data — this
+   is the code behaving exactly as written, not a defect. **This means "item 2 is proven" is
+   only true in the narrow sense of "computed correctly when exercised" — it is not yet true
+   in the sense of "actually the formula driving live behavior."** No behavior changed in
+   this patch; whether to reorder branches, blend both confidence sources, or otherwise
+   address this is an open design question needing its own sign-off, not decided here.
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live

--- a/scripts/analysis/measure_attention_reason_branch_starvation.py
+++ b/scripts/analysis/measure_attention_reason_branch_starvation.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Read-only measurement: is the AST/HOT reducer's `field_salience_only`
+branch structurally starved by the broadcast-lane branch above it?
+
+Context: `orion/substrate/attention_self_model.py::reduce_attention_self_model`
+branches on `attention_reason` in strict elif order --
+`top_down_override` > `bottom_up_salience` > `field_salience_only` > `no_data`.
+The new Active-Inference confidence formula (PR #1301/#1304,
+`_aggregate_prediction_error_confidence`) only computes/surfaces inside the
+`field_salience_only` branch. A live run of `measure_ast_hot_reducer.py`
+(2026-07-24, 8h window, 9208 ticks) found that branch fires on only 4 ticks
+(0.04%) -- this script traces *why*, quantitatively, instead of guessing from
+reading the branch order alone.
+
+No DB, no bus, no I/O beyond reading the CSV artifact
+`measure_ast_hot_reducer.py` already writes (`/tmp/ast-hot-reducer/ticks.csv`
+by default) -- this is a secondary analysis pass over that script's own
+real-data replay output, not a duplicate Postgres-querying pipeline. Per
+program-charter section 7 ("measure before minting"): this exists to check
+whether item 2's Active-Inference confidence claim (Sentience Striving
+Program charter section 6 objective 2) is real in the sense of "computed
+correctly when it runs" AND real in the sense of "actually exercised by live
+traffic" -- these are different claims, and only the first has been checked
+so far.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+DEFAULT_TICKS_CSV = "/tmp/ast-hot-reducer/ticks.csv"
+
+
+def _parse_bool(value: str) -> bool | None:
+    v = (value or "").strip().lower()
+    if v in ("true", "1"):
+        return True
+    if v in ("false", "0"):
+        return False
+    return None
+
+
+def analyze_branch_starvation(rows: list[dict]) -> dict:
+    """Pure function: given parsed tick rows (dicts with at least
+    `attention_reason`, `broadcast_lane_present`, `broadcast_lane_stale`),
+    quantify how often the broadcast lane is fresh (present and not stale)
+    -- the condition that structurally preempts `field_salience_only` -- and
+    cross-check that the reducer's own elif ordering was actually honored in
+    this real data (a broadcast-fresh tick should never show
+    `field_salience_only`; a contradiction here would mean either this
+    script's row-parsing is wrong or the reducer's branch logic changed
+    since this script was written).
+
+    Never raises on malformed rows: an unparseable bool is treated as
+    "unknown" and excluded from the fresh/stale denominator, not defaulted
+    to True or False (a silent default here would quietly bias the
+    percentage this script exists to report honestly).
+    """
+    total = len(rows)
+    reason_counts: dict[str, int] = {}
+    broadcast_fresh = 0
+    broadcast_known = 0
+    contradictions: list[dict] = []
+
+    for row in rows:
+        reason = row.get("attention_reason") or "unknown"
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+
+        present = _parse_bool(row.get("broadcast_lane_present", ""))
+        stale = _parse_bool(row.get("broadcast_lane_stale", ""))
+        if present is None or stale is None:
+            continue
+        broadcast_known += 1
+        fresh = present and not stale
+        if fresh:
+            broadcast_fresh += 1
+            if reason == "field_salience_only":
+                contradictions.append(row)
+
+    fresh_pct = (broadcast_fresh / broadcast_known * 100.0) if broadcast_known else 0.0
+    field_salience_only_count = reason_counts.get("field_salience_only", 0)
+    field_salience_only_pct = (field_salience_only_count / total * 100.0) if total else 0.0
+
+    return {
+        "total_ticks": total,
+        "reason_counts": reason_counts,
+        "broadcast_known_ticks": broadcast_known,
+        "broadcast_fresh_ticks": broadcast_fresh,
+        "broadcast_fresh_pct": round(fresh_pct, 4),
+        "field_salience_only_count": field_salience_only_count,
+        "field_salience_only_pct": round(field_salience_only_pct, 4),
+        "elif_ordering_contradictions": len(contradictions),
+        "starvation_confirmed": (
+            broadcast_known > 0
+            and fresh_pct > 90.0
+            and field_salience_only_pct < 10.0
+            and len(contradictions) == 0
+        ),
+    }
+
+
+def render_report(result: dict, csv_path: str) -> str:
+    lines = [
+        "# AST/HOT reducer: field_salience_only branch-starvation check",
+        "",
+        f"Source: `{csv_path}` (real replay output from `measure_ast_hot_reducer.py`)",
+        f"Total ticks: {result['total_ticks']}",
+        "",
+        "## attention_reason distribution",
+        "",
+        "| reason | count | pct |",
+        "| --- | --- | --- |",
+    ]
+    total = result["total_ticks"] or 1
+    for reason, count in sorted(result["reason_counts"].items(), key=lambda kv: -kv[1]):
+        lines.append(f"| {reason} | {count} | {count / total * 100:.2f}% |")
+
+    lines += [
+        "",
+        "## Broadcast-lane freshness (the gating condition)",
+        "",
+        f"- Ticks with known broadcast presence/staleness: {result['broadcast_known_ticks']}",
+        f"- Fresh (present AND not stale): {result['broadcast_fresh_ticks']} "
+        f"({result['broadcast_fresh_pct']}%)",
+        "",
+        "## Elif-ordering sanity check",
+        "",
+        f"- Contradictions (a broadcast-fresh tick showing `field_salience_only`): "
+        f"{result['elif_ordering_contradictions']}",
+        (
+            "  - Zero contradictions: the reducer's own elif order "
+            "(`top_down_override` > `bottom_up_salience` > `field_salience_only`) "
+            "was honored exactly as coded in this real data."
+            if result["elif_ordering_contradictions"] == 0
+            else "  - NONZERO -- either this script's parsing is wrong or the reducer's "
+            "branch order has changed since this script was written. Investigate before "
+            "trusting the conclusion below."
+        ),
+        "",
+        "## Conclusion",
+        "",
+    ]
+    if result["starvation_confirmed"]:
+        lines.append(
+            f"**Confirmed: `field_salience_only` is structurally starved, not broken.** "
+            f"The broadcast/GWT-dispatch lane is fresh on {result['broadcast_fresh_pct']}% of "
+            f"real ticks, which -- because of the reducer's elif branch order -- preempts "
+            f"`field_salience_only` (and therefore the new Active-Inference confidence formula, "
+            f"PR #1301/#1304) on all but {result['field_salience_only_pct']}% of ticks. This is "
+            f"not a bug: the code and its own docstrings document this priority deliberately. "
+            f"It is, however, a real gap in claiming Sentience Striving Program charter section 6 "
+            f"objective 2 (the AST/HOT reducer) is 'proven' -- the new confidence formula is "
+            f"correct when it runs (unit-tested, live-verified this session) but is almost never "
+            f"the formula actually driving `AttentionSelfModelV1.confidence` in production."
+        )
+    else:
+        lines.append(
+            "NOT confirmed as branch-starvation by this data -- either the broadcast lane is "
+            "not as consistently fresh as hypothesized, `field_salience_only` fires more than "
+            "expected, or an elif-ordering contradiction was found (see above). Re-read the "
+            "numbers above before assuming the starvation hypothesis holds."
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ticks-csv",
+        default=DEFAULT_TICKS_CSV,
+        help=f"Path to measure_ast_hot_reducer.py's ticks.csv artifact (default {DEFAULT_TICKS_CSV})",
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.ticks_csv)
+    if not path.exists():
+        print(
+            f"ERROR: {path} not found. Run scripts/analysis/measure_ast_hot_reducer.py first "
+            "(it writes this CSV as one of its artifacts).",
+            file=sys.stderr,
+        )
+        return 1
+
+    with path.open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    if not rows:
+        print(f"ERROR: {path} has no data rows.", file=sys.stderr)
+        return 1
+
+    result = analyze_branch_starvation(rows)
+    print(render_report(result, str(path)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_measure_attention_reason_branch_starvation.py
+++ b/scripts/analysis/tests/test_measure_attention_reason_branch_starvation.py
@@ -94,6 +94,25 @@ def test_malformed_bool_excluded_not_defaulted():
     assert result["broadcast_fresh_ticks"] == 2
 
 
+def test_field_salience_only_pct_gate_checked_independently():
+    # Isolates the `field_salience_only_pct < 10.0` gate from the freshness and
+    # contradiction gates: 85 known-fresh bottom_up_salience ticks (100% fresh
+    # among known) plus 15 field_salience_only ticks with unparseable broadcast
+    # bools (excluded from the known/fresh denominator entirely, so they can't
+    # trip the contradiction check either). Freshness and contradiction gates
+    # both pass; only the field_salience_only_pct gate (15% of the 100 total
+    # ticks) should fail starvation_confirmed.
+    rows = [_row("bottom_up_salience", "True", "False") for _ in range(85)]
+    rows += [_row("field_salience_only", "", "") for _ in range(15)]
+    result = mod.analyze_branch_starvation(rows)
+    assert result["total_ticks"] == 100
+    assert result["broadcast_known_ticks"] == 85
+    assert result["broadcast_fresh_pct"] == 100.0
+    assert result["elif_ordering_contradictions"] == 0
+    assert result["field_salience_only_pct"] == 15.0
+    assert result["starvation_confirmed"] is False
+
+
 def test_empty_rows_no_crash():
     result = mod.analyze_branch_starvation([])
     assert result["total_ticks"] == 0

--- a/scripts/analysis/tests/test_measure_attention_reason_branch_starvation.py
+++ b/scripts/analysis/tests/test_measure_attention_reason_branch_starvation.py
@@ -1,0 +1,111 @@
+"""Deterministic unit tests for measure_attention_reason_branch_starvation.py.
+
+No DB, no CSV file I/O -- exercises the pure `analyze_branch_starvation` function
+directly with synthetic row dicts, same pattern as
+scripts/analysis/tests/test_measure_ast_hot_reducer.py.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "measure_attention_reason_branch_starvation.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "measure_attention_reason_branch_starvation", _MODULE_PATH
+)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_attention_reason_branch_starvation"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _row(reason: str, present: str, stale: str) -> dict:
+    return {
+        "attention_reason": reason,
+        "broadcast_lane_present": present,
+        "broadcast_lane_stale": stale,
+    }
+
+
+def test_all_broadcast_fresh_bottom_up_wins_every_tick():
+    rows = [_row("bottom_up_salience", "True", "False") for _ in range(10)]
+    result = mod.analyze_branch_starvation(rows)
+    assert result["total_ticks"] == 10
+    assert result["broadcast_fresh_pct"] == 100.0
+    assert result["field_salience_only_count"] == 0
+    assert result["elif_ordering_contradictions"] == 0
+    # Starvation requires field_salience_only to actually be rare in this
+    # dataset; with zero field_salience_only ticks and 100% freshness, the
+    # hypothesis is trivially confirmed.
+    assert result["starvation_confirmed"] is True
+
+
+def test_realistic_live_ratio_confirms_starvation():
+    # Mirrors the real 2026-07-24 8h-window measurement: 9204 bottom_up_salience,
+    # 4 field_salience_only, all broadcast-fresh ticks except the 4 that fell
+    # back (present=False or stale=True for those 4).
+    rows = [_row("bottom_up_salience", "True", "False") for _ in range(9204)]
+    rows += [_row("field_salience_only", "False", "True") for _ in range(4)]
+    result = mod.analyze_branch_starvation(rows)
+    assert result["total_ticks"] == 9208
+    assert result["field_salience_only_count"] == 4
+    assert result["broadcast_fresh_ticks"] == 9204
+    assert result["broadcast_fresh_pct"] > 99.0
+    assert result["field_salience_only_pct"] < 1.0
+    assert result["elif_ordering_contradictions"] == 0
+    assert result["starvation_confirmed"] is True
+
+
+def test_contradiction_detected_when_field_salience_only_on_fresh_broadcast():
+    # A broadcast-fresh tick claiming field_salience_only should never happen
+    # per the reducer's real elif order -- this simulates a data/logic
+    # mismatch and confirms the script flags it instead of silently reporting
+    # a clean starvation story.
+    rows = [_row("bottom_up_salience", "True", "False") for _ in range(5)]
+    rows.append(_row("field_salience_only", "True", "False"))
+    result = mod.analyze_branch_starvation(rows)
+    assert result["elif_ordering_contradictions"] == 1
+    assert result["starvation_confirmed"] is False
+
+
+def test_not_starved_when_broadcast_mostly_stale():
+    # If the broadcast lane were mostly stale/absent, field_salience_only
+    # would fire often -- this is NOT a starvation scenario, and the function
+    # must say so rather than always confirming the hypothesis.
+    rows = [_row("field_salience_only", "False", "True") for _ in range(8)]
+    rows += [_row("bottom_up_salience", "True", "False") for _ in range(2)]
+    result = mod.analyze_branch_starvation(rows)
+    assert result["broadcast_fresh_pct"] == 20.0
+    assert result["starvation_confirmed"] is False
+
+
+def test_malformed_bool_excluded_not_defaulted():
+    rows = [
+        _row("bottom_up_salience", "True", "False"),
+        _row("no_data", "", ""),  # unparseable -- must be excluded, not defaulted
+        _row("bottom_up_salience", "True", "False"),
+    ]
+    result = mod.analyze_branch_starvation(rows)
+    assert result["total_ticks"] == 3
+    assert result["broadcast_known_ticks"] == 2
+    assert result["broadcast_fresh_ticks"] == 2
+
+
+def test_empty_rows_no_crash():
+    result = mod.analyze_branch_starvation([])
+    assert result["total_ticks"] == 0
+    assert result["broadcast_fresh_pct"] == 0.0
+    assert result["starvation_confirmed"] is False
+
+
+def test_render_report_smoke():
+    rows = [_row("bottom_up_salience", "True", "False") for _ in range(3)]
+    rows.append(_row("field_salience_only", "False", "True"))
+    result = mod.analyze_branch_starvation(rows)
+    report = mod.render_report(result, "/tmp/fake/ticks.csv")
+    assert "attention_reason distribution" in report
+    assert "Conclusion" in report
+    assert "/tmp/fake/ticks.csv" in report


### PR DESCRIPTION
## Summary

- Follow-up to today's live harness-turn + reducer-replay sanity check (real post-Postgres-rebuild data, 8h window, 9208 ticks), which found the new Active-Inference confidence formula (PR #1301/#1304) fires on only 4/9208 ticks (0.04%).
- New read-only measurement, `scripts/analysis/measure_attention_reason_branch_starvation.py`, confirms this is **structural, not a bug**: `reduce_attention_self_model()`'s `attention_reason` branches in strict elif order (`top_down_override` > `bottom_up_salience` > `field_salience_only` > `no_data`), and the broadcast/GWT-dispatch lane is fresh on 99.9566% of real ticks — which wins the branch every time, with zero elif-ordering contradictions confirmed against real data.
- Sentience Striving Program charter (`orion/sentience_striving_program/README.md`, section 6, objective 2) updated: "item 2 is proven" currently means "correct when exercised" (unit-tested, live-verified), not yet "actually driving live behavior" — that's a real, previously-unflagged gap this patch surfaces honestly rather than papering over.
- New docs finding note: `docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md`.

## Outcome moved

Closes an open question from today's live-verification pass (why does the new confidence formula almost never fire?) with real data instead of speculation, and corrects the charter's own "proven" claim for objective 2 before anything else gets built on top of it — per charter section 7's "measure before minting" discipline.

## Current architecture

`orion/substrate/attention_self_model.py::reduce_attention_self_model()`'s `field_salience_only` branch is the only one that computes the new Active-Inference confidence (`_aggregate_prediction_error_confidence`, PR #1301/#1304). It's an `elif`, reached only when the broadcast lane is absent or stale (>60s). No code in that reducer changed in this patch.

## Architecture touched

Docs + new standalone analysis tooling only. No service/schema/bus/runtime changes.

## Files changed

- `scripts/analysis/measure_attention_reason_branch_starvation.py` (new): pure `analyze_branch_starvation()` function + CLI wrapper reading the existing `ticks.csv` artifact `measure_ast_hot_reducer.py` already writes — no new DB/bus access, a secondary analysis pass over already-real data, not a duplicate pipeline.
- `scripts/analysis/tests/test_measure_attention_reason_branch_starvation.py` (new, 8 tests): synthetic-row coverage including the realistic live ratio, a deliberately-constructed elif-ordering contradiction, a non-starvation scenario, malformed-bool handling, and an isolation test (added after review) proving the `field_salience_only_pct<10%` gate matters independently of the freshness/contradiction gates.
- `docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md` (new): the finding write-up.
- `orion/sentience_striving_program/README.md`: appended a dated status note to section 6 objective 2, matching this doc's existing convention of recording objective status as it's measured.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
.venv/bin/python -m pytest scripts/analysis/tests -q
198 passed (190 pre-existing + 8 new)
```

## Evals run

N/A — this patch *is* the eval/measurement (a read-only data-analysis script), matching the pattern of every other `scripts/analysis/measure_*.py` script in this repo.

## Docker/build/smoke checks

N/A — pure Python analysis tooling + docs, no runtime/service/dependency changes.

## Review findings fixed

- Finding: no test isolated the `starvation_confirmed` boolean's `field_salience_only_pct < 10.0` gate independently of the freshness/contradiction gates — the two existing negative-case tests happened to fail via the other two gates instead.
  - Fix: added `test_field_salience_only_pct_gate_checked_independently`, using rows with unparseable broadcast bools (excluded from the known/fresh denominator, so freshness and contradiction gates both pass) to isolate the third gate.
  - Evidence: new test passes; all 8 tests in the new file pass; full `scripts/analysis/tests` suite (198 tests) passes.
- Finding (non-blocking, not fixed): the elif-ordering contradiction check is one-directional (only flags a broadcast-fresh tick showing `field_salience_only`, not the mirror case) — a claim-precision note, not an exploitable bug, since both fields in each CSV row come from the same single reducer call in practice.
- Reviewer independently re-ran the new script against the real `/tmp/ast-hot-reducer/ticks.csv` artifact and confirmed every numeric claim in the doc/README addition matches real output exactly.

No other findings — reviewer verdict: "No material/blocking issues. Safe to proceed."

## Restart required

```text
No restart required. Read-only analysis script + docs only.
```

## Risks / concerns

- Severity: low
- Concern: this patch does not change `attention_self_model.py`'s branch order, confidence blending, or the broadcast-staleness threshold — the underlying starvation itself is unaddressed, by design (that's a real cognition-adjacent design decision needing its own sign-off per this repo's proposal-mode rule, not bundled into a measurement patch).
- Mitigation: explicitly named as a non-goal in the new docs note; charter status update makes the gap visible for whoever scopes that follow-up.

## PR link
(filled in by gh pr create output)