### PR TITLE
feat(bus-mirror): collapse dynamic reply channels into catalog wildcard families

### DIFF
--- a/orion/bus/census.py
+++ b/orion/bus/census.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
-__all__ = ["CensusResult", "compute_census"]
+import yaml
+
+__all__ = [
+    "CensusResult",
+    "compute_census",
+    "load_channel_catalog_names",
+    "normalize_channel_name",
+]
+
+_DEFAULT_CATALOG_PATH = Path(__file__).resolve().parent / "channels.yaml"
 
 
 @dataclass(frozen=True)
@@ -56,3 +66,71 @@ def compute_census(catalog_names: set[str], active_channels: dict[str, float]) -
 
     undeclared_active = sorted(ch for ch in active_channels if ch not in covered_active)
     return CensusResult(declared_silent=declared_silent, undeclared_active=undeclared_active)
+
+
+def load_channel_catalog_names(catalog_path: str | Path | None = None) -> set[str]:
+    """Load every declared channel name (exact and wildcard) from
+    orion/bus/channels.yaml. Defaults to the file living right next to this
+    module -- __file__-relative, so resolution doesn't depend on the calling
+    process's CWD or which service imports this (unlike
+    services/orion-bus/app/bus_observer.py's own near-identical loader, which
+    needs a multi-base-path fallback because it's reaching for a file outside
+    its own service directory; this one never has to reach anywhere).
+
+    A near-duplicate of that function exists in bus_observer.py -- not
+    consolidated here to avoid a cross-service refactor out of scope for this
+    patch, but any new consumer of catalog names should prefer this shared
+    orion.bus.census version over reaching into another service's internals.
+    """
+    path = Path(catalog_path) if catalog_path else _DEFAULT_CATALOG_PATH
+    if not path.is_file():
+        return set()
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    names: set[str] = set()
+    for ch in data.get("channels") or []:
+        if isinstance(ch, dict) and ch.get("name"):
+            names.add(str(ch["name"]))
+    return names
+
+
+def normalize_channel_name(channel: str, catalog_names: set[str]) -> str:
+    """Collapse a live channel name to its matching wildcard catalog entry,
+    if any, else return it unchanged.
+
+    Exists to fix a real, live-found problem: a consumer that creates one
+    graph node (or any other per-channel record) per literal channel string
+    it observes -- without this normalization -- creates one node per dynamic
+    per-request reply channel (e.g.
+    "orion:exec:result:LLMGatewayService:<uuid>") instead of one node per
+    real, bounded catalog entry. Found live 2026-07-24: services/orion-bus-mirror's
+    synaptic graph had ~9K Channel nodes against a 264-entry declared catalog,
+    almost entirely from this exact pattern.
+
+    If more than one wildcard matches (e.g. both a broad umbrella like
+    "orion:exec:result:*" and a narrower per-service pattern like
+    "orion:exec:result:LLMGatewayService:*" -- both real, both present in
+    channels.yaml today), the narrowest (longest prefix) match wins -- the
+    more specific grouping is the more useful one for anything downstream
+    that cares which service's replies are hot, not just that "some" reply
+    channel is.
+
+    An exact literal catalog entry is checked FIRST and short-circuits any
+    wildcard matching, even if a wildcard sibling would also prefix-match it
+    -- caught in review: channels.yaml has real cases (e.g.
+    "orion:exec:result:LLMGatewayService" as its own standalone entry,
+    alongside the "orion:exec:result:*" umbrella and/or a
+    "...LLMGatewayService:*" wildcard) where a literal, already-bounded,
+    already-declared channel would otherwise get merged into a broader
+    bucket -- exactly backwards from why this function exists. A channel
+    that's already a real catalog entry needs no collapsing at all.
+    """
+    if channel in catalog_names:
+        return channel
+    matches = [
+        name
+        for name in catalog_names
+        if _is_wildcard(name) and channel.startswith(_wildcard_prefix(name))
+    ]
+    if not matches:
+        return channel
+    return max(matches, key=lambda name: len(_wildcard_prefix(name)))

