### PR TITLE
feat(biometrics): real iLO/BMC hardware telemetry piggybacked on heartbeat

### DIFF
--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -45,6 +45,12 @@ NEVER_SYNC_KEYS = frozenset(
         # accident of the prefix list, and holds even under --all-keys --force.
         "RECALL_GRAPHITI_IN_CHAT",
         "RECALL_GRAPHITI_ADAPTER_URL",
+        # Per-node BMC/iLO secret (orion-biometrics). .env_example intentionally
+        # ships these empty; --force must never flatten a real per-node
+        # credential back to that placeholder.
+        "ILO_HOST",
+        "ILO_USERNAME",
+        "ILO_PASSWORD",
     }
 )
 

--- a/services/orion-biometrics/.env_example
+++ b/services/orion-biometrics/.env_example
@@ -44,3 +44,13 @@ POWER_BAND_ALPHA=0.1
 # mounts independently once redeployed there. See README.md for the
 # details.disk_usage_pct.<mount_name> key convention.
 DISK_CAPACITY_MOUNTS={"docker":"/host_mnt/docker","scripts":"/host_mnt/scripts","postgres":"/host_mnt/postgres","graphdb":"/host_mnt/graphdb","telemetry":"/host_mnt/telemetry"}
+
+# --- iLO/BMC out-of-band hardware telemetry (piggybacked onto the same
+# heartbeat as disk capacity, above) ---
+# Node-level and secret: each node (athena/atlas/circe) has its own BMC IP and
+# credentials, set directly in that node's local .env, never here. Empty here
+# means iLO telemetry collection is skipped for this node. See
+# docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md.
+ILO_HOST=
+ILO_USERNAME=
+ILO_PASSWORD=

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -79,6 +79,46 @@ Key convention:
   `disk_pressure_signal` -> field-digester's `disk_pressure` lattice channel). Do not conflate the
   two -- `collect_disk_capacity()` is intentionally a separate function/key, not an extension of
   `_collect_disk()`.
