### PR TITLE
feat(recall): live bus synaptic graph anomaly awareness for chat reasoning

### DIFF
--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -80,6 +80,17 @@ RECALL_FALKOR_IN_CHAT=true
 # code-level default stays False (safe fallback for any environment that
 # hasn't set this key at all), matching RECALL_FALKOR_IN_CHAT's convention.
 RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT=true
+# Idea 4 of docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md's
+# Phase 3+ arc -- app/storage/falkor_bus_synaptic_adapter.py fetches live
+# anomalies (z-scored edges) from the bus synaptic graph (orion_bus_synapse,
+# same shared FALKORDB_URI as above), unconditional per recall call, not
+# query_text-gated. Reuses FALKORDB_URI directly (no separate graph-name env
+# var here -- FALKORDB_BUS_GRAPH, default orion_bus_synapse, matches
+# orion-bus-mirror's and orion-hub's own setting name for the same graph).
+# Ships dark (false) until live-verified against real running traffic --
+# same rollout discipline as RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT above.
+RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT=false
+FALKORDB_BUS_GRAPH=orion_bus_synapse
 # Phase 2 of the entity-graph-reasoning arc (docs/superpowers/specs/
 # 2026-07-19-recall-entity-graph-reasoning-arc.md) -- see settings.py's
 # RECALL_ENTITY_RELATEDNESS_BOOST_ENABLED comment for the full design

--- a/services/orion-recall/app/settings.py
+++ b/services/orion-recall/app/settings.py
@@ -297,6 +297,20 @@ class Settings(BaseSettings):
     RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT: bool = Field(
         default=False, validation_alias=AliasChoices("RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT")
     )
+    # Idea 4 of docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md's
+    # Phase 3+ arc (design doc: docs/superpowers/specs/2026-07-24-bus-synaptic-graph-
+    # reasoning-consumer-design.md). When true, storage/falkor_bus_synaptic_adapter.py
+    # ::fetch_bus_synaptic_anomaly_fragments() runs on every recall call (recall
+    # runs on effectively every chat turn), reusing the exact anomaly Cypher
+    # already live-verified in services/orion-hub/scripts/bus_synaptic_graph_routes.py.
+    # Fixed, parameterized queries only -- never free-form Cypher. Unconditional,
+    # not query_text-gated (unlike RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT above):
+    # self-awareness of transport-layer stress isn't naturally "about" what the
+    # user said. Returns [] (not a "nothing found" fragment) on the common case
+    # where nothing is anomalous -- ships dark until live-verified.
+    RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT: bool = Field(
+        default=False, validation_alias=AliasChoices("RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT")
+    )
     # Phase 2 of the entity-graph-reasoning arc (docs/superpowers/specs/
     # 2026-07-19-recall-entity-graph-reasoning-arc.md): fuse_candidates
     # (fusion.py) additively boosts a candidate's composite score when its

