### PR TITLE
feat(execution-dispatch): replace blind daily action-count cap with real risk budget

### DIFF
--- a/services/orion-execution-dispatch-runtime/.env_example
+++ b/services/orion-execution-dispatch-runtime/.env_example
@@ -25,7 +25,17 @@ ORION_BUS_ENABLED=true
 # connection from the RPC dispatch client above.
 HEARTBEAT_INTERVAL_SEC=10
 EXECUTION_DISPATCH_RPC_TIMEOUT_SEC=120
-ORION_DISPATCH_MAX_PER_DAY=24
+# Replaces ORION_DISPATCH_MAX_PER_DAY (2026-07-26) -- a blind action count
+# never empirically derived (the checked-in 24 and a live-drifted 88 both
+# traced to a hand-picked round number, never validated against real
+# behavior). Spent against each dispatched candidate's own real risk_score
+# ([0,1]) instead of counting actions. Default anchored to the first real
+# day this pipeline dispatched successfully (2026-07-26): 4.4 real
+# cumulative risk across 88 dispatches -- this is ~2x that observed total,
+# not a fresh guess. Needs real re-derivation as more history accumulates
+# across a wider risk_score mix -- a disclosed starting judgment call, not
+# a settled constant.
+ORION_DISPATCH_MAX_RISK_PER_DAY=10.0
 # Real-send outcomes publish here so load_action_outcomes() (chat-stance,
 # reducer) sees them the same way it already sees curiosity-fetch outcomes --
 # same channel orion-spark-concept-induction already produces onto.

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -30,7 +30,19 @@ promotes the candidate to a real, evidenced `dispatched` status.
 
 **Budgets**, both enforced per tick before any send happens:
 - `config/execution_dispatch/execution_dispatch_policy.v1.yaml`'s `limits.max_dispatches_per_tick`
-- `ORION_DISPATCH_MAX_PER_DAY` (rolling UTC calendar day, counted against `substrate_dispatch_results`)
+- `ORION_DISPATCH_MAX_RISK_PER_DAY` (rolling UTC calendar day) -- a real cumulative risk-score
+  budget, not a blind action count. Replaces the old `ORION_DISPATCH_MAX_PER_DAY` (2026-07-26):
+  that was a hand-picked round number (checked-in 24, live-drifted to an unexplained 88) never
+  validated against real behavior -- exactly the kind of un-measured hand-authored proxy the
+  Sentience Striving Program exists to replace. Each dispatched candidate already carries a
+  real, already-computed `risk_score` ([0,1]); the budget is spent against the sum of those
+  scores (`ExecutionDispatchRuntimeStore.sum_risk_dispatched_today()`, reading
+  `dispatched_candidates` off `substrate_execution_dispatch_frames`, not
+  `substrate_dispatch_results`), so five trivial inspects no longer cost the same as five
+  genuinely higher-risk candidates. The default (10.0) is anchored to real observed data (the
+  first day this pipeline dispatched successfully spent a real cumulative risk of 4.4 across 88
+  dispatches) rather than a fresh guess, but is still a disclosed starting judgment call --
+  expect it to need re-derivation as more real history accumulates across a wider risk_score mix.
 
 **Theater tripwire**: if more than half of the trailing 10 real results have `status="empty"`
 (a real send that produced no usable observation), the worker stops sending for the rest of

--- a/services/orion-execution-dispatch-runtime/app/settings.py
+++ b/services/orion-execution-dispatch-runtime/app/settings.py
@@ -43,7 +43,26 @@ class Settings(BaseSettings):
     execution_dispatch_rpc_timeout_sec: float = Field(
         120.0, alias="EXECUTION_DISPATCH_RPC_TIMEOUT_SEC"
     )
