### PR TITLE
docs: propose bus synaptic graph as candidate 3rd transport-domain evidence source

### DIFF
--- a/docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md
+++ b/docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md
@@ -233,3 +233,95 @@ implementation time, same as every other signal built this session:
   the signal this spec proposes, even after implementation. Not a reason to change approach
   (instrumenting the one shared client is still the correct thin seam for everything that
   actually uses it), but stated here plainly rather than implied as complete coverage.
+
+## Revision, 2026-07-25 -- bus synaptic graph as a candidate third evidence source
+
+Status: **proposed, design-only, not decided.** Does not resolve Missing Question 5 (old
+`transport_pressure`/`bus_health` family's fate -- now renamed `stream_backlog_pressure`/
+`stream_backlog_health`, PR #1331, a plain rename per that PR, not a product of this redesign).
+Written the same week the `transport` metacog trigger (Options A+C, RpcHealthSnapshotV1 +
+`rpc_transport_timeout` grammar) shipped -- disabled at first (`95db26ba9`,
+`EQUILIBRIUM_METACOG_TRANSPORT_TRIGGER_ENABLE=false`), then flipped on about an hour later the
+same day (`40cd21f80`, "live verification is the next step") -- confirmed live in this worktree's
+own `services/orion-equilibrium-service/.env_example`, which reads `=true`. Re-check this flag's
+live value before relying on its state in any future revision; don't assume this note stays
+current. Also the same week `orion-bus-mirror`'s bus synaptic graph (`orion_bus_synapse`,
+FalkorDB) came back online after a `distutils`/Python-3.12 crash-loop fix (`redis` bumped to
+5.2.1, commit `2e1fa7f2`).
+
+**Arsonist read.** This spec's own "Related work" section already names the blind spot: Options
+A+C both depend on a service self-reporting (`RpcHealthSnapshotV1`) or calling the one
+instrumented shared client (`OrionBusAsync.rpc_request()`). `orion-harness-governor` does neither
+-- it has its own bespoke long-poll RPC (mid-run liveness checks for long FCC motor turns), so it
+is invisible to both existing evidence sources, permanently, even after full implementation of
+this spec's Recommended-next-patch. The bus synaptic graph does not have this limitation: it is a
+passive wiretap on envelope `correlation_id` co-occurrence, agnostic to which RPC mechanism (or
+no RPC mechanism at all -- ordinary pub/sub) produced the traffic. Verified live, same day:
+
+```text
+MATCH (a:Organ)-[e:CAUSALLY_FOLLOWED_BY]->(b:Organ)
+WHERE a.organ_id CONTAINS 'harness' OR b.organ_id CONTAINS 'harness'
+RETURN a.organ_id, b.organ_id, e.count, e.latency_zscore
+```
+`hub -> orion-harness-governor`: `count=5, latency_zscore=-2.10`. `cortex-exec ->
+orion-harness-governor`: `count=34, latency_zscore=-0.25`. Real edges, real z-scores, on the exact
+organ this spec's Related-work section names as structurally unreachable by its own proposed
+signal.
+
+This is not a proposal to replace Options A/C -- `RpcHealthSnapshotV1`/`rpc_transport_timeout`
+measure something the graph cannot (an actual timeout/error outcome, not just a latency
+deviation) -- but a candidate **third** input specifically for the coverage gap those two leave
+open, using infrastructure that already exists, is already live, and required zero new
+instrumentation to produce the numbers above.
+
+**Relationship to the bus synaptic graph's own arc.** This is a narrow, transport-domain-specific
+use case, not a duplicate of work already scoped there. The graph's brainstorm doc
+(`docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md`) and its already-built
+Phase-3+ Ideas (labeled 1, 4, 5 in that doc's "Signal families this substrate opens up" section --
+**not** the same numbers as that doc's own earlier "Idea 1-6" list under "Proposed schema / API
+changes", which the doc itself flags as a labeling collision; catalog-drift fix, live recall/chat
+anomaly awareness, and Hub debug routes, respectively) do not include feeding the Sentience
+Striving Program's transport prediction-error/metacog-trigger gap; the closest sibling, Phase-3+
+Idea 4
+(`docs/superpowers/specs/2026-07-24-bus-synaptic-graph-reasoning-consumer-design.md`, merged), is a
+different consumer entirely -- unconditional per-chat-turn awareness fed into `orion-recall`'s
+fragment fusion, not a metacog trigger or a `FieldStateV1` node write. The Cypher this proposal
+would reuse (`anomalies` -- already live-verified and tested via
+`services/orion-hub/scripts/bus_synaptic_graph_routes.py`, the same query Idea 4's adapter reuses)
+is shared infrastructure; the consumption target (transport metacog trigger / prediction-error
+substrate) is new and out of scope for both existing Ideas.
+
+**Missing questions, additive to the ones already open above:**
+
+- Should this feed the `transport` metacog trigger (Option A/C's `trigger_kind`) as a third
+  evidence branch, or feed a new `node:substrate.bus_synaptic` `FieldStateV1` node directly (the
+  "compute signals from the graph" consumption mode the brainstorm doc names, as opposed to Idea
+  4's "reason from the graph directly" mode)? Real trade-off: the metacog-trigger route reuses an
+  already-shipped, already-enabled dispatch mechanism (live since `40cd21f80`, re-check before
+  relying on this) -- if anything this favors reusing it over building a new path; the
+  `FieldStateV1` route matches the other four domains' shape but would need its own periodic reducer (mirroring
+  `orion-substrate-runtime`'s `_*_tick()` pattern, per this spec's own "Proposed schema / API
+  changes" section above) reading a graph instead of Postgres. Not decided here.
+- What z-score/count thresholds distinguish "worth feeding a cognition-adjacent signal" from "Hub
+  debug noise"? The recall consumer design doc flags this exact question as unresolved for its own
+  use case (Hub's `zscore_threshold=3.0, min_count=5` were tuned for a human reading a table) --
+  applies here too, not re-derived.
+- Cold-start reliability: this session's own numbers above (`count=5`) sit right at the graph's
+  own documented `count < ~5` unreliable-z-score floor. Needs a longer live window before treating
+  any single edge's z-score as trustworthy, not just this one example.
+- Does `orion-harness-governor` traffic reliably produce a `CAUSALLY_FOLLOWED_BY` edge at all, or
+  did this session's example only work because `hub` also happens to route other traffic through
+  channels the graph tracks? Needs checking across more of the 37+ real RPC-adjacent services this
+  spec's Arsonist Summary names, not generalized from one organ pair.
+
+**Non-goals, additive:** not deciding Missing Question 5 (old channel's rename-vs-deprecate fate)
+here or as a side effect of this revision. Not building the metacog-trigger wiring, the
+`FieldStateV1` reducer, or any adapter in this patch -- proposal only, per CLAUDE.md §0A's
+proposal-mode requirement for changes touching this substrate, same standard the rest of this doc
+already holds itself to.
+
+**Recommended next patch (revised):** before choosing between the two consumption modes above,
+run a real-data pass over a longer window (a day or more) confirming `CAUSALLY_FOLLOWED_BY` edges
+involving RPC-health-invisible organs (`orion-harness-governor` and any others sharing its
+bespoke-RPC pattern, not yet audited) are a recurring, non-degenerate signal -- not a one-off
+artifact of this session's snapshot.

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -239,6 +239,14 @@ first place. Full reasoning and phased detail:
    override) still needs a fresh trigger to occur post-rebuild, independent of how much
    history accumulates — "item 2 is proven" therefore still means "correct when exercised,"
    not yet "exercised against a fresh real override since the rebuild."
+   **Candidate for the excluded transport domain, proposed 2026-07-25 (not built):** PR #1329's
+   `prediction_error_confidence` explicitly excludes `transport` (confirmed structurally dead —
+   `0.0` for 100% of a real 8h window). The bus synaptic graph (`orion_bus_synapse`,
+   `services/orion-bus-mirror`, live since the same-day `distutils` crash-loop fix) gives a real,
+   passively-observed, mesh-wide anomaly signal that isn't gated on that domain's dead instrument
+   — see `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`'s 2026-07-25
+   revision for the full proposal. Not decided or built here; does not change this item's
+   confidence formula.
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live

--- a/services/orion-bus-mirror/README.md
+++ b/services/orion-bus-mirror/README.md
@@ -123,6 +123,16 @@ ORDER BY abs(e.gap_zscore) DESC
 (`GET /api/bus-synaptic-graph/summary|hot-organs|hot-edges|anomalies`) — see that service's README
 "Bus synaptic graph debug routes" section.
 
+**Candidate consumer, proposed 2026-07-25 (not built): transport-domain redesign.** Live-verified
+this graph already covers `orion-harness-governor` traffic (`hub -> orion-harness-governor`,
+`latency_zscore=-2.10, count=5`) — a blind spot the RPC-health-only transport redesign
+(`docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`) explicitly can't
+see, since that service's RPC mechanism isn't `OrionBusAsync.rpc_request()`. See that spec's
+2026-07-25 revision. Distinct from the already-built recall reasoning consumer (Idea 4,
+`docs/superpowers/specs/2026-07-24-bus-synaptic-graph-reasoning-consumer-design.md`) — this would
+feed the Sentience Striving Program's transport prediction-error/metacog-trigger gap specifically,
+not chat context.
+
 ---
 
 ## Bus synaptic graph (Phase 2)

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -381,6 +381,18 @@ rename, not a deprecation, and not a product of this RPC-health redesign reachin
 replacing it. This redesign's own "not yet wired to replace this channel" status is unchanged; do
 not assume this redesign has already replaced it, only that the old channel's name changed.
 
+**Candidate third evidence source, proposed 2026-07-25 (not built): the bus synaptic graph
+(`orion_bus_synapse`, `services/orion-bus-mirror`).** Live-verified same day: `hub ->
+orion-harness-governor` shows a real `CAUSALLY_FOLLOWED_BY` edge (`latency_zscore=-2.10, count=5`)
+— this is real coverage of exactly the blind spot `docs/superpowers/specs/2026-07-23-transport-
+domain-rpc-health-redesign.md` names in its own "Related work" section: `orion-harness-governor`
+uses a bespoke long-poll RPC, not `OrionBusAsync.rpc_request()`, so the RPC-health signal that
+spec proposes structurally cannot see it. The bus-mirror graph is a passive wiretap on envelope
+`correlation_id`s, agnostic to which RPC mechanism produced them, so it catches this traffic
+anyway. See that spec's 2026-07-25 revision for the full proposal — not decided or built here,
+and does not change Missing Question 5's still-open "rename vs. deprecate" call for
+`stream_backlog_pressure`/`stream_backlog_health`.
+
 **Reverie semantic lift:** unresolved closures also upsert human referent rows into
 `substrate_turn_referent` via `turn_referent_store.persist_turn_referent`. Apply
 `services/orion-sql-db/manual_migration_substrate_turn_referent_v1.sql` before enabling


### PR DESCRIPTION
## Summary
- Live-verified the `orion_bus_synapse` FalkorDB graph (`orion-bus-mirror`) already covers `orion-harness-governor` traffic (`hub -> orion-harness-governor`, `latency_zscore=-2.10, count=5`) — exactly the blind spot the transport-domain RPC-health redesign spec names as invisible to its own Options A/C (harness-governor uses a bespoke long-poll RPC, not the instrumented shared client).
- Adds a "Revision, 2026-07-25" proposal section to `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md` proposing the graph as a candidate **third** evidence source, without deciding Missing Question 5 (old channel's rename-vs-deprecate fate, already resolved separately by PR #1331) or implementing any code.
- Adds short cross-reference pointers in `services/orion-substrate-runtime/README.md`, `orion/sentience_striving_program/README.md`, and `services/orion-bus-mirror/README.md`.
- Confirmed the branch-starvation gap that motivated this investigation (`AttentionSelfModelV1.confidence` only driven by the new Active-Inference formula on 0.04% of ticks) is already resolved by a concurrent session's PR #1329/#1334 — did not duplicate that documentation, only linked to it.

## Design-mode status
Proposal-only, per CLAUDE.md §0A (proposal-mode required before invasive changes to the Sentience Striving Program's cognition-adjacent substrate). No code in this patch. Two consumption-mode options left explicitly undecided: feed the already-live `transport` metacog trigger as a third evidence branch, or write a new `node:substrate.bus_synaptic` `FieldStateV1` node via its own reducer.

## Review findings fixed
- **Finding (must-fix):** the revision claimed the `transport` metacog trigger "shipped disabled by default" and used that as a stated design trade-off. Actual live state: it was flipped to enabled ~1h after shipping, same day (commit `40cd21f80`), confirmed live in this worktree's own `services/orion-equilibrium-service/.env_example` (`=true`). Fixed both instances — corrected the claim and flagged it reverses the trade-off (favors reusing the trigger, not building a new path). Caught by `orion-repo-agent` review checking runtime truth against the file the claim was about.
- **Finding (should-fix):** "already-built Ideas (1, 4, 5)" citation collided with a *different* numbered "Idea 1-6" list in the same cited brainstorm doc (the doc itself flags this exact collision risk). Fixed by disambiguating as "Phase-3+ Ideas" throughout.

## Tests run
Docs-only patch — no code changed. `git diff --check` clean.

## Docker/build/smoke checks
None applicable (docs-only).

## Restart required
No restart required.

## Risks / concerns
- Low. Proposal-mode only, no runtime behavior changed. Two open missing-questions items (consumption mode, threshold calibration) explicitly deferred to a future implementation pass per the doc's own Non-goals section.