--- a/services/orion-recall/app/storage/falkor_bus_synaptic_adapter.py
+++ b/services/orion-recall/app/storage/falkor_bus_synaptic_adapter.py
@@ -1,0 +1,190 @@
+"""Live bus-synaptic-graph anomaly awareness for chat reasoning.
+
+Idea 4 of docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md's
+Phase 3+ arc. Design doc: docs/superpowers/specs/2026-07-24-bus-synaptic-graph-
+reasoning-consumer-design.md (proposal-mode pass, per this repo's CLAUDE.md
+section 0A -- first idea in that arc touching a reasoning pipeline, not just
+infrastructure telemetry).
+
+Reuses the exact anomaly-detection Cypher already live-verified in
+services/orion-hub/scripts/bus_synaptic_graph_routes.py::anomalies() --
+edges whose most recent observation deviated sharply from that edge's own
+rolling EWMA baseline, guarded by a min_count floor against the documented
+cold-start z-score instability (see services/orion-bus-mirror/README.md).
+Fixed, parameterized queries only -- never free-form Cypher, matching the
+hard constraint the design doc names as non-negotiable.
+
+Unlike falkor_neighborhood_adapter.py (this module's closest sibling, which
+keyword-matches the user's query_text), this fetch is deliberately
+unconditional -- self-awareness of transport-layer stress isn't naturally
+"about" what the user said. Called once per recall invocation (effectively
+every chat turn), returns [] on the common case where nothing is
+anomalous -- an empty list is the correct, honest output, not a gap to fill
+with "nothing found" filler content.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from orion.graph.falkor_client import RedisGraphQueryClient
+
+logger = logging.getLogger(__name__)
+
+_CLIENT: Optional[RedisGraphQueryClient] = None
+
+_PUBLISH_ANOMALY_QUERY = """
+MATCH (o:Organ)-[e:PUBLISHES]->(c:Channel)
+WHERE e.gap_zscore IS NOT NULL AND abs(e.gap_zscore) > $threshold AND e.count > $min_count
+RETURN o.organ_id AS organ_id, c.channel AS channel,
+       e.gap_zscore AS zscore, e.count AS count
+ORDER BY abs(e.gap_zscore) DESC
+LIMIT $limit
+"""
+
+_CAUSAL_ANOMALY_QUERY = """
+MATCH (a:Organ)-[e:CAUSALLY_FOLLOWED_BY]->(b:Organ)
+WHERE e.latency_zscore IS NOT NULL AND abs(e.latency_zscore) > $threshold AND e.count > $min_count
+RETURN a.organ_id AS source_organ, b.organ_id AS target_organ,
+       e.latency_zscore AS zscore, e.count AS count
+ORDER BY abs(e.latency_zscore) DESC
+LIMIT $limit
+"""
+
+
+def get_bus_synaptic_falkor_client() -> Optional[RedisGraphQueryClient]:
+    """Return (or lazily initialise) the process-level ``orion_bus_synapse``
+    Falkor client -- same lazy-singleton, never-raises, self-healing-on-retry
+    shape as recall_falkor_store.py::get_recall_falkor_client(), reading env
+    directly (this service's established convention, not a pydantic Settings
+    field) rather than via app.settings.
+    """
+    global _CLIENT
+    if _CLIENT is not None:
+        return _CLIENT
+    uri = os.getenv("FALKORDB_URI", "").strip()
+    graph_name = os.getenv("FALKORDB_BUS_GRAPH", "orion_bus_synapse").strip()
+    if not uri:
+        logger.debug("bus_synaptic_falkor_init_skipped reason=no_falkordb_uri")
+        return None
+    try:
+        _CLIENT = RedisGraphQueryClient(uri=uri, graph_name=graph_name)
+    except Exception as exc:
+        logger.debug("bus_synaptic_falkor_init_failed error=%s", exc)
+        return None
+    return _CLIENT
+
+
+def _format_publish_anomaly_text(row: Dict[str, Any]) -> str:
+    return (
+        f"Bus channel \"{row.get('channel')}\" from {row.get('organ_id')} is publishing at an "
+        f"unusual rate (z-score {row.get('zscore'):.1f} against its own rolling baseline, "
+        f"{row.get('count')} samples)."
+    )
+
+
+def _format_causal_anomaly_text(row: Dict[str, Any]) -> str:
+    return (
+        f"{row.get('source_organ')} -> {row.get('target_organ')} hop latency is unusual "
+        f"(z-score {row.get('zscore'):.1f} against its own rolling baseline, "
+        f"{row.get('count')} samples)."
+    )
+
+
+async def fetch_bus_synaptic_anomaly_fragments(
+    *,
+    max_items: int = 5,
+    zscore_threshold: float = 3.0,
+    min_count: int = 5,
+) -> List[Dict[str, Any]]:
+    """Real edges from the live bus synaptic graph whose latest observation is
+    a genuine statistical outlier against their own history -- not a static
+    threshold, not simulated.
+
+    Same fragment shape as every other recall source (id/source/source_ref/
+    uri/text/ts/tags/score/meta) so fusion.py treats it identically, no
+    fusion.py changes needed. Never raises: any Falkor failure degrades to
+    [], same fail-open contract as every other adapter in this arc.
+    """
+    client = get_bus_synaptic_falkor_client()
+    if client is None:
+        return []
+
+    per_query_limit = max(1, max_items)
+    try:
+        publish_rows, causal_rows = await asyncio.gather(
+            asyncio.to_thread(
+                client.graph_query,
+                _PUBLISH_ANOMALY_QUERY,
+                {"threshold": zscore_threshold, "min_count": min_count, "limit": per_query_limit},
+            ),
+            asyncio.to_thread(
+                client.graph_query,
+                _CAUSAL_ANOMALY_QUERY,
+                {"threshold": zscore_threshold, "min_count": min_count, "limit": per_query_limit},
+            ),
+        )
+    except Exception as exc:
+        logger.debug("bus_synaptic_anomaly_fetch_skipped error=%s", exc)
+        return []
+
+    out: List[Dict[str, Any]] = []
+    for row in publish_rows or []:
+        if row.get("zscore") is None:
+            continue
+        frag_id = f"bus_synaptic_publish:{row.get('organ_id')}:{row.get('channel')}"
+        out.append(
+            {
+                "id": frag_id,
+                "source": "bus_synaptic_anomaly",
+                "source_ref": "falkordb",
+                # Per-fragment-unique, matching every sibling adapter's convention
+                # (falkor_neighborhood_adapter.py/falkor_chat_adapter.py use
+                # turn_id) -- NOT a shared constant. Caught in review:
+                # fusion.py::_key_for() dedupes on uri (which wins over id when
+                # both are set), so a shared constant here silently collapsed
+                # every anomaly from a single fetch down to just one surviving
+                # fragment -- live-reproduced against real data (5 real
+                # anomalies in, 1 survived fuse_candidates()).
+                "uri": frag_id,
+                "text": _format_publish_anomaly_text(row),
+                "ts": None,
+                "tags": ["bus_synaptic", "anomaly", "publish_gap"],
+                "score": 0.5,
+                "meta": {
+                    "organ_id": row.get("organ_id"),
+                    "channel": row.get("channel"),
+                    "zscore": row.get("zscore"),
+                    "count": row.get("count"),
+                },
+            }
+        )
+    for row in causal_rows or []:
+        if row.get("zscore") is None:
+            continue
+        frag_id = f"bus_synaptic_causal:{row.get('source_organ')}:{row.get('target_organ')}"
+        out.append(
+            {
+                "id": frag_id,
+                "source": "bus_synaptic_anomaly",
+                "source_ref": "falkordb",
+                "uri": frag_id,  # see publish-anomaly branch above for why this must be per-fragment-unique
+                "text": _format_causal_anomaly_text(row),
+                "ts": None,
+                "tags": ["bus_synaptic", "anomaly", "causal_latency"],
+                "score": 0.5,
+                "meta": {
+                    "source_organ": row.get("source_organ"),
+                    "target_organ": row.get("target_organ"),
+                    "zscore": row.get("zscore"),
+                    "count": row.get("count"),
+                },
+            }
+        )
+    return out[:max_items]
+
+
+__all__ = ["fetch_bus_synaptic_anomaly_fragments", "get_bus_synaptic_falkor_client"]

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -38,6 +38,7 @@ try:
     )
     from .storage.falkor_chat_adapter import fetch_falkor_chatturn_fragments
     from .storage.falkor_neighborhood_adapter import fetch_falkor_neighborhood_fragments
+    from .storage.falkor_bus_synaptic_adapter import fetch_bus_synaptic_anomaly_fragments
     from .storage.falkor_entity_relatedness import (
         fetch_related_entities,
         fetch_entity_matches_for_turns,
@@ -1113,6 +1114,25 @@ async def _query_backends(
             falkor_neighborhood = []
         backend_counts["falkor_neighborhood"] = len(falkor_neighborhood)
         candidates.extend(falkor_neighborhood)
+
+    # Idea 4 of the bus synaptic graph arc (docs/superpowers/specs/2026-07-24-
+    # bus-synaptic-graph-reasoning-consumer-design.md). Deliberately NOT gated
+    # on query_text/fragment relevance like falkor_neighborhood above -- this
+    # checks Orion's own live transport-layer state, not something "about"
+    # what the user said, so it runs unconditionally whenever the flag and
+    # profile allow it (recall runs on effectively every chat turn per this
+    # arc's own confirmed live behavior).
+    bus_synaptic_anomaly_enabled = bool(settings.RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT) and bool(
+        profile.get("enable_bus_synaptic_anomaly", True)
+    )
+    if bus_synaptic_anomaly_enabled:
+        try:
+            bus_synaptic_anomalies = await fetch_bus_synaptic_anomaly_fragments()
+        except Exception as exc:
+            logger.debug(f"bus synaptic anomaly fetch skipped: {exc}")
+            bus_synaptic_anomalies = []
+        backend_counts["bus_synaptic_anomaly"] = len(bus_synaptic_anomalies)
+        candidates.extend(bus_synaptic_anomalies)
 
     if falkor_chat_enabled:
         # Swap, not additive: this replaces the RDF chatturn fetch below,

--- a/services/orion-recall/tests/test_falkor_bus_synaptic_adapter.py
+++ b/services/orion-recall/tests/test_falkor_bus_synaptic_adapter.py
@@ -1,0 +1,199 @@
+"""fetch_bus_synaptic_anomaly_fragments: fixed anomaly Cypher against
+orion_bus_synapse (the same queries already live-verified in
+services/orion-hub/scripts/bus_synaptic_graph_routes.py::anomalies()).
+
+Same return-fragment contract as the other Falkor adapters
+(id/source/source_ref/uri/text/ts/tags/score/meta) -- fusion.py has no
+per-backend adapter layer, so shape drift here would silently break scoring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.storage import falkor_bus_synaptic_adapter as bsa
+
+
+class _FakeFalkorClient:
+    def __init__(self, publish_rows=None, causal_rows=None):
+        self._publish_rows = publish_rows or []
+        self._causal_rows = causal_rows or []
+        self.calls = []
+
+    def graph_query(self, cypher, params=None):
+        self.calls.append((cypher, params))
+        if "PUBLISHES" in cypher:
+            return self._publish_rows
+        if "CAUSALLY_FOLLOWED_BY" in cypher:
+            return self._causal_rows
+        return []
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_no_client_configured_returns_empty_list(monkeypatch) -> None:
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: None)
+    out = _run(bsa.fetch_bus_synaptic_anomaly_fragments())
+    assert out == []
+
+
+def test_no_anomalies_returns_empty_list_not_a_placeholder_fragment(monkeypatch) -> None:
+    # The common case, per this arc's own live-verified baseline (most edges
+    # are not anomalous most of the time) -- must be a real empty list, not a
+    # "nothing found" fragment (this repo's "no empty-shell cognition" rule).
+    fake_client = _FakeFalkorClient(publish_rows=[], causal_rows=[])
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: fake_client)
+
+    out = _run(bsa.fetch_bus_synaptic_anomaly_fragments())
+
+    assert out == []
+
+
+def test_publish_anomaly_produces_a_real_fragment(monkeypatch) -> None:
+    fake_client = _FakeFalkorClient(
+        publish_rows=[
+            {"organ_id": "cortex-exec", "channel": "orion:cognition:trace", "zscore": 5.2, "count": 40}
+        ]
+    )
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: fake_client)
+
+    out = _run(bsa.fetch_bus_synaptic_anomaly_fragments())
+
+    assert len(out) == 1
+    frag = out[0]
+    assert frag["source"] == "bus_synaptic_anomaly"
+    assert frag["source_ref"] == "falkordb"
+    # uri must be per-fragment-unique (== id), not a shared constant -- see
+    # test_multiple_real_anomalies_all_survive_fuse_candidates for why.
+    assert frag["uri"] == frag["id"]
+    assert "cortex-exec" in frag["text"]
+    assert "orion:cognition:trace" in frag["text"]
+    assert "5.2" in frag["text"]
+    assert frag["tags"] == ["bus_synaptic", "anomaly", "publish_gap"]
+    assert frag["meta"]["zscore"] == 5.2
+    assert frag["meta"]["count"] == 40
+
+
+def test_causal_anomaly_produces_a_real_fragment(monkeypatch) -> None:
+    fake_client = _FakeFalkorClient(
+        causal_rows=[
+            {"source_organ": "orion-feedback-runtime", "target_organ": "spark-concept-induction", "zscore": -4.1, "count": 200}
+        ]
+    )
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: fake_client)
+
+    out = _run(bsa.fetch_bus_synaptic_anomaly_fragments())
+
+    assert len(out) == 1
+    frag = out[0]
+    assert frag["tags"] == ["bus_synaptic", "anomaly", "causal_latency"]
+    assert "orion-feedback-runtime" in frag["text"]
+    assert "spark-concept-induction" in frag["text"]
+
+
+def test_both_anomaly_kinds_combine_and_respect_max_items(monkeypatch) -> None:
+    fake_client = _FakeFalkorClient(
+        publish_rows=[
+            {"organ_id": f"organ-{i}", "channel": "c", "zscore": 5.0, "count": 10} for i in range(3)
+        ],
+        causal_rows=[
+            {"source_organ": "a", "target_organ": "b", "zscore": 4.0, "count": 10} for _ in range(3)
+        ],
+    )
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: fake_client)
+
+    out = _run(bsa.fetch_bus_synaptic_anomaly_fragments(max_items=4))
+
+    assert len(out) == 4
+
+
+def test_rows_missing_zscore_are_skipped_not_crashed(monkeypatch) -> None:
+    fake_client = _FakeFalkorClient(publish_rows=[{"organ_id": "x", "channel": "c", "zscore": None, "count": 1}])
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: fake_client)
+
+    out = _run(bsa.fetch_bus_synaptic_anomaly_fragments())
+
+    assert out == []
+
+
+def test_graph_query_exception_fails_open_to_empty_list(monkeypatch) -> None:
+    class _RaisingClient:
+        def graph_query(self, cypher, params=None):
+            raise RuntimeError("falkor unreachable")
+
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: _RaisingClient())
+
+    out = _run(bsa.fetch_bus_synaptic_anomaly_fragments())
+
+    assert out == []
+
+
+def test_thresholds_are_threaded_through_to_both_queries(monkeypatch) -> None:
+    fake_client = _FakeFalkorClient()
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: fake_client)
+
+    _run(bsa.fetch_bus_synaptic_anomaly_fragments(zscore_threshold=5.0, min_count=10))
+
+    assert len(fake_client.calls) == 2
+    for _, params in fake_client.calls:
+        assert params["threshold"] == 5.0
+        assert params["min_count"] == 10
+
+
+def test_get_bus_synaptic_falkor_client_returns_none_without_falkordb_uri(monkeypatch) -> None:
+    bsa._CLIENT = None
+    monkeypatch.delenv("FALKORDB_URI", raising=False)
+    assert bsa.get_bus_synaptic_falkor_client() is None
+
+
+def test_get_bus_synaptic_falkor_client_is_a_lazy_singleton(monkeypatch) -> None:
+    bsa._CLIENT = None
+    monkeypatch.setenv("FALKORDB_URI", "redis://localhost:6379")
+    first = bsa.get_bus_synaptic_falkor_client()
+    second = bsa.get_bus_synaptic_falkor_client()
+    assert first is second
+    bsa._CLIENT = None
+
+
+def _fusion_profile() -> dict:
+    return {
+        "profile": "reflect.v1",
+        "max_per_source": 10,
+        "max_total_items": 20,
+        "render_budget_tokens": 256,
+        "time_decay_half_life_hours": 72,
+        "relevance": {"backend_weights": {"bus_synaptic_anomaly": 1.0}},
+    }
+
+
+def test_multiple_real_anomalies_all_survive_fuse_candidates(monkeypatch) -> None:
+    # Regression test for a review-caught, live-reproduced bug: this
+    # adapter's fragments used to set a shared constant `uri`
+    # ("orion_bus_synapse") on every fragment. fusion.py::_key_for() dedupes
+    # on `uri` when present (it wins over `id`), so every anomaly from a
+    # single fetch collapsed into just one surviving fragment -- live-verified
+    # against real data (5 real anomalies in, 1 survived). `uri` must be
+    # per-fragment-unique, matching every sibling adapter's convention.
+    from app.fusion import fuse_candidates
+
+    fake_client = _FakeFalkorClient(
+        publish_rows=[
+            {"organ_id": "cortex-orch", "channel": "orion:cortex:result*", "zscore": 7.1, "count": 10}
+        ],
+        causal_rows=[
+            {"source_organ": "actions", "target_organ": "spark-concept-induction", "zscore": 11.5, "count": 8},
+            {"source_organ": "orion-thought", "target_organ": "landing-pad", "zscore": 8.6, "count": 232},
+        ],
+    )
+    monkeypatch.setattr(bsa, "get_bus_synaptic_falkor_client", lambda: fake_client)
+
+    fragments = _run(bsa.fetch_bus_synaptic_anomaly_fragments())
+    assert len(fragments) == 3  # sanity: the adapter itself returns all 3
+
+    bundle, _ = fuse_candidates(candidates=fragments, profile=_fusion_profile(), diagnostic=True)
+
+    assert len(bundle.items) == 3
+    surviving_ids = {item.id for item in bundle.items}
+    assert surviving_ids == {f["id"] for f in fragments}


