### PR TITLE
feat: deterministic gate for orion-substrate-runtime projection schema drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions bus-core-health-watchdog worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
+.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions check-substrate-projection-schema-drift bus-core-health-watchdog worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
 
 SERVICE ?=
 ARGS ?=
@@ -87,6 +87,22 @@ check-journal-dispatch-registry:
 # this isn't a hard gate today.
 check-daily-schedule-collisions:
 	@python scripts/check_daily_schedule_collisions.py $(if $(THRESHOLD_MINUTES),--threshold-minutes $(THRESHOLD_MINUTES),) $(if $(FAIL_ON_COLLISION),--fail-on-collision,)
+
+# Detection gate for the 2026-07-24 orion-substrate-runtime crash-loop incident
+# (PR #1331 renamed TransportBusStateV1 fields; the one stale persisted row still
+# had the old names, and extra="forbid" turned every tick's load into a hard
+# ValidationError crash-loop for ~10 hours undetected). For each of the seven
+# persisted, fixed-projection_id singleton rows in
+# services/orion-substrate-runtime/app/store.py, loads the CURRENT live row
+# against the CURRENT schema and fails if it does not validate -- see
+# scripts/check_substrate_projection_schema_drift.py's docstring for the full
+# incident writeup and scope rationale. Skips cleanly (exit 0) if POSTGRES_URI is
+# unset or Postgres is unreachable -- deliberately different from
+# check-activation-saturation/check-concept-relation-digest-liveness's exit-2
+# convention, see that script's "DB unavailability" note for why. Requires
+# POSTGRES_URI (see services/orion-substrate-runtime/.env).
+check-substrate-projection-schema-drift:
+	@python scripts/check_substrate_projection_schema_drift.py $(if $(JSON),--json,)
 
 # Host-level crash-loop detector for bus-core (Redis, services/orion-bus/docker-
 # compose.yml). Reads container health/restart-count via `docker inspect` ONLY --