--- a/orion/bus/tests/test_census.py
+++ b/orion/bus/tests/test_census.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from orion.bus.census import compute_census
+from pathlib import Path
+
+from orion.bus.census import compute_census, load_channel_catalog_names, normalize_channel_name
 
 
 def test_compute_census_finds_silent_and_undeclared_literal_channels() -> None:
@@ -93,3 +95,80 @@ def test_compute_census_overlapping_wildcard_family_matches_narrowest_and_broade
         "orion:exec:result:PadRpc:*",
         "orion:exec:result:StateService:*",
     ]
+
+
+def test_normalize_channel_name_collapses_a_dynamic_reply_channel() -> None:
+    catalog = {"orion:exec:result:*"}
+    channel = "orion:exec:result:LLMGatewayService:0cf10589-4bae-4cb7-bc13-40684d7d321e"
+
+    assert normalize_channel_name(channel, catalog) == "orion:exec:result:*"
+
+
+def test_normalize_channel_name_leaves_exact_catalog_channels_unchanged() -> None:
+    catalog = {"orion:system:health", "orion:exec:result:*"}
+    assert normalize_channel_name("orion:system:health", catalog) == "orion:system:health"
+
+
+def test_normalize_channel_name_exact_match_short_circuits_a_wildcard_sibling() -> None:
+    # Regression test for a real bug caught in review: channels.yaml has
+    # standalone literal entries that share a prefix with a broader wildcard
+    # sibling (e.g. "orion:exec:result:LLMGatewayService" alongside the
+    # "orion:exec:result:*" umbrella). Before this fix, the literal entry was
+    # incorrectly collapsed into the broad bucket -- exactly backwards, since
+    # it's already a real, bounded, declared catalog channel that needs no
+    # collapsing at all. Live-verified against the real channels.yaml: 8
+    # literal entries hit exactly this case.
+    catalog = {"orion:exec:result:LLMGatewayService", "orion:exec:result:*"}
+    assert normalize_channel_name("orion:exec:result:LLMGatewayService", catalog) == "orion:exec:result:LLMGatewayService"
+
+
+def test_normalize_channel_name_leaves_uncataloged_channels_unchanged() -> None:
+    catalog = {"orion:exec:result:*"}
+    assert normalize_channel_name("orion:totally:unrelated:channel", catalog) == "orion:totally:unrelated:channel"
+
+
+def test_normalize_channel_name_picks_the_narrowest_matching_wildcard() -> None:
+    # Mirrors the real orion/bus/channels.yaml shape: a broad umbrella plus a
+    # narrower per-service wildcard both match the same live channel -- the
+    # narrower one is more useful (distinguishes which service, not just
+    # "some" reply channel).
+    catalog = {"orion:exec:result:*", "orion:exec:result:LLMGatewayService:*"}
+    channel = "orion:exec:result:LLMGatewayService:0cf10589"
+
+    assert normalize_channel_name(channel, catalog) == "orion:exec:result:LLMGatewayService:*"
+
+
+def test_normalize_channel_name_handles_bare_star_wildcards() -> None:
+    catalog = {"orion:cortex:result*"}
+    channel = "orion:cortex:result:184992b1-7922-4616-8b26-f2f40e5d0c77"
+
+    assert normalize_channel_name(channel, catalog) == "orion:cortex:result*"
+
+
+def test_normalize_channel_name_empty_catalog_returns_channel_unchanged() -> None:
+    assert normalize_channel_name("orion:x", set()) == "orion:x"
+
+
+def test_load_channel_catalog_names_reads_the_real_channels_yaml() -> None:
+    # No path given -- must resolve orion/bus/channels.yaml relative to this
+    # module's own location, not the test process's CWD.
+    names = load_channel_catalog_names()
+
+    assert len(names) > 100  # real catalog has 264 entries as of this arc
+    assert "orion:system:health" in names
+
+
+def test_load_channel_catalog_names_missing_file_returns_empty_set() -> None:
+    assert load_channel_catalog_names(Path("/nonexistent/channels.yaml")) == set()
+
+
+def test_load_channel_catalog_names_explicit_path_overrides_default(tmp_path) -> None:
+    catalog_file = tmp_path / "custom_channels.yaml"
+    catalog_file.write_text(
+        "channels:\n  - name: orion:custom:channel\n  - name: orion:other:*\n",
+        encoding="utf-8",
+    )
+
+    names = load_channel_catalog_names(catalog_file)
+
+    assert names == {"orion:custom:channel", "orion:other:*"}

