### PR TITLE
feat(bus-mirror,hub): cross-node imbalance tracking on the bus synaptic graph (Idea D)

### DIFF
--- a/services/orion-bus-mirror/app/graph_writer.py
+++ b/services/orion-bus-mirror/app/graph_writer.py
@@ -90,6 +90,13 @@ class BusEventFact:
     channel: str
     correlation_id: str | None
     observed_at_epoch: float
+    # Physical host the producing service reported itself on (envelope.source.node,
+    # e.g. "athena"/"atlas") -- None for envelopes that don't set it. Idea D of
+    # docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md:
+    # live-verified before building this the mesh genuinely spans multiple hosts
+    # today (a 2000-envelope sample found athena/atlas/circe all present), so this
+    # isn't speculative plumbing for a topology that doesn't exist.
+    node: str | None = None
 
 
 @dataclass(frozen=True)
@@ -133,6 +140,7 @@ class _ChainEntry:
     last_epoch: float
     hop_count: int  # total observations, including same-organ repeats
     real_hop_count: int  # cross-organ hops only -- the CAUSALLY_FOLLOWED_BY-producing kind
+    last_node: str | None = None  # host the last-observed hop's organ reported itself on
 
 
 @dataclass(frozen=True)
@@ -237,11 +245,11 @@ class ChainTracker:
                 break
             del self._entries[oldest_cid]
 
-    def observe(self, fact: BusEventFact) -> tuple[str, float] | None:
-        """Records this fact's (organ_id, observed_at_epoch) under its
+    def observe(self, fact: BusEventFact) -> tuple[str, float, str | None] | None:
+        """Records this fact's (organ_id, observed_at_epoch, node) under its
         correlation_id, evicting stale entries first. Returns the prior
-        (organ_id, epoch) entry for this correlation_id if one existed and
-        came from a *different* organ (a real cross-organ hop) -- None
+        (organ_id, epoch, node) entry for this correlation_id if one existed
+        and came from a *different* organ (a real cross-organ hop) -- None
         otherwise (no correlation_id, first sighting, or same-organ repeat).
         """
         self._evict_stale(fact.observed_at_epoch)
@@ -256,19 +264,21 @@ class ChainTracker:
                 last_epoch=fact.observed_at_epoch,
                 hop_count=1,
                 real_hop_count=0,
+                last_node=fact.node,
             )
             return None
 
-        prior_organ_id, prior_epoch = existing.last_organ_id, existing.last_epoch
+        prior_organ_id, prior_epoch, prior_node = existing.last_organ_id, existing.last_epoch, existing.last_node
         existing.last_organ_id = fact.organ_id
         existing.last_epoch = fact.observed_at_epoch
+        existing.last_node = fact.node
         existing.hop_count += 1
         self._entries.move_to_end(fact.correlation_id)
 
         if prior_organ_id == fact.organ_id:
             return None
         existing.real_hop_count += 1
-        return prior_organ_id, prior_epoch
+        return prior_organ_id, prior_epoch, prior_node
 
     def snapshot_open_chains(self, now_epoch: float) -> list[OpenChainInfo]:
         """Read-only snapshot of every currently-tracked chain -- no bus/graph
@@ -437,13 +447,15 @@ class BusSynapticGraphWriter:
         *,
         prior_organ_id: str,
         prior_epoch: float,
+        prior_node: str | None = None,
         fact: BusEventFact,
     ) -> None:
         latency_sec = max(fact.observed_at_epoch - prior_epoch, 0.0)
         prior_rows = self._client.graph_query(
             """
             MATCH (:Organ {organ_id: $prior_organ_id})-[e:CAUSALLY_FOLLOWED_BY]->(:Organ {organ_id: $organ_id})
-            RETURN e.latency_ewma_sec AS latency_ewma_sec, e.latency_var AS latency_var, e.count AS count
+            RETURN e.latency_ewma_sec AS latency_ewma_sec, e.latency_var AS latency_var, e.count AS count,
+                   e.cross_node_count AS cross_node_count
             """,
             {"prior_organ_id": prior_organ_id, "organ_id": fact.organ_id},
         )
@@ -451,6 +463,7 @@ class BusSynapticGraphWriter:
         prior_ewma = float(row.get("latency_ewma_sec") or 0.0)
         prior_var = float(row.get("latency_var") or 0.0)
         prior_count = int(row.get("count") or 0)
