### PR TITLE
fix(agent-board): stop Stop-hook nagging on stale ownerless board items

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-24-agent-board-stale-ownerless-item-nag-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-24-agent-board-stale-ownerless-item-nag-pr.md
@@ -1,0 +1,77 @@
+# PR report: agent-board Stop-hook stale ownerless item nag
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1358
+Branch: `fix/agent-board-stale-ownerless-item-nag`
+
+## Summary
+
+- The agent-board Stop hook (`scripts/hooks/session_stop_agent_board.py`) nagged every session that stopped in a worktree about ownerless board items (no `session_id`, e.g. items added before that field existed, or via a plain CLI call) forever -- `agent_board.py checkout` only closes *presence*, it never touches item status.
+- Live-confirmed 2026-07-24: a session got the identical "22 open item(s) remain for this worktree" nag on repeated Stops, and running `checkout` did not clear it -- consistent with the pre-existing `project_agent_board_stop_hook_nag_recurrence_2026-07-22` memory, but this time root-caused to a specific line rather than left as "possible regression, cause unknown."
+- Fix: ownerless items older than 24h (by `updated_at`) are excluded from the nag count. Items belonging to the *current* session still nag regardless of age. The existing fail-open behavior when our own `session_id` can't be resolved (non-Claude-Code harness, malformed stdin payload) is unchanged.
+
+## Outcome moved
+
+The Stop hook no longer nags indefinitely about historical, unowned backlog a session never touched. It still nags about the current session's own open items (any age) and about genuinely recent (<24h) ownerless items that might need attribution -- so real same-day work isn't silently hidden.
+
+## Current architecture
+
+`session_stop_agent_board.py` reads board state via `agent_board_lib.load_state()`, filters items to the current worktree with status `open`/`parked`, and includes an item in the nag count if it has no `session_id` or its `session_id` matches the current session (or if the current session's own `session_id` couldn't be resolved, in which case it fails open and includes everything). No staleness concept existed.
+
+## Architecture touched
+
+- `scripts/hooks/session_stop_agent_board.py`
+- `scripts/test_session_stop_agent_board.py` (new)
+
+## Files changed
+
+- `scripts/hooks/session_stop_agent_board.py`: added `_is_stale_ownerless_item()` (24h cutoff on `updated_at`, fails open to "not stale" on a missing/malformed timestamp) and folded it into the existing item filter.
+- `scripts/test_session_stop_agent_board.py`: new -- 5 tests covering stale-ownerless-silent, fresh-ownerless-nags, own-session-nags-regardless-of-age, mixed stale/fresh aggregation, and fail-open-on-unresolved-session_id.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```
+$ python3 scripts/test_session_stop_agent_board.py
+all tests passed
+```
+
+## Evals run
+
+N/A -- no eval harness exists for this hook script; it's small and fails silently by design.
+
+## Docker/build/smoke checks
+
+N/A -- pure local Python hook invoked by the Claude Code harness at Stop time, no service/container/runtime surface touched.
+
+## Review findings fixed
+
+- Finding: no test covering nag-count aggregation across a mix of stale and fresh ownerless items (only single-item cases existed).
+  - Fix: added `test_mixed_stale_and_fresh_ownerless_items_counts_only_fresh`.
+  - Evidence: `python3 scripts/test_session_stop_agent_board.py` -- all 5 tests pass.
+- Reviewer independently verified `updated_at` is reliably present on every item that lands in `state.items` (traced to `agent_board_lib.py`'s `payload.setdefault("updated_at", event.at)` inside `load_state()`, and the single `item_upserted` producer path in `add_item()`), confirming the staleness check reads a real, always-present field rather than assuming one exists.
+- Verdict: clean overall, no material findings requiring a fix beyond the one test added above.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+This is a Claude Code Stop hook read fresh at hook-invocation time from `.claude/settings.json` -- no long-running process to restart.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the 24h cutoff is a judgment call, not derived from measured data on how often ownerless items are legitimately still-relevant same-day work.
+- Mitigation: items belonging to the current session are never filtered by age regardless of the cutoff, so a session's own in-progress work is never silently hidden by this change -- only cross-session unowned backlog older than a day stops nagging by default. The underlying backlog (dozens of real `note/finding`/`should/finding` items surfaced via `agent_board.py checkin` during this investigation) still exists on the board and still needs someone to actually triage it via `resolve`/`park` -- this PR only stops the mechanical nag-forever side effect, it does not resolve the backlog itself.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1358

--- a/scripts/hooks/session_stop_agent_board.py
+++ b/scripts/hooks/session_stop_agent_board.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -18,6 +19,25 @@ from agent_board_lib import (  # noqa: E402
     read_session_id_from_stdin_hook_payload,
     resolve_current_identity,
 )
+
+# Ownerless items (no session_id) older than this stop nagging every session
+# that ever stops in the worktree -- see _is_stale_ownerless_item below.
+_OWNERLESS_ITEM_STALE_AFTER = timedelta(hours=24)
+
+
+def _is_stale_ownerless_item(item: dict) -> bool:
+    raw = item.get("updated_at")
+    if not raw:
+        # No timestamp to judge age by -- keep the old fail-open behavior
+        # (treat as fresh, i.e. still nag) rather than guessing.
+        return False
+    try:
+        updated_at = datetime.fromisoformat(str(raw))
+    except (ValueError, TypeError):
+        return False
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - updated_at) > _OWNERLESS_ITEM_STALE_AFTER
 
 
 def main() -> None:
@@ -37,18 +57,28 @@ def main() -> None:
         # items still gets nagged every Stop about work it never touched.
         # Items with no session_id (added before this field existed, or by a
         # plain shell call outside Claude Code) have no session to attribute
-        # them to, so they keep nagging rather than going silently unowned.
-        # If *our own* session_id couldn't be resolved (missing/malformed
-        # stdin payload, or a non-Claude-Code harness whose Stop payload
-        # doesn't carry one), we can't tell "mine" from "someone else's"
-        # either -- fail open (fall back to plain worktree scoping) rather
-        # than silently excluding every item that happens to carry a real
-        # session_id.
+        # them to, so a *recent* one still nags rather than going silently
+        # unowned. But without a staleness cutoff this becomes permanent: a
+        # legacy ownerless item never stops nagging, for every future session
+        # that stops in the worktree, since `checkout` closes presence, not
+        # items -- live-confirmed 2026-07-24 (dozens of pre-session_id-field
+        # findings nagging a session that never touched them). Past the
+        # cutoff, treat it as backlog to triage explicitly, not a per-Stop
+        # reminder. If *our own* session_id couldn't be resolved
+        # (missing/malformed stdin payload, or a non-Claude-Code harness
+        # whose Stop payload doesn't carry one), we can't tell "mine" from
+        # "someone else's" either -- fail open (fall back to plain worktree
+        # scoping, no staleness filter) rather than silently excluding every
+        # item that happens to carry a real session_id.
         open_items = [
             item for item in state.items.values()
             if item.get("worktree_path") == current
             and item.get("status") in {"open", "parked"}
-            and (session_id is None or not item.get("session_id") or item.get("session_id") == session_id)
+            and (
+                session_id is None
+                or item.get("session_id") == session_id
+                or (not item.get("session_id") and not _is_stale_ownerless_item(item))
+            )
         ]
     except Exception:
         return

