### PR TITLE
feat(substrate): bus synaptic graph as sixth Active-Inference domain

### DIFF
--- a/docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md
+++ b/docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md
@@ -325,3 +325,71 @@ run a real-data pass over a longer window (a day or more) confirming `CAUSALLY_F
 involving RPC-health-invisible organs (`orion-harness-governor` and any others sharing its
 bespoke-RPC pattern, not yet audited) are a recurring, non-degenerate signal -- not a one-off
 artifact of this session's snapshot.
+
+## Revision, 2026-07-25 (same day, continued) -- one of the two consumption modes built
+
+Status: **built, shadow-only, off by default.** Juniper approved both consumption-mode directions
+in principle ("1 and 2 sound good"), then asked the two open questions to collapse into one shared
+foundation rather than two bespoke builds ("what about reducers back into grammar substrate?"):
+real precedent already exists (`OrionBusAsync._emit_rpc_timeout_grammar`,
+`orion/core/bus/async_service.py:363`, emits `GrammarEventV1(semantic_role=
+"rpc_transport_timeout", ...)` -- Option C from the earlier transport-metacog-trigger patch).
+
+**What actually got built is simpler than a new grammar-event emission, on inspection.** The five
+existing domains' `prediction_error` functions all diff a `prev`/`curr` projection pair built from
+grammar events accumulated in Postgres. The bus synaptic graph doesn't need that shape at all: its
+own EWMA baseline per edge (`services/orion-bus-mirror/app/graph_writer.py::compute_ewma_update`)
+already *is* the "prev expectation," continuously maintained as new traffic arrives -- there is no
+separate prev/curr snapshot to diff. So `bus_synaptic_prediction_error()`
+(`orion/substrate/prediction_error.py`) takes a flat list of current `|zscore|` values (queried
+fresh from FalkorDB each tick, not accumulated in Postgres via a new grammar event type), and a
+new `_bus_synaptic_tick`/`_bus_synaptic_tick_loop` (`services/orion-substrate-runtime/app/
+worker.py`, mirroring `_dynamics_tick_loop`'s periodic-poll shape, not the four grammar-driven
+`_*_tick` methods) reads both `PUBLISHES.gap_zscore` and `CAUSALLY_FOLLOWED_BY.latency_zscore`
+edges (filtered to `count > SUBSTRATE_BUS_SYNAPTIC_MIN_EDGE_COUNT`, mirroring Hub's own
+`min_count=5` cold-start floor), aggregates `mean(|zscore|)`, and writes a new sixth domain node
+(`node:substrate.bus_synaptic`) via the same shared `_write_prediction_error_node()` the other
+five domains use. No new `GrammarEventV1` type, no new reducer, no new Postgres table -- this
+reuses `RedisGraphQueryClient` (`orion/graph/falkor_client.py`, already a proven dependency of
+this service via `orion.substrate.falkor_store`, already pinned to `redis==5.2.1` so it doesn't
+hit the `distutils` crash the rest of the bus-synaptic-graph arc found) pointed at a second graph
+name (`FALKORDB_BUS_GRAPH=orion_bus_synapse`) on the same FalkorDB instance
+`SUBSTRATE_STORE_BACKEND=falkor` already connects to.
+
+**This resolves as originally analyzed: the "no threshold needed" consumption mode is the one
+that's buildable now, the metacog-trigger dispatch mode is not.** Saturation uses a fixed 3.0
+z-score constant (`_BUS_SYNAPTIC_ZSCORE_SATURATION`, reusing Hub's own `zscore_threshold=3.0`
+convention) rather than a tuned "is this notable" threshold -- the continuous magnitude score
+itself is the signal, same as the other five domains' continuous `prediction_error` values. The
+genuinely open question (what z-score/count is worth *interrupting cognition* for, via the
+metacog trigger) remains untouched and explicitly tabled, per Juniper: "not sure about zscore
+thresholds, probably table without more data."
+
+**Shadow-only, off by default** (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`) -- CLAUDE.md
+metric-quality-gate step 4 (live-data sanity check) has not yet been run against this specific
+aggregate. Real edge z-scores were confirmed live earlier this session (see this doc's prior
+revision), but `bus_synaptic_prediction_error()`'s own aggregate output (mean over both edge
+kinds, saturated) has never run against live traffic. Do not flip the flag before running that
+check.
+
+Tests: `orion/substrate/tests/test_prediction_error.py::TestBusSynapticPredictionError` (6 tests,
+pure function) and `services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py` (7
+tests, disabled-is-noop, fail-open on client-init/query error, aggregation-and-write wiring,
+client caching). Full suite run clean against a stashed baseline of the same worktree: same 13
+pre-existing failures present with or without this patch (unrelated -- `test_cursor_reset_auth.py`
+and `test_quarantine_truth.py` need a real operator-token fixture not available in this sandbox;
+`test_worker_independent_reducers.py::test_start_spawns_independent_reducer_poll_tasks` asserts a
+stale poll-task count of 3 against a codebase that already has 5, unrelated to this patch's new
+task which isn't even named `*-poll`).
+
+**Non-goals, additive:** not building the metacog-trigger wiring in this patch (still needs the
+threshold decision, still tabled). Not folding `node:substrate.bus_synaptic` into
+`_aggregate_prediction_error_confidence`'s existing four-domain mean (PR #1329) -- that's a
+separate call about whether a sixth domain changes that formula's semantics, not a side effect of
+writing the node. Not flipping `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED` to `true` -- shadow-only until
+the live-data sanity check above runs.
+
+**Recommended next patch:** flip `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true` on a real deployment,
+run `measure_ast_hot_reducer.py`-style replay against real `node:substrate.bus_synaptic` history
+to confirm non-degenerate variance (not flat/always-0/always-saturated), then decide the
+`_aggregate_prediction_error_confidence` integration question above with real numbers in hand.

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -239,14 +239,19 @@ first place. Full reasoning and phased detail:
    override) still needs a fresh trigger to occur post-rebuild, independent of how much
    history accumulates — "item 2 is proven" therefore still means "correct when exercised,"
    not yet "exercised against a fresh real override since the rebuild."
