### PR TITLE
chore: exclude orion-rdf-writer/orion-rdf-store from mesh bring-up scripts

### DIFF
--- a/mesh-utilities/common/exclude_services.txt
+++ b/mesh-utilities/common/exclude_services.txt
@@ -21,3 +21,13 @@ orion-bus-tap
 #orion-biometrics
 #orion-dream
 #orion-meta-tags
+# Fuseki decommission campaign (docs/superpowers/pr-reports/2026-07-23-fuseki-
+# decommission-*.md, 8 PRs): every real Fuseki-writing pipeline in the codebase
+# has been killed. orion-rdf-store (the Fuseki container itself) crash-loops on
+# a volume-permission error (cp: cannot create /fuseki/shiro.ini) and orion-rdf-
+# writer has nothing left worth persisting -- both excluded from auto-bringup so
+# they stop redeploying on every up_all_services*.sh run. This was previously
+# only a local, uncommitted edit to this file -- never actually took effect for
+# anyone running from a fresh worktree/clone. Committed for real 2026-07-24.
+orion-rdf-writer
+orion-rdf-store


### PR DESCRIPTION
## Summary

- `orion-rdf-writer`/`orion-rdf-store` exclusion from `mesh-utilities/common/exclude_services.txt` was previously only an uncommitted local edit in one checkout — never actually took effect for anyone running `up_all_services.sh`/`up_all_services_batched.sh` from a fresh worktree or clone.
- This is why Fuseki (`orion-rdf-store`) kept redeploying and crash-looping on every batch run, despite the Fuseki decommission campaign (8 PRs, 2026-07-23) already killing every real Fuseki-writing pipeline in the codebase.
- Committed the exclusion for real. Also stopped the currently-running `orion-athena-fuseki` (crash-looping, `cp: cannot create /fuseki/shiro.ini: Permission denied` — unrelated to the decommission work, a volume-permission issue) and `orion-athena-rdf-writer` containers live.

## Files changed

- `mesh-utilities/common/exclude_services.txt`: added `orion-rdf-writer`, `orion-rdf-store`.

## Tests run

N/A — plain-text exclude-list addition, no code logic touched. Not run through the full review gate given the triviality/low risk (matches this repo's own proportionality principle for config-only changes).

## Docker/build/smoke checks

Live-verified: stopped both containers directly (`docker stop orion-athena-fuseki orion-athena-rdf-writer`), confirmed no other running container depends on either.

## Restart required

None from this change alone — it only affects future `up_all_services*.sh` runs. Both containers are already stopped.

## Risks / concerns

- Severity: low
- Concern: full removal (deleting the service directories / docker volumes) is a separate, more permanent decision — this PR only stops auto-bringup, it doesn't delete anything. Volume/container deletion still needs explicit go-ahead per this repo's own safety rules.
- Mitigation: n/a for this PR's scope.

## PR link

(filled after creation)