--- a/services/orion-bus-mirror/README.md
+++ b/services/orion-bus-mirror/README.md
@@ -58,6 +58,26 @@ shared FalkorDB instance at `FALKORDB_URI`):
   *different* organ arrives within `MIRROR_GRAPH_CHAIN_TTL_SEC` (default 120s). Same
   EWMA/z-score shape, over hop latency instead of publish gap.
 
+**Channel node collapsing (fixed 2026-07-24, found via the Hub hot-path view):** `Channel`
+node identity is normalized against `orion/bus/channels.yaml`'s wildcard catalog entries
+(`orion.bus.census.normalize_channel_name`, the same wildcard-prefix matching
+`compute_census()` already used for Phase 2's census diff) before being written. Without
+this, every dynamic per-request reply channel (e.g.
+`orion:exec:result:LLMGatewayService:<uuid>`) got its own permanent node — live-found:
+~9K `Channel` nodes against a 264-entry declared catalog. Now they collapse to the
+matching catalog wildcard entry (narrowest/most-specific match wins when more than one
+wildcard matches the same channel; an exact literal catalog entry always short-circuits
+wildcard matching, even if a wildcard sibling would also prefix-match it -- otherwise
+already-declared, already-bounded channels like `orion:exec:result:LLMGatewayService`
+would themselves get incorrectly merged into the broader `orion:exec:result:*` bucket,
+exactly backwards -- caught in review). Catalog is loaded once at process startup (static
+for the process lifetime), not re-read per message -- a channel added to `channels.yaml`
+while this service is running won't be normalized (or a channel removed will keep being
+normalized against the stale entry) until the next restart. **Known gap, not fixed here:**
+this only affects *new* writes — the ~9K already-inflated `Channel` nodes from before this
+fix are not retroactively merged or cleaned up. A one-off migration/cleanup pass is a
+real, separate follow-up, not silently assumed unnecessary.
+
 **What this deliberately does NOT build** (honesty over completeness):
 - **No `CONSUMES` edge.** A passive wiretap only ever observes publishes — it cannot
   see who actually received a pub/sub message. A live `CONSUMES` edge would need each

--- a/services/orion-bus-mirror/app/graph_writer.py
+++ b/services/orion-bus-mirror/app/graph_writer.py
@@ -62,6 +62,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
 
+from orion.bus.census import normalize_channel_name
 from orion.graph.falkor_client import FalkorGraphClient
 
 __all__ = [
@@ -525,20 +526,36 @@ class BusSynapticGraphWriter:
         )
 
 
-def extract_bus_event_fact(envelope: Any, *, channel: str, now: float | None = None) -> BusEventFact | None:
+def extract_bus_event_fact(
+    envelope: Any,
+    *,
+    channel: str,
+    now: float | None = None,
+    catalog_names: set[str] | None = None,
+) -> BusEventFact | None:
     """``envelope`` is a decoded BaseEnvelope (or envelope-shaped object with
     ``source.name`` and ``correlation_id``). Returns None if it doesn't carry
     enough identity to place on the graph (no source name) -- fails open,
     consistent with the rest of this arc's fail-open-on-malformed-data rule.
+
+    If ``catalog_names`` is given, ``channel`` is normalized via
+    ``orion.bus.census.normalize_channel_name`` before being placed on the
+    graph -- collapses dynamic per-request reply channels (e.g.
+    "orion:exec:result:LLMGatewayService:<uuid>") to their catalog wildcard
+    entry, fixing a real, live-found problem where the graph's Channel node
+    count (~9K) badly overshot the real 264-entry declared catalog. The
+    SQLite raw-log path is unaffected -- it keeps exact literal channel names
+    for debugging/replay, only the graph's node identity is collapsed.
     """
     source = getattr(envelope, "source", None)
     organ_id = getattr(source, "name", None) if source is not None else None
     if not organ_id:
         return None
     correlation_id = getattr(envelope, "correlation_id", None)