-   **Candidate for the excluded transport domain, proposed 2026-07-25 (not built):** PR #1329's
+   **New sixth domain for the excluded transport gap, built 2026-07-25:** PR #1329's
    `prediction_error_confidence` explicitly excludes `transport` (confirmed structurally dead —
-   `0.0` for 100% of a real 8h window). The bus synaptic graph (`orion_bus_synapse`,
-   `services/orion-bus-mirror`, live since the same-day `distutils` crash-loop fix) gives a real,
-   passively-observed, mesh-wide anomaly signal that isn't gated on that domain's dead instrument
-   — see `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`'s 2026-07-25
-   revision for the full proposal. Not decided or built here; does not change this item's
-   confidence formula.
+   `0.0` for 100% of a real 8h window). `bus_synaptic_prediction_error()`
+   (`orion/substrate/prediction_error.py`) reads the bus synaptic graph (`orion_bus_synapse`,
+   `services/orion-bus-mirror`) and writes a real, passively-observed, mesh-wide anomaly signal to
+   a new `node:substrate.bus_synaptic` node — see
+   `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`'s 2026-07-25
+   revision. **Scope, stated plainly:** this is a sibling domain node, not yet folded into
+   `_aggregate_prediction_error_confidence`'s existing four-domain mean — building that requires
+   deciding whether a sixth domain changes that formula's semantics, a separate call from writing
+   the node itself. Shadow-only, off by default
+   (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false` in `services/orion-substrate-runtime`) pending a
+   live-data sanity check; does not change this item's confidence formula.
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -11,6 +11,12 @@ from orion.substrate.chat_loop.grammar_extract import compute_chat_pressure_hint
 
 _THRESHOLD = 0.30
 
+# Z-score saturation for bus_synaptic_prediction_error, distinct from _THRESHOLD
+# above (calibrated for 0-1-scale pressure-hint deltas, not z-score units).
+# Reuses the zscore_threshold=3.0 convention already live in
+# services/orion-hub/scripts/bus_synaptic_graph_routes.py's anomalies() route.
+_BUS_SYNAPTIC_ZSCORE_SATURATION = 3.0
+
 
 def _mean(values: list[float]) -> float:
     return sum(values) / len(values) if values else 0.0
@@ -268,3 +274,34 @@ def route_prediction_error(
         ]
         run_scores.append(_mean(field_scores))
     return _mean(run_scores) if run_scores else 0.0
+
+
+def bus_synaptic_prediction_error(edge_zscores: list[float]) -> float:
+    """0-1 surprise score: how anomalous is live bus traffic right now, aggregated
+    across the bus synaptic graph's (``orion_bus_synapse``) real-time EWMA/z-score
+    edges.
+
+    **Deliberately not a prev/curr diff, unlike the other continuous-magnitude
+    instruments in this module.** The bus synaptic graph
+    (``services/orion-bus-mirror/app/graph_writer.py::compute_ewma_update``)
+    already maintains its own rolling EWMA baseline per edge and computes each
+    edge's z-score against that baseline continuously as new traffic arrives --
+    the "prev expectation" is already baked into the z-score itself, so there is
+    no separate prev/curr snapshot for this function to diff. The caller queries
+    current ``|zscore|`` values from FalkorDB (see
+    ``services/orion-substrate-runtime/app/worker.py::_bus_synaptic_tick``) and
+    is responsible for filtering to edges above the graph's own documented
+    cold-start reliability floor (``services/orion-bus-mirror/README.md``:
+    ``count < ~5`` is unreliable) -- this function does no filtering itself, it
+    only aggregates whatever list it is given.
+
+    Saturates via ``_BUS_SYNAPTIC_ZSCORE_SATURATION`` (3.0), not this module's
+    ``_THRESHOLD`` (0.30) -- that constant is calibrated for the other domains'
+    0-1-scale pressure-hint deltas, not z-score units. 3.0 reuses the
+    ``zscore_threshold=3.0`` convention already live in
+    ``services/orion-hub/scripts/bus_synaptic_graph_routes.py``'s ``anomalies()``
+    route rather than inventing a new calibration.
+    """
+    if not edge_zscores:
+        return 0.0
+    return min(1.0, _mean([abs(z) for z in edge_zscores]) / _BUS_SYNAPTIC_ZSCORE_SATURATION)

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -24,6 +24,7 @@ from orion.schemas.route_projection import (
 )
 from orion.substrate.prediction_error import (
     biometrics_prediction_error,
+    bus_synaptic_prediction_error,
     chat_prediction_error,
     execution_prediction_error,
     route_prediction_error,
@@ -493,3 +494,36 @@ def test_route_prediction_error_zero_when_prev_empty_no_fallback() -> None:
     prev = _route_projection({})
     curr = _route_projection({"r1": _route_run("r1", lane="chat")})
     assert route_prediction_error(prev, curr) == 0.0
+
+
+class TestBusSynapticPredictionError:
+    """Unlike the other five instruments, this takes a flat list of current
+    |zscore| values, not a prev/curr projection pair -- the bus synaptic
+    graph's own EWMA baseline already encodes "prev expectation" per edge."""
+
+    def test_empty_list_is_zero(self) -> None:
+        assert bus_synaptic_prediction_error([]) == 0.0
+
+    def test_zero_zscores_is_zero(self) -> None:
+        assert bus_synaptic_prediction_error([0.0, 0.0, 0.0]) == 0.0
+
+    def test_takes_absolute_value_of_negative_zscores(self) -> None:
+        """A z-score of -1.5 is just as surprising as +1.5 -- must not cancel
+        out in the mean the way a signed average would."""
+        assert bus_synaptic_prediction_error([-1.5]) == pytest.approx(
+            bus_synaptic_prediction_error([1.5])
+        )
+
+    def test_saturates_at_one_not_min_030_threshold(self) -> None:
+        """Must use the 3.0 z-score saturation, not this module's 0.30
+        pressure-hint-delta _THRESHOLD -- a mean |zscore| of 1.5 dividing by
+        0.30 would already saturate to 1.0, destroying the distinction this
+        instrument exists to make."""
+        result = bus_synaptic_prediction_error([1.5])
+        assert result == pytest.approx(0.5)  # 1.5 / 3.0, not min(1.0, 1.5/0.30)
+
+    def test_saturates_at_one_for_large_zscore(self) -> None:
+        assert bus_synaptic_prediction_error([50.0]) == 1.0
+
+    def test_averages_across_multiple_edges(self) -> None:
+        assert bus_synaptic_prediction_error([0.0, 3.0]) == pytest.approx(0.5)

--- a/services/orion-bus-mirror/README.md
+++ b/services/orion-bus-mirror/README.md
@@ -134,15 +134,20 @@ ORDER BY abs(e.gap_zscore) DESC
 (`GET /api/bus-synaptic-graph/summary|hot-organs|hot-edges|anomalies`) — see that service's README
 "Bus synaptic graph debug routes" section.
 
-**Candidate consumer, proposed 2026-07-25 (not built): transport-domain redesign.** Live-verified
-this graph already covers `orion-harness-governor` traffic (`hub -> orion-harness-governor`,
-`latency_zscore=-2.10, count=5`) — a blind spot the RPC-health-only transport redesign
+**Consumer, built 2026-07-25: transport-domain redesign.** Live-verified this graph already covers
+`orion-harness-governor` traffic (`hub -> orion-harness-governor`, `latency_zscore=-2.10, count=5`)
+— a blind spot the RPC-health-only transport redesign
 (`docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`) explicitly can't
-see, since that service's RPC mechanism isn't `OrionBusAsync.rpc_request()`. See that spec's
-2026-07-25 revision. Distinct from the already-built recall reasoning consumer (Idea 4,
-`docs/superpowers/specs/2026-07-24-bus-synaptic-graph-reasoning-consumer-design.md`) — this would
-feed the Sentience Striving Program's transport prediction-error/metacog-trigger gap specifically,
-not chat context.
+see, since that service's RPC mechanism isn't `OrionBusAsync.rpc_request()`. `orion-substrate-
+runtime`'s new `_bus_synaptic_tick` (shadow-only, `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`)
+reads this graph's `PUBLISHES.gap_zscore`/`CAUSALLY_FOLLOWED_BY.latency_zscore` edges directly via
+`RedisGraphQueryClient` and writes `node:substrate.bus_synaptic`
+(`orion/substrate/prediction_error.py::bus_synaptic_prediction_error`). Distinct from the
+already-built recall reasoning consumer (Idea 4,
+`docs/superpowers/specs/2026-07-24-bus-synaptic-graph-reasoning-consumer-design.md`) — this feeds
+the Sentience Striving Program's transport prediction-error gap specifically, not chat context.
+The metacog-trigger dispatch half of that spec's original two options is still not built (needs a
+real threshold decision, explicitly tabled).
 
 ---
 

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -74,6 +74,22 @@ SUBSTRATE_EPISODIC_TICK_INTERVAL_SEC=300.0
 SUBSTRATE_EPISODIC_WINDOW_SECONDS=900
 SUBSTRATE_EPISODIC_MAX_RECEIPTS=64
 SUBSTRATE_EPISODIC_RETENTION_DAYS=14.0
+# bus_synaptic_prediction_error: reads the live bus synaptic graph
+# (orion_bus_synapse, written by orion-bus-mirror) and writes a sixth
+# Active-Inference domain node (node:substrate.bus_synaptic) via the same
+# shared writer SUBSTRATE_WRITE_PREDICTION_ERROR_NODES uses. Own explicit
+# flag, not piggybacked on that one -- new kind of signal (FalkorDB read, no
+# grammar-event batch), shadow-only until a live-data sanity pass confirms
+# non-degenerate variance (CLAUDE.md metric-quality-gate step 4). Left off
+# here on purpose -- do not flip true without running that check first. See
+# docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md.
+SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false
+SUBSTRATE_BUS_SYNAPTIC_TICK_INTERVAL_SEC=30.0
+SUBSTRATE_BUS_SYNAPTIC_MIN_EDGE_COUNT=5
+# Excludes edges not updated within this window from the aggregate, so a
+# decommissioned organ/channel's frozen last z-score doesn't drag "right
+# now" forever (review finding, 2026-07-25).
+SUBSTRATE_BUS_SYNAPTIC_MAX_EDGE_AGE_SEC=3600.0
 # Rung 3: continuous workspace competition over the substrate graph; winning
 # coalition persisted to substrate_attention_broadcast_projection (apply
 # manual_migration_attention_broadcast_v1.sql first). Needs the shared sparql
@@ -103,6 +119,11 @@ ORION_ENDOGENOUS_CURIOSITY_TICK_INTERVAL_SEC=60.0
 # reverting to sparql. Options: falkor|routed|sparql|in_memory.
 SUBSTRATE_STORE_BACKEND=falkor
 FALKORDB_URI=redis://orion-athena-falkordb:6379
+# Same FalkorDB instance as above (FALKORDB_URI), different graph name --
+# read-only, used only by the bus_synaptic tick above. Same env var name
+# services/orion-bus-mirror and services/orion-recall already use for the
+# same graph, not a new name.
+FALKORDB_BUS_GRAPH=orion_bus_synapse
 FALKORDB_SUBSTRATE_GRAPH=orion_substrate
 # SUBSTRATE_STORE_PRIMARY=falkor
 # SUBSTRATE_STORE_SHADOW=sparql

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -381,17 +381,33 @@ rename, not a deprecation, and not a product of this RPC-health redesign reachin
 replacing it. This redesign's own "not yet wired to replace this channel" status is unchanged; do
 not assume this redesign has already replaced it, only that the old channel's name changed.
 
-**Candidate third evidence source, proposed 2026-07-25 (not built): the bus synaptic graph
-(`orion_bus_synapse`, `services/orion-bus-mirror`).** Live-verified same day: `hub ->
-orion-harness-governor` shows a real `CAUSALLY_FOLLOWED_BY` edge (`latency_zscore=-2.10, count=5`)
-— this is real coverage of exactly the blind spot `docs/superpowers/specs/2026-07-23-transport-
-domain-rpc-health-redesign.md` names in its own "Related work" section: `orion-harness-governor`
-uses a bespoke long-poll RPC, not `OrionBusAsync.rpc_request()`, so the RPC-health signal that
-spec proposes structurally cannot see it. The bus-mirror graph is a passive wiretap on envelope
-`correlation_id`s, agnostic to which RPC mechanism produced them, so it catches this traffic
-anyway. See that spec's 2026-07-25 revision for the full proposal — not decided or built here,
-and does not change Missing Question 5's still-open "rename vs. deprecate" call for
-`stream_backlog_pressure`/`stream_backlog_health`.
+**Third evidence source, built 2026-07-25: the bus synaptic graph (`orion_bus_synapse`,
+`services/orion-bus-mirror`).** Live-verified 2026-07-25: `hub -> orion-harness-governor` shows a
+real `CAUSALLY_FOLLOWED_BY` edge (`latency_zscore=-2.10, count=5`) — real coverage of exactly the
+blind spot `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md` names in
+its own "Related work" section: `orion-harness-governor` uses a bespoke long-poll RPC, not
+`OrionBusAsync.rpc_request()`, so the RPC-health signal that spec proposes structurally cannot see
+it. The bus-mirror graph is a passive wiretap on envelope `correlation_id`s, agnostic to which RPC
+mechanism produced them, so it catches this traffic anyway.
+
+Built as the "no threshold needed" half of that spec's two consumption-mode options
+(`orion/substrate/prediction_error.py::bus_synaptic_prediction_error`, a sixth domain node
+`node:substrate.bus_synaptic`, written via the same shared `_write_prediction_error_node()` the
+other five domains use) — **not** the metacog-trigger dispatch half, which still needs a real
+threshold decision and stays explicitly tabled. Deliberately not a prev/curr diff like the other
+five instruments: the bus synaptic graph's own EWMA baseline per edge already encodes "prev
+expectation," so this reads current `|zscore|` values from FalkorDB fresh each tick (both
+`PUBLISHES.gap_zscore` and `CAUSALLY_FOLLOWED_BY.latency_zscore`, filtered to `count >
+SUBSTRATE_BUS_SYNAPTIC_MIN_EDGE_COUNT` to respect the graph's own cold-start reliability floor) and
+aggregates `mean(|zscore|)`, saturating at 3.0 (reuses Hub's own `zscore_threshold=3.0` convention,
+not this module's `_THRESHOLD=0.30` — that's calibrated for the other domains' 0-1-scale deltas, a
+different unit entirely). New periodic tick `_bus_synaptic_tick`/`_bus_synaptic_tick_loop`
+(`services/orion-substrate-runtime/app/worker.py`), mirroring `_dynamics_tick_loop`'s shape (no
+grammar-event batch, since there's no grammar event to poll for here). **Shadow-only, off by
+default** (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`) — CLAUDE.md metric-quality-gate step 4
+(live-data sanity check) has not yet been run against this specific aggregate; do not flip true
+without running that check first. Does not change Missing Question 5's still-open "rename vs.
+deprecate" call for `stream_backlog_pressure`/`stream_backlog_health`.
 
 **Reverie semantic lift:** unresolved closures also upsert human referent rows into
 `substrate_turn_referent` via `turn_referent_store.persist_turn_referent`. Apply

