### PR TITLE
feat(substrate): unconditional Active-Inference confidence, exclude dead transport domain

### DIFF
--- a/orion/schemas/attention_self_model.py
+++ b/orion/schemas/attention_self_model.py
@@ -78,6 +78,20 @@ class AttentionSelfModelV1(BaseModel):
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     confidence_basis: str = ""
 
+    # --- Unconditional Active-Inference confidence, additive to the above --
+    # 2026-07-24: `confidence` above only populates from the real
+    # prediction-error formula inside the `field_salience_only` branch,
+    # which live data showed fires on ~0.04% of ticks (structurally
+    # preempted by the broadcast lane being fresh almost always -- see
+    # `docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md`).
+    # These two fields are computed unconditionally (mirroring
+    # `predicted_shift`'s existing positioning) and restricted to
+    # `orion.substrate.attention_self_model.ACTIVE_INFERENCE_DOMAINS`
+    # (excludes the confirmed-dead `transport` domain). Additive only --
+    # `confidence`/`confidence_basis` above are unchanged.
+    prediction_error_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    prediction_error_confidence_basis: str = ""
+
     # --- What's predicted to shift next (modest, honestly scoped) ----------
     predicted_shift: str | None = None
     predicted_shift_basis: str = ""

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -53,6 +53,24 @@ from orion.schemas.field_attention_frame import FieldAttentionFrameV1
 # already uses for its own staleness gates (curiosity_signals, reverie).
 DEFAULT_BROADCAST_STALE_THRESHOLD_SEC = 60.0
 
+# The real Active-Inference prediction_error domains used for the
+# UNCONDITIONAL `prediction_error_confidence` field (see
+# `_unconditional_prediction_error_confidence` below). Deliberately excludes
+# `transport` -- confirmed live 2026-07-24
+# (`docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md`):
+# `transport_prediction_error` reads exactly 0.0 for 100% of a real 8h
+# window (`BUS_OBSERVER_STREAMS` only watches 2 real Redis Streams), so
+# averaging it in with the other four real, varying domains systematically
+# inflates confidence by a fixed, mechanical amount every tick -- harmless
+# while this formula fired on 0.04% of ticks, not harmless once it fires on
+# nearly all of them. Re-include `transport` here once a real, bounded,
+# prediction-error-shaped transport signal exists -- tracked as the
+# reversal condition against PR #1323's bus-synaptic-graph work, not before.
+# This constant does NOT affect the pre-existing branch-gated
+# `confidence`/`confidence_basis` fields below, which keep their original
+# (unfiltered, all-domains) formula unchanged -- additive only.
+ACTIVE_INFERENCE_DOMAINS = frozenset({"execution", "biometrics", "chat", "route"})
+
 
 def _round_or_none(value: float | None, digits: int = 4) -> float | None:
     return None if value is None else round(float(value), digits)