+    graph_channel = normalize_channel_name(channel, catalog_names) if catalog_names else channel
     return BusEventFact(
         organ_id=str(organ_id),
-        channel=channel,
+        channel=graph_channel,
         correlation_id=str(correlation_id) if correlation_id else None,
         observed_at_epoch=now if now is not None else time.time(),
     )

--- a/services/orion-bus-mirror/app/main.py
+++ b/services/orion-bus-mirror/app/main.py
@@ -6,6 +6,7 @@ from typing import Optional
 import aiosqlite
 from loguru import logger
 
+from orion.bus.census import load_channel_catalog_names
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.codec import DecodeResult, OrionCodec
 from orion.graph.falkor_client import RedisGraphQueryClient
@@ -61,9 +62,12 @@ async def _record_graph_event(
     decoded: DecodeResult,
     channel: str,
     now_epoch: float,
+    catalog_names: set[str],
 ) -> None:
     try:
-        fact = extract_bus_event_fact(decoded.envelope, channel=channel, now=now_epoch)
+        fact = extract_bus_event_fact(
+            decoded.envelope, channel=channel, now=now_epoch, catalog_names=catalog_names
+        )
         if fact is None:
             return
         # Chain-tracker bookkeeping runs before the (possibly-failing) Falkor
@@ -135,11 +139,18 @@ async def mirror_bus() -> None:
 
     graph_writer = _build_graph_writer()
     chain_tracker = ChainTracker(ttl_sec=settings.MIRROR_GRAPH_CHAIN_TTL_SEC) if graph_writer else None
+    # Loaded once at startup, not per-message: channels.yaml is static for the
+    # life of this process. Used to collapse dynamic reply channels (e.g.
+    # "orion:exec:result:LLMGatewayService:<uuid>") to their catalog wildcard
+    # entry before they become graph nodes -- see extract_bus_event_fact's
+    # docstring for why this matters (a real, live-found ~9K-node inflation).
+    catalog_names = load_channel_catalog_names() if graph_writer else set()
     if graph_writer:
         logger.info(
-            "Bus synaptic graph writer enabled: graph={} alpha={}",
+            "Bus synaptic graph writer enabled: graph={} alpha={} catalog_channels={}",
             settings.FALKORDB_BUS_GRAPH,
             settings.MIRROR_GRAPH_EWMA_ALPHA,
+            len(catalog_names),
         )
 
     inflight_task: Optional[asyncio.Task] = None
@@ -173,7 +184,7 @@ async def mirror_bus() -> None:
 
                     if graph_writer is not None and decoded.ok:
                         await _record_graph_event(
-                            graph_writer, chain_tracker, decoded, channel, now.timestamp()
+                            graph_writer, chain_tracker, decoded, channel, now.timestamp(), catalog_names
                         )
     finally:
         if inflight_task is not None:

--- a/services/orion-bus-mirror/tests/test_graph_writer.py
+++ b/services/orion-bus-mirror/tests/test_graph_writer.py
@@ -235,6 +235,36 @@ class TestExtractBusEventFact:
         assert fact is not None
         assert fact.correlation_id is None
 
+    def test_channel_collapsed_to_matching_catalog_wildcard(self) -> None:
+        envelope = self._FakeEnvelope(source=self._FakeSource(name="llm-gateway"))
+        fact = extract_bus_event_fact(
+            envelope,
+            channel="orion:exec:result:LLMGatewayService:0cf10589-4bae-4cb7-bc13-40684d7d321e",
+            now=1.0,
+            catalog_names={"orion:exec:result:*"},
+        )
+        assert fact is not None
+        assert fact.channel == "orion:exec:result:*"
+
+    def test_channel_left_unchanged_without_catalog_names(self) -> None:
+        envelope = self._FakeEnvelope(source=self._FakeSource(name="llm-gateway"))
+        fact = extract_bus_event_fact(
+            envelope, channel="orion:exec:result:LLMGatewayService:0cf10589", now=1.0
+        )
+        assert fact is not None
+        assert fact.channel == "orion:exec:result:LLMGatewayService:0cf10589"
+
+    def test_exact_catalog_channel_unaffected_by_normalization(self) -> None:
+        envelope = self._FakeEnvelope(source=self._FakeSource(name="cortex-exec"))
+        fact = extract_bus_event_fact(
+            envelope,
+            channel="orion:system:health",
+            now=1.0,
+            catalog_names={"orion:system:health", "orion:exec:result:*"},
+        )
+        assert fact is not None
+        assert fact.channel == "orion:system:health"
+
 
 class TestChainTrackerInFlight:
     def _fact(self, organ_id: str, correlation_id: Optional[str], epoch: float) -> BusEventFact:

--- a/services/orion-bus-mirror/tests/test_main_graph_integration.py
+++ b/services/orion-bus-mirror/tests/test_main_graph_integration.py
@@ -38,7 +38,7 @@ class TestRecordGraphEventFailsOpen:
 
         # Must not raise -- this is the whole point of the fail-open contract:
         # a graph-write failure can never block or crash the mirror's main loop.
-        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0)
+        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0, set())
 
         writer.record_publish.assert_called_once()
 
@@ -48,7 +48,7 @@ class TestRecordGraphEventFailsOpen:
         chain_tracker = ChainTracker(ttl_sec=60.0)
         decoded = _FakeDecodeResult(envelope=_FakeEnvelope(source=_FakeSource(name=None)))
 
-        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0)
+        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0, set())
 
         writer.record_publish.assert_not_called()
         writer.record_causal_hop.assert_not_called()
@@ -67,7 +67,7 @@ class TestRecordGraphEventFailsOpen:
             envelope=_FakeEnvelope(source=_FakeSource(name="cortex-exec"), correlation_id="corr-1")
         )
 
-        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0)
+        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0, set())
 
         assert len(chain_tracker) == 1
 
@@ -82,8 +82,8 @@ class TestRecordGraphEventFailsOpen:
             envelope=_FakeEnvelope(source=_FakeSource(name="llm-gateway"), correlation_id="corr-1")
         )
 
-        await _record_graph_event(writer, chain_tracker, first, "orion:a", 100.0)
-        await _record_graph_event(writer, chain_tracker, second, "orion:b", 117.0)
+        await _record_graph_event(writer, chain_tracker, first, "orion:a", 100.0, set())
+        await _record_graph_event(writer, chain_tracker, second, "orion:b", 117.0, set())
 
         writer.record_causal_hop.assert_called_once()
         _, kwargs = writer.record_causal_hop.call_args
@@ -103,7 +103,7 @@ class TestRecordGraphEventVerbSteps:
             )
         )
 
-        await _record_graph_event(writer, chain_tracker, decoded, "orion:cognition:trace", 100.0)
+        await _record_graph_event(writer, chain_tracker, decoded, "orion:cognition:trace", 100.0, set())
 
         writer.record_verb_step.assert_called_once()
         (fact,), _ = writer.record_verb_step.call_args
@@ -116,7 +116,7 @@ class TestRecordGraphEventVerbSteps:
         chain_tracker = ChainTracker(ttl_sec=60.0)
         decoded = _FakeDecodeResult(envelope=_FakeEnvelope(source=_FakeSource(name="cortex-exec")))
 
-        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0)
+        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0, set())
 
         writer.record_verb_step.assert_not_called()
 
@@ -132,4 +132,37 @@ class TestRecordGraphEventVerbSteps:
             )
         )
 
-        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0)  # must not raise
+        await _record_graph_event(writer, chain_tracker, decoded, "orion:test", 100.0, set())  # must not raise
+
+
+class TestRecordGraphEventChannelNormalization:
+    @pytest.mark.asyncio
+    async def test_dynamic_reply_channel_collapsed_to_catalog_wildcard(self) -> None:
+        writer = MagicMock()
+        chain_tracker = ChainTracker(ttl_sec=60.0)
+        decoded = _FakeDecodeResult(envelope=_FakeEnvelope(source=_FakeSource(name="llm-gateway")))
+
+        await _record_graph_event(
+            writer,
+            chain_tracker,
+            decoded,
+            "orion:exec:result:LLMGatewayService:0cf10589-4bae-4cb7-bc13-40684d7d321e",
+            100.0,
+            {"orion:exec:result:*"},
+        )
+
+        (fact,), _ = writer.record_publish.call_args
+        assert fact.channel == "orion:exec:result:*"
+
+    @pytest.mark.asyncio
+    async def test_empty_catalog_leaves_channel_unchanged(self) -> None:
+        writer = MagicMock()
+        chain_tracker = ChainTracker(ttl_sec=60.0)
+        decoded = _FakeDecodeResult(envelope=_FakeEnvelope(source=_FakeSource(name="llm-gateway")))
+
+        await _record_graph_event(
+            writer, chain_tracker, decoded, "orion:exec:result:LLMGatewayService:abc", 100.0, set()
+        )
+
+        (fact,), _ = writer.record_publish.call_args
+        assert fact.channel == "orion:exec:result:LLMGatewayService:abc"


