### PR TITLE
fix(orion-graph): make sparql_client import optional (fixes bus-mirror crash)

### DIFF
--- a/orion/graph/__init__.py
+++ b/orion/graph/__init__.py
@@ -18,14 +18,6 @@ from orion.graph.backend_config import (
     resolve_graph_update_url,
     strip_graph_credentials,
 )
-from orion.graph.sparql_client import (
-    GraphStoreClient,
-    SparqlHttpClient,
-    SparqlQueryClient,
-    SparqlUpdateClient,
-    redact_http_url_for_log,
-    resolve_substrate_sparql_http_basic_auth,
-)
 
 __all__ = [
     "GraphPersistenceRouter",
@@ -34,18 +26,47 @@ __all__ = [
     "WorkloadRoute",
     "load_persistence_routes",
     "resolve_workload_route",
-    "GraphStoreClient",
-    "SparqlHttpClient",
-    "SparqlQueryClient",
-    "SparqlUpdateClient",
     "is_legacy_graphdb_enabled",
-    "redact_http_url_for_log",
     "resolve_autonomy_read_query_url",
     "resolve_generic_sparql_read_query_url",
     "resolve_graph_backend",
     "resolve_graph_query_url",
     "resolve_graph_store_url",
     "resolve_graph_update_url",
-    "resolve_substrate_sparql_http_basic_auth",
     "strip_graph_credentials",
 ]
+
+# orion.graph.sparql_client is Fuseki/SPARQL-specific (needs `requests`) and was
+# previously re-exported here unconditionally -- meaning EVERY consumer of this
+# package, including Falkor-only ones (orion-bus-mirror, orion-graph-compression,
+# orion-meta-tags, orion-recall -- 6 real call sites across 4 services import
+# orion.graph.falkor_client directly, none of it SPARQL-related), was forced to
+# have `requests` installed just to import anything from orion.graph at all.
+# orion-bus-mirror never had `requests` in its own requirements.txt and crash-
+# looped on this (ModuleNotFoundError, live 2026-07-24) -- confirmed not a recent
+# regression (git log on that requirements.txt shows no `requests` in the last 3
+# commits touching it), a latent bug that surfaced on this restart. Made optional
+# instead of adding `requests` to bus-mirror's requirements.txt as a one-off patch,
+# since the same crash risk applies to any of the other 3 services too, and this
+# repo is actively decommissioning Fuseki -- a Falkor-only consumer requiring
+# Fuseki's own HTTP client library is exactly the wrong direction for that effort.
+try:
+    from orion.graph.sparql_client import (
+        GraphStoreClient,
+        SparqlHttpClient,
+        SparqlQueryClient,
+        SparqlUpdateClient,
+        redact_http_url_for_log,
+        resolve_substrate_sparql_http_basic_auth,
+    )
+
+    __all__ += [
+        "GraphStoreClient",
+        "SparqlHttpClient",
+        "SparqlQueryClient",
+        "SparqlUpdateClient",
+        "redact_http_url_for_log",
+        "resolve_substrate_sparql_http_basic_auth",
+    ]
+except ImportError:
+    pass

--- a/orion/graph/tests/test_graph_init_optional_sparql.py
+++ b/orion/graph/tests/test_graph_init_optional_sparql.py
@@ -1,0 +1,73 @@
+"""Regression test: orion.graph package must be importable (including
+falkor_client, the Falkor-only consumers' real entry point) even when
+`requests` isn't installed. orion.graph.sparql_client is Fuseki/SPARQL-
+specific and needs `requests`; orion/graph/__init__.py previously imported
+it unconditionally, so ANY consumer of orion.graph -- including Falkor-only
+ones with no SPARQL involvement at all (orion-bus-mirror, orion-graph-
+compression, orion-meta-tags, orion-recall) -- crashed if `requests` wasn't
+in their requirements.txt. orion-bus-mirror hit this live, 2026-07-24
+(ModuleNotFoundError: No module named 'requests').
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+
+
+def test_falkor_client_importable_without_requests() -> None:
+    real_import = builtins.__import__
+    graph_related = [m for m in sys.modules if m == "requests" or m.startswith("orion.graph")]
+    saved = {m: sys.modules[m] for m in graph_related}
+
+    def fake_import(name, *args, **kwargs):
+        if name == "requests":
+            raise ModuleNotFoundError("No module named 'requests'")
+        return real_import(name, *args, **kwargs)
+
+    try:
+        for m in graph_related:
+            del sys.modules[m]
+        builtins.__import__ = fake_import
+
+        from orion.graph.falkor_client import RedisGraphQueryClient  # noqa: F401
+
+        import orion.graph as g
+
+        assert not hasattr(g, "GraphStoreClient")
+        assert not hasattr(g, "SparqlHttpClient")
+        # Non-SPARQL exports must still be present.
+        assert hasattr(g, "GraphPersistenceRouter")
+        assert hasattr(g, "resolve_graph_backend")
+    finally:
+        builtins.__import__ = real_import
+        # Drop whatever got cached mid-test (the degraded orion.graph included)
+        # and restore exactly what was present before this test ran, so later
+        # tests in this session never see the degraded module.
+        for m in list(sys.modules):
+            if m == "requests" or m.startswith("orion.graph"):
+                del sys.modules[m]
+        sys.modules.update(saved)
+        # `import orion.graph as g` resolves via attribute access on the parent
+        # package object (`orion`), NOT a fresh sys.modules lookup -- restoring
+        # the sys.modules entry above isn't enough by itself, since the parent
+        # package's own `.graph` attribute still points at the degraded
+        # submodule object created during this test. Confirmed empirically:
+        # without this line, a later `import orion.graph as g` anywhere else in
+        # the same process returns the stale degraded object even though
+        # sys.modules['orion.graph'] itself is already correct.
+        if "orion.graph" in saved and "orion" in sys.modules:
+            sys.modules["orion"].graph = saved["orion.graph"]
+
+
+def test_sparql_symbols_still_exported_when_requests_present() -> None:
+    """Backward-compat: real SPARQL consumers (requests genuinely installed)
+    see identical behavior to before this fix."""
+    import orion.graph as g
+
+    assert hasattr(g, "GraphStoreClient")
+    assert hasattr(g, "SparqlHttpClient")
+    assert hasattr(g, "SparqlQueryClient")
+    assert hasattr(g, "SparqlUpdateClient")
+    assert hasattr(g, "redact_http_url_for_log")
+    assert hasattr(g, "resolve_substrate_sparql_http_basic_auth")

--- a/orion/graph/tests/test_graph_init_optional_sparql.py
+++ b/orion/graph/tests/test_graph_init_optional_sparql.py
@@ -17,7 +17,16 @@ import sys
 
 def test_falkor_client_importable_without_requests() -> None:
     real_import = builtins.__import__
-    graph_related = [m for m in sys.modules if m == "requests" or m.startswith("orion.graph")]
+    # Package-boundary match, not a raw prefix match -- "orion.graph".startswith
+    # would also sweep up the unrelated sibling package orion.graph_cognition
+    # (orion/graph_cognition/), since "orion.graph_cognition".startswith("orion.graph")
+    # is True. No cross-import exists between the two packages today (checked), so
+    # that would currently be a silent no-op, but tightening this now removes the
+    # trap before some future refactor makes it a real source of contamination.
+    def _is_graph_module(name: str) -> bool:
+        return name == "orion.graph" or name.startswith("orion.graph.")
+
+    graph_related = [m for m in sys.modules if m == "requests" or _is_graph_module(m)]
     saved = {m: sys.modules[m] for m in graph_related}
 
     def fake_import(name, *args, **kwargs):
@@ -45,7 +54,7 @@ def test_falkor_client_importable_without_requests() -> None:
         # and restore exactly what was present before this test ran, so later
         # tests in this session never see the degraded module.
         for m in list(sys.modules):
-            if m == "requests" or m.startswith("orion.graph"):
+            if m == "requests" or _is_graph_module(m):
                 del sys.modules[m]
         sys.modules.update(saved)
         # `import orion.graph as g` resolves via attribute access on the parent


### PR DESCRIPTION
## Summary

- Live crash, 2026-07-24: `orion-athena-bus-mirror` crash-looped (`ModuleNotFoundError: No module named 'requests'`) after a full mesh redeploy.
- Root cause: `orion/graph/__init__.py` unconditionally imported `orion.graph.sparql_client` (Fuseki/SPARQL HTTP client, needs `requests`). Since Python executes a package's `__init__.py` on any submodule import, EVERY consumer of `orion.graph` -- including Falkor-only ones with zero SPARQL involvement -- was forced to have `requests` installed just to import anything from the package at all.
- `orion-bus-mirror`'s `requirements.txt` never had `requests` (confirmed via `git log` on that file -- not a recent regression, a latent bug that surfaced on this restart).
- 6 real call sites across 4 services (`orion-bus-mirror`, `orion-graph-compression`, `orion-meta-tags`, `orion-recall`) import `orion.graph.falkor_client` directly, none of it SPARQL-related. Review independently confirmed `orion-meta-tags` also lacks `requests` in its own `requirements.txt` -- same latent crash risk, likely masked so far only by a transitive `requests` pull from `huggingface_hub`, not a guarantee.
- Fixed by wrapping the `sparql_client` import in `try/except ImportError` in `orion/graph/__init__.py`, rather than patching `bus-mirror`'s `requirements.txt` as a one-off -- covers all 4 services (and any future Falkor-only consumer) with one change, and moves in the right direction given this repo's active Fuseki decommission (a Falkor-only consumer requiring Fuseki's own HTTP client library was exactly backwards).
- Backward compatible: when `requests` is present (real SPARQL consumers), behavior is byte-identical to before.

## Files changed

- `orion/graph/__init__.py`: `sparql_client` import + its `__all__` entries moved behind `try/except ImportError`.
- `orion/graph/tests/test_graph_init_optional_sparql.py` (new): 2 tests -- package importable without `requests` (non-SPARQL exports still present, SPARQL ones absent), and unchanged behavior when `requests` is present.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
python -m pytest orion/graph/tests -q
44 passed
```

Review also ran a broader cross-suite check (`orion/graph/tests orion/schemas/tests orion/substrate/tests`, 515 tests) to check for `sys.modules`-manipulation contamination from the new test -- 514 passed, 1 pre-existing unrelated failure reproduced independently in isolation (`test_static_ctx_assignments_covered`, a provenance-registry gap unrelated to this change).

## Review findings fixed

- Finding: `sys.modules` sweep filter in the new test (`m.startswith("orion.graph")`) also matches the unrelated sibling package `orion.graph_cognition`. Currently a no-op (no cross-import between the two packages), but a raw prefix match is a trap for a future refactor.
  - Fix: tightened to an exact package-boundary check.
  - Evidence: `orion/graph/tests -q` still 44/44 after the change.
- Verified correct, no fix needed: the `try/except ImportError` is not a bare `except:` and cannot mask a real bug (traced `orion/graph/sparql_client.py` + `orion/graph/fuseki_http.py`'s full import-time behavior -- only `requests` absence can raise there); zero package-root consumers of the SPARQL symbol names exist anywhere in the repo (independently re-grepped); the parent-package-attribute restoration in the test's cleanup (a genuinely subtle Python import-semantics detail: `import a.b as c` resolves via attribute access on the parent, not a fresh `sys.modules` lookup) is correct and necessary.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-bus-mirror/.env \
  -f services/orion-bus-mirror/docker-compose.yml \
  up -d --build
```

Also worth a rebuild for `orion-graph-compression`, `orion-meta-tags`, `orion-recall` at Juniper's discretion, though those three already have `requests` installed so this change is a no-op for them today.

## Risks / concerns

- Severity: low
- Concern: none -- purely additive/wrapping change, no functionality removed, verified backward compatible by test.
- Mitigation: n/a

## PR link

(filled after creation)