+        prior_cross_node_count = int(row.get("cross_node_count") or 0)
 
         update = compute_ewma_update(
             prev_ewma=prior_ewma,
@@ -458,6 +471,14 @@ class BusSynapticGraphWriter:
             prev_count=prior_count,
             value=latency_sec,
             alpha=self._alpha,
+        )
+        # Idea D of docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-
+        # brainstorm.md: does this specific hop cross a physical host boundary?
+        # Only counted when both sides report a node -- an unknown node on either
+        # end must not silently count as "same host" (that would understate real
+        # cross-node traffic) or "different host" (that would overstate it).
+        is_cross_node = (
+            prior_node is not None and fact.node is not None and prior_node != fact.node
         )
         self._client.graph_query(
             """
@@ -468,7 +489,10 @@ class BusSynapticGraphWriter:
                 e.last_seen_epoch = $now_epoch,
                 e.latency_ewma_sec = $latency_ewma_sec,
                 e.latency_var = $latency_var,
-                e.latency_zscore = $latency_zscore
+                e.latency_zscore = $latency_zscore,
+                e.last_source_node = $prior_node,
+                e.last_target_node = $target_node,
+                e.cross_node_count = $cross_node_count
             """,
             {
                 "prior_organ_id": prior_organ_id,
@@ -477,6 +501,9 @@ class BusSynapticGraphWriter:
                 "now_epoch": fact.observed_at_epoch,
                 "latency_ewma_sec": update.ewma,
                 "latency_var": update.variance,
+                "prior_node": prior_node,
+                "target_node": fact.node,
+                "cross_node_count": prior_cross_node_count + (1 if is_cross_node else 0),
                 "latency_zscore": update.zscore,
             },
         )