### PR DESCRIPTION
## Summary

- "Idea 1" from the Phase 3+ brainstorm on the bus synaptic graph arc (`docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md`), found via the Hub hot-path view built in PR #1335.
- `orion-bus-mirror`'s FalkorDB graph had ~9K `Channel` nodes against a 264-entry declared catalog — every dynamic per-request reply channel (e.g. `orion:exec:result:LLMGatewayService:<uuid>`) got its own permanent node.
- `orion.bus.census.compute_census()` already had wildcard-prefix matching that solves exactly this, built earlier in this arc (PR #1312) for catalog-vs-live-traffic diffing, never applied to the graph's own node identity.
- Two new functions in `orion/bus/census.py` (shared, not service-specific): `load_channel_catalog_names()` and `normalize_channel_name()`. Wired into `orion-bus-mirror`'s graph writer.
- Live-verified end-to-end: 5 distinct simulated dynamic reply channels collapsed into exactly 1 `Channel` node with correctly accumulated edge count.

## Outcome moved

Going forward, `Channel` node cardinality tracks the real declared catalog (264 entries + genuinely undeclared traffic), not the catalog inflated by every dynamic reply-channel UUID. Sets up any future centrality/clustering analysis on top of this graph (Ideas 2/6 from the same brainstorm) to work against real topology instead of noise.

## Current architecture

`services/orion-bus-mirror/app/graph_writer.py::extract_bus_event_fact()` used the raw, literal `channel` string from every observed envelope as the `Channel` node's identity with no normalization. `orion.bus.census.compute_census()` (a different module in the same arc) already had the wildcard-matching logic needed to fix this, but nothing wired it into the graph writer.

## Architecture touched

- `orion/bus/census.py`: two new functions, `load_channel_catalog_names()` and `normalize_channel_name()`, plus a new module-level `import yaml` (verified safe — only 2 real importers of this module exist today, both already have `pyyaml` in `requirements.txt`; not a repeat of today's earlier `orion/graph/__init__.py`/`sparql_client` incident, which was a package-level `__init__.py` forcing the import on every importer of a whole package).
- `services/orion-bus-mirror/app/graph_writer.py::extract_bus_event_fact()`: new optional `catalog_names` param, normalizes `channel` before building the fact. SQLite raw-log path unaffected.
- `services/orion-bus-mirror/app/main.py::mirror_bus()`: loads the catalog once at startup, threads it through `_record_graph_event()` on every message.

## Files changed

- `orion/bus/census.py`: the two new shared functions.
- `orion/bus/tests/test_census.py`: 10 new tests.
- `services/orion-bus-mirror/app/graph_writer.py`, `app/main.py`: wiring.
- `services/orion-bus-mirror/tests/test_graph_writer.py`, `tests/test_main_graph_integration.py`: 6 new/changed tests (3 unit + 2 integration + `catalog_names=set()` mechanically added to 8 pre-existing `_record_graph_event()` call sites to keep their signature current).
- `services/orion-bus-mirror/README.md`: new "Channel node collapsing" section — what changed, the exact-match precedence fix, the stale-catalog-until-restart caveat, and the explicit known gap (existing inflated nodes not retroactively cleaned up).

## Schema / bus / API changes

- Added: none new. `Channel` node *identity* changes for new writes only (collapses to catalog wildcard entries where applicable) — not a new node/edge type.
- Removed: none.
- Renamed: none.
- Behavior changed: `Channel` nodes for dynamic reply channels now collapse to their catalog wildcard entry instead of each getting a unique node. Already-created nodes from before this fix are untouched (see Known gap).
- Compatibility notes: fully additive at the code level; existing graph data is not migrated.

## Env/config changes

None. No new settings — catalog path resolution is `__file__`-relative with a sensible default, no new env var needed.

## Tests run

```text
PYTHONPATH="services/orion-bus-mirror:." venv/bin/python -m pytest services/orion-bus-mirror/tests/ orion/bus/tests/test_census.py -q
72 passed (23 new)
```

## Evals run

No eval harness exists for this module (pre-existing gap). Live-verified twice against the real running FalkorDB instance and the real `orion/bus/channels.yaml` (265 entries):
1. Before the review fix: 5 distinct simulated dynamic reply channels for the same wildcard family collapsed into exactly 1 `Channel` node, `PUBLISHES` edge count correctly accumulated to 5.
2. After the review fix: ran `normalize_channel_name()` against every literal (non-wildcard) entry in the real catalog — confirmed 0 get incorrectly rewritten (was 8 before the fix), while a dynamic reply channel still correctly collapses to `orion:exec:result:LLMGatewayService:*`.

## Docker/build/smoke checks

Verified `orion/bus/channels.yaml` survives the container build: `services/orion-bus-mirror/Dockerfile` does `COPY orion /app/orion` (whole tree, no `.dockerignore` excluding yaml files anywhere in the repo), so `_DEFAULT_CATALOG_PATH`'s `__file__`-relative resolution (`/app/orion/bus/channels.yaml`) is correct inside the real container image, not just local dev.

## Review findings fixed

- Finding (material — would have shipped exactly backwards from this patch's own stated goal): `normalize_channel_name()` only checked wildcard-prefix matches, never exact catalog membership first. `channels.yaml` has real cases where a literal, standalone, already-declared channel (`orion:exec:result:LLMGatewayService`, `ContextExecService`, `VisionWindowService`, `VisionScribeService`, `VisionCouncilService`, `MetaTagsService`, `orion:cortex:result`, `orion:signals:memory_consolidation` — 8 total) shares a prefix with a broader wildcard sibling. These were getting merged into the coarse bucket instead of staying distinct — the opposite of "narrowest match wins."
  - Fix: added an exact-match short-circuit before wildcard matching.
  - Evidence: new test `test_normalize_channel_name_exact_match_short_circuits_a_wildcard_sibling` using the real `LLMGatewayService`/`orion:exec:result:*` pair; live-verified against the full real catalog — 0 of 265 literal entries now get rewritten (was 8).
- Verified, no change needed: `__file__`-relative catalog path resolution is correct inside the real Docker image (traced the Dockerfile's `COPY` layout directly).
- Verified, no change needed: the new module-level `yaml` import in `orion/bus/census.py` doesn't repeat today's earlier `sparql_client` crash class — independently re-confirmed only 2 real files import `orion.bus.census` today (`orion-bus-mirror`'s `graph_writer.py`/`main.py`), both already have `pyyaml` in `requirements.txt`, and `orion/bus/__init__.py` is empty so nothing re-exports `census` at the package level (unlike the `orion/graph/__init__.py` incident, which forced the import on every importer of that whole package).
- Verified, no change needed: the 8 mechanically-updated `_record_graph_event()` test call sites (added `catalog_names=set()` as a 6th positional arg via sed) — confirmed correct argument order against the new signature, no syntax breakage, no behavior change to those 8 pre-existing tests (all still pass).
- Addressed as documentation (non-blocking): the README now spells out the operational consequence of loading the catalog once at startup — a `channels.yaml` change won't take effect until the mirror restarts.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-bus-mirror/.env \
  -f services/orion-bus-mirror/docker-compose.yml \
  up -d --build
```

Restart is required for this fix to take effect (catalog is loaded once at startup — see README's new stale-catalog note).

## Risks / concerns

- Severity: informational
- Concern: the ~9K already-inflated `Channel` nodes from before this fix are not retroactively cleaned up — a real, separate migration/cleanup pass is still needed to fully resolve the original finding.
- Mitigation: named explicitly in README "Channel node collapsing" section as a known gap, not silently assumed unnecessary.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1337