--- a/scripts/check_substrate_projection_schema_drift.py
+++ b/scripts/check_substrate_projection_schema_drift.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Schema-drift gate for orion-substrate-runtime's persisted singleton projection rows.
+
+Context (2026-07-24 incident): PR #1331 (chore/rename-transport-pressure-stream-
+backlog, merged same day) renamed `TransportBusStateV1` fields `bus_health` ->
+`stream_backlog_health` and `transport_pressure` -> `stream_backlog_pressure`
+(orion/schemas/transport_projection.py). The rename itself was correct and reviewed.
+
+`services/orion-substrate-runtime` maintains exactly ONE persisted singleton row for
+its transport-bus projection: table `substrate_transport_bus_projection`,
+`projection_id = 'active_transport_bus_projection'` -- a materialized cache rebuilt
+from live `world_pulse` Redis Stream data on every reducer tick, NOT source-of-truth
+data (see app/worker.py's `_transport_tick()` and app/store.py's
+`load_transport_bus_projection()`). That loader does
+`TransportBusProjectionV1.model_validate(payload)` against a model with
+`extra="forbid"`. The persisted row still had the OLD field names baked into its
+stored JSON from before the rename. When `orion-athena-substrate-runtime` restarted
+onto the new code, EVERY tick's `load_projection()` call threw
+`pydantic_core.ValidationError: ... Extra inputs are not permitted
+[type=extra_forbidden]` -- and since the reducer cannot complete a tick without
+first successfully loading its previous state, this was a hard crash-loop: the
+service ran for ~10 hours writing nothing, undetected until someone happened to
+check `age_sec` on the live data by hand. Fixed live by deleting the one stale row
+(safe, since it self-heals from live stream data) -- but nothing in the repo would
+have caught this class of bug BEFORE a deploy crash-loops in production for hours.
+
+This script is that gate: for every known persisted singleton/materialized
+projection row in this codebase, load the CURRENT live row (if reachable) against
+the CURRENT schema and fail loudly with a clear diagnostic if it does not validate.
+
+Scope (grepped 2026-07-24 across services/*/app/store.py and orion/substrate/*):
+`services/orion-substrate-runtime/app/store.py` is the ONLY place in this repo that
+persists a projection as a fixed `projection_id` singleton row, UPSERTed in place on
+every tick (`ON CONFLICT (projection_id) DO UPDATE ...`) -- exactly the shape that
+produced the incident above. Seven such rows exist there today, all loaded via
+`<Model>.model_validate(payload)` against a model with `extra="forbid"` (confirmed
+directly against each model class in orion/schemas/*.py, not assumed) -- see the
+PROJECTIONS tuple below for the full list of (table, projection_id, model).
+
+Other services with a `store.py` that persists projections (orion-attention-runtime,
+orion-consolidation-runtime, orion-execution-dispatch-runtime, orion-feedback-
+runtime, orion-field-digester, orion-policy-runtime, orion-proposal-runtime) all use
+a genuinely different shape: an append-only log table, loaded via
+`ORDER BY generated_at DESC LIMIT 1` ("latest row"), not a fixed-projection_id UPSERT
+target. That shape could in principle hit the same extra="forbid" + stale-field
+crash on its own most-recent row, but a fresh write there immediately supersedes any
+stale one -- no row is ever silently "stuck" forever the way a singleton UPSERT row
+is. Genuinely different failure mode; out of scope for this patch, not built here.
+
+`orion/substrate/felt_state_reader.py`'s `SubstrateFeltStateReader` reads five of
+the same seven tables (including `substrate_transport_bus_projection` itself) via
+raw SQL with no `model_validate()` call at all -- it hydrates a plain dict and is
+fail-open by design (catches and swallows every exception), so it was never at
+crash-loop risk from this incident and needs no gate of its own.
+
+Usage:
+    POSTGRES_URI=postgresql://user:pass@host:port/db python scripts/check_substrate_projection_schema_drift.py
+    python scripts/check_substrate_projection_schema_drift.py --postgres-uri postgresql://...
+    python scripts/check_substrate_projection_schema_drift.py --json
+
+Exit codes: 0 = every reachable row (if any) validates against the current schema,
+                OR Postgres is unreachable (see "DB unavailability" note below).
+            1 = at least one persisted row fails schema validation -- FAIL, this is
+                the exact incident class this gate exists to catch.
+            2 = the check could not run for an unrelated reason: a per-table query
+                error once connected (e.g. a typo'd SQL identifier), a stored row
+                whose payload could not be read/parsed (a genuinely different, and
+                arguably worse, incident than the one this gate was built for --
+                see `payload_error` below), a model that failed to import, or any
+                other unexpected error raised after a successful connect. NOT the
+                same as "no live Postgres available at all".
+
+Note on DB unavailability, and why this diverges from
+scripts/check_activation_saturation.py / scripts/check_concept_relation_digest_liveness.py
+(which exit 2 when POSTGRES_URI is unset or the connection fails): those two are
+standing, run-by-hand gates that are meaningless without a live Postgres, so a hard
+failure is the right call there. This gate is meant to run unattended as part of a
+pre-deploy/pre-PR check in environments -- a laptop, CI -- that may have no live
+Postgres at all; treating that as a failure would be noise, not signal. So: no
+POSTGRES_URI configured, or the `asyncpg.connect()` call itself fails for ANY reason
+(refused, DNS, timeout, wrong password, TLS -- deliberately not narrowed to a
+specific exception type; see `_ConnectFailure`), prints `SKIPPED: ...` and exits 0.
+
+Everything that goes wrong AFTER a successful connect is a different story and is
+never folded into that same skip path (a real bug found in review: an earlier
+version of this script caught connection failures with a `try/except` wrapped
+around the *entire* per-table check loop, which meant a corrupted/unparseable
+stored row -- arguably a more alarming version of the exact incident this gate
+exists to catch -- silently printed "SKIPPED: could not connect to Postgres" and
+exited 0). Now: a per-table query error, a payload that fails to parse
+(`payload_error`), a model import failure, or a missing table are all handled
+per-row inside `_check_projection` and reported individually (a missing table is
+the one non-error case among these: treated as an unmigrated/fresh deploy). Any
+*other* exception that still escapes all of that is caught once more in `main()`,
+separately from the connect-failure path, and reported as a real error (exit 2) --
+never silently downgraded to "no live DB".
+
+This is a detection gate only. It does not delete stale rows or otherwise remediate
+-- the fix (row reset, or a `validation_alias` backward-compat shim at rename time)
+stays a human/agent judgment call, same as how the live incident above was handled.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/check_substrate_projection_schema_drift.py` puts
+# scripts/ on sys.path[0], which shadows stdlib modules (same issue documented in
+# scripts/check_inner_state_registry.py / scripts/check_activation_saturation.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@dataclass(frozen=True)
+class ProjectionSpec:
+    table: str
+    projection_id: str
+    model_module: str
+    model_name: str
+    payload_column: str = "projection_json"
+
+    @property
+    def label(self) -> str:
+        return f"{self.table}[{self.projection_id}]"
+
+
+# The full, deliberately short list -- see the module docstring's "Scope" section
+# for why this is the complete set of fixed-projection_id singleton rows in the
+# repo today, all living in services/orion-substrate-runtime/app/store.py.
+PROJECTIONS: tuple[ProjectionSpec, ...] = (
+    ProjectionSpec(
+        table="substrate_transport_bus_projection",
+        projection_id="active_transport_bus_projection",
+        model_module="orion.schemas.transport_projection",
+        model_name="TransportBusProjectionV1",
+    ),
+    ProjectionSpec(
+        table="substrate_node_biometrics_projection",
+        projection_id="node_biometrics_projection",
+        model_module="orion.schemas.biometrics_projection",
+        model_name="NodeBiometricsProjectionV1",
+    ),
+    ProjectionSpec(
+        table="substrate_active_node_pressure_projection",
+        projection_id="active_node_pressure_projection",
+        model_module="orion.schemas.biometrics_projection",
+        model_name="ActiveNodePressureProjectionV1",
+    ),
+    ProjectionSpec(
+        table="substrate_execution_trajectory_projection",
+        projection_id="active_execution_trajectory",
+        model_module="orion.schemas.execution_projection",
+        model_name="ExecutionTrajectoryProjectionV1",
+    ),
+    ProjectionSpec(
+        table="substrate_chat_session_projection",
+        projection_id="active_chat_session",
+        model_module="orion.schemas.chat_projection",
+        model_name="ChatSessionProjectionV1",
+    ),
+    ProjectionSpec(
+        table="substrate_route_arbitration_projection",
+        projection_id="active_route_arbitration",
+        model_module="orion.schemas.route_projection",
+        model_name="RouteArbitrationProjectionV1",
+    ),
+    ProjectionSpec(
+        table="substrate_attention_broadcast_projection",
+        projection_id="substrate.attention.broadcast.v1",
+        model_module="orion.schemas.attention_frame",
+        model_name="AttentionBroadcastProjectionV1",
+    ),
+)
+
+
+@dataclass
+class ProjectionResult:
+    spec: ProjectionSpec
+    # ok | no_row | table_missing | validation_failed | query_error |
+    # payload_error | model_import_error
+    status: str
+    detail: str = ""
+
+
+# Statuses that represent a real, reportable problem with a specific row/table --
+# as opposed to "connection to Postgres itself never succeeded" (see
+# _ConnectFailure below), which is handled entirely separately so it can never be
+# confused with one of these.
+_ERROR_STATUSES = ("query_error", "payload_error", "model_import_error")
+
+
+class _ConnectFailure(Exception):
+    """Raised only when `asyncpg.connect()` itself fails. Deliberately kept
+    separate from any exception raised while checking an individual row -- main()
+    treats this class as "no live DB reachable" (skip, exit 0) and everything else
+    as a real bug in the check (exit 2), so a corrupt row or an unrelated crash can
+    never get silently mislabeled as "could not connect to Postgres"."""
+
+    def __init__(self, cause: BaseException) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+
+
+def _load_model(spec: ProjectionSpec) -> type:
+    module = importlib.import_module(spec.model_module)
+    return getattr(module, spec.model_name)
+
+
+async def _check_projection(conn: Any, spec: ProjectionSpec) -> ProjectionResult:
+    import asyncpg
+
+    query = f"""
+        SELECT {spec.payload_column} FROM {spec.table}
+        WHERE projection_id = $1
+    """
+    try:
+        row = await conn.fetchrow(query, spec.projection_id)
+    except asyncpg.exceptions.UndefinedTableError as exc:
+        return ProjectionResult(spec, "table_missing", str(exc))
+    except Exception as exc:  # noqa: BLE001 - surfaced verbatim to the operator
+        return ProjectionResult(spec, "query_error", str(exc))
+
+    if row is None:
+        return ProjectionResult(spec, "no_row", "no persisted row (fresh deploy, or self-healed after a reset)")
+
+    try:
+        payload = row[spec.payload_column]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+    except Exception as exc:  # noqa: BLE001 - malformed/truncated stored JSON
+        return ProjectionResult(spec, "payload_error", str(exc))
+
+    try:
+        model = _load_model(spec)
+    except Exception as exc:  # noqa: BLE001
+        return ProjectionResult(spec, "model_import_error", str(exc))
+
+    try:
+        model.model_validate(payload)
+    except Exception as exc:  # noqa: BLE001 - pydantic ValidationError, printed verbatim
+        return ProjectionResult(spec, "validation_failed", str(exc))
+
+    return ProjectionResult(spec, "ok", "validates against current schema")
+
+
+async def _run_all(postgres_uri: str) -> list[ProjectionResult]:
+    """Connects, then checks every known projection. A failure to connect raises
+    `_ConnectFailure` (mapped by main() to a skip); any other exception here is a
+    real bug in this check and is left to propagate as-is, so main() can tell the
+    two apart -- see `_ConnectFailure`'s docstring."""
+    import asyncpg
+
+    try:
+        conn = await asyncpg.connect(postgres_uri, timeout=5)
+    except Exception as exc:  # noqa: BLE001 - deliberately broad: any failure to
+        # establish the connection at all (refused, DNS, timeout, auth, TLS, ...)
+        # is "no live DB reachable" for this gate's purposes.
+        raise _ConnectFailure(exc) from exc
+    try:
+        return [await _check_projection(conn, spec) for spec in PROJECTIONS]
+    finally:
+        await conn.close()
+
+
+def _print_result(result: ProjectionResult) -> None:
+    label = result.spec.label
+    if result.status == "ok":
+        print(f"  OK      {label} -- {result.detail}")
+    elif result.status == "no_row":
+        print(f"  OK      {label} -- {result.detail}")
+    elif result.status == "table_missing":
+        print(f"  NOTE    {label} -- table not present yet ({result.detail})")
+    elif result.status == "validation_failed":
+        print(f"  FAIL    {label} -- persisted row does not validate against {result.spec.model_name}:")
+        for line in result.detail.splitlines():
+            print(f"            {line}")
+        print(
+            "            Fix: either reset this row (safe if it self-heals from "
+            "live data on the next tick -- confirm before deleting) or add a "
+            "validation_alias/migration for the old field name(s) before shipping "
+            "the rename that caused this."
+        )
+    elif result.status == "query_error":
+        print(f"  ERROR   {label} -- query failed: {result.detail}")
+    elif result.status == "payload_error":
+        print(f"  ERROR   {label} -- stored {result.spec.payload_column} could not be read/parsed: {result.detail}")
+    elif result.status == "model_import_error":
+        print(f"  ERROR   {label} -- could not import {result.spec.model_module}.{result.spec.model_name}: {result.detail}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--postgres-uri",
+        default=os.getenv("POSTGRES_URI", ""),
+        help="Postgres DSN. Defaults to $POSTGRES_URI (e.g. services/orion-hub/.env or services/orion-substrate-runtime/.env).",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose.")
+    args = parser.parse_args(argv)
+
+    if not args.postgres_uri.strip():
+        if args.json:
+            print(json.dumps({"status": "skipped", "reason": "no_postgres_uri", "checked": 0}))
+        else:
+            print(
+                "check_substrate_projection_schema_drift: SKIPPED -- no --postgres-uri given "
+                "and $POSTGRES_URI is unset. This is expected in environments with no live "
+                "Postgres (a laptop without services running, some CI runners); check "
+                "services/orion-substrate-runtime/.env for POSTGRES_URI if a live check was "
+                "expected here."
+            )
+        return 0
+
+    try:
+        results = asyncio.run(_run_all(args.postgres_uri))
+    except _ConnectFailure as exc:
+        # Only a failure inside asyncpg.connect() itself lands here -- refused,
+        # DNS, timeout, auth, TLS, whatever. Anything that goes wrong *after* a
+        # successful connect (a corrupt row, a bug in this script) falls through
+        # to the `except Exception` below instead, so it can never be mislabeled
+        # as "no live DB" -- see _ConnectFailure's docstring.
+        if args.json:
+            print(json.dumps({
+                "status": "skipped",
+                "reason": "connection_failed",
+                "detail": str(exc.cause),
+                "checked": 0,
+            }))
+        else:
+            print(
+                f"check_substrate_projection_schema_drift: SKIPPED -- could not connect to "
+                f"Postgres ({exc.cause}). Treating this as a no-live-DB environment, not a "
+                f"failure. If Postgres should have been reachable, this needs a human look."
+            )
+        return 0
+    except Exception as exc:  # noqa: BLE001 - a real bug in this check, not a DB-
+        # reachability problem (e.g. an unhandled shape in a fetched row). Must
+        # NOT be silently reported as "skipped" -- that would hide the fact that
+        # something is actually broken.
+        if args.json:
+            print(json.dumps({
+                "status": "error",
+                "reason": "unexpected_error",
+                "detail": str(exc),
+                "checked": 0,
+            }))
+        else:
+            print(
+                f"check_substrate_projection_schema_drift: ERROR -- unexpected failure while "
+                f"running the check (not a DB-reachability issue): {exc!r}",
+                file=sys.stderr,
+            )
+        return 2
+
+    failures = [r for r in results if r.status == "validation_failed"]
+    errors = [r for r in results if r.status in _ERROR_STATUSES]
+
+    if args.json:
+        print(json.dumps({
+            "status": "ran",
+            "checked": len(results),
+            "results": [
+                {
+                    "table": r.spec.table,
+                    "projection_id": r.spec.projection_id,
+                    "model": f"{r.spec.model_module}.{r.spec.model_name}",
+                    "status": r.status,
+                    "detail": r.detail,
+                }
+                for r in results
+            ],
+            "failures": len(failures),
+            "errors": len(errors),
+        }))
+    else:
+        print(
+            f"check_substrate_projection_schema_drift: checked {len(results)} persisted "
+            f"singleton projection row(s):"
+        )
+        for result in results:
+            _print_result(result)
+        if failures:
+            print(
+                f"check_substrate_projection_schema_drift FAILED: {len(failures)} of "
+                f"{len(results)} persisted row(s) do not validate against the current schema. "
+                f"This is the exact failure class that crash-looped orion-substrate-runtime "
+                f"for ~10 hours on 2026-07-24 (PR #1331) -- do not deploy a field rename "
+                f"without either resetting the stale row or shimming backward compatibility.",
+                file=sys.stderr,
+            )
+        elif errors:
+            print(
+                f"check_substrate_projection_schema_drift: {len(errors)} row(s) could not be "
+                f"checked due to an unrelated error (see ERROR lines above).",
+                file=sys.stderr,
+            )
+        else:
+            print("check_substrate_projection_schema_drift: OK -- no schema drift detected.")
+
+    if failures:
+        return 1
+    if errors:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_substrate_projection_schema_drift.py
+++ b/tests/test_check_substrate_projection_schema_drift.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import check_substrate_projection_schema_drift as gate  # noqa: E402
+
+
+class FakeConn:
+    """Fakes asyncpg's connection object across all seven known projection tables.
+
+    `payloads` maps table name -> dict payload (row present, will be JSON-encoded
+    like a real jsonb column) or None (no row). Any table not present in `payloads`
+    is treated as "no row" by default. `missing_tables` simulates a table that does
+    not exist yet (fresh/unmigrated deploy).
+    """
+
+    def __init__(self, payloads: dict[str, dict | None] | None = None, missing_tables: set[str] | None = None,
+                 query_errors: dict[str, Exception] | None = None) -> None:
+        self._payloads = payloads or {}
+        self._missing_tables = missing_tables or set()
+        self._query_errors = query_errors or {}
+        self.closed = False
+
+    def _table_for_query(self, query: str) -> str:
+        for spec in gate.PROJECTIONS:
+            if spec.table in query:
+                return spec.table
+        raise AssertionError(f"unrecognized query: {query}")
+
+    async def fetchrow(self, query: str, *args):
+        table = self._table_for_query(query)
+        if table in self._query_errors:
+            raise self._query_errors[table]
+        if table in self._missing_tables:
+            import asyncpg
+
+            raise asyncpg.exceptions.UndefinedTableError(f'relation "{table}" does not exist')
+        payload = self._payloads.get(table)
+        if payload is None:
+            return None
+        return {"projection_json": json.dumps(payload)}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _connect_returning(conn: FakeConn):
+    return patch("asyncpg.connect", new=AsyncMock(return_value=conn))
+
+
+# --- DB unavailability fallback (the branchable behavior CLAUDE.md flags as worth
+# testing without a live DB) ---------------------------------------------------
+
+
+def test_main_skips_with_exit_zero_when_no_postgres_uri(monkeypatch):
+    monkeypatch.delenv("POSTGRES_URI", raising=False)
+    exit_code = gate.main([])
+    assert exit_code == 0
+
+
+def test_main_skips_with_exit_zero_on_blank_postgres_uri(monkeypatch):
+    monkeypatch.delenv("POSTGRES_URI", raising=False)
+    exit_code = gate.main(["--postgres-uri", "   "])
+    assert exit_code == 0
+
+
+def test_main_json_shape_when_no_postgres_uri(monkeypatch, capsys):
+    monkeypatch.delenv("POSTGRES_URI", raising=False)
+    exit_code = gate.main(["--json"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "skipped"
+    assert payload["reason"] == "no_postgres_uri"
+    assert payload["checked"] == 0
+
+
+def test_main_skips_with_exit_zero_when_connection_refused():
+    with patch("asyncpg.connect", new=AsyncMock(side_effect=ConnectionRefusedError("refused"))):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 0
+
+
+def test_main_json_shape_when_connection_fails(capsys):
+    with patch("asyncpg.connect", new=AsyncMock(side_effect=OSError("no route to host"))):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db", "--json"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "skipped"
+    assert payload["reason"] == "connection_failed"
+
+
+# --- real per-row checks (live-shaped: a real connection object, real pydantic
+# models, no mocking of the validation itself) ----------------------------------
+
+
+def test_main_exits_zero_when_every_row_is_absent():
+    """Fresh deploy / self-healed after a stale-row reset: no rows anywhere is a
+    healthy state, not a failure -- matches how the live 2026-07-24 incident was
+    actually fixed (delete the one stale row, let it self-heal)."""
+    conn = FakeConn(payloads={})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 0
+    assert conn.closed
+
+
+def test_main_exits_zero_when_rows_validate():
+    valid_transport = {
+        "schema_version": "transport_bus.projection.v1",
+        "updated_at": "2026-07-24T00:00:00Z",
+        "projection_id": "active_transport_bus_projection",
+        "buses": {
+            "node-1": {
+                "target_id": "t1",
+                "node_id": "node-1",
+                "sample_window_id": "w1",
+                "source_trace_id": "s1",
+                "stream_backlog_health": 0.5,
+                "stream_backlog_pressure": 0.1,
+            }
+        },
+    }
+    conn = FakeConn(payloads={"substrate_transport_bus_projection": valid_transport})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 0
+
+
+def test_main_reproduces_the_live_incident_exit_one():
+    """The exact 2026-07-24 shape: a persisted row still carrying the pre-rename
+    field names (bus_health/transport_pressure) against the current, renamed
+    TransportBusStateV1 model (extra='forbid'). This must FAIL, not silently pass --
+    that gap is precisely what let the real incident crash-loop for ~10 hours."""
+    stale_transport = {
+        "schema_version": "transport_bus.projection.v1",
+        "updated_at": "2026-07-24T00:00:00Z",
+        "projection_id": "active_transport_bus_projection",
+        "buses": {
+            "node-1": {
+                "target_id": "t1",
+                "node_id": "node-1",
+                "sample_window_id": "w1",
+                "source_trace_id": "s1",
+                "bus_health": 0.5,
+                "transport_pressure": 0.1,
+            }
+        },
+    }
+    conn = FakeConn(payloads={"substrate_transport_bus_projection": stale_transport})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 1
+
+
+def test_main_reports_the_failing_table_in_output(capsys):
+    stale_transport = {
+        "schema_version": "transport_bus.projection.v1",
+        "updated_at": "2026-07-24T00:00:00Z",
+        "projection_id": "active_transport_bus_projection",
+        "buses": {
+            "node-1": {
+                "target_id": "t1",
+                "node_id": "node-1",
+                "sample_window_id": "w1",
+                "source_trace_id": "s1",
+                "bus_health": 0.5,
+                "transport_pressure": 0.1,
+            }
+        },
+    }
+    conn = FakeConn(payloads={"substrate_transport_bus_projection": stale_transport})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "substrate_transport_bus_projection" in out
+    assert "FAIL" in out
+
+
+def test_main_json_shape_when_a_row_fails(capsys):
+    stale_transport = {
+        "schema_version": "transport_bus.projection.v1",
+        "updated_at": "2026-07-24T00:00:00Z",
+        "projection_id": "active_transport_bus_projection",
+        "buses": {"node-1": {"target_id": "t1", "node_id": "node-1", "sample_window_id": "w1",
+                              "source_trace_id": "s1", "bus_health": 0.5}},
+    }
+    conn = FakeConn(payloads={"substrate_transport_bus_projection": stale_transport})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db", "--json"])
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ran"
+    assert payload["failures"] == 1
+    failing = [r for r in payload["results"] if r["status"] == "validation_failed"]
+    assert failing and failing[0]["table"] == "substrate_transport_bus_projection"
+
+
+def test_main_treats_missing_table_as_non_fatal():
+    """An unmigrated/fresh deploy (table doesn't exist yet) is reported but must not
+    fail the gate -- distinct from a row that exists but fails validation."""
+    conn = FakeConn(payloads={}, missing_tables={"substrate_chat_session_projection"})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 0
+
+
+def test_main_exits_two_on_unrelated_query_error():
+    conn = FakeConn(payloads={}, query_errors={
+        "substrate_route_arbitration_projection": RuntimeError("syntax error at or near ...")
+    })
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 2
+
+
+def test_malformed_stored_payload_is_a_real_error_not_a_skip():
+    """Regression: a corrupt/truncated stored JSON payload must surface as a real
+    per-row error (exit 2), NOT get silently relabeled 'SKIPPED: could not connect
+    to Postgres' -- caught in review, where an earlier version of this script
+    routed any exception raised anywhere after a successful connect through the
+    same broad except-block used for connection failures. A malformed row is
+    arguably a worse version of the exact incident this gate exists to catch, so
+    it must never produce the friendliest possible non-answer."""
+
+    class _BadJSONConn(FakeConn):
+        async def fetchrow(self, query: str, *args):
+            table = self._table_for_query(query)
+            if table == "substrate_transport_bus_projection":
+                return {"projection_json": "{not valid json"}
+            return await super().fetchrow(query, *args)
+
+    conn = _BadJSONConn(payloads={})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db", "--json"])
+    assert exit_code == 2
+    assert conn.closed
+
+
+def test_malformed_stored_payload_reported_as_payload_error(capsys):
+    class _BadJSONConn(FakeConn):
+        async def fetchrow(self, query: str, *args):
+            table = self._table_for_query(query)
+            if table == "substrate_transport_bus_projection":
+                return {"projection_json": "{not valid json"}
+            return await super().fetchrow(query, *args)
+
+    conn = _BadJSONConn(payloads={})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db", "--json"])
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ran"
+    bad = [r for r in payload["results"] if r["status"] == "payload_error"]
+    assert bad and bad[0]["table"] == "substrate_transport_bus_projection"
+
+
+def test_unexpected_error_after_successful_connect_is_not_treated_as_skip(capsys):
+    """A bug or unhandled exception raised after the connection already succeeded
+    must never print 'SKIPPED: could not connect to Postgres' -- that would hide a
+    real problem behind the friendliest possible non-answer. Simulated here via a
+    conn whose close() raises: this happens in _run_all's `finally` block, after
+    every per-row check already ran and returned cleanly, so it deliberately lands
+    outside both `_check_projection`'s per-row try/except *and* the connect-only
+    `_ConnectFailure` wrapping -- exactly the class of bug review found live."""
+
+    class _CloseExplodingConn(FakeConn):
+        async def close(self) -> None:
+            raise SystemError("simulated unrelated internal bug during close")
+
+    conn = _CloseExplodingConn(payloads={})
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db", "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert out["status"] == "error"
+    assert out["reason"] == "unexpected_error"
+
+
+def test_validation_failure_takes_priority_over_query_error():
+    stale_transport = {
+        "schema_version": "transport_bus.projection.v1",
+        "updated_at": "2026-07-24T00:00:00Z",
+        "projection_id": "active_transport_bus_projection",
+        "buses": {"node-1": {"target_id": "t1", "node_id": "node-1", "sample_window_id": "w1",
+                              "source_trace_id": "s1", "bus_health": 0.5}},
+    }
+    conn = FakeConn(
+        payloads={"substrate_transport_bus_projection": stale_transport},
+        query_errors={"substrate_route_arbitration_projection": RuntimeError("boom")},
+    )
+    with _connect_returning(conn):
+        exit_code = gate.main(["--postgres-uri", "postgresql://fake/db"])
+    assert exit_code == 1
+
+
+# --- spec-list integrity: catches the PROJECTIONS list itself going stale (e.g. a
+# model renamed/removed without updating this gate) -----------------------------
+
+
+def test_every_projection_spec_model_imports_today():
+    for spec in gate.PROJECTIONS:
+        model = gate._load_model(spec)
+        assert model.model_config.get("extra") == "forbid", (
+            f"{spec.label}: model {spec.model_name} no longer has extra='forbid' -- "
+            "this gate assumes strict validation is what makes a stale field name a "
+            "hard failure. If this is intentional, this gate needs a rethink, not a "
+            "silent pass."
+        )
+
+
+def test_projection_specs_have_unique_tables():
+    tables = [spec.table for spec in gate.PROJECTIONS]
+    assert len(tables) == len(set(tables))


### PR DESCRIPTION
## Summary

- Adds `scripts/check_substrate_projection_schema_drift.py`: a deterministic gate that root-causes the 2026-07-24 production incident (PR #1331) by connecting to live Postgres and validating each of orion-substrate-runtime's 7 persisted singleton projection rows against their current Pydantic model.
- Adds `make check-substrate-projection-schema-drift` (Makefile target + PHONY entry), following the existing `check-activation-saturation`/`check-concept-relation-digest-liveness` pattern.
- Adds 18 tests in `tests/test_check_substrate_projection_schema_drift.py`.
- Skips cleanly (exit 0) when Postgres is unreachable so it's safe in CI/dev environments with no live DB, while a real per-row problem is never mislabeled as "no live DB" (a bug found and fixed during review).

## Outcome moved

Before this patch, a field rename on a Pydantic model with `extra="forbid"` backing a persisted singleton row had zero repo-level detection before deploy. On 2026-07-24, exactly this happened: PR #1331 renamed `TransportBusStateV1.bus_health`->`stream_backlog_health` and `.transport_pressure`->`stream_backlog_pressure`. The one persisted row in `substrate_transport_bus_projection` (table `projection_id='active_transport_bus_projection'`) still had the old field names. Every reducer tick's `load_transport_bus_projection()` call threw `pydantic_core.ValidationError: Extra inputs are not permitted`, and since the reducer cannot complete a tick without first loading its previous state, `orion-athena-substrate-runtime` crash-looped for ~10 hours writing nothing, undetected until someone checked `age_sec` on the live data by hand.

This gate would have caught that class of bug before deploy: run it against the live DB after any schema-affecting rename, and it fails loudly (exit 1) instead of a silent crash-loop.

## Current architecture

`services/orion-substrate-runtime/app/store.py` persists 7 tick-loop projections as fixed-`projection_id` singleton rows, UPSERTed in place every tick (`ON CONFLICT (projection_id) DO UPDATE ...`), rebuilt from live Redis Stream / event data (NOT source-of-truth). Loaders do `Model.model_validate(payload)` against `extra="forbid"` models. Nothing validated the *persisted* row against the *current* schema outside of the live reducer tick itself, so a rename could only ever be discovered by crash-looping in production.

## Architecture touched

- `scripts/` (new gate script, no service code touched)
- `Makefile` (new target, PHONY entry)
- `tests/` (new test file)

No service code, schema, bus channel, or env key was changed. This is a read-only, additive gate.

## Files changed

- `scripts/check_substrate_projection_schema_drift.py`: new gate script.
- `tests/test_check_substrate_projection_schema_drift.py`: new tests (18).
- `Makefile`: adds `check-substrate-projection-schema-drift` target + PHONY entry.

## Schema / bus / API changes

- Added: none (this script only reads existing tables/schemas; it does not add, remove, or change any schema, bus channel, or API contract).
- Removed: none.
- Renamed: none.
- Behavior changed: none in runtime code -- this is a new, standalone gate script.
- Compatibility notes: n/a.

## Scope: which persisted projections this gate covers, and why the list is complete

Grepped `services/*/app/store.py` and `orion/substrate/*` for the exact incident shape: a `model_validate()`-style call loading an `extra="forbid"` model from a table row keyed by a **fixed** `projection_id`, UPSERTed in place (`ON CONFLICT (projection_id) DO UPDATE ...`).

**`services/orion-substrate-runtime/app/store.py` is the only place in the repo using this shape.** It has exactly 7 such rows, all with `payload_column="projection_json"`:

| table | projection_id | model |
|---|---|---|
| `substrate_transport_bus_projection` | `active_transport_bus_projection` | `orion.schemas.transport_projection.TransportBusProjectionV1` |
| `substrate_node_biometrics_projection` | `node_biometrics_projection` | `orion.schemas.biometrics_projection.NodeBiometricsProjectionV1` |
| `substrate_active_node_pressure_projection` | `active_node_pressure_projection` | `orion.schemas.biometrics_projection.ActiveNodePressureProjectionV1` |
| `substrate_execution_trajectory_projection` | `active_execution_trajectory` | `orion.schemas.execution_projection.ExecutionTrajectoryProjectionV1` |
| `substrate_chat_session_projection` | `active_chat_session` | `orion.schemas.chat_projection.ChatSessionProjectionV1` |
| `substrate_route_arbitration_projection` | `active_route_arbitration` | `orion.schemas.route_projection.RouteArbitrationProjectionV1` |
| `substrate_attention_broadcast_projection` | `substrate.attention.broadcast.v1` | `orion.schemas.attention_frame.AttentionBroadcastProjectionV1` |

All 7 `projection_id` values traced to their real constants (`orion/substrate/*_loop/constants.py`), and all 7 models confirmed `model_config = ConfigDict(extra="forbid")` directly in `orion/schemas/*.py` (not assumed).

**Other services with a `store.py` that persist projections** (orion-attention-runtime, orion-consolidation-runtime, orion-execution-dispatch-runtime, orion-feedback-runtime, orion-field-digester, orion-policy-runtime, orion-proposal-runtime) all use a genuinely different shape: append-only log tables, loaded via `ORDER BY generated_at DESC LIMIT 1` ("latest row"), never a fixed-`projection_id` UPSERT target. A fresh write there immediately supersedes any stale row -- no row is ever silently "stuck" the way a singleton UPSERT row is. Spot-checked `orion-attention-runtime/app/store.py` in review to confirm this holds (it has an `ON CONFLICT (frame_id) DO UPDATE`, but `frame_id` varies per frame and every load is `ORDER BY ... LIMIT 1`, not a fixed-id lookup). Genuinely different failure mode; deliberately out of scope, not built here.

`orion/substrate/felt_state_reader.py` reads 5 of the same 7 tables (including the transport-bus one) via raw SQL with **no** `model_validate()` call at all -- it hydrates a plain dict and is fail-open by design (swallows every exception), so it was never at crash-loop risk and needs no gate of its own.

This is a short, hand-verified list, not a generic "all Pydantic models" scanner -- 7 entries is the complete, confirmed count.

## Env/config changes

None. Uses the existing `POSTGRES_URI` env key (same one already used by `services/orion-substrate-runtime/.env_example` and `scripts/check_activation_saturation.py`/`scripts/check_concept_relation_digest_liveness.py`).

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: n/a (no key change)
- local `.env` synced: n/a (no key change)
- skipped keys requiring operator action: none

## Tests run

```
$ pytest tests/test_check_substrate_projection_schema_drift.py -q
18 passed in 0.25s
```

(Run in a dedicated venv with `pydantic`, `asyncpg`, `pytest`, `pytest-asyncio` installed -- the ambient system Python in this sandbox has none of these; note that review found `/mnt/scripts/Orion-Sapienform/.venv` already has them.)

## Evals run

No existing eval harness for this class of gate script (matches the pattern of `check_activation_saturation.py`/`check_concept_relation_digest_liveness.py`, which also have no eval lane -- they're standing checks, not model-quality evals). Not applicable here: this is a deterministic pass/fail gate, not a quality metric.

## Docker/build/smoke checks

Ran the script live against the real dev Postgres (`postgresql://postgres:postgres@localhost:55432/conjourney`, per the existing "Live Postgres directly queryable" convention):

```
$ POSTGRES_URI=postgresql://postgres:postgres@localhost:55432/conjourney python scripts/check_substrate_projection_schema_drift.py
check_substrate_projection_schema_drift: checked 7 persisted singleton projection row(s):
  OK      substrate_transport_bus_projection[active_transport_bus_projection] -- validates against current schema
  OK      substrate_node_biometrics_projection[node_biometrics_projection] -- validates against current schema
  OK      substrate_active_node_pressure_projection[active_node_pressure_projection] -- validates against current schema
  OK      substrate_execution_trajectory_projection[active_execution_trajectory] -- validates against current schema
  OK      substrate_chat_session_projection[active_chat_session] -- validates against current schema
  OK      substrate_route_arbitration_projection[active_route_arbitration] -- validates against current schema
  OK      substrate_attention_broadcast_projection[substrate.attention.broadcast.v1] -- validates against current schema
check_substrate_projection_schema_drift: OK -- no schema drift detected.
$ echo $?
0
```

This confirms today's live rows (post-incident-fix) all currently validate, and confirms the PROJECTIONS table/projection_id list is correct against real data, not just internally consistent.

Also verified both skip paths live: no `POSTGRES_URI` -> `SKIPPED`, exit 0; unreachable host -> `SKIPPED`, exit 0. And `make check-substrate-projection-schema-drift` / `make check-substrate-projection-schema-drift JSON=1` both work correctly through the Makefile target.

No Docker rebuild needed -- this is a standalone script, no service runtime code touched.

## Review findings fixed

- Finding (must-fix): the outer `except Exception` around `asyncio.run(_run_all(...))` in `main()` caught *any* exception raised anywhere in the check -- not just a failed `asyncpg.connect()` -- and mislabeled it "SKIPPED: could not connect to Postgres", exit 0. Live-reproduced with a malformed/corrupt stored JSON payload (`{"projection_json": "{not valid json"}`): got silently swallowed as a DB-unreachable skip instead of surfacing as a real problem -- arguably a worse incident than the one this gate targets.
  - Fix: introduced `_ConnectFailure`, raised only from inside the `asyncpg.connect()` call itself; `main()` now catches `_ConnectFailure` specifically for the skip path and a separate `except Exception` for anything else, reported as a real error (exit 2, `reason: "unexpected_error"`), never as a skip. Also gave the payload-parsing step its own try/except inside `_check_projection`, producing a new `payload_error` status (contributes to exit 2, per-row, without aborting checks of the other tables).
  - Evidence: `tests/test_malformed_stored_payload_is_a_real_error_not_a_skip`, `tests/test_malformed_stored_payload_reported_as_payload_error`, `tests/test_unexpected_error_after_successful_connect_is_not_treated_as_skip` all pass; full suite re-run (18/18 pass) and live-DB smoke re-verified after the fix.
- Finding (should-fix): no test exercised "row exists but payload is malformed" or a failure occurring after a successful connect.
  - Fix: added the three regression tests above.
  - Evidence: `pytest tests/test_check_substrate_projection_schema_drift.py -q` -> 18 passed.
- Finding (nit): `model_import_error` branch had no direct test coverage.
  - Fix: not fixed in this patch -- low risk (simple `getattr`/`importlib.import_module` call, same shape as the already-tested `query_error`/`payload_error` branches), noted as a known gap rather than adding a test for a branch this thin. See Concerns below.

Everything else the review checked out clean: PROJECTIONS list verified line-by-line against real source; scope-discipline claim about other services spot-checked and held up; DB-unavailable fallback correct for the intended cases; `extra="forbid"` failure-mode correctness confirmed (no pydantic v1 assumptions); FakeConn fidelity to real asyncpg confirmed; Makefile wiring correct; no SQL injection surface (table names are hardcoded literals); confirmed read-only (no INSERT/UPDATE/DELETE anywhere in the script).

## Restart required

```text
No restart required.
```

This is a standalone script with no runtime service dependency -- nothing to restart.

## Risks / concerns

- Severity: low
- Concern: `model_import_error` status has no direct unit test (only the "models import successfully today" sanity test covers the happy path).
- Mitigation: the code path is a two-line `importlib.import_module`/`getattr` call, structurally identical to the already-tested `query_error` and `payload_error` branches (same try/except-to-status pattern); a follow-up test can be added cheaply if this ever needs hardening.

- Severity: low
- Concern: this gate is not wired into any automated CI trigger -- it's a `make` target, run by hand or by an agent before a rename-shaped PR. `make agent-check` (referenced in CLAUDE.md section 17) does not exist in this repo (confirmed already-documented in `Makefile`'s own comments, not a gap introduced by this patch).
- Mitigation: out of scope for this patch per the task's own instructions (wire into `agent-check` "if that Makefile target exists" -- confirmed it does not). Building `agent-check` itself is a separate, larger decision for Juniper.

## PR link

(filled in by `gh pr create`)
