### PR TITLE
fix(execution-dispatch): theater tripwire's restart-to-re-arm is now real

### DIFF
--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -317,6 +317,15 @@ class ExecutionDispatchRuntimeStore:
         return int(row["n"]) if row else 0
 
     def recent_dispatch_result_statuses(self, limit: int = 10) -> list[str]:
+        """Kept, not removed: no longer called by worker.py's theater tripwire
+        as of 2026-07-25 (that check moved to an in-process deque so a
+        restart gives it a genuinely clean slate -- querying this table let
+        stale pre-restart rows defeat "restart to re-arm" in a real
+        incident). Still real, still tested (test_execution_dispatch_
+        runtime_store.py), left in place as a real building block for a
+        possible future debug/inspection endpoint over actual historical
+        Postgres data, not the live tripwire's own decision.
+        """
         with self._engine.connect() as conn:
             rows = conn.execute(
                 text(

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -57,6 +58,20 @@ class ExecutionDispatchRuntimeWorker:
         # parent spec -- a self-clearing tripwire could silently resume
         # sending on a coincidentally-good sample).
         self.theater_tripwire_active = False
+        # Per-process window for the tripwire's own judgment. Deliberately
+        # NOT sourced from substrate_dispatch_results' full history (that
+        # table persists real history for other consumers and is never
+        # pruned by this service) -- a restart must give the tripwire a
+        # genuinely clean slate. Real incident, 2026-07-25: 10 rows from a
+        # cold post-Postgres-rebuild window (all status="empty", the
+        # substrate hadn't repopulated yet) were still the newest rows in
+        # the table days later, so every restart re-evaluated the SAME
+        # stale evidence and re-tripped on the same tick, making "requires a
+        # restart to re-arm" false in this case -- not a self-clearing
+        # tripwire (still requires a real restart, still can't clear itself
+        # mid-process), just a tripwire whose restart-to-re-arm contract
+        # actually holds now.
+        self._recent_dispatch_statuses: deque[str] = deque(maxlen=THEATER_TRIPWIRE_WINDOW)
 
     async def start(self) -> None:
         asyncio.create_task(self._poll_loop(), name="execution-dispatch-runtime-poll")
@@ -199,14 +214,14 @@ class ExecutionDispatchRuntimeWorker:
             }
         )
 
-        # Re-check after this tick's real sends landed new rows -- lets the
-        # tripwire fire the same tick it actually crosses the threshold,
-        # not one tick late.
+        # Re-check after this tick's real sends appended to the in-process
+        # window -- lets the tripwire fire the same tick it actually crosses
+        # the threshold, not one tick late.
         self._check_theater_tripwire()
         return updated
 
     def _check_theater_tripwire(self) -> bool:
-        recent = self._store.recent_dispatch_result_statuses(THEATER_TRIPWIRE_WINDOW)
+        recent = list(self._recent_dispatch_statuses)
         if len(recent) < THEATER_TRIPWIRE_WINDOW:
             return self.theater_tripwire_active
         empty_count = sum(1 for s in recent if s == "empty")
@@ -248,6 +263,10 @@ class ExecutionDispatchRuntimeWorker:
                 candidate.dispatch_id,
                 existing["status"],
             )
+            # Real information about a real attempt even on replay -- counts
+            # toward this process's own tripwire window the same as a fresh
+            # send would.
+            self._recent_dispatch_statuses.append(existing["status"])
             # Re-emit on replay too: action_outcomes.action_id is the SQL
             # primary key and sql-writer's route upserts by merge(), so a
             # repeat emit for the same dispatch_id idempotently overwrites
@@ -314,6 +333,7 @@ class ExecutionDispatchRuntimeWorker:
                 result_json={"error": str(exc)[:2000], "evidence_refs": [result_id]},
                 raw_len=0,
             )
+            self._recent_dispatch_statuses.append("failed")
             await self._emit_action_outcome(
                 bus,
                 candidate=candidate,
@@ -341,6 +361,7 @@ class ExecutionDispatchRuntimeWorker:
             result_json={**observation_data, "evidence_refs": [result_id]},
             raw_len=raw_len,
         )
