### PR TITLE
feat(telemetry): standardize /health liveness shape, pilot on 5 services

### DIFF
--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -453,6 +453,7 @@ from orion.schemas.telemetry.system_health import (
     EquilibriumServiceTransitionV1,
     SystemHealthV1,
     BusConsumerReadinessV1,
+    ServiceLivenessV1,
 )
 from orion.schemas.telemetry.rpc_health import RpcHealthSnapshotV1
 from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
@@ -753,6 +754,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "SystemHealthV1": SystemHealthV1,
     "RpcHealthSnapshotV1": RpcHealthSnapshotV1,
     "BusConsumerReadinessV1": BusConsumerReadinessV1,
+    "ServiceLivenessV1": ServiceLivenessV1,
     "EquilibriumSnapshotV1": EquilibriumSnapshotV1,
     "EquilibriumServiceTransitionV1": EquilibriumServiceTransitionV1,
     "RdfWriteRequest": RdfWriteRequest,

--- a/orion/schemas/telemetry/system_health.py
+++ b/orion/schemas/telemetry/system_health.py
@@ -138,6 +138,27 @@ class EquilibriumServiceTransitionV1(BaseModel):
         return v
 
 
+class ServiceLivenessV1(BaseModel):
+    """
+    Minimal, standardized `/health` liveness payload -- "is the process up,"
+    not "are its dependencies ready" (that's `BusConsumerReadinessV1`, meant
+    for a separate `/ready` route on services with a real bus-consumer loop).
+
+    Introduced because a live grep across services found 6+ distinct ad-hoc
+    `/health` shapes (some keyed "status", some "ok"; some included
+    service/version/node, most didn't) -- see
+    docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md.
+    Piloted on 5 services before a wider rollout.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    ok: bool
+    service: str
+    version: str
+    node: str
+
+
 class BusConsumerReadinessV1(BaseModel):
     """
     Structured readiness snapshot for bus-backed service consumers.

--- a/services/orion-attention-runtime/app/main.py
+++ b/services/orion-attention-runtime/app/main.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 
 from orion.core.bus.bus_service_chassis import ChassisConfig, HeartbeatOnly
+from orion.schemas.telemetry.system_health import ServiceLivenessV1
 
 from app.settings import get_settings
 from app.store import AttentionRuntimeStore
@@ -70,8 +71,11 @@ app = FastAPI(title="orion-attention-runtime", lifespan=lifespan)
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok", "service": get_settings().service_name}
+async def health() -> dict:
+    s = get_settings()
+    return ServiceLivenessV1(
+        ok=True, service=s.service_name, version=s.service_version, node=s.node_name
+    ).model_dump(mode="json")
 
 
 @app.get("/latest")

