### PR TITLE
docs: Idea E measurement result -- inconclusive, no mechanism built

### DIFF
--- a/docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md
+++ b/docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md
@@ -140,3 +140,28 @@ Build G, then F, then B, in that order, this session — G is free and de-risks 
 hygiene, low-risk with dry-run-first; B is the smallest wider-net idea that most directly answers the
 parent design doc's own stated goal (a real alternative to `ORGAN_REGISTRY`'s hand-authored edges).
 A/C/D/E remain named, gated, additive candidates for a later pass — not scheduled here.
+
+## Idea E measurement result (same session, after G/F/B/A/C/D shipped)
+
+Per Idea E's own scoping ("measure first, don't build the mechanism yet"), attempted the smallest
+buildable version: a live correlation check between concurrent open-chain count
+(`orion-bus-mirror`'s existing periodic in-flight-chain-summary log line, PR #1328) and
+currently-elevated edges (`/api/bus-synaptic-graph/anomalies`).
+
+**Available data**: ~30 minutes of real `open_count` history from container logs, ranging 121→135
+(a ~12% swing, gradual drift, no sharp bursts). Paired against a live `/anomalies` snapshot at the
+same rough window: 7 elevated edges (1 publish-gap, 6 causal-latency).
+
+**Finding: inconclusive, not negative.** The available observation window never contained a real
+burst in open-chain-count (the kind of sharp swing the hypothesis — "the mesh is busy because
+Juniper is actively chatting" vs. "busy for no reason" — actually needs to be tested against). A
+single snapshot pair, or a slow 12% drift, cannot distinguish "load-conditioning would matter" from
+"it wouldn't" — there simply wasn't enough dynamic range in this window to test either way. This is
+a real, honest result per Idea E's own escape valve ("if it turns out the load-conditioning question
+can't be cheaply answered right now, that's still a fine deliverable"), not a disguised negative.
+
+**Recommendation**: do not build the bucketed-EWMA mechanism yet. If revisited, the right next step
+is a longer-window, real-burst-inclusive sample (e.g. an active development/chat session, which this
+arc's own traffic patterns suggest produces sharper open-chain-count swings than a quiet period) —
+not more measurement during another quiet window, which would likely reproduce the same
+inconclusive result. No code shipped for Idea E in this session, per its own non-goal.


### PR DESCRIPTION
## Summary

- Idea E from `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md` (PR #1352): "measure first, don't build the mechanism yet" -- a log-only correlation check between concurrent open-chain count and edge z-score spikes, to test whether load-conditioning would actually change any anomaly classification before investing in bucketed-EWMA machinery.
- Attempted the smallest buildable version live: correlated ~30 minutes of real `open_count` history (`orion-bus-mirror`'s existing periodic in-flight-chain-summary log line) against a live `/api/bus-synaptic-graph/anomalies` snapshot.

## Outcome

**Inconclusive, not negative.** `open_count` ranged 121->135 over the observation window -- gradual drift, no real burst. 7 elevated edges present at the matching snapshot. A slow ~12% drift can't distinguish "load-conditioning matters" from "it doesn't" -- there wasn't enough dynamic range in this window to test the hypothesis either way. This is an honest result per Idea E's own escape valve, not a disguised negative.

## Files changed

- `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-wider-net-brainstorm.md`: new "Idea E measurement result" section recording the finding and recommendation.

## Recommendation

Do not build the bucketed-EWMA mechanism yet. If revisited, needs a longer window that actually includes a real activity burst (e.g. an active chat/dev session), not more measurement during another quiet period -- which would likely reproduce the same inconclusive result.

## Non-goals

- No mechanism code shipped -- per Idea E's own explicit scoping, this PR is measurement-only.

## Tests run

Not applicable -- docs-only change.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1359
