### PR TITLE
docs: correct Objective 3 roadmap staleness + close out branch-starvation status

### DIFF
--- a/docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-roadmap-design.md
+++ b/docs/superpowers/specs/2026-07-18-objective-3-consciousness-scaffolded-roadmap-design.md
@@ -1,5 +1,21 @@
 # Objective 3 roadmap — consciousness-theory scaffolding before math/logic lock-in
 
+**Correction (2026-07-24, docs-only, no phase started yet).** Phase 2 below names "self-state
+deltas" as the first producer domain to reframe — "the richest and best-understood." That
+producer no longer exists: `SelfStateV1` was fully removed 2026-07-23 (PR #1266), one day
+before this correction, and replaced by `orion/substrate/prediction_error.py`'s five
+Active-Inference domains (`execution`, `transport`, `biometrics`, `chat`, `route`;
+`orion/schemas/attention_self_model.py`'s module docstring has the full account). Phase 1's
+"hard gate" below (a `SelfStateV1` signal-quality pass, blocking before Phase 1 is trusted) is
+now **moot by obsolescence, not resolved** — the gated input doesn't exist anymore, so there is
+nothing left to sign off on there; do not read the gate's absence as "passed." When Phase 2
+actually starts, re-anchor its first domain choice on the *live* prediction-error domains
+above (`biometrics` already has a real shadow-measure slice as of 2026-07-21, per the charter
+§6 item 3 status note — the natural real starting point now, not self-state deltas) and
+exclude `transport` (confirmed dead, 2026-07-24, reads exactly `0.0` for 100% of a real 8h
+window — see charter §6 item 2's 2026-07-24 note). This correction does not start Phase 2; it
+only prevents a future Phase 2 kickoff from building against a producer that's already gone.
+
 Status: design mode. No code changes proposed here. Reorders the charter's own Objective
 2/3 sequencing based on a real, named risk: building Objective 3's field-routing mechanics
 before any consciousness-theory scaffolding exists would repeat the exact failure mode that

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -215,6 +215,30 @@ first place. Full reasoning and phased detail:
    in the sense of "actually the formula driving live behavior."** No behavior changed in
    this patch; whether to reorder branches, blend both confidence sources, or otherwise
    address this is an open design question needing its own sign-off, not decided here.
+   **Fixed, 2026-07-24 (PR #1329, Option C — decouple, don't reorder or blend yet):** added
+   `prediction_error_confidence`/`prediction_error_confidence_basis`, computed unconditionally
+   (same positioning as `predicted_shift`, before the elif branching) and restricted to
+   `ACTIVE_INFERENCE_DOMAINS = {execution, biometrics, chat, route}` — `transport` excluded,
+   confirmed live via direct Postgres query that same day to read exactly `0.0` for 100% of a
+   real 8h window (10387 ticks), the other four domains showing real non-degenerate variance.
+   Live-verified against real post-rebuild data: this field populates on ~99.9% of ticks vs.
+   the branch-gated `confidence` field's ~0.04% (11899/11901 vs. ~4/11901). Purely additive —
+   `confidence`/`confidence_basis` unchanged, still branch-gated as before. The open design
+   question above (reorder vs. blend) is still **not** resolved by this patch; it sidesteps it
+   by giving the reducer's output a real, populated confidence value most of the time without
+   deciding how (or whether) to reconcile it with the older field.
+   **Re-checked, 2026-07-24 (this note):** `ORION_ATTENTION_TOPDOWN_ENABLED` and
+   `ORION_ATTENTION_SALIENCE_V2_ENABLED` are confirmed `true` live in the actual producing
+   container (`orion-athena-substrate-runtime`) — an earlier same-day check in this session
+   had wrongly concluded this flag was off, from checking the wrong container. The flags are
+   correctly on. What's still real: across 2015 broadcast-lane rows since the Postgres
+   rebuild (~16.7h, `substrate_attention_broadcast_log`), zero carry a real (non-JSON-null)
+   `voluntary_override` — consistent with this being a genuinely rare event (the 2026-07-18
+   design doc itself only claims "at least once in the last 24h" for the pre-rebuild data),
+   not a config regression. Phase 1's full acceptance check (correctly narrating a real live
+   override) still needs a fresh trigger to occur post-rebuild, independent of how much
+   history accumulates — "item 2 is proven" therefore still means "correct when exercised,"
+   not yet "exercised against a fresh real override since the rebuild."
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live


### PR DESCRIPTION
## Summary
- Charter §6 item 2: records PR #1329's fix (unconditional `prediction_error_confidence`, ~99.9% tick coverage vs. the old branch-gated `confidence` field's ~0.04%) and corrects a same-session mistake — `ORION_ATTENTION_TOPDOWN_ENABLED`/`ORION_ATTENTION_SALIENCE_V2_ENABLED` are confirmed `true` live in the real producing container (`orion-athena-substrate-runtime`); I'd wrongly checked a different container earlier and reported it off. The real, still-open finding: 2015 broadcast-lane rows since the Postgres rebuild (~16.7h) show zero real (non-JSON-null) `voluntary_override` events — a rare-event gap, not a config regression.
- Objective 3 Phase 2 roadmap doc (2026-07-18): flags that its plan to start with "self-state deltas" is stale — `SelfStateV1` was removed entirely the day before that doc was written (PR #1266). Phase 1's `SelfStateV1` hard gate is now moot by obsolescence, not passed. Re-anchors any future Phase 2 kickoff on the live `prediction_error` domains instead (biometrics already has a real shadow-measure slice; transport confirmed dead/excluded).

Docs only, no code/schema/behavior changes.

## Why now
Found while checking "what's next" after PR #1329 shipped — both staleness issues would have misled whoever picks up Phase 2 next if left uncorrected.

## Test plan
- [x] Docs-only diff, no tests applicable
- [x] Both corrections verified against live Postgres/docker state before writing (container env dump, real row counts on `substrate_attention_broadcast_log`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)