### PR TITLE
fix(recall): wire bus-synaptic env keys into compose environment whitelist

### DIFF
--- a/services/orion-recall/docker-compose.yml
+++ b/services/orion-recall/docker-compose.yml
@@ -67,6 +67,14 @@ services:
       - FALKORDB_RECALL_GRAPH=${FALKORDB_RECALL_GRAPH:-orion_recall}
       - RECALL_FALKOR_IN_CHAT=${RECALL_FALKOR_IN_CHAT:-false}
       - RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT=${RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT:-false}
+      # falkor_bus_synaptic_adapter.py reads FALKORDB_BUS_GRAPH directly from
+      # os.environ (same "no env_file:, must be listed here" constraint as
+      # every entry above) -- missed in PR #1342, found live 2026-07-24 when
+      # flipping RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT on in .env/.env_example
+      # had zero effect on the running container (both keys absent from
+      # `docker exec ... printenv`, not just false).
+      - FALKORDB_BUS_GRAPH=${FALKORDB_BUS_GRAPH:-orion_bus_synapse}
+      - RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT=${RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT:-false}
       - RECALL_BELIEF_RENDER_BUDGET=${RECALL_BELIEF_RENDER_BUDGET:-128}
       # No compose-level default on these two: they are NEVER_SYNC_KEYS-protected in
       # scripts/sync_local_env_from_example.py (must be set by hand in .env) and their


### PR DESCRIPTION
## Summary

- `services/orion-recall` has no `env_file:` directive, so any env key not explicitly listed in `docker-compose.yml`'s `environment:` block never reaches the container's real OS environment, regardless of what `.env`/`.env_example` say (this exact failure mode is already documented inline at lines 52-59 of the file, for the `SUBSTRATE_STORE_BACKEND`/`FALKORDB_URI` trio).
- PR #1342 added `falkor_bus_synaptic_adapter.py` (reads `FALKORDB_BUS_GRAPH` from `os.environ` directly) and the `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` settings field + `.env_example` keys, but never added the corresponding `environment:` entries to `docker-compose.yml`.
- Found live after deploying #1345 (which flipped the flag to `true` in `.env`/`.env_example`): `docker exec orion-athena-recall printenv RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` returned nothing -- not `false`, completely absent. Same for `FALKORDB_BUS_GRAPH`. The feature has been dead on arrival since #1342 merged; #1345 changed nothing at runtime.

## Outcome moved

`RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` and `FALKORDB_BUS_GRAPH` now actually reach the container. Once rebuilt/restarted, `worker.py`'s bus-synaptic-anomaly fragment fetch will actually be gated on the real flag value instead of always defaulting to `False` inside the container (pydantic's code-level default), silently ignoring `.env`.

## Current architecture

`orion-recall`'s compose file whitelists env keys one by one into the container's `environment:` block rather than using `env_file:`. Every other Falkor-related key (`FALKORDB_URI`, `FALKORDB_SUBSTRATE_GRAPH`, `FALKORDB_RECALL_GRAPH`, `RECALL_FALKOR_NEIGHBORHOOD_IN_CHAT`) already follows this pattern; the two new bus-synaptic keys were the only omission.

## Files changed

- `services/orion-recall/docker-compose.yml`: added `FALKORDB_BUS_GRAPH` and `RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT` to the `environment:` block, same `${VAR:-default}` convention as every neighboring entry.

## Schema / bus / API changes

None -- compose config only, no code/contract change.

## Env/config changes

- No new keys added (both already existed in `.env`/`.env_example` since #1342/#1345) -- this only wires already-defined keys through to the container.
- `.env_example` updated: not applicable, no change needed there.
- local `.env` synced: not applicable, already synced in #1345.

## Tests run

Not applicable -- YAML-only config change, no Python code touched. Validated with `docker compose config` (see below).

## Evals run

None applicable.

## Docker/build/smoke checks

```text
docker compose --env-file .env --env-file services/orion-recall/.env -f services/orion-recall/docker-compose.yml config | grep -A1 FALKORDB_BUS_GRAPH
# confirms both keys resolve into the rendered config with the live .env values
```

Live verification after deploy (post-merge, operator-run):
```bash
docker exec orion-athena-recall printenv RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT FALKORDB_BUS_GRAPH
# expected: true / orion_bus_synapse
```

## Review findings fixed

Not run as a separate subagent review pass -- single-line-pattern compose fix, matches an existing documented convention in the same file, low risk. Root cause independently confirmed via live `docker exec printenv` before and will be re-confirmed after deploy.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: informational
- Concern: real non-empty-firing rate of the anomaly adapter against sustained live traffic is still unmeasured -- this PR only makes the flag functional, it doesn't change adapter behavior.
- Mitigation: adapter is fail-open and unconditional but low-weight (score 0.5) in fusion; watch real chat turns post-deploy.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1347
