### PR TITLE
feat(biometrics): real host disk-capacity telemetry on the bus heartbeat

### DIFF
--- a/orion/core/bus/bus_service_chassis.py
+++ b/orion/core/bus/bus_service_chassis.py
@@ -6,7 +6,7 @@ import signal
 import traceback
 from dataclasses import dataclass
 from uuid import uuid4
-from typing import Any, Awaitable, Callable, Optional, List, Union
+from typing import Any, Awaitable, Callable, Dict, Optional, List, Union
 from datetime import datetime, timezone
 
 try:
@@ -21,6 +21,14 @@ from orion.schemas.telemetry.system_health import SystemHealthV1
 
 
 Handler = Callable[[BaseEnvelope], Awaitable[BaseEnvelope | None]]
+
+# Optional, synchronous, no-arg callable a chassis owner can supply to fold extra
+# free-form data into every SystemHealthV1.details payload the heartbeat publishes.
+# Kept separate from ChassisConfig (a frozen dataclass meant for stable, serializable
+# settings) since this carries a live callable, not config. Must not raise -- the
+# heartbeat loop catches and logs any exception so a broken/missing data source never
+# blocks the liveness pulse itself.
+HeartbeatDetailsProvider = Callable[[], Dict[str, Any]]
 
 
 @dataclass(frozen=True)
@@ -50,10 +58,11 @@ class BaseChassis:
     - exception wrapping to system.error
     """
 
-    def __init__(self, cfg: ChassisConfig):
+    def __init__(self, cfg: ChassisConfig, *, heartbeat_details: Optional[HeartbeatDetailsProvider] = None):
         self.cfg = cfg
         self.bus = OrionBusAsync(cfg.bus_url, enabled=cfg.bus_enabled)
         self.boot_id = str(uuid4())
+        self._heartbeat_details = heartbeat_details
 
         self._stop = asyncio.Event()
         self._tasks: list[asyncio.Task] = []
@@ -122,6 +131,18 @@ class BaseChassis:
             try:
                 node = self.cfg.node_name or "unknown"
                 now = datetime.now(timezone.utc)
+                details: Dict[str, Any] = {}
+                if self._heartbeat_details is not None:
+                    try:
+                        extra = self._heartbeat_details()
+                        if isinstance(extra, dict):
+                            details.update(extra)
+                        else:
+                            logger.warning(
+                                f"heartbeat_details provider returned non-dict ({type(extra)!r}); ignoring"
+                            )
+                    except Exception as details_exc:
+                        logger.warning(f"heartbeat_details provider failed: {details_exc}")
                 v1_payload = SystemHealthV1(
                     service=self.cfg.service_name,
                     node=node,
@@ -131,7 +152,7 @@ class BaseChassis:
                     status="ok",
                     last_seen_ts=now,
                     heartbeat_interval_sec=float(self.cfg.heartbeat_interval_sec or 10.0),
-                    details={},
+                    details=details,
                 )
                 v1_env = BaseEnvelope(
                     kind="system.health.v1",
@@ -527,8 +548,15 @@ class Clock(BaseChassis):
     Periodic ticker/loop with safe cancellation.
     """
 
-    def __init__(self, cfg: ChassisConfig, *, interval_sec: float, tick: Callable[[], Awaitable[None]]):
-        super().__init__(cfg)
+    def __init__(
+        self,
+        cfg: ChassisConfig,
+        *,
+        interval_sec: float,
+        tick: Callable[[], Awaitable[None]],
+        heartbeat_details: Optional[HeartbeatDetailsProvider] = None,
+    ):
+        super().__init__(cfg, heartbeat_details=heartbeat_details)
         self.interval_sec = float(interval_sec)
         self.tick = tick
 

--- a/orion/core/bus/bus_service_chassis.py
+++ b/orion/core/bus/bus_service_chassis.py
@@ -134,13 +134,29 @@ class BaseChassis:
                 details: Dict[str, Any] = {}
                 if self._heartbeat_details is not None:
                     try:
-                        extra = self._heartbeat_details()
+                        # Run in a worker thread with a bounded wait: the provider is a
+                        # synchronous callable (e.g. shutil.disk_usage() against a bind
+                        # mount) that could block on a wedged/stale filesystem. A plain
+                        # synchronous call here would stall this shared event loop --
+                        # not just the heartbeat, every other task in the process (other
+                        # Clock ticks, Rabbit/Hunter consumers). to_thread keeps a hang
+                        # off the loop; wait_for gives up (leaving details={} for this
+                        # tick) rather than waiting indefinitely.
+                        details_timeout = min(3.0, max(0.5, float(self.cfg.heartbeat_interval_sec or 10.0) / 2.0))
+                        extra = await asyncio.wait_for(
+                            asyncio.to_thread(self._heartbeat_details),
+                            timeout=details_timeout,
+                        )
                         if isinstance(extra, dict):
                             details.update(extra)
                         else:
                             logger.warning(
                                 f"heartbeat_details provider returned non-dict ({type(extra)!r}); ignoring"
                             )
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            f"heartbeat_details provider timed out after {details_timeout:.1f}s"
+                        )
                     except Exception as details_exc:
                         logger.warning(f"heartbeat_details provider failed: {details_exc}")
                 v1_payload = SystemHealthV1(

--- a/services/orion-biometrics/.env_example
+++ b/services/orion-biometrics/.env_example
@@ -37,3 +37,10 @@ THERMAL_MAX_C=85.0
 DISK_BW_MBPS=200.0
 NET_BW_MBPS=125.0
 POWER_BAND_ALPHA=0.1
+
+# --- Disk capacity telemetry (piggybacked onto the SystemHealthV1 heartbeat) ---
+# Maps a short mount name to the read-only in-container bind-mount path from
+# docker-compose.yml. Node-level: each node (athena/atlas/circe) reports its own
+# mounts independently once redeployed there. See README.md for the
+# details.disk_usage_pct.<mount_name> key convention.
+DISK_CAPACITY_MOUNTS={"docker":"/host_mnt/docker","scripts":"/host_mnt/scripts","postgres":"/host_mnt/postgres","graphdb":"/host_mnt/graphdb","telemetry":"/host_mnt/telemetry"}

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -62,7 +62,16 @@ Key convention:
   configurable via `DISK_CAPACITY_MOUNTS` (JSON object, mount name -> in-container path).
 - `disk_usage_errors` only appears when at least one configured mount is missing/inaccessible
   inside the container (e.g. not bind-mounted on this node yet). A missing mount is skipped, not
-  fatal -- it never blocks the heartbeat itself.
+  fatal -- it never blocks the heartbeat itself. `collect_disk_capacity()` checks
+  `os.path.ismount()`, not just `os.path.isdir()` -- if a bind-mount source doesn't exist on the
+  host, Docker silently creates an empty directory at the container target instead of failing,
+  and `isdir()` alone can't tell that apart from a real mount (it would then report the
+  *container's own* overlay filesystem usage as if it were the host mount's).
+- The heartbeat loop runs `_heartbeat_details()` in a worker thread (`asyncio.to_thread`) with a
+  bounded wait (`min(3.0, heartbeat_interval_sec / 2)`, floor 0.5s), not inline on the event loop.
+  A wedged/stale mount blocking synchronously inside `shutil.disk_usage()` would otherwise stall
+  every other task sharing this process's event loop, not just the heartbeat. A timeout drops that
+  tick's details (`{}`) rather than hanging.
 - This is capacity (how full a filesystem is), not the same thing as the existing `disk` key in
   `biometrics.sample.v1`/`BiometricsSampleV1`, which is I/O *throughput* (`_collect_disk()` in
   `app/metrics.py`, read/write bytes/sec from `/proc/diskstats`) and feeds a separate, already-wired

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -35,8 +35,47 @@ Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
 | `PUBLISH_BIOMETRICS_GRAMMAR` | `true` | Enable grammar trace publish after each biometrics tick. |
 | `GRAMMAR_EVENT_CHANNEL` | `orion:grammar:event` | Grammar event publish channel. |
 | `NODE_CATALOG_PATH` | `/app/config/biometrics/node_catalog.yaml` | Path to node catalog YAML (host: `config/biometrics/node_catalog.yaml`). |
+| `DISK_CAPACITY_MOUNTS` | `{"docker":"/host_mnt/docker","scripts":"/host_mnt/scripts","postgres":"/host_mnt/postgres","graphdb":"/host_mnt/graphdb","telemetry":"/host_mnt/telemetry"}` | Mount name -> in-container path for disk-capacity heartbeat telemetry (see below). |
 
 Node identity for grammar traces is resolved via `config/biometrics/node_catalog.yaml` (aliases canonicalize hostnames, e.g. `prometheous` → `prometheus`).
+
+### Disk capacity telemetry (`details.disk_usage_pct`)
+
+This service is one of the 25 already using `orion.core.bus.bus_service_chassis.BaseChassis`
+(via `Clock`), so it already publishes a bus-native `SystemHealthV1` heartbeat to
+`orion:system:health` every `HEARTBEAT_INTERVAL_SEC` (default 10s). `SystemHealthV1.details`
+is a free-form dict; `app/main.py::_heartbeat_details()` folds real host disk-*capacity*
+(not I/O throughput -- see below) into it via `app/metrics.py::collect_disk_capacity()`.
+
+Key convention:
+
+```json
+{
+  "disk_usage_pct": {"docker": 87.3, "scripts": 14.1, "postgres": 14.4, "graphdb": 0.3, "telemetry": 20.4},
+  "disk_usage_errors": {"<mount_name>": "not_mounted"}
+}
+```
+
+- `disk_usage_pct.<mount_name>` -- percent-used (0-100, 2dp) for that mount, from
+  `shutil.disk_usage()` against the read-only bind mount configured in `docker-compose.yml`
+  (`/mnt/<name>` on the host -> `/host_mnt/<name>:ro` in the container). Mount names/paths are
+  configurable via `DISK_CAPACITY_MOUNTS` (JSON object, mount name -> in-container path).
+- `disk_usage_errors` only appears when at least one configured mount is missing/inaccessible
+  inside the container (e.g. not bind-mounted on this node yet). A missing mount is skipped, not
+  fatal -- it never blocks the heartbeat itself.
+- This is capacity (how full a filesystem is), not the same thing as the existing `disk` key in
+  `biometrics.sample.v1`/`BiometricsSampleV1`, which is I/O *throughput* (`_collect_disk()` in
+  `app/metrics.py`, read/write bytes/sec from `/proc/diskstats`) and feeds a separate, already-wired
+  consumer chain (`BiometricsPipeline`'s `disk` pressure -> `grammar_emit.py`'s
+  `disk_pressure_signal` -> field-digester's `disk_pressure` lattice channel). Do not conflate the
+  two -- `collect_disk_capacity()` is intentionally a separate function/key, not an extension of
+  `_collect_disk()`.
+- Cross-node: because this same `services/orion-biometrics` codebase runs independently on
+  athena/atlas/circe (each with its own `NODE_NAME`), redeploying this patch on each node gives
+  real disk-capacity visibility per node with no new SSH/credential surface -- the bus already
+  proven to carry heartbeats cross-node (`SystemHealthV1.node` distinguishes them).
+- No alerting/threshold logic here by design -- this is pure telemetry collection, matching
+  `_collect_disk()`'s existing scope (report numbers, don't act on them).
 
 ### Grammar node `pressure_hints` (consumed by `orion-field-digester`)
 

--- a/services/orion-biometrics/app/main.py
+++ b/services/orion-biometrics/app/main.py
@@ -18,7 +18,7 @@ from orion.schemas.telemetry.biometrics import (
     BiometricsClusterV1,
 )
 from orion.schemas.telemetry.spark_signal import SparkSignalV1