--- a/scripts/test_session_stop_agent_board.py
+++ b/scripts/test_session_stop_agent_board.py
@@ -1,0 +1,103 @@
+"""Tests for the session_stop_agent_board Stop hook's staleness filtering.
+
+Regression coverage for a live bug found 2026-07-24: ownerless items (no
+session_id, e.g. pre-dating that field) nagged every session that ever
+stopped in the worktree, forever, since `checkout` closes presence but never
+touches item status. See scripts/hooks/session_stop_agent_board.py.
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.insert(0, "scripts")
+sys.path.insert(0, "scripts/hooks")
+
+hook = importlib.import_module("session_stop_agent_board")
+
+
+def _state_with_items(items: dict) -> SimpleNamespace:
+    return SimpleNamespace(items=items)
+
+
+def _run_hook(items: dict, session_id: str | None = "current-session") -> str | None:
+    with mock.patch.object(hook, "read_session_id_from_stdin_hook_payload", return_value=session_id), \
+         mock.patch.object(hook, "board_config_from_env", return_value=object()), \
+         mock.patch.object(hook, "resolve_current_identity", return_value={"worktree_path": "/repo"}), \
+         mock.patch.object(hook, "load_state", return_value=_state_with_items(items)):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            hook.main()
+        return buf.getvalue()
+
+
+def test_stale_ownerless_item_does_not_nag() -> None:
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    items = {
+        "item-1": {
+            "worktree_path": "/repo",
+            "status": "open",
+            "session_id": None,
+            "updated_at": old_ts,
+        }
+    }
+    out = _run_hook(items)
+    assert out == "", f"expected silence for stale ownerless item, got: {out!r}"
+
+
+def test_fresh_ownerless_item_still_nags() -> None:
+    fresh_ts = datetime.now(timezone.utc).isoformat()
+    items = {
+        "item-1": {
+            "worktree_path": "/repo",
+            "status": "open",
+            "session_id": None,
+            "updated_at": fresh_ts,
+        }
+    }
+    out = _run_hook(items)
+    assert out, "expected a nag for a fresh ownerless item"
+    payload = json.loads(out)
+    assert "1 open item" in payload["hookSpecificOutput"]["additionalContext"]
+
+
+def test_own_session_item_nags_regardless_of_age() -> None:
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    items = {
+        "item-1": {
+            "worktree_path": "/repo",
+            "status": "open",
+            "session_id": "current-session",
+            "updated_at": old_ts,
+        }
+    }
+    out = _run_hook(items, session_id="current-session")
+    assert out, "expected a nag for the current session's own old item"
+
+
+def test_unresolved_session_id_fails_open_ignoring_staleness() -> None:
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    items = {
+        "item-1": {
+            "worktree_path": "/repo",
+            "status": "open",
+            "session_id": None,
+            "updated_at": old_ts,
+        }
+    }
+    out = _run_hook(items, session_id=None)
+    assert out, "expected fail-open nag when our own session_id can't be resolved"
+
+
+if __name__ == "__main__":
+    test_stale_ownerless_item_does_not_nag()
+    test_fresh_ownerless_item_still_nags()
+    test_own_session_item_nags_regardless_of_age()
+    test_unresolved_session_id_fails_open_ignoring_staleness()
+    print("all tests passed")

--- a/scripts/test_session_stop_agent_board.py
+++ b/scripts/test_session_stop_agent_board.py
@@ -81,6 +81,20 @@ def test_own_session_item_nags_regardless_of_age() -> None:
     assert out, "expected a nag for the current session's own old item"
 
 
+def test_mixed_stale_and_fresh_ownerless_items_counts_only_fresh() -> None:
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    fresh_ts = datetime.now(timezone.utc).isoformat()
+    items = {
+        "stale-1": {"worktree_path": "/repo", "status": "open", "session_id": None, "updated_at": old_ts},
+        "stale-2": {"worktree_path": "/repo", "status": "open", "session_id": None, "updated_at": old_ts},
+        "fresh-1": {"worktree_path": "/repo", "status": "open", "session_id": None, "updated_at": fresh_ts},
+    }
+    out = _run_hook(items)
+    assert out, "expected a nag since one item is fresh"
+    payload = json.loads(out)
+    assert "1 open item" in payload["hookSpecificOutput"]["additionalContext"], payload
+
+
 def test_unresolved_session_id_fails_open_ignoring_staleness() -> None:
     old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
     items = {
@@ -99,5 +113,6 @@ if __name__ == "__main__":
     test_stale_ownerless_item_does_not_nag()
     test_fresh_ownerless_item_still_nags()
     test_own_session_item_nags_regardless_of_age()
+    test_mixed_stale_and_fresh_ownerless_items_counts_only_fresh()
     test_unresolved_session_id_fails_open_ignoring_staleness()
     print("all tests passed")


### PR DESCRIPTION
## Summary
- The agent-board Stop hook (`scripts/hooks/session_stop_agent_board.py`) nagged every session that stopped in a worktree about ownerless board items (no `session_id`, e.g. pre-dating that field) forever -- `checkout` only closes presence, it never touches item status.
- Live-confirmed 2026-07-24: a session that never touched the board got the identical "N open items" nag on every single Stop, and `python3 scripts/agent_board.py checkout` did not clear it.
- Fix: ownerless items older than 24h (by `updated_at`) are excluded from the nag count. Items belonging to the *current* session still nag regardless of age. The existing fail-open behavior when our own `session_id` can't be resolved is unchanged.

## Outcome moved
Stop-hook nag no longer fires forever on historical, unowned backlog items for sessions that never created or touched them -- it now only nags about the current session's own open work, plus genuinely recent (<24h) ownerless items that might still need attribution.

## Current architecture
`session_stop_agent_board.py` reads the board state and counts items matching the current worktree with status `open`/`parked`, filtering by whether the item's `session_id` is empty or matches the current session. No staleness concept existed before this patch.

## Architecture touched
- `scripts/hooks/session_stop_agent_board.py` (Stop hook logic)
- `scripts/test_session_stop_agent_board.py` (new)

## Files changed
- `scripts/hooks/session_stop_agent_board.py`: added `_is_stale_ownerless_item()` (24h cutoff on `updated_at`) and folded it into the existing item filter.
- `scripts/test_session_stop_agent_board.py`: new tests covering stale-ownerless-silent, fresh-ownerless-nags, own-session-nags-regardless-of-age, mixed stale/fresh count, and fail-open-on-unresolved-session_id.

## Schema / bus / API changes
None.

## Env/config changes
None.

## Tests run
```
$ python3 scripts/test_session_stop_agent_board.py
all tests passed
```

## Evals run
N/A -- no eval harness for this script; it's a small, fail-silent hook.

## Docker/build/smoke checks
N/A -- pure local Python hook script, no runtime/container surface touched.

## Review findings fixed
- Finding: no test covering nag-count aggregation across a mix of stale and fresh ownerless items (only single-item cases existed).
  - Fix: added `test_mixed_stale_and_fresh_ownerless_items_counts_only_fresh`.
  - Evidence: `python3 scripts/test_session_stop_agent_board.py` -- all 5 tests pass.
- Reviewer also independently verified `updated_at` is reliably present on every item in `state.items` (traced to `agent_board_lib.py`'s `payload.setdefault("updated_at", event.at)` and the single `item_upserted` producer path), confirming the staleness check has a real field to read, not an assumption.

## Restart required
No restart required -- this is a Claude Code Stop hook read at hook-invocation time, not a running service.

## Risks / concerns
- Severity: low
- Concern: the 24h cutoff is a judgment call, not derived from data on how often ownerless items are legitimately still-relevant same-day work.
- Mitigation: items belonging to the current session are never filtered by age, so a session's own in-progress work is never silently hidden; only cross-session unowned backlog older than a day stops nagging by default.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/agent-board-stale-ownerless-item-nag