--- a/services/orion-biometrics/app/main.py
+++ b/services/orion-biometrics/app/main.py
@@ -429,6 +429,7 @@ def raw_recent(limit: int = Query(10, ge=1, le=100), node: Optional[str] = Query
 @app.get("/health")
 def health():
     return {
+        "ok": True,
         "status": "ok",
         "service": settings.SERVICE_NAME,
         "version": settings.SERVICE_VERSION,

--- a/services/orion-consolidation-runtime/app/main.py
+++ b/services/orion-consolidation-runtime/app/main.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 
 from orion.core.bus.bus_service_chassis import ChassisConfig, HeartbeatOnly
+from orion.schemas.telemetry.system_health import ServiceLivenessV1
 
 from app.settings import get_settings
 from app.store import ConsolidationRuntimeStore
@@ -70,8 +71,11 @@ app = FastAPI(title="orion-consolidation-runtime", lifespan=lifespan)
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok", "service": get_settings().service_name}
+async def health() -> dict:
+    s = get_settings()
+    return ServiceLivenessV1(
+        ok=True, service=s.service_name, version=s.service_version, node=s.node_name
+    ).model_dump(mode="json")
 
 
 @app.get("/latest")

--- a/services/orion-substrate-runtime/app/main.py
+++ b/services/orion-substrate-runtime/app/main.py
@@ -124,12 +124,15 @@ app = FastAPI(title="orion-substrate-runtime", lifespan=lifespan)
 
 @app.get("/health")
 async def health() -> dict:
+    s = get_settings()
     snap = build_substrate_grammar_truth(worker._store)
     return {
         "status": "ok" if snap["ok"] else "degraded",
         "ok": snap["ok"],
         "degraded": snap["degraded"],
-        "service": get_settings().service_name,
+        "service": s.service_name,
+        "version": s.service_version,
+        "node": s.node_name,
     }
 
 

--- a/services/orion-vision-edge/app/routes.py
+++ b/services/orion-vision-edge/app/routes.py
@@ -33,6 +33,9 @@ async def health():
         "ok": True,
         "service": settings.SERVICE_NAME,
         "version": settings.SERVICE_VERSION,
+        # Matches the literal `node` reported by main.py's heartbeat_loop -- no
+        # per-node NODE_NAME setting exists yet for this service.
+        "node": "vision-edge-node",
         "stream_id": settings.STREAM_ID,
         "source": settings.SOURCE,
         "detectors": settings.detector_names,


### PR DESCRIPTION
## Summary
- `/health` HTTP response shapes across ~84 services are ad-hoc: confirmed live by grepping 6 sampled services, all 6 came back different (some keyed "status", some "ok"; service/version/node presence varies, one had neither).
- A separate, already-adopted readiness schema (`BusConsumerReadinessV1`) exists for bus-consumer readiness on a distinct `/ready` route (7 services). Not touched here — that's a different concern (dependency readiness, not process liveness).
- Adds `ServiceLivenessV1` (`ok: bool, service: str, version: str, node: str`, `extra="forbid"`) as the standard `/health` shape, and pilots it on 5 services before deciding on a wider rollout.

## Outcome moved
5 services now report a consistent `/health` liveness shape (or a superset of it, where a service already reports real extra health data). Establishes the pattern for a follow-up rollout batch, same structure as the earlier heartbeat rollout.

## Files changed
- `orion/schemas/telemetry/system_health.py`: new `ServiceLivenessV1` model.
- `orion/schemas/registry.py`: registered `ServiceLivenessV1`.
- `services/orion-attention-runtime/app/main.py`, `services/orion-consolidation-runtime/app/main.py`: `/health` now returns `ServiceLivenessV1(...)` — full replacement, both are simple Postgres-poll workers with no other health signal.
- `services/orion-biometrics/app/main.py`: added `"ok": True` to the existing `/health` dict, additive only — kept `status` and all existing channel-diagnostic fields.
- `services/orion-substrate-runtime/app/main.py`: added `version`/`node` to its existing grammar-truth-derived `/health` dict, additive only — kept as a plain dict (not `ServiceLivenessV1`) since it carries a genuine extra `degraded` field that `extra="forbid"` would reject.
- `services/orion-vision-edge/app/routes.py`: added `node` (hardcoded to `"vision-edge-node"`, matching the literal already used by `main.py`'s heartbeat loop — this service has no `NODE_NAME` setting yet, judged out of scope for this pilot).

## Schema / bus / API changes
- Added: `ServiceLivenessV1` schema (HTTP-only, not bus-published — same convention as `BusConsumerReadinessV1`).
- Removed: nothing. All 5 service changes are additive or a full-replacement of a route with no existing test/consumer dependency (verified via grep — no test in any of the 5 services' test suites asserts on the old `/health` shape).

## Tests run
```text
orion_dev/bin/python -m pytest orion/schemas -q
  57 passed, 1 failed (test_context_provenance.py::test_static_ctx_assignments_covered
  -- confirmed pre-existing on unmodified main, unrelated to this diff)

orion_dev/bin/python -m pytest services/orion-attention-runtime/tests -q
  16 passed

orion_dev/bin/python -m pytest services/orion-consolidation-runtime/tests -q
  3 passed

PYTHONPATH="services/orion-biometrics:." orion_dev/bin/python -m pytest services/orion-biometrics/tests -q
  15 passed, 2 failed (test_circe_expected_offline / test_circe_node_availability_reflects_expected_offline
  -- known pre-existing config-data failures, unrelated to this diff)

orion_dev/bin/python -m pytest services/orion-substrate-runtime/tests -q --ignore=.../test_grammar_consumer_integration.py
  151 passed, 16 failed -- confirmed identical failure set/count on unmodified main (needs live Postgres
  for the ignored integration test; the 16 others are pre-existing, unrelated to this diff)

orion_dev/bin/python -m pytest services/orion-vision-edge/tests -q
  4 passed
```

## Review findings fixed
- No material findings from orion-repo-agent review. Confirmed: `extra="forbid"` construction sites pass exactly the declared fields, no registry key collision, no test asserts on the old shapes, biometrics/substrate-runtime changes are strictly additive, no dead imports.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-attention-runtime/.env -f services/orion-attention-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-consolidation-runtime/.env -f services/orion-consolidation-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-biometrics/.env -f services/orion-biometrics/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env -f services/orion-substrate-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-vision-edge/.env -f services/orion-vision-edge/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: low
- Concern: `ServiceLivenessV1`'s `extra="forbid"` means any future field added to a service's `/health` route that adopts the full model (rather than the additive-dict pattern) needs to either fit the 4-field shape or use the additive-dict pattern like biometrics/substrate-runtime did.
- Mitigation: none needed yet — no current adopter hit this; documented in the model's own docstring.

## PR link
(filled in by gh pr create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)