-from app.metrics import collect_biometrics
+from app.metrics import collect_biometrics, collect_disk_capacity
 from orion.telemetry.biometrics_pipeline import BiometricsPipeline, PipelineConfig
 from app.settings import settings
 
@@ -162,6 +162,20 @@ def _source() -> ServiceRef:
     return ServiceRef(name=settings.SERVICE_NAME, version=settings.SERVICE_VERSION, node=settings.NODE_NAME)
 
 
+def _heartbeat_details() -> Dict[str, Any]:
+    """Extra data folded into every SystemHealthV1 heartbeat's `details` dict.
+
+    Real host disk-capacity telemetry, piggybacked onto the existing bus-native
+    heartbeat rather than a new channel/service (see
+    docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md).
+    Node-level, not per-service -- once this same code is redeployed on atlas/circe
+    (each already an independent orion-biometrics deployment publishing its own
+    per-node heartbeat, confirmed live via `orion:system:health`), each node reports
+    its own mounts with no new SSH/credential surface.
+    """
+    return collect_disk_capacity(settings.DISK_CAPACITY_MOUNTS)
+
+
 _pipeline = BiometricsPipeline(
     PipelineConfig(
         thermal_min_c=settings.THERMAL_MIN_C,
@@ -251,7 +265,7 @@ async def _publish(bus: OrionBusAsync, channel: str, kind: str, payload: object)
 
 class BiometricsWorker(Clock):
     def __init__(self, cfg: ChassisConfig, *, interval_sec: float):
-        super().__init__(cfg, interval_sec=interval_sec, tick=self.do_tick)
+        super().__init__(cfg, interval_sec=interval_sec, tick=self.do_tick, heartbeat_details=_heartbeat_details)
 
     async def do_tick(self) -> None:
         await publish_metrics(self.bus)
@@ -342,7 +356,7 @@ class BiometricsHub:
 
 class BiometricsHubWorker(Clock):
     def __init__(self, cfg: ChassisConfig, hub: BiometricsHub, *, interval_sec: float):
-        super().__init__(cfg, interval_sec=interval_sec, tick=self.do_tick)
+        super().__init__(cfg, interval_sec=interval_sec, tick=self.do_tick, heartbeat_details=_heartbeat_details)
         self.hub = hub
 
     async def do_tick(self) -> None:

--- a/services/orion-biometrics/app/metrics.py
+++ b/services/orion-biometrics/app/metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import subprocess
 import time
 from dataclasses import dataclass
@@ -294,3 +295,45 @@ _COLLECTOR = BiometricsCollector()
 
 def collect_biometrics() -> Dict[str, Any]:
     return _COLLECTOR.collect()
+
+
+def collect_disk_capacity(mounts: Dict[str, str]) -> Dict[str, Any]:
+    """Real host disk-capacity (percent-used) telemetry, keyed by mount name.
+
+    This is deliberately separate from `BiometricsCollector._collect_disk()`, which
+    reads `/proc/diskstats` for I/O *throughput* (read/write bytes-per-sec) and feeds
+    `BiometricsPipeline`'s `disk` pressure -- a different metric with an existing
+    consumer chain (pipeline -> summary.pressures.disk -> grammar_emit's
+    disk_pressure_signal -> field-digester's disk_pressure lattice channel). Disk
+    *capacity* (how full a filesystem is) has no existing collector anywhere in this
+    repo (confirmed by design-doc grep: zero hits for `disk_usage`/
+    `docker system prune` under `scripts/`) and is not part of that pipeline -- it
+    rides the bus-native `SystemHealthV1` heartbeat's free-form `details` dict
+    instead. See `services/orion-biometrics/README.md`'s "Disk capacity telemetry"
+    section for the documented `details.disk_usage_pct.<mount_name>` key convention.
+
+    `mounts` maps a short mount name (e.g. "docker") to the in-container path it is
+    bind-mounted at (e.g. "/host_mnt/docker", read-only -- see docker-compose.yml).
+    A mount that doesn't exist inside this container (not yet bind-mounted on this
+    node, or a host path that genuinely doesn't exist on atlas/circe) is skipped, not
+    fatal -- one missing mount must never take down the whole heartbeat.
+    """
+    percent_used: Dict[str, float] = {}
+    errors: Dict[str, str] = {}
+    for name, path in mounts.items():
+        try:
+            if not path or not os.path.isdir(path):
+                errors[name] = "not_mounted"
+                continue
+            usage = shutil.disk_usage(path)
+            if usage.total <= 0:
+                errors[name] = "zero_total_bytes"
+                continue
+            percent_used[name] = round((usage.used / usage.total) * 100.0, 2)
+        except Exception as exc:
+            errors[name] = str(exc)
+
+    result: Dict[str, Any] = {"disk_usage_pct": percent_used}
+    if errors:
+        result["disk_usage_errors"] = errors
+    return result

--- a/services/orion-biometrics/app/metrics.py
+++ b/services/orion-biometrics/app/metrics.py
@@ -325,6 +325,15 @@ def collect_disk_capacity(mounts: Dict[str, str]) -> Dict[str, Any]:
             if not path or not os.path.isdir(path):
                 errors[name] = "not_mounted"
                 continue
+            if not os.path.ismount(path):
+                # If a bind-mount source doesn't exist on the host, Docker silently
+                # auto-creates an empty directory at the target instead of failing --
+                # os.path.isdir() alone would report that empty dir as present and
+                # shutil.disk_usage() would then report the *container's own* overlay
+                # filesystem capacity, a plausible-looking but meaningless number, not
+                # a "not mounted" error. os.path.ismount() catches that case.
+                errors[name] = "not_mounted"
+                continue
             usage = shutil.disk_usage(path)
             if usage.total <= 0:
                 errors[name] = "zero_total_bytes"

--- a/services/orion-biometrics/app/settings.py
+++ b/services/orion-biometrics/app/settings.py
@@ -56,6 +56,21 @@ class Settings(BaseSettings):
     ERROR_CHANNEL: str = "orion:system:error"
     SHUTDOWN_GRACE_SEC: float = 10.0
 
+    # Disk-capacity telemetry (piggybacked onto the SystemHealthV1 heartbeat's
+    # `details` dict -- see README.md "Disk capacity telemetry" section). Maps a
+    # short mount name to the read-only in-container bind-mount path configured in
+    # docker-compose.yml. Node-level, not per-service: every node running this
+    # service reports its own 5 mounts independently once redeployed there.
+    DISK_CAPACITY_MOUNTS: Dict[str, str] = Field(
+        default_factory=lambda: {
+            "docker": "/host_mnt/docker",
+            "scripts": "/host_mnt/scripts",
+            "postgres": "/host_mnt/postgres",
+            "graphdb": "/host_mnt/graphdb",
+            "telemetry": "/host_mnt/telemetry",
+        }
+    )
+
     @field_validator("role_weights", mode="before")
     @classmethod
     def _parse_role_weights(cls, value: object) -> Dict[str, float]:
@@ -69,6 +84,29 @@ class Settings(BaseSettings):
             if isinstance(data, dict):
                 return {str(k): float(v) for k, v in data.items()}
         return {"atlas": 0.7, "athena": 0.3, "other": 0.5}
+
+    @field_validator("DISK_CAPACITY_MOUNTS", mode="before")
+    @classmethod
+    def _parse_disk_capacity_mounts(cls, value: object) -> Dict[str, str]:
+        _default = {
+            "docker": "/host_mnt/docker",
+            "scripts": "/host_mnt/scripts",
+            "postgres": "/host_mnt/postgres",
+            "graphdb": "/host_mnt/graphdb",
+            "telemetry": "/host_mnt/telemetry",
+        }
+        if isinstance(value, dict):
+            return {str(k): str(v) for k, v in value.items()}
+        if isinstance(value, str):
+            if not value.strip():
+                return _default
+            try:
+                data = json.loads(value)
+            except json.JSONDecodeError:
+                return _default
+            if isinstance(data, dict):
+                return {str(k): str(v) for k, v in data.items()}
+        return _default
 
 settings = Settings()
 

--- a/services/orion-biometrics/docker-compose.yml
+++ b/services/orion-biometrics/docker-compose.yml
@@ -47,11 +47,21 @@ services:
       - DISK_BW_MBPS=${DISK_BW_MBPS}
       - NET_BW_MBPS=${NET_BW_MBPS}
       - POWER_BAND_ALPHA=${POWER_BAND_ALPHA}
+      - DISK_CAPACITY_MOUNTS=${DISK_CAPACITY_MOUNTS}
 
     volumes:
       - ../../config/biometrics:/app/config/biometrics:ro
       - /mnt/scripts/Orion-Sapienform/orion/sensors:/orion/sensors # access host gpus
       - ${ORION_DATA_ROOT:-/mnt/graphdb}/logs/biometrics/logs:/app/logs
+      # Read-only host disk-capacity telemetry mounts (piggybacked onto the
+      # SystemHealthV1 heartbeat's `details.disk_usage_pct` -- see README.md).
+      # Mounted under a parallel /host_mnt/* prefix, not the host's real absolute
+      # path, so container code never confuses a host path with a container-real one.
+      - /mnt/docker:/host_mnt/docker:ro
+      - /mnt/scripts:/host_mnt/scripts:ro
+      - /mnt/postgres:/host_mnt/postgres:ro
+      - /mnt/graphdb:/host_mnt/graphdb:ro
+      - /mnt/telemetry:/host_mnt/telemetry:ro
 
     deploy:
       resources:

--- a/services/orion-biometrics/tests/test_disk_capacity.py
+++ b/services/orion-biometrics/tests/test_disk_capacity.py
@@ -8,19 +8,37 @@ separate from `_collect_disk()` (I/O throughput, feeds BiometricsPipeline's `dis
 pressure) -- it reports filesystem capacity via `shutil.disk_usage()` against
 read-only bind mounts (see docker-compose.yml), independent of the biometrics
 sample/pipeline/grammar path.
+
+`collect_disk_capacity()` requires `os.path.ismount(path)`, not just `os.path.isdir(path)`
+(2026-07-24 review fix). A `tmp_path` subdirectory is a real directory but never a real
+mount point, so most tests here monkeypatch `os.path.ismount` to simulate "this path is a
+real bind-mount root" without needing an actual host mount inside the test sandbox --
+`shutil.disk_usage()` itself is still called for real against `tmp_path`, so the
+percent-used computation is exercised end to end, not mocked.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from app.metrics import collect_disk_capacity
 
 
-def test_collect_disk_capacity_reports_percent_used_for_real_paths(tmp_path: Path) -> None:
-    """A real, existing directory should produce a plausible 0-100 percent-used value
-    and no error entry. Uses tmp_path (a real filesystem path) rather than mocking
-    shutil.disk_usage, so this exercises the real stdlib call end to end."""
+def _mount_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate every path handed to os.path.ismount() as a real mount point."""
+    monkeypatch.setattr(os.path, "ismount", lambda path: True)
+
+
+def test_collect_disk_capacity_reports_percent_used_for_real_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real, existing, mounted directory should produce a plausible 0-100
+    percent-used value and no error entry. shutil.disk_usage() is called for real
+    against tmp_path (not mocked), so this exercises the real stdlib call end to end."""
+    _mount_everything(monkeypatch)
     mount_a = tmp_path / "docker"
     mount_a.mkdir()
     mount_b = tmp_path / "scripts"
@@ -36,10 +54,13 @@ def test_collect_disk_capacity_reports_percent_used_for_real_paths(tmp_path: Pat
         assert 0.0 <= value <= 100.0
 
 
-def test_collect_disk_capacity_skips_missing_mount_without_failing(tmp_path: Path) -> None:
+def test_collect_disk_capacity_skips_missing_mount_without_failing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """One missing/not-yet-bind-mounted path (e.g. a host path that doesn't exist on
     atlas/circe today) must be skipped, not raise -- the heartbeat must still publish
     with whatever mounts *are* present."""
+    _mount_everything(monkeypatch)
     real_mount = tmp_path / "graphdb"
     real_mount.mkdir()
     missing_mount = tmp_path / "does_not_exist_at_all"
@@ -53,12 +74,30 @@ def test_collect_disk_capacity_skips_missing_mount_without_failing(tmp_path: Pat
     assert result["disk_usage_errors"] == {"telemetry": "not_mounted"}
 
 
+def test_collect_disk_capacity_treats_unmounted_dir_as_not_mounted(tmp_path: Path) -> None:
+    """Regression for the Docker auto-create-empty-dir footgun: when a bind-mount
+    source doesn't exist on the host, Docker silently creates an empty directory at
+    the container target instead of failing the mount. A plain os.path.isdir() check
+    can't tell that apart from a real mount, and would then report the *container's
+    own* overlay filesystem usage as if it were the host mount's -- a plausible-looking
+    but meaningless number. No monkeypatching here: tmp_path is a real directory that
+    is genuinely not a mount point, exactly this scenario."""
+    unmounted_dir = tmp_path / "telemetry"
+    unmounted_dir.mkdir()
+    assert not os.path.ismount(unmounted_dir)  # sanity: this really isn't a mount
+
+    result = collect_disk_capacity({"telemetry": str(unmounted_dir)})
+
+    assert result["disk_usage_pct"] == {}
+    assert result["disk_usage_errors"] == {"telemetry": "not_mounted"}
+
+
 def test_collect_disk_capacity_empty_mounts_returns_empty_dict() -> None:
     result = collect_disk_capacity({})
     assert result == {"disk_usage_pct": {}}
 
 
-def test_collect_disk_capacity_rejects_empty_path_value(tmp_path: Path) -> None:
+def test_collect_disk_capacity_rejects_empty_path_value() -> None:
     """A mount configured with an empty string path (e.g. a malformed
     DISK_CAPACITY_MOUNTS env override) is treated as not-mounted, not as cwd."""
     result = collect_disk_capacity({"bad": ""})

--- a/services/orion-biometrics/tests/test_disk_capacity.py
+++ b/services/orion-biometrics/tests/test_disk_capacity.py
@@ -1,0 +1,66 @@
+"""Regression coverage for `collect_disk_capacity()` (app/metrics.py).
+
+Added alongside real host disk-usage telemetry piggybacked onto orion-biometrics'
+existing bus-native SystemHealthV1 heartbeat (see
+docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md,
+"Cross-node disk telemetry: bus-piggyback vs. SSH?"). This collector is deliberately
+separate from `_collect_disk()` (I/O throughput, feeds BiometricsPipeline's `disk`
+pressure) -- it reports filesystem capacity via `shutil.disk_usage()` against
+read-only bind mounts (see docker-compose.yml), independent of the biometrics
+sample/pipeline/grammar path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.metrics import collect_disk_capacity
+
+
+def test_collect_disk_capacity_reports_percent_used_for_real_paths(tmp_path: Path) -> None:
+    """A real, existing directory should produce a plausible 0-100 percent-used value
+    and no error entry. Uses tmp_path (a real filesystem path) rather than mocking
+    shutil.disk_usage, so this exercises the real stdlib call end to end."""
+    mount_a = tmp_path / "docker"
+    mount_a.mkdir()
+    mount_b = tmp_path / "scripts"
+    mount_b.mkdir()
+
+    result = collect_disk_capacity({"docker": str(mount_a), "scripts": str(mount_b)})
+
+    assert "disk_usage_errors" not in result
+    pct = result["disk_usage_pct"]
+    assert set(pct.keys()) == {"docker", "scripts"}
+    for value in pct.values():
+        assert isinstance(value, float)
+        assert 0.0 <= value <= 100.0
+
+
+def test_collect_disk_capacity_skips_missing_mount_without_failing(tmp_path: Path) -> None:
+    """One missing/not-yet-bind-mounted path (e.g. a host path that doesn't exist on
+    atlas/circe today) must be skipped, not raise -- the heartbeat must still publish
+    with whatever mounts *are* present."""
+    real_mount = tmp_path / "graphdb"
+    real_mount.mkdir()
+    missing_mount = tmp_path / "does_not_exist_at_all"
+
+    result = collect_disk_capacity(
+        {"graphdb": str(real_mount), "telemetry": str(missing_mount)}
+    )
+
+    assert "graphdb" in result["disk_usage_pct"]
+    assert "telemetry" not in result["disk_usage_pct"]
+    assert result["disk_usage_errors"] == {"telemetry": "not_mounted"}
+
+
+def test_collect_disk_capacity_empty_mounts_returns_empty_dict() -> None:
+    result = collect_disk_capacity({})
+    assert result == {"disk_usage_pct": {}}
+
+
+def test_collect_disk_capacity_rejects_empty_path_value(tmp_path: Path) -> None:
+    """A mount configured with an empty string path (e.g. a malformed
+    DISK_CAPACITY_MOUNTS env override) is treated as not-mounted, not as cwd."""
+    result = collect_disk_capacity({"bad": ""})
+    assert result["disk_usage_errors"] == {"bad": "not_mounted"}
+    assert result["disk_usage_pct"] == {}

--- a/tests/test_chassis_heartbeat_details.py
+++ b/tests/test_chassis_heartbeat_details.py
@@ -1,0 +1,112 @@
+"""Regression coverage for the optional `heartbeat_details` provider hook added to
+`BaseChassis`/`Clock` (orion/core/bus/bus_service_chassis.py).
+
+Added alongside orion-biometrics' real host disk-usage telemetry, piggybacked onto its
+existing bus-native SystemHealthV1 heartbeat (see
+docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md,
+"Cross-node disk telemetry: bus-piggyback vs. SSH?"). `SystemHealthV1.details` was
+previously always published as a hardcoded `{}` -- this hook lets a chassis owner
+(any of the 25 services already using BaseChassis) supply extra free-form data
+without touching `_heartbeat_loop()` itself. This is additive: omitting the kwarg
+(as every pre-existing caller does) must reproduce the old `details={}` behavior
+exactly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orion.core.bus.bus_schemas import ServiceRef
+from orion.core.bus.bus_service_chassis import ChassisConfig, Clock, HeartbeatOnly
+
+
+def _cfg(**overrides) -> ChassisConfig:
+    base = dict(
+        service_name="test-heartbeat-details",
+        service_version="0.1.0",
+        node_name="node-a",
+        bus_url="redis://localhost:6379/0",
+        bus_enabled=True,
+        heartbeat_interval_sec=0.01,
+    )
+    base.update(overrides)
+    return ChassisConfig(**base)
+
+
+async def _run_one_heartbeat(chassis) -> dict:
+    """Run a single _heartbeat_loop iteration and return the published details dict."""
+    publish = AsyncMock()
+    chassis.bus = SimpleNamespace(publish=publish, reconnect=AsyncMock())
+    chassis._source = lambda: ServiceRef(
+        name=chassis.cfg.service_name, node=chassis.cfg.node_name, version=chassis.cfg.service_version
+    )
+    chassis._stop.clear()
+    # Stop after the first publish so the while loop exits on the next check.
+    orig_publish = publish
+
+    async def _publish_then_stop(*args, **kwargs):
+        chassis._stop.set()
+        return await orig_publish(*args, **kwargs)
+
+    chassis.bus.publish = _publish_then_stop
+    await chassis._heartbeat_loop()
+    assert publish.await_count == 1
+    env = publish.await_args.args[1]
+    return env.payload["details"]
+
+
+@pytest.mark.asyncio
+async def test_no_provider_publishes_empty_details_unchanged() -> None:
+    """Omitting heartbeat_details (every pre-existing BaseChassis caller) must keep
+    publishing details={} exactly as before this patch."""
+    chassis = HeartbeatOnly(_cfg())
+    details = await _run_one_heartbeat(chassis)
+    assert details == {}
+
+
+@pytest.mark.asyncio
+async def test_provider_result_is_folded_into_details() -> None:
+    chassis = HeartbeatOnly(_cfg(), heartbeat_details=lambda: {"disk_usage_pct": {"docker": 87.3}})
+    details = await _run_one_heartbeat(chassis)
+    assert details == {"disk_usage_pct": {"docker": 87.3}}
+
+
+@pytest.mark.asyncio
+async def test_provider_exception_does_not_block_heartbeat() -> None:
+    """A broken details provider (e.g. a filesystem read failure) must never prevent
+    the liveness pulse itself from publishing."""
+
+    def _boom() -> dict:
+        raise RuntimeError("disk read failed")
+
+    chassis = HeartbeatOnly(_cfg(), heartbeat_details=_boom)
+    details = await _run_one_heartbeat(chassis)
+    assert details == {}
+
+
+@pytest.mark.asyncio
+async def test_provider_non_dict_result_is_ignored() -> None:
+    chassis = HeartbeatOnly(_cfg(), heartbeat_details=lambda: "not-a-dict")
+    details = await _run_one_heartbeat(chassis)
+    assert details == {}
+
+
+@pytest.mark.asyncio
+async def test_clock_threads_heartbeat_details_to_base_chassis() -> None:
+    """Clock (the chassis subclass orion-biometrics actually uses) must forward the
+    kwarg through to BaseChassis, not just HeartbeatOnly."""
+
+    async def _tick() -> None:
+        return None
+
+    clock = Clock(
+        _cfg(),
+        interval_sec=1.0,
+        tick=_tick,
+        heartbeat_details=lambda: {"disk_usage_pct": {"scripts": 14.1}},
+    )
+    details = await _run_one_heartbeat(clock)
+    assert details == {"disk_usage_pct": {"scripts": 14.1}}

--- a/tests/test_chassis_heartbeat_details.py
+++ b/tests/test_chassis_heartbeat_details.py
@@ -14,6 +14,7 @@ exactly.
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -110,3 +111,23 @@ async def test_clock_threads_heartbeat_details_to_base_chassis() -> None:
     )
     details = await _run_one_heartbeat(clock)
     assert details == {"disk_usage_pct": {"scripts": 14.1}}
+
+
+@pytest.mark.asyncio
+async def test_slow_provider_runs_off_the_event_loop_and_times_out() -> None:
+    """A provider that blocks synchronously (e.g. shutil.disk_usage() against a wedged
+    filesystem) must not stall _heartbeat_loop() indefinitely -- it runs in a worker
+    thread (asyncio.to_thread) with a bounded wait_for, so the heartbeat still
+    publishes (with an empty details fold for that tick) instead of hanging forever."""
+
+    def _slow_provider() -> dict:
+        time.sleep(0.6)  # longer than the 0.5s floor on details_timeout
+        return {"disk_usage_pct": {"docker": 87.3}}
+
+    chassis = HeartbeatOnly(_cfg(heartbeat_interval_sec=0.01), heartbeat_details=_slow_provider)
+    start = time.monotonic()
+    details = await _run_one_heartbeat(chassis)
+    elapsed = time.monotonic() - start
+
+    assert details == {}, "timed-out provider must not block the heartbeat publish"
+    assert elapsed < 1.5, "heartbeat must give up around the bounded timeout, not hang"


### PR DESCRIPTION
## Summary

- Piggybacks real host disk-*capacity* (percent-used) telemetry onto orion-biometrics' existing bus-native `SystemHealthV1` heartbeat instead of standing up new SSH infrastructure, per `docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md`'s "bus-piggyback vs. SSH" decision.
- Adds an additive, backward-compatible `heartbeat_details` callable hook to `BaseChassis`/`Clock` (`orion/core/bus/bus_service_chassis.py`) so a chassis owner can fold extra data into `SystemHealthV1.details` (previously hardcoded to `{}` for all ~25 chassis-adopted services).
- New `collect_disk_capacity()` in `app/metrics.py`, deliberately separate from the existing `_collect_disk()` (I/O throughput, feeds a different already-wired pressure/grammar consumer chain).
- 5 new read-only bind mounts in `docker-compose.yml` (`/mnt/docker`, `/mnt/scripts`, `/mnt/postgres`, `/mnt/graphdb`, `/mnt/telemetry` -> `/host_mnt/*:ro`).
- Since `services/orion-biometrics` is already independently deployed on athena/atlas/circe (confirmed live via `orion:system:health` heartbeats tagged per node), redeploying this same code on each node gives real cross-node disk visibility with zero new SSH/credential surface.

## Outcome moved

Disk capacity (how full a filesystem is) had zero collectors anywhere in this repo before this patch (confirmed via design-doc grep). Now it rides the existing heartbeat, per-node, with no new channel/service.

## Current architecture

`orion-biometrics` is one of 25 services already using `orion.core.bus.bus_service_chassis.BaseChassis` (via `Clock`), publishing a `SystemHealthV1` heartbeat to `orion:system:health` every `HEARTBEAT_INTERVAL_SEC` (default 10s) from `_heartbeat_loop()`. That loop previously always published `details={}` -- there was no hook for a chassis owner to inject anything into it. Separately, `app/metrics.py::_collect_disk()` already existed but measures I/O *throughput* (`/proc/diskstats` read/write bytes/sec), feeding `BiometricsPipeline`'s `disk` pressure -> `grammar_emit.py`'s `disk_pressure_signal` -> field-digester's `disk_pressure` lattice channel. Nothing measured capacity.

## Architecture touched

- `orion/core/bus/bus_service_chassis.py` (shared by ~25 services)
- `services/orion-biometrics/app/{main.py,metrics.py,settings.py}`
- `services/orion-biometrics/docker-compose.yml`, `.env_example`, `README.md`

## Files changed

- `orion/core/bus/bus_service_chassis.py`: new `HeartbeatDetailsProvider` type alias; `BaseChassis.__init__`/`Clock.__init__` accept optional `heartbeat_details` callable (default `None`, backward compatible); `_heartbeat_loop()` runs it via `asyncio.to_thread` + bounded `asyncio.wait_for` (not inline -- a blocking `shutil.disk_usage()` call must not stall the shared event loop) and merges the dict result into `SystemHealthV1.details`.
- `services/orion-biometrics/app/metrics.py`: new `collect_disk_capacity(mounts: Dict[str,str])` using `shutil.disk_usage()`, checking both `os.path.isdir()` and `os.path.ismount()` (Docker silently auto-creates an empty dir when a bind-mount source is missing on the host -- `isdir()` alone can't tell that apart from a real mount).
- `services/orion-biometrics/app/main.py`: new `_heartbeat_details()` wired into both `BiometricsWorker` and `BiometricsHubWorker`.
- `services/orion-biometrics/app/settings.py`: new `DISK_CAPACITY_MOUNTS: Dict[str, str]` field (JSON-configurable, same pattern as existing `role_weights`), default 5 mounts -> `/host_mnt/<name>`.
- `services/orion-biometrics/docker-compose.yml`: 5 new `:ro` bind mounts + `DISK_CAPACITY_MOUNTS` env passthrough.
- `services/orion-biometrics/.env_example`, `README.md`: documented `DISK_CAPACITY_MOUNTS` and the `details.disk_usage_pct.<mount_name>` key convention, including the `ismount` and timeout behavior.
- `services/orion-biometrics/tests/test_disk_capacity.py`: new, unit tests for `collect_disk_capacity()`.
- `tests/test_chassis_heartbeat_details.py`: new, repo-root regression coverage for the shared chassis hook (no-provider = old behavior unchanged, provider result folded in, exceptions swallowed, non-dict ignored, `Clock` threads the kwarg through, slow-provider timeout doesn't block the heartbeat).

## Schema / bus / API changes

- Added: none (no new channel, no `SystemHealthV1` schema field change -- `details: Dict[str, Any]` already existed and accepted arbitrary content).
- Removed: none.
- Renamed: none.
- Behavior changed: `SystemHealthV1.details` on orion-biometrics' heartbeat now carries `disk_usage_pct`/`disk_usage_errors` instead of always being `{}`. All other 24 chassis-adopted services are unaffected (they don't pass the new kwarg, so `details` stays `{}` exactly as before).
- Compatibility notes: purely additive; easy to revert (remove the `heartbeat_details=` wiring in `main.py`, the mounts in `docker-compose.yml`).

## Env/config changes

- Added keys: `DISK_CAPACITY_MOUNTS` (services/orion-biometrics)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: yes
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: ran it -- this sandbox worktree has no local `.env` files for any service (all skipped as "no .env"), so there was nothing to sync here. **Juniper needs to add `DISK_CAPACITY_MOUNTS` to the real `services/orion-biometrics/.env` on athena (and atlas/circe once redeployed there)** -- either by running the sync script on the real host or copying the default from `.env_example`.
- skipped keys requiring operator action: none beyond the above (not on the documented skip-list, just genuinely absent from this sandbox).

## Tests run

```text
# New/touched-code tests
PYTHONPATH=<worktree> .venv/bin/python -m pytest tests/test_chassis_heartbeat_details.py tests/test_heartbeat_only_chassis.py tests/test_chassis_heartbeat_reconnect.py tests/test_hunter_reconnect.py tests/test_queue_service_chassis.py orion/core/bus/tests/test_resilience.py -q
-> 28 passed, 1 skipped

cd services/orion-biometrics && PYTHONPATH=<worktree>:. .venv/bin/python -m pytest tests -q
-> 15 passed, 2 failed (pre-existing, unrelated -- see below)

# Pilot-5 chassis-consumer services (shared bus_service_chassis.py change)
services/orion-cortex-gateway/tests/test_heartbeat_chassis.py -> 3 passed
services/orion-field-digester/tests/test_heartbeat_chassis.py -> 3 passed
services/orion-harness-governor/tests/test_heartbeat_chassis.py -> 3 passed
services/orion-substrate-runtime/tests/test_heartbeat_chassis.py -> 3 passed
```

Pre-existing failures confirmed unrelated by `git stash`-ing this patch and re-running: `test_biometrics_grammar_emit.py::test_circe_node_availability_reflects_expected_offline` and `test_node_catalog.py::test_circe_expected_offline` both fail identically on a clean checkout (drift in `config/biometrics/node_catalog.yaml`'s `circe.expected_online` flag vs. the test's expectation -- unrelated to this patch, not touched here).

`python scripts/check_service_env_compose_parity.py orion-biometrics`: 1 pre-existing gap (`PORT`, used in `ports:` not `environment:`) confirmed unchanged before/after this patch via the same stash comparison. `DISK_CAPACITY_MOUNTS` itself has full parity across `.env_example`/`docker-compose.yml`/`settings.py`.

## Evals run

No eval harness exists for `services/orion-biometrics` (no `evals/` directory). Not building one for this thin telemetry-collection patch -- flagging as a gap consistent with CLAUDE.md section 11 rather than skipping silently.

## Docker/build/smoke checks

Not run -- Docker is not available in this sandbox. `docker compose ... config` should be run by Juniper before redeploy to confirm the new bind mounts and env passthrough parse correctly:

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-biometrics/.env \
  -f services/orion-biometrics/docker-compose.yml \
  config
```

**Live-verify vs. needs-Juniper split (metric quality gate step 4):**
- **Live-verified in this sandbox**: `/mnt/docker`, `/mnt/scripts`, `/mnt/postgres`, `/mnt/graphdb`, `/mnt/telemetry` all exist at those exact host paths here, with real `df -h` numbers matching the design doc's athena figures (`/mnt/docker` 87% used, 385G/469G -- consistent with the design doc's earlier 85%/377G reading, i.e. it's grown since). `shutil.disk_usage()` was exercised for real (not mocked) in `test_disk_capacity.py` against `tmp_path`, and manually sanity-checked against these real paths during development.
- **Needs Juniper's confirmation post-deploy**: whether these same 5 host paths exist identically on atlas/circe (the design doc explicitly flagged this as unmeasured/unverified), and whether the container actually receives real numbers once redeployed there. After redeploying `orion-biometrics` on athena/atlas/circe, verify with:
  ```bash
  redis-cli -h <bus-host> psubscribe 'orion:system:health'
  # look for "service":"biometrics" envelopes per node and confirm
  # details.disk_usage_pct has real (non-empty, plausible) values, not {} or disk_usage_errors for every mount
  ```

## Review findings fixed

- Finding: `heartbeat_details()` was called synchronously inline in the shared async `_heartbeat_loop()`. A blocking `shutil.disk_usage()` call against a wedged/stale mount would stall the entire event loop for the process, not just the heartbeat.
  - Fix: wrapped in `asyncio.to_thread()` + `asyncio.wait_for()` with a bounded timeout (`min(3.0, heartbeat_interval_sec/2)`, floor 0.5s); a timeout drops that tick's details rather than hanging.
  - Evidence: `tests/test_chassis_heartbeat_details.py::test_slow_provider_runs_off_the_event_loop_and_times_out` -- a 0.6s-sleeping provider still lets the heartbeat publish (with `details={}`) in well under 1.5s.
- Finding: `collect_disk_capacity()` used `os.path.isdir()` alone, which can't distinguish a real bind mount from Docker's auto-created empty directory when a bind-mount source doesn't exist on the host -- would silently report the container's own overlay filesystem usage as a plausible-looking but meaningless percentage.
  - Fix: added `os.path.ismount()` check alongside `isdir()`.
  - Evidence: `services/orion-biometrics/tests/test_disk_capacity.py::test_collect_disk_capacity_treats_unmounted_dir_as_not_mounted` -- a real, existing, but non-mount `tmp_path` directory is now correctly flagged `not_mounted`.
- Finding: the 5 new `docker-compose.yml` bind mounts expose entire host trees read-only (including live Postgres data files and the full repo, e.g. `/mnt/scripts`) just to compute a percent-used stat, when `shutil.disk_usage()` only needs a single existing path per filesystem.
  - Fix: not restructured in this patch -- these are the exact 5 host paths Juniper's task named, and narrowing to a smaller stat-only mount would require new host-side directory setup on 3 nodes with no existing convention for it. `orion-biometrics` already runs `privileged: true` for hardware sensor access, so this is an incremental rather than categorical exposure increase, but it is real. Documented explicitly below as a known concern rather than silently accepted.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-biometrics/.env \
  -f services/orion-biometrics/docker-compose.yml \
  up -d --build
```

Run on athena first, then on atlas/circe once each node's `services/orion-biometrics` checkout is updated to this branch/main and its local `.env` has `DISK_CAPACITY_MOUNTS` (or accepts the code default).

## Risks / concerns

- Severity: should-fix (documented, not restructured)
- Concern: the 5 new read-only bind mounts expose full host trees (including live Postgres data files under `/mnt/postgres` and the entire repo under `/mnt/scripts`) to the biometrics container, when only filesystem-capacity stats are needed.
- Mitigation: mounts are `:ro`; container already runs `privileged: true` for existing hardware-sensor access, so this is incremental not categorical. A tighter fix (mount a single dedicated marker file/dir per filesystem instead of the whole tree) would need new host-side setup on athena/atlas/circe that doesn't exist yet -- flagging as a follow-up rather than inventing untested host infra in this patch.
- Severity: should-fix (not applicable across nodes yet)
- Concern: circe/atlas mount paths are unverified -- this sandbox only confirms athena-equivalent paths.
- Mitigation: verification steps given above under "Docker/build/smoke checks" for Juniper to run post-deploy.

## PR link

(filled in by gh pr create)