--- a/services/orion-substrate-runtime/app/settings.py
+++ b/services/orion-substrate-runtime/app/settings.py
@@ -54,6 +54,28 @@ class Settings(BaseSettings):
     dynamics_tick_interval_sec: float = Field(30.0, alias="SUBSTRATE_DYNAMICS_TICK_INTERVAL_SEC")
     enable_episodic_tick: bool = Field(False, alias="SUBSTRATE_EPISODIC_TICK_ENABLED")
     episodic_tick_interval_sec: float = Field(300.0, alias="SUBSTRATE_EPISODIC_TICK_INTERVAL_SEC")
+    # bus_synaptic_prediction_error: own explicit flag, not piggybacked on
+    # SUBSTRATE_WRITE_PREDICTION_ERROR_NODES -- new kind of signal (reads FalkorDB
+    # directly, no grammar-event batch), not a sixth instance of the existing
+    # grammar-event-driven prediction-error shape. See
+    # docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md.
+    enable_bus_synaptic_tick: bool = Field(False, alias="SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED")
+    bus_synaptic_tick_interval_sec: float = Field(
+        30.0, alias="SUBSTRATE_BUS_SYNAPTIC_TICK_INTERVAL_SEC"
+    )
+    # Cold-start reliability floor, mirrors Hub's own min_count=5
+    # (services/orion-hub/scripts/bus_synaptic_graph_routes.py::anomalies()).
+    bus_synaptic_min_edge_count: int = Field(5, alias="SUBSTRATE_BUS_SYNAPTIC_MIN_EDGE_COUNT")
+    # Staleness floor (review finding, 2026-07-25): an edge from a
+    # decommissioned organ/channel keeps its frozen z-score forever once
+    # count clears the floor above -- exclude edges not updated in this
+    # window so a long-dead edge ages out of the aggregate.
+    bus_synaptic_max_edge_age_sec: float = Field(
+        3600.0, alias="SUBSTRATE_BUS_SYNAPTIC_MAX_EDGE_AGE_SEC"
+    )
+    # Same env var name services/orion-bus-mirror and services/orion-recall
+    # already use for the same graph -- not a new name.
+    falkordb_bus_graph: str = Field("orion_bus_synapse", alias="FALKORDB_BUS_GRAPH")
     # Window + tick interval must stay under receipt retention (default 30 min),
     # or completed windows will already be pruned when consolidated.
     episodic_window_seconds: int = Field(900, alias="SUBSTRATE_EPISODIC_WINDOW_SECONDS")

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -40,6 +41,7 @@ from orion.substrate.transport_loop.constants import (
 )
 from orion.substrate.prediction_error import (
     biometrics_prediction_error,
+    bus_synaptic_prediction_error,
     chat_prediction_error,
     execution_prediction_error,
     route_prediction_error,
@@ -233,6 +235,7 @@ class BiometricsSubstrateWorker:
         self._tasks: list[asyncio.Task[None]] = []
         self._substrate_graph_store: Any = None
         self._sql_engine: Any = None
+        self._bus_synaptic_client: Any = None
         # Orion embodiment (C producer): latest drive state cached off the bus,
         # mapped to one involuntary intent per dynamics tick. Default-off.
         self._latest_drive_state: DriveStateV1 | None = None
@@ -269,6 +272,9 @@ class BiometricsSubstrateWorker:
             asyncio.create_task(self._health_loop(), name="substrate-health-monitor"),
             asyncio.create_task(self._dynamics_tick_loop(), name="substrate-dynamics-tick"),
             asyncio.create_task(self._episodic_tick_loop(), name="substrate-episodic-tick"),
+            asyncio.create_task(
+                self._bus_synaptic_tick_loop(), name="substrate-bus-synaptic-tick"
+            ),
             asyncio.create_task(
                 self._attention_broadcast_loop(), name="substrate-attention-broadcast"
             ),
@@ -737,6 +743,130 @@ class BiometricsSubstrateWorker:
         except Exception:
             logger.exception(log_label)
             return None
+
+    def _get_bus_synaptic_client(self):
+        """Return the cached read-only FalkorDB client for the bus synaptic graph
+        (``orion_bus_synapse``, written by ``orion-bus-mirror``), building it on
+        first use.
+
+        Deliberately a separate client from ``_get_substrate_graph_store`` --
+        that one is a ``ConceptNodeV1``-aware store bound to this service's own
+        durable substrate graph name; this is a plain read-only Cypher client
+        pointed at a *different* graph name on the same FalkorDB instance
+        (``FALKORDB_URI`` already used by ``_get_substrate_graph_store``, same
+        pattern ``orion.substrate.graphdb_store.build_substrate_store_from_env``
+        reads it -- ``os.environ`` directly, not a pydantic ``Settings`` field).
+        Fail-open: returns None on init error (caller decides whether that means
+        "skip this tick").
+        """
+        try:
+            client = self._bus_synaptic_client
+            if client is None:
+                from orion.graph.falkor_client import RedisGraphQueryClient
+
+                client = RedisGraphQueryClient(
+                    uri=os.getenv("FALKORDB_URI", "redis://localhost:6379"),
+                    graph_name=self._settings.falkordb_bus_graph,
+                )
+                self._bus_synaptic_client = client
+            return client
+        except Exception:
+            logger.exception("substrate_bus_synaptic_client_init_failed")
+            return None
+
+    _BUS_SYNAPTIC_EDGE_QUERIES = (
+        "MATCH (o:Organ)-[e:PUBLISHES]->(c:Channel) "
+        "WHERE e.gap_zscore IS NOT NULL AND e.count > $min_count "
+        "AND e.last_seen_epoch > $stale_cutoff_epoch "
+        "RETURN e.gap_zscore AS zscore",
+        "MATCH (a:Organ)-[e:CAUSALLY_FOLLOWED_BY]->(b:Organ) "
+        "WHERE e.latency_zscore IS NOT NULL AND e.count > $min_count "
+        "AND e.last_seen_epoch > $stale_cutoff_epoch "
+        "RETURN e.latency_zscore AS zscore",
+    )
+
+    def _bus_synaptic_tick(self) -> None:
+        """Periodic read of the live bus synaptic graph, feeding
+        ``bus_synaptic_prediction_error`` (mirrors the shared writer the other
+        five Active-Inference domains use). Default-off, fail-open: never raises
+        out of a tick.
+
+        No grammar-event batch, no persisted ``prev`` projection -- unlike
+        every other ``_*_tick`` in this module, this reads FalkorDB fresh each
+        call. The z-score baseline this reads is already maintained
+        continuously by ``orion-bus-mirror``'s own EWMA writer -- see
+        ``bus_synaptic_prediction_error``'s docstring for why that means no
+        prev/curr diff is needed here.
+
+        ``e.last_seen_epoch > stale_cutoff`` (review finding, 2026-07-25):
+        neither this query nor the Hub debug routes it mirrors filter on edge
+        recency -- an edge from a decommissioned organ or abandoned channel
+        keeps its frozen last-computed z-score forever once ``count`` clears
+        the cold-start floor, which would silently drag this "right now"
+        aggregate with stale history. Bounded by
+        ``bus_synaptic_max_edge_age_sec`` (default 1h) so a long-dead edge
+        ages out of the aggregate instead of contributing forever.
+        """
+        if not self._settings.enable_bus_synaptic_tick:
+            return
+
+        client = self._get_bus_synaptic_client()
+        if client is None:
+            return
+
+        try:
+            min_count = self._settings.bus_synaptic_min_edge_count
+            stale_cutoff_epoch = (
+                datetime.now(timezone.utc).timestamp()
+                - self._settings.bus_synaptic_max_edge_age_sec
+            )
+            params = {"min_count": min_count, "stale_cutoff_epoch": stale_cutoff_epoch}
+            zscores: list[float] = []
+            for cypher in self._BUS_SYNAPTIC_EDGE_QUERIES:
+                rows = client.graph_query(cypher, params)
+                for row in rows:
+                    value = row.get("zscore") if isinstance(row, dict) else None
+                    if isinstance(value, (int, float)) and math.isfinite(value):
+                        zscores.append(float(value))
+
+            error = bus_synaptic_prediction_error(zscores)
+            now = datetime.now(timezone.utc)
+            if error > 0.0:
+                self._store.save_receipt(
+                    _prediction_error_receipt(
+                        reducer_key="bus_synaptic",
+                        node_id="node:substrate.bus_synaptic",
+                        prediction_error=error,
+                        now=now,
+                    )
+                )
+                self._write_prediction_error_node(
+                    node_id="node:substrate.bus_synaptic",
+                    error=error,
+                    now=now,
+                    reducer_key="bus_synaptic",
+                )
+            logger.info(
+                "substrate_bus_synaptic_tick_completed edge_count=%d error=%.3f",
+                len(zscores),
+                error,
+            )
+        except Exception:
+            logger.exception("substrate_bus_synaptic_tick_failed")
+
+    async def _bus_synaptic_tick_loop(self) -> None:
+        interval = float(self._settings.bus_synaptic_tick_interval_sec)
+        while not self._stop.is_set():
+            try:
+                await asyncio.to_thread(self._bus_synaptic_tick)
+            except Exception:
+                logger.exception("substrate_bus_synaptic_tick_loop_failed")
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
 
     def _get_sql_engine(self):
         """Return a cached SQLAlchemy engine for direct Postgres writes.

--- a/services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py
+++ b/services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py
@@ -1,0 +1,169 @@
+"""Unit tests for the periodic bus-synaptic-graph tick (feeds
+``bus_synaptic_prediction_error`` from the live ``orion_bus_synapse`` FalkorDB
+graph, mirroring the shared writer the other five Active-Inference domains
+use -- see ``docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-
+redesign.md``'s 2026-07-25 revision).
+
+Default-off, fail-open, no grammar-event batch -- closest existing sibling is
+``test_worker_dynamics_tick.py``'s pattern, not the four grammar-driven
+``_*_tick`` tests.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SUBSTRATE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SUBSTRATE_ROOT))
+
+from app.worker import BiometricsSubstrateWorker
+
+
+def _make_worker(monkeypatch, *, enabled: bool = True) -> BiometricsSubstrateWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused/unused")
+    monkeypatch.setenv("SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED", "true" if enabled else "false")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._settings = settings_mod.get_settings()
+    worker._bus_synaptic_client = None
+    worker._substrate_graph_store = None
+    worker._store = MagicMock()
+    return worker
+
+
+def _client_returning(publishes_rows, causal_rows):
+    """A client whose graph_query alternates publishes/causal rows forever,
+    so it supports more than one tick (a fixed 2-item side_effect list would
+    raise StopIteration, silently swallowed by the tick's own fail-open
+    except-Exception, on any second call -- passing the test for the wrong
+    reason)."""
+    client = MagicMock()
+    responses = [publishes_rows, causal_rows]
+    call_count = {"n": 0}
+
+    def _respond(_cypher, _params):
+        row = responses[call_count["n"] % 2]
+        call_count["n"] += 1
+        return row
+
+    client.graph_query.side_effect = _respond
+    return client
+
+
+def test_bus_synaptic_tick_disabled_is_noop(monkeypatch):
+    worker = _make_worker(monkeypatch, enabled=False)
+    with patch("orion.graph.falkor_client.RedisGraphQueryClient") as client_cls:
+        worker._bus_synaptic_tick()
+    client_cls.assert_not_called()
+    worker._store.save_receipt.assert_not_called()
+
+
+def test_bus_synaptic_tick_fails_open_on_client_init_error(monkeypatch):
+    worker = _make_worker(monkeypatch, enabled=True)
+    with patch(
+        "orion.graph.falkor_client.RedisGraphQueryClient",
+        side_effect=RuntimeError("falkor down"),
+    ):
+        worker._bus_synaptic_tick()  # must not raise
+    worker._store.save_receipt.assert_not_called()
+
+
+def test_bus_synaptic_tick_fails_open_on_query_error(monkeypatch):
+    worker = _make_worker(monkeypatch, enabled=True)
+    client = MagicMock()
+    client.graph_query.side_effect = RuntimeError("cypher failed")
+    worker._bus_synaptic_client = client
+    worker._bus_synaptic_tick()  # must not raise
+    worker._store.save_receipt.assert_not_called()
+
+
+def test_bus_synaptic_tick_skips_nan_and_infinite_zscores(monkeypatch):
+    worker = _make_worker(monkeypatch, enabled=True)
+    worker._bus_synaptic_client = _client_returning(
+        [{"zscore": float("nan")}, {"zscore": float("inf")}, {"zscore": 1.5}],
+        [],
+    )
+    with patch.object(worker, "_write_prediction_error_node") as write_node:
+        worker._bus_synaptic_tick()
+    # Only the real 1.5 should count -- mean(1.5)/3.0 saturation = 0.5, not
+    # NaN-poisoned or maxed out by the infinite value.
+    write_node.assert_called_once()
+    assert write_node.call_args.kwargs["error"] == pytest.approx(0.5)
+
+
+def test_bus_synaptic_edge_queries_filter_stale_edges() -> None:
+    """Regression guard for the review finding (2026-07-25): a frozen edge
+    from a decommissioned organ/channel must not contribute forever."""
+    for cypher in BiometricsSubstrateWorker._BUS_SYNAPTIC_EDGE_QUERIES:
+        assert "last_seen_epoch" in cypher
+        assert "$stale_cutoff_epoch" in cypher
+
+
+def test_bus_synaptic_tick_no_edges_writes_nothing(monkeypatch):
+    worker = _make_worker(monkeypatch, enabled=True)
+    worker._bus_synaptic_client = _client_returning([], [])
+    with patch.object(worker, "_write_prediction_error_node") as write_node:
+        worker._bus_synaptic_tick()
+    write_node.assert_not_called()
+    worker._store.save_receipt.assert_not_called()
+
+
+def test_bus_synaptic_tick_aggregates_both_edge_kinds_and_writes(monkeypatch):
+    worker = _make_worker(monkeypatch, enabled=True)
+    worker._bus_synaptic_client = _client_returning(
+        [{"zscore": 1.5}, {"zscore": -3.0}],
+        [{"zscore": 4.5}],
+    )
+    with patch.object(worker, "_write_prediction_error_node") as write_node:
+        worker._bus_synaptic_tick()
+
+    # mean(|1.5|, |-3.0|, |4.5|) / 3.0 saturation = mean(1.5,3.0,4.5)/3.0 = 1.0 (saturated)
+    write_node.assert_called_once()
+    _, kwargs = write_node.call_args
+    assert kwargs["node_id"] == "node:substrate.bus_synaptic"
+    assert kwargs["error"] == 1.0
+    assert kwargs["reducer_key"] == "bus_synaptic"
+    worker._store.save_receipt.assert_called_once()
+
+
+def test_bus_synaptic_tick_passes_configured_min_count_and_stale_cutoff(monkeypatch):
+    monkeypatch.setenv("SUBSTRATE_BUS_SYNAPTIC_MIN_EDGE_COUNT", "9")
+    monkeypatch.setenv("SUBSTRATE_BUS_SYNAPTIC_MAX_EDGE_AGE_SEC", "120")
+    worker = _make_worker(monkeypatch, enabled=True)
+    client = _client_returning([], [])
+    worker._bus_synaptic_client = client
+    before = time.time()
+    worker._bus_synaptic_tick()
+    after = time.time()
+    assert len(client.graph_query.call_args_list) == 2
+    for call in client.graph_query.call_args_list:
+        params = call.args[1]
+        assert params["min_count"] == 9
+        # cutoff = now - max_age_sec, computed inside the tick -- bound it
+        # against wall-clock time taken around the call instead of asserting
+        # an exact float.
+        assert (before - 120) <= params["stale_cutoff_epoch"] <= (after - 120)
+
+
+def test_bus_synaptic_client_is_cached_across_ticks(monkeypatch):
+    worker = _make_worker(monkeypatch, enabled=True)
+    with patch("orion.graph.falkor_client.RedisGraphQueryClient") as client_cls:
+        client_cls.return_value = _client_returning([], [])
+        worker._bus_synaptic_tick()
+        worker._bus_synaptic_tick()
+    client_cls.assert_called_once()
+    # second tick's two graph_query calls must have actually run (not just
+    # silently no-op'd on a cached-but-broken client).
+    assert client_cls.return_value.graph_query.call_count == 4


### PR DESCRIPTION
## Summary
- New `bus_synaptic_prediction_error()` (`orion/substrate/prediction_error.py`) aggregates real `|zscore|` values from the live `orion_bus_synapse` FalkorDB graph into a 0-1 surprise score.
- New periodic `_bus_synaptic_tick`/`_bus_synaptic_tick_loop` (`services/orion-substrate-runtime/app/worker.py`) reads `PUBLISHES.gap_zscore` and `CAUSALLY_FOLLOWED_BY.latency_zscore` edges and writes a sixth Active-Inference domain node, `node:substrate.bus_synaptic`, via the existing shared `_write_prediction_error_node()` writer.
- Deliberately **not** a prev/curr diff like the other five domains (execution/transport/biometrics/chat/route) — the bus graph's own EWMA baseline per edge already encodes "prev expectation," so there's nothing to diff against.
- Implements the "no threshold needed" half of two consumption-mode options scoped in `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`'s 2026-07-25 revisions (see that doc's newest section for full rationale). The metacog-trigger dispatch half is **not** built here — it needs a real threshold decision that's explicitly tabled pending more data.
- **Shadow-only, off by default** (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`) — no live-data sanity check has been run against this specific aggregate yet (only against the raw z-score data feeding it, in an earlier session).

## Outcome moved
Closes the "buildable now" half of two previously-tabled design questions with a real, tested implementation — a genuine transport-domain-adjacent Active-Inference signal where the existing `prediction_error_confidence` formula structurally excludes `transport` (confirmed dead, `0.0` for 100% of an 8h window).

## Architecture touched
- `orion/substrate/prediction_error.py` — new function, new module-level constant.
- `services/orion-substrate-runtime/app/worker.py` — new cached FalkorDB client getter, new tick + loop, registered in `start()`.
- `services/orion-substrate-runtime/app/settings.py` — 5 new settings fields.
- `services/orion-substrate-runtime/.env_example` + shared checkout's live `.env` — synced.
- 3 READMEs updated from "proposed, not built" to "built, shadow-only."

## Files changed
- `orion/substrate/prediction_error.py`: new `bus_synaptic_prediction_error()`.
- `orion/substrate/tests/test_prediction_error.py`: 6 new tests (`TestBusSynapticPredictionError`).
- `services/orion-substrate-runtime/app/worker.py`: new tick/loop/client getter, `math` import, `__init__` state.
- `services/orion-substrate-runtime/app/settings.py`: `enable_bus_synaptic_tick`, `bus_synaptic_tick_interval_sec`, `bus_synaptic_min_edge_count`, `bus_synaptic_max_edge_age_sec`, `falkordb_bus_graph`.
- `services/orion-substrate-runtime/.env_example`: new keys, all shadow-safe defaults.
- `services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py` (new): 9 tests.
- `services/orion-substrate-runtime/README.md`, `orion/sentience_striving_program/README.md`, `services/orion-bus-mirror/README.md`: updated to reflect built status.
- `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`: new "Revision, 2026-07-25 (same day, continued)" section documenting what was built and why the design simplified on inspection (no new grammar-event type needed).

## Schema / bus / API changes
- Added: `node:substrate.bus_synaptic` (a new `FieldStateV1` domain node, written via the existing shared writer — no new schema type).
- No bus channel / registry changes (this reads FalkorDB directly, no grammar events emitted).

## Env/config changes
- Added keys: `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED` (false), `SUBSTRATE_BUS_SYNAPTIC_TICK_INTERVAL_SEC` (30.0), `SUBSTRATE_BUS_SYNAPTIC_MIN_EDGE_COUNT` (5), `SUBSTRATE_BUS_SYNAPTIC_MAX_EDGE_AGE_SEC` (3600.0), `FALKORDB_BUS_GRAPH` (orion_bus_synapse).
- `.env_example` updated: yes.
- local `.env` synced: yes, shared checkout's `services/orion-substrate-runtime/.env` updated directly (no `.env` files exist in a fresh worktree, so `sync_local_env_from_example.py` had nothing to sync there).
- skipped keys requiring operator action: none.

## Tests run
```
orion_dev/bin/python -m pytest orion/substrate/tests/test_prediction_error.py services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py -q
47 passed

orion_dev/bin/python -m pytest services/orion-substrate-runtime/tests -q --ignore=tests/test_grammar_consumer_integration.py
13 failed, 154 passed, 9 errors  (identical failure set with/without this patch, confirmed via `git stash -u` + rerun — pre-existing fixture/env issues, e.g. missing operator-token fixtures and a stale poll-task-count assertion unrelated to this domain's new task, which isn't even named `*-poll`)
```

## Docker/build/smoke checks
```
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env -f services/orion-substrate-runtime/docker-compose.yml config --quiet
(clean, exit 0, before and after the staleness-filter fixes)
```

## Review findings fixed
- Finding: neither the new Cypher queries nor the Hub `anomalies()` route they mirror filter on edge recency — a decommissioned organ/channel's frozen last-computed z-score would silently drag the "right now" aggregate forever.
  - Fix: added `e.last_seen_epoch > $stale_cutoff_epoch` to both queries, new `SUBSTRATE_BUS_SYNAPTIC_MAX_EDGE_AGE_SEC` setting (default 1h).
  - Evidence: `test_bus_synaptic_edge_queries_filter_stale_edges`, `test_bus_synaptic_tick_passes_configured_min_count_and_stale_cutoff`.
- Finding: no NaN/Infinity guard on parsed z-score values (sibling code elsewhere in the bus-synaptic-graph arc does guard against this).
  - Fix: added `math.isfinite(value)` check alongside the existing `isinstance` check.
  - Evidence: `test_bus_synaptic_tick_skips_nan_and_infinite_zscores`.
- Finding: `test_bus_synaptic_client_is_cached_across_ticks`'s second tick silently exhausted a 2-item `side_effect` list into `StopIteration`, caught by the tick's own fail-open handler — the test passed without actually exercising a second successful tick.
  - Fix: rewrote `_client_returning` to alternate responses via a callable `side_effect` instead of a fixed list; added an explicit `call_count == 4` assertion to prove the second tick's queries actually ran.
  - Evidence: same test, now genuinely exercises 2 ticks × 2 queries.

## Restart required
```bash
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env -f services/orion-substrate-runtime/docker-compose.yml up -d --build orion-substrate-runtime
```
Not urgent — the new tick is off by default (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`), so this patch is inert until an operator deliberately flips the flag after running the promised live-data sanity check.

## Risks / concerns
- Severity: low. Concern: `bus_synaptic_prediction_error`'s own aggregate output has not been validated against real live traffic (only the raw z-score data feeding it was, in an earlier session). Mitigation: shadow-only by default; do not flip `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true` without running a `measure_ast_hot_reducer.py`-style replay against real `node:substrate.bus_synaptic` history first (non-degenerate variance check, per CLAUDE.md metric-quality-gate step 4).
- Severity: low. Concern: this new domain is not yet folded into `_aggregate_prediction_error_confidence`'s existing four-domain mean (PR #1329) — deliberately deferred, a separate design call about whether a sixth domain changes that formula's semantics.

## PR link
(populated by `gh pr create` output)