@@ -94,6 +112,48 @@ def _aggregate_prediction_error_confidence(
     basis = (
         f"1 - mean(prediction_error) across {len(values)} domains ({domains}) "
         "(broadcast lane stale/absent)"
+    )
+    return confidence, basis
+
+
+def _unconditional_prediction_error_confidence(
+    prediction_error_by_domain: dict[str, float] | None,
+) -> tuple[float | None, str]:
+    """Unconditional counterpart to `_aggregate_prediction_error_confidence`,
+    populating the new `prediction_error_confidence`/`prediction_error_confidence_basis`
+    fields regardless of which `attention_reason` branch wins -- mirrors
+    `predicted_shift`'s existing unconditional positioning (computed once,
+    before the elif branching, not gated on `field_salience_only` firing).
+
+    Restricted to `ACTIVE_INFERENCE_DOMAINS` (excludes the confirmed-dead
+    `transport` domain -- see that constant's docstring for the live-data
+    finding behind this exclusion). Returns `(None, "")` when no domain in
+    that set has data, matching every other "honestly absent" convention in
+    this reducer (never invents a confidence value from nothing).
+
+    Does NOT read or affect the pre-existing branch-gated
+    `confidence`/`confidence_basis` fields -- those keep computing their
+    original (unfiltered, all-domains) formula via
+    `_aggregate_prediction_error_confidence` unchanged. This function exists
+    so a real, non-diluted Active-Inference confidence signal is available
+    on (almost) every tick instead of only the ~0.04% of ticks where the
+    broadcast/GWT-dispatch lane happens to be absent or stale -- see
+    `docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md`.
+    """
+    if not prediction_error_by_domain:
+        return None, ""
+    filtered = {
+        domain: value
+        for domain, value in prediction_error_by_domain.items()
+        if domain in ACTIVE_INFERENCE_DOMAINS
+    }
+    if not filtered:
+        return None, ""
+    confidence, _ = _aggregate_prediction_error_confidence(filtered)
+    domains = ", ".join(sorted(filtered))
+    basis = (
+        f"1 - mean(prediction_error) across {len(filtered)} ACTIVE_INFERENCE_DOMAINS "
+        f"({domains}) (unconditional -- computed regardless of attention_reason branch)"
     )
     return confidence, basis
 
@@ -193,6 +253,18 @@ def reduce_attention_self_model(
             model.predicted_shift_basis = (
                 "prediction_error_trend_by_domain (Active Inference, argmax by |trend|)"
             )
+
+    # --- Prediction-error confidence (unconditional, ACTIVE_INFERENCE_DOMAINS
+    # only): mirrors predicted_shift's positioning above -- computed regardless
+    # of which attention_reason branch wins below. Additive only: does not
+    # read or change the pre-existing branch-gated confidence/confidence_basis
+    # fields set inside the elif branching further down.
+    pe_confidence, pe_confidence_basis = _unconditional_prediction_error_confidence(
+        prediction_error_by_domain
+    )
+    if pe_confidence is not None:
+        model.prediction_error_confidence = _round_or_none(pe_confidence)
+        model.prediction_error_confidence_basis = pe_confidence_basis
 
     # --- Broadcast lane: what was last dispatched + cadence-mismatch state -
     broadcast_age_sec: float | None = None

--- a/orion/substrate/tests/test_attention_self_model.py
+++ b/orion/substrate/tests/test_attention_self_model.py
@@ -316,6 +316,78 @@ class TestPredictedShift:
         assert "biometrics" in model.predicted_shift
 
 
+class TestUnconditionalPredictionErrorConfidence:
+    """`prediction_error_confidence`/`prediction_error_confidence_basis`
+    (2026-07-24): additive, unconditional (mirrors predicted_shift's
+    positioning), restricted to ACTIVE_INFERENCE_DOMAINS (excludes the
+    confirmed-dead `transport` domain -- see
+    docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md)."""
+
+    def test_computed_even_when_top_down_override_wins(self) -> None:
+        # The pre-existing `confidence` field only populates in the
+        # field_salience_only branch. This one must not share that gate.
+        override = _override()
+        broadcast = _broadcast(override=override)
+        model = reduce_attention_self_model(
+            broadcast, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        assert model.attention_reason == "top_down_override"
+        assert model.prediction_error_confidence is not None
+        assert "unconditional" in model.prediction_error_confidence_basis
+
+    def test_computed_even_when_bottom_up_salience_wins(self) -> None:
+        broadcast = _broadcast(override=None)
+        model = reduce_attention_self_model(
+            broadcast, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        assert model.attention_reason == "bottom_up_salience"
+        assert model.prediction_error_confidence is not None
+
+    def test_transport_excluded_from_domain_set(self) -> None:
+        # {execution: 0.0001, biometrics: 0.0459, chat: 0.0, route: 0.0}
+        # mean = 0.0115 -> confidence = 0.9885. If transport's guaranteed
+        # 0.0 were included (5 domains), the mean would instead be 0.0092
+        # (confidence 0.9908) -- this test would fail if transport leaked
+        # back into the filtered set.
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        assert model.prediction_error_confidence == pytest.approx(1.0 - 0.0115, abs=1e-4)
+        assert "transport" not in model.prediction_error_confidence_basis
+        assert "4 ACTIVE_INFERENCE_DOMAINS" in model.prediction_error_confidence_basis
+
+    def test_only_transport_data_yields_honestly_absent_not_zero(self) -> None:
+        # If the caller only ever has transport data (degenerate but
+        # possible), filtering must yield None, not a fabricated 0.0/1.0.
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain={"transport": 0.0},
+        )
+        assert model.prediction_error_confidence is None
+        assert model.prediction_error_confidence_basis == ""
+
+    def test_none_prediction_error_by_domain_yields_none(self) -> None:
+        model = reduce_attention_self_model(None, _field_frame(), now=NOW)
+        assert model.prediction_error_confidence is None
+        assert model.prediction_error_confidence_basis == ""
+
+    def test_does_not_affect_the_existing_branch_gated_confidence_field(self) -> None:
+        # Regression guard: the old field must keep its original unfiltered
+        # (all-5-domains) formula, unchanged by this patch.
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        assert model.confidence == pytest.approx(1.0 - 0.0092, abs=1e-4)
+        assert "5 domains" in model.confidence_basis
+        # The two fields now genuinely differ because of the transport
+        # exclusion -- confirms they are computed independently, not aliased.
+        assert model.confidence != model.prediction_error_confidence
+
+
 def test_reference_tick_defaults_to_field_frame_generated_at() -> None:
     field_frame = _field_frame(generated_at=NOW)
     model = reduce_attention_self_model(None, field_frame)

--- a/scripts/analysis/measure_ast_hot_reducer.py
+++ b/scripts/analysis/measure_ast_hot_reducer.py
@@ -149,6 +149,7 @@ class ReplayTick:
     generated_at: datetime
     attention_reason: str
     confidence: Optional[float]
+    prediction_error_confidence: Optional[float]
     broadcast_lane_present: bool
     broadcast_lane_stale: bool
     broadcast_lane_age_sec: Optional[float]
@@ -326,6 +327,7 @@ def replay_reducer(
                 generated_at=ts,
                 attention_reason=model.attention_reason,
                 confidence=model.confidence,
+                prediction_error_confidence=model.prediction_error_confidence,
                 broadcast_lane_present=model.broadcast_lane_present,
                 broadcast_lane_stale=model.broadcast_lane_stale,
                 broadcast_lane_age_sec=model.broadcast_lane_age_sec,
@@ -576,6 +578,7 @@ def write_ticks_csv(path: Path, ticks: list[ReplayTick]) -> None:
         writer.writerow(
             [
                 "generated_at", "attention_reason", "confidence",
+                "prediction_error_confidence",
                 "broadcast_lane_present", "broadcast_lane_stale", "broadcast_lane_age_sec",
                 "field_lane_present", "predicted_shift", "has_voluntary_override",
             ]
@@ -585,6 +588,7 @@ def write_ticks_csv(path: Path, ticks: list[ReplayTick]) -> None:
                 [
                     t.generated_at.isoformat(), t.attention_reason,
                     "" if t.confidence is None else f"{t.confidence:.4f}",
+                    "" if t.prediction_error_confidence is None else f"{t.prediction_error_confidence:.4f}",
                     t.broadcast_lane_present, t.broadcast_lane_stale,
                     "" if t.broadcast_lane_age_sec is None else f"{t.broadcast_lane_age_sec:.3f}",
                     t.field_lane_present, t.predicted_shift or "", t.has_voluntary_override,
@@ -651,6 +655,19 @@ def render_report(
     n_aid_confidence = len(aid_confidences)
     aid_confidence_min = min(aid_confidences) if aid_confidences else None
     aid_confidence_max = max(aid_confidences) if aid_confidences else None
+
+    # prediction_error_confidence (2026-07-24): unconditional counterpart,
+    # computed regardless of attention_reason branch, restricted to
+    # ACTIVE_INFERENCE_DOMAINS (excludes the confirmed-dead transport
+    # domain). This is the field that closes the branch-starvation gap
+    # named above -- expect its coverage to track prediction_error data
+    # availability (like predicted_shift), not the narrow field_salience_only
+    # branch count.
+    pe_confidences = [t.prediction_error_confidence for t in ticks if t.prediction_error_confidence is not None]
+    n_pe_confidence = len(pe_confidences)
+    pe_confidence_min = min(pe_confidences) if pe_confidences else None
+    pe_confidence_max = max(pe_confidences) if pe_confidences else None
+    pe_confidence_mean = (sum(pe_confidences) / n_pe_confidence) if pe_confidences else None
 
     predicted_shifts = [t.predicted_shift for t in ticks if t.predicted_shift]
     n_predicted_shift = len(predicted_shifts)
@@ -728,6 +745,21 @@ def render_report(
         f"- Ticks using the NEW prediction_error-based confidence specifically "
         f"(field_salience_only branch): {n_aid_confidence} / {n} ({pct(n_aid_confidence)})",
         f"  - min={_fmt(aid_confidence_min)} max={_fmt(aid_confidence_max)}",
+        "",
+        "### `prediction_error_confidence` (2026-07-24, unconditional, ACTIVE_INFERENCE_DOMAINS only)",
+        "",
+        "Closes the branch-starvation gap above: computed regardless of attention_reason, "
+        "restricted to execution/biometrics/chat/route (transport excluded -- confirmed "
+        "live 2026-07-24 that it reads exactly 0.0 for 100% of a real window, see "
+        "docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md).",
+        "",
+        f"- Ticks with a non-null `prediction_error_confidence`: {n_pe_confidence} / {n} "
+        f"({pct(n_pe_confidence)})",
+        f"  - min={_fmt(pe_confidence_min)} max={_fmt(pe_confidence_max)} mean={_fmt(pe_confidence_mean)}",
+        "  - Expected: this should track prediction_error data availability (like "
+        "predicted_shift), not the narrow field_salience_only branch count above -- if "
+        "coverage here is still near 0%, the ACTIVE_INFERENCE_DOMAINS filter or its wiring "
+        "should be re-checked before trusting this signal.",
         f"- Ticks with a non-null `predicted_shift`: {n_predicted_shift} / {n} ({pct(n_predicted_shift)})",
         "  - domain breakdown: "
         + (

--- a/scripts/analysis/tests/test_measure_ast_hot_reducer.py
+++ b/scripts/analysis/tests/test_measure_ast_hot_reducer.py
@@ -244,9 +244,9 @@ def test_replay_reducer_predicted_shift_tracks_rolling_trend_window() -> None:
 
 def test_reason_histogram_counts_each_category() -> None:
     ticks = [
-        mod.ReplayTick(BASE, "top_down_override", 0.5, True, False, 1.0, True, None, True, ""),
-        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, None, False, ""),
-        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, True, False, 1.0, True, None, False, ""),
+        mod.ReplayTick(BASE, "top_down_override", 0.5, None, True, False, 1.0, True, None, True, ""),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, None, True, False, 1.0, True, None, False, ""),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.5, None, True, False, 1.0, True, None, False, ""),
     ]
     hist = mod.reason_histogram(ticks)
     assert hist["top_down_override"] == 1
@@ -255,9 +255,9 @@ def test_reason_histogram_counts_each_category() -> None:
 
 def test_find_override_examples_returns_context_window() -> None:
     ticks = [
-        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, None, False, "a"),
-        mod.ReplayTick(BASE, "top_down_override", 0.9, True, False, 1.0, True, None, True, "override!"),
-        mod.ReplayTick(BASE, "bottom_up_salience", 0.7, True, False, 1.0, True, None, False, "c"),
+        mod.ReplayTick(BASE, "field_salience_only", None, None, False, True, None, True, None, False, "a"),
+        mod.ReplayTick(BASE, "top_down_override", 0.9, None, True, False, 1.0, True, None, True, "override!"),
+        mod.ReplayTick(BASE, "bottom_up_salience", 0.7, None, True, False, 1.0, True, None, False, "c"),
     ]
     examples = mod.find_override_examples(ticks, context=1)
     assert len(examples) == 1
@@ -267,6 +267,6 @@ def test_find_override_examples_returns_context_window() -> None:
 
 def test_find_override_examples_empty_when_no_override_present() -> None:
     ticks = [
-        mod.ReplayTick(BASE, "field_salience_only", None, False, True, None, True, None, False, "a"),
+        mod.ReplayTick(BASE, "field_salience_only", None, None, False, True, None, True, None, False, "a"),
     ]
     assert mod.find_override_examples(ticks) == []


### PR DESCRIPTION
## Summary

- Closes the branch-starvation gap found in `docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md` (already merged, PR #1320): the existing `confidence`/`confidence_basis` fields only populate the new prediction-error-based formula inside `reduce_attention_self_model`'s `field_salience_only` branch, which live data showed fires on ~0.04% of real ticks (the broadcast/GWT-dispatch lane is fresh almost always, so `bottom_up_salience` wins first).
- Adds `prediction_error_confidence`/`prediction_error_confidence_basis`, computed **unconditionally** (mirrors `predicted_shift`'s existing positioning, before the elif branching) — **additive only**, the pre-existing `confidence`/`confidence_basis` fields and their computation are completely untouched.
- New field's mean is restricted to `ACTIVE_INFERENCE_DOMAINS = frozenset({"execution", "biometrics", "chat", "route"})`, deliberately excluding `transport` — confirmed live via direct Postgres query that `transport_prediction_error` reads exactly 0.0 for 100% of a real 8h window (the known `BUS_OBSERVER_STREAMS` narrow-scope bug). Averaging in a permanently-zero domain would mechanically dilute/inflate confidence, harmless while this formula fired on 0.04% of ticks, not harmless once it fires on nearly all of them.
- Reversal condition for re-including transport: a real, bounded, prediction-error-shaped transport signal, tracked against PR #1323's bus-synaptic-graph work.

## Outcome moved

The new Active-Inference confidence signal (PR #1301/#1304's formula) now actually drives a field on ~99.9% of real ticks instead of ~0.04%, without touching or risking the pre-existing `confidence` field any existing/future caller might rely on.

## Current architecture

`reduce_attention_self_model()` computed `predicted_shift` unconditionally (before the elif branch) but only computed the prediction-error-based confidence inside the `field_salience_only` branch — an inconsistency between two supposedly-parallel Active-Inference outputs that this patch corrects for confidence specifically, without changing the old field's meaning.

## Architecture touched

- `orion/substrate/attention_self_model.py`: new `ACTIVE_INFERENCE_DOMAINS` constant, new `_unconditional_prediction_error_confidence()` function, wired in unconditionally alongside the existing `predicted_shift` block. `_aggregate_prediction_error_confidence` (the old field's formula) is byte-for-byte unchanged — confirmed via AST diff in review.
- `orion/schemas/attention_self_model.py`: two new `Optional`-with-default fields on `AttentionSelfModelV1`. No fields removed/renamed; `extra="forbid"` unaffected for existing callers.
- `scripts/analysis/measure_ast_hot_reducer.py`: `ReplayTick` gains `prediction_error_confidence`, new CSV column, new report section mirroring the existing confidence sanity-check pattern.

## Files changed

- `orion/substrate/attention_self_model.py`: core logic.
- `orion/schemas/attention_self_model.py`: schema fields.
- `orion/substrate/tests/test_attention_self_model.py`: new `TestUnconditionalPredictionErrorConfidence` class (6 tests); all 27 pre-existing tests unmodified.
- `scripts/analysis/measure_ast_hot_reducer.py`: replay/report wiring for the new field.
- `scripts/analysis/tests/test_measure_ast_hot_reducer.py`: 6 `ReplayTick(...)` positional call sites updated for the new field (dataclass gained a positional member); review hand-verified each insertion point against the dataclass field order.

## Schema / bus / API changes

- Added: `AttentionSelfModelV1.prediction_error_confidence` (float|None, [0,1]), `.prediction_error_confidence_basis` (str).
- Removed: none.
- Renamed: none.
- Behavior changed: none for existing fields/callers — purely additive.
- Compatibility notes: `reduce_attention_self_model` still has zero bus/consumer wiring (confirmed in review — its only two callers are both offline analysis scripts); `orion/schemas/registry.py`'s existing registration entry is untouched.

## Env/config changes

None.

## Tests run

```text
.venv/bin/python -m pytest orion/substrate/tests scripts/analysis/tests -q
624 passed
```

## Evals run

Live-verified against real Postgres data via `scripts/analysis/measure_ast_hot_reducer.py --window-hours 8` (real 8h window, 11901 ticks, 2026-07-24T22:24-06:24 UTC):
- `prediction_error_confidence`: 11888/11901 (99.89%) non-null, mean=0.9877, real variance (min 0.472, max 1.0) — up from the pre-patch 0.04% (`field_salience_only` branch count).
- `confidence` (old field): 11899/11901 (99.98%, not literally 100% — corrected from an earlier overclaim caught in review) non-null, mean=0.8766 — unchanged from its pre-patch behavior, confirming the additive-only claim held on real data, not just unit tests.

## Docker/build/smoke checks

N/A — pure Python reducer logic + analysis script, no runtime/service/dependency changes. `reduce_attention_self_model` has no bus/Docker wiring.

## Review findings fixed

- Finding: none material. Reviewer independently reproduced the CSV-level coverage/mean numbers from the live artifact, hand-verified the domain-filtering arithmetic (5-domain mean 0.0092 vs 4-domain 0.0115), confirmed via `ast.dump()` diff that `_aggregate_prediction_error_confidence`/`_round_or_none` are byte-identical before/after, and hand-checked all 6 updated `ReplayTick(...)` positional test call-sites against the dataclass field order.
- Finding (nit, not fixed in code — documented here instead): the old `confidence` field's real coverage is 99.98%, not literally 100% as an earlier draft of this description claimed. Corrected above; no code change needed.

## Restart required

```text
No restart required. Read-only reducer logic with zero bus/service wiring.
```

## Risks / concerns

- Severity: low
- Concern: the transport-exclusion rationale depends on a prior finding (already merged, PR #1320) rather than a from-scratch re-verification in this specific patch's review pass.
- Mitigation: the underlying live-data claim (`transport_prediction_error` == 0.0 for 100% of a real window) was independently confirmed via direct Postgres query in the prior finding's own patch, and this patch doesn't touch the transport data path itself, only excludes it from one new aggregate.

## PR link
(filled in by gh pr create output)