+
+### iLO/BMC hardware telemetry (`details.ilo_*`)
+
+Real out-of-band hardware telemetry (thermal, fan, power) pulled from the node's iLO/BMC
+RedFish API, piggybacked onto the same `SystemHealthV1.details` dict as disk capacity, above.
+Node-level and optional -- a node with no `ILO_HOST` configured simply omits these keys
+entirely (`IloPoller.details()` returns `{}`).
+
+Key convention:
+
+```json
+{
+  "ilo_fetched_at": 1721923200.123,
+  "ilo_thermal_c": {"01-Inlet Ambient": 24.0, "02-CPU 1": 40.0},
+  "ilo_fan_pct": {"Fan 1": 29.0, "Fan 2": 29.0},
+  "ilo_power_watts": 310.0,
+  "ilo_error": "connection timeout"
+}
+```
+
+- `ilo_thermal_c`/`ilo_fan_pct` are keyed by the sensor's own RedFish `Name` (vendor-specific
+  strings, e.g. HPE's `"01-Inlet Ambient"`) -- not normalized across vendors. Sensors reporting
+  `Status.State != "Enabled"` (e.g. `"Absent"`, an unpopulated slot) are skipped rather than
+  recorded as a fake `0`. Fans additionally require `ReadingUnits == "Percent"` -- RedFish fans
+  can report Percent or RPM depending on vendor, and only HPE/athena is verified so far; an RPM
+  reading is skipped rather than silently mislabeled as a percentage.
+- `ilo_error` appears whenever the last poll failed (bad creds, network unreachable, non-RedFish
+  BMC) or `ILO_HOST` isn't configured on this node (`"not_configured"`) -- never fatal to the
+  heartbeat itself.
+- Unlike disk capacity (a cheap local `shutil.disk_usage()` call, safe to run inline in the
+  heartbeat's bounded per-tick hook), an iLO RedFish round-trip is a real network call to a
+  comparatively weak out-of-band management processor -- not safe to run on every heartbeat tick
+  (default 10s) or inside that hook's ~3s budget. `app/ilo.py::IloPoller` runs on its own
+  `ILO_POLL_INTERVAL_SEC` cadence (default 60s) as a separate background task; the heartbeat hook
+  just reads the last cached snapshot (`ilo_fetched_at` tells you how stale it is).
+- Credentials (`ILO_HOST`/`ILO_USERNAME`/`ILO_PASSWORD`) are node-specific secrets -- set only in
+  this node's local `.env`, never in `.env_example` (which ships them empty) or committed
+  anywhere. Uses standard DMTF RedFish (`/redfish/v1/Chassis/` -> first chassis's `/Thermal/` and
+  `/Power/`), confirmed live against athena's HPE iLO; unverified so far against Circe's Gigabyte
+  BMC.
 - Cross-node: because this same `services/orion-biometrics` codebase runs independently on
   athena/atlas/circe (each with its own `NODE_NAME`), redeploying this patch on each node gives
   real disk-capacity visibility per node with no new SSH/credential surface -- the bus already

--- a/services/orion-biometrics/app/ilo.py
+++ b/services/orion-biometrics/app/ilo.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import requests
+import urllib3
+
+logger = logging.getLogger("orion.biometrics.ilo")
+
+# iLO/BMC RedFish endpoints use a self-signed cert by default on nearly every
+# deployment (HPE iLO, Gigabyte BMC alike) -- verify=False below is intentional,
+# not an oversight. Suppress the resulting per-request InsecureRequestWarning
+# once at import instead of it spamming every poll tick.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+@dataclass
+class IloSnapshot:
+    fetched_at: float = 0.0
+    thermal_c: Dict[str, float] = field(default_factory=dict)
+    fan_pct: Dict[str, float] = field(default_factory=dict)
+    power_watts: Optional[float] = None
+    error: Optional[str] = None
+
+
+def fetch_ilo_snapshot(
+    host: str, username: str, password: str, timeout_sec: float = 8.0
+) -> IloSnapshot:
+    """One blocking RedFish pull of thermal/fan/power data from an iLO/BMC.
+
+    Standard DMTF RedFish (`/redfish/v1/Chassis/` -> first chassis member's
+    `/Thermal/` and `/Power/`) rather than hardcoding an HPE-specific chassis
+    path -- confirmed live against athena's iLO 2026-07-25 (real, non-degenerate
+    temps/fans/power). Should generalize to other RedFish-compliant BMCs (e.g.
+    circe's Gigabyte variant) without code changes, though that's unverified
+    until credentials for a second vendor are available.
+
+    Not fatal on any failure -- returns an IloSnapshot with `.error` set so the
+    caller (a slow-poll background loop, not the heartbeat's own bounded hook --
+    see IloPoller below) can just log and retry next interval.
+    """
+    if not (host and username and password):
+        return IloSnapshot(fetched_at=time.time(), error="not_configured")
+
+    base = host.rstrip("/")
+    session = requests.Session()
+    session.verify = False
+    session.auth = (username, password)
+    # Confirmed live against athena's iLO 2026-07-25: requests' default headers
+    # (gzip/deflate Accept-Encoding, keep-alive) cause this BMC's embedded HTTP
+    # server to abort the connection mid-handshake ("Remote end closed connection
+    # without response") even though plain curl and a raw TLS socket both work
+    # fine against the same host -- explicit identity encoding + connection-close
+    # avoids whatever iLO's web server mishandles.
+    session.headers.update(
+        {"Accept-Encoding": "identity", "Connection": "close", "OData-Version": "4.0"}
+    )
+    try:
+        chassis_resp = session.get(f"{base}/redfish/v1/Chassis/", timeout=timeout_sec)
+        chassis_resp.raise_for_status()
+        members = chassis_resp.json().get("Members") or []
+        if not members:
+            return IloSnapshot(fetched_at=time.time(), error="no_chassis_members")
+        chassis_path = members[0]["@odata.id"].rstrip("/")
+
+        thermal_c: Dict[str, float] = {}
+        fan_pct: Dict[str, float] = {}
+        power_watts: Optional[float] = None
+
+        thermal_resp = session.get(f"{base}{chassis_path}/Thermal/", timeout=timeout_sec)
+        if thermal_resp.ok:
+            data = thermal_resp.json()
+            for t in data.get("Temperatures") or []:
+                if (t.get("Status") or {}).get("State") != "Enabled":
+                    # "Absent" sensors report ReadingCelsius=0 for an unpopulated
+                    # slot -- not real data, skip rather than record a fake zero.
+                    continue
+                reading = t.get("ReadingCelsius")
+                name = t.get("Name")
+                if reading is not None and name:
+                    thermal_c[name] = float(reading)
+            for fan in data.get("Fans") or []:
+                if (fan.get("Status") or {}).get("State") != "Enabled":
+                    continue
+                reading = fan.get("Reading")
+                name = fan.get("Name")
+                # RedFish fans can report Percent or RPM depending on vendor --
+                # confirmed live only against athena's HPE iLO (Percent). Only
+                # HPE/athena is verified so far; skip (don't mislabel) rather than
+                # record an RPM value under a field named/typed as a percentage
+                # once a second vendor (e.g. circe's Gigabyte BMC) is wired in.
+                units = fan.get("ReadingUnits")
+                if reading is not None and name and units == "Percent":
+                    fan_pct[name] = float(reading)
+
+        power_resp = session.get(f"{base}{chassis_path}/Power/", timeout=timeout_sec)
+        if power_resp.ok:
+            controls = power_resp.json().get("PowerControl") or []
+            if controls:
+                watts = controls[0].get("PowerConsumedWatts")
+                if watts is not None:
+                    power_watts = float(watts)
+
+        return IloSnapshot(
+            fetched_at=time.time(),
+            thermal_c=thermal_c,
+            fan_pct=fan_pct,
+            power_watts=power_watts,
+        )
+    except Exception as exc:
+        return IloSnapshot(fetched_at=time.time(), error=str(exc))
+
+
+class IloPoller:
+    """Background slow-poll loop, decoupled from the fast SystemHealthV1
+    heartbeat cadence.
+
+    The chassis's `heartbeat_details` hook is bounded to roughly half the
+    heartbeat interval (commonly ~3s) and runs synchronously in a worker thread
+    on every heartbeat tick -- a live network round-trip to an out-of-band BMC
+    (which is a much weaker processor than the host CPU, not built for
+    high-frequency polling) does not reliably fit that budget, and a slow iLO
+    call would risk silently dropping the *other* heartbeat_details producer
+    (disk-capacity telemetry) sharing that same bounded hook. Instead this
+    poller runs on its own `ILO_POLL_INTERVAL_SEC` cadence (default 60s) and
+    caches the last result; `details()` just reads the cache, which is instant.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        username: str,
+        password: str,
+        *,
+        interval_sec: float = 60.0,
+        timeout_sec: float = 8.0,
+    ) -> None:
+        self._host = host
+        self._username = username
+        self._password = password
+        self._interval_sec = interval_sec
+        self._timeout_sec = timeout_sec
+        self._snapshot = IloSnapshot(
+            error=None if self.enabled else "not_configured"
+        )
+        self._task: Optional[asyncio.Task] = None
+        self._stop = asyncio.Event()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._host and self._username and self._password)
+
+    async def start_background(self) -> None:
+        if not self.enabled or self._task is not None:
+            return
+        self._task = asyncio.create_task(self._poll_loop(), name="ilo-poller")
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=2.0)
+            except Exception:
+                self._task.cancel()
+            self._task = None
+
+    async def _poll_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self._snapshot = await asyncio.to_thread(
+                    fetch_ilo_snapshot,
+                    self._host,
+                    self._username,
+                    self._password,
+                    self._timeout_sec,
+                )
+                if self._snapshot.error:
+                    logger.warning("ilo_poll_failed error=%s", self._snapshot.error)
+            except Exception as exc:
+                logger.warning("ilo_poll_loop_error error=%s", exc)
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._interval_sec)
+            except asyncio.TimeoutError:
+                pass
+
+    def details(self) -> Dict[str, Any]:
+        """Synchronous, instant read of the last cached poll -- safe to call
+        from the heartbeat's bounded heartbeat_details hook."""
+        if not self.enabled:
+            return {}
+        snap = self._snapshot
+        result: Dict[str, Any] = {"ilo_fetched_at": snap.fetched_at}
+        if snap.thermal_c:
+            result["ilo_thermal_c"] = snap.thermal_c
+        if snap.fan_pct:
+            result["ilo_fan_pct"] = snap.fan_pct
+        if snap.power_watts is not None:
+            result["ilo_power_watts"] = snap.power_watts
+        if snap.error:
+            result["ilo_error"] = snap.error
+        return result

--- a/services/orion-biometrics/app/main.py
+++ b/services/orion-biometrics/app/main.py
@@ -19,6 +19,7 @@ from orion.schemas.telemetry.biometrics import (
 )
 from orion.schemas.telemetry.spark_signal import SparkSignalV1
 from app.metrics import collect_biometrics, collect_disk_capacity
+from app.ilo import IloPoller
 from orion.telemetry.biometrics_pipeline import BiometricsPipeline, PipelineConfig
 from app.settings import settings
 
@@ -162,18 +163,34 @@ def _source() -> ServiceRef:
     return ServiceRef(name=settings.SERVICE_NAME, version=settings.SERVICE_VERSION, node=settings.NODE_NAME)
 
 
+_ilo_poller = IloPoller(
+    settings.ILO_HOST,
+    settings.ILO_USERNAME,
+    settings.ILO_PASSWORD,
+    interval_sec=settings.ILO_POLL_INTERVAL_SEC,
+    timeout_sec=settings.ILO_REQUEST_TIMEOUT_SEC,
+)
+
+
 def _heartbeat_details() -> Dict[str, Any]:
     """Extra data folded into every SystemHealthV1 heartbeat's `details` dict.
 
-    Real host disk-capacity telemetry, piggybacked onto the existing bus-native
-    heartbeat rather than a new channel/service (see
+    Real host disk-capacity telemetry plus (when this node has iLO/BMC
+    credentials configured) real thermal/fan/power telemetry, piggybacked onto
+    the existing bus-native heartbeat rather than a new channel/service (see
     docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md).
     Node-level, not per-service -- once this same code is redeployed on atlas/circe
     (each already an independent orion-biometrics deployment publishing its own
     per-node heartbeat, confirmed live via `orion:system:health`), each node reports
-    its own mounts with no new SSH/credential surface.
+    its own mounts/BMC with no new SSH/credential surface. `_ilo_poller.details()`
+    reads a background-cached snapshot (see IloPoller docstring) rather than making
+    a live network call here -- this function runs inside the heartbeat's own
+    bounded per-tick budget, too tight for a real BMC round-trip.
     """
-    return collect_disk_capacity(settings.DISK_CAPACITY_MOUNTS)
+    return {
+        **collect_disk_capacity(settings.DISK_CAPACITY_MOUNTS),
+        **_ilo_poller.details(),
+    }
 
 
 _pipeline = BiometricsPipeline(
@@ -371,6 +388,8 @@ async def lifespan(app: FastAPI):
     hunter_task: Optional[asyncio.Task] = None
     hunter_stop = asyncio.Event()
 
+    await _ilo_poller.start_background()
+
     if settings.BIOMETRICS_MODE in {"agent", "both"}:
         metrics_worker = BiometricsWorker(chassis_cfg(), interval_sec=settings.TELEMETRY_INTERVAL)
         await metrics_worker.start_background()
@@ -399,6 +418,7 @@ async def lifespan(app: FastAPI):
                 await asyncio.wait_for(hunter_task, timeout=2.0)
             except Exception:
                 hunter_task.cancel()
+        await _ilo_poller.stop()
 
 
 app = FastAPI(title=settings.SERVICE_NAME, version=settings.SERVICE_VERSION, lifespan=lifespan)

--- a/services/orion-biometrics/app/settings.py
+++ b/services/orion-biometrics/app/settings.py
@@ -72,6 +72,16 @@ class Settings(BaseSettings):
         }
     )
 
