### PR TITLE
feat(hub): node-centrality route on the bus synaptic graph (Idea B)

### DIFF
--- a/services/orion-hub/scripts/bus_synaptic_graph_routes.py
+++ b/services/orion-hub/scripts/bus_synaptic_graph_routes.py
@@ -89,6 +89,42 @@ async def hot_edges(limit: int = Query(default=10, ge=1, le=100)) -> dict[str, A
     return {"edges": rows}
 
 
+@router.get("/node-centrality")
+async def node_centrality(limit: int = Query(default=15, ge=1, le=100)) -> dict[str, Any]:
+    """Real in+out degree over the CAUSALLY_FOLLOWED_BY organ-to-organ
+    subgraph -- Idea B of docs/superpowers/specs/2026-07-24-bus-synaptic-graph-
+    wider-net-brainstorm.md's "node centrality" wider-net idea.
+
+    Deliberately scoped to CAUSALLY_FOLLOWED_BY (organ-to-organ), not
+    PUBLISHES (organ-to-channel): the latter's Channel-node side was found
+    live to hold ~9K stale pre-normalization duplicates (fixed via
+    services/orion-bus-mirror/scripts/stale_channel_node_cleanup.py), and
+    even post-cleanup, PUBLISHES out-degree already has its own partial view
+    via /hot-organs. This route answers a genuinely different question: which
+    organs are structurally load-bearing in the *causal* flow of real
+    traffic, based on live observed cross-organ hops -- distinct from
+    ORGAN_REGISTRY's hand-authored, admittedly-approximate causal_parent_organs
+    edges. Degree only (not betweenness) -- FalkorDB has no native
+    betweenness-centrality query, and loading the whole graph into an
+    external library for it is an unmeasured cost, deferred to a later pass.
+    """
+    client = _client()
+    rows = client.graph_query(
+        """
+        MATCH (o:Organ)
+        OPTIONAL MATCH (o)-[out:CAUSALLY_FOLLOWED_BY]->()
+        OPTIONAL MATCH ()-[inc:CAUSALLY_FOLLOWED_BY]->(o)
+        WITH o, count(DISTINCT out) AS out_degree, count(DISTINCT inc) AS in_degree
+        WHERE out_degree > 0 OR in_degree > 0
+        RETURN o.organ_id AS organ_id, out_degree, in_degree, (out_degree + in_degree) AS total_degree
+        ORDER BY total_degree DESC
+        LIMIT $limit
+        """,
+        {"limit": limit},
+    )
+    return {"organs": rows}
+
+
 @router.get("/anomalies")
 async def anomalies(zscore_threshold: float = 3.0, min_count: int = 5) -> dict[str, Any]:
     """Edges whose most recent observation deviated sharply from that edge's

--- a/services/orion-hub/tests/test_bus_synaptic_graph_routes.py
+++ b/services/orion-hub/tests/test_bus_synaptic_graph_routes.py
@@ -63,6 +63,7 @@ class FakeGraphClient:
         "/api/bus-synaptic-graph/hot-organs",
         "/api/bus-synaptic-graph/hot-edges",
         "/api/bus-synaptic-graph/anomalies",
+        "/api/bus-synaptic-graph/node-centrality",
     ],
 )
 def test_falkordb_not_configured_returns_503(client: TestClient, path: str) -> None:
@@ -201,3 +202,46 @@ def test_anomalies_thresholds_are_configurable(client: TestClient) -> None:
 
     query_params = [p for _, p in fake.calls]
     assert all(p["threshold"] == 5.0 and p["min_count"] == 10 for p in query_params)
+
+
+def test_node_centrality_returns_ranked_list(client: TestClient) -> None:
+    fake = FakeGraphClient(
+        {
+            "total_degree": [
+                {"organ_id": "landing-pad", "out_degree": 15, "in_degree": 17, "total_degree": 32},
+                {"organ_id": "cortex-exec", "out_degree": 15, "in_degree": 16, "total_degree": 31},
+            ]
+        }
+    )
+    with patch.object(bus_synaptic_graph_routes, "_client", return_value=fake):
+        r = client.get("/api/bus-synaptic-graph/node-centrality")
+
+    assert r.status_code == 200
+    organs = r.json()["organs"]
+    assert organs[0]["organ_id"] == "landing-pad"
+    assert organs[0]["total_degree"] == 32
+    _, params = fake.calls[-1]
+    assert params["limit"] == 15
+
+
+def test_node_centrality_limit_rejects_out_of_range_values(client: TestClient) -> None:
+    fake = FakeGraphClient({"total_degree": []})
+    with patch.object(bus_synaptic_graph_routes, "_client", return_value=fake):
+        too_high = client.get("/api/bus-synaptic-graph/node-centrality?limit=1000")
+        too_low = client.get("/api/bus-synaptic-graph/node-centrality?limit=0")
+    assert too_high.status_code == 422
+    assert too_low.status_code == 422
+
+
+def test_node_centrality_only_matches_causally_followed_by_not_publishes(client: TestClient) -> None:
+    # A regression guard against accidentally widening this query to
+    # PUBLISHES (the Channel-node side, historically polluted with stale
+    # duplicates -- see stale_channel_node_cleanup.py). The query string
+    # itself must reference CAUSALLY_FOLLOWED_BY, not PUBLISHES.
+    fake = FakeGraphClient({"total_degree": []})
+    with patch.object(bus_synaptic_graph_routes, "_client", return_value=fake):
+        client.get("/api/bus-synaptic-graph/node-centrality")
+
+    cypher, _ = fake.calls[-1]
+    assert "CAUSALLY_FOLLOWED_BY" in cypher
+    assert "PUBLISHES" not in cypher


### PR DESCRIPTION
## Summary

- Idea B from `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md` (PR #1352): new `GET /api/bus-synaptic-graph/node-centrality` route -- real in+out degree over the `CAUSALLY_FOLLOWED_BY` organ-to-organ subgraph, ranked.
- Answers the design doc's own stated goal directly: a real, data-derived view of which organs are structurally load-bearing right now, based on actual observed traffic -- distinct from `orion/signals/registry.py::ORGAN_REGISTRY`'s hand-authored, admittedly-approximate `causal_parent_organs` edges.
- Deliberately scoped to `CAUSALLY_FOLLOWED_BY` (134 edges, clean), not `PUBLISHES`/`Channel` -- the latter held ~9K stale pre-normalization duplicate nodes until PR #1353's cleanup, and even post-cleanup, `PUBLISHES` out-degree already has a partial view via the existing `/hot-organs` route. This is a genuinely different question (causal-flow centrality vs. fan-out breadth).
- Degree only, not betweenness -- FalkorDB has no native betweenness-centrality query; loading the whole graph into an external library (networkx or similar) for it is an unmeasured cost, explicitly deferred per the design doc's own Non-goals.

## Outcome moved

Gives Orion (via Hub's debug API, same access pattern as `/hot-organs`/`/hot-edges`/`/anomalies`) a real answer to "which of my own subsystems am I most structurally dependent on right now" -- grounded in live traffic, not a hand-authored guess.

## Current architecture

`services/orion-hub/scripts/bus_synaptic_graph_routes.py` already exposes 4 read-only routes over the live `orion_bus_synapse` FalkorDB graph. `hot-organs` computes raw `PUBLISHES` out-degree only (a partial, already-shipped instance of "node centrality" on the noisier Channel side). No route existed for the `CAUSALLY_FOLLOWED_BY` subgraph's own centrality.

## Files changed

- `services/orion-hub/scripts/bus_synaptic_graph_routes.py`: new `/node-centrality` route.
- `services/orion-hub/tests/test_bus_synaptic_graph_routes.py`: 4 new tests (503 guard coverage extended to the new path, ranked-list shape, limit bounds, and a regression guard confirming the query only matches `CAUSALLY_FOLLOWED_BY`, never `PUBLISHES`).

## Schema / bus / API changes

- Added: `GET /api/bus-synaptic-graph/node-centrality` (Hub debug API). Read-only, no new graph node/edge type, no write path.

## Tests run

```text
cd services/orion-hub && PYTHONPATH="." venv/bin/python -m pytest tests/test_bus_synaptic_graph_routes.py -q
17 passed
```
(`.env` copied into the worktree temporarily for this run only, per this service's CWD-relative `env_file` setting -- removed immediately after, never committed.)

## Evals run

None applicable -- read-only debug route, same shape as its 4 siblings, none of which have a separate eval harness.

## Docker/build/smoke checks

Live-verified against real production data by running the exact same Cypher directly against the live `orion_bus_synapse` graph before writing the route (the running Hub container needs a real rebuild to pick up new route code, not a hot file copy -- deferred to actual deploy, same as every other PR in this arc):

```text
landing-pad: out=15 in=17 total=32
cortex-exec: out=15 in=16 total=31
spark-concept-induction: out=12 in=13 total=25
orion-vector-host: out=11 in=11 total=22
cortex-orch: out=12 in=10 total=22
```
Non-degenerate, plausible result -- `landing-pad`/`cortex-exec` as the most structurally central organs matches their role as central orchestration points.

## Review findings fixed

Not run as a separate subagent pass -- single new read-only route following an established, 4-times-precedented pattern in the same file, covered by 4 new tests including a regression guard.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: informational
- Concern: degree centrality is a real but limited signal -- betweenness would be more informative for "which organ, if it failed, would fragment the causal graph" but its cost is unmeasured.
- Mitigation: named explicitly as a deferred follow-up in the source design doc, not silently skipped.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1354
