### PR TITLE
feat(bus-mirror): in-progress chain-shape clustering (Idea C)

### DIFF
--- a/services/orion-bus-mirror/app/graph_writer.py
+++ b/services/orion-bus-mirror/app/graph_writer.py
@@ -73,6 +73,7 @@ __all__ = [
     "OpenChainInfo",
     "OpenChainSummary",
     "summarize_open_chains",
+    "summarize_chain_shapes",
     "VerbStepFact",
     "extract_verb_step_facts",
     "BusSynapticGraphWriter",
@@ -126,6 +127,9 @@ def compute_ewma_update(
     return EwmaUpdate(ewma=new_ewma, variance=new_variance, zscore=zscore)
 
 
+_MAX_ORGAN_SEQUENCE_LEN = 20
+
+
 @dataclass
 class _ChainEntry:
     started_at_epoch: float
@@ -133,6 +137,12 @@ class _ChainEntry:
     last_epoch: float
     hop_count: int  # total observations, including same-organ repeats
     real_hop_count: int  # cross-organ hops only -- the CAUSALLY_FOLLOWED_BY-producing kind
+    # Idea C of docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-
+    # brainstorm.md: distinct organs touched so far, in order -- only real
+    # cross-organ hops append (same-organ repeats don't, matching real_hop_count's
+    # own filtering), and bounded at _MAX_ORGAN_SEQUENCE_LEN so a pathologically
+    # long-lived chain can't grow this entry's memory footprint without bound.
+    organ_sequence: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -143,6 +153,7 @@ class OpenChainInfo:
     duration_sec: float
     hop_count: int
     real_hop_count: int
+    organ_sequence: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -188,6 +199,32 @@ def summarize_open_chains(
         long_running_count=long_running,
         max_duration_sec=max(durations),
     )
+
+
+def summarize_chain_shapes(
+    open_chains: list[OpenChainInfo], *, top_n: int = 10, min_real_hop_count: int = 1
+) -> list[tuple[tuple[str, ...], int]]:
+    """Idea C of docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-
+    brainstorm.md: bucket currently-open chains by the sequence of organs
+    touched so far, report frequency -- an "in-progress-shape distribution,"
+    explicitly not a "completed-routine distribution": chain termination has
+    no defined closing event in this codebase today (see ``ChainTracker``'s
+    own docstring), so this sidesteps that unresolved question rather than
+    solving it. A small number of common shapes dominating real traffic would
+    be a real, observed structural signal; a shape appearing only once is
+    itself worth noticing, just not flagged as "novel" here (that needs
+    persistent shape history across restarts -- a bigger, separate slice, not
+    built here).
+
+    Same ``min_real_hop_count`` filtering as ``summarize_open_chains`` -- a
+    chain with no real cross-organ hop has no shape beyond a single organ,
+    which isn't a "shape" worth bucketing.
+    """
+    chains = [c for c in open_chains if c.real_hop_count >= min_real_hop_count]
+    counts: dict[tuple[str, ...], int] = {}
+    for chain in chains:
+        counts[chain.organ_sequence] = counts.get(chain.organ_sequence, 0) + 1
+    return sorted(counts.items(), key=lambda item: item[1], reverse=True)[:top_n]
 
 
 class ChainTracker:
@@ -256,6 +293,7 @@ class ChainTracker:
                 last_epoch=fact.observed_at_epoch,
                 hop_count=1,
                 real_hop_count=0,
+                organ_sequence=(fact.organ_id,),
             )
             return None
 
@@ -268,6 +306,8 @@ class ChainTracker:
         if prior_organ_id == fact.organ_id:
             return None
         existing.real_hop_count += 1
+        if len(existing.organ_sequence) < _MAX_ORGAN_SEQUENCE_LEN:
+            existing.organ_sequence = existing.organ_sequence + (fact.organ_id,)
         return prior_organ_id, prior_epoch
 
     def snapshot_open_chains(self, now_epoch: float) -> list[OpenChainInfo]:
@@ -286,6 +326,7 @@ class ChainTracker:
                 duration_sec=max(now_epoch - entry.started_at_epoch, 0.0),
                 hop_count=entry.hop_count,
                 real_hop_count=entry.real_hop_count,
+                organ_sequence=entry.organ_sequence,
             )
             for cid, entry in self._entries.items()
         ]

--- a/services/orion-bus-mirror/app/main.py
+++ b/services/orion-bus-mirror/app/main.py
@@ -16,6 +16,7 @@ from app.graph_writer import (
     ChainTracker,
     extract_bus_event_fact,
     extract_verb_step_facts,
+    summarize_chain_shapes,
     summarize_open_chains,
 )
 from app.settings import settings
@@ -125,6 +126,16 @@ async def _run_inflight_chain_summary_loop(chain_tracker: ChainTracker) -> None:
                     summary.long_running_count,
                     summary.max_duration_sec,
                 )
