### PR TITLE
fix(deps): bump redis to 5.2.1 to drop broken distutils import in falkor-client consumers

### DIFF
--- a/services/orion-bus-mirror/requirements.txt
+++ b/services/orion-bus-mirror/requirements.txt
@@ -2,5 +2,5 @@ aiosqlite==0.19.0
 loguru==0.7.2
 pydantic==2.7.1
 pydantic-settings==2.3.0
-redis==5.0.7
+redis==5.2.1
 pyyaml==6.0.3

--- a/services/orion-hub/requirements.txt
+++ b/services/orion-hub/requirements.txt
@@ -8,7 +8,7 @@ python-dotenv==1.0.1
 Jinja2==3.1.4
 soundfile==0.12.1
 aiohttp==3.12.15
-redis[hiredis]==5.0.7
+redis[hiredis]==5.2.1
 pydantic==2.11.5
 pydantic-settings==2.5.2
 tzdata==2025.3

--- a/services/orion-meta-tags/requirements.txt
+++ b/services/orion-meta-tags/requirements.txt
@@ -4,5 +4,5 @@ spacy==3.8.7
 sentence-transformers==3.0.1
 pydantic==2.9.2
 pydantic-settings==2.5.2
-redis[hiredis]==5.0.7
+redis[hiredis]==5.2.1
 loguru>0.7

--- a/services/orion-recall/requirements.txt
+++ b/services/orion-recall/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.111.*
 uvicorn[standard]==0.30.*
-redis==5.0.*
+redis==5.2.1
 sqlalchemy==2.0.*
 psycopg2-binary==2.9.*
 asyncpg==0.29.*


### PR DESCRIPTION
## Summary
- `orion-bus-mirror` was crash-looping (`fix -bus-mirror 0/1 FAIL`) with `ModuleNotFoundError: No module named 'distutils'`
- Root cause: redis-py <5.1.0 imports `from distutils.util import strtobool` in `redis/commands/graph/query_result.py`; Python 3.12 removed `distutils` from stdlib. redis-py 5.1.0+ vendors its own `strtobool` instead.
- This exact bug was already fixed once for `orion-graph-compression` (commit a845bb06, bumped to `redis==5.2.1`). This PR bumps the same pin in every other consumer of the shared `orion/graph/falkor_client.py` (`RedisGraphQueryClient`, which does `from redis.commands.graph import Graph`): `orion-bus-mirror`, `orion-recall`, `orion-meta-tags`, `orion-hub`.
- No API/behavior change — redis-py 5.1.0–5.2.1 keeps the same `Graph.query()` / `result_set` / `header` shape this client relies on (confirmed by diffing redis-py source across versions).

## Outcome moved
`orion-bus-mirror` container: crash loop at import time → connects to the bus cleanly (live-verified). Three more services (`orion-recall`, `orion-meta-tags`, `orion-hub`) had the same latent bug on their FalkorDB code path and are now fixed proactively before it surfaces there too.

## Current architecture
`orion/graph/falkor_client.py::RedisGraphQueryClient.__init__` lazily imports `redis.commands.graph.Graph` when a FalkorDB client is actually constructed. Six services in the repo import this client (directly or via `orion.substrate.falkor_store`, which re-exports it): `orion-bus-mirror`, `orion-recall`, `orion-meta-tags`, `orion-hub`, `orion-graph-compression` (already fixed), `orion-substrate-runtime` (already on 5.2.1). All run on `python:3.12-slim` (or an equivalent 3.12 base), so all are exposed to the distutils removal once that import path is exercised.

## Architecture touched
No contract, schema, or bus change. Dependency pin only, in 4 services' `requirements.txt`.

## Files changed
- `services/orion-bus-mirror/requirements.txt`: `redis==5.0.7` → `redis==5.2.1`
- `services/orion-recall/requirements.txt`: `redis==5.0.*` → `redis==5.2.1`
- `services/orion-meta-tags/requirements.txt`: `redis[hiredis]==5.0.7` → `redis[hiredis]==5.2.1`
- `services/orion-hub/requirements.txt`: `redis[hiredis]==5.0.7` → `redis[hiredis]==5.2.1` (hub's route handler reaches `falkor_client` several lazy-import layers deep: `scripts/concept_atlas_routes.py` → `orion.substrate.materializer` → `graphdb_store.build_substrate_store_from_env()` → `orion.substrate.falkor_store` → `orion.graph.falkor_client`, active when `SUBSTRATE_STORE_BACKEND=falkor`)

## Schema / bus / API changes
None.

## Env/config changes
None. No `.env_example` changed.

## Tests run
```text
PYTHONPATH=. python -m pytest orion/graph/tests/test_falkor_client.py -q
10 passed, 1 warning (unrelated RedisGraph-deprecation warning from redis-py itself)

cd services/orion-bus-mirror && PYTHONPATH=..:. python -m pytest tests/ -q
23 passed
```
Run in a scratch venv with `redis==5.2.1` + `pytest-asyncio` installed (no system `pip` in the sandbox otherwise).

## Evals run
No eval harness for these services; not applicable to a dependency pin bump.

## Docker/build/smoke checks
```text
scripts/safe_docker_build.sh orion-bus-mirror build   # image builds clean, redis-5.2.1 wheel installs
scripts/safe_docker_build.sh orion-bus-mirror up -d   # container recreated
docker logs orion-athena-bus-mirror --tail 60
# 2026-07-24 06:24:49 | Bus synaptic graph writer enabled: graph=orion_bus_synapse alpha=0.2
# 2026-07-24 06:24:49 | Bus mirror connected: redis://100.92.216.81:6379/0 pattern=orion:*
docker ps --filter name=orion-athena-bus-mirror   # Up 25s+, no crash loop
```
`orion-recall`, `orion-meta-tags`, `orion-hub` were not container-built (heavier dependency trees — spacy/sentence-transformers/CUDA base — not currently deployed, and not the service that was actually reported crashing). Fix verified for these at the redis-py/Python-3.12 import level via the scratch venv (`from redis.commands.graph import Graph` imports cleanly under 5.2.1) and via subagent code review confirming no other version-pin conflicts in their requirements.txt and no other missed falkor_client consumers repo-wide.

## Review findings fixed
- Finding: none — orion-repo-agent review subagent confirmed the diff is correct and complete (all 4 real falkor_client consumers covered, no dependency conflicts in any of the 4 services' requirements.txt, `requirements-dev.txt`'s floating `>=5.0.7,<6` range already tolerates 5.2.1).
  - Fix: n/a
  - Evidence: subagent review transcript, in-session

## Restart required
`orion-bus-mirror` was already restarted live during verification (see Docker smoke above) and is running with the fix. No further restart needed for it.

For `orion-recall`, `orion-meta-tags`, `orion-hub`, restart after merge/deploy if/when their FalkorDB code path is actually exercised in production:
```bash
scripts/safe_docker_build.sh orion-recall up -d --build
scripts/safe_docker_build.sh orion-meta-tags up -d --build
scripts/safe_docker_build.sh orion-hub up -d --build
```

## Risks / concerns
- Severity: low
- Concern: `orion-recall`, `orion-meta-tags`, `orion-hub` fixes are verified at the dependency/import level and via code review, but not with a full container smoke (heavier dependency trees, not currently deployed/crashing).
- Mitigation: same exact code path, same exact fix already live-verified in `orion-bus-mirror`; low risk. Rebuild+smoke each at next deploy if extra confidence is wanted.

## PR link
(filled in after gh pr create)