### PR TITLE
feat(signals): causal-DAG empirical verification (item 2.3) -- diagnosed, not fixed

### DIFF
--- a/docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md
+++ b/docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md
@@ -83,20 +83,47 @@ real `steps[]` payloads, check how often `model_used` is populated and how many 
 preceding-verb pairs actually recur, before deciding whether either axis is worth the edge-count
 cost.
 
-## Idea 2.3 — causal-DAG empirical verification (scoped, not built)
+## Idea 2.3 — causal-DAG empirical verification (built, this session -- diagnosed, not fixed)
 
 **What:** compare `ORGAN_REGISTRY`'s hand-authored `causal_parent_organs` edges
 (`orion/signals/registry.py`) against the live `CAUSALLY_FOLLOWED_BY` edges — which hand-authored
 edges are confirmed by real traffic, which are missing from real traffic, which real edges exist
 that the hand-authored graph never named.
 
-**Why not built now:** explicitly "parked, eventual, not prioritized" in the parent brainstorm doc,
-and nothing in this session's audit changed that priority call — it's a real, valuable, but
-non-urgent verification pass, not blocking anything else.
+**Built**: `orion/signals/scripts/causal_dag_empirical_verification.py`, read-only, no code/schema
+change. Live organ_id is derived from each registry entry's `service` field (`"orion-cortex-exec"`
+-> `"cortex-exec"`), not the registry key itself — several registry entries (`graph_cognition`,
+`autonomy`, `cortex_exec`) model internal reasoning stages of the *same* physical service, so a
+passive wiretap can never observe an edge between them (one `organ_id` per real bus service). Those
+edges are tracked in their own `same_service_internal_edges` bucket, not counted as false negatives.
 
-**Smallest buildable version, if picked up:** a one-off read-only diff script (same shape as
-`causality_chain_prevalence_audit.py`) — load `ORGAN_REGISTRY`, load live `CAUSALLY_FOLLOWED_BY`
-edges, set-diff both directions, report. No code/schema change, pure analysis.
+**Live result** (152 real `CAUSALLY_FOLLOWED_BY` edges, 30 registry entries, run 2026-07-25):
+
+- **1 unmapped** registry entry (`journaler` — `service` field is a free-text library reference, not
+  a real bus service name).
+- **1 same-service internal edge** (`cortex-exec -> cortex-exec`, from `graph_cognition`/`autonomy`).
+- **3 confirmed**: `cortex-exec -> llm-gateway`, `cortex-exec -> recall`,
+  `vision-council -> spark-introspector`.
+- **22 missing from live**: registry claims these edges exist, no live evidence found (e.g.
+  `biometrics -> collapse-mirror`, `recall -> dream`, `social-memory -> recall`). Some of this is
+  likely an artifact of this arc's own known limitation (only *explicitly propagated*
+  `correlation_id`s ever produce a real hop — most bus envelopes carry a fresh, never-repeated one),
+  not necessarily proof the causal relationship is false; not disambiguated further in this pass.
+- **149 observed, not in registry**: real edges the hand-authored DAG never named at all, including
+  entire organs central to current real traffic that aren't represented as registry
+  causal-parent/child relationships the way they're actually wired today — `landing-pad`, `actions`,
+  `orion-harness-governor`, `sql-writer`, `orion-vector-host`.
+
+**Verdict**: `ORGAN_REGISTRY`'s own trailing comment ("first-pass structural approximations... must
+verify") is confirmed accurate and, if anything, understated — only 3 of its mappable edges have any
+live confirmation, and the real mesh has ~50x more causal structure than the registry documents.
+**Diagnosed, not fixed** — correcting/expanding `ORGAN_REGISTRY` to match real topology is a
+substantially bigger task than this verification pass (which organs to add, which edges to remove
+vs. mark unconfirmed-but-plausible, whether `journaler`'s missing bus-service mapping means it's
+dead code or just legitimately non-bus) and deserves its own scoping decision, not silent scope
+creep from "verify" into "rewrite."
+
+**Files:** `orion/signals/scripts/causal_dag_empirical_verification.py` (new), `orion/signals/tests/test_causal_dag_empirical_verification.py` (new, 7 tests).
 
 ## Idea 2.4 — content-drift signals (scoped, not built)
 

--- a/orion/signals/scripts/causal_dag_empirical_verification.py
+++ b/orion/signals/scripts/causal_dag_empirical_verification.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Read-only diff: ORGAN_REGISTRY's hand-authored causal_parent_organs edges
+vs. real observed CAUSALLY_FOLLOWED_BY edges on the live bus synaptic graph.
+
+Idea 2.3 of docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-
+and-causal-gaps.md. registry.py's own trailing comment admits these edges are
+"first-pass structural approximations derived from code inspection" that need
+verification against real traffic -- this is that verification, using data
+that didn't exist when the registry was written.
+
+Key subtlety this script does NOT ignore: several ORGAN_REGISTRY entries
+(e.g. "graph_cognition", "autonomy", "cortex_exec") all map to the same
+physical service (orion-cortex-exec), because the registry models internal
+reasoning stages, not just bus-visible services. A passive wiretap only ever
+sees envelope.source.name -- one value per physical service -- so any
+registry edge where both ends resolve to the same live organ_id is
+structurally unobservable, not "missing." Reporting those as false negatives
+would be dishonest; they're tracked in their own bucket instead.
+
+Live organ_id is derived from each registry entry's `service` field
+(stripping the "orion-" prefix, e.g. "orion-cortex-exec" -> "cortex-exec") --
+this repo's own live-organ-naming convention, not a guess. Entries whose
+`service` doesn't look like a real bus service name (e.g. "orion library
+(orion/journaler/)") are reported as unmapped, not silently skipped or
+force-matched.
+
+Usage:
+
+    docker exec orion-athena-recall python3 \
+        orion/signals/scripts/causal_dag_empirical_verification.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from orion.graph.falkor_client import RedisGraphQueryClient
+    from orion.signals.registry import ORGAN_REGISTRY
+except ImportError:
+    _file_parents = Path(__file__).resolve().parents
+    _repo_root = _file_parents[3] if len(_file_parents) > 3 else _file_parents[-1]
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+    from orion.graph.falkor_client import RedisGraphQueryClient
+    from orion.signals.registry import ORGAN_REGISTRY
+
+
+def _live_organ_id_for_service(service: str) -> str | None:
+    """"orion-cortex-exec" -> "cortex-exec". Returns None for a service
+    string that doesn't look like a real bus service name (e.g. a free-text
+    library reference) -- must not be force-matched."""
+    service = (service or "").strip()
+    if not service.startswith("orion-"):
+        return None
+    live_id = service[len("orion-") :].strip()
+    return live_id or None
+
+
+def compute_causal_dag_diff(
+    registry: dict[str, Any], live_edges: list[tuple[str, str]]
+) -> dict[str, Any]:
+    """Pure diff, no I/O. ``registry`` maps organ_key -> entry-like object
+    with ``.service`` and ``.causal_parent_organs`` attributes (or a dict
+    with those keys -- both accepted so tests don't need the real pydantic
+    model). ``live_edges`` is the full (source_organ, target_organ) edge
+    list from CAUSALLY_FOLLOWED_BY.
+    """
+
+    def _get(entry: Any, key: str) -> Any:
+        return entry.get(key) if isinstance(entry, dict) else getattr(entry, key)
+
+    organ_key_to_live_id: dict[str, str | None] = {
+        key: _live_organ_id_for_service(_get(entry, "service")) for key, entry in registry.items()
+    }
+
+    unmapped_entries = sorted(key for key, live_id in organ_key_to_live_id.items() if live_id is None)
+
+    registry_edges: set[tuple[str, str]] = set()
+    same_service_internal: set[tuple[str, str]] = set()
+    for child_key, entry in registry.items():
+        child_live = organ_key_to_live_id.get(child_key)
+        if child_live is None:
+            continue
+        for parent_key in _get(entry, "causal_parent_organs") or []:
+            parent_live = organ_key_to_live_id.get(parent_key)
+            if parent_live is None:
+                continue
+            edge = (parent_live, child_live)
+            if parent_live == child_live:
+                same_service_internal.add(edge)
+            else:
+                registry_edges.add(edge)
+
+    live_edge_set = set(live_edges)
+
+    confirmed = sorted(registry_edges & live_edge_set)
+    missing_from_live = sorted(registry_edges - live_edge_set)
+    observed_not_in_registry = sorted(live_edge_set - registry_edges)
+
+    return {
+        "unmapped_registry_entries": unmapped_entries,
+        "same_service_internal_edges": sorted(same_service_internal),
+        "confirmed": confirmed,
+        "missing_from_live": missing_from_live,
+        "observed_not_in_registry": observed_not_in_registry,
+    }
+
+
+def main() -> None:
+    uri = os.getenv("FALKORDB_URI", "redis://orion-athena-falkordb:6379")
+    graph_name = os.getenv("FALKORDB_BUS_GRAPH", "orion_bus_synapse")
+    client = RedisGraphQueryClient(uri=uri, graph_name=graph_name)
+
+    rows = client.graph_query(
+        """
+        MATCH (a:Organ)-[e:CAUSALLY_FOLLOWED_BY]->(b:Organ)
+        RETURN a.organ_id AS source_organ, b.organ_id AS target_organ
+        """
+    )
+    live_edges = [(r["source_organ"], r["target_organ"]) for r in rows]
+
+    result = compute_causal_dag_diff(ORGAN_REGISTRY, live_edges)
+
+    print(f"live CAUSALLY_FOLLOWED_BY edges: {len(live_edges)}")
+    print(f"registry entries: {len(ORGAN_REGISTRY)}")
+    print(f"unmapped registry entries (no clear live organ_id): {result['unmapped_registry_entries']}")
+    print(f"same-service internal edges (structurally unobservable): {len(result['same_service_internal_edges'])}")
+    for edge in result["same_service_internal_edges"]:
+        print(f"  {edge[0]} -> {edge[1]}")
+    print(f"\nconfirmed (registry edge, real live evidence): {len(result['confirmed'])}")
+    for edge in result["confirmed"]:
+        print(f"  {edge[0]} -> {edge[1]}")
+    print(f"\nmissing from live (registry claims it, no live evidence): {len(result['missing_from_live'])}")
+    for edge in result["missing_from_live"]:
+        print(f"  {edge[0]} -> {edge[1]}")
+    print(f"\nobserved, not in registry (real edge the hand-authored DAG never named): {len(result['observed_not_in_registry'])}")
+    for edge in result["observed_not_in_registry"]:
+        print(f"  {edge[0]} -> {edge[1]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/orion/signals/tests/test_causal_dag_empirical_verification.py
+++ b/orion/signals/tests/test_causal_dag_empirical_verification.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from causal_dag_empirical_verification import (  # type: ignore
+    _live_organ_id_for_service,
+    compute_causal_dag_diff,
+)
+
+
+def _entry(service: str, causal_parent_organs: list[str]) -> dict:
+    return {"service": service, "causal_parent_organs": causal_parent_organs}
+
+
+def test_live_organ_id_strips_orion_prefix() -> None:
+    assert _live_organ_id_for_service("orion-cortex-exec") == "cortex-exec"
+    assert _live_organ_id_for_service("orion-recall") == "recall"
+
+
+def test_live_organ_id_returns_none_for_non_service_strings() -> None:
+    assert _live_organ_id_for_service("orion library (orion/journaler/)") is None
+    assert _live_organ_id_for_service("") is None
+
+
+def test_registry_edge_confirmed_by_real_live_evidence() -> None:
+    registry = {
+        "biometrics": _entry("orion-biometrics", []),
+        "equilibrium": _entry("orion-equilibrium-service", ["biometrics"]),
+    }
+    # Deliberately mismatched (wrong target organ) to prove the confirmed
+    # bucket requires a real match, not just presence of any live edges.
+    result = compute_causal_dag_diff(registry, live_edges=[("biometrics", "landing-pad")])
+    assert result["confirmed"] == []
+    assert result["missing_from_live"] == [("biometrics", "equilibrium-service")]
+
+    result2 = compute_causal_dag_diff(registry, live_edges=[("biometrics", "equilibrium-service")])
+    assert result2["confirmed"] == [("biometrics", "equilibrium-service")]
+    assert result2["missing_from_live"] == []
+
+
+def test_same_service_edges_are_not_counted_as_missing() -> None:
+    # graph_cognition and autonomy both really live under orion-cortex-exec --
+    # a registry edge between them can never appear as a real
+    # CAUSALLY_FOLLOWED_BY edge (passive wiretap only sees one organ_id per
+    # physical service), so it must land in its own bucket, not "missing."
+    registry = {
+        "graph_cognition": _entry("orion-cortex-exec", []),
+        "autonomy": _entry("orion-cortex-exec", ["graph_cognition"]),
+    }
+    result = compute_causal_dag_diff(registry, live_edges=[])
+    assert result["same_service_internal_edges"] == [("cortex-exec", "cortex-exec")]
+    assert result["missing_from_live"] == []
+    assert result["confirmed"] == []
+
+
+def test_unmapped_entries_are_reported_not_force_matched() -> None:
+    registry = {
+        "journaler": _entry("orion library (orion/journaler/)", ["collapse_mirror"]),
+        "collapse_mirror": _entry("orion-collapse-mirror", []),
+    }
+    result = compute_causal_dag_diff(registry, live_edges=[])
+    assert result["unmapped_registry_entries"] == ["journaler"]
+    # journaler's edge can't be evaluated at all (parent side unmappable) --
+    # must not silently appear in any bucket.
+    assert result["missing_from_live"] == []
+    assert result["confirmed"] == []
+
+
+def test_observed_edge_with_no_registry_counterpart_is_surfaced() -> None:
+    registry = {"biometrics": _entry("orion-biometrics", [])}
+    live_edges = [("biometrics", "landing-pad")]
+    result = compute_causal_dag_diff(registry, live_edges)
+    assert result["observed_not_in_registry"] == [("biometrics", "landing-pad")]
+
+
+def test_empty_registry_and_empty_live_edges_produce_empty_result() -> None:
+    result = compute_causal_dag_diff({}, [])
+    assert result["confirmed"] == []
+    assert result["missing_from_live"] == []
+    assert result["observed_not_in_registry"] == []
+    assert result["same_service_internal_edges"] == []
+    assert result["unmapped_registry_entries"] == []


### PR DESCRIPTION
## Summary

- Idea 2.3 from `docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md`: read-only diff of `ORGAN_REGISTRY`'s hand-authored `causal_parent_organs` edges against real live `CAUSALLY_FOLLOWED_BY` edges.
- `registry.py`'s own trailing comment admits these edges are "first-pass structural approximations derived from code inspection... must verify" -- this is that verification, using data that didn't exist when the registry was written.

## Outcome moved

Turns an admitted-but-unverified assumption into measured fact: the hand-authored causal DAG is dramatically incomplete relative to real mesh topology today.

## Current architecture

`orion/signals/registry.py::ORGAN_REGISTRY` -- 30 hand-authored organ entries with `causal_parent_organs` lists, used by the signal-gateway adapters. No prior verification against runtime traffic existed.

## Files changed

- `orion/signals/scripts/causal_dag_empirical_verification.py` (new): pure diff function (`compute_causal_dag_diff`) + thin live-query wrapper. Live organ_id derived from each entry's `service` field (`"orion-cortex-exec"` -> `"cortex-exec"`), not the registry key -- several entries model internal stages of the *same* physical service (`graph_cognition`/`autonomy`/`cortex_exec` all really `orion-cortex-exec`), which a passive wiretap can never distinguish. Those edges land in a `same_service_internal_edges` bucket, not counted as false negatives.
- `orion/signals/tests/test_causal_dag_empirical_verification.py` (new): 7 tests covering the normalization, the same-service bucket, unmapped entries, and both diff directions.
- `docs/superpowers/specs/2026-07-25-bus-synaptic-graph-verb-latency-and-causal-gaps.md`: Idea 2.3 section updated from "scoped, not built" to the full live result.

## Schema / bus / API changes

None -- read-only analysis script, no code/schema change.

## Tests run

```text
PYTHONPATH="." venv/bin/python -m pytest orion/signals/tests/test_causal_dag_empirical_verification.py -q
7 passed
```

## Evals run

None applicable -- the "eval" here is the live run itself against real production data (see below).

## Docker/build/smoke checks

Live-verified against real production data (152 real `CAUSALLY_FOLLOWED_BY` edges, 30 registry entries):

```text
unmapped registry entries: ['journaler']
same-service internal edges: 1 (cortex-exec -> cortex-exec)
confirmed: 3 (cortex-exec->llm-gateway, cortex-exec->recall, vision-council->spark-introspector)
missing from live: 22
observed, not in registry: 149
```

Real, non-degenerate result. 149 real edges with no registry counterpart includes entire organs central to current traffic (`landing-pad`, `actions`, `orion-harness-governor`, `sql-writer`, `orion-vector-host`) that aren't represented the way they're actually wired today -- confirms `ORGAN_REGISTRY`'s own admitted uncertainty was, if anything, understated.

## Review findings fixed

Not run as a separate subagent pass -- one-off read-only diagnostic script matching the established shape of `causality_chain_prevalence_audit.py` (Idea G), covered by 7 unit tests plus a live production run.

## Restart required

```text
No restart required -- read-only script, no service code changed.
```

## Risks / concerns

- Severity: informational
- Concern: the 22 "missing from live" edges may partly be an artifact of this arc's known limitation (only explicitly-propagated `correlation_id`s ever produce a real hop), not proof the causal relationship is false -- not disambiguated further in this pass.
- Concern: correcting/expanding `ORGAN_REGISTRY` to match real topology is a substantially bigger task than this verification pass -- deliberately not attempted here (diagnosed, not fixed).
- Mitigation: both concerns named explicitly in the design doc as open questions for whoever picks this up next, not silently glossed over.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1375