+                # Idea C: same log-only-first visibility step Phase 2 already
+                # used for the in-flight signal above -- report the top
+                # in-progress chain shapes before deciding how (or whether)
+                # this becomes a real consumer-facing signal.
+                top_shapes = summarize_chain_shapes(open_chains, top_n=5)
+                if top_shapes:
+                    logger.info(
+                        "bus synaptic graph top in-progress chain shapes: {}",
+                        [f"{'->'.join(shape)} x{count}" for shape, count in top_shapes],
+                    )
         except Exception as exc:  # fail-open, matching _record_graph_event's discipline:
             # an unhandled exception here would otherwise die silently (nothing
             # awaits this task directly) instead of just skipping one tick.

--- a/services/orion-bus-mirror/tests/test_graph_writer.py
+++ b/services/orion-bus-mirror/tests/test_graph_writer.py
@@ -13,6 +13,7 @@ from app.graph_writer import (
     compute_ewma_update,
     extract_bus_event_fact,
     extract_verb_step_facts,
+    summarize_chain_shapes,
     summarize_open_chains,
 )
 
@@ -318,6 +319,35 @@ class TestChainTrackerInFlight:
         tracker = ChainTracker(ttl_sec=60.0)
         assert tracker.snapshot_open_chains(now_epoch=1.0) == []
 
+    def test_organ_sequence_records_distinct_organs_in_order(self) -> None:
+        tracker = ChainTracker(ttl_sec=120.0)
+        tracker.observe(self._fact("a", "corr-1", 0.0))
+        tracker.observe(self._fact("b", "corr-1", 1.0))
+        tracker.observe(self._fact("c", "corr-1", 2.0))
+
+        snapshot = tracker.snapshot_open_chains(now_epoch=10.0)
+
+        assert snapshot[0].organ_sequence == ("a", "b", "c")
+
+    def test_organ_sequence_does_not_grow_on_same_organ_repeat(self) -> None:
+        tracker = ChainTracker(ttl_sec=120.0)
+        tracker.observe(self._fact("a", "corr-1", 0.0))
+        tracker.observe(self._fact("a", "corr-1", 1.0))
+        tracker.observe(self._fact("b", "corr-1", 2.0))
+
+        snapshot = tracker.snapshot_open_chains(now_epoch=10.0)
+
+        assert snapshot[0].organ_sequence == ("a", "b")
+
+    def test_organ_sequence_is_bounded_for_pathologically_long_chains(self) -> None:
+        tracker = ChainTracker(ttl_sec=1000.0)
+        for i in range(50):
+            tracker.observe(self._fact(f"organ-{i}", "corr-1", float(i)))
+
+        snapshot = tracker.snapshot_open_chains(now_epoch=1000.0)
+
+        assert len(snapshot[0].organ_sequence) == 20  # _MAX_ORGAN_SEQUENCE_LEN
+
 
 class TestSummarizeOpenChains:
     def test_empty_input_is_a_zeroed_summary(self) -> None:
@@ -377,6 +407,58 @@ class TestSummarizeOpenChains:
         # chain, proving the threshold is a real, honored parameter.
         summary = summarize_open_chains(snapshot, long_running_threshold_sec=30.0, min_real_hop_count=0)
         assert summary.open_count == 1
+
+
+class TestSummarizeChainShapes:
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert summarize_chain_shapes([]) == []
+
+    def test_groups_identical_shapes_and_counts_them(self) -> None:
+        tracker = ChainTracker(ttl_sec=120.0)
+        tracker.observe(BusEventFact(organ_id="a", channel="c", correlation_id="corr-1", observed_at_epoch=0.0))
+        tracker.observe(BusEventFact(organ_id="b", channel="c", correlation_id="corr-1", observed_at_epoch=1.0))
+        tracker.observe(BusEventFact(organ_id="a", channel="c", correlation_id="corr-2", observed_at_epoch=0.0))
+        tracker.observe(BusEventFact(organ_id="b", channel="c", correlation_id="corr-2", observed_at_epoch=1.0))
+        snapshot = tracker.snapshot_open_chains(now_epoch=100.0)
+
+        shapes = summarize_chain_shapes(snapshot)
+
+        assert shapes == [(("a", "b"), 2)]
+
+    def test_distinct_shapes_are_ranked_by_frequency(self) -> None:
+        tracker = ChainTracker(ttl_sec=120.0)
+        for cid in ("corr-1", "corr-2", "corr-3"):
+            tracker.observe(BusEventFact(organ_id="a", channel="c", correlation_id=cid, observed_at_epoch=0.0))
+            tracker.observe(BusEventFact(organ_id="b", channel="c", correlation_id=cid, observed_at_epoch=1.0))
+        tracker.observe(BusEventFact(organ_id="x", channel="c", correlation_id="corr-4", observed_at_epoch=0.0))
+        tracker.observe(BusEventFact(organ_id="y", channel="c", correlation_id="corr-4", observed_at_epoch=1.0))
+        snapshot = tracker.snapshot_open_chains(now_epoch=100.0)
+
+        shapes = summarize_chain_shapes(snapshot)
+
+        assert shapes[0] == (("a", "b"), 3)
+        assert shapes[1] == (("x", "y"), 1)
+
+    def test_single_hop_chains_have_no_shape_by_default(self) -> None:
+        # Matches summarize_open_chains's own min_real_hop_count=1 default --
+        # a never-hopped chain has no shape beyond a single organ, not worth
+        # bucketing as a "routine."
+        tracker = ChainTracker(ttl_sec=120.0)
+        tracker.observe(BusEventFact(organ_id="a", channel="c", correlation_id="one-shot", observed_at_epoch=0.0))
+        snapshot = tracker.snapshot_open_chains(now_epoch=100.0)
+
+        assert summarize_chain_shapes(snapshot) == []
+
+    def test_top_n_caps_the_number_of_shapes_returned(self) -> None:
+        tracker = ChainTracker(ttl_sec=120.0)
+        for i in range(5):
+            tracker.observe(BusEventFact(organ_id=f"a{i}", channel="c", correlation_id=f"corr-{i}", observed_at_epoch=0.0))
+            tracker.observe(BusEventFact(organ_id=f"b{i}", channel="c", correlation_id=f"corr-{i}", observed_at_epoch=1.0))
+        snapshot = tracker.snapshot_open_chains(now_epoch=100.0)
+
+        shapes = summarize_chain_shapes(snapshot, top_n=2)
+
+        assert len(shapes) == 2
 
     def test_multi_hop_chain_below_duration_threshold_is_not_long_running(self) -> None:
         tracker = ChainTracker(ttl_sec=120.0)


