### PR TITLE
fix: 3 live crash-loops from the heartbeat rollout

### DIFF
--- a/services/orion-attention-runtime/requirements.txt
+++ b/services/orion-attention-runtime/requirements.txt
@@ -6,3 +6,4 @@ sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 PyYAML==6.0.2
 requests==2.31.0
+redis[hiredis]==5.0.7

--- a/services/orion-biometrics/app/settings.py
+++ b/services/orion-biometrics/app/settings.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Dict
 
 from pydantic import Field, field_validator
@@ -107,6 +108,15 @@ class Settings(BaseSettings):
             if isinstance(data, dict):
                 return {str(k): str(v) for k, v in data.items()}
         return _default
+
+# pydantic-settings decodes Dict-typed env vars as JSON at its own source layer,
+# before _parse_disk_capacity_mounts (which already handles "" gracefully) ever
+# runs -- an empty string (e.g. docker-compose interpolating an unset host env
+# var) throws SettingsError there instead of reaching our validator's fallback.
+# Confirmed live 2026-07-24: orion-biometrics crash-looped on exactly this after
+# .env_example gained DISK_CAPACITY_MOUNTS but a live .env hadn't been synced yet.
+if not os.environ.get("DISK_CAPACITY_MOUNTS", "").strip():
+    os.environ["DISK_CAPACITY_MOUNTS"] = "{}"
 
 settings = Settings()
 

--- a/services/orion-consolidation-runtime/requirements.txt
+++ b/services/orion-consolidation-runtime/requirements.txt
@@ -5,3 +5,4 @@ pydantic-settings==2.6.1
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 PyYAML==6.0.2
+redis[hiredis]==5.0.7


### PR DESCRIPTION
## Summary

Post-deploy live check found 3 of the newly heartbeat-wired services crash-looping in production. Two are the same root cause, one is different.

## Root causes

**`orion-attention-runtime`, `orion-consolidation-runtime`** (PR #1361): wired `BaseChassis`/`HeartbeatOnly` in but never added `redis[hiredis]` to either service's `requirements.txt`. `ModuleNotFoundError: No module named 'redis'` on every boot.

**`orion-biometrics`** (PR #1360): different bug. `docker-compose.yml` passes `DISK_CAPACITY_MOUNTS=${DISK_CAPACITY_MOUNTS}` through from the host `.env`, but only `.env_example` got the new key -- the live `.env` sync never happened. Compose interpolates an empty string, and pydantic-settings JSON-decodes `Dict`-typed env vars at its own source layer *before* the existing `_parse_disk_capacity_mounts` validator (which already handles `""` fine) ever runs -- hard crash with `SettingsError` instead of the graceful fallback the validator was written for.

## Fixes

- Added `redis[hiredis]==5.0.7` to both requirements.txt files.
- Fixed the live `.env` directly (immediate unblock, done before this PR).
- Hardened `settings.py` with a pre-construction `os.environ` guard so an empty/unset `DISK_CAPACITY_MOUNTS` can't crash-loop the service again if the same env-sync gap recurs on a future deploy (falls back to `{}` -- no mounts, no error -- rather than the rich 5-mount default, since an empty env var here likely also means docker-compose's bind mounts aren't configured either).

## Tests run

```text
orion_dev/bin/python -m pytest services/orion-attention-runtime/tests -q   -> 16 passed
orion_dev/bin/python -m pytest services/orion-consolidation-runtime/tests -q -> 3 passed
PYTHONPATH="services/orion-biometrics:." orion_dev/bin/python -m pytest services/orion-biometrics/tests -q
  -> 15 passed, 2 failed (pre-existing circe-expected-offline config-data assertions,
     confirmed identical via git stash against unmodified main)
```

Live-verified the actual fix: simulated `DISK_CAPACITY_MOUNTS=""` against the patched `settings.py` boots clean with `DISK_CAPACITY_MOUNTS = {}` instead of raising `SettingsError`.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-attention-runtime/.env -f services/orion-attention-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-consolidation-runtime/.env -f services/orion-consolidation-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-biometrics/.env -f services/orion-biometrics/docker-compose.yml up -d --build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bvjRYhyQsKQ1K9bbaWQYR