### PR TITLE
docs(backup): correct Convex/Chroma downtime estimate from "seconds" to measured ~4min

### DIFF
--- a/scripts/backup/README.md
+++ b/scripts/backup/README.md
@@ -194,10 +194,19 @@ file copy:
 | Convex | Same stop/copy/start treatment, against the resolved Docker volume mountpoint (`docker volume inspect ... --format '{{.Mountpoint}}'`) | Same reason -- confirmed live that a raw copy of Convex's `db.sqlite3` tears mid-write ("file changed as we read it"), and its data directory also mixes in live RocksDB-style segment files that have no safe online-backup API exposed to this tool either |
 
 Chroma and Convex are non-critical services (an internal vector store and an
-AI-town simulation backend, not user-facing production data paths), so a few
-seconds of downtime during the 03:45 backup window is an acceptable trade for
-actual consistency -- unlike Postgres/FalkorDB above, which stay fully up via
-their own online-backup mechanisms.
+AI-town simulation backend, not user-facing production data paths), so the
+downtime during the 03:45 backup window is an acceptable trade for actual
+consistency -- unlike Postgres/FalkorDB above, which stay fully up via their
+own online-backup mechanisms.
+
+Measured live 2026-07-24 against the real ~19.5GB Convex dataset: **about 4
+minutes** of unavailability, not "a few seconds" as an earlier draft of this
+doc assumed -- most of that is Convex's own cold-start cost after any
+restart (bootstrapping 8 tables/21 indexes, then a vector/search index
+backfill), not the copy itself. `docker inspect`'s health status correctly
+reports `unhealthy` for the full duration; that's expected and resolves on
+its own once `SearchIndexBoostrapWorker finished!` appears in the container
+logs. Confirm this before assuming something broke.
 
 Layout mirrors the `/mnt/scripts` backup, one level down per target:
 `/mnt/storage-warm/backups/<node-name>/db/<target>/{snapshots,latest,status,logs,manifests}`,


### PR DESCRIPTION
## Summary
Corrects the downtime estimate for the Chroma/Convex stop-copy-restart backup targets (#1316) from an untested "a few seconds" guess to a measured real number, after actually live-testing the Convex path for the first time against the real ~19.5GB dataset.

## Why this exists
#1316's own PR description flagged that the Convex path had never been live-tested (root-required, unavailable in that session). Ran the supervised manual test today: `docker inspect` showed `unhealthy` for about 4 minutes after the restart, which is real and expected (Convex's own cold-start cost — index bootstrap + vector/search backfill — not a sign anything broke), confirmed by `SearchIndexBoostrapWorker finished!` appearing in the logs once it resolved to `healthy`.

## Files changed
- `scripts/backup/README.md`: updated the downtime claim with the measured number and what to check before assuming a failure.

## Tests run
N/A — documentation only.

## Restart required
None.

## Risks / concerns
None — this only corrects a number in documentation to match what was actually observed.