### PR TITLE
fix(biometrics): pass ILO_* env vars through docker-compose

### DIFF
--- a/services/orion-biometrics/.env_example
+++ b/services/orion-biometrics/.env_example
@@ -54,3 +54,5 @@ DISK_CAPACITY_MOUNTS={"docker":"/host_mnt/docker","scripts":"/host_mnt/scripts",
 ILO_HOST=
 ILO_USERNAME=
 ILO_PASSWORD=
+ILO_POLL_INTERVAL_SEC=60.0
+ILO_REQUEST_TIMEOUT_SEC=8.0

--- a/services/orion-biometrics/docker-compose.yml
+++ b/services/orion-biometrics/docker-compose.yml
@@ -48,6 +48,11 @@ services:
       - NET_BW_MBPS=${NET_BW_MBPS}
       - POWER_BAND_ALPHA=${POWER_BAND_ALPHA}
       - DISK_CAPACITY_MOUNTS=${DISK_CAPACITY_MOUNTS}
+      - ILO_HOST=${ILO_HOST}
+      - ILO_USERNAME=${ILO_USERNAME}
+      - ILO_PASSWORD=${ILO_PASSWORD}
+      - ILO_POLL_INTERVAL_SEC=${ILO_POLL_INTERVAL_SEC:-60.0}
+      - ILO_REQUEST_TIMEOUT_SEC=${ILO_REQUEST_TIMEOUT_SEC:-8.0}
 
     volumes:
       - ../../config/biometrics:/app/config/biometrics:ro


### PR DESCRIPTION
## Summary
- Real production bug found while verifying the just-deployed iLO PR (#1372) against live data: `docker-compose.yml` never got the 5 `ILO_*` keys added to its `environment:` block, so the real credentials sitting in athena's `.env` never reach the container.
- Confirmed live via `redis-cli subscribe orion:system:health`: athena's `biometrics` heartbeat shows `details.disk_usage_pct` correctly populated (that key WAS wired) but zero `ilo_*` keys at all.

## Outcome moved
Once redeployed, athena's biometrics heartbeat will actually carry real iLO thermal/fan/power data, closing the gap between "code shipped" and "data flowing" for the whole iLO/field-digester arc from this session.

## Current architecture
`services/orion-biometrics/docker-compose.yml` enumerates every env var explicitly under `environment:` — no `env_file:` directive. Any Settings field not listed there silently falls back to its Python-level default inside the container, regardless of the host `.env`.

## Files changed
- `services/orion-biometrics/docker-compose.yml`: added `ILO_HOST`, `ILO_USERNAME`, `ILO_PASSWORD` (no fallback — must come from real `.env`), `ILO_POLL_INTERVAL_SEC`/`ILO_REQUEST_TIMEOUT_SEC` (`:-60.0`/`:-8.0` fallback, matching `Settings`' own defaults).
- `services/orion-biometrics/.env_example`: added `ILO_POLL_INTERVAL_SEC=60.0`/`ILO_REQUEST_TIMEOUT_SEC=8.0` (adjacent operator-contract gap found in review — not part of the silent-no-op bug since both had safe defaults, but missing from the documented contract).

## Env/config changes
- `.env_example` updated: yes.
- local `.env`: athena's already has real `ILO_HOST`/`ILO_USERNAME`/`ILO_PASSWORD` values (added directly by the operator in a prior session turn) — no sync needed, this fix is purely the compose-side passthrough.

## Review findings fixed
Reviewer cross-checked every `Settings` field in `app/settings.py` against the compose `environment:` block exhaustively (not just the 5 already-known keys) — confirmed nothing else is missing. Found the adjacent `.env_example` gap noted above, fixed in the same commit.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-biometrics/.env -f services/orion-biometrics/docker-compose.yml up -d --build
```

## Risks / concerns
None — additive env passthrough only, same pattern as the already-working `DISK_CAPACITY_MOUNTS` line right above it.

## PR link
(filled in by gh pr create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)