### PR TITLE
feat(hub): anomaly propagation trace on the bus synaptic graph (Idea A)

### DIFF
--- a/services/orion-hub/scripts/bus_synaptic_graph_routes.py
+++ b/services/orion-hub/scripts/bus_synaptic_graph_routes.py
@@ -9,6 +9,7 @@ sitting in the data. No new edge/node type, no write path -- pure read.
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
@@ -18,6 +19,77 @@ from orion.graph.falkor_client import RedisGraphQueryClient
 from app.settings import settings
 
 router = APIRouter(prefix="/api/bus-synaptic-graph", tags=["bus-synaptic-graph"])
+
+
+def propagate_from_organ(
+    edges: list[dict[str, Any]],
+    *,
+    seed_organ_id: str,
+    max_hops: int,
+    zscore_threshold: float,
+    min_count: int,
+) -> dict[str, Any]:
+    """Pure bounded-BFS over an already-fetched CAUSALLY_FOLLOWED_BY edge list
+    (small -- 150 live edges as of this patch, cheap to load whole and walk
+    in Python rather than express as a Cypher variable-length path, which
+    FalkorDB requires a literal hop bound for, not a runtime parameter).
+
+    Idea A of docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-
+    brainstorm.md: trace a spike outward from ``seed_organ_id`` via real
+    observed cross-organ hops, to see which *downstream* organs are
+    currently absorbing that stress -- a propagation trace, not an isolated
+    per-edge alarm. "Elevated" uses the same threshold/min_count semantics
+    as the existing /anomalies route (min_count guards the same cold-start
+    z-score instability documented in orion-bus-mirror's README).
+
+    Separated from DB I/O so the traversal logic is testable against a
+    fixed edge list, matching this arc's established pattern (e.g.
+    stale_channel_node_cleanup.py's compute_stale_channel_candidates).
+    """
+    adjacency: dict[str, list[dict[str, Any]]] = {}
+    for edge in edges:
+        adjacency.setdefault(edge["source_organ"], []).append(edge)
+
+    edges_traversed: list[dict[str, Any]] = []
+    elevated_edges: list[dict[str, Any]] = []
+    organs_reached: set[str] = set()
+    visited_organs = {seed_organ_id}
+
+    frontier: deque[tuple[str, int]] = deque([(seed_organ_id, 0)])
+    while frontier:
+        organ_id, hop = frontier.popleft()
+        if hop >= max_hops:
+            continue
+        for edge in adjacency.get(organ_id, []):
+            target = edge["target_organ"]
+            zscore = edge.get("zscore")
+            is_elevated = (
+                zscore is not None
+                and abs(zscore) > zscore_threshold
+                and (edge.get("count") or 0) > min_count
+            )
+            entry = {**edge, "hop": hop + 1, "elevated": is_elevated}
+            edges_traversed.append(entry)
+            # A cycle back to the seed is real structure (kept in
+            # edges_traversed) but the seed is where the stress originated,
+            # not a downstream organ absorbing it -- excluded here so a
+            # cyclic CAUSALLY_FOLLOWED_BY chain doesn't report the seed as
+            # part of its own blast radius.
+            if target != seed_organ_id:
+                organs_reached.add(target)
+            if is_elevated:
+                elevated_edges.append(entry)
+            if target not in visited_organs:
+                visited_organs.add(target)
+                frontier.append((target, hop + 1))
+
+    return {
+        "seed_organ_id": seed_organ_id,
+        "max_hops": max_hops,
+        "edges_traversed": edges_traversed,
+        "elevated_edges": elevated_edges,
+        "organs_reached": sorted(organs_reached),
+    }
 
 
 def _client() -> RedisGraphQueryClient:
@@ -123,6 +195,40 @@ async def node_centrality(limit: int = Query(default=15, ge=1, le=100)) -> dict[
         {"limit": limit},
     )
     return {"organs": rows}
