### PR TITLE
chore(equilibrium): enable bus_synaptic transport metacog poll, off -> live

### DIFF
--- a/services/orion-equilibrium-service/.env_example
+++ b/services/orion-equilibrium-service/.env_example
@@ -138,10 +138,15 @@ EQUILIBRIUM_METACOG_TRANSPORT_LATENCY_P95_THRESHOLD_MS=5000
 # orion-substrate-runtime's _bus_synaptic_tick -- PR #1377/#1380). Passively
 # covers RPC-health-invisible organs (bespoke long-poll clients) Options A/C
 # above structurally cannot see. Shares trigger_kind="transport"'s cooldown
-# lane above, not a new one. Ships disabled -- this is a new dispatch path,
-# not yet live-verified to fire correctly against real traffic; flip on and
-# watch for a real trigger before trusting it, same standard as A/C.
-EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE=false
+# lane above, not a new one.
+# Enabled 2026-07-26 (Juniper's go-ahead) -- unlike SUBSTRATE_BUS_SYNAPTIC_
+# TICK_ENABLED (a pure shadow write nothing consumed), this dispatches a
+# real MetacogTriggerV1 into orion_metacog, so it needed its own explicit
+# go-ahead separate from "is the underlying data worth collecting." Watch
+# the first real fire (orion_metacog row, trigger_kind=transport,
+# upstream.evidence_source=bus_synaptic_prediction_error) before fully
+# trusting this path the same way Options A/C were already trusted.
+EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE=true
 EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_INTERVAL_SEC=30
 # 1.0 = bus_synaptic_prediction_error's own saturation ceiling (mean |zscore|
 # already reached 3.0 across aggregated edges) -- reuses Hub's own

--- a/services/orion-equilibrium-service/README.md
+++ b/services/orion-equilibrium-service/README.md
@@ -149,7 +149,7 @@ Full design: `docs/superpowers/specs/2026-07-24-transport-metacog-trigger-design
 
 Own cooldown lane from day one (`EQUILIBRIUM_METACOG_TRANSPORT_COOLDOWN_SEC`) -- not sharing the global lane, avoiding the exact bug `chat_turn` had to fix after the fact (see above). All three evidence sources share this one lane.
 
-`EQUILIBRIUM_METACOG_TRANSPORT_TRIGGER_ENABLE` is live (`true`) as of 2026-07-24 (flipped shortly after shipping, commit `40cd21f80` -- correcting a stale claim this paragraph carried before). Options A/C are live. **Option bus_synaptic ships disabled** (`EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE=false`) -- new dispatch path, not yet live-verified to fire correctly against real traffic; needs the same live-verification standard as A/C before flipping on.
+`EQUILIBRIUM_METACOG_TRANSPORT_TRIGGER_ENABLE` is live (`true`) as of 2026-07-24 (flipped shortly after shipping, commit `40cd21f80` -- correcting a stale claim this paragraph carried before). All three evidence sources (A/C/bus_synaptic) are now live as of 2026-07-26 (`EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE=true`) -- unlike `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED` (a pure shadow write nothing consumed, so flipping it carried near-zero risk), this dispatches a real `MetacogTriggerV1` into `orion_metacog`, so it needed its own explicit go-ahead. Watch for the first real fire (`orion_metacog` row, `trigger_kind=transport`, `upstream.evidence_source=bus_synaptic_prediction_error`) before fully trusting this path the same way A/C were already trusted.
 
 | Env | Default | Purpose |
 |-----|---------|---------|
@@ -158,7 +158,7 @@ Own cooldown lane from day one (`EQUILIBRIUM_METACOG_TRANSPORT_COOLDOWN_SEC`) --
 | `EQUILIBRIUM_METACOG_TRANSPORT_LATENCY_P95_THRESHOLD_MS` | `5000` | Option A's latency-spike threshold; unvalidated starting default |
 | `CHANNEL_RPC_HEALTH_SNAPSHOT` | `orion:rpc_health:snapshot` | Option A's source channel |
 | `CHANNEL_GRAMMAR_EVENT` | `orion:grammar:event` | Option C's source channel, filtered to `semantic_role=="rpc_transport_timeout"` |
-| `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE` | `false` | Master gate for Option bus_synaptic |
+| `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE` | `true` | Master gate for Option bus_synaptic |
 | `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_INTERVAL_SEC` | `30` | Poll cadence for Option bus_synaptic |
 | `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_ERROR_THRESHOLD` | `1.0` | Option bus_synaptic's fire threshold (saturation ceiling) |
 | `FALKORDB_URI` / `FALKORDB_SUBSTRATE_GRAPH` | `orion_substrate` | Option bus_synaptic's read-only FalkorDB connection |


### PR DESCRIPTION
## Summary
- Flips `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE` from `false` to `true` (Juniper's explicit go-ahead).
- Unlike `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED` (a pure shadow write nothing consumed, near-zero risk to flip), this dispatches a real `MetacogTriggerV1` into `orion_metacog` — a visible, consumed artifact — so it needed its own separate go-ahead rather than riding on "is the underlying data worth collecting."
- Already deployed and verified live before this PR: 0 container restarts, no errors, current `node:substrate.bus_synaptic` `prediction_error` reads `0.174` (below the `1.0` fire threshold) — correctly quiet, matching the already-documented "real anomalies are rare" expectation.

## Files changed
- `services/orion-equilibrium-service/.env_example`: flag flipped, comment rewritten.
- `services/orion-equilibrium-service/README.md`: updated to say all 3 evidence sources are live; added the watch-for-first-fire note.

## Env/config changes
- Changed: `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE` `false` → `true`.
- local `.env` synced: yes, already deployed.
- `docker-compose.yml` fallback deliberately unchanged (`:-false`, matches the established convention).

## Docker/build/smoke checks
```
docker exec orion-athena-equilibrium env | grep BUS_SYNAPTIC
# EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE=true

docker logs orion-athena-equilibrium --tail 60
# no errors, 0 restarts, normal baseline metacog ticks continuing

docker exec orion-athena-falkordb redis-cli GRAPH.QUERY orion_substrate \
  "MATCH (n:SubstrateNode) WHERE n.node_id = 'node:substrate.bus_synaptic' RETURN n.prediction_error"
# 0.173577 (below 1.0 threshold, correctly not firing yet)
```

## Restart required
Already applied live. No further action needed.

## Risks / concerns
- Severity: low. Concern: no real fire has been observed yet (current signal is well below threshold). Mitigation: this PR is exactly the mechanism for observing that — watch `orion_metacog` for a `trigger_kind=transport`, `upstream.evidence_source=bus_synaptic_prediction_error` row before fully trusting the path.