### PR TITLE
chore(substrate-runtime): enable bus_synaptic tick, off-by-default -> live

### DIFF
--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -79,11 +79,18 @@ SUBSTRATE_EPISODIC_RETENTION_DAYS=14.0
 # Active-Inference domain node (node:substrate.bus_synaptic) via the same
 # shared writer SUBSTRATE_WRITE_PREDICTION_ERROR_NODES uses. Own explicit
 # flag, not piggybacked on that one -- new kind of signal (FalkorDB read, no
-# grammar-event batch), shadow-only until a live-data sanity pass confirms
-# non-degenerate variance (CLAUDE.md metric-quality-gate step 4). Left off
-# here on purpose -- do not flip true without running that check first. See
+# grammar-event batch).
+# Enabled 2026-07-25 (Juniper's explicit go-ahead): this is a pure shadow
+# write into an isolated node -- confirmed live via repo-wide grep that
+# nothing reads node:substrate.bus_synaptic anywhere yet (the only two
+# references are this writer's own upsert calls) -- so flipping it on
+# cannot propagate a bad signal, and is how the CLAUDE.md metric-quality-gate
+# step 4 live-data sanity pass (non-degenerate variance check) actually gets
+# its data. Do not wire any consumer to node:substrate.bus_synaptic (e.g.
+# folding it into prediction_error_confidence, PR #1329) until that check
+# has run against real accumulated history. See
 # docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md.
-SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false
+SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true
 SUBSTRATE_BUS_SYNAPTIC_TICK_INTERVAL_SEC=30.0
 SUBSTRATE_BUS_SYNAPTIC_MIN_EDGE_COUNT=5
 # Excludes edges not updated within this window from the aggregate, so a

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -403,11 +403,20 @@ aggregates `mean(|zscore|)`, saturating at 3.0 (reuses Hub's own `zscore_thresho
 not this module's `_THRESHOLD=0.30` — that's calibrated for the other domains' 0-1-scale deltas, a
 different unit entirely). New periodic tick `_bus_synaptic_tick`/`_bus_synaptic_tick_loop`
 (`services/orion-substrate-runtime/app/worker.py`), mirroring `_dynamics_tick_loop`'s shape (no
-grammar-event batch, since there's no grammar event to poll for here). **Shadow-only, off by
-default** (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`) — CLAUDE.md metric-quality-gate step 4
-(live-data sanity check) has not yet been run against this specific aggregate; do not flip true
-without running that check first. Does not change Missing Question 5's still-open "rename vs.
-deprecate" call for `stream_backlog_pressure`/`stream_backlog_health`.
+grammar-event batch, since there's no grammar event to poll for here). Does not change Missing
+Question 5's still-open "rename vs. deprecate" call for
+`stream_backlog_pressure`/`stream_backlog_health`.
+
+**Enabled 2026-07-25** (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true`, Juniper's explicit go-ahead) —
+confirmed via repo-wide grep that `node:substrate.bus_synaptic` has exactly two references
+anywhere in the codebase, both this tick's own upsert calls, so nothing consumes this node yet and
+flipping the flag can't propagate a bad signal. Enabling it is how CLAUDE.md's metric-quality-gate
+step 4 (live-data sanity check) actually gets real accumulated history to check against — it
+couldn't happen while the tick was off. Live-verified immediately post-deploy: real, varying,
+non-degenerate output (`edge_count=219`, `error=0.162` then `0.308` ~30s later), 0 container
+restarts. **Do not wire any consumer to `node:substrate.bus_synaptic`** (e.g. folding it into
+`prediction_error_confidence`, PR #1329) until the sanity-check pass has run against real
+accumulated history, not just this first live sample.
 
 **Fixed 2026-07-25 (same day, follow-up): the 5 new env keys above weren't reaching the
 container.** Same class of gotcha already documented for `SUBSTRATE_STORE_BACKEND`/`FALKORDB_URI`


### PR DESCRIPTION
## Summary
- Flips `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED` from `false` to `true` in `.env_example` (Juniper's explicit go-ahead: "yes and update the env example").
- Confirmed via repo-wide grep that `node:substrate.bus_synaptic` has exactly two references anywhere in the codebase, both the tick's own upsert calls — nothing consumes this node yet, so flipping the flag can't propagate a bad signal.
- Enabling it is how CLAUDE.md's metric-quality-gate step 4 (live-data sanity check) actually gets real accumulated history to check against — it couldn't happen while the tick was off.
- Already deployed and verified live before this PR: `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true` confirmed in the running container's env, 0 restarts, real varying output (`edge_count=219`, `error=0.162` → `0.308` across two 30s ticks). This PR is docs/config catching up to that already-verified live state.

## Outcome moved
Starts real data collection for the sanity check gating whether this new domain gets folded into `prediction_error_confidence` (PR #1329) or any other consumer.

## Files changed
- `services/orion-substrate-runtime/.env_example`: flag flipped, comment rewritten to explain why this is safe and what still must not happen (no consumer wiring) until the sanity check runs.
- `services/orion-substrate-runtime/README.md`: the "Shadow-only, off by default" paragraph from PR #1377 was now stale (contradicted the new state) — replaced with an "Enabled 2026-07-25" paragraph.

## Schema / bus / API changes
None — config only.

## Env/config changes
- Changed: `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED` `false` → `true`.
- `.env_example` updated: yes (this PR).
- local `.env` synced: yes, done before this PR, already deployed.
- `docker-compose.yml`'s `${SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED:-false}` fallback deliberately unchanged — matches the existing `.env_example`-true/compose-fallback-false convention already used for `SUBSTRATE_DYNAMICS_TICK_ENABLED`/`SUBSTRATE_EPISODIC_TICK_ENABLED`.

## Tests run
None — config/doc only, no code changed.

## Docker/build/smoke checks
```
docker exec orion-athena-substrate-runtime env | grep BUS_SYNAPTIC
# SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true

docker logs orion-athena-substrate-runtime --tail 60 | grep bus_synaptic
# substrate_bus_synaptic_tick_completed edge_count=219 error=0.162
# substrate_bus_synaptic_tick_completed edge_count=219 error=0.308
# (0 container restarts)
```

## Review findings fixed
- Finding: `README.md` still said "Shadow-only, off by default ... do not flip true without running that check first," directly contradicting the newly-enabled state.
  - Fix: rewrote the paragraph to document the enable decision, the no-consumer-yet safety reasoning, and the live-verified output, while keeping the "do not wire a consumer" warning intact.
  - Evidence: reviewer independently re-ran the repo-wide `node:substrate.bus_synaptic` grep and confirmed the no-consumer claim before flagging the stale paragraph.
- Also verified by review (no fix needed): the no-consumer claim holds up independently; `docker-compose.yml`'s unchanged `:-false` fallback is the correct, established convention, not an oversight; no resource/contention concern from the new 30s FalkorDB read.

## Restart required
Already applied live (see Docker checks above). No further action needed.

## Risks / concerns
- Severity: low. Concern: this is real accumulated history now feeding a metric nobody has validated for non-degenerate variance over a full window yet (only 2 sample ticks observed so far). Mitigation: explicitly no consumer wired to this node — a bad/flat signal here has zero downstream effect until someone deliberately decides to consume it after running the sanity check.