+    # iLO/BMC out-of-band hardware telemetry (piggybacked onto the same heartbeat
+    # `details` dict as disk capacity, above). Node-level secret: real values live
+    # only in this node's local .env, never in .env_example. Empty ILO_HOST means
+    # iLO collection is disabled for this node -- not every node has one.
+    ILO_HOST: str = Field(default="")
+    ILO_USERNAME: str = Field(default="")
+    ILO_PASSWORD: str = Field(default="")
+    ILO_POLL_INTERVAL_SEC: float = Field(default=60.0)
+    ILO_REQUEST_TIMEOUT_SEC: float = Field(default=8.0)
+
     @field_validator("role_weights", mode="before")
     @classmethod
     def _parse_role_weights(cls, value: object) -> Dict[str, float]:

--- a/services/orion-biometrics/requirements.txt
+++ b/services/orion-biometrics/requirements.txt
@@ -7,4 +7,6 @@ redis[hiredis]==5.0.7
 psycopg2-binary==2.9.9
 loguru>0.7
 PyYAML==6.0.2
+requests==2.32.3
 pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/services/orion-biometrics/tests/test_ilo.py
+++ b/services/orion-biometrics/tests/test_ilo.py
@@ -1,0 +1,143 @@
+"""Regression coverage for iLO/BMC RedFish telemetry (app/ilo.py).
+
+Added alongside real out-of-band hardware telemetry piggybacked onto
+orion-biometrics' existing bus-native SystemHealthV1 heartbeat (see
+docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md).
+`fetch_ilo_snapshot()` was live-verified against athena's real HPE iLO
+2026-07-25 (42 real temp sensors, 6 fans, real wattage) -- these tests mock
+`requests.Session` instead of hitting real hardware, so they exercise the
+parsing/skip logic deterministically in CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.ilo import IloPoller, IloSnapshot, fetch_ilo_snapshot
+
+
+class _FakeResponse:
+    def __init__(self, payload: Dict[str, Any], *, ok: bool = True, status: int = 200):
+        self._payload = payload
+        self.ok = ok
+        self.status_code = status
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if not self.ok:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _fake_session(monkeypatch: pytest.MonkeyPatch, responses: Dict[str, _FakeResponse]) -> None:
+    def fake_get(self, url: str, timeout: float = 8.0):  # noqa: ANN001
+        for suffix, resp in responses.items():
+            if url.endswith(suffix):
+                return resp
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr("requests.Session.get", fake_get, raising=True)
+
+
+def test_fetch_ilo_snapshot_not_configured_without_credentials() -> None:
+    snap = fetch_ilo_snapshot("", "", "")
+    assert snap.error == "not_configured"
+    assert snap.thermal_c == {}
+    assert snap.fan_pct == {}
+    assert snap.power_watts is None
+
+
+def test_fetch_ilo_snapshot_parses_real_shaped_redfish_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_session(
+        monkeypatch,
+        {
+            "/redfish/v1/Chassis/": _FakeResponse({"Members": [{"@odata.id": "/redfish/v1/Chassis/1/"}]}),
+            "/redfish/v1/Chassis/1/Thermal/": _FakeResponse(
+                {
+                    "Temperatures": [
+                        {"Name": "01-Inlet Ambient", "ReadingCelsius": 24, "Status": {"State": "Enabled"}},
+                        {"Name": "02-CPU 1", "ReadingCelsius": 40, "Status": {"State": "Enabled"}},
+                        # Unpopulated slot -- must be skipped, not recorded as 0.
+                        {"Name": "05-PMM 1-6", "ReadingCelsius": 0, "Status": {"State": "Absent"}},
+                    ],
+                    "Fans": [
+                        {"Name": "Fan 1", "Reading": 29, "ReadingUnits": "Percent", "Status": {"State": "Enabled"}},
+                    ],
+                }
+            ),
+            "/redfish/v1/Chassis/1/Power/": _FakeResponse(
+                {"PowerControl": [{"PowerConsumedWatts": 310}]}
+            ),
+        },
+    )
+
+    snap = fetch_ilo_snapshot("https://192.168.1.200", "Administrator", "hunter2", timeout_sec=8.0)
+
+    assert snap.error is None
+    assert snap.thermal_c == {"01-Inlet Ambient": 24.0, "02-CPU 1": 40.0}
+    assert "05-PMM 1-6" not in snap.thermal_c
+    assert snap.fan_pct == {"Fan 1": 29.0}
+    assert snap.power_watts == 310.0
+    assert snap.fetched_at > 0
+
+
+def test_fetch_ilo_snapshot_no_chassis_members_is_a_soft_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_session(monkeypatch, {"/redfish/v1/Chassis/": _FakeResponse({"Members": []})})
+    snap = fetch_ilo_snapshot("https://host", "user", "pw")
+    assert snap.error == "no_chassis_members"
+
+
+def test_fetch_ilo_snapshot_network_failure_is_soft_not_raised(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_get(self, url: str, timeout: float = 8.0):  # noqa: ANN001
+        raise ConnectionError("boom")
+
+    monkeypatch.setattr("requests.Session.get", raise_get, raising=True)
+    snap = fetch_ilo_snapshot("https://host", "user", "pw")
+    assert snap.error is not None
+    assert "boom" in snap.error
+
+
+def test_ilo_poller_disabled_without_host_returns_empty_details() -> None:
+    poller = IloPoller("", "", "")
+    assert poller.enabled is False
+    assert poller.details() == {}
+
+
+def test_ilo_poller_details_reads_cached_snapshot_not_live_network() -> None:
+    poller = IloPoller("https://host", "user", "pw", interval_sec=60.0)
+    assert poller.enabled is True
+    # Simulate a completed background poll without actually running the loop --
+    # details() must be a pure cache read, per its own docstring contract (it is
+    # called from the heartbeat's bounded per-tick hook and must never block).
+    poller._snapshot = IloSnapshot(
+        fetched_at=123.0,
+        thermal_c={"CPU 1": 40.0},
+        fan_pct={"Fan 1": 29.0},
+        power_watts=310.0,
+    )
+    details = poller.details()
+    assert details["ilo_thermal_c"] == {"CPU 1": 40.0}
+    assert details["ilo_fan_pct"] == {"Fan 1": 29.0}
+    assert details["ilo_power_watts"] == 310.0
+    assert details["ilo_fetched_at"] == 123.0
+    assert "ilo_error" not in details
+
+
+def test_ilo_poller_details_surfaces_error_from_last_poll() -> None:
+    poller = IloPoller("https://host", "user", "pw")
+    poller._snapshot = IloSnapshot(fetched_at=1.0, error="connection timeout")
+    details = poller.details()
+    assert details["ilo_error"] == "connection timeout"
+
+
+@pytest.mark.asyncio
+async def test_ilo_poller_start_background_noop_when_disabled() -> None:
+    poller = IloPoller("", "", "")
+    await poller.start_background()
+    assert poller._task is None
+    await poller.stop()


### PR DESCRIPTION
## Summary
- Adds `app/ilo.py`: real thermal/fan/power telemetry pulled from a node's iLO/BMC via standard DMTF RedFish (`/redfish/v1/Chassis/` -> first chassis's `/Thermal/` and `/Power/`).
- Live-verified against athena's real HPE iLO: 42 real temp sensors (CPU, GPU, PSU, BMC, DIMM, chipset), 6 fans, real wattage (~307W). Not mocked data — pulled from real hardware during this session.
- Fixes a gap from earlier in the conversation: `.env_example` was never actually updated with the `ILO_HOST`/`ILO_USERNAME`/`ILO_PASSWORD` stubs after the credentials were placed in athena's live `.env` — done now, plus added to `NEVER_SYNC_KEYS`.

## Outcome moved
`orion-biometrics` on athena now reports real out-of-band hardware telemetry (independent of host-OS software sensors) on its existing heartbeat, with zero new bus channel/service. Atlas/circe get the same capability once their own credentials land in their local `.env`.

## Current architecture
`orion-biometrics` already piggybacks disk-capacity telemetry onto its bus-native `SystemHealthV1` heartbeat's `details` dict (prior PR #1360). This adds a second piggyback via the same mechanism.

## Architecture touched
- `services/orion-biometrics/app/ilo.py` (new): `fetch_ilo_snapshot()` (one blocking RedFish pull, never raises — all failures land in `IloSnapshot.error`) and `IloPoller` (background task on its own `ILO_POLL_INTERVAL_SEC` cadence, default 60s, caching the last snapshot).
- `services/orion-biometrics/app/main.py`: `_heartbeat_details()` now merges `_ilo_poller.details()` (a pure, instant cache read) alongside `collect_disk_capacity()`. `IloPoller.start_background()`/`.stop()` wired into `lifespan()`.
- `services/orion-biometrics/app/settings.py`: new `ILO_HOST`/`ILO_USERNAME`/`ILO_PASSWORD`/`ILO_POLL_INTERVAL_SEC`/`ILO_REQUEST_TIMEOUT_SEC` fields, all plain str/float (not the `Dict` type that caused the earlier `DISK_CAPACITY_MOUNTS` crash — confirmed not applicable here).

**Design note (why a separate poller, not inline in the heartbeat hook):** the chassis's `heartbeat_details` hook bounds collection to roughly half the heartbeat interval (~3s default) and runs it synchronously per tick. A live network round-trip to an out-of-band BMC (a much weaker processor than the host CPU) isn't safe inside that budget — and a slow/hung iLO call would risk silently dropping the *other* producer sharing that same hook (disk capacity). `IloPoller` decouples iLO polling onto its own slower cadence; the heartbeat just reads the cache.

**Real bug found and fixed live:** `requests.Session.get()` against athena's iLO failed with `"Remote end closed connection without response"` even though `curl` and a raw TLS socket both succeeded against the same host. Root cause: this BMC's embedded HTTP server doesn't tolerate `requests`'/urllib3's default headers (gzip/deflate `Accept-Encoding`, keep-alive). Fixed by setting `Accept-Encoding: identity`, `Connection: close`, `OData-Version: 4.0` explicitly — confirmed working against real hardware after the fix.

## Files changed
- `services/orion-biometrics/app/ilo.py`: new module.
- `services/orion-biometrics/tests/test_ilo.py`: new, 8 tests (mocked RedFish responses — happy path, Absent-sensor skip, no-chassis-members, network failure, disabled poller, cache-read contract, error surfacing).
- `services/orion-biometrics/app/main.py`: wiring.
- `services/orion-biometrics/app/settings.py`: new fields.
- `services/orion-biometrics/.env_example`: `ILO_HOST=`/`ILO_USERNAME=`/`ILO_PASSWORD=` stubs (empty, safe to commit).
- `services/orion-biometrics/requirements.txt`: `requests==2.32.3`, `pytest-asyncio==0.24.0`.
- `services/orion-biometrics/README.md`: new "iLO/BMC hardware telemetry" section documenting the `details.ilo_*` key convention.
- `scripts/sync_local_env_from_example.py`: added `ILO_HOST`/`ILO_USERNAME`/`ILO_PASSWORD` to `NEVER_SYNC_KEYS`.

## Schema / bus / API changes
- Added: `details.ilo_thermal_c`, `details.ilo_fan_pct`, `details.ilo_power_watts`, `details.ilo_error`, `details.ilo_fetched_at` keys on the existing `SystemHealthV1` heartbeat's free-form `details` dict. Not a schema change (still free-form), not a new channel.
- Compatibility notes: a node with no `ILO_HOST` configured omits these keys entirely — zero behavior change for atlas/circe until their credentials are added.

## Env/config changes
- Added keys: `ILO_HOST`, `ILO_USERNAME`, `ILO_PASSWORD`, `ILO_POLL_INTERVAL_SEC`, `ILO_REQUEST_TIMEOUT_SEC` (service: orion-biometrics).
- `.env_example` updated: yes (empty placeholders for the 3 secret keys).
- local `.env` synced: athena's `.env` already had the real `ILO_HOST`/`ILO_USERNAME`/`ILO_PASSWORD` values (added directly by the operator, not via sync script, per the established secret-handling convention). `ILO_POLL_INTERVAL_SEC`/`ILO_REQUEST_TIMEOUT_SEC` are non-secret and will pick up their code defaults (60s/8s) until explicitly overridden.
- Skipped keys requiring operator action: atlas and circe still need their own `ILO_HOST`/`ILO_USERNAME`/`ILO_PASSWORD` added to their respective local `.env` files before they'll report iLO telemetry. Circe's Gigabyte BMC variant is unverified against this RedFish implementation.

## Tests run
```text
PYTHONPATH="services/orion-biometrics:." orion_dev/bin/python -m pytest services/orion-biometrics/tests -q
23 passed, 2 failed (test_circe_expected_offline / test_circe_node_availability_reflects_expected_offline
-- known pre-existing config-data failures, confirmed unrelated to this diff)
```
Plus a live smoke test against athena's real iLO (not part of the automated suite, credentials not available in CI): `fetch_ilo_snapshot()` and `IloPoller.details()` both exercised against real hardware, returning 42 real thermal sensors, 6 real fan readings, and real wattage (~307W) with zero errors.

## Docker/build/smoke checks
Not run — no Docker available in this environment for this pass; `requirements.txt`/settings changes verified via direct Python import + live network smoke test instead.

## Review findings fixed
- Finding: `pytest-asyncio` used by the new async test but not declared in `services/orion-biometrics/requirements.txt` — silently no-ops the async test's assertions in a clean per-service install rather than failing loudly.
  - Fix: added `pytest-asyncio==0.24.0` to `requirements.txt`, matching the version other services in this repo already pin.
  - Evidence: re-ran the full suite after the fix — 23 passed (unchanged from before the fix in this dev venv, which already had pytest-asyncio installed globally; the fix matters for a clean per-service install matching CLAUDE.md's `pytest services/<service_name>/tests -q` gate).
- Finding: fan readings recorded into `ilo_fan_pct` without checking `ReadingUnits` — RedFish fans can report Percent or RPM depending on vendor; a future circe (Gigabyte BMC, unverified) deploy could silently mix RPM values into a field typed/named as a percentage.
  - Fix: added a `ReadingUnits == "Percent"` guard before recording a fan reading; non-percent readings are skipped, not mislabeled.
  - Evidence: `test_fetch_ilo_snapshot_parses_real_shaped_redfish_payload` fixture explicitly includes `"ReadingUnits": "Percent"` and still passes after the fix; README documents the guard.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-biometrics/.env -f services/orion-biometrics/docker-compose.yml up -d --build
```

## Risks / concerns
- Severity: low
- Concern: Circe's Gigabyte BMC RedFish implementation is unverified — may use different chassis paths, sensor naming, or fan units than HPE's iLO.
- Mitigation: `fetch_ilo_snapshot()` fails soft (populates `.error`, never crashes) if circe's BMC doesn't match the expected shape; nothing breaks, it just reports `ilo_error` until confirmed working there.

## PR link
(filled in by gh pr create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)