-    orion_dispatch_max_per_day: int = Field(24, alias="ORION_DISPATCH_MAX_PER_DAY")
+    # Replaces the old ORION_DISPATCH_MAX_PER_DAY (a blind action count, never
+    # empirically derived -- confirmed 2026-07-25 the checked-in default (24)
+    # and the live drifted value (88) both trace to a hand-picked round
+    # number in docs/superpowers/specs/2026-07-13-endogenous-action-motor-
+    # nerve-spec.md's risk table, never validated against real behavior).
+    # This budget is spent against each dispatched candidate's own real,
+    # already-computed `risk_score` (ExecutionDispatchCandidateV1.risk_score,
+    # [0,1] per candidate) instead of counting actions -- five trivial
+    # inspects (risk_score ~0.05 each) no longer cost the same as five
+    # higher-risk candidates. Starting value anchored to real observed
+    # data, not another guess: the first real day this pipeline dispatched
+    # successfully (2026-07-26, post theater-tripwire fix) spent a real
+    # cumulative risk of 4.4 across 88 dispatches (all risk_score=0.05 that
+    # day). This default is ~2x that real observed total -- a margin over
+    # actually-observed behavior, not a fresh round number. Needs real
+    # re-derivation as more real history accumulates across a wider mix of
+    # dispatch_kind/risk_score, per this program's own "measure before
+    # minting" discipline -- treat this as a disclosed starting judgment
+    # call, not a settled constant.
+    orion_dispatch_max_risk_per_day: float = Field(10.0, alias="ORION_DISPATCH_MAX_RISK_PER_DAY")
     action_outcome_channel: str = Field(
         "orion:autonomy:action:outcome", alias="BUS_ACTION_OUTCOME_OUT"
     )

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -295,7 +295,18 @@ class ExecutionDispatchRuntimeStore:
             "raw_len": row["raw_len"],
         }
 
-    def count_dispatches_today(self) -> int:
+    def sum_risk_dispatched_today(self) -> float:
+        """Real cumulative risk_score spent today, not a blind action count.
+
+        Replaces count_dispatches_today() (2026-07-26) -- a flat count
+        couldn't distinguish five trivial risk_score~0.05 inspects from five
+        genuinely higher-risk candidates. Reads `dispatched_candidates` off
+        `substrate_execution_dispatch_frames` directly -- each candidate
+        already carries its own real, already-computed `risk_score`
+        (ExecutionDispatchCandidateV1.risk_score); no schema migration or
+        new column needed, this is purely a smarter read of data already
+        being written.
+        """
         # Explicit UTC bound computed in Python, not date_trunc('day', now())
         # -- matches this file's own datetime.now(timezone.utc) convention
         # elsewhere and doesn't depend on the Postgres session's configured
@@ -307,14 +318,26 @@ class ExecutionDispatchRuntimeStore:
             row = conn.execute(
                 text(
                     """
-                    SELECT count(*) AS n
-                    FROM substrate_dispatch_results
-                    WHERE created_at >= :today_start
+                    SELECT COALESCE(SUM((cand.value ->> 'risk_score')::float), 0.0) AS total_risk
+                    FROM substrate_execution_dispatch_frames f
+                    CROSS JOIN LATERAL jsonb_array_elements(
+                        f.dispatch_frame_json -> 'dispatched_candidates'
+                    ) AS cand(value)
+                    WHERE f.created_at >= :today_start
+                      -- jsonb_array_elements() errors on a literal JSON null
+                      -- (as opposed to a missing key or a real [] array) --
+                      -- not reachable today (Pydantic's default_factory=list
+                      -- means normal serialization can't produce one, and
+                      -- 0 of today's real rows have this shape, confirmed
+                      -- live), but this guard means a future/legacy row of
+                      -- that shape degrades that row to zero contribution
+                      -- instead of throwing this whole query.
+                      AND jsonb_typeof(f.dispatch_frame_json -> 'dispatched_candidates') = 'array'
                     """
                 ),
                 {"today_start": today_start_utc},
             ).mappings().first()
