### PR TITLE
feat(bus-mirror): per-node verb-latency partitioning (item 2.1)

### DIFF
--- a/docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md
+++ b/docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md
@@ -1,0 +1,139 @@
+# Bus synaptic graph — verb-latency slicing gaps + causal-DAG/content-drift (item 2)
+
+Status: **scoping + first build.** Follow-up to this session's post-arc audit (after G/F/B/A/C/D
+shipped and live-verified, item 1 — `bus_mirror.sqlite` retention — fixed separately). Covers four
+named-but-unbuilt gaps from `services/orion-bus-mirror/README.md`'s "Phase 2" section and the parent
+`2026-07-24-bus-vitality-field-signal-brainstorm.md`'s "Signal families" list:
+
+1. **Per-node verb-latency partitioning** — `EXECUTES_VERB` edges capture `last_node` but do not
+   partition the EWMA baseline by it; an organ running the same verb on two hosts blends both
+   hosts' latencies into one baseline. Named explicitly as a "Real limitation, not solved here" in
+   the README.
+2. **Preceding-verb / `model_used` / concurrent-load slicing** — same README paragraph, same
+   "not built" status. A flat per-verb average can't separate "this verb is slow" from "it's slow
+   *because* of what ran before it, or which model served it, or how loaded the mesh was."
+3. **Causal-DAG empirical verification** — `orion/signals/registry.py`'s `ORGAN_REGISTRY`
+   `causal_parent_organs` edges are hand-authored, "first-pass structural approximations" per that
+   file's own comment. The live `CAUSALLY_FOLLOWED_BY` edges are the mechanism to verify them
+   against real traffic; parked as "eventual, not prioritized" in the parent brainstorm doc.
+4. **Content-drift signals** — three concrete, non-phi ideas named in the parent doc, none built:
+   verb-sequence drift (does the *set* of distinct chain shapes change over a window — Idea C's
+   `summarize_chain_shapes` now gives this a real data source it didn't have before), payload schema
+   drift (do the *keys present* in a channel's payload change over time), error-kind recurrence
+   (which `error`/`status=failed` messages repeat verbatim vs. are novel).
+
+**Sequencing, same "additive, not exclusive" framing as the wider-net doc:** build (1) now — data is
+already captured (`last_node` exists on every `EXECUTES_VERB` edge today), the fix is purely how the
+graph key partitions it, no new extraction logic needed. (2), (3), (4) are scoped below but not built
+in this pass — each is either a bigger mechanism (2), explicitly "not prioritized" already (3), or a
+fresh extraction pipeline with no existing data source (4). None block each other.
+
+## Ground truth
+
+`BusSynapticGraphWriter.record_verb_step()` (`app/graph_writer.py`) currently:
+```cypher
+MATCH (:Organ {organ_id: $organ_id})-[e:EXECUTES_VERB]->(:Verb {verb_name: $verb_name})
+```
+— one edge per `(organ_id, verb_name)` pair, full stop. `node` is written as a mutable `SET`
+property (`e.last_node = $node`), overwritten on every observation regardless of which host actually
+produced it — so the *baseline itself* (`latency_ewma_sec`/`latency_var`/`latency_zscore`) is a blend
+across every host that organ has ever run on, and `last_node` only ever reflects whichever host
+happened to report most recently.
+
+## Idea 2.1 — per-node verb-latency partitioning (built this pass)
+
+**What:** include `node` in the `EXECUTES_VERB` relationship's identity, not just as a mutable
+property — `MERGE (o)-[e:EXECUTES_VERB {node: $node}]->(v)` instead of
+`MERGE (o)-[e:EXECUTES_VERB]->(v)` + `SET e.last_node`. Creates one distinct edge per
+`(organ_id, verb_name, node)` triple (a real multigraph between the same two nodes, which Cypher/
+FalkorDB supports natively), each with its own independent EWMA baseline.
+
+**Why:** the README already names this as the specific thing preventing "this verb is slow" from
+being separated from "this specific machine is loaded" — the original motivation for capturing
+`node` at all. Directly closes that gap with no new data collection.
+
+**Smallest buildable version:** exactly the MERGE/MATCH pattern change above, in both the read
+(`MATCH ... {node: $node}`) and write (`MERGE ... {node: $node}`) queries. `node=None` (a real,
+common case — verb-step payloads don't always carry it) becomes its own valid partition (an
+"unknown-node" bucket), not an error or a dropped observation.
+
+**Files:** `services/orion-bus-mirror/app/graph_writer.py` (`record_verb_step`), its tests, README.
+
+## Idea 2.2 — preceding-verb / model_used / concurrent-load slicing (scoped, not built)
+
+**What:** three separate slicing axes on `EXECUTES_VERB`, each a real, distinct signal:
+- Preceding verb: partition by `(organ, verb, preceding_verb)` — needs the chain-shape machinery
+  Idea C just built (`organ_sequence`) extended to track *verb* sequence, not just organ sequence,
+  since "preceding verb" isn't the same as "preceding organ."
+- `model_used`: partition by whatever field in the step payload names the serving model (needs a
+  live check of whether `model_used` is actually populated in real `steps[]` payloads — unverified,
+  same class of question Idea G resolved for `causality_chain`).
+- Concurrent-load: z-score a verb's latency against how loaded the mesh was *when it ran* (ties
+  directly to the in-flight-chain-count signal Phase 2 already built) — this is structurally the
+  same mechanism the wider-net doc's Idea E scoped and found inconclusive for edge-level anomalies;
+  the same measure-first caution applies here.
+
+**Why not built now:** each of these needs its own live-data check before committing to a graph
+shape (matching this arc's own repeated lesson: don't build partitioning on an axis until you know
+it's actually populated/meaningful in real traffic). Real added complexity too — 2.1 alone already
+splits one edge into N; stacking more partition axes multiplies edge count fast.
+
+**Smallest next step if picked up:** a read-only prevalence check (same shape as Idea G) — sample
+real `steps[]` payloads, check how often `model_used` is populated and how many distinct
+preceding-verb pairs actually recur, before deciding whether either axis is worth the edge-count
+cost.
+
+## Idea 2.3 — causal-DAG empirical verification (scoped, not built)
+
+**What:** compare `ORGAN_REGISTRY`'s hand-authored `causal_parent_organs` edges
+(`orion/signals/registry.py`) against the live `CAUSALLY_FOLLOWED_BY` edges — which hand-authored
+edges are confirmed by real traffic, which are missing from real traffic, which real edges exist
+that the hand-authored graph never named.
+
+**Why not built now:** explicitly "parked, eventual, not prioritized" in the parent brainstorm doc,
+and nothing in this session's audit changed that priority call — it's a real, valuable, but
+non-urgent verification pass, not blocking anything else.
+
+**Smallest buildable version, if picked up:** a one-off read-only diff script (same shape as
+`causality_chain_prevalence_audit.py`) — load `ORGAN_REGISTRY`, load live `CAUSALLY_FOLLOWED_BY`
+edges, set-diff both directions, report. No code/schema change, pure analysis.
+
+## Idea 2.4 — content-drift signals (scoped, not built)
+
+**What:** three concrete alternatives, all content-grounded rather than volume-grounded:
+- Verb-sequence drift: does the *set* of distinct chain shapes change over a window? Idea C's
+  `summarize_chain_shapes` (shipped) is the data source this now has that it didn't before — a
+  never-before-seen shape appearing, or a previously-common one disappearing, is itself a signal.
+  This is the closest of the four to already having a foundation.
+- Payload schema drift: do the *keys present* in a channel's payload change over time, independent
+  of what the values say — cheap key-set diffing, catches producer changes without reading every
+  changelog.
+- Error-kind recurrence: which `error`/`status=failed` messages repeat verbatim vs. are novel over
+  time — a real regression-detector shape.
+
+**Why not built now:** all three need a persistence layer this arc hasn't built (a rolling window of
+*sets*, not scalars — different shape than every EWMA-based signal shipped so far). Real, worthwhile
+direction, genuinely bigger than a single-patch slice.
+
+**Smallest next step if picked up:** verb-sequence drift specifically, since Idea C already produces
+the raw material (`summarize_chain_shapes`' output) — would need a small persistence addition
+(remember the shape set from N ticks ago, diff against current) rather than a whole new extraction
+pipeline like the other two.
+
+## Non-goals
+
+- Not building 2.2/2.3/2.4 in this pass — each named, scoped, sequenced as a future candidate, not
+  silently dropped.
+- Not attempting to unify all four into one mechanism — they are genuinely different shapes (edge
+  partitioning, DAG diffing, set-drift detection), forcing a shared abstraction would be premature.
+
+## Acceptance checks
+
+Same discipline as the rest of this arc: live-data sanity check against the real running graph
+before calling 2.1 done (confirm distinct per-node baselines actually diverge on a real multi-host
+verb, not just that the query executes).
+
+## Recommended next patch
+
+2.1 now (this session). 2.2/2.3/2.4 remain named, scoped, additive candidates — no build order
+imposed among them, same as A/C/D/E in the wider-net doc.

--- a/services/orion-bus-mirror/README.md
+++ b/services/orion-bus-mirror/README.md
@@ -168,19 +168,24 @@ with `move_to_end()` on every touch, so eviction pops only the genuinely-stale p
 instead of scanning the full (thousands-of-entries) table on every single message —
 a real, measured contributor to CPU usage at full mesh traffic volume.
 
-**Per-verb latency** (`EXECUTES_VERB` edges, `(:Organ)-[:EXECUTES_VERB {count,
-last_seen_epoch, last_node, latency_ewma_sec, latency_var, latency_zscore}]->(:Verb
+**Per-verb latency** (`EXECUTES_VERB` edges, `(:Organ)-[:EXECUTES_VERB {node,
+count, last_seen_epoch, latency_ewma_sec, latency_var, latency_zscore}]->(:Verb
 {verb_name})`): mined from any envelope whose payload has a `steps[]` array with real
 measured `latency_ms` per step (the `cognition.trace` shape) — same EWMA/z-score
-mechanism as Phase 1's edges, applied per (organ, verb) pair.
+mechanism as Phase 1's edges, applied per (organ, verb, node) triple.
 
-Real limitation, not solved here: **`last_node` is captured but does not partition
-the baseline.** If the same organ runs the same verb on more than one physical host,
-their latencies blend into one EWMA — this does not yet cleanly separate "this verb
-is slow" from "this specific machine is loaded," despite that being the original
-motivation for wanting a per-node slice. Also not built: slicing by preceding verb in
-a chain, by `model_used`, or by concurrent in-flight-chain count at the same moment —
-all named as real ideas in the design doc, none implemented.
+**Fixed 2026-07-25** (was: "`last_node` captured but does not partition the
+baseline"): `node` is now part of the relationship's identity (in both the read
+and write Cypher), not just a mutable `SET` property -- an organ running the same
+verb on two hosts now gets two independent EWMA baselines, cleanly separating
+"this verb is slow" from "this specific machine is loaded." A missing node is its
+own real `"unknown"` partition, not silently dropped or blended into whichever
+host happened to report most recently. See
+`docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md`.
+
+Still not built: slicing by preceding verb in a chain, by `model_used`, or by
+concurrent in-flight-chain count at the same moment — named as real ideas in the
+design doc, scoped but not implemented (same doc as above, Idea 2.2).
 
 **Fixed in review, worth knowing about**: unlike Phase 1's facts (derived only from
 trusted envelope metadata and wall-clock timestamps), `extract_verb_step_facts` reads
@@ -194,7 +199,7 @@ edge's EWMA baseline with no self-healing (verified live in review).
 ```cypher
 MATCH (o:Organ)-[e:EXECUTES_VERB]->(v:Verb)
 WHERE abs(e.latency_zscore) > 3 AND e.count > 5
-RETURN o.organ_id, v.verb_name, e.latency_ewma_sec, e.latency_zscore, e.last_node
+RETURN o.organ_id, v.verb_name, e.node, e.latency_ewma_sec, e.latency_zscore
 ORDER BY abs(e.latency_zscore) DESC
 ```
 

--- a/services/orion-bus-mirror/app/graph_writer.py
+++ b/services/orion-bus-mirror/app/graph_writer.py
@@ -36,13 +36,14 @@ Phase 2 additions:
 - **Per-verb latency** (``EXECUTES_VERB`` edges, Organ -> Verb): mined from
   ``cognition.trace``-shaped payloads' ``steps[]`` array (real measured
   ``latency_ms`` per step, already present in the wire format -- see
-  ``extract_verb_step_facts``). Only the "which organ, which verb, what's the
-  latency baseline" slice is built here. The physical `node` a step ran on is
-  captured as an edge property for manual inspection but does NOT partition
-  the EWMA baseline (an organ running on multiple hosts would have its
-  latencies blended) -- and preceding-verb / model_used / concurrent-load
-  slicing (also named in the design doc) are not built at all. Named
-  explicitly in README "Known gaps", not silently pretended solved.
+  ``extract_verb_step_facts``). The physical ``node`` a step ran on now
+  partitions the EWMA baseline itself (fixed 2026-07-25, see
+  docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-
+  causal-gaps.md) -- one independent baseline per (organ, verb, node), not
+  one blended baseline per (organ, verb). Preceding-verb / model_used /
+  concurrent-load slicing (also named in the design doc) are still not
+  built -- scoped as Idea 2.2 in that same doc, not silently pretended
+  solved.
 
 Both edge kinds carry a rolling EWMA baseline plus a live z-score of the most
 recent observation against that baseline -- the "connected components get
@@ -50,8 +51,7 @@ zscored on volume/latency" mechanism from the design brainstorm.
 
 Deliberately out of scope for this module (Phase 3+, not built here):
 anomaly propagation across edges, node centrality, chain-shape clustering,
-per-node-partitioned verb latency, preceding-verb/model_used/concurrent-load
-slicing.
+preceding-verb/model_used/concurrent-load slicing.
 """
 
 from __future__ import annotations
@@ -550,12 +550,24 @@ class BusSynapticGraphWriter:
         )
 
     def record_verb_step(self, fact: VerbStepFact) -> None:
+        # Idea 2.1 of docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-
+        # latency-and-causal-gaps.md: node is part of the relationship's identity
+        # (in both MATCH and MERGE), not just a mutable SET property -- an organ
+        # running the same verb on two hosts now gets two independent EWMA
+        # baselines instead of one blended one (the README's own named "Real
+        # limitation, not solved here" from Phase 2). A literal "unknown" string,
+        # not null, represents a missing node -- avoids relying on how a
+        # specific Cypher engine's MERGE handles a null-valued property in a
+        # pattern map (undefined/inconsistent across implementations for
+        # equality-based matching), and keeps "verb ran, host unknown" as its
+        # own real, honest partition rather than silently dropped or blended.
+        node_key = fact.node if fact.node else "unknown"
         prior_rows = self._client.graph_query(
             """
-            MATCH (:Organ {organ_id: $organ_id})-[e:EXECUTES_VERB]->(:Verb {verb_name: $verb_name})
+            MATCH (:Organ {organ_id: $organ_id})-[e:EXECUTES_VERB {node: $node}]->(:Verb {verb_name: $verb_name})
             RETURN e.latency_ewma_sec AS latency_ewma_sec, e.latency_var AS latency_var, e.count AS count
             """,
-            {"organ_id": fact.organ_id, "verb_name": fact.verb_name},
+            {"organ_id": fact.organ_id, "verb_name": fact.verb_name, "node": node_key},
         )
         row = prior_rows[0] if prior_rows else {}
         prior_ewma = float(row.get("latency_ewma_sec") or 0.0)
@@ -573,10 +585,9 @@ class BusSynapticGraphWriter:
             """
             MERGE (o:Organ {organ_id: $organ_id})
             MERGE (v:Verb {verb_name: $verb_name})
-            MERGE (o)-[e:EXECUTES_VERB]->(v)
+            MERGE (o)-[e:EXECUTES_VERB {node: $node}]->(v)
             SET e.count = $count,
                 e.last_seen_epoch = $now_epoch,
-                e.last_node = $node,
                 e.latency_ewma_sec = $latency_ewma_sec,
                 e.latency_var = $latency_var,
                 e.latency_zscore = $latency_zscore
@@ -584,9 +595,9 @@ class BusSynapticGraphWriter:
             {
                 "organ_id": fact.organ_id,
                 "verb_name": fact.verb_name,
+                "node": node_key,
                 "count": prior_count + 1,
                 "now_epoch": fact.observed_at_epoch,
-                "node": fact.node,
                 "latency_ewma_sec": update.ewma,
                 "latency_var": update.variance,
                 "latency_zscore": update.zscore,

--- a/services/orion-bus-mirror/scripts/migrate_execute_verb_node_property.py
+++ b/services/orion-bus-mirror/scripts/migrate_execute_verb_node_property.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""One-off migration: copy the old ``EXECUTES_VERB`` edges' ``last_node``
+property onto the new ``node`` property Idea 2.1 introduces
+(docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md).
+
+Why this is needed: as of that patch, ``BusSynapticGraphWriter.record_verb_step``
+matches/creates edges via ``MERGE (o)-[e:EXECUTES_VERB {node: $node}]->(v)`` --
+``node`` is now part of the relationship's identity, not a mutable ``SET``
+property. Edges written by the *old* code (which only ever set ``e.last_node``,
+never ``e.node``) would never match that new pattern again -- they'd sit
+orphaned forever with a stale, blended baseline, exactly the same class of
+problem ``stale_channel_node_cleanup.py`` fixed for pre-normalization Channel
+nodes. Unlike that fix, this one is purely additive (copies a value onto a new
+property, deletes nothing) -- safe to run without a separate dry-run/execute
+split.
+
+Already run live 2026-07-24 against the real ``orion_bus_synapse`` graph (11
+edges, all migrated cleanly, verified via direct query before and after) as
+part of shipping this PR -- this script exists so the migration is reproducible
+and auditable, not just a one-off interactive command.
+
+Usage:
+
+    docker exec orion-athena-recall python3 \
+        services/orion-bus-mirror/scripts/migrate_execute_verb_node_property.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+try:
+    from orion.graph.falkor_client import RedisGraphQueryClient
+except ImportError:
+    _file_parents = Path(__file__).resolve().parents
+    _repo_root = _file_parents[3] if len(_file_parents) > 3 else _file_parents[-1]
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+    from orion.graph.falkor_client import RedisGraphQueryClient
+
+
+def main() -> None:
+    uri = os.getenv("FALKORDB_URI", "redis://orion-athena-falkordb:6379")
+    graph_name = os.getenv("FALKORDB_BUS_GRAPH", "orion_bus_synapse")
+    client = RedisGraphQueryClient(uri=uri, graph_name=graph_name)
+
+    result = client.graph_query(
+        """
+        MATCH (:Organ)-[e:EXECUTES_VERB]->(:Verb)
+        WHERE e.node IS NULL
+        SET e.node = coalesce(e.last_node, "unknown")
+        RETURN count(e) AS migrated
+        """
+    )
+    migrated = result[0]["migrated"] if result else 0
+    print(f"migrated {migrated} EXECUTES_VERB edges (last_node -> node)")
+
+    verify = client.graph_query(
+        """
+        MATCH (o:Organ)-[e:EXECUTES_VERB]->(v:Verb)
+        RETURN o.organ_id AS organ_id, v.verb_name AS verb_name, e.node AS node, e.count AS count
+        """
+    )
+    for row in verify:
+        print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/orion-bus-mirror/tests/test_graph_writer.py
+++ b/services/orion-bus-mirror/tests/test_graph_writer.py
@@ -38,7 +38,10 @@ class FakeGraphClient:
         elif "CAUSALLY_FOLLOWED_BY" in cypher:
             key = ("CAUSALLY_FOLLOWED_BY", params.get("prior_organ_id"), params.get("organ_id"))
         elif "EXECUTES_VERB" in cypher:
-            key = ("EXECUTES_VERB", params.get("organ_id"), params.get("verb_name"))
+            # node is part of this edge's identity (Idea 2.1) -- include it in
+            # the fake's key so two different nodes running the same verb are
+            # tracked as genuinely independent edges, matching real behavior.
+            key = ("EXECUTES_VERB", params.get("organ_id"), params.get("verb_name"), params.get("node"))
         else:
             return []
 
@@ -678,5 +681,30 @@ class TestBusSynapticGraphWriterVerbStep:
         writer.record_verb_step(VerbStepFact(organ_id="cortex-exec", verb_name="verb_a", latency_sec=5.0, node="athena", observed_at_epoch=1000.0))
         writer.record_verb_step(VerbStepFact(organ_id="cortex-exec", verb_name="verb_b", latency_sec=5.0, node="athena", observed_at_epoch=1000.5))
 
-        assert fake_client._edges[("EXECUTES_VERB", "cortex-exec", "verb_a")]["count"] == 1
-        assert fake_client._edges[("EXECUTES_VERB", "cortex-exec", "verb_b")]["count"] == 1
+        assert fake_client._edges[("EXECUTES_VERB", "cortex-exec", "verb_a", "athena")]["count"] == 1
+        assert fake_client._edges[("EXECUTES_VERB", "cortex-exec", "verb_b", "athena")]["count"] == 1
+
+    def test_same_verb_on_different_nodes_gets_independent_baselines(self, fake_client: FakeGraphClient) -> None:
+        # Idea 2.1: the whole point of the fix -- an organ running the same
+        # verb on two hosts must not blend their latencies into one EWMA.
+        writer = BusSynapticGraphWriter(fake_client, alpha=0.2)
+        writer.record_verb_step(VerbStepFact(organ_id="cortex-exec", verb_name="draft_entry", latency_sec=1.0, node="athena", observed_at_epoch=1000.0))
+        writer.record_verb_step(VerbStepFact(organ_id="cortex-exec", verb_name="draft_entry", latency_sec=1.0, node="athena", observed_at_epoch=1001.0))
+        writer.record_verb_step(VerbStepFact(organ_id="cortex-exec", verb_name="draft_entry", latency_sec=99.0, node="atlas", observed_at_epoch=1002.0))
+
+        athena_edge = fake_client._edges[("EXECUTES_VERB", "cortex-exec", "draft_entry", "athena")]
+        atlas_edge = fake_client._edges[("EXECUTES_VERB", "cortex-exec", "draft_entry", "atlas")]
+        assert athena_edge["count"] == 2
+        # atlas's first-ever observation on this edge -- no baseline yet, not
+        # blended with athena's, and no z-score for a genuine first sighting.
+        assert atlas_edge["count"] == 1
+        assert atlas_edge["latency_zscore"] is None
+        assert atlas_edge["latency_ewma_sec"] == pytest.approx(99.0)
+
+    def test_missing_node_becomes_its_own_unknown_partition_not_null(self, fake_client: FakeGraphClient) -> None:
+        writer = BusSynapticGraphWriter(fake_client, alpha=0.2)
+        writer.record_verb_step(VerbStepFact(organ_id="cortex-exec", verb_name="draft_entry", latency_sec=5.0, node=None, observed_at_epoch=1000.0))
+
+        write_call = fake_client.calls[-1]
+        assert write_call[1]["node"] == "unknown"
+        assert fake_client._edges[("EXECUTES_VERB", "cortex-exec", "draft_entry", "unknown")]["count"] == 1


### PR DESCRIPTION
## Summary

- Item 2.1: `EXECUTES_VERB` edges previously matched/merged on `(organ_id, verb_name)` only, with `node` as a mutable `SET` property -- README named this as a "Real limitation, not solved here" (an organ running the same verb on multiple hosts blended their latencies into one EWMA baseline).
- Fixed: `node` is now part of the relationship's identity in both read and write Cypher, not just a property -- one independent baseline per `(organ, verb, node)` triple.
- New scoping doc also names three related, still-unbuilt gaps (preceding-verb/`model_used`/concurrent-load slicing, causal-DAG empirical verification, content-drift signals) as additive, sequenced-later candidates.

## Outcome moved

Closes a README-documented gap with no new data collection -- `node` was already captured, this only changes how it partitions the graph. Cleanly separates "this verb is slow" from "this specific machine is loaded."

## Current architecture

`BusSynapticGraphWriter.record_verb_step()` in `services/orion-bus-mirror/app/graph_writer.py`.

## Files changed

- `services/orion-bus-mirror/app/graph_writer.py`: `record_verb_step()`'s MATCH/MERGE now includes `{node: $node}`; missing node maps to a literal `"unknown"` string, not `null` (avoids relying on undefined/inconsistent null-matching semantics in a Cypher engine's MERGE property map). Module docstring updated.
- `services/orion-bus-mirror/README.md`: "Fixed 2026-07-25" note replacing the stale "Real limitation, not solved here" language; sample Cypher query updated (`e.last_node` -> `e.node`).
- `services/orion-bus-mirror/tests/test_graph_writer.py`: `FakeGraphClient`'s edge key now includes `node` (matching real identity); 2 new tests (independent baselines per node, missing-node-as-"unknown").
- `services/orion-bus-mirror/scripts/migrate_execute_verb_node_property.py` (new): one-off migration copying old edges' `last_node` onto the new `node` property -- **already run live** against production (11/11 edges migrated, verified before/after), committed for reproducibility/audit.
- `docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md` (new): scopes all four related gaps, sequences 2.1 first, 2.2/2.3/2.4 as additive future candidates.

## Schema / bus / API changes

- `EXECUTES_VERB` edge shape: `node` becomes part of the relationship's identity (was a mutable property). Old edges migrated in-place (additive, non-destructive) rather than orphaned -- see migration script.

## Tests run

```text
PYTHONPATH="services/orion-bus-mirror:." venv/bin/python -m pytest services/orion-bus-mirror/tests/ -q
84 passed
```

## Evals run

None applicable.

## Docker/build/smoke checks

Live-verified against the real FalkorDB engine before committing (not just unit tests against a fake):
1. Confirmed `MERGE` with a relationship property map correctly creates genuinely distinct edges for different `node` values between the same two nodes -- ran three simulated `record_verb_step` calls (athena, atlas, athena) against a throwaway `__test_organ__`/`__test_verb__`, got 2 real independent edges (`athena: count=2`, `atlas: count=1`), then cleaned up the test data.
2. Ran the migration script live against production: 11/11 real `EXECUTES_VERB` edges (all currently `node=athena` -- no cross-host verb execution observed yet, confirming this fix is architecturally correct for when it does happen, not yet visibly different in current traffic) migrated cleanly, verified via direct query before and after.

## Review findings fixed

Not run as a separate subagent pass -- scoped, tested change directly closing a README-documented gap, live-verified against the real graph engine (the actual risk here -- MERGE-with-property-map semantics -- rather than deferred to review).

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-bus-mirror/.env \
  -f services/orion-bus-mirror/docker-compose.yml \
  up -d --build
```

Migration already applied live -- no post-deploy migration step needed, just the restart to pick up the new code.

## Risks / concerns

- Severity: informational
- Concern: no live traffic currently exercises multi-host verb execution (all 11 edges are `athena`-only), so the partitioning behavior itself is unverified against real divergent baselines -- only the mechanism (via the throwaway test) is confirmed.
- Mitigation: will become visible automatically once/if verb execution genuinely spans hosts; no action needed now.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1368
