### PR TITLE
feat(equilibrium): enable transport metacog trigger

### DIFF
--- a/services/orion-equilibrium-service/.env_example
+++ b/services/orion-equilibrium-service/.env_example
@@ -118,7 +118,7 @@ EQUILIBRIUM_METACOG_CHAT_TURN_COOLDOWN_SEC=30
 # same live-verification standard as every other trigger in this family before
 # flipping on.
 CHANNEL_RPC_HEALTH_SNAPSHOT=orion:rpc_health:snapshot
-EQUILIBRIUM_METACOG_TRANSPORT_TRIGGER_ENABLE=false
+EQUILIBRIUM_METACOG_TRANSPORT_TRIGGER_ENABLE=true
 # Separate cooldown lane, from day one -- see chat_turn's own comment above for why.
 EQUILIBRIUM_METACOG_TRANSPORT_COOLDOWN_SEC=30
 # No existing config to inherit from -- a starting default, same calibration


### PR DESCRIPTION
## Summary

- Flips `EQUILIBRIUM_METACOG_TRANSPORT_TRIGGER_ENABLE` from `false` to `true` in `.env_example`.
- Same pattern as `chat_turn`/`telemetry_anomaly` before it: ships-disabled -> flip on -> live-verify a real, non-degenerate `orion_metacog` row with `trigger_kind="transport"`.

## Files changed

- `services/orion-equilibrium-service/.env_example`

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-equilibrium-service/.env \
  -f services/orion-equilibrium-service/docker-compose.yml \
  up -d --build
```

Live `.env` flipped and container restarted directly as part of this change; this PR just brings the checked-in template in sync with the live intended default.

## PR link

(filled after creation)