-        return int(row["n"]) if row else 0
+        return float(row["total_risk"]) if row else 0.0
 
     def recent_dispatch_result_statuses(self, limit: int = 10) -> list[str]:
         """Kept, not removed: no longer called by worker.py's theater tripwire

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -31,6 +31,18 @@ logger = logging.getLogger("orion.execution_dispatch.runtime")
 
 THEATER_TRIPWIRE_WINDOW = 10
 THEATER_TRIPWIRE_EMPTY_THRESHOLD = 0.5
+# Real, disclosed gap closed defensively (review, 2026-07-26): every live
+# proposal_kind_to_cortex-routed template today has base_risk >= 0.02 (the
+# one base_risk=0.0 template, defer_due_to_low_readiness, has no cortex
+# route and never reaches a dispatch candidate) -- so risk_score=0.0 is not
+# currently reachable in production. But ExecutionDispatchCandidateV1.
+# risk_score only enforces [0,1] at the schema level, nothing prevents a
+# future template from shipping one at 0.0, and a genuinely zero-risk
+# candidate would make the cumulative risk budget below provide no ceiling
+# at all (cumulative_risk + 0.0 > remaining_risk_budget is never true once
+# remaining_risk_budget is positive). This floor is a config-independent
+# backstop, not a claim any real candidate is actually this risky.
+MINIMUM_REAL_RISK_FLOOR = 0.01
 # ActionOutcomeEmitV1.summary lands in chat-visible evidence via
 # chat_stance.py's _project_recent_dispatch_actions -- bounded here at the
 # producer so nothing downstream needs to re-truncate raw model output.
@@ -164,23 +176,41 @@ class ExecutionDispatchRuntimeWorker:
         if self._check_theater_tripwire():
             return frame  # tripped (this tick or a prior one) -- send nothing
 
-        remaining_daily_budget = (
-            self._settings.orion_dispatch_max_per_day - self._store.count_dispatches_today()
+        remaining_risk_budget = (
+            self._settings.orion_dispatch_max_risk_per_day - self._store.sum_risk_dispatched_today()
         )
-        if remaining_daily_budget <= 0:
+        if remaining_risk_budget <= 0:
             logger.info(
-                "execution_dispatch_daily_cap_reached max_per_day=%d",
-                self._settings.orion_dispatch_max_per_day,
+                "execution_dispatch_daily_risk_cap_reached max_risk_per_day=%.4f",
+                self._settings.orion_dispatch_max_risk_per_day,
             )
             return frame
 
-        budget = max(0, min(remaining_daily_budget, self._policy.limits.max_dispatches_per_tick))
-        if budget <= 0:
-            return frame
+        # Real, risk-weighted selection -- not a blind count. `frame.candidates`
+        # is already priority-sorted (build_proposal_frame), so this takes
+        # the highest-priority prepared candidates whose cumulative
+        # risk_score fits inside what's left of today's real budget,
+        # stopping at the first one that would exceed it (no skip-ahead to
+        # squeeze in a smaller one later, matching the existing simple
+        # sequential-take style this replaces). max_dispatches_per_tick
+        # stays a separate, independent per-tick burst cap.
+        to_send: list[ExecutionDispatchCandidateV1] = []
+        cumulative_risk = 0.0
+        for candidate in frame.candidates:
+            if candidate.dispatch_status != "prepared_for_dispatch":
+                continue
+            if len(to_send) >= self._policy.limits.max_dispatches_per_tick:
+                break
+            # max(..., MINIMUM_REAL_RISK_FLOOR): a real risk_score=0.0 must
+            # still cost something against the daily budget, or the budget
+            # provides no ceiling at all for that candidate (see the
+            # constant's own docstring above).
+            spend = max(candidate.risk_score, MINIMUM_REAL_RISK_FLOOR)
+            if cumulative_risk + spend > remaining_risk_budget:
+                break
+            to_send.append(candidate)
+            cumulative_risk += spend
 
-        to_send = [c for c in frame.candidates if c.dispatch_status == "prepared_for_dispatch"][
-            :budget
-        ]
         if not to_send:
             return frame
 

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -264,19 +264,19 @@ def test_save_dispatch_result_inserts_expected_row(monkeypatch) -> None:
     assert params["raw_len"] == 6
 
 
-def test_count_dispatches_today_returns_row_count(monkeypatch) -> None:
+def test_sum_risk_dispatched_today_returns_real_cumulative_risk(monkeypatch) -> None:
     store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
     fake_engine = MagicMock()
     conn = MagicMock()
     fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
     fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
-    conn.execute.return_value.mappings.return_value.first.return_value = {"n": 3}
+    conn.execute.return_value.mappings.return_value.first.return_value = {"total_risk": 4.4}
     monkeypatch.setattr(store, "_engine", fake_engine)
 
-    assert store.count_dispatches_today() == 3
+    assert store.sum_risk_dispatched_today() == 4.4
 
 
-def test_count_dispatches_today_zero_when_no_row(monkeypatch) -> None:
+def test_sum_risk_dispatched_today_zero_when_no_row(monkeypatch) -> None:
     store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
     fake_engine = MagicMock()
     conn = MagicMock()
@@ -285,7 +285,7 @@ def test_count_dispatches_today_zero_when_no_row(monkeypatch) -> None:
     conn.execute.return_value.mappings.return_value.first.return_value = None
     monkeypatch.setattr(store, "_engine", fake_engine)
 
-    assert store.count_dispatches_today() == 0
+    assert store.sum_risk_dispatched_today() == 0.0
 
 
 def test_recent_dispatch_result_statuses_returns_ordered_list(monkeypatch) -> None:

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -118,7 +118,9 @@ def _make_worker(monkeypatch) -> ExecutionDispatchRuntimeWorker:
     return ExecutionDispatchRuntimeWorker()
 
 
-def _candidate(dispatch_id: str, status: str = "prepared_for_dispatch") -> ExecutionDispatchCandidateV1:
+def _candidate(
+    dispatch_id: str, status: str = "prepared_for_dispatch", risk_score: float = 0.05
+) -> ExecutionDispatchCandidateV1:
     return ExecutionDispatchCandidateV1(
         dispatch_id=dispatch_id,
         source_decision_id=f"pd:{dispatch_id}",
@@ -131,7 +133,7 @@ def _candidate(dispatch_id: str, status: str = "prepared_for_dispatch") -> Execu
         cortex_verb="substrate.inspect",
         cortex_mode="brain",
         request_envelope={"context": {"target_id": "capability:orchestration"}},
-        risk_score=0.05,
+        risk_score=risk_score,
         confidence_score=0.9,
     )
 
@@ -180,7 +182,7 @@ def _patch_bus_and_client(monkeypatch, outcomes: dict[str, object]) -> MagicMock
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(
@@ -212,7 +214,7 @@ async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None
 @pytest.mark.asyncio
 async def test_send_one_emits_action_outcome_on_success(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(
@@ -237,7 +239,7 @@ async def test_send_one_emits_action_outcome_on_success(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_send_one_emits_action_outcome_on_empty_observation(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(monkeypatch, {"dispatch:1": {"result": {"final_text": ""}}})
@@ -254,7 +256,7 @@ async def test_send_one_emits_action_outcome_on_empty_observation(monkeypatch) -
 @pytest.mark.asyncio
 async def test_send_one_emits_action_outcome_on_rpc_failure(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(monkeypatch, {"dispatch:1": RuntimeError("rpc timed out")})
@@ -278,7 +280,7 @@ async def test_send_one_re_emits_action_outcome_on_idempotent_replay(monkeypatch
     # that emit itself failed transiently -- every later tick also hits
     # this same replay branch, so there'd be no other chance to retry it.
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
         return_value={
@@ -304,7 +306,7 @@ async def test_send_one_re_emits_action_outcome_on_idempotent_replay(monkeypatch
 @pytest.mark.asyncio
 async def test_send_one_action_outcome_publish_failure_does_not_raise(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(
@@ -324,7 +326,7 @@ async def test_send_one_action_outcome_publish_failure_does_not_raise(monkeypatc
 @pytest.mark.asyncio
 async def test_send_one_action_outcome_summary_is_truncated(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     long_observation = "x" * 5000
@@ -343,7 +345,7 @@ async def test_send_one_action_outcome_summary_is_truncated(monkeypatch) -> None
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(monkeypatch, {"dispatch:1": RuntimeError("rpc timed out")})
@@ -362,7 +364,7 @@ async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeyp
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_empty_observation_status_empty(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(monkeypatch, {"dispatch:1": {"result": {"final_text": ""}}})
@@ -385,7 +387,7 @@ async def test_send_prepared_candidates_respects_per_tick_budget(monkeypatch) ->
     worker._policy = worker._policy.model_copy(
         update={"limits": worker._policy.limits.model_copy(update={"max_dispatches_per_tick": 1})}
     )
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
@@ -406,13 +408,152 @@ async def test_send_prepared_candidates_respects_per_tick_budget(monkeypatch) ->
 
 
 @pytest.mark.asyncio
+async def test_send_prepared_candidates_stops_at_first_candidate_exceeding_remaining_risk_budget(
+    monkeypatch,
+) -> None:
+    """The real, new behavior this patch adds: selection is risk-weighted,
+    not a blind count. A candidate whose own risk_score would push
+    cumulative spend over what's left of today's budget is left prepared
+    (not sent, and not skipped-past to try a smaller one later in priority
+    order -- matches the existing simple sequential-take style)."""
+    worker = _make_worker(monkeypatch)
+    worker._settings.orion_dispatch_max_risk_per_day = 0.10
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    _patch_bus_and_client(
+        monkeypatch,
+        {
+            "dispatch:1": {"result": {"final_text": '{"observation": "a"}'}},
+            "dispatch:2": {"result": {"final_text": '{"observation": "b"}'}},
+        },
+    )
+    # risk_score 0.06 + 0.06 = 0.12 > the 0.10 budget -- the second must not send.
+    frame = _frame_with_candidates(
+        _candidate("dispatch:1", risk_score=0.06), _candidate("dispatch:2", risk_score=0.06)
+    )
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert len(updated.dispatched_candidates) == 1
+    assert updated.dispatched_candidates[0].dispatch_id == "dispatch:1"
+    assert len(updated.candidates) == 1
+    assert updated.candidates[0].dispatch_id == "dispatch:2"
+    assert updated.candidates[0].dispatch_status == "prepared_for_dispatch"
+    worker._store.save_dispatch_result.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_sends_all_when_cumulative_risk_fits_budget(
+    monkeypatch,
+) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._policy = worker._policy.model_copy(
+        update={"limits": worker._policy.limits.model_copy(update={"max_dispatches_per_tick": 5})}
+    )
+    worker._settings.orion_dispatch_max_risk_per_day = 1.0
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    _patch_bus_and_client(
+        monkeypatch,
+        {
+            "dispatch:1": {"result": {"final_text": '{"observation": "a"}'}},
+            "dispatch:2": {"result": {"final_text": '{"observation": "b"}'}},
+            "dispatch:3": {"result": {"final_text": '{"observation": "c"}'}},
+        },
+    )
+    frame = _frame_with_candidates(
+        _candidate("dispatch:1", risk_score=0.05),
+        _candidate("dispatch:2", risk_score=0.05),
+        _candidate("dispatch:3", risk_score=0.05),
+    )
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert len(updated.dispatched_candidates) == 3
+    assert updated.candidates == []
+    assert worker._store.save_dispatch_result.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_skips_non_prepared_without_consuming_per_tick_budget(
+    monkeypatch,
+) -> None:
+    """Defensive coverage for a shape not currently reachable in production
+    (build_execution_dispatch_frame routes anything not prepared_for_dispatch
+    into blocked_candidates, never candidates -- confirmed via review) but
+    real code path nonetheless: a non-prepared candidate earlier in
+    frame.candidates must not count against max_dispatches_per_tick before
+    the loop reaches a real prepared one."""
+    worker = _make_worker(monkeypatch)
+    worker._policy = worker._policy.model_copy(
+        update={"limits": worker._policy.limits.model_copy(update={"max_dispatches_per_tick": 1})}
+    )
+    worker._settings.orion_dispatch_max_risk_per_day = 1.0
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    _patch_bus_and_client(
+        monkeypatch, {"dispatch:2": {"result": {"final_text": '{"observation": "b"}'}}}
+    )
+    frame = _frame_with_candidates(
+        _candidate("dispatch:1", status="blocked"),
+        _candidate("dispatch:2"),
+    )
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert len(updated.dispatched_candidates) == 1
+    assert updated.dispatched_candidates[0].dispatch_id == "dispatch:2"
+    worker._store.save_dispatch_result.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_zero_risk_candidate_still_spends_the_floor(
+    monkeypatch,
+) -> None:
+    """MINIMUM_REAL_RISK_FLOOR closes a real, disclosed gap: a risk_score=0.0
+    candidate (not reachable with today's live proposal templates, but not
+    prevented at the schema level either) must still cost something against
+    the daily budget, or the budget provides no ceiling at all for it."""
+    worker = _make_worker(monkeypatch)
+    worker._policy = worker._policy.model_copy(
+        update={"limits": worker._policy.limits.model_copy(update={"max_dispatches_per_tick": 5})}
+    )
+    worker._settings.orion_dispatch_max_risk_per_day = worker_mod.MINIMUM_REAL_RISK_FLOOR
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    _patch_bus_and_client(
+        monkeypatch,
+        {
+            "dispatch:1": {"result": {"final_text": '{"observation": "a"}'}},
+            "dispatch:2": {"result": {"final_text": '{"observation": "b"}'}},
+        },
+    )
+    frame = _frame_with_candidates(
+        _candidate("dispatch:1", risk_score=0.0), _candidate("dispatch:2", risk_score=0.0)
+    )
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    # Budget is exactly one floor-spend's worth -- the first candidate fits
+    # (spends the floor, hitting the budget exactly), the second does not.
+    assert len(updated.dispatched_candidates) == 1
+    assert updated.dispatched_candidates[0].dispatch_id == "dispatch:1"
+    assert len(updated.candidates) == 1
+    assert updated.candidates[0].dispatch_id == "dispatch:2"
+
+
+@pytest.mark.asyncio
 async def test_send_one_replays_existing_result_without_resending(monkeypatch) -> None:
     # Crash-recovery scenario: dispatch_id is deterministic, so if a prior
     # tick already sent this exact candidate and recorded a result (but the
     # process died before save_dispatch_frame persisted that), the next
     # tick must NOT fire a second real cortex-exec RPC for it.
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
         return_value={
@@ -436,7 +577,7 @@ async def test_send_one_replays_existing_result_without_resending(monkeypatch) -
 @pytest.mark.asyncio
 async def test_send_one_replays_existing_failed_result_without_resending(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
         return_value={
@@ -459,10 +600,10 @@ async def test_send_one_replays_existing_failed_result_without_resending(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_send_prepared_candidates_skips_when_daily_cap_reached(monkeypatch) -> None:
+async def test_send_prepared_candidates_skips_when_daily_risk_cap_reached(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(
-        return_value=worker._settings.orion_dispatch_max_per_day
+    worker._store.sum_risk_dispatched_today = MagicMock(
+        return_value=worker._settings.orion_dispatch_max_risk_per_day
     )
     worker._store.save_dispatch_result = MagicMock()
     _patch_bus_and_client(monkeypatch, {})
@@ -484,7 +625,7 @@ async def test_send_prepared_candidates_skips_when_tripwire_active(monkeypatch) 
     worker._recent_dispatch_statuses = deque(
         ["empty"] * 6 + ["success"] * 4, maxlen=worker_mod.THEATER_TRIPWIRE_WINDOW
     )
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._notify.send = MagicMock()
     _patch_bus_and_client(monkeypatch, {})
@@ -504,7 +645,7 @@ async def test_send_prepared_candidates_tripwire_stays_tripped_across_calls(monk
     worker._recent_dispatch_statuses = deque(
         ["empty"] * 6 + ["success"] * 4, maxlen=worker_mod.THEATER_TRIPWIRE_WINDOW
     )
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     worker._store.save_dispatch_result = MagicMock()
     worker._notify.send = MagicMock()
     _patch_bus_and_client(monkeypatch, {})
@@ -520,7 +661,7 @@ async def test_send_prepared_candidates_tripwire_stays_tripped_across_calls(monk
 @pytest.mark.asyncio
 async def test_send_prepared_candidates_noop_when_nothing_prepared(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
-    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
     frame = _frame_with_candidates(_candidate("dispatch:1", status="blocked"))
 
     updated = await worker._send_prepared_candidates(frame)


### PR DESCRIPTION
## Summary

The daily dispatch cap (`ORION_DISPATCH_MAX_PER_DAY`) traced to a hand-picked round number in `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md`'s risk table (24, ~once/hour), never empirically derived — the live `.env` had also silently drifted to 88 with no record of who changed it or why. Exactly the kind of un-measured hand-authored proxy the Sentience Striving Program exists to replace with instruments measured against real outcomes.

**Replaced with `ORION_DISPATCH_MAX_RISK_PER_DAY`**: a real cumulative risk-score budget, spent against each dispatched candidate's own real, already-computed `risk_score` (`[0,1]`, `ExecutionDispatchCandidateV1.risk_score`) instead of counting actions. Five trivial `risk_score~0.05` inspects no longer cost the same as five genuinely higher-risk candidates. No schema migration needed — `sum_risk_dispatched_today()` reads `dispatched_candidates` (which already carries each candidate's `risk_score`) directly off `substrate_execution_dispatch_frames` via a JSONB lateral join, rather than adding a new column.

Default (10.0) is anchored to real observed data, not a fresh guess: the first real day this pipeline dispatched successfully (2026-07-26, after the same-day theater-tripwire fix in #1386) spent a real cumulative risk of 4.4 across 88 dispatches. ~2x that observed total — a disclosed starting judgment call per this program's own "measure before minting" discipline, not asserted as a settled number.

Live `.env` already synced directly (not deferred to an operator TODO).

## Tests run
```
cd services/orion-execution-dispatch-runtime && pytest tests/ -q   # (from repo root)
pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_runtime_store.py services/orion-execution-dispatch-runtime/tests/ -q
-> 47 passed
```
4 new tests: risk-weighted stop condition, cumulative-fits-budget, non-prepared-candidate defensive coverage, zero-risk-floor.

## Review findings fixed (orion-repo-agent)

- Finding (moderate): README.md's Budgets section still described the old count-based mechanism and the wrong backing table; rewritten to describe the real risk-budget mechanism and its real anchoring.
- Finding (low): no test covered a non-prepared candidate appearing before a real prepared one in `frame.candidates` — confirmed via review this shape isn't currently reachable in production (`build_execution_dispatch_frame` routes non-prepared candidates into `blocked_candidates`, never `candidates`), but added real defensive coverage anyway.
- Finding (low/design): a `risk_score=0.0` candidate would let the budget provide no ceiling at all for it — confirmed not live-exploitable today (every real `proposal_kind_to_cortex`-routed template has `base_risk >= 0.02`), but added `MINIMUM_REAL_RISK_FLOOR=0.01` as a config-independent backstop plus a dedicated test, since nothing at the schema level actually prevents a future template from shipping 0.0.
- Finding (low/robustness): `sum_risk_dispatched_today()`'s SQL would hard-error (not degrade) against a literal JSON `null` for `dispatched_candidates` — not reachable today (0 real rows have this shape, Pydantic's `default_factory=list` can't produce one), but added a `jsonb_typeof(...) = 'array'` guard so a future/legacy row of that shape degrades to zero contribution instead of throwing the whole query.

## Env/config changes

- Removed: `ORION_DISPATCH_MAX_PER_DAY`
- Added: `ORION_DISPATCH_MAX_RISK_PER_DAY=10.0`
- `.env_example` updated, live `.env` synced directly, `scripts/check_env_template_parity.py` passes clean.

## Restart required

```bash
docker restart orion-athena-execution-dispatch-runtime
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)