+        self._recent_dispatch_statuses.append(status)
         logger.info(
             "execution_dispatch_result dispatch_id=%s status=%s raw_len=%d",
             candidate.dispatch_id,

--- a/services/orion-execution-dispatch-runtime/tests/test_theater_tripwire.py
+++ b/services/orion-execution-dispatch-runtime/tests/test_theater_tripwire.py
@@ -1,0 +1,103 @@
+"""Unit tests for the execution-dispatch-runtime theater tripwire's in-process
+window (worker.py's `_check_theater_tripwire`).
+
+Constructs `ExecutionDispatchRuntimeWorker` via `object.__new__` rather than
+`__init__` -- the real constructor builds a live Postgres store, loads a policy
+YAML off disk, and constructs a NotifyClient, none of which this pure logic
+test needs or should depend on. Only the attributes `_check_theater_tripwire`
+and `_notify_tripwire` actually touch are set.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+from app.worker import THEATER_TRIPWIRE_EMPTY_THRESHOLD, THEATER_TRIPWIRE_WINDOW, ExecutionDispatchRuntimeWorker
+
+
+def _bare_worker() -> ExecutionDispatchRuntimeWorker:
+    worker = object.__new__(ExecutionDispatchRuntimeWorker)
+    worker.theater_tripwire_active = False
+    worker._recent_dispatch_statuses = deque(maxlen=THEATER_TRIPWIRE_WINDOW)
+    worker._notify = None  # _notify_tripwire wraps its use in try/except
+    return worker
+
+
+class TestTheaterTripwireInProcessWindow:
+    def test_fresh_process_is_not_tripped_regardless_of_postgres_history(self) -> None:
+        """The regression case for the real 2026-07-25 incident: a fresh
+        process (empty in-memory deque) must read as not-tripped even if
+        substrate_dispatch_results (Postgres, not touched by this test at
+        all) still holds stale rows from before this restart -- the whole
+        point of moving off a live Postgres query.
+        """
+        worker = _bare_worker()
+        assert worker._check_theater_tripwire() is False
+
+    def test_fewer_than_window_statuses_does_not_trip(self) -> None:
+        worker = _bare_worker()
+        for _ in range(THEATER_TRIPWIRE_WINDOW - 1):
+            worker._recent_dispatch_statuses.append("empty")
+        assert worker._check_theater_tripwire() is False
+
+    def test_trips_when_more_than_threshold_fraction_is_empty(self) -> None:
+        worker = _bare_worker()
+        n_empty = int(THEATER_TRIPWIRE_WINDOW * THEATER_TRIPWIRE_EMPTY_THRESHOLD) + 1
+        for _ in range(n_empty):
+            worker._recent_dispatch_statuses.append("empty")
+        for _ in range(THEATER_TRIPWIRE_WINDOW - n_empty):
+            worker._recent_dispatch_statuses.append("success")
+        assert worker._check_theater_tripwire() is True
+
+    def test_does_not_trip_at_exactly_the_threshold_fraction(self) -> None:
+        """The real condition is `>`, not `>=` -- exactly half empty (the
+        literal threshold value) must not trip."""
+        worker = _bare_worker()
+        half = int(THEATER_TRIPWIRE_WINDOW * THEATER_TRIPWIRE_EMPTY_THRESHOLD)
+        for _ in range(half):
+            worker._recent_dispatch_statuses.append("empty")
+        for _ in range(THEATER_TRIPWIRE_WINDOW - half):
+            worker._recent_dispatch_statuses.append("success")
+        assert worker._check_theater_tripwire() is False
+
+    def test_does_not_self_clear_once_tripped(self) -> None:
+        """Deliberate design (worker.py's own docstring): once tripped, stays
+        tripped for this process's lifetime even if fresh appends show a
+        healthy window -- only a real restart (a fresh process, fresh deque)
+        re-arms it. This is NOT a regression to fix; it's the property this
+        patch is careful to preserve while fixing the separate, real bug
+        (stale pre-restart Postgres rows defeating restart-to-re-arm)."""
+        worker = _bare_worker()
+        n_empty = int(THEATER_TRIPWIRE_WINDOW * THEATER_TRIPWIRE_EMPTY_THRESHOLD) + 1
+        for _ in range(n_empty):
+            worker._recent_dispatch_statuses.append("empty")
+        for _ in range(THEATER_TRIPWIRE_WINDOW - n_empty):
+            worker._recent_dispatch_statuses.append("success")
+        assert worker._check_theater_tripwire() is True
+
+        # Window now fills with nothing but healthy results -- old entries
+        # fall off the maxlen deque, but the process-level latch must still
+        # hold.
+        for _ in range(THEATER_TRIPWIRE_WINDOW):
+            worker._recent_dispatch_statuses.append("success")
+        assert worker._check_theater_tripwire() is True
+
+    def test_deque_is_bounded_to_window_size(self) -> None:
+        """maxlen enforces the window itself -- appending well beyond
+        THEATER_TRIPWIRE_WINDOW must never grow the deque past it."""
+        worker = _bare_worker()
+        for _ in range(THEATER_TRIPWIRE_WINDOW * 3):
+            worker._recent_dispatch_statuses.append("success")
+        assert len(worker._recent_dispatch_statuses) == THEATER_TRIPWIRE_WINDOW
+
+    def test_failed_status_does_not_count_as_empty(self) -> None:
+        """`_check_theater_tripwire` only counts literal "empty" -- "failed"
+        (an RPC/send error, a different failure mode than a hollow-but-
+        technically-successful response) must not contribute to the empty
+        count, matching pre-existing behavior this patch does not change."""
+        worker = _bare_worker()
+        for _ in range(THEATER_TRIPWIRE_WINDOW):
+            worker._recent_dispatch_statuses.append("failed")
+        assert worker._check_theater_tripwire() is False

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -179,7 +180,6 @@ def _patch_bus_and_client(monkeypatch, outcomes: dict[str, object]) -> MagicMock
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -212,7 +212,6 @@ async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None
 @pytest.mark.asyncio
 async def test_send_one_emits_action_outcome_on_success(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -238,7 +237,6 @@ async def test_send_one_emits_action_outcome_on_success(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_send_one_emits_action_outcome_on_empty_observation(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -256,7 +254,6 @@ async def test_send_one_emits_action_outcome_on_empty_observation(monkeypatch) -
 @pytest.mark.asyncio
 async def test_send_one_emits_action_outcome_on_rpc_failure(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -281,7 +278,6 @@ async def test_send_one_re_emits_action_outcome_on_idempotent_replay(monkeypatch
     # that emit itself failed transiently -- every later tick also hits
     # this same replay branch, so there'd be no other chance to retry it.
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
@@ -308,7 +304,6 @@ async def test_send_one_re_emits_action_outcome_on_idempotent_replay(monkeypatch
 @pytest.mark.asyncio
 async def test_send_one_action_outcome_publish_failure_does_not_raise(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -329,7 +324,6 @@ async def test_send_one_action_outcome_publish_failure_does_not_raise(monkeypatc
 @pytest.mark.asyncio
 async def test_send_one_action_outcome_summary_is_truncated(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -349,7 +343,6 @@ async def test_send_one_action_outcome_summary_is_truncated(monkeypatch) -> None
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -369,7 +362,6 @@ async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeyp
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_empty_observation_status_empty(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -393,7 +385,6 @@ async def test_send_prepared_candidates_respects_per_tick_budget(monkeypatch) ->
     worker._policy = worker._policy.model_copy(
         update={"limits": worker._policy.limits.model_copy(update={"max_dispatches_per_tick": 1})}
     )
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
@@ -421,7 +412,6 @@ async def test_send_one_replays_existing_result_without_resending(monkeypatch) -
     # process died before save_dispatch_frame persisted that), the next
     # tick must NOT fire a second real cortex-exec RPC for it.
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
@@ -446,7 +436,6 @@ async def test_send_one_replays_existing_result_without_resending(monkeypatch) -
 @pytest.mark.asyncio
 async def test_send_one_replays_existing_failed_result_without_resending(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
@@ -472,7 +461,6 @@ async def test_send_one_replays_existing_failed_result_without_resending(monkeyp
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_skips_when_daily_cap_reached(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(
         return_value=worker._settings.orion_dispatch_max_per_day
     )
@@ -490,8 +478,11 @@ async def test_send_prepared_candidates_skips_when_daily_cap_reached(monkeypatch
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_skips_when_tripwire_active(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(
-        return_value=["empty"] * 6 + ["success"] * 4
+    # Tripwire window is now in-process (worker.py, fixed 2026-07-25 -- a live
+    # Postgres query let stale pre-restart rows defeat "restart to re-arm";
+    # see the theater-tripwire-age-gate fix), not backed by the store.
+    worker._recent_dispatch_statuses = deque(
+        ["empty"] * 6 + ["success"] * 4, maxlen=worker_mod.THEATER_TRIPWIRE_WINDOW
     )
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
@@ -510,8 +501,8 @@ async def test_send_prepared_candidates_skips_when_tripwire_active(monkeypatch) 
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_tripwire_stays_tripped_across_calls(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(
-        return_value=["empty"] * 6 + ["success"] * 4
+    worker._recent_dispatch_statuses = deque(
+        ["empty"] * 6 + ["success"] * 4, maxlen=worker_mod.THEATER_TRIPWIRE_WINDOW
     )
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
@@ -529,7 +520,6 @@ async def test_send_prepared_candidates_tripwire_stays_tripped_across_calls(monk
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_noop_when_nothing_prepared(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     frame = _frame_with_candidates(_candidate("dispatch:1", status="blocked"))
 


### PR DESCRIPTION
## Summary

Real production incident, found and fixed live 2026-07-25: the Postgres host had a disk failure and full rebuild on 2026-07-23. The first 10 real dispatch attempts by `orion-execution-dispatch-runtime` right after the rebuild (a 2-minute cold-start window) all returned `status=empty` — correctly tripping the **theater tripwire**, a deliberate safety mechanism that permanently stops sending real dispatches once >50% of the trailing 10 results are hollow (a real, direct enforcement of "no empty-shell cognition").

**The bug**: `_check_theater_tripwire()` queried Postgres for "the 10 most recent rows in `substrate_dispatch_results`" — not "the 10 most recent attempts by this process." Since nothing ever got past the tripwire to write a new row, those same 10 stale rows stayed the newest rows in the table for 40+ hours. Confirmed live: restarting the container (which resets the in-memory `theater_tripwire_active` flag) did **not** fix it — the very next tick re-read the same stale rows and instantly re-tripped, silently breaking "requires a restart to re-arm."

This is not a flaw in the tripwire's judgment — those 10 results really were empty — it's a bug in what data source the check reads.

## Fix

The tripwire's evaluation window is now an in-process `deque(maxlen=10)`, populated only by real statuses this process instance itself produces (all three real sites: the failed/exception branch, the success/empty branch, and the idempotency-replay branch). A restart now gives it a genuinely clean slate. **Deliberately does not add self-clearing mid-process** — once tripped, `theater_tripwire_active` still only clears via a real restart, preserving the code's own explicit design intent ("a self-clearing tripwire could silently resume sending on a coincidentally-good sample").

## Operational recovery (already done live, not part of this patch)

The 10 stale rows were snapshotted to `/tmp/theater-tripwire-stale-clear/` and deleted, the container restarted, and real dispatch confirmed working again — 6/6 genuine successes since, real `raw_len` values (145, 155, ...).

## Env/config changes

None. The tripwire's window size and empty-threshold are, and remain, hardcoded module constants — never env-driven, before or after this patch.

## Tests run
```
cd services/orion-execution-dispatch-runtime && pytest tests/ -q   # (from repo root)
pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_runtime_store.py services/orion-execution-dispatch-runtime/tests/ -q
-> 43 passed
```
7 new unit tests cover: fresh-process not tripped regardless of simulated history (the core regression test), below-window never trips, trips above threshold, does not trip at exactly the threshold fraction, does not self-clear once tripped, deque respects maxlen, "failed" status doesn't count toward "empty".

## Review findings fixed (orion-repo-agent)

- Finding (high): two pre-existing tests in `tests/test_execution_dispatch_runtime_worker.py` mocked the now-dead store method and would have silently failed against this branch — not caught by the narrower service-scoped test command. Fixed both to seed the real in-process deque instead.
- Finding (medium): ~12 other tests in the same file mocked the same now-dead method with an inert empty-list return; removed as cleanup.
- Finding (medium): `app/store.py`'s `recent_dispatch_result_statuses` is now unused by the tripwire; explicit decision recorded in its own docstring (kept as a real, tested building block for a possible future debug endpoint, not removed).

## Restart required

Already done live as part of the incident response (see above) — no further restart needed once this PR merges, since the fix only changes behavior starting from each process's own next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)