### PR TITLE
rename+fix(field-digester): execution_load -> cortex_exec_step_load, lane-gate cross-lane stomp

### DIFF
--- a/config/attention/field_attention_policy.v1.yaml
+++ b/config/attention/field_attention_policy.v1.yaml
@@ -26,7 +26,7 @@ node_channel_weights:
   thermal_pressure: 0.75
   staleness: 0.60
   availability: -0.40
-  execution_load: 0.70
+  cortex_exec_step_load: 0.70
   execution_friction: 0.85
   reasoning_load: 0.45
   failure_pressure: 1.00

--- a/config/field/biometrics_lattice.yaml
+++ b/config/field/biometrics_lattice.yaml
@@ -25,7 +25,7 @@ node_channels:
   - thermal_pressure
   - disk_pressure
   - expected_offline_suppression
-  - execution_load
+  - cortex_exec_step_load
   - execution_friction
   - reasoning_load
   - failure_pressure
@@ -75,7 +75,7 @@ edges:
     weight: 0.90
     channel_map:
       cpu_pressure: pressure
-      execution_load: execution_pressure
+      cortex_exec_step_load: execution_pressure
       execution_friction: reliability_pressure
       failure_pressure: reliability_pressure
       stream_backlog_pressure: pressure

--- a/config/field/field_channel_glossary.v1.yaml
+++ b/config/field/field_channel_glossary.v1.yaml
@@ -85,10 +85,17 @@ channels:
     meaning: "Signals a node is expected to be offline, so its absence shouldn't be read as a failure."
     self_state_dimension: coherence
 
-  - channel: execution_load
+  - channel: cortex_exec_step_load
     level: [node]
     category: task_execution
-    meaning: "How much active execution work (agent runs, tool calls) is in flight on a node."
+    meaning: "Renamed from execution_load 2026-07-24 for scope honesty (the sibling of
+      harness_step_load, cortex-exec-scoped instead of harness-governor-scoped) and
+      lane-gated to exclude the harness_motor lane (whose cortex_exec_started_step_count
+      is structurally always 0, since that counter only increments for
+      orion-cortex-exec-sourced exec_step_started events) -- previously that always-0
+      harness_motor-lane reading stomped the real cortex-exec-lane value via
+      mode=\"replace\" on the shared node key. cortex-exec-only proxy for how much active
+      execution work (agent runs, tool calls) is in flight on a node."
     evidence_dimension: execution_pressure
 
   - channel: execution_friction
@@ -122,7 +129,7 @@ channels:
   - channel: harness_step_load
     level: [node]
     category: task_execution
-    meaning: "FCC-motor-only step-load proxy for one unified Hub turn, split out of execution_load (which blends cortex-exec + harness-governor step counts and hard-caps at 8) -- a compute/thermal/power cost proxy for how much processing one turn actually cost on the expensive GPU node running the motor."
+    meaning: "FCC-motor-only step-load proxy for one unified Hub turn, split out of cortex_exec_step_load (renamed from execution_load 2026-07-24; blended cortex-exec + harness-governor step counts and hard-capped at 8 before the 2026-07-23 fix) -- a compute/thermal/power cost proxy for how much processing one turn actually cost on the expensive GPU node running the motor."
 
   - channel: tool_failure_streak_pressure
     level: [node]

--- a/config/field/orion_field_topology.v1.yaml
+++ b/config/field/orion_field_topology.v1.yaml
@@ -25,7 +25,7 @@ node_channels:
   - thermal_pressure
   - disk_pressure
   - expected_offline_suppression
-  - execution_load
+  - cortex_exec_step_load
   - execution_friction
   - reasoning_load
   - failure_pressure
@@ -75,7 +75,7 @@ edges:
     weight: 0.90
     channel_map:
       cpu_pressure: pressure
-      execution_load: execution_pressure
+      cortex_exec_step_load: execution_pressure
       execution_friction: reliability_pressure
       failure_pressure: reliability_pressure
       stream_backlog_pressure: pressure

--- a/docs/context-engineering/04_layer_1_to_11_pipeline.md
+++ b/docs/context-engineering/04_layer_1_to_11_pipeline.md
@@ -76,7 +76,7 @@ Field digestion maps pressure hints onto nodes, capabilities, channels, and edge
 Examples:
 
 ```text
-execution_load -> execution_pressure
+cortex_exec_step_load -> execution_pressure
 failure_pressure -> reliability_pressure
 cpu_pressure -> resource pressure
 ```

--- a/docs/context-engineering/05_reducer_and_state_delta_pattern.md
+++ b/docs/context-engineering/05_reducer_and_state_delta_pattern.md
@@ -113,7 +113,7 @@ Example:
 
 ```json
 {
-  "execution_load": 0.375,
+  "cortex_exec_step_load": 0.375,
   "reasoning_load": 0.05,
   "failure_pressure": 0.0,
   "egress_confidence": 1.0,

--- a/orion/field/pressure.py
+++ b/orion/field/pressure.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from orion.schemas.field_state import FieldStateV1
 
 PRESSURE_CHANNELS = frozenset({
-    "execution_load",
+    "cortex_exec_step_load",
     "execution_friction",
     "execution_pressure",
     "failure_pressure",

--- a/orion/field_coherence.py
+++ b/orion/field_coherence.py
@@ -6,8 +6,8 @@ from orion.schemas.field_state import FieldStateV1
 # Suspicion fires when channel_a is HIGH and channel_b is LOW, suggesting
 # the two reducers disagree about the node's actual state.
 _RULES: tuple[tuple[str, str], ...] = (
-    ("execution_load", "cpu_pressure"),
-    ("execution_load", "gpu_pressure"),
+    ("cortex_exec_step_load", "cpu_pressure"),
+    ("cortex_exec_step_load", "gpu_pressure"),
     ("failure_pressure", "availability"),
     ("stream_backlog_pressure", "stream_backlog_health"),
     ("reasoning_load", "cpu_pressure"),

--- a/orion/mood_arc/README.md
+++ b/orion/mood_arc/README.md
@@ -195,6 +195,18 @@ python orion/mood_arc/fit_encoder.py train \
   `--min-generated-at` command and full reasoning. Juniper's explicit call: don't block the
   rename on retrain timing — `v3` keeps serving with 2 of 15 inputs dark until a `v4` retrain,
   same posture as every prior cutoff.
+- **Seventh cutoff, same day (2026-07-24):** `execution_load` renamed to
+  `cortex_exec_step_load` (the cortex-exec-scoped sibling of `harness_step_load`), same
+  genuinely-absent-by-name failure mode as the sixth cutoff. Only 1 of `v3`'s 15 trained
+  channels affected here (vs. 2 for the sixth cutoff). The same patch also fixed a live
+  cross-lane stomp bug on this channel's values (a `harness_motor`-lane delta's
+  structurally-always-`0.0` reading was overwriting the real cortex-exec-lane value via
+  `mode="replace"` on the shared node key) — a behavior change to the channel's values,
+  not just its name, landing in the same restart. See
+  `services/orion-field-digester/README.md`'s matching seventh-cutoff entry and
+  `cortex_exec_step_load` glossary entry for the full mechanism and `--min-generated-at`
+  command. Same posture as every prior cutoff: don't block on retrain timing, `v3` keeps
+  serving with 1 of 15 inputs dark until a `v4` retrain.
 - **Scope caveat on `prediction_error`'s "transport" contributor (found 2026-07-22, not a new
   cutoff — no code changed, just what the channel actually means):** `prediction_error` is a
   `max()`-merge across five nodes; one of them, `node:substrate.transport`, is fed entirely by

--- a/orion/schemas/execution_projection.py
+++ b/orion/schemas/execution_projection.py
@@ -36,7 +36,7 @@ class ExecutionRunStateV1(BaseModel):
     # subtraction silently reads 0 despite real cortex-exec steps having occurred (live
     # in code review). Tracking it directly avoids this entirely, mirroring
     # harness_started_step_count's own correct pattern. See NODE_CHANNELS
-    # "execution_load".
+    # "cortex_exec_step_load" (renamed from "execution_load" 2026-07-24).
     cortex_exec_started_step_count: int = 0
     # HarnessRunV1.compliance_verdict threaded through as a grammar-stream kv; "unknown"
     # until a real exec_result_assembled event sets it.

--- a/orion/schemas/telemetry/field_channel_corpus.py
+++ b/orion/schemas/telemetry/field_channel_corpus.py
@@ -22,7 +22,7 @@ node/per-capability channel pressures from `FieldStateV1`, via
 tuple[dict[str, float], dict[str, str]]` -- the function that merges
 `node_vectors` + `capability_vectors` into one flat channel-name-keyed dict
 (e.g. `cpu_pressure`, `gpu_pressure`, `memory_pressure`,
-`thermal_pressure`, `execution_load`, `execution_friction`,
+`thermal_pressure`, `cortex_exec_step_load`, `execution_friction`,
 `reliability_pressure`, typically 10-20 channels), already used by
 `coherence_score()`/`uncertainty_score()`. This is BEFORE any of the
 coherence/novelty/valence hand-weighting is applied -- the right layer to

--- a/orion/substrate/execution_loop/grammar_extract.py
+++ b/orion/substrate/execution_loop/grammar_extract.py
@@ -25,19 +25,21 @@ _COMPLIANCE_DEFICIT_RANK = {
 }
 
 # Reference denominator for harness_step_load's log-ratio, not a hard cap. Chosen well
-# above execution_load's *former* hard cap (8) so an 8-step run reads meaningfully below
-# saturation (~0.53) instead of identical to a 40-step run (~0.90) -- unlike the old
+# above cortex_exec_step_load's *former* hard cap (8) so an 8-step run reads meaningfully
+# below saturation (~0.53) instead of identical to a 40-step run (~0.90) -- unlike the old
 # execution_load's min(1.0, n/8.0). A starting anchor, not yet calibrated against live
 # step-count distributions -- see spec doc's Missing Questions.
 _HARNESS_STEP_LOAD_SATURATION_STEPS = 60
 
-# execution_load now uses the same log-ratio shape as harness_step_load, once it stopped
-# being a hard-capped min(1.0, n/8.0) (see 2026-07-23-fcc-motor-field-digester-signals-
-# design.md Appendix item 1). Reuses the same saturation anchor as harness_step_load --
-# the two channels are now structurally symmetric (cortex-exec-only magnitude vs
-# harness-governor-only magnitude), and inventing a second, differently-calibrated
-# constant with no live data to justify it would just be a second unvalidated guess.
-_EXECUTION_LOAD_SATURATION_STEPS = _HARNESS_STEP_LOAD_SATURATION_STEPS
+# cortex_exec_step_load (renamed from execution_load 2026-07-24 for scope honesty -- see
+# NODE_CHANNELS glossary entry) now uses the same log-ratio shape as harness_step_load,
+# once it stopped being a hard-capped min(1.0, n/8.0) (see 2026-07-23-fcc-motor-field-
+# digester-signals-design.md Appendix item 1). Reuses the same saturation anchor as
+# harness_step_load -- the two channels are now structurally symmetric (cortex-exec-only
+# magnitude vs harness-governor-only magnitude), and inventing a second, differently-
+# calibrated constant with no live data to justify it would just be a second unvalidated
+# guess.
+_CORTEX_EXEC_STEP_LOAD_SATURATION_STEPS = _HARNESS_STEP_LOAD_SATURATION_STEPS
 
 # reasoning_load's saturation anchor for its new log-ratio-of-chars shape (see Appendix
 # item 2). Matches avg_step_chars_pressure's existing 4000-char/step anchor -- both are
@@ -90,10 +92,10 @@ def compute_pressure_hints(
     # despite real cortex-exec steps having occurred. See
     # docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md
     # Appendix item 1.
-    execution_load = min(
+    cortex_exec_step_load = min(
         1.0,
         math.log1p(max(0, run.cortex_exec_started_step_count))
-        / math.log1p(_EXECUTION_LOAD_SATURATION_STEPS),
+        / math.log1p(_CORTEX_EXEC_STEP_LOAD_SATURATION_STEPS),
     )
     execution_friction = min(1.0, failed / max(1, started))
     # Was a boolean wearing a magnitude's name (0.35 if reasoning_present else 0.05) --
@@ -129,8 +131,8 @@ def compute_pressure_hints(
     status_fail = run.status.lower() in {"fail", "partial", "failed", "error"}
     failure_pressure = 1.0 if status_fail or failed > 0 else 0.0
     egress_confidence = 1.0 if egress_emitted else 0.25
-    # FCC-motor-only step load, split from `execution_load` above (both now log-ratio
-    # shaped over their own source-scoped step count, cortex-exec-only vs
+    # FCC-motor-only step load, split from `cortex_exec_step_load` above (both now
+    # log-ratio shaped over their own source-scoped step count, cortex-exec-only vs
     # harness-governor-only, instead of one blended hard-capped counter).
     # log1p-then-ratio, NOT bare log1p: every NODE_CHANNELS value gets hard-clamped to
     # [0,1] at write time by apply_perturbations() (mode="replace" ->
@@ -179,7 +181,7 @@ def compute_pressure_hints(
     # need it (services/orion-field-digester/app/ingest/state_deltas.py)
     # should read it from there directly, not from pressure_hints.
     return {
-        "execution_load": execution_load,
+        "cortex_exec_step_load": cortex_exec_step_load,
         "execution_friction": execution_friction,
         "reasoning_load": reasoning_load,
         "failure_pressure": failure_pressure,

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -55,7 +55,7 @@ def execution_prediction_error(
             prev_run = prev_fallback
         if prev_run is None:
             continue
-        for key in ("execution_load", "execution_friction", "failure_pressure", "reasoning_load"):
+        for key in ("cortex_exec_step_load", "execution_friction", "failure_pressure", "reasoning_load"):
             pv = prev_run.pressure_hints.get(key, 0.0)
             cv = curr_run.pressure_hints.get(key, 0.0)
             deltas.append(abs(cv - pv))

--- a/orion/substrate/relational/adapters/execution_ctx.py
+++ b/orion/substrate/relational/adapters/execution_ctx.py
@@ -1,7 +1,7 @@
 """Execution-trajectory adapter — binds the substrate's execution "felt state".
 
 Maps ``ExecutionTrajectoryProjectionV1`` (per-run trace state: verb, status,
-step counts, and the pressure hints the execution lane derives — execution_load,
+step counts, and the pressure hints the execution lane derives — cortex_exec_step_load,
 execution_friction, failure_pressure, reasoning_load) into substrate belief nodes
 anchored to Orion, so the unified belief set contains beliefs about Orion's own
 in-flight execution.

--- a/orion/substrate/relational/tests/test_reducer_lane_adapters.py
+++ b/orion/substrate/relational/tests/test_reducer_lane_adapters.py
@@ -43,7 +43,7 @@ def _execution_projection(n: int = 1) -> ExecutionTrajectoryProjectionV1:
             status="running",
             step_count=3 + i,
             pressure_hints={
-                "execution_load": 0.4,
+                "cortex_exec_step_load": 0.4,
                 "execution_friction": 0.9,
                 "failure_pressure": 0.1,
                 "reasoning_load": 0.2,

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -158,14 +158,14 @@ def _exec_projection(runs: dict[str, ExecutionRunStateV1]) -> ExecutionTrajector
 
 
 def test_execution_prediction_error_zero_when_no_change() -> None:
-    prev = _exec_projection({"r1": _exec_run("r1", pressure_hints={"execution_load": 0.25})})
-    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"execution_load": 0.25})})
+    prev = _exec_projection({"r1": _exec_run("r1", pressure_hints={"cortex_exec_step_load": 0.25})})
+    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"cortex_exec_step_load": 0.25})})
     assert execution_prediction_error(prev, curr) == 0.0
 
 
 def test_execution_prediction_error_scales_with_delta_magnitude_on_exact_match() -> None:
-    prev = _exec_projection({"r1": _exec_run("r1", pressure_hints={"execution_load": 0.0})})
-    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"execution_load": 0.3})})
+    prev = _exec_projection({"r1": _exec_run("r1", pressure_hints={"cortex_exec_step_load": 0.0})})
+    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"cortex_exec_step_load": 0.3})})
     # mean of one key's delta (0.3) across the other three implicit-0.0 keys:
     # (0.3 + 0 + 0 + 0) / 4 = 0.075 -> 0.075 / 0.30 = 0.25
     assert execution_prediction_error(prev, curr) == pytest.approx(0.25)
@@ -175,7 +175,7 @@ def test_execution_prediction_error_zero_when_prev_empty() -> None:
     """No prev runs at all -- no fallback reference exists either, must stay 0.0,
     not raise."""
     prev = _exec_projection({})
-    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"execution_load": 0.9})})
+    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"cortex_exec_step_load": 0.9})})
     assert execution_prediction_error(prev, curr) == 0.0
 
 
@@ -187,10 +187,10 @@ def test_execution_prediction_error_falls_back_to_latest_prev_run_for_new_trace_
     curr with no prev counterpart must now diff against prev's most-recently-updated
     run instead of contributing nothing."""
     prev = _exec_projection(
-        {"prior-run": _exec_run("prior-run", pressure_hints={"execution_load": 0.0})}
+        {"prior-run": _exec_run("prior-run", pressure_hints={"cortex_exec_step_load": 0.0})}
     )
     curr = _exec_projection(
-        {"new-run": _exec_run("new-run", pressure_hints={"execution_load": 0.3})}
+        {"new-run": _exec_run("new-run", pressure_hints={"cortex_exec_step_load": 0.3})}
     )
     # Same magnitude as the exact-match case above: must not silently stay 0.0.
     assert execution_prediction_error(prev, curr) == pytest.approx(0.25)
@@ -202,18 +202,18 @@ def test_execution_prediction_error_fallback_uses_most_recently_updated_prev_run
         {
             "older": _exec_run(
                 "older",
-                pressure_hints={"execution_load": 0.9},
+                pressure_hints={"cortex_exec_step_load": 0.9},
                 last_updated_at=_NOW - timedelta(minutes=5),
             ),
             "newer": _exec_run(
                 "newer",
-                pressure_hints={"execution_load": 0.0},
+                pressure_hints={"cortex_exec_step_load": 0.0},
                 last_updated_at=_NOW,
             ),
         }
     )
     curr = _exec_projection(
-        {"brand-new": _exec_run("brand-new", pressure_hints={"execution_load": 0.3})}
+        {"brand-new": _exec_run("brand-new", pressure_hints={"cortex_exec_step_load": 0.3})}
     )
     # Must diff against "newer" (delta 0.3), not "older" (delta 0.6).
     assert execution_prediction_error(prev, curr) == pytest.approx(0.25)
@@ -227,17 +227,17 @@ def test_execution_prediction_error_prefers_exact_trace_id_match_over_fallback()
         {
             "r1": _exec_run(
                 "r1",
-                pressure_hints={"execution_load": 0.25},
+                pressure_hints={"cortex_exec_step_load": 0.25},
                 last_updated_at=_NOW - timedelta(minutes=5),
             ),
             "unrelated-newer": _exec_run(
                 "unrelated-newer",
-                pressure_hints={"execution_load": 0.9},
+                pressure_hints={"cortex_exec_step_load": 0.9},
                 last_updated_at=_NOW,
             ),
         }
     )
-    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"execution_load": 0.25})})
+    curr = _exec_projection({"r1": _exec_run("r1", pressure_hints={"cortex_exec_step_load": 0.25})})
     assert execution_prediction_error(prev, curr) == 0.0
 
 

--- a/services/orion-field-digester/README.md
+++ b/services/orion-field-digester/README.md
@@ -155,7 +155,7 @@ v1 persists projections to Postgres only; bus emit is deferred (`orion/bus/chann
 JSONL sink (`FIELD_CHANNEL_CORPUS_PATH`) — the flat, channel-name-keyed
 output of `orion.self_state.scoring.collect_field_channel_pressures(state)`
 (the merged `node_vectors`/`capability_vectors` pressure dict, e.g.
-`cpu_pressure`/`gpu_pressure`/`memory_pressure`/`execution_load`/etc.,
+`cpu_pressure`/`gpu_pressure`/`memory_pressure`/`cortex_exec_step_load`/etc.,
 typically 10-20 channels, not a fixed set). This is Item 1 v2 of
 `docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md` — the
 corrected replacement target for `orion-spark-introspector`'s
@@ -566,6 +566,34 @@ is latest — as of this writing, that's this sixth cutoff, superseding the fift
 `orion/mood_arc/README.md`'s matching sixth-cutoff entry — keep the two in sync if either is ever
 revised, same convention as the first five.
 
+## `field_channel_corpus.v1` seventh training-data quality cutoff (2026-07-24)
+
+Same day, same failure mode as the sixth cutoff, different channel: `execution_load` renamed
+to `cortex_exec_step_load` (see that channel's glossary entry above) — the cortex-exec-scoped
+sibling of `harness_step_load`, split off from a name that implied "all execution work" when
+it was always cortex-exec-only. `execution_load` is one of `v3`'s 15 trained channels (the
+fifth cutoff above), so this is genuinely-absent-by-name for `build_windows()`, same mechanism
+as the sixth cutoff — not a distribution shift, a field going dark. Unlike the sixth cutoff's
+two renamed channels, only one of `v3`'s 15 inputs is affected here.
+
+The same patch also lane-gated `cortex_exec_step_load` against the cross-lane stomp described
+in its glossary entry above — a live behavior change to the channel's *values*, not just its
+name, on top of the rename. Both changes land in the same restart, so one cutoff timestamp
+covers both.
+
+```bash
+python orion/mood_arc/fit_encoder.py train \
+  --corpus /mnt/telemetry/field_channels/corpus/field_channels.jsonl \
+  --min-generated-at <this patch's deploy restart timestamp, `docker inspect orion-athena-field-digester --format '{{.State.StartedAt}}'`> \
+  --out <out-dir>
+```
+
+Same posture as every prior cutoff: don't block on retrain timing, `v3` keeps serving with 1 of
+15 inputs dark until a `v4` retrain. If multiple cutoffs apply, use whichever is latest — as of
+this writing, that's this seventh cutoff, superseding the sixth's. See
+`orion/mood_arc/README.md`'s matching seventh-cutoff entry — keep the two in sync if either is
+ever revised, same convention as the first six.
+
 ## Field channel glossary
 
 This is the consolidated reference for all 35 channels in
@@ -708,7 +736,7 @@ subset for the mood-arc windowed-autoencoder spike (see
 1. **Physical substrate / embodiment** — `cpu_pressure`, `gpu_pressure`,
    `thermal_pressure`, `memory_pressure`, `disk_pressure`. Pure hardware
    sensor readings. Nothing cognitive here at all.
-2. **Task-execution domain** — `execution_load`, `execution_friction`,
+2. **Task-execution domain** — `cortex_exec_step_load`, `execution_friction`,
    `execution_pressure`, `reasoning_load`, `reasoning_pressure`,
    `failure_pressure`, `egress_confidence_deficit`. What Orion is actively
    *doing* computationally right now (all sourced from `execution_run`
@@ -880,14 +908,18 @@ subset for the mood-arc windowed-autoencoder spike (see
 - **Live-data verdict**: one-way ratchet — latched at `1.0` for the entire
   observed corpus span. Confirmed live 2026-07-16.
 
-#### `execution_load`
-- **Meaning**: how much active execution work (agent runs, tool calls) is in
-  flight on a node.
-- **Producer**: `execution_run` delta, mode=`replace`. In
-  `NODE_DECAY_CHANNELS`. Diffuses into `capability:orchestration`
-  (`execution_pressure`, weight `0.90`).
+#### `cortex_exec_step_load`
+- **Renamed from `execution_load` 2026-07-24** for scope honesty -- the
+  cortex-exec-scoped sibling of `harness_step_load` (harness-governor-scoped), not
+  "all execution work" the old name implied. Seventh training-data cutoff, below.
+- **Meaning**: how much active cortex-exec-sourced execution work (agent runs, tool
+  calls) is in flight on a node -- specifically the cortex-exec side; the
+  harness-governor side is `harness_step_load`.
+- **Producer**: `execution_run` delta, mode=`replace`, gated to exclude the
+  `harness_motor` lane (2026-07-24 fix, below). In `NODE_DECAY_CHANNELS`. Diffuses
+  into `capability:orchestration` (`execution_pressure`, weight `0.90`).
 - **SelfState dimension fed**: not in `channel_dimension_map` directly
-  (removed 2026-07-12). `evidence_channel_map`: `execution_load` →
+  (removed 2026-07-12). `evidence_channel_map`: `cortex_exec_step_load` →
   `execution_pressure` (evidence-only).
 - **Live-data verdict**: real signal, continuous. Confirmed live 2026-07-16.
   **Correction 2026-07-23:** "continuous" was true of the values seen, not the
@@ -901,6 +933,40 @@ subset for the mood-arc windowed-autoencoder spike (see
   log-ratio shape `harness_step_load` already uses, instead of a hard cap. See
   `docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md`
   Appendix item 1.
+- **LIVE-CONFIRMED BUG, fixed 2026-07-24 (cross-lane stomp, same class as PR #1289's
+  fix for `harness_step_load`/`tool_failure_streak_pressure`/`avg_step_chars_pressure`/
+  `compliance_deficit`/`context_gathering_ratio`, just never gated for this channel
+  before now):** `run.cortex_exec_started_step_count` only increments for
+  `event.provenance.source_service == "orion-cortex-exec"` events
+  (`grammar_extract.py`'s event loop) -- a `harness_motor`-lane `ExecutionRunStateV1`
+  object (whose events all come from `orion-harness-governor`) structurally can never
+  populate that counter, so this channel's value is always `0.0` on that lane, every
+  time, not just usually. Before this gate, that always-`0.0` harness_motor-lane
+  delta stomped whatever real value cortex-exec's own bare-trace lane had just
+  written, via `mode="replace"` on the shared node key (both lanes always resolve to
+  `node:athena`). Confirmed live against `substrate_field_state.field_json` (3h
+  window, 2026-07-24): `node:athena.execution_load` sat flat at
+  `0.3372261973790022` except two consecutive ~2-second samples (17:29:45-47Z)
+  dipping to `0.2672454385532547` before recovering -- a smaller/gentler symptom
+  than the pre-2026-07-23 blended-counter flapping (`0.25→1.0→0.25...` within one
+  turn) because `apply_decay()`'s hold-if-fresh logic (see "Decay vs.
+  injection-interval mismatch" above) only smooths, not eliminates, an intermittent
+  partial stomp -- the next real cortex-exec-lane delta overwrote the stomped `0.0`
+  again within its own tick, unlike a channel that never recovers. Fixed by
+  excluding this channel entirely from `harness_motor`-lane emission in
+  `state_deltas.py`'s unconditional per-lane loop, with **no re-emission** (unlike
+  `reasoning_load` below) -- `harness_step_load` already covers the
+  harness-governor side of step-load separately, so no data is lost.
+  `execution_friction`/`failure_pressure` were investigated for the same bug class
+  and found NOT to have it: unlike this channel, their source fields
+  (`run.failed_step_count`, `run.status`) are set unconditionally regardless of
+  `event.provenance.source_service`, so a `harness_motor`-lane run object's own
+  `execution_friction`/`failure_pressure` can be a real, independently-meaningful
+  observation (the motor's own step genuinely failed), not a structural always-`0.0`
+  placeholder. Gating them out the same way would silently discard real
+  harness-side failure signal -- flagged as a follow-up needing a compose-not-replace
+  design decision (e.g. `max()` across a turn's sub-lanes), not a mechanical
+  gate-exclusion; not built here.
 
 #### `execution_friction`
 - **Meaning**: how much resistance (retries/backoff) execution is
@@ -1036,8 +1102,9 @@ follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
 
 #### `harness_step_load`
 - **Meaning**: FCC-motor-only step-load proxy for one unified Hub turn, split out of
-  `execution_load` (which blends cortex-exec + harness-governor step counts and hard-caps
-  at 8). A compute/thermal/power cost proxy for how much processing one turn actually cost
+  `cortex_exec_step_load` (renamed from `execution_load` 2026-07-24; blended cortex-exec +
+  harness-governor step counts and hard-capped at 8 before the 2026-07-23 fix). A
+  compute/thermal/power cost proxy for how much processing one turn actually cost
   on the expensive GPU node running the motor.
 - **Producer**: `execution_run` delta, `min(1.0, log1p(harness_started_step_count) /
   log1p(60))`, mode=`replace`. In `NODE_DECAY_CHANNELS`.
@@ -1058,9 +1125,11 @@ follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
   patch.
 - **Live-data verdict**: not yet live-verified, pending deploy. See
   `docs/superpowers/specs/2026-07-23-fcc-motor-field-digester-signals-design.md` for the
-  full design and the `execution_load` split rationale (also flagged there as needing its
-  own follow-up: `execution_load` itself was left unnarrowed in this patch, so it still
-  double-counts harness-governor steps that this channel now also measures separately).
+  full design and the `cortex_exec_step_load` (then still named `execution_load`) split
+  rationale (also flagged there as needing its own follow-up: `execution_load` itself was
+  left unnarrowed in that patch, so it still double-counted harness-governor steps that
+  this channel now also measures separately -- narrowed 2026-07-23, see that channel's own
+  glossary entry above).
 
 #### `tool_failure_streak_pressure`
 - **Meaning**: is the FCC motor stuck repeating the same tool failure (e.g. a denied
@@ -1403,8 +1472,8 @@ follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
 - **Meaning**: per-node incoherence score — fires when one channel is high
   and a paired channel that should track it is simultaneously low,
   suggesting two different reducers disagree about the node's actual
-  state (rules: `execution_load`/`cpu_pressure`,
-  `execution_load`/`gpu_pressure`, `failure_pressure`/`availability`,
+  state (rules: `cortex_exec_step_load`/`cpu_pressure`,
+  `cortex_exec_step_load`/`gpu_pressure`, `failure_pressure`/`availability`,
   `stream_backlog_pressure`/`stream_backlog_health`, `reasoning_load`/`cpu_pressure` —
   `orion/field_coherence.py`).
 - **Producer**: **not** one of `state_deltas.py`'s six `target_kind`
@@ -1501,14 +1570,14 @@ follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
 - **Meaning**: capability-level execution-load pressure (currently only
   populated for `orchestration`).
 - **Producer**: capability-level, diffused from `node:athena →
-  capability:orchestration` (`execution_load` → `execution_pressure`,
+  capability:orchestration` (`cortex_exec_step_load` → `execution_pressure`,
   weight `0.90`). In `CAPABILITY_DECAY_CHANNELS`, same dead-weight caveat as
   `pressure` (overwritten by `apply_diffusion()` immediately after decay,
   every tick).
 - **SelfState dimension fed**: `channel_dimension_map`: `execution_pressure`
   → `execution_pressure` (direct, 1:1 dimension name).
 - **Live-data verdict**: real signal, continuous — same underlying trace as
-  `execution_load`. Confirmed live 2026-07-16.
+  `cortex_exec_step_load`. Confirmed live 2026-07-16.
 
 #### `reasoning_pressure`
 - **Meaning**: capability-level reasoning-load pressure. Nominally
@@ -1560,7 +1629,7 @@ follow-up note, and `test_execution_run_fcc_channels_ignored_off_lane` /
   on the run, and routing `reasoning_load`'s perturbation to that node
   specifically instead of the orchestrating node — see `reasoning_load`'s
   entry above and `app/ingest/state_deltas.py`. Deliberately scoped to
-  `reasoning_load` only; `execution_load`/`execution_friction`/
+  `reasoning_load` only; `cortex_exec_step_load`/`execution_friction`/
   `failure_pressure` are legitimately orchestrator-node concerns and stay on
   `node:athena`. Re-verify `capability:llm_inference.reasoning_pressure`'s
   liveness against `substrate_field_state` once post-deploy LLM traffic has

--- a/services/orion-field-digester/app/digestion/decay.py
+++ b/services/orion-field-digester/app/digestion/decay.py
@@ -18,7 +18,7 @@ NODE_DECAY_CHANNELS = {
     "thermal_pressure",
     "disk_pressure",
     # execution
-    "execution_load",
+    "cortex_exec_step_load",
     "execution_friction",
     "reasoning_load",
     "failure_pressure",

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -47,7 +47,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                     # this intensity is a full current-availability estimate
                     # recomputed fresh from this tick's pressure_score, not an
                     # incremental delta -- same "current reading" shape as
-                    # stream_backlog_health/delivery_confidence/execution_load elsewhere
+                    # stream_backlog_health/delivery_confidence/cortex_exec_step_load elsewhere
                     # in this file. Without mode="replace",
                     # apply_perturbations() special-cases channel=="availability"
                     # to floor-only (min(current, intensity)): can decrease but
@@ -244,8 +244,26 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
         reasoning_node_key = (
             _node_key(str(llm_serving_node)) if llm_serving_node else node_key
         )
+        # execution_friction/failure_pressure investigated for the same cross-lane stomp
+        # (2026-07-24, alongside the cortex_exec_step_load fix above) and deliberately
+        # left UNGATED here -- not the same bug class, confirmed by code trace (no live
+        # harness_motor-lane execution_run data survived the 2026-07-23 Postgres disk
+        # loss to reproduce against directly). Unlike cortex_exec_step_load,
+        # grammar_extract.py's "exec_step_failed"/"exec_result_assembled" handlers
+        # increment run.failed_step_count / set run.status unconditionally, with no
+        # source_service branch -- so a harness_motor-lane ExecutionRunStateV1 object's
+        # own execution_friction/failure_pressure can be a real, independently-meaningful
+        # observation (the motor's own step genuinely failed), not a structural always-0
+        # placeholder the way cortex_exec_step_load's harness_motor reading always was.
+        # Gating them out the same way would silently discard real harness-side failure
+        # signal, the same tradeoff PR #1318 avoided for reasoning_load by re-emitting
+        # rather than excluding. These two channels don't have reasoning_load's clean
+        # escape hatch (a second node_key to attribute to) since both always target the
+        # same node_key regardless of lane -- a real fix needs a compose-not-replace
+        # policy decision (e.g. max() across a turn's sub-lanes) or per-lane node keys,
+        # not a mechanical gate-exclusion. Flagged as a follow-up, not built here.
         for channel, key, target_node in (
-            ("execution_load", "execution_load", node_key),
+            ("cortex_exec_step_load", "cortex_exec_step_load", node_key),
             ("execution_friction", "execution_friction", node_key),
             ("reasoning_load", "reasoning_load", reasoning_node_key),
             ("failure_pressure", "failure_pressure", node_key),
@@ -262,6 +280,34 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
             # not expanding scope to audit lanes this patch doesn't add a new data source
             # to.
             if channel == "reasoning_load" and delta.target_id.endswith(":harness_motor"):
+                continue
+            # cortex_exec_step_load (renamed from execution_load 2026-07-24) is excluded
+            # entirely from the harness_motor lane, with NO re-emission -- unlike
+            # reasoning_load, this channel has no legitimate harness_motor-lane value.
+            # compute_pressure_hints()'s cortex_exec_step_load is derived solely from
+            # run.cortex_exec_started_step_count, which grammar_extract.py's event loop
+            # only increments for event.provenance.source_service == "orion-cortex-exec"
+            # -- a harness_motor-lane ExecutionRunStateV1 object (whose events all come
+            # from orion-harness-governor) structurally can never populate that counter,
+            # so this key is always 0.0 on that lane, every time, not just usually. Before
+            # this gate, that always-0.0 stomped whatever real value cortex-exec's own
+            # bare-trace lane had written to the same node_key (always "node:athena" for
+            # both producers) -- same cross-lane mode="replace" stomp class PR #1289
+            # fixed for harness_step_load/tool_failure_streak_pressure/
+            # avg_step_chars_pressure/compliance_deficit/context_gathering_ratio, just
+            # never gated for this one. Confirmed live 2026-07-24:
+            # substrate_field_state.field_json's node:athena.execution_load sat flat at
+            # 0.3372261973790022 except two consecutive ~2s samples dipping to
+            # 0.2672454385532547 before recovering -- a smaller/gentler symptom than
+            # execution_load's pre-2026-07-23 blended-counter flapping (0.25->1.0->0.25
+            # within one turn) because apply_decay()'s hold-if-fresh logic (see this
+            # service's README "Decay vs. injection-interval mismatch") only smooths, not
+            # eliminates, an intermittent partial-stomp -- the next real cortex-exec-lane
+            # delta still overwrites the stomped 0.0 within its own tick, unlike a channel
+            # that never recovers. harness_step_load already covers the harness-governor
+            # side of step-load separately -- no data is lost by excluding this channel
+            # from the harness_motor lane outright.
+            if channel == "cortex_exec_step_load" and delta.target_id.endswith(":harness_motor"):
                 continue
             if key in hints:
                 out.append(
@@ -392,7 +438,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
         # scratch via extract_transport_bus_state_from_events every time it
         # reduces new bus-trace events -- not an incremental delta), the same
         # "here's the current reading" shape already used for
-        # execution_load/execution_friction/reasoning_load/failure_pressure/
+        # cortex_exec_step_load/execution_friction/reasoning_load/failure_pressure/
         # egress_confidence_deficit/prediction_error elsewhere in this file,
         # all of which use mode="replace".
         #

--- a/services/orion-field-digester/app/tensor/channels.py
+++ b/services/orion-field-digester/app/tensor/channels.py
@@ -7,7 +7,7 @@ NODE_CHANNELS = [
     "thermal_pressure",
     "disk_pressure",
     "expected_offline_suppression",
-    "execution_load",
+    "cortex_exec_step_load",
     "execution_friction",
     "reasoning_load",
     "failure_pressure",

--- a/services/orion-field-digester/tests/test_decay_hold.py
+++ b/services/orion-field-digester/tests/test_decay_hold.py
@@ -42,7 +42,7 @@ def _state(node_vectors: dict[str, dict[str, float]] | None = None) -> FieldStat
 def test_new_fcc_motor_channels_are_registered_for_decay() -> None:
     """A channel only decays if listed in NODE_DECAY_CHANNELS (separate from being in
     NODE_CHANNELS) -- otherwise it holds forever. Written through the normal
-    state_deltas.py -> apply_perturbations() path (same as execution_load), these get
+    state_deltas.py -> apply_perturbations() path (same as cortex_exec_step_load), these get
     node_vector_updated_at stamped automatically, so no manual-stamping test is needed
     here -- this just confirms the registration itself, the miss this service's own
     CLAUDE.md warns has already happened once for a different channel."""

--- a/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_execution_run_perturbations.py
@@ -44,7 +44,7 @@ def test_execution_run_without_llm_serving_node_targets_run_node() -> None:
     today's behavior."""
     delta = _make_execution_run_delta(
         pressure_hints={
-            "execution_load": 0.5,
+            "cortex_exec_step_load": 0.5,
             "execution_friction": 0.1,
             "reasoning_load": 0.05,
             "failure_pressure": 0.0,
@@ -53,12 +53,12 @@ def test_execution_run_without_llm_serving_node_targets_run_node() -> None:
     perturbations = delta_to_perturbations(delta)
     by_channel = {p.channel: p for p in perturbations}
     assert by_channel["reasoning_load"].node_id == "node:athena"
-    assert by_channel["execution_load"].node_id == "node:athena"
+    assert by_channel["cortex_exec_step_load"].node_id == "node:athena"
 
 
 def test_execution_run_with_llm_serving_node_routes_reasoning_load_only() -> None:
     """A run whose LLM call was served by atlas attributes reasoning_load to
-    node:atlas specifically, while execution_load/execution_friction/
+    node:atlas specifically, while cortex_exec_step_load/execution_friction/
     failure_pressure stay on the orchestrating node (athena) -- see
     services/orion-field-digester/README.md's reasoning_pressure glossary
     entry for why node:atlas.reasoning_load was permanently 0.0 before this.
@@ -68,7 +68,7 @@ def test_execution_run_with_llm_serving_node_routes_reasoning_load_only() -> Non
     over the same dict)."""
     delta = _make_execution_run_delta(
         pressure_hints={
-            "execution_load": 0.5,
+            "cortex_exec_step_load": 0.5,
             "execution_friction": 0.1,
             "reasoning_load": 0.35,
             "failure_pressure": 0.0,
@@ -79,7 +79,7 @@ def test_execution_run_with_llm_serving_node_routes_reasoning_load_only() -> Non
     by_channel = {p.channel: p for p in perturbations}
     assert by_channel["reasoning_load"].node_id == "node:atlas"
     assert by_channel["reasoning_load"].intensity == 0.35
-    assert by_channel["execution_load"].node_id == "node:athena"
+    assert by_channel["cortex_exec_step_load"].node_id == "node:athena"
     assert by_channel["execution_friction"].node_id == "node:athena"
     assert by_channel["failure_pressure"].node_id == "node:athena"
 
@@ -262,3 +262,49 @@ def test_execution_run_noop_delta_skipped() -> None:
     )
     delta = delta.model_copy(update={"operation": "noop"})
     assert delta_to_perturbations(delta) == []
+
+
+def test_execution_run_cortex_exec_step_load_ignored_off_lane() -> None:
+    """cortex_exec_step_load (renamed from execution_load 2026-07-24) must produce NO
+    perturbation from the harness_motor lane -- unlike harness_step_load's sibling gate
+    above, there is no re-emission for this channel: a harness_motor-lane
+    ExecutionRunStateV1 object's cortex_exec_started_step_count is structurally always 0
+    (grammar_extract.py only increments it for orion-cortex-exec-sourced
+    exec_step_started events), so compute_pressure_hints() always returns
+    cortex_exec_step_load == 0.0 for that lane -- never a real value worth re-emitting."""
+    delta = _make_execution_run_delta(
+        lane="harness_motor",
+        pressure_hints={"cortex_exec_step_load": 0.0, "harness_step_load": 0.5},
+    )
+    perturbations = delta_to_perturbations(delta)
+    channels = {p.channel for p in perturbations}
+    assert "cortex_exec_step_load" not in channels
+    assert "harness_step_load" in channels
+
+
+def test_execution_run_off_lane_delta_does_not_reset_prior_cortex_exec_step_load_value() -> None:
+    """LIVE-CONFIRMED BUG regression test (2026-07-24): before this gate, a
+    harness_motor-lane delta's always-0.0 cortex_exec_step_load (see the test above for
+    why it's structurally always 0 on that lane) stomped a real value the bare
+    cortex-exec lane had just written, via mode="replace" on the shared node_key (both
+    lanes always resolve to "node:athena"). Confirmed live against
+    substrate_field_state.field_json: node:athena.execution_load sat flat at
+    0.3372261973790022 except two consecutive ~2s samples dipping to
+    0.2672454385532547 before recovering. End-to-end reproduction via
+    apply_perturbations(), same shape as harness_step_load's own off-lane regression
+    test above."""
+    from app.digestion.perturbation import apply_perturbations
+    from orion.schemas.field_state import FieldStateV1
+
+    state = FieldStateV1(generated_at=FIXED_TS, tick_id="tick_x", node_vectors={}, edges=[])
+    real_delta = _make_execution_run_delta(
+        lane=None, pressure_hints={"cortex_exec_step_load": 0.3372261973790022}
+    )
+    state = apply_perturbations(state, delta_to_perturbations(real_delta), now=FIXED_TS)
+    assert state.node_vectors["node:athena"]["cortex_exec_step_load"] == 0.3372261973790022
+
+    off_lane_delta = _make_execution_run_delta(
+        lane="harness_motor", pressure_hints={"cortex_exec_step_load": 0.0}
+    )
+    state = apply_perturbations(state, delta_to_perturbations(off_lane_delta), now=FIXED_TS)
+    assert state.node_vectors["node:athena"]["cortex_exec_step_load"] == 0.3372261973790022

--- a/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
+++ b/services/orion-field-digester/tests/test_field_node_biometrics_perturbations.py
@@ -68,7 +68,7 @@ def test_gpu_and_cpu_perturbations_use_replace_mode() -> None:
     # 2026-07-17: live corpus verification (see state_deltas.py comment on
     # this block) confirmed gpu_pressure/cpu_pressure were hitting the
     # post-decay saturation ceiling far more often than a comparable
-    # mode="replace" channel (execution_load) -- the same fan-out mechanism
+    # mode="replace" channel (cortex_exec_step_load) -- the same fan-out mechanism
     # as memory/thermal/disk below, just pre-existing. Fixed to match.
     delta = _make_node_biometrics_delta(pressure_hints={"gpu": 0.75, "strain": 0.4})
     perturbations = delta_to_perturbations(delta)
@@ -156,7 +156,7 @@ def test_old_add_mode_would_have_saturated_gpu_and_cpu_pressure() -> None:
     # 1.0 clamp regardless of the real hint value -- exactly the pattern
     # observed live (cpu_pressure/gpu_pressure pinned at their post-decay
     # ceiling in 16.60%/12.98% of ~134k live corpus rows, vs. 0.01%/0.00%
-    # for the already-mode="replace" execution_load/execution_friction).
+    # for the already-mode="replace" cortex_exec_step_load/execution_friction).
     old_style_perturbations = [
         Perturbation(node_id="node:atlas", channel="gpu_pressure", intensity=0.4, label=f"delta_{i}")
         for i in range(18)

--- a/services/orion-field-digester/tests/test_perturbation_recency.py
+++ b/services/orion-field-digester/tests/test_perturbation_recency.py
@@ -19,7 +19,7 @@ def _empty_state(tick_id: str) -> FieldStateV1:
 
 
 def _perturbation(label: str) -> Perturbation:
-    return Perturbation(node_id="node:athena", channel="execution_load", intensity=0.1, label=label)
+    return Perturbation(node_id="node:athena", channel="cortex_exec_step_load", intensity=0.1, label=label)
 
 
 def test_more_than_old_cap_within_one_instant_does_not_saturate_forever() -> None:

--- a/services/orion-hub/tests/test_substrate_attention_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_attention_debug_api.py
@@ -48,8 +48,8 @@ def _sample_attention_frame() -> dict:
                 "novelty_score": 0.0,
                 "urgency_score": 0.0,
                 "confidence_score": 0.1,
-                "dominant_channels": {"execution_load": 0.7},
-                "reasons": ["node execution_load is elevated"],
+                "dominant_channels": {"cortex_exec_step_load": 0.7},
+                "reasons": ["node cortex_exec_step_load is elevated"],
                 "evidence_refs": ["field:tick_exec"],
                 "suggested_observation_mode": "inspect",
             }

--- a/services/orion-hub/tests/test_substrate_lattice_routes.py
+++ b/services/orion-hub/tests/test_substrate_lattice_routes.py
@@ -906,12 +906,12 @@ def test_normalize_targets_dicts_preserve_fields() -> None:
 
 def test_coerce_str_list_handles_dict_channel_shapes() -> None:
     """Attention frames may store dominant_channels as a dict, not a list."""
-    assert substrate_lattice_routes._coerce_str_list({"execution_load": 0.7}) == ["execution_load"]
+    assert substrate_lattice_routes._coerce_str_list({"cortex_exec_step_load": 0.7}) == ["cortex_exec_step_load"]
     result = substrate_lattice_routes._normalize_targets(
-        [{"target_id": "capability:transport", "dominant_channels": {"execution_load": 0.7}}],
+        [{"target_id": "capability:transport", "dominant_channels": {"cortex_exec_step_load": 0.7}}],
         "dominant_targets",
     )
-    assert result[0]["dominant_channels"] == ["execution_load"]
+    assert result[0]["dominant_channels"] == ["cortex_exec_step_load"]
 
 
 # ── New V1.1 tests: response shape completeness ───────────────────

--- a/services/orion-llm-gateway/README.md
+++ b/services/orion-llm-gateway/README.md
@@ -177,7 +177,7 @@ LLM_GATEWAY_ROUTE_TABLE_JSON='{
 > the live route table points at them -- this was never deliberate, just
 > deprioritized while getting circe fully online. Consequence: `node:circe`
 > never appears as an `execution_run` producer, so `orion-field-digester`'s
-> `reasoning_load`/`execution_load`/etc. channels for `node:circe` read
+> `reasoning_load`/`cortex_exec_step_load`/etc. channels for `node:circe` read
 > permanently `0.0` -- not a code bug (see
 > `services/orion-field-digester/README.md`'s `reasoning_load` glossary
 > entry), just zero real traffic ever routing there. When circe comes

--- a/tests/test_attention_field_scoring.py
+++ b/tests/test_attention_field_scoring.py
@@ -12,13 +12,13 @@ REPO = Path(__file__).resolve().parents[1]
 POLICY = load_attention_policy(REPO / "config" / "attention" / "field_attention_policy.v1.yaml")
 
 
-def test_execution_load_raises_node_pressure() -> None:
+def test_cortex_exec_step_load_raises_node_pressure() -> None:
     pressure, dominant = weighted_pressure(
-        {"execution_load": 1.0, "reasoning_load": 0.35},
+        {"cortex_exec_step_load": 1.0, "reasoning_load": 0.35},
         POLICY.node_channel_weights,
     )
     assert pressure > 0.5
-    assert "execution_load" in dominant
+    assert "cortex_exec_step_load" in dominant
 
 
 def test_failure_pressure_high_urgency() -> None:

--- a/tests/test_attention_frame_builder.py
+++ b/tests/test_attention_frame_builder.py
@@ -16,7 +16,7 @@ def _synthetic_field() -> FieldStateV1:
         tick_id="tick_exec_attention",
         node_vectors={
             "node:athena": {
-                "execution_load": 1.0,
+                "cortex_exec_step_load": 1.0,
                 "reasoning_load": 0.35,
                 "availability": 1.0,
             },
@@ -46,7 +46,7 @@ def test_dominant_channels_present() -> None:
     frame = build_attention_frame(field=_synthetic_field(), policy=POLICY, now=NOW)
     athena = next(t for t in frame.node_targets if t.target_id == "node:athena")
     orch = next(t for t in frame.capability_targets if t.target_id == "capability:orchestration")
-    assert "execution_load" in athena.dominant_channels
+    assert "cortex_exec_step_load" in athena.dominant_channels
     assert "execution_pressure" in orch.dominant_channels
 
 

--- a/tests/test_attention_frame_schemas.py
+++ b/tests/test_attention_frame_schemas.py
@@ -15,8 +15,8 @@ def test_field_attention_target_v1_validates() -> None:
         novelty_score=0.0,
         urgency_score=0.5,
         confidence_score=0.2,
-        dominant_channels={"execution_load": 0.7},
-        reasons=["node execution_load is elevated"],
+        dominant_channels={"cortex_exec_step_load": 0.7},
+        reasons=["node cortex_exec_step_load is elevated"],
         evidence_refs=["field:tick_abc"],
         suggested_observation_mode="inspect",
     )

--- a/tests/test_attention_policy_loader.py
+++ b/tests/test_attention_policy_loader.py
@@ -10,5 +10,5 @@ def test_load_attention_policy_v1() -> None:
     policy = load_attention_policy(POLICY)
     assert isinstance(policy, FieldAttentionPolicyV1)
     assert policy.policy_id == "field_attention_policy.v1"
-    assert policy.node_channel_weights["execution_load"] == 0.70
+    assert policy.node_channel_weights["cortex_exec_step_load"] == 0.70
     assert policy.limits.max_node_targets == 5

--- a/tests/test_attention_runtime_store.py
+++ b/tests/test_attention_runtime_store.py
@@ -60,7 +60,7 @@ def test_load_latest_field(monkeypatch) -> None:
     field = FieldStateV1(
         generated_at=NOW,
         tick_id="tick_field",
-        node_vectors={"node:athena": {"execution_load": 0.5}},
+        node_vectors={"node:athena": {"cortex_exec_step_load": 0.5}},
     )
     payload = field.model_dump(mode="json")
     store = AttentionRuntimeStore("postgresql://test:test@localhost/test")

--- a/tests/test_attention_runtime_worker.py
+++ b/tests/test_attention_runtime_worker.py
@@ -21,7 +21,7 @@ def _field() -> FieldStateV1:
     return FieldStateV1(
         generated_at=NOW,
         tick_id="tick_existing",
-        node_vectors={"node:athena": {"execution_load": 1.0}},
+        node_vectors={"node:athena": {"cortex_exec_step_load": 1.0}},
     )
 
 

--- a/tests/test_causal_geometry_report.py
+++ b/tests/test_causal_geometry_report.py
@@ -70,7 +70,7 @@ def _fixture_topology() -> Dict:
                 "weight": 0.9,
                 "channel_map": {
                     "reasoning_load": "reasoning_pressure",
-                    "execution_load": "execution_pressure",
+                    "cortex_exec_step_load": "execution_pressure",
                 },
             },
             {

--- a/tests/test_execution_projection_schemas.py
+++ b/tests/test_execution_projection_schemas.py
@@ -19,7 +19,7 @@ def test_execution_projection_roundtrip() -> None:
         started_step_count=2,
         completed_step_count=2,
         failed_step_count=0,
-        pressure_hints={"execution_load": 0.25},
+        pressure_hints={"cortex_exec_step_load": 0.25},
         evidence_event_ids=["gev_1"],
         last_updated_at=now,
     )

--- a/tests/test_execution_substrate_reducer.py
+++ b/tests/test_execution_substrate_reducer.py
@@ -196,12 +196,12 @@ def test_pressure_hints_harness_step_load_stays_bounded_and_log_compressed() -> 
     assert huge_hints["harness_step_load"] <= 1.0
 
 
-def test_pressure_hints_execution_load_excludes_harness_steps() -> None:
-    """execution_load must read from cortex_exec_started_step_count directly, not a
+def test_pressure_hints_cortex_exec_step_load_excludes_harness_steps() -> None:
+    """cortex_exec_step_load must read from cortex_exec_started_step_count directly, not a
     derived (started - harness_started) subtraction -- a run whose steps are entirely
     harness-governor-sourced (cortex_exec_started_step_count stays at its default 0,
     even though started_step_count/harness_started_step_count both reflect real
-    activity) must read execution_load == 0.0, even though harness_step_load is high
+    activity) must read cortex_exec_step_load == 0.0, even though harness_step_load is high
     for the exact same run."""
     run = ExecutionRunStateV1(
         trace_id=TRACE, correlation_id="corr-abc", node_id="athena",
@@ -209,21 +209,21 @@ def test_pressure_hints_execution_load_excludes_harness_steps() -> None:
         last_updated_at=FIXED_TS,
     )
     hints = compute_pressure_hints(run, egress_emitted=False)
-    assert hints["execution_load"] == 0.0
+    assert hints["cortex_exec_step_load"] == 0.0
     assert hints["harness_step_load"] > 0.0
 
 
-def test_pressure_hints_execution_load_survives_cross_batch_merge() -> None:
+def test_pressure_hints_cortex_exec_step_load_survives_cross_batch_merge() -> None:
     """Regression guard for the cross-batch desync a derived (started -
     harness_started) subtraction would silently reintroduce: a real 8-step
     cortex-exec-only batch, merged with a separate, later 20-step
     harness-governor-only batch (as they'd arrive in production -- the two services
     flush their grammar events independently, so a poll-bounded batch commonly
-    contains only one service's steps), must still show real execution_load after the
+    contains only one service's steps), must still show real cortex_exec_step_load after the
     merge, not 0.0. Found live in code review: a derived subtraction reads
     max(started) - max(harness_started), and whichever batch's started_step_count is
     larger "wins" both fields under merge.py's independent per-field max()-merge --
-    silently zeroing execution_load despite genuine cortex-exec steps having
+    silently zeroing cortex_exec_step_load despite genuine cortex-exec steps having
     occurred. cortex_exec_started_step_count's own independent max()-merge avoids
     this entirely."""
     cortex_exec_batch = ExecutionRunStateV1(
@@ -241,12 +241,12 @@ def test_pressure_hints_execution_load_survives_cross_batch_merge() -> None:
     assert merged.harness_started_step_count == 20
     assert merged.cortex_exec_started_step_count == 8
     hints = compute_pressure_hints(merged, egress_emitted=False)
-    assert hints["execution_load"] > 0.0
+    assert hints["cortex_exec_step_load"] > 0.0
     assert hints["harness_step_load"] > 0.0
 
 
-def test_pressure_hints_execution_load_stays_bounded_and_log_compressed() -> None:
-    """Same regression shape as harness_step_load's own test: execution_load must
+def test_pressure_hints_cortex_exec_step_load_stays_bounded_and_log_compressed() -> None:
+    """Same regression shape as harness_step_load's own test: cortex_exec_step_load must
     differentiate an 8-step and a 40-step cortex-exec-only run (unlike the old
     min(1.0, started/8.0) hard cap, which read both identically), while staying
     <=1.0 even for very large step counts."""
@@ -265,9 +265,9 @@ def test_pressure_hints_execution_load_stays_bounded_and_log_compressed() -> Non
     short_hints = compute_pressure_hints(short, egress_emitted=False)
     long_hints = compute_pressure_hints(long_run, egress_emitted=False)
     huge_hints = compute_pressure_hints(huge, egress_emitted=False)
-    assert 0.0 < short_hints["execution_load"] < long_hints["execution_load"] <= 1.0
-    assert huge_hints["execution_load"] <= 1.0
-    assert short_hints["execution_load"] == pytest.approx(math.log1p(8) / math.log1p(60))
+    assert 0.0 < short_hints["cortex_exec_step_load"] < long_hints["cortex_exec_step_load"] <= 1.0
+    assert huge_hints["cortex_exec_step_load"] <= 1.0
+    assert short_hints["cortex_exec_step_load"] == pytest.approx(math.log1p(8) / math.log1p(60))
 
 
 def test_pressure_hints_reasoning_load_uses_char_count_when_present() -> None:
@@ -430,7 +430,7 @@ def test_reducer_emits_execution_run_delta() -> None:
     assert delta.target_kind == "execution_run"
     assert delta.target_id == TRACE
     assert delta.after["node_id"] == "athena"
-    assert "execution_load" in delta.after["pressure_hints"]
+    assert "cortex_exec_step_load" in delta.after["pressure_hints"]
     assert TRACE in proj.runs
 
 
@@ -649,7 +649,7 @@ def test_merge_takes_max_of_new_scalar_fields() -> None:
     assert merged.pressure_hints["harness_step_load"] == pytest.approx(
         math.log1p(5) / math.log1p(60)
     )
-    assert merged.pressure_hints["execution_load"] == pytest.approx(
+    assert merged.pressure_hints["cortex_exec_step_load"] == pytest.approx(
         math.log1p(3) / math.log1p(60)
     )
 

--- a/tests/test_field_digestion_rules.py
+++ b/tests/test_field_digestion_rules.py
@@ -47,7 +47,7 @@ def test_decay_covers_execution_and_transport_channels() -> None:
         tick_id="tick_decay_exec",
         node_vectors={
             "node:athena": {
-                "execution_load": 1.0,
+                "cortex_exec_step_load": 1.0,
                 "execution_friction": 1.0,
                 "failure_pressure": 1.0,
                 "reasoning_load": 1.0,
@@ -77,7 +77,7 @@ def test_decay_covers_execution_and_transport_channels() -> None:
     node = state.node_vectors["node:athena"]
     cap = state.capability_vectors["capability:orchestration"]
 
-    for ch in ("execution_load", "execution_friction", "failure_pressure",
+    for ch in ("cortex_exec_step_load", "execution_friction", "failure_pressure",
                "reasoning_load", "stream_backlog_pressure", "contract_pressure", "reliability_pressure"):
         assert node[ch] < 1.0, f"node channel {ch!r} should have decayed"
 

--- a/tests/test_field_execution_perturbations.py
+++ b/tests/test_field_execution_perturbations.py
@@ -25,7 +25,7 @@ def test_execution_run_delta_maps_to_node_channels() -> None:
         after={
             "node_id": "athena",
             "pressure_hints": {
-                "execution_load": 0.45,
+                "cortex_exec_step_load": 0.45,
                 "execution_friction": 0.05,
                 "reasoning_load": 0.35,
                 "failure_pressure": 0.0,
@@ -36,7 +36,7 @@ def test_execution_run_delta_maps_to_node_channels() -> None:
     )
     perturbations = delta_to_perturbations(delta)
     channels = {p.channel: p.intensity for p in perturbations}
-    assert channels["execution_load"] == 0.45
+    assert channels["cortex_exec_step_load"] == 0.45
     assert channels["reasoning_load"] == 0.35
     assert perturbations[0].node_id == "node:athena"
 
@@ -49,7 +49,7 @@ def test_execution_perturbations_use_replace_mode() -> None:
         target_kind="execution_run",
         target_id="cortex.exec:athena:corr-a",
         operation="update",
-        after={"node_id": "athena", "pressure_hints": {"execution_load": 1.0, "failure_pressure": 1.0}},
+        after={"node_id": "athena", "pressure_hints": {"cortex_exec_step_load": 1.0, "failure_pressure": 1.0}},
         caused_by_event_ids=["gev_a"],
         reducer_id="execution_trajectory_reducer",
     )
@@ -59,7 +59,7 @@ def test_execution_perturbations_use_replace_mode() -> None:
         target_kind="execution_run",
         target_id="cortex.exec:athena:corr-b",
         operation="update",
-        after={"node_id": "athena", "pressure_hints": {"execution_load": 0.25, "failure_pressure": 0.0}},
+        after={"node_id": "athena", "pressure_hints": {"cortex_exec_step_load": 0.25, "failure_pressure": 0.0}},
         caused_by_event_ids=["gev_b"],
         reducer_id="execution_trajectory_reducer",
     )
@@ -77,8 +77,8 @@ def test_execution_perturbations_use_replace_mode() -> None:
     )
 
     node = field.node_vectors.get("node:athena") or {}
-    # replace mode: last write wins — execution_load should be 0.25, not 1.0
-    assert node.get("execution_load") == 0.25, f"expected 0.25 got {node.get('execution_load')}"
+    # replace mode: last write wins — cortex_exec_step_load should be 0.25, not 1.0
+    assert node.get("cortex_exec_step_load") == 0.25, f"expected 0.25 got {node.get('cortex_exec_step_load')}"
     assert node.get("failure_pressure") == 0.0, f"expected 0.0 got {node.get('failure_pressure')}"
 
     # verify all execution perturbations carry replace mode
@@ -97,7 +97,7 @@ def test_execution_perturbations_diffuse_to_orchestration_capability() -> None:
         after={
             "node_id": "athena",
             "pressure_hints": {
-                "execution_load": 0.8,
+                "cortex_exec_step_load": 0.8,
                 "execution_friction": 0.1,
                 "failure_pressure": 0.2,
             },

--- a/tests/test_field_topology_config.py
+++ b/tests/test_field_topology_config.py
@@ -15,5 +15,5 @@ def test_canonical_and_alias_lattice_load_same_edges() -> None:
         if e.source_id == "node:athena" and e.target_id == "capability:orchestration"
     ]
     assert len(athena_orch) == 1
-    assert "execution_load" in athena_orch[0].channel_map
-    assert athena_orch[0].channel_map["execution_load"] == "execution_pressure"
+    assert "cortex_exec_step_load" in athena_orch[0].channel_map
+    assert athena_orch[0].channel_map["cortex_exec_step_load"] == "execution_pressure"

--- a/tests/test_field_topology_reconciliation.py
+++ b/tests/test_field_topology_reconciliation.py
@@ -47,11 +47,11 @@ def _stale_athena_state() -> FieldStateV1:
     )
 
 
-def test_reconcile_adds_execution_load_channel() -> None:
+def test_reconcile_adds_cortex_exec_step_load_channel() -> None:
     lattice = load_lattice(LATTICE_PATH)
     reconciled = reconcile_field_state_with_lattice(_stale_athena_state(), lattice=lattice)
-    assert "execution_load" in reconciled.node_vectors["node:athena"]
-    assert reconciled.node_vectors["node:athena"]["execution_load"] == 0.0
+    assert "cortex_exec_step_load" in reconciled.node_vectors["node:athena"]
+    assert reconciled.node_vectors["node:athena"]["cortex_exec_step_load"] == 0.0
     assert reconciled.node_vectors["node:athena"]["cpu_pressure"] == 0.42
 
 
@@ -63,7 +63,7 @@ def test_reconcile_refreshes_athena_orchestration_edge_mappings() -> None:
         for e in reconciled.edges
         if e.source_id == "node:athena" and e.target_id == "capability:orchestration"
     )
-    assert edge.channel_map.get("execution_load") == "execution_pressure"
+    assert edge.channel_map.get("cortex_exec_step_load") == "execution_pressure"
     assert edge.channel_map.get("execution_friction") == "reliability_pressure"
     assert edge.channel_map.get("failure_pressure") == "reliability_pressure"
     assert edge.channel_map.get("cpu_pressure") == "pressure"

--- a/tests/test_proposal_runtime_worker.py
+++ b/tests/test_proposal_runtime_worker.py
@@ -21,7 +21,7 @@ def _field() -> FieldStateV1:
     return FieldStateV1(
         generated_at=NOW,
         tick_id="tick_existing",
-        node_vectors={"node:athena": {"execution_load": 1.0}},
+        node_vectors={"node:athena": {"cortex_exec_step_load": 1.0}},
     )
 
 

--- a/tests/test_self_state_schemas.py
+++ b/tests/test_self_state_schemas.py
@@ -13,8 +13,8 @@ def test_self_state_dimension_v1_validates() -> None:
         dimension_id="execution_pressure",
         score=0.8,
         confidence=0.7,
-        dominant_evidence=["node:athena.execution_load"],
-        reasons=["execution_load elevated"],
+        dominant_evidence=["node:athena.cortex_exec_step_load"],
+        reasons=["cortex_exec_step_load elevated"],
     )
     assert d.dimension_id == "execution_pressure"
 


### PR DESCRIPTION
## Summary

- Renamed the field-digester channel `execution_load` -> `cortex_exec_step_load` everywhere it's a real identifier (schema/config/code/tests), for scope honesty: it's the cortex-exec-scoped sibling of `harness_step_load`, not "all execution work" as the old name implied.
- Fixed the same cross-lane `mode="replace"` stomp bug PR #1289/#1318 already fixed for 5 other `execution_run` channels: a `harness_motor`-lane `ExecutionRunStateV1` object's `cortex_exec_started_step_count` is structurally always `0` (`grammar_extract.py` only increments it for `orion-cortex-exec`-sourced events), so that lane's delta always carried `0.0` and stomped the real cortex-exec-lane value via last-write-wins on the shared node key (`node:athena`).
- Fixed by excluding `cortex_exec_step_load` from the `harness_motor` lane entirely in `state_deltas.py`'s unconditional per-lane emission loop, with **no re-emission** (unlike `reasoning_load`'s fix -- `harness_step_load` already covers the harness-governor side separately, so nothing is lost).
- Investigated `execution_friction`/`failure_pressure` for the same bug class per the task's explicit ask: confirmed **not** identical -- their source fields (`run.failed_step_count`, `run.status`) are set unconditionally regardless of `source_service`, so a `harness_motor`-lane value can be real, independent signal, not a structural always-`0` placeholder. Left ungated, flagged as a follow-up needing a compose-not-replace design decision (not built here).
- Added 2 new regression tests mirroring PR #1289's pattern; updated 4 config YAMLs, 2 README "training-data quality cutoff" logs (field-digester's 7th, mood-arc's matching 7th), and ~30 test files.

## Outcome moved

`node:athena.execution_load`'s live post-2026-07-24 dip (`0.3372261973790022` -> `0.2672454385532547` for two ~2s samples, then recovery -- confirmed via live Postgres query against `substrate_field_state.field_json`) should no longer occur once deployed: the harness_motor lane can no longer emit a stomping perturbation for this channel at all.

## Current architecture

`execution_load` sat in `services/orion-field-digester/app/ingest/state_deltas.py`'s unconditional per-`execution_run`-delta emission loop (target `node_key`, `mode="replace"`), alongside `execution_friction`/`reasoning_load`/`failure_pressure`. `reasoning_load` was already gated (PR #1318) to exclude the `harness_motor` lane from that loop, with re-emission in a `harness_motor`-gated block further down. `execution_load` had no such gate, despite its harness_motor-lane value being structurally always `0.0` (unlike `reasoning_load`, which can carry a real harness_motor-lane value from `reasoning_output_tokens`).

## Architecture touched

- `orion/substrate/execution_loop/grammar_extract.py`: formula variable/dict key/comments renamed (formula logic itself unchanged, already fixed in prior PR #1293).
- `services/orion-field-digester/app/ingest/state_deltas.py`: the actual bug fix -- new exclusion in the unconditional per-lane loop, plus a documented "investigated, not the same bug" note for `execution_friction`/`failure_pressure`.
- `services/orion-field-digester/app/tensor/channels.py`, `app/digestion/decay.py`: channel-name list entries renamed.
- `config/field/orion_field_topology.v1.yaml`, `config/field/biometrics_lattice.yaml` (compatibility alias, kept in sync), `config/field/field_channel_glossary.v1.yaml`, `config/attention/field_attention_policy.v1.yaml`: renamed channel references.
- `orion/substrate/prediction_error.py`, `orion/field/pressure.py` (`PRESSURE_CHANNELS`), `orion/field_coherence.py` (`_RULES`), `orion/substrate/relational/adapters/execution_ctx.py` (docstring only, no literal key): the 5 real consumers rewired (the plan named 4; `orion/field/pressure.py`'s `PRESSURE_CHANNELS` frozenset was a 5th found during the sweep).
- `services/orion-field-digester/README.md`, `orion/mood_arc/README.md`: glossary entry rewritten + new "seventh training-data quality cutoff" sections (mirroring the "sixth cutoff" pattern added the same day for an unrelated `transport_pressure` rename -- this repo tracks every field-digester channel rename as a mood-arc-encoder training-data cutoff since `v3` was trained on the old names).
- `docs/context-engineering/04_layer_1_to_11_pipeline.md`, `05_reducer_and_state_delta_pattern.md`: stale example snippets updated (found in review -- these are living architecture-guide docs, not the dated-historical-doc category left alone elsewhere).
- `services/orion-llm-gateway/README.md`: one current-state "Known gap" note updated.

## Files changed

- `orion/substrate/execution_loop/grammar_extract.py`: renamed `execution_load` -> `cortex_exec_step_load` (dict key, local var, `_EXECUTION_LOAD_SATURATION_STEPS` -> `_CORTEX_EXEC_STEP_LOAD_SATURATION_STEPS`), comments updated.
- `services/orion-field-digester/app/ingest/state_deltas.py`: renamed channel in the emission loop; added the `harness_motor`-lane exclusion (the actual bug fix); added a code comment documenting the `execution_friction`/`failure_pressure` investigation.
- `services/orion-field-digester/app/tensor/channels.py`, `app/digestion/decay.py`: `NODE_CHANNELS`/`NODE_DECAY_CHANNELS` entry renamed.
- `config/field/orion_field_topology.v1.yaml`, `config/field/biometrics_lattice.yaml`: `node_channels` list + `channel_map` entry renamed (both files, kept symmetric).
- `config/field/field_channel_glossary.v1.yaml`: glossary entry renamed + expanded with rename/fix rationale; `harness_step_load`'s own entry updated to reference the new name.
- `config/attention/field_attention_policy.v1.yaml`: `node_channel_weights` key renamed.
- `orion/substrate/prediction_error.py`, `orion/field/pressure.py`, `orion/field_coherence.py`, `orion/substrate/relational/adapters/execution_ctx.py`, `orion/schemas/execution_projection.py`, `orion/schemas/telemetry/field_channel_corpus.py`: consumer/doc references renamed.
- `services/orion-field-digester/README.md`, `orion/mood_arc/README.md`: glossary + new 7th training-data-cutoff sections.
- `services/orion-llm-gateway/README.md`, `docs/context-engineering/04_layer_1_to_11_pipeline.md`, `docs/context-engineering/05_reducer_and_state_delta_pattern.md`: stale references updated.
- ~28 test files (`services/orion-field-digester/tests/*`, `orion/substrate/tests/*`, `orion/substrate/relational/tests/*`, `services/orion-hub/tests/*`, `tests/test_attention_*.py`, `tests/test_execution_*.py`, `tests/test_field_*.py`, `tests/test_causal_geometry_report.py`, `tests/test_proposal_runtime_worker.py`, `tests/test_self_state_schemas.py`): renamed assertions/fixtures/function names; 2 new regression tests added to `services/orion-field-digester/tests/test_field_execution_run_perturbations.py`.

## Schema / bus / API changes

- Renamed: field-digester channel `execution_load` -> `cortex_exec_step_load` (a `FieldStateV1.node_vectors`/`pressure_hints` dict key, not a bus channel or Pydantic schema field -- `ExecutionRunStateV1.cortex_exec_started_step_count` schema field name is unchanged, only the *output* channel/key name changed).
- Behavior changed: `cortex_exec_step_load` no longer emits a perturbation from the `harness_motor` trace lane (previously always emitted `0.0`, stomping the real cortex-exec-lane value).
- Compatibility notes: not a bus/registry contract change (no entries in `orion/bus/channels.yaml` or `orion/schemas/registry.py` reference this name). The mood-arc `v3` encoder was trained on the old name -- see the new "seventh training-data quality cutoff" sections in `services/orion-field-digester/README.md`/`orion/mood_arc/README.md` for the retrain implications (not blocking, same posture as every prior cutoff).

## Env/config changes

No env keys added/removed/renamed. No `.env_example` changes. Local `.env` sync not needed.

## Tests run

```text
services/orion-field-digester/tests -q: 147 passed
orion/harness/tests -q: 171 passed, 3 pre-existing failures unrelated to this patch
  (jinja2 'mind_coloring' undefined x2, a grounding_status string-vs-code assertion --
  none reference execution_load/cortex_exec_step_load, confirmed via grep and
  independently reproduced by the review subagent)
orion/substrate/tests/test_prediction_error.py + orion/substrate/relational/tests/test_reducer_lane_adapters.py -q: 43 passed
services/orion-hub/tests/test_substrate_attention_debug_api.py + test_substrate_lattice_routes.py -q: 47 passed
tests/test_attention_*.py + test_causal_geometry_report.py + test_execution_projection_schemas.py
  + test_execution_substrate_reducer.py + test_self_state_schemas.py -q: 85 passed
PYTHONPATH=services/orion-field-digester tests/test_field_digestion_rules.py
  + test_field_execution_perturbations.py + test_field_topology_config.py
  + test_field_topology_reconciliation.py -q: 16 passed, 1 pre-existing failure
  (test_canonical_and_alias_lattice_load_same_edges: canonical/alias lattice files
  have a 9-vs-7 edge count mismatch that predates this patch -- confirmed via
  `git show HEAD:<path>`, my diff only changed 2 lines symmetrically in each file)
PYTHONPATH=services/orion-proposal-runtime tests/test_proposal_runtime_worker.py -q: 2 passed
```

## Evals run

No dedicated eval harness exists for this seam. The 2 new regression tests
(`test_execution_run_cortex_exec_step_load_ignored_off_lane`,
`test_execution_run_off_lane_delta_does_not_reset_prior_cortex_exec_step_load_value`)
serve as the closest equivalent -- they reproduce the exact live-observed stomp
(`0.3372261973790022` -> stomped -> recovered) end-to-end via `apply_perturbations()`.

## Docker/build/smoke checks

Not applicable -- no runtime config, dependency, port, health-check, worker, or
Redis/compose wiring changed. Pure Python/YAML rename + one gating-logic fix,
verified by the test suite above.

## Review findings fixed

- Finding: `docs/context-engineering/04_layer_1_to_11_pipeline.md:79` and `05_reducer_and_state_delta_pattern.md:116` had stale `execution_load` example snippets -- living architecture-guide docs, not the dated-historical-doc category correctly left alone elsewhere.
  - Fix: renamed both examples to `cortex_exec_step_load`.
  - Evidence: `git diff docs/context-engineering/`.
- Finding: `orion/substrate/execution_loop/grammar_extract.py`'s private `_EXECUTION_LOAD_SATURATION_STEPS` constant wasn't renamed despite the file's own adjacent comment documenting the rename.
  - Fix: renamed to `_CORTEX_EXEC_STEP_LOAD_SATURATION_STEPS` (no functional impact, private constant).
  - Evidence: `git diff orion/substrate/execution_loop/grammar_extract.py`; `services/orion-field-digester/tests` (147 passed) and `tests/test_execution_substrate_reducer.py` (45 passed) re-run clean after the fix.
- Finding: two present-tense comments in `state_deltas.py` (lines 50, 441) still named `execution_load` when describing current code structure.
  - Fix: renamed to `cortex_exec_step_load`.
  - Evidence: `git diff services/orion-field-digester/app/ingest/state_deltas.py`.
- Reviewer independently verified: rename completeness (no missed `.js`/`.html`/`.sh` or compound-identifier scope, unlike PR #1331's sibling incident), the `state_deltas.py` gating logic (confirmed non-tautological by temporarily neutralizing the gate and re-running the new tests, which failed as expected), the `execution_friction`/`failure_pressure` non-fix call, no missed consumers, and the `field_attention_policy.v1.yaml` rename's 2 real consumers (both generic pass-throughs, no hardcoded key). Verdict: safe to commit as-is after the 3 findings above were fixed.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build orion-field-digester
```

No other services need a restart for this change (config/consumer files are read by
this same service and by `orion-substrate-runtime`'s adapters, but those adapters
have no persistent state tied to the old channel name -- they just stop finding it
under the old key going forward, same "genuinely absent by name" mechanism the
7th training-data cutoff section describes).

## Risks / concerns

- Severity: low
- Concern: the mood-arc `v3` encoder was trained on `execution_load` by name (1 of its 15 trained channels). Post-deploy, `build_windows()` will find that field genuinely absent and default it to `0.0` for every row, degrading (not invalidating) `v3`'s live scoring on that one input until a `v4` retrain.
- Mitigation: documented as the new "seventh training-data quality cutoff" in both `services/orion-field-digester/README.md` and `orion/mood_arc/README.md`, with the exact `--min-generated-at` retrain command to use once real post-deploy data accumulates. Same posture Juniper explicitly approved for the same-day `transport_pressure` rename (sixth cutoff): don't block the rename on retrain timing.
- Severity: low
- Concern: `execution_friction`/`failure_pressure` still have the same *mechanism* (unconditional per-lane `mode="replace"` emission) as `cortex_exec_step_load` had, even though I found their harness_motor-lane values are real signal rather than a defaulted placeholder -- meaning a genuine "which lane's real failure signal wins" non-determinism still exists for those two channels.
- Mitigation: documented explicitly in code (`state_deltas.py`, above the loop) and in the `cortex_exec_step_load` README glossary entry, flagged as a follow-up needing a compose-not-replace design decision (not a mechanical gate-exclusion) -- not built in this patch per the task's explicit scope.
- Severity: informational
- Concern: `graphify update .` hit the known destructive-shrink failure mode again during this session (`scripts/safe_graphify_update.sh` caught it, auto-restored `graph.json`/`manifest.json`; `GRAPH_REPORT.md` needed a manual `git checkout --` since the wrapper doesn't restore that file). Root cause still unknown per prior incident notes -- not something this patch attempts to fix.
- Mitigation: none needed for this PR; graph state was fully restored before commit, confirmed via `git status --short graphify-out/`.

## PR link

(filled in after creation)
