### PR TITLE
docs: fix stale bus_synaptic flag-state claims across 3 files

### DIFF
--- a/docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md
+++ b/docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md
@@ -393,3 +393,42 @@ the live-data sanity check above runs.
 run `measure_ast_hot_reducer.py`-style replay against real `node:substrate.bus_synaptic` history
 to confirm non-degenerate variance (not flat/always-0/always-saturated), then decide the
 `_aggregate_prediction_error_confidence` integration question above with real numbers in hand.
+
+## Revision, 2026-07-26 -- both flags flipped, metacog-trigger dispatch built
+
+Everything the previous revision section left open has since moved. Read this section for the
+current live state; the sections above are historical (frozen at the time each was written), not
+current status.
+
+- **`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED` is `true` (PR #1380, 2026-07-25).** Confirmed via
+  repo-wide grep that `node:substrate.bus_synaptic` had exactly two references anywhere in the
+  codebase at the time (both this tick's own upsert calls) -- nothing consumed it, so flipping it
+  couldn't propagate a bad signal, and was the only way to collect the real history the
+  metric-quality-gate step 4 check needs. Live-verified real, varying, non-degenerate output
+  immediately (`edge_count=219`, `error=0.162` then `0.308` across two ticks; later samples ranged
+  0.17-1.0 over hours of real traffic).
+- **The metacog-trigger dispatch mode -- the piece this doc's earlier sections called "not built,"
+  "explicitly tabled" -- is also now built and live: PR #1385/#1387, 2026-07-26.**
+  `build_transport_metacog_trigger_from_bus_synaptic()`
+  (`services/orion-equilibrium-service/app/transport_metacog_gate.py`) polls
+  `node:substrate.bus_synaptic`'s `prediction_error` directly from FalkorDB every 30s (not
+  message-driven like Options A/C -- this data lives in a graph node, not a bus channel), fires at
+  `error >= 1.0` (`EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_ERROR_THRESHOLD`), shares
+  `trigger_kind="transport"`'s existing cooldown lane. The "genuinely open question" the prior
+  section named (what threshold is worth interrupting cognition for) resolved cleanly, not
+  arbitrarily: `error_threshold=1.0` is `bus_synaptic_prediction_error()`'s own saturation ceiling
+  (mean `|zscore|` already at 3.0), reusing Hub's own already-established anomaly bar rather than
+  inventing a new calibration -- the thing that made this feel tabled (needing more data to pick a
+  threshold) turned out not to require new data at all, just reusing a number that already existed.
+- **`EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE` is `true` (PR #1387, 2026-07-26).**
+  Needed its own separate go-ahead from the tick flag above -- unlike the tick (a pure shadow
+  write nothing consumed), this dispatches a real `MetacogTriggerV1` into `orion_metacog`, a
+  visible, consumed artifact. Live-verified: 0 container restarts, no errors, current signal reads
+  well below the fire threshold (correctly quiet -- matches this session's own "real anomalies are
+  rare" expectation from Options A/C, not evidence of breakage).
+- **Not yet true, still open:** no real fire has been observed from this evidence source yet
+  (current `node:substrate.bus_synaptic` values have stayed below `1.0`). Watch `orion_metacog` for
+  a `trigger_kind=transport`, `upstream.evidence_source=bus_synaptic_prediction_error` row before
+  fully trusting this path, same standard already applied to Options A/C when they shipped. The
+  `_aggregate_prediction_error_confidence` (PR #1329) integration question is also still
+  undecided -- this domain remains a sibling node, not folded into that formula.

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -249,9 +249,9 @@ first place. Full reasoning and phased detail:
    revision. **Scope, stated plainly:** this is a sibling domain node, not yet folded into
    `_aggregate_prediction_error_confidence`'s existing four-domain mean — building that requires
    deciding whether a sixth domain changes that formula's semantics, a separate call from writing
-   the node itself. Shadow-only, off by default
-   (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false` in `services/orion-substrate-runtime`) pending a
-   live-data sanity check; does not change this item's confidence formula.
+   the node itself. Live since 2026-07-25
+   (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true` in `services/orion-substrate-runtime`, PR #1380)
+   — real accumulated history is now collecting; does not change this item's confidence formula.
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live

--- a/services/orion-bus-mirror/README.md
+++ b/services/orion-bus-mirror/README.md
@@ -139,15 +139,20 @@ ORDER BY abs(e.gap_zscore) DESC
 — a blind spot the RPC-health-only transport redesign
 (`docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`) explicitly can't
 see, since that service's RPC mechanism isn't `OrionBusAsync.rpc_request()`. `orion-substrate-
-runtime`'s new `_bus_synaptic_tick` (shadow-only, `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`)
-reads this graph's `PUBLISHES.gap_zscore`/`CAUSALLY_FOLLOWED_BY.latency_zscore` edges directly via
+runtime`'s `_bus_synaptic_tick` (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true`, live since 2026-07-25,
+PR #1380 -- correcting a stale "shadow-only" claim this paragraph carried before) reads this
+graph's `PUBLISHES.gap_zscore`/`CAUSALLY_FOLLOWED_BY.latency_zscore` edges directly via
 `RedisGraphQueryClient` and writes `node:substrate.bus_synaptic`
 (`orion/substrate/prediction_error.py::bus_synaptic_prediction_error`). Distinct from the
 already-built recall reasoning consumer (Idea 4,
 `docs/superpowers/specs/2026-07-24-bus-synaptic-graph-reasoning-consumer-design.md`) — this feeds
 the Sentience Striving Program's transport prediction-error gap specifically, not chat context.
-The metacog-trigger dispatch half of that spec's original two options is still not built (needs a
-real threshold decision, explicitly tabled).
+The metacog-trigger dispatch half is now also built and live
+(`EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE=true`, 2026-07-26, PR #1385/#1387 --
+`build_transport_metacog_trigger_from_bus_synaptic()`, `services/orion-equilibrium-service`) --
+no real fire observed yet (current signal sits below the fire threshold), so watch `orion_metacog`
+for the first real `trigger_kind=transport` row from this evidence source before fully trusting
+the path.
 
 ---
 


### PR DESCRIPTION
## Summary
- Found via Juniper asking "why is the graph on shadow when its on true?" — `services/orion-bus-mirror/README.md` and `orion/sentience_striving_program/README.md` still said `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=false`/"shadow-only," stale since PR #1380 flipped it to `true` on 2026-07-25. Missed these two READMEs when updating the others at the time.
- Added a "Revision, 2026-07-26" addendum to `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`: the metacog-trigger dispatch mode that same doc's earlier sections called "not built"/"explicitly tabled" is now also built and live (PR #1385/#1387). Left the historical sections as-is (frozen narrative, correct for when they were written) and appended current state instead of rewriting history in place.

## Files changed
- `services/orion-bus-mirror/README.md`: corrected the stale tick-flag reference.
- `orion/sentience_striving_program/README.md`: corrected the same stale reference.
- `docs/superpowers/specs/2026-07-23-transport-domain-rpc-health-redesign.md`: new addendum section.

## Review findings
Review (orion-repo-agent) independently re-verified all corrected claims against the live rail (not just trusting the commit message):
- `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true` confirmed in both `.env_example` and the shared checkout's live `.env`.
- `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_POLL_ENABLE=true` confirmed in both `.env_example` and live `.env`.
- `build_transport_metacog_trigger_from_bus_synaptic()` confirmed to exist with a real call site in `app/service.py`, not just a docstring claim.
- Repo-wide grep found no other stale references to either flag.
- No fixes needed — reviewed clean.

## Tests run
None — docs only, no code changed.

## Restart required
No restart required.

## Risks / concerns
None. Docs-only correction, independently re-verified.