### PR TITLE
fix(recall): explicit backend weight for bus_synaptic_anomaly

### DIFF
--- a/services/orion-recall/app/fusion.py
+++ b/services/orion-recall/app/fusion.py
@@ -35,6 +35,17 @@ DEFAULT_BACKEND_WEIGHTS = {
     # have scored 67% higher than an equivalent "rdf" one for no real reason).
     "falkor_neighborhood": 0.3,
     "cards": 0.0,
+    # Unconditional, not query-text-gated (unlike every source above) -- its
+    # relevance to a given turn is not about what the user said, so
+    # text_similarity_weight contributes near-nothing for this source and
+    # backend_weight alone controls its influence. Given an explicit value
+    # (same class of gap the falkor_neighborhood comment above already
+    # describes: found live 2026-07-24 after RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT
+    # was flipped on -- this key was absent, so real anomaly fragments were
+    # silently scoring at the generic 0.5 fallback instead of a deliberate
+    # weight). Set equal to rdf/falkor_neighborhood: a real signal, but a
+    # background one that shouldn't outrank query-relevant sql/rdf content.
+    "bus_synaptic_anomaly": 0.3,
 }
 OVERLAP_WEIGHT = 0.15
 EXACT_MATCH_WEIGHT = 0.45

--- a/services/orion-recall/tests/test_fusion_bus_synaptic_backend_weight.py
+++ b/services/orion-recall/tests/test_fusion_bus_synaptic_backend_weight.py
@@ -1,0 +1,34 @@
+"""Regression test for a live-caught gap: DEFAULT_BACKEND_WEIGHTS must give
+bus_synaptic_anomaly an explicit weight, not fusion.py's generic 0.5
+fallback for unrecognized sources. Same class of bug the repo's own
+falkor_neighborhood comment describes -- found live 2026-07-24 after
+RECALL_BUS_SYNAPTIC_ANOMALY_IN_CHAT was flipped on in production.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+_RECALL_ROOT = _REPO / "services" / "orion-recall"
+if str(_RECALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RECALL_ROOT))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from app.fusion import DEFAULT_BACKEND_WEIGHTS, _backend_weights
+
+
+def test_bus_synaptic_anomaly_has_an_explicit_default_weight() -> None:
+    assert "bus_synaptic_anomaly" in DEFAULT_BACKEND_WEIGHTS
+    assert DEFAULT_BACKEND_WEIGHTS["bus_synaptic_anomaly"] == 0.3
+
+
+def test_bus_synaptic_anomaly_weight_survives_into_a_real_profile() -> None:
+    # A profile with no explicit backend_weights override (the common case --
+    # no on-disk profile YAML mentions this source) must still resolve to the
+    # deliberate default, not the 0.5 fallback reserved for truly unknown sources.
+    profile = {"relevance": {"backend_weights": {"sql_chat": 0.6}}}
+    weights = _backend_weights(profile)
+    assert weights["bus_synaptic_anomaly"] == 0.3


### PR DESCRIPTION
## Summary

- Follow-up to #1342/#1345/#1347: `fusion.py`'s `DEFAULT_BACKEND_WEIGHTS` dict had no entry for `bus_synaptic_anomaly`, so it silently fell through to the generic `weights.get(source, 0.5)` fallback instead of a deliberately chosen weight.
- This is the exact same class of gap the repo's own comment already documents and fixed for `falkor_neighborhood` (lines 31-35: "a `falkor_neighborhood` candidate would have scored 67% higher than an equivalent `rdf` one for no real reason").
- Found live: after #1347 fixed the compose env gap, a real chat turn came through and I verified the adapter directly inside the running container (`docker exec orion-athena-recall python -c "..."`) -- 2 real anomaly fragments with genuine sample-backed z-scores (602 and 390 samples). Tracing the scoring path for those fragments turned up this second gap.

## Outcome moved

`bus_synaptic_anomaly` fragments now score with a deliberate, documented weight (0.3, matching `rdf`/`falkor_neighborhood`) instead of an arbitrary fallback that happened to outrank several query-relevant sources for no design reason.

## Current architecture

`fusion.py::_backend_weights()` seeds from `DEFAULT_BACKEND_WEIGHTS`, then layers any profile-specific override on top. No on-disk profile YAML (`orion/recall/profiles/*.yaml`) mentions `bus_synaptic_anomaly` or `falkor_neighborhood` at all, so every turn was resolving purely off the default dict -- which is exactly why an omission there is a live, not theoretical, gap.

## Files changed

- `services/orion-recall/app/fusion.py`: added `"bus_synaptic_anomaly": 0.3` to `DEFAULT_BACKEND_WEIGHTS`, with a comment explaining why (unconditional/not query-gated, so `backend_weight` alone controls its influence).
- `services/orion-recall/tests/test_fusion_bus_synaptic_backend_weight.py` (new): asserts the explicit weight exists and survives `_backend_weights()` resolution against a profile with no override.

## Schema / bus / API changes

None -- scoring-constant change only.

## Tests run

```text
PYTHONPATH="services/orion-recall:." venv/bin/python -m pytest services/orion-recall/tests/test_fusion_bus_synaptic_backend_weight.py services/orion-recall/tests/test_falkor_bus_synaptic_adapter.py -q
13 passed

PYTHONPATH="services/orion-recall:." venv/bin/python -m pytest services/orion-recall/tests/ -k fusion -q
22 passed
```

## Evals run

None applicable -- constant/weight change, covered by the new unit test plus the full fusion regression suite.

## Docker/build/smoke checks

Live-verified pre-fix, inside the running container, against real production data:
```text
docker exec orion-athena-recall python -c "... fetch_bus_synaptic_anomaly_fragments() ..."
fragments: 2
- bus_synaptic_publish:orion-field-digester:orion:field_channel:anomaly_score {zscore: 4.46, count: 602}
- bus_synaptic_causal:landing-pad:spark-concept-induction {zscore: 3.21, count: 390}
```
This confirmed the adapter and env wiring (#1347) both work end-to-end; tracing these fragments' composite score through `fuse_candidates()` is what surfaced the missing weight entry.

## Review findings fixed

Not run as a separate subagent pass -- single-entry addition to an existing, well-precedented dict, directly modeled on this repo's own prior fix for the same class of bug (`falkor_neighborhood`), covered by a new regression test.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: informational
- Concern: 0.3 is a judgment call (matched to `rdf`/`falkor_neighborhood`'s existing precedent), not empirically tuned against real chat-turn outcomes yet.
- Mitigation: easy to retune later -- single constant, now named and documented instead of an accidental fallback.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1348