### PR DESCRIPTION
## Summary

- Idea C from `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md` (PR #1352, carried as an additive candidate): buckets currently-open chains by the sequence of organs touched so far, reports frequency.
- Explicitly an "in-progress-shape distribution," not "completed-routine distribution" -- chain termination has no defined closing event in this codebase today (`ChainTracker`'s own docstring), so this sidesteps that unresolved question per the design doc's own scoping, rather than solving it.
- `_ChainEntry`/`OpenChainInfo` gain `organ_sequence`: only real cross-organ hops append (same-organ repeats don't, matching `real_hop_count`'s own filtering), bounded at 20 entries so a pathologically long-lived chain can't grow this without bound.
- New `summarize_chain_shapes()` pure function, wired into the existing periodic in-flight-chain-summary log line -- same "log-only visibility first" pattern Phase 2 already used for the in-flight-chain signal itself before any consumer wiring.

## Outcome moved

Surfaces Orion's own habitual cognitive routines (observed organ-sequences) as a real, data-derived structure for the first time -- previously this state existed only as `hop_count`/`real_hop_count` scalars per chain, with no shape information at all.

## Current architecture

`services/orion-bus-mirror/app/graph_writer.py`'s `ChainTracker` already tracks `hop_count`/`real_hop_count`/duration per correlation_id (Phase 2, PR #1328/#1333) but not the sequence of organs touched. `_run_inflight_chain_summary_loop` in `main.py` already logs a periodic in-flight-chain summary, log-only, no consumer wired.

## Files changed

- `services/orion-bus-mirror/app/graph_writer.py`: `_ChainEntry.organ_sequence`/`OpenChainInfo.organ_sequence`, populated in `ChainTracker.observe()`/`snapshot_open_chains()`; new `summarize_chain_shapes()`.
- `services/orion-bus-mirror/app/main.py`: wires `summarize_chain_shapes()` into the existing periodic log loop.
- `services/orion-bus-mirror/tests/test_graph_writer.py`: 8 new tests (sequence recording, same-organ-repeat exclusion, bounding, grouping/ranking, single-hop exclusion, top_n cap).

## Schema / bus / API changes

None -- in-memory process state only, no graph node/edge/schema change, no new route in this PR (matches the idea's own stated smallest-buildable-version: log-only visibility first, consumer wiring deferred).

## Tests run

```text
PYTHONPATH="services/orion-bus-mirror:." venv/bin/python -m pytest services/orion-bus-mirror/tests/ -q
71 passed
```

## Evals run

None applicable.

## Docker/build/smoke checks

**Not live-verifiable the way this arc's Falkor-backed read-only ideas (A/B/G/F) were** -- `ChainTracker` is in-memory process state inside the running `orion-bus-mirror` service, not queryable externally. Live verification is a post-deploy log check: watch for the new `"bus synaptic graph top in-progress chain shapes: [...]"` log line appearing with real, non-degenerate content once real chains accumulate. Same honest framing as Idea D (PR #1356), which has the same limitation for a different reason (write-path change needing fresh traffic).

## Review findings fixed

Not run as a separate subagent pass -- pure, additive extension to an already-tested, already-live data structure, covered by 8 new unit tests including a bounding regression test.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-bus-mirror/.env \
  -f services/orion-bus-mirror/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: informational
- Concern: real shape diversity/dominance in production traffic is unmeasured -- this PR only makes the signal observable, doesn't yet answer "do a small number of shapes actually dominate."
- Mitigation: log-only first, matching the same discipline Phase 2 used before deciding whether to wire a real consumer.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1357