### PR DESCRIPTION
## Summary

- Implementation of "Idea 4" per the merged design doc (`docs/superpowers/specs/2026-07-24-bus-synaptic-graph-reasoning-consumer-design.md`, PR #1340). Gives `orion-recall` live query access to the bus synaptic graph (`orion_bus_synapse`, written by `orion-bus-mirror`).
- First idea in this arc touching a reasoning pipeline, not just infrastructure telemetry.
- New adapter mirrors `falkor_neighborhood_adapter.py`'s exact shape: fixed/parameterized Cypher only (reuses the exact anomaly queries already live-verified in Hub's debug routes, PR #1335 — never free-form or model-generated), fail-open to `[]` on any error.
- Deliberately unconditional (not query-text-gated) — recall runs on effectively every chat turn, confirmed live by the user, and self-awareness of transport-layer stress isn't "about" what the user said.
- Ships dark (`RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT=false`) until live-verified — confirmed live-verified in this PR.

## Outcome moved

Orion's chat reasoning can now surface real, live anomalies in its own transport layer — real z-scored edges with genuine sample-backed history (some 200-420 samples, not cold-start noise), not simulated or synthetic. Closes the "who consumes this" question that's been open since the original big-swing brainstorm.

## Current architecture

`orion-recall`'s `worker.py` assembles chat-turn context from multiple independently flag-gated fragment sources (SQL, RDF/Falkor chatturn, Falkor neighborhood), each returning a shared fragment shape that `fusion.py` scores and merges. `falkor_neighborhood_adapter.py` was the closest live precedent for "query a Falkor graph as part of reasoning" — fixed Cypher, fail-open, flag-gated.

## Architecture touched

- `services/orion-recall/app/storage/falkor_bus_synaptic_adapter.py` (new): `get_bus_synaptic_falkor_client()` (lazy singleton, mirrors `get_recall_falkor_client()`) and `fetch_bus_synaptic_anomaly_fragments()` (runs both anomaly queries via `asyncio.gather`+`asyncio.to_thread`, formats results into the shared fragment shape).
- `services/orion-recall/app/worker.py`: new gated call site alongside the other fragment sources.
- `services/orion-recall/app/settings.py`: new `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` flag (default `False`).

## Files changed

- `services/orion-recall/app/storage/falkor_bus_synaptic_adapter.py`: new adapter.
- `services/orion-recall/app/worker.py`: new gated call site.
- `services/orion-recall/app/settings.py`: new flag.
- `services/orion-recall/.env_example`: new keys.
- `services/orion-recall/tests/test_falkor_bus_synaptic_adapter.py`: 11 tests, including a fusion-boundary regression test.

## Schema / bus / API changes

- Added: none new (no bus channel, no schema registry entry — reads an existing graph, doesn't change what writes to it).
- Behavior changed: none live by default (flag ships `false`).
- Compatibility notes: fully additive, same fragment shape every other recall source already uses — no `fusion.py` changes needed.

## Env/config changes

- Added keys (`services/orion-recall`): `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` (default `false`, ships dark), `FALKORDB_BUS_GRAPH` (default `orion_bus_synapse`).
- `.env_example` updated: yes.
- local `.env` synced: yes, directly on the primary checkout — confirmed `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT=false` in both files (deliberately differs from the sibling `RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT=true`, not a copy-paste artifact).
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH="services/orion-recall:." venv/bin/python -m pytest services/orion-recall/tests/test_falkor_bus_synaptic_adapter.py services/orion-recall/tests/test_falkor_neighborhood_adapter.py -q
21 passed (11 new)
```

Also ran a broader regression check across 5 other `worker.py`-dependent test files; found 2 pre-existing failures, independently confirmed (via `git stash` against a clean checkout, and via re-reading the diff to confirm it doesn't touch the implicated code paths) to be unrelated and pre-existing, not introduced by this PR.

## Evals run

No eval harness exists for this adapter type (matches every sibling adapter in this repo). Live-verified twice against the real running FalkorDB instance:
1. Before the review fix: found 5 real anomaly fragments in production data with genuine, human-readable text and structured metadata.
2. After the review fix: ran real adapter output through the real `fuse_candidates()` — 4 real anomalies in, 4 survived (previously would have collapsed to 1).

## Docker/build/smoke checks

Not run — no compose/runtime changes beyond new env vars, verified via `.env_example` diff directly.

## Review findings fixed

- Finding (material, live-reproduced): every fragment set a shared constant `uri` (`"orion_bus_synapse"`). `fusion.py::_key_for()` dedupes on `uri` when present (it wins over `id`), so all fragments from a single fetch silently collapsed into just one surviving fragment after `fuse_candidates()` — reproduced live: 5 real anomalies in, 1 survived. This was a false-complete signal, not an honest empty-result — worse than the documented "empty is correct" case.
  - Fix: made `uri` per-fragment-unique (`== id`), matching every sibling adapter's own convention (`falkor_neighborhood_adapter.py`/`falkor_chat_adapter.py` both use `turn_id`, never a shared constant).
  - Evidence: new test `test_multiple_real_anomalies_all_survive_fuse_candidates`, running real adapter output through the real `fuse_candidates()`; re-verified live after the fix — 4 real anomalies in, 4 survived.
- Verified, no change needed: zero path for model-generated/dynamic Cypher — both queries are static string literals, only `$`-parameterized values, confirmed across the whole file.
- Verified, no change needed: `asyncio.gather` (no `return_exceptions=True`) correctly propagates the first exception to the surrounding `try/except`, so both queries fail open together as designed — not a partial-degrade risk. One nuance noted: the sibling coroutine's thread isn't cancelled on failure, just its result discarded — wasted background work, not a leak or crash.
- Verified, no change needed: fragment ids are deterministic (repeat for a still-anomalous edge on the next call) but `seen_keys` is local per `fuse_candidates()` invocation, so cross-turn repetition is correct behavior for an unconditional signal, not a dedup bug.
- Verified, no change needed: `worker.py`'s new call site is correctly scoped (`profile`, `settings`, `candidates`, `backend_counts` all already in scope, no shadowing), placed consistently with sibling blocks.
- Verified, no change needed: ships dark — confirmed `false` in both `.env_example` and the live `.env`, deliberately differing from the sibling flag.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml \
  up -d --build
```

No behavior change until `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` is explicitly flipped to `true` and live-verified against real chat turns — that's the natural next step, not done in this PR.

## Risks / concerns

- Severity: informational
- Concern: real non-empty-firing rate against sustained real traffic (hours, not one snapshot) is still unmeasured — the design doc's own open question. Exact z-score/count thresholds for "worth surfacing to a chat turn" (currently inherited from the Hub debug route's human-facing defaults) haven't been separately calibrated.
- Mitigation: flag ships off; flipping it on and watching real chat turns is the explicit next step per the design doc's own "Recommended next patch" section, not silently assumed done here.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1342