### PR TITLE
feat: flip RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT on live

### DIFF
--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -87,9 +87,13 @@ RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT=true
 # query_text-gated. Reuses FALKORDB_URI directly (no separate graph-name env
 # var here -- FALKORDB_BUS_GRAPH, default orion_bus_synapse, matches
 # orion-bus-mirror's and orion-hub's own setting name for the same graph).
-# Ships dark (false) until live-verified against real running traffic --
-# same rollout discipline as RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT above.
-RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT=false
+# Flipped live 2026-07-24 after fetch_bus_synaptic_anomaly_fragments() was
+# confirmed against the real running FalkorDB instance (real anomalies
+# found, correctly surviving fuse_candidates() after the uri-collision fix
+# -- see PR #1342's review findings). The pydantic code-level default stays
+# False (safe fallback for any environment that hasn't set this key at
+# all), matching RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT's convention.
+RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT=true
 FALKORDB_BUS_GRAPH=orion_bus_synapse
 # Phase 2 of the entity-graph-reasoning arc (docs/superpowers/specs/
 # 2026-07-19-recall-entity-graph-reasoning-arc.md) -- see settings.py's


### PR DESCRIPTION
## Summary

- Follow-up to #1342 (merged): flips `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` from `false` to `true` in `services/orion-recall/.env_example`, now that `fetch_bus_synaptic_anomaly_fragments()` has been confirmed against the real running FalkorDB instance -- real anomalies found, correctly surviving `fuse_candidates()` after the uri-collision fix (PR #1342's review findings).
- Local operator `.env` synced to match (not part of this diff -- gitignored, edited directly per CLAUDE.md's env-parity rule).
- Pydantic code-level default in `settings.py` stays `False` (safe fallback for any environment that hasn't set this key at all), matching `RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT`'s own convention.

## Outcome moved

Orion's chat reasoning now actually receives live bus-synaptic-graph anomaly fragments on real chat turns (previously implemented but shipped dark). This is the "flip it on and watch real chat turns" step named as the explicit next step in PR #1342's own "Risks / concerns" section.

## Files changed

- `services/orion-recall/.env_example`: flag flipped `false` -> `true`, comment rewritten to document the live-verification rationale.

## Env/config changes

- Changed keys: `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` (`false` -> `true`).
- `.env_example` updated: yes.
- local `.env` synced: yes (`services/orion-recall/.env`, line 185).
- skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH="services/orion-recall:." venv/bin/python -m pytest services/orion-recall/tests/test_falkor_bus_synaptic_adapter.py -q
11 passed
```

No code changes, so no new test coverage needed -- existing adapter tests (11, all monkeypatching client/settings, none depending on the `.env_example` default) confirm nothing broke.

## Evals run

None applicable -- config-only change, no new behavior to eval beyond what PR #1342 already live-verified.

## Docker/build/smoke checks

Not run -- config-only change. Restart required for the live container to pick up the new default (see below).

## Review findings fixed

Not run as a separate review pass -- this is a scoped follow-up to an already-reviewed PR (#1342), flipping a single documented flag with no code change.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: informational
- Concern: real non-empty-firing rate against sustained real traffic (hours, not one snapshot) is still unmeasured -- carried over from PR #1342's own open concern.
- Mitigation: fail-open adapter, unconditional but low weight (score 0.5) in fusion; watch real chat turns post-deploy.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1345
