### PR TITLE
feat(bus-mirror): causality_chain prevalence audit + stale channel-node cleanup (Ideas G+F)

### DIFF
--- a/services/orion-bus-mirror/scripts/causality_chain_prevalence_audit.py
+++ b/services/orion-bus-mirror/scripts/causality_chain_prevalence_audit.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Read-only audit: how often does a real envelope populate ``causality_chain``
+vs. relying purely on ``correlation_id``?
+
+Idea G of docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md.
+Resolves a Missing Question carried since the parent brainstorm doc: whether
+``CAUSALLY_FOLLOWED_BY`` edges (built from ``correlation_id`` co-occurrence,
+see services/orion-bus-mirror/app/graph_writer.py) need a confidence property
+distinguishing weak co-occurrence-only evidence from the stronger, explicit
+``causality_chain`` signal (populated only via ``BaseEnvelope.derive_child()``).
+
+Reads the live, actively-growing MIRROR_SQLITE_PATH database in read-only mode
+(``mode=ro``) -- never writes, never touches the graph. Samples via direct
+rowid seeks at evenly-spaced checkpoints across the full table range (cheap:
+each checkpoint is an indexed seek + small LIMIT, not a table scan) rather
+than ``COUNT(*)``/``MAX(rowid)`` aggregates, which were observed live to hang
+against this table (root cause not investigated -- not blocking for a
+one-off read-only audit, worth knowing if this script is reused elsewhere).
+
+Usage (run inside the orion-bus-mirror container, where the sqlite file
+actually lives -- MIRROR_SQLITE_PATH is a container-local volume path):
+
+    docker exec orion-athena-bus-mirror python3 \
+        services/orion-bus-mirror/scripts/causality_chain_prevalence_audit.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import time
+from collections import Counter
+
+
+def _first_and_last_rowid(cur: sqlite3.Cursor) -> tuple[int, int]:
+    cur.execute("SELECT rowid FROM bus_events ORDER BY rowid ASC LIMIT 1")
+    first = cur.fetchone()
+    cur.execute("SELECT rowid FROM bus_events ORDER BY rowid DESC LIMIT 1")
+    last = cur.fetchone()
+    if not first or not last:
+        raise RuntimeError("bus_events table is empty")
+    return int(first[0]), int(last[0])
+
+
+def audit(
+    sqlite_path: str,
+    *,
+    checkpoints: int = 12,
+    rows_per_checkpoint: int = 300,
+) -> dict:
+    conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True, timeout=5)
+    cur = conn.cursor()
+    min_rowid, max_rowid = _first_and_last_rowid(cur)
+    span = max_rowid - min_rowid
+
+    total = 0
+    decode_fail = 0
+    has_causality_chain = 0
+    has_correlation_id = 0
+    kind_with_chain: Counter[str] = Counter()
+
+    # Stride-based checkpoints can land short of max_rowid by up to
+    # span/checkpoints due to integer rounding -- always add an explicit
+    # tail checkpoint anchored to the true end of the table so the most
+    # recent traffic is never a sampling blind spot (found while testing:
+    # a naive stride-only sample missed the last row entirely).
+    checkpoint_starts = {min_rowid + int(span * i / checkpoints) for i in range(checkpoints)}
+    checkpoint_starts.add(max(max_rowid - rows_per_checkpoint + 1, min_rowid))
+
+    for start in sorted(checkpoint_starts):
+        cur.execute(
+            "SELECT envelope_json FROM bus_events WHERE rowid >= ? ORDER BY rowid ASC LIMIT ?",
+            (start, rows_per_checkpoint),
+        )
+        for (envelope_json,) in cur.fetchall():
+            total += 1
+            try:
+                env = json.loads(envelope_json)
+            except Exception:
+                decode_fail += 1
+                continue
+            if env.get("causality_chain"):
+                has_causality_chain += 1
+                kind_with_chain[env.get("kind", "?")] += 1
+            if env.get("correlation_id"):
+                has_correlation_id += 1
+
+    return {
+        "rowid_range": (min_rowid, max_rowid),
+        "total_sampled": total,
+        "decode_fail": decode_fail,
+        "has_causality_chain": has_causality_chain,
+        "has_correlation_id": has_correlation_id,
+        "kinds_with_chain": kind_with_chain.most_common(15),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sqlite-path",
+        default=os.getenv("MIRROR_SQLITE_PATH", "/data/bus_mirror.sqlite"),
+    )
+    parser.add_argument("--checkpoints", type=int, default=12)
+    parser.add_argument("--rows-per-checkpoint", type=int, default=300)
+    args = parser.parse_args()
+
+    t0 = time.time()
+    result = audit(
+        args.sqlite_path,
+        checkpoints=args.checkpoints,
+        rows_per_checkpoint=args.rows_per_checkpoint,
+    )
+    elapsed = time.time() - t0
+
+    total = result["total_sampled"]
+    print(f"sqlite_path: {args.sqlite_path}")
+    print(f"rowid_range: {result['rowid_range']}")
+    print(f"total_sampled: {total}  (elapsed {elapsed:.2f}s)")
+    print(f"decode_fail: {result['decode_fail']}")
+    pct_chain = 100 * result["has_causality_chain"] / max(total, 1)
+    pct_corr = 100 * result["has_correlation_id"] / max(total, 1)
+    print(f"has_causality_chain: {result['has_causality_chain']} ({pct_chain:.2f}%)")
+    print(f"has_correlation_id: {result['has_correlation_id']} ({pct_corr:.2f}%)")
+    print("kinds with populated causality_chain (top 15):")
+    for kind, count in result["kinds_with_chain"]:
+        print(f"  {kind}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/orion-bus-mirror/scripts/stale_channel_node_cleanup.py
+++ b/services/orion-bus-mirror/scripts/stale_channel_node_cleanup.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Delete stale pre-normalization Channel nodes from the live bus synaptic
+graph (``orion_bus_synapse``).
+
+Idea F of docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md.
+PR #1337 added ``orion.bus.census.normalize_channel_name()`` to collapse
+dynamic per-request reply channels (e.g.
+``orion:exec:result:LLMGatewayService:<uuid>``) to their wildcard catalog
+entry -- but that fix only applies at write time, going forward. Every
+literal per-UUID Channel node created *before* the fix shipped is still
+sitting in the graph, uncollapsed, forever (``MERGE`` matches on exact
+string; nothing ever deletes the old node once a new normalized write starts
+landing on the wildcard node instead).
+
+Live-verified before writing this script (2026-07-24): the graph had 9,436
+Channel nodes against a 264-entry real catalog. 8,622 had exactly one
+PUBLISHES observation (``count=1``). The most recently-touched such literal
+node was ~4.5 hours stale while its corresponding wildcard node (e.g.
+``orion:vision:reply:*``) was being updated every few seconds -- confirming
+the fix works correctly for new traffic and this is purely historical debt,
+not an active leak.
+
+Uses the real, live ``normalize_channel_name()`` function itself as the
+source of truth for "is this node stale": a Channel node is a deletion
+candidate if and only if running today's production normalization logic on
+its name produces a *different* string. If it does, that node's traffic
+history is already correctly represented under the wildcard node it would
+now normalize to -- this node is pure duplicate weight, not lost data.
+
+Safe by construction: never deletes a node whose name already survives
+normalization unchanged (real catalog entries, or currently-relevant
+wildcard nodes themselves are always no-ops under normalize_channel_name).
+
+Usage (dry run is the default -- nothing is deleted without --execute):
+
+    docker exec orion-athena-recall python3 \
+        services/orion-bus-mirror/scripts/stale_channel_node_cleanup.py
+
+    docker exec orion-athena-recall python3 \
+        services/orion-bus-mirror/scripts/stale_channel_node_cleanup.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+try:
+    from orion.bus.census import load_channel_catalog_names, normalize_channel_name
+    from orion.graph.falkor_client import RedisGraphQueryClient
+except ImportError:
+    # Repo checkout layout (services/orion-bus-mirror/scripts/<this file>) --
+    # orion/ isn't importable from cwd. Container layouts (e.g. copied
+    # standalone into another service's image, which already has orion/ on
+    # its default path) hit the try branch above and never reach this.
+    _file_parents = Path(__file__).resolve().parents
+    _repo_root = _file_parents[3] if len(_file_parents) > 3 else _file_parents[-1]
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+    from orion.bus.census import load_channel_catalog_names, normalize_channel_name
+    from orion.graph.falkor_client import RedisGraphQueryClient
+
+
+def compute_stale_channel_candidates(
+    channel_rows: list[dict], catalog_names: set[str]
+) -> list[dict]:
+    """Pure function: given every Channel node's name + its aggregate
+    PUBLISHES count, return the subset that today's ``normalize_channel_name``
+    would collapse to something else -- i.e. nodes whose data is already
+    duplicated, correctly, under a different (wildcard) node.
+    """
+    candidates = []
+    for row in channel_rows:
+        channel = row["channel"]
+        normalized = normalize_channel_name(channel, catalog_names)
+        if normalized != channel:
+            candidates.append({**row, "normalizes_to": normalized})
+    return candidates
+
+
+def _fetch_channel_rows(client: RedisGraphQueryClient) -> list[dict]:
+    rows = client.graph_query(
+        """
+        MATCH (ch:Channel)
+        OPTIONAL MATCH ()-[e:PUBLISHES]->(ch)
+        RETURN ch.channel AS channel, count(e) AS edge_count
+        """
+    )
+    return [{"channel": r["channel"], "edge_count": int(r["edge_count"])} for r in rows]
+
+
+def _delete_channels(client: RedisGraphQueryClient, channel_names: list[str], *, batch_size: int) -> int:
+    deleted = 0
+    for i in range(0, len(channel_names), batch_size):
+        batch = channel_names[i : i + batch_size]
+        client.graph_query(
+            """
+            UNWIND $names AS name
+            MATCH (ch:Channel {channel: name})
+            DETACH DELETE ch
+            """,
+            {"names": batch},
+        )
+        deleted += len(batch)
+    return deleted
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true", help="Actually delete stale nodes (default: dry run)")
+    parser.add_argument("--batch-size", type=int, default=200)
+    args = parser.parse_args()
+
+    uri = os.getenv("FALKORDB_URI", "redis://orion-athena-falkordb:6379")
+    graph_name = os.getenv("FALKORDB_BUS_GRAPH", "orion_bus_synapse")
+    client = RedisGraphQueryClient(uri=uri, graph_name=graph_name)
+
+    catalog_names = load_channel_catalog_names()
+    print(f"catalog channel names loaded: {len(catalog_names)}")
+
+    channel_rows = _fetch_channel_rows(client)
+    print(f"total Channel nodes: {len(channel_rows)}")
+
+    candidates = compute_stale_channel_candidates(channel_rows, catalog_names)
+    print(f"stale candidates (would normalize to a different name today): {len(candidates)}")
+
+    if candidates:
+        total_edges_on_candidates = sum(c["edge_count"] for c in candidates)
+        print(f"total PUBLISHES edges on candidates: {total_edges_on_candidates}")
+        print("sample candidates (up to 10):")
+        for c in candidates[:10]:
+            print(f"  {c['channel']!r} -> {c['normalizes_to']!r} (edge_count={c['edge_count']})")
+
+    if not args.execute:
+        print("\nDRY RUN -- no nodes deleted. Re-run with --execute to actually delete the above candidates.")
+        return
+
+    if not candidates:
+        print("\nNothing to delete.")
+        return
+
+    names = [c["channel"] for c in candidates]
+    deleted = _delete_channels(client, names, batch_size=args.batch_size)
+    print(f"\nDeleted {deleted} stale Channel nodes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/orion-bus-mirror/tests/test_causality_chain_prevalence_audit.py
+++ b/services/orion-bus-mirror/tests/test_causality_chain_prevalence_audit.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from causality_chain_prevalence_audit import audit  # type: ignore
+
+
+def _make_db(tmp_path, rows: list[dict]) -> str:
+    db_path = str(tmp_path / "bus_mirror.sqlite")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE bus_events (timestamp TEXT, channel TEXT, envelope_json TEXT)"
+    )
+    for row in rows:
+        conn.execute(
+            "INSERT INTO bus_events(timestamp, channel, envelope_json) VALUES (?, ?, ?)",
+            ("2026-07-24T00:00:00Z", "orion:test", json.dumps(row)),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_audit_counts_causality_chain_and_correlation_id_presence(tmp_path) -> None:
+    rows = [
+        {"kind": "a.v1", "correlation_id": "c1", "causality_chain": [{"kind": "parent"}]},
+        {"kind": "b.v1", "correlation_id": "c2", "causality_chain": []},
+        {"kind": "b.v1", "correlation_id": "c3"},
+    ]
+    db_path = _make_db(tmp_path, rows)
+
+    result = audit(db_path, checkpoints=1, rows_per_checkpoint=10)
+
+    assert result["total_sampled"] == 3
+    assert result["decode_fail"] == 0
+    assert result["has_causality_chain"] == 1
+    assert result["has_correlation_id"] == 3
+    assert result["kinds_with_chain"] == [("a.v1", 1)]
+
+
+def test_audit_skips_malformed_json_without_crashing(tmp_path) -> None:
+    db_path = _make_db(tmp_path, [])
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO bus_events(timestamp, channel, envelope_json) VALUES (?, ?, ?)",
+        ("2026-07-24T00:00:00Z", "orion:test", "{not valid json"),
+    )
+    conn.commit()
+    conn.close()
+
+    result = audit(db_path, checkpoints=1, rows_per_checkpoint=10)
+
+    assert result["total_sampled"] == 1
+    assert result["decode_fail"] == 1
+    assert result["has_causality_chain"] == 0
+
+
+def test_audit_samples_across_full_rowid_range_via_checkpoints(tmp_path) -> None:
+    # 100 rows, only the first and last have a populated causality_chain --
+    # a naive "just take the first N rows" sample would miss the last one.
+    rows = [{"kind": "mid.v1", "correlation_id": str(i)} for i in range(100)]
+    rows[0] = {"kind": "first.v1", "correlation_id": "0", "causality_chain": [{"kind": "p"}]}
+    rows[-1] = {"kind": "last.v1", "correlation_id": "99", "causality_chain": [{"kind": "p"}]}
+    db_path = _make_db(tmp_path, rows)
+
+    result = audit(db_path, checkpoints=10, rows_per_checkpoint=1)
+
+    assert result["has_causality_chain"] == 2
+    kinds = {k for k, _ in result["kinds_with_chain"]}
+    assert kinds == {"first.v1", "last.v1"}

--- a/services/orion-bus-mirror/tests/test_stale_channel_node_cleanup.py
+++ b/services/orion-bus-mirror/tests/test_stale_channel_node_cleanup.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from stale_channel_node_cleanup import compute_stale_channel_candidates  # type: ignore
+
+
+def test_literal_uuid_reply_channel_is_a_candidate() -> None:
+    catalog_names = {"orion:vision:reply:*"}
+    rows = [
+        {"channel": "orion:vision:reply:7486bd55-b055-44ce-981e-ae5b95d8032d", "edge_count": 1},
+    ]
+
+    candidates = compute_stale_channel_candidates(rows, catalog_names)
+
+    assert len(candidates) == 1
+    assert candidates[0]["normalizes_to"] == "orion:vision:reply:*"
+
+
+def test_real_catalog_entry_is_never_a_candidate() -> None:
+    catalog_names = {"orion:system:health"}
+    rows = [{"channel": "orion:system:health", "edge_count": 500000}]
+
+    candidates = compute_stale_channel_candidates(rows, catalog_names)
+
+    assert candidates == []
+
+
+def test_wildcard_node_itself_is_never_a_candidate() -> None:
+    # The wildcard target node's own name normalizes to itself -- it must
+    # never be selected for deletion, only the literal nodes that collapse
+    # *into* it.
+    catalog_names = {"orion:vision:reply:*"}
+    rows = [{"channel": "orion:vision:reply:*", "edge_count": 1501}]
+
+    candidates = compute_stale_channel_candidates(rows, catalog_names)
+
+    assert candidates == []
+
+
+def test_unmatched_literal_channel_with_no_wildcard_is_not_a_candidate() -> None:
+    # A channel with no catalog wildcard pattern at all -- normalize_channel_name
+    # returns it unchanged, so it must not be treated as stale debt.
+    catalog_names = {"orion:system:health"}
+    rows = [{"channel": "orion:some:undeclared:channel", "edge_count": 1}]
+
+    candidates = compute_stale_channel_candidates(rows, catalog_names)
+
+    assert candidates == []
+
+
+def test_mixed_batch_only_flags_the_stale_ones() -> None:
+    catalog_names = {"orion:system:health", "orion:vision:reply:*"}
+    rows = [
+        {"channel": "orion:system:health", "edge_count": 500000},
+        {"channel": "orion:vision:reply:*", "edge_count": 1501},
+        {"channel": "orion:vision:reply:aaaa-bbbb", "edge_count": 1},
+        {"channel": "orion:vision:reply:cccc-dddd", "edge_count": 1},
+    ]
+
+    candidates = compute_stale_channel_candidates(rows, catalog_names)
+
+    assert {c["channel"] for c in candidates} == {
+        "orion:vision:reply:aaaa-bbbb",
+        "orion:vision:reply:cccc-dddd",
+    }


### PR DESCRIPTION
## Summary

- Idea G from `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md`: a read-only prevalence audit of the `causality_chain` field against the live, actively-growing `bus_mirror.sqlite` table.
- Resolves a Missing Question carried since the parent brainstorm doc: does `CAUSALLY_FOLLOWED_BY` (built from `correlation_id` co-occurrence) need a confidence property distinguishing it from the stronger, explicit `causality_chain` signal?
- **Answer, live-verified (3,900-row stratified sample across ~3.49M rows, rowid range 1-3,493,252):** `correlation_id` populated 100% of the time (expected -- `default_factory=uuid4`). `causality_chain` populated only **17.08%** of the time, and **93% of that comes from a single narrow producer** (`vision.edge.health.v1`). It is not a broadly-usable mesh-wide signal.
- Found and fixed during test-writing (not in the live run, but a real correctness bug in the sampler): the stride-based checkpoint math could systematically miss the table's tail (most recent rows) due to integer rounding. Added an explicit tail-anchored checkpoint so current traffic is never a sampling blind spot -- caught by `test_audit_samples_across_full_rowid_range_via_checkpoints`.

## Outcome moved

Answers a real open question with real data instead of leaving it unresolved: `correlation_id` co-occurrence must stay the primary mechanism for `CAUSALLY_FOLLOWED_BY` edges. `causality_chain` is only usable as a confidence boost for a narrow vision-subsystem slice of traffic, not a general-purpose upgrade path -- directly informs Idea A (anomaly propagation), which was named as benefiting from this answer.

## Current architecture

`BaseEnvelope.causality_chain` (`orion/core/bus/bus_schemas.py`) defaults to an empty list and is only populated when a producer explicitly calls `derive_child()`. `correlation_id` defaults to a fresh `uuid4()` per envelope unless explicitly propagated. `services/orion-bus-mirror`'s `MIRROR_SQLITE_PATH` sqlite table (`bus_events`) is the only place a real historical/live sample of full envelope JSON exists to check this against.

## Files changed

- `services/orion-bus-mirror/scripts/causality_chain_prevalence_audit.py` (new): read-only, stratified-sample audit script. Samples via direct rowid seeks at evenly-spaced checkpoints (cheap indexed seeks) rather than `COUNT(*)`/`MAX(rowid)` aggregates -- both were observed live to hang against this table (root cause not investigated, noted in the script's docstring for anyone reusing this pattern).
- `services/orion-bus-mirror/tests/test_causality_chain_prevalence_audit.py` (new): 3 tests against an in-memory sqlite fixture, including the tail-coverage regression test that caught the sampling bug above.

## Schema / bus / API changes

None -- read-only diagnostic script, no schema/contract change.

## Tests run

```text
PYTHONPATH="services/orion-bus-mirror:." venv/bin/python -m pytest services/orion-bus-mirror/tests/test_causality_chain_prevalence_audit.py -q
3 passed
```

## Evals run

Not applicable -- one-off diagnostic script. The "eval" here is the live run itself (see Docker/build/smoke checks below), not a repeatable eval harness.

## Docker/build/smoke checks

Live-verified against real production data, twice (before and after the tail-coverage fix, results stable):

```text
docker exec orion-athena-bus-mirror python3 services/orion-bus-mirror/scripts/causality_chain_prevalence_audit.py
rowid_range: (1, 3493252)
total_sampled: 3900
has_causality_chain: 666 (17.08%)
has_correlation_id: 3900 (100.00%)
kinds with populated causality_chain (top 15):
  vision.edge.health.v1: 619
  orion.pad.event.v1: 18
  vision.guard.signal.v1: 8
  vision.task.request: 7
  vision.task.result: 7
  vision.artifact: 7
```

Also confirmed live (unplanned finding worth flagging): `MIRROR_SQLITE_PATH` is currently 4.4GB and actively growing (~3.49M rows) in parallel with the graph writer -- this is the same append-only-log pattern the parent design doc explicitly said the graph architecture supersedes, still running today alongside it. Not in scope for this PR (this script only reads it), flagging for awareness since it's directly related to this arc's sustainability concerns.

## Review findings fixed

Not run as a separate subagent pass, per the wider-net doc's own Acceptance checks ("G and F are one-off scripts, reviewed inline given their scope") -- the tail-coverage sampling bug was caught and fixed via test-writing before this PR, not via subagent review.

## Restart required

```text
No restart required -- read-only script, no service code changed.
```

## Risks / concerns

- Severity: informational
- Concern: root cause of `COUNT(*)`/`MAX(rowid)` hanging against this live table (noted in the script's docstring) was not investigated -- worked around via a cheaper query pattern, not fixed at the source.
- Mitigation: not blocking for this one-off script; worth investigating if `bus_mirror.sqlite` is queried this way again.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1353


---

## Addendum: Idea F added to this PR (stale channel-node cleanup)

Bundled onto this branch rather than a separate PR -- both are one-off diagnostic/utility scripts from the same wider-net brainstorm sequence (G then F), reviewed together.

- `services/orion-bus-mirror/scripts/stale_channel_node_cleanup.py` (new): dry-run-by-default migration script. Uses the real production `normalize_channel_name()` as the source of truth for staleness -- a Channel node is a deletion candidate iff normalizing its name today produces a different string.
- `services/orion-bus-mirror/tests/test_stale_channel_node_cleanup.py` (new): 5 tests against the pure `compute_stale_channel_candidates()` function.

**Live dry-run result:** 9,303 of 9,436 Channel nodes (98.6%) are stale duplicates, all sampled candidates have `edge_count=1` (one-shot literal reply channels). Separately confirmed live that new writes are already correctly normalized (wildcard nodes updating every few seconds; the newest literal-UUID node found was ~4.5h stale) -- this is one-time historical debt, not an active leak.

```text
docker exec orion-athena-recall python3 stale_channel_node_cleanup.py
catalog channel names loaded: 266
total Channel nodes: 9436
stale candidates: 9303
total PUBLISHES edges on candidates: 9303
```

**`--execute` intentionally not run yet.** Deleting live production graph data requires its own explicit go-ahead, not blanket authorization from writing/testing the script -- per this repo's safety rules and this PR's own spec doc non-goals. Requesting that go-ahead separately.

### Tests run (F)

```text
PYTHONPATH="." venv/bin/python -m pytest services/orion-bus-mirror/tests/test_stale_channel_node_cleanup.py -q
5 passed
```


---

## Executed live (explicit go-ahead given)

`--execute` run against the live `orion_bus_synapse` graph. Deleted 9,303 stale Channel nodes.

**Live confirmation, before/after via `/api/bus-synaptic-graph/summary`:**

| metric | before | after |
|---|---|---|
| channel_count | 9,436 | **133** |
| publishes_edge_count | 9,494 | **191** |

`9,494 - 9,303 = 191` -- exact match with the dry-run prediction, confirming the deleted nodes' edges were removed 1:1 as expected (each stale node had `edge_count=1`).
