### PR TITLE
fix(vision-edge): remove duplicate per-frame system-health publisher

### DIFF
--- a/services/orion-vision-edge/app/detector_worker.py
+++ b/services/orion-vision-edge/app/detector_worker.py
@@ -5,15 +5,13 @@ import time
 import os
 import uuid
 import numpy as np
-from datetime import datetime, timezone
 from typing import Any, List, Tuple
 
-from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.bus_schemas import ServiceRef
 from orion.schemas.vision import (
-    VisionEdgeArtifact, VisionObject, VisionEdgeHealth, 
+    VisionEdgeArtifact, VisionObject, VisionEdgeHealth,
     VisionFramePointerPayload, VisionEdgeError
 )
-from orion.schemas.telemetry.system_health import SystemHealthV1
 
 from .activity import ActivityRateLimiter, labels_from_detections, publish_activity_if_allowed
 from .context import settings, bus, detectors
@@ -209,27 +207,6 @@ async def run_detector_loop():
                     payload=health_payload
                 )
                 await bus.publish(settings.CHANNEL_VISION_EDGE_HEALTH, health_env)
-
-                # Standard System Health (for Equilibrium)
-                sys_health = SystemHealthV1(
-                    service=settings.SERVICE_NAME,
-                    node="unknown", # edge usually unknown/dynamic or settings.DEVICE
-                    version=settings.SERVICE_VERSION,
-                    instance=settings.SOURCE,
-                    boot_id=str(uuid.uuid4()), # We should ideally persist this but per-frame random is acceptable for liveliness
-                    status="ok" if health_payload.ok else "error",
-                    last_seen_ts=datetime.now(timezone.utc),
-                    heartbeat_interval_sec=1.0 / settings.FPS if settings.FPS else 10.0,
-                    details={"camera": settings.SOURCE, "fps": health_payload.fps}
-                )
-                sys_env = BaseEnvelope(
-                    kind="system.health.v1",
-                    source=ServiceRef(name=settings.SERVICE_NAME, version=settings.SERVICE_VERSION),
-                    payload=sys_health.model_dump(mode="json"),
-                )
-                # Hardcoded channel or need to add to settings? settings.py usually has common ones.
-                # Assuming "orion:system:health" standard.
-                await bus.publish("orion:system:health", sys_env)
 
             except Exception as e:
                 logger.warning(f"Health check failed: {e}")


### PR DESCRIPTION
## Summary
- `orion-vision-edge` had two publishers of `orion:system:health` (SystemHealthV1) — root-caused during the service-heartbeat rollout arc but left unfixed until now.
- `main.py`'s `heartbeat_loop()` is correct: fixed 30s cadence, stable `BOOT_ID` set once at module load, `node="vision-edge-node"`.
- `detector_worker.py`'s per-frame "Health Check" block ALSO published `orion:system:health`, once per processed frame (`heartbeat_interval_sec=1.0/settings.FPS`, i.e. tied to camera FPS), with a fresh random `boot_id` every single frame and `node="unknown"`.
- To `orion-equilibrium-service` (the consumer computing uptime/distress from these heartbeats) this looked like vision-edge was constantly rebooting, at ~FPS Hz, from an unknown node.

## Outcome moved
`orion-vision-edge` now has exactly one `orion:system:health` publisher, matching every other service on the bus-native heartbeat pattern. Equilibrium's uptime/distress tracking for this service should stop seeing spurious boot-id churn.

## Files changed
- `services/orion-vision-edge/app/detector_worker.py`: removed the duplicate `SystemHealthV1`/`orion:system:health` publish block and its now-unused imports (`BaseEnvelope`, `SystemHealthV1`, `datetime`, `timezone`). Kept the legitimate per-frame `CHANNEL_VISION_EDGE_HEALTH`/`VisionEdgeHealth` publish — different channel, different payload (camera diagnostics: brightness, resolution), not the system heartbeat.

## Schema / bus / API changes
- Removed: nothing schema-level — `orion:system:health` channel/schema unchanged, just one fewer (buggy) producer.

## Tests run
```text
PYTHONPATH="services/orion-vision-edge:." orion_dev/bin/python -m pytest services/orion-vision-edge/tests -q
4 passed
```
No test previously covered this path (no test asserted on `detector_worker.py`'s system-health publish).

## Review findings fixed
- Findings from orion-repo-agent review: none material. Confirmed no other code/tests depend on the per-frame duplicate, confirmed unused imports were fully removed, confirmed `main.py` untouched and remains sole publisher.

## Restart required
```bash
docker compose \
  --env-file .env \
  --env-file services/orion-vision-edge/.env \
  -f services/orion-vision-edge/docker-compose.yml \
  up -d --build
```

## Risks / concerns
None — pure deletion of a duplicate/buggy publisher, no behavior change to the surviving heartbeat or to camera-diagnostics publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)