+
+
+@router.get("/anomaly-propagation")
+async def anomaly_propagation(
+    organ_id: str = Query(...),
+    max_hops: int = Query(default=2, ge=1, le=5),
+    zscore_threshold: float = 3.0,
+    min_count: int = 5,
+) -> dict[str, Any]:
+    """Trace downstream from ``organ_id`` via real CAUSALLY_FOLLOWED_BY hops,
+    flagging which edges along the way are themselves currently elevated --
+    a blast-radius view, not just an isolated per-edge alarm. Idea A of
+    docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md.
+
+    Loads the whole (small, ~150-edge) CAUSALLY_FOLLOWED_BY subgraph in one
+    query and walks it in Python via ``propagate_from_organ`` -- see that
+    function's docstring for why (FalkorDB variable-length paths need a
+    literal hop bound, not a runtime parameter).
+    """
+    client = _client()
+    rows = client.graph_query(
+        """
+        MATCH (a:Organ)-[e:CAUSALLY_FOLLOWED_BY]->(b:Organ)
+        RETURN a.organ_id AS source_organ, b.organ_id AS target_organ,
+               e.latency_zscore AS zscore, e.count AS count
+        """
+    )
+    return propagate_from_organ(
+        rows,
+        seed_organ_id=organ_id,
+        max_hops=max_hops,
+        zscore_threshold=zscore_threshold,
+        min_count=min_count,
+    )
 
 
 @router.get("/anomalies")

--- a/services/orion-hub/tests/test_bus_synaptic_graph_routes.py
+++ b/services/orion-hub/tests/test_bus_synaptic_graph_routes.py
@@ -245,3 +245,100 @@ def test_node_centrality_only_matches_causally_followed_by_not_publishes(client:
     cypher, _ = fake.calls[-1]
     assert "CAUSALLY_FOLLOWED_BY" in cypher
     assert "PUBLISHES" not in cypher
+
+
+# --- propagate_from_organ (pure BFS, Idea A) ---
+
+
+def test_propagate_traces_a_two_hop_chain() -> None:
+    edges = [
+        {"source_organ": "a", "target_organ": "b", "zscore": 1.0, "count": 100},
+        {"source_organ": "b", "target_organ": "c", "zscore": 9.0, "count": 100},
+    ]
+
+    result = bus_synaptic_graph_routes.propagate_from_organ(
+        edges, seed_organ_id="a", max_hops=2, zscore_threshold=3.0, min_count=5
+    )
+
+    assert result["organs_reached"] == ["b", "c"]
+    assert len(result["edges_traversed"]) == 2
+    assert [e["target_organ"] for e in result["elevated_edges"]] == ["c"]
+    assert result["elevated_edges"][0]["hop"] == 2
+
+
+def test_propagate_stops_at_max_hops() -> None:
+    edges = [
+        {"source_organ": "a", "target_organ": "b", "zscore": 9.0, "count": 100},
+        {"source_organ": "b", "target_organ": "c", "zscore": 9.0, "count": 100},
+    ]
+
+    result = bus_synaptic_graph_routes.propagate_from_organ(
+        edges, seed_organ_id="a", max_hops=1, zscore_threshold=3.0, min_count=5
+    )
+
+    assert result["organs_reached"] == ["b"]
+
+
+def test_propagate_does_not_revisit_organs_in_a_cycle() -> None:
+    edges = [
+        {"source_organ": "a", "target_organ": "b", "zscore": 1.0, "count": 100},
+        {"source_organ": "b", "target_organ": "a", "zscore": 1.0, "count": 100},
+    ]
+
+    result = bus_synaptic_graph_routes.propagate_from_organ(
+        edges, seed_organ_id="a", max_hops=5, zscore_threshold=3.0, min_count=5
+    )
+
+    # Must terminate (no infinite loop). Both real edges are recorded (a->b,
+    # b->a) -- the cycle back is real structure -- but the seed is never
+    # listed in organs_reached, since it's where the stress originated, not
+    # a downstream organ absorbing it.
+    assert result["organs_reached"] == ["b"]
+    assert len(result["edges_traversed"]) == 2
+    assert "a" not in result["organs_reached"]
+
+
+def test_propagate_respects_min_count_floor() -> None:
+    # High zscore but low count -- the same cold-start guard /anomalies uses.
+    edges = [{"source_organ": "a", "target_organ": "b", "zscore": 12.0, "count": 2}]
+
+    result = bus_synaptic_graph_routes.propagate_from_organ(
+        edges, seed_organ_id="a", max_hops=2, zscore_threshold=3.0, min_count=5
+    )
+
+    assert result["elevated_edges"] == []
+
+
+def test_propagate_handles_seed_with_no_outgoing_edges() -> None:
+    edges = [{"source_organ": "x", "target_organ": "y", "zscore": 9.0, "count": 100}]
+
+    result = bus_synaptic_graph_routes.propagate_from_organ(
+        edges, seed_organ_id="a", max_hops=2, zscore_threshold=3.0, min_count=5
+    )
+
+    assert result["organs_reached"] == []
+    assert result["edges_traversed"] == []
+
+
+def test_anomaly_propagation_route_requires_organ_id(client: TestClient) -> None:
+    fake = FakeGraphClient({"latency_zscore": []})
+    with patch.object(bus_synaptic_graph_routes, "_client", return_value=fake):
+        r = client.get("/api/bus-synaptic-graph/anomaly-propagation")
+    assert r.status_code == 422
+
+
+def test_anomaly_propagation_route_returns_traced_edges(client: TestClient) -> None:
+    fake = FakeGraphClient(
+        {
+            "latency_zscore": [
+                {"source_organ": "a", "target_organ": "b", "zscore": 9.0, "count": 100},
+            ]
+        }
+    )
+    with patch.object(bus_synaptic_graph_routes, "_client", return_value=fake):
+        r = client.get("/api/bus-synaptic-graph/anomaly-propagation?organ_id=a")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["organs_reached"] == ["b"]
+    assert len(body["elevated_edges"]) == 1


### PR DESCRIPTION
## Summary

- Idea A from `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md` (PR #1352, carried as an additive candidate): new `GET /api/bus-synaptic-graph/anomaly-propagation?organ_id=X` route.
- Bounded BFS outward from a seed organ via real `CAUSALLY_FOLLOWED_BY` hops, flagging which edges along the way are themselves currently elevated (same threshold/`min_count` semantics as the existing `/anomalies` route) -- a blast-radius trace, not just an isolated per-edge alarm.
- `propagate_from_organ()` is a pure function over an already-fetched edge list -- the whole ~150-edge `CAUSALLY_FOLLOWED_BY` subgraph is small enough to load once and walk in Python. FalkorDB variable-length paths need a literal hop bound, not a runtime parameter, so Cypher-side traversal wasn't a clean option.

## Outcome moved

Answers "what part of my own transport layer is under stress, and where does it flow" -- a real propagation trace, not a flat z-scored list. Closest thing in this arc so far to reasoning over the graph's own structure rather than reading isolated scalars off it.

## Files changed

- `services/orion-hub/scripts/bus_synaptic_graph_routes.py`: `propagate_from_organ()` (pure BFS) + `/anomaly-propagation` route.
- `services/orion-hub/tests/test_bus_synaptic_graph_routes.py`: 7 new tests -- 5 unit tests against the pure function (two-hop trace, max-hops cutoff, cycle handling, min_count floor, seed-with-no-edges), 2 route-level tests.

## Schema / bus / API changes

- Added: `GET /api/bus-synaptic-graph/anomaly-propagation` (Hub debug API). Read-only, no new graph node/edge type.

## Tests run

```text
cd services/orion-hub && PYTHONPATH="." venv/bin/python -m pytest tests/test_bus_synaptic_graph_routes.py -q
24 passed
```
(`.env` copied into the worktree temporarily for this run, removed immediately after, never committed.)

## Evals run

None applicable -- read-only debug route, same shape as its siblings.

## Docker/build/smoke checks

Live-verified `propagate_from_organ()` directly against real production data (the whole live `CAUSALLY_FOLLOWED_BY` edge set, fetched via the same Cypher the route uses):

```text
seed=landing-pad: organs_reached=22, edges_traversed=114
  elevated: cortex-orch->spark-concept-induction (zscore=6.4), orion-thought->spark-concept-induction (zscore=6.1),
            vision-council->landing-pad (zscore=17.5), cortex-gateway->landing-pad (zscore=-3.1)
seed=cortex-exec: organs_reached=21, edges_traversed=118
  elevated: cortex-orch->spark-concept-induction (zscore=6.4), orion-thought->spark-concept-induction (zscore=6.1),
            state-service->cortex-exec (zscore=3.6)
```
Non-degenerate, real elevated edges found within 2 hops from both seeds -- consistent with their #1/#2 node-centrality ranking from PR #1354.

## Review findings fixed

- Finding (caught via test-writing, before any subagent review): a cycle back to the seed organ incorrectly reported the seed itself as part of its own downstream blast radius (`organs_reached` included the seed).
  - Fix: excluded the seed from `organs_reached` while still recording the cyclic edge in `edges_traversed` as real structure -- the cycle itself is meaningful graph shape, just not "a downstream organ absorbing stress."
  - Evidence: `test_propagate_does_not_revisit_organs_in_a_cycle`.

Not run as a separate subagent pass beyond this -- new pure-function + single read-only route, directly modeled on PR #1354's precedent, covered by 7 new tests including the regression above.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: informational
- Concern: loads the whole `CAUSALLY_FOLLOWED_BY` edge set on every request (no caching) -- fine at 150 edges, would need revisiting if that subgraph grows by orders of magnitude.
- Mitigation: matches this arc's existing routes' cost profile; not a new pattern.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1355