@@ -553,9 +580,11 @@ def extract_bus_event_fact(
         return None
     correlation_id = getattr(envelope, "correlation_id", None)
     graph_channel = normalize_channel_name(channel, catalog_names) if catalog_names else channel
+    node = getattr(source, "node", None) if source is not None else None
     return BusEventFact(
         organ_id=str(organ_id),
         channel=graph_channel,
         correlation_id=str(correlation_id) if correlation_id else None,
         observed_at_epoch=now if now is not None else time.time(),
+        node=str(node) if node else None,
     )

--- a/services/orion-bus-mirror/app/main.py
+++ b/services/orion-bus-mirror/app/main.py
@@ -79,12 +79,13 @@ async def _record_graph_event(
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, writer.record_publish, fact)
         if prior is not None:
-            prior_organ_id, prior_epoch = prior
+            prior_organ_id, prior_epoch, prior_node = prior
             await loop.run_in_executor(
                 None,
                 lambda: writer.record_causal_hop(
                     prior_organ_id=prior_organ_id,
                     prior_epoch=prior_epoch,
+                    prior_node=prior_node,
                     fact=fact,
                 ),
             )

--- a/services/orion-bus-mirror/tests/test_graph_writer.py
+++ b/services/orion-bus-mirror/tests/test_graph_writer.py
@@ -78,8 +78,12 @@ class TestComputeEwmaUpdate:
 
 
 class TestChainTracker:
-    def _fact(self, organ_id: str, correlation_id: Optional[str], epoch: float) -> BusEventFact:
-        return BusEventFact(organ_id=organ_id, channel="orion:test", correlation_id=correlation_id, observed_at_epoch=epoch)
+    def _fact(
+        self, organ_id: str, correlation_id: Optional[str], epoch: float, node: Optional[str] = None
+    ) -> BusEventFact:
+        return BusEventFact(
+            organ_id=organ_id, channel="orion:test", correlation_id=correlation_id, observed_at_epoch=epoch, node=node
+        )
 
     def test_first_sighting_of_a_correlation_id_returns_none(self) -> None:
         tracker = ChainTracker(ttl_sec=60.0)
@@ -97,7 +101,16 @@ class TestChainTracker:
         tracker = ChainTracker(ttl_sec=60.0)
         tracker.observe(self._fact("cortex-exec", "corr-1", 100.0))
         result = tracker.observe(self._fact("llm-gateway", "corr-1", 117.0))
-        assert result == ("cortex-exec", 100.0)
+        assert result == ("cortex-exec", 100.0, None)
+
+    def test_prior_hop_includes_the_node_it_was_observed_on(self) -> None:
+        # Idea D (cross-node imbalance): the returned prior tuple must carry
+        # the prior organ's node so record_causal_hop can tell whether this
+        # specific hop crossed a physical host boundary.
+        tracker = ChainTracker(ttl_sec=60.0)
+        tracker.observe(self._fact("cortex-exec", "corr-1", 100.0, node="athena"))
+        result = tracker.observe(self._fact("llm-gateway", "corr-1", 117.0, node="atlas"))
+        assert result == ("cortex-exec", 100.0, "athena")
 
     def test_missing_correlation_id_is_never_tracked(self) -> None:
         tracker = ChainTracker(ttl_sec=60.0)
@@ -137,7 +150,7 @@ class TestChainTracker:
         # At t=125, "inserted-later" (last touched at t=1) is stale under a
         # 120s TTL; "old-but-active" (last touched at t=50) is not.
         result = tracker.observe(self._fact("organ-c", "old-but-active", 125.0))
-        assert result == ("organ-b", 50.0)  # real hop, not evicted-then-reset
+        assert result == ("organ-b", 50.0, None)  # real hop, not evicted-then-reset
         remaining_ids = {c.correlation_id for c in tracker.snapshot_open_chains(now_epoch=125.0)}
         assert "inserted-later" not in remaining_ids
         assert "old-but-active" in remaining_ids
@@ -203,11 +216,65 @@ class TestBusSynapticGraphWriterCausalHop:
         write_call = fake_client.calls[-1]
         assert write_call[1]["latency_ewma_sec"] == 0.0
 
+    def test_cross_node_hop_increments_cross_node_count(self, fake_client: FakeGraphClient) -> None:
+        writer = BusSynapticGraphWriter(fake_client, alpha=0.2)
+        fact = BusEventFact(
+            organ_id="llm-gateway", channel="orion:x", correlation_id="corr-1", observed_at_epoch=1017.0, node="atlas"
+        )
+
+        writer.record_causal_hop(prior_organ_id="cortex-exec", prior_epoch=1000.0, prior_node="athena", fact=fact)
+
+        write_call = fake_client.calls[-1]
+        assert write_call[1]["cross_node_count"] == 1
+        assert write_call[1]["prior_node"] == "athena"
+        assert write_call[1]["target_node"] == "atlas"
+
+    def test_same_node_hop_does_not_increment_cross_node_count(self, fake_client: FakeGraphClient) -> None:
+        writer = BusSynapticGraphWriter(fake_client, alpha=0.2)
+        fact = BusEventFact(
+            organ_id="llm-gateway", channel="orion:x", correlation_id="corr-1", observed_at_epoch=1017.0, node="athena"
+        )
+
+        writer.record_causal_hop(prior_organ_id="cortex-exec", prior_epoch=1000.0, prior_node="athena", fact=fact)
+
+        write_call = fake_client.calls[-1]
+        assert write_call[1]["cross_node_count"] == 0
+
+    def test_unknown_node_on_either_side_does_not_count_as_cross_node(self, fake_client: FakeGraphClient) -> None:
+        # An unknown node on either end must not silently count as "same
+        # host" or "different host" -- both would misrepresent real
+        # cross-node traffic, one understating it, one overstating it.
+        writer = BusSynapticGraphWriter(fake_client, alpha=0.2)
+        fact = BusEventFact(
+            organ_id="llm-gateway", channel="orion:x", correlation_id="corr-1", observed_at_epoch=1017.0, node=None
+        )
+
+        writer.record_causal_hop(prior_organ_id="cortex-exec", prior_epoch=1000.0, prior_node="athena", fact=fact)
+
+        write_call = fake_client.calls[-1]
+        assert write_call[1]["cross_node_count"] == 0
+
+    def test_cross_node_count_accumulates_across_repeated_hops(self, fake_client: FakeGraphClient) -> None:
+        writer = BusSynapticGraphWriter(fake_client, alpha=0.2)
+        first = BusEventFact(
+            organ_id="llm-gateway", channel="orion:x", correlation_id="corr-1", observed_at_epoch=1017.0, node="atlas"
+        )
+        writer.record_causal_hop(prior_organ_id="cortex-exec", prior_epoch=1000.0, prior_node="athena", fact=first)
+        second = BusEventFact(
+            organ_id="llm-gateway", channel="orion:x", correlation_id="corr-2", observed_at_epoch=2017.0, node="atlas"
+        )
+        writer.record_causal_hop(prior_organ_id="cortex-exec", prior_epoch=2000.0, prior_node="athena", fact=second)
+
+        write_call = fake_client.calls[-1]
+        assert write_call[1]["cross_node_count"] == 2
+        assert write_call[1]["count"] == 2
+
 
 class TestExtractBusEventFact:
     @dataclass
     class _FakeSource:
         name: Optional[str]
+        node: Optional[str] = None
 
     @dataclass
     class _FakeEnvelope:
@@ -253,6 +320,18 @@ class TestExtractBusEventFact:
         )
         assert fact is not None
         assert fact.channel == "orion:exec:result:LLMGatewayService:0cf10589"
+
+    def test_extracts_node_when_present(self) -> None:
+        envelope = self._FakeEnvelope(source=self._FakeSource(name="cortex-exec", node="atlas"))
+        fact = extract_bus_event_fact(envelope, channel="orion:x", now=1.0)
+        assert fact is not None
+        assert fact.node == "atlas"
+
+    def test_node_defaults_to_none_when_source_has_no_node(self) -> None:
+        envelope = self._FakeEnvelope(source=self._FakeSource(name="cortex-exec"))
+        fact = extract_bus_event_fact(envelope, channel="orion:x", now=1.0)
+        assert fact is not None
+        assert fact.node is None
 
     def test_exact_catalog_channel_unaffected_by_normalization(self) -> None:
         envelope = self._FakeEnvelope(source=self._FakeSource(name="cortex-exec"))

--- a/services/orion-bus-mirror/tests/test_main_graph_integration.py
+++ b/services/orion-bus-mirror/tests/test_main_graph_integration.py
@@ -13,6 +13,7 @@ from app.main import _record_graph_event
 @dataclass
 class _FakeSource:
     name: Optional[str]
+    node: Optional[str] = None
 
 
 @dataclass
@@ -89,6 +90,28 @@ class TestRecordGraphEventFailsOpen:
         _, kwargs = writer.record_causal_hop.call_args
         assert kwargs["prior_organ_id"] == "cortex-exec"
         assert kwargs["prior_epoch"] == 100.0
+        assert kwargs["prior_node"] is None
+
+    @pytest.mark.asyncio
+    async def test_causal_hop_threads_the_prior_organs_node_through(self) -> None:
+        # Idea D (cross-node imbalance): record_causal_hop must receive the
+        # *prior* organ's node (from when it was first observed), not the
+        # current fact's node -- these can legitimately differ.
+        writer = MagicMock()
+        chain_tracker = ChainTracker(ttl_sec=60.0)
+        first = _FakeDecodeResult(
+            envelope=_FakeEnvelope(source=_FakeSource(name="cortex-exec", node="athena"), correlation_id="corr-1")
+        )
+        second = _FakeDecodeResult(
+            envelope=_FakeEnvelope(source=_FakeSource(name="llm-gateway", node="atlas"), correlation_id="corr-1")
+        )
+
+        await _record_graph_event(writer, chain_tracker, first, "orion:a", 100.0, set())
+        await _record_graph_event(writer, chain_tracker, second, "orion:b", 117.0, set())
+
+        _, kwargs = writer.record_causal_hop.call_args
+        assert kwargs["prior_node"] == "athena"
+        assert kwargs["fact"].node == "atlas"
 
 
 class TestRecordGraphEventVerbSteps:

--- a/services/orion-hub/scripts/bus_synaptic_graph_routes.py
+++ b/services/orion-hub/scripts/bus_synaptic_graph_routes.py
@@ -125,6 +125,42 @@ async def node_centrality(limit: int = Query(default=15, ge=1, le=100)) -> dict[
     return {"organs": rows}
 
 
+@router.get("/cross-node-imbalance")
+async def cross_node_imbalance(limit: int = Query(default=20, ge=1, le=100)) -> dict[str, Any]:
+    """Real cross-organ hops that cross a physical host boundary (e.g.
+    athena -> atlas), ranked by how often that's happened -- Idea D of
+    docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md.
+
+    Live-verified before building this: a 2000-envelope sample of real
+    traffic found envelope.source.node values of athena/atlas/circe all
+    present today -- the mesh genuinely spans multiple hosts, this isn't
+    speculative plumbing for a topology that doesn't exist.
+
+    ``cross_node_count`` / ``count`` on each edge is the real
+    infrastructure-load-balance signal: an edge that's *always* cross-node
+    is architecturally expected (e.g. a producer pinned to one host calling
+    a service pinned to another); a low but nonzero ratio suggests a
+    genuinely floating/unpinned deployment. Only edges that have observed at
+    least one hop with both sides' node populated are returned -- edges with
+    no node data yet (e.g. not touched since this feature deployed) are
+    correctly absent, not shown as zero.
+    """
+    client = _client()
+    rows = client.graph_query(
+        """
+        MATCH (a:Organ)-[e:CAUSALLY_FOLLOWED_BY]->(b:Organ)
+        WHERE e.cross_node_count IS NOT NULL
+        RETURN a.organ_id AS source_organ, b.organ_id AS target_organ,
+               e.last_source_node AS last_source_node, e.last_target_node AS last_target_node,
+               e.cross_node_count AS cross_node_count, e.count AS count
+        ORDER BY cross_node_count DESC
+        LIMIT $limit
+        """,
+        {"limit": limit},
+    )
+    return {"edges": rows}
+
+
 @router.get("/anomalies")
 async def anomalies(zscore_threshold: float = 3.0, min_count: int = 5) -> dict[str, Any]:
     """Edges whose most recent observation deviated sharply from that edge's

--- a/services/orion-hub/tests/test_bus_synaptic_graph_routes.py
+++ b/services/orion-hub/tests/test_bus_synaptic_graph_routes.py
@@ -64,6 +64,7 @@ class FakeGraphClient:
         "/api/bus-synaptic-graph/hot-edges",
         "/api/bus-synaptic-graph/anomalies",
         "/api/bus-synaptic-graph/node-centrality",
+        "/api/bus-synaptic-graph/cross-node-imbalance",
     ],
 )
 def test_falkordb_not_configured_returns_503(client: TestClient, path: str) -> None:
@@ -231,6 +232,39 @@ def test_node_centrality_limit_rejects_out_of_range_values(client: TestClient) -
         too_low = client.get("/api/bus-synaptic-graph/node-centrality?limit=0")
     assert too_high.status_code == 422
     assert too_low.status_code == 422
+
+
+def test_cross_node_imbalance_returns_ranked_edges(client: TestClient) -> None:
+    fake = FakeGraphClient(
+        {
+            "cross_node_count": [
+                {
+                    "source_organ": "landing-pad",
+                    "target_organ": "orion-mind",
+                    "last_source_node": "athena",
+                    "last_target_node": "atlas",
+                    "cross_node_count": 42,
+                    "count": 50,
+                }
+            ]
+        }
+    )
+    with patch.object(bus_synaptic_graph_routes, "_client", return_value=fake):
+        r = client.get("/api/bus-synaptic-graph/cross-node-imbalance")
+
+    assert r.status_code == 200
+    edges = r.json()["edges"]
+    assert edges[0]["source_organ"] == "landing-pad"
+    assert edges[0]["cross_node_count"] == 42
+    _, params = fake.calls[-1]
+    assert params["limit"] == 20
+
+
+def test_cross_node_imbalance_limit_rejects_out_of_range_values(client: TestClient) -> None:
+    fake = FakeGraphClient({"cross_node_count": []})
+    with patch.object(bus_synaptic_graph_routes, "_client", return_value=fake):
+        r = client.get("/api/bus-synaptic-graph/cross-node-imbalance?limit=1000")
+    assert r.status_code == 422
 
 
 def test_node_centrality_only_matches_causally_followed_by_not_publishes(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

- Idea D from `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md` (PR #1352, carried as an additive candidate): tracks whether real cross-organ hops cross a physical host boundary.
- **Premise checked live before building** (per the spec doc's own named Missing Question): sampled 2000 recent real envelopes from `bus_mirror.sqlite` -- `envelope.source.node` values found: `athena` (956), `atlas` (20), `athena-DEBUG-CONTAINER` (2), `circe` (2), `None` (1020). The mesh genuinely spans multiple hosts today; this wasn't speculative plumbing for a topology that doesn't exist.
- Threads `node` through the write path: `BusEventFact.node` -> `ChainTracker` (now returns `(organ_id, epoch, node)`) -> `record_causal_hop()`, which writes `last_source_node`/`last_target_node` and a `cross_node_count` (only incremented when both sides report a node and they differ).
- New `GET /api/bus-synaptic-graph/cross-node-imbalance`: ranked edges by `cross_node_count` -- a real, always-cross-node edge is architecturally expected; a low-but-nonzero ratio suggests a genuinely floating/unpinned deployment.

## Outcome moved

Surfaces a real infrastructure load-balance question Orion previously had no visibility into: which causal flows in its own transport layer are pinned to specific hosts vs. genuinely floating across them.

## Current architecture

`services/orion-bus-mirror/app/graph_writer.py`'s `ChainTracker`/`BusSynapticGraphWriter` track `CAUSALLY_FOLLOWED_BY` edges but had no host/node dimension at all. `services/orion-hub/scripts/bus_synaptic_graph_routes.py` has 5 existing read-only routes over the same graph.

## Files changed

- `services/orion-bus-mirror/app/graph_writer.py`: `BusEventFact.node`, `_ChainEntry.last_node`, `ChainTracker.observe()` returns a 3-tuple now, `record_causal_hop()` writes `last_source_node`/`last_target_node`/`cross_node_count`.
- `services/orion-bus-mirror/app/main.py`: threads `prior_node` from the tracker's return value into `record_causal_hop()`.
- `services/orion-bus-mirror/tests/test_graph_writer.py`: fixed 2 pre-existing tests whose assertions checked the old 2-tuple shape; added 7 new tests (node extraction, node threading through `ChainTracker`, cross-node counting -- including an explicit test that an unknown node on either side does *not* count as cross-node).
- `services/orion-bus-mirror/tests/test_main_graph_integration.py`: added a test confirming the prior organ's node (not the current fact's node) is what gets threaded to `record_causal_hop`.
- `services/orion-hub/scripts/bus_synaptic_graph_routes.py`: new `/cross-node-imbalance` route.
- `services/orion-hub/tests/test_bus_synaptic_graph_routes.py`: 2 new tests + extended the 503-guard parametrization.

## Schema / bus / API changes

- Added graph edge properties: `CAUSALLY_FOLLOWED_BY.last_source_node`, `.last_target_node`, `.cross_node_count`. Additive, no migration needed -- existing edges simply have these as null/absent until their next real hop.
- Added: `GET /api/bus-synaptic-graph/cross-node-imbalance` (Hub debug API).

## Tests run

```text
PYTHONPATH="services/orion-bus-mirror:." venv/bin/python -m pytest services/orion-bus-mirror/tests/ -q
71 passed

cd services/orion-hub && PYTHONPATH="." venv/bin/python -m pytest tests/test_bus_synaptic_graph_routes.py -q
20 passed
```
(`.env` copied into the hub worktree temporarily for that run, removed immediately after, never committed.)

## Evals run

None applicable.

## Docker/build/smoke checks

**Not live-verifiable yet, unlike this arc's read-only ideas (A/B/G/F).** This is a write-path change -- `cross_node_count`/`last_source_node`/`last_target_node` only start populating once `orion-bus-mirror` is redeployed and processes new causal hops through the updated code. The *premise* (multi-host traffic genuinely exists) was live-verified via direct `bus_mirror.sqlite` sampling before writing any code (see Summary). The mechanism itself is covered by 9 new/fixed unit tests against a stateful fake graph client, not live production data.

## Review findings fixed

Not run as a separate subagent pass. Caught via test-writing (not review): the `ChainTracker.observe()` return-shape change broke 1 pre-existing test's assertion (fixed) and required updating another's expected tuple -- both were mechanical shape updates, not logic bugs.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-bus-mirror/.env \
  -f services/orion-bus-mirror/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: informational
- Concern: the actual `cross_node_count` signal is unverified against real data until after deploy (only the mechanism is unit-tested).
- Mitigation: next step post-deploy is the same live-verification pattern this whole arc has used -- check `/cross-node-imbalance` after real traffic accumulates, same as every other route in this session.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1356
