### PR TITLE
feat(substrate): wire bus_synaptic into AST/HOT confidence formula

### DIFF
--- a/docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md
+++ b/docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md
@@ -227,3 +227,32 @@ five instruments or into `dynamic_pressure` itself). The zombie
 independently confirmed and resolved same-day by the other thread that produced #1275/#1283
 (stopped and removed via `docker stop`/`docker rm`, confirmed via growing write-lag post-stop) —
 Recommended next patch step 1 is therefore already done, not still pending.
+
+## Revision, 2026-07-25 (`bus_synaptic` sixth domain wired into `ACTIVE_INFERENCE_DOMAINS`)
+
+Does not change the core recommendation or the theory-fit argument. Updates Item 3's status:
+one of its three named substrate-quality caveats now has a real, bounded, live-verified
+*replacement candidate* sitting alongside it — not a repair of it.
+
+A separate, concurrent session built `bus_synaptic_prediction_error()`
+(`orion/substrate/prediction_error.py`, PR #1377), aggregating live EWMA/z-score anomaly edges
+from the bus-synaptic-graph arc (`orion_bus_synapse` FalkorDB graph, written continuously by
+`services/orion-bus-mirror`). This patch (`feat/ast-hot-bus-synaptic-domain`) added
+`"bus_synaptic"` to `attention_self_model.py`'s `ACTIVE_INFERENCE_DOMAINS` frozenset (now
+`{execution, biometrics, chat, route, bus_synaptic}`, five domains) and to
+`scripts/analysis/measure_ast_hot_reducer.py`'s `PREDICTION_ERROR_DOMAIN_NODES`. Confirmed live
+before wiring (2026-07-25, 2h real window, `substrate_field_state`): 3534/3534 ticks (100%
+coverage) with real variance (min=0.17, max=1.0, mean=0.30) — not degenerate, and better coverage
+than execution/chat/route's near-0% live coverage at time of writing.
+
+**This does not resolve the transport miscalibration or route subnormal-float caveats named
+above.** The old `transport` domain (`transport_prediction_error()`, narrow 2-Redis-Streams
+scope) remains excluded from `ACTIVE_INFERENCE_DOMAINS` and unfixed. `bus_synaptic` is additive:
+a sixth instrument, five of which now feed the confidence aggregate, sitting next to (not
+replacing) the still-broken `transport` instrument. Item 3's metric-quality-gate pass still needs
+to independently clear route and the `execution_load`/`reasoning_load` substrate before being
+treated as fully gate-passable — this revision only adds a new, healthy contributor to the
+aggregate, it does not audit or fix the remaining two-and-a-half compromised domains.
+
+Also unchanged by this patch: the silent-timeout blind spot (Patch B / `harness_rpc_timeout`)
+remains open — `bus_synaptic`'s real coverage does not by itself detect a silently-hung turn.

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -25,18 +25,27 @@ producer that no longer exists (`orion/self_state/` was deleted, PR #1266;
 `orion-athena-self-state-runtime` was confirmed stopped same-day per
 `docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-
 design.md`'s Missing Question 1). Per that design doc's items 3/4: confidence
-is now the inverse of aggregate prediction-error volatility across the five
-real, live Predictive-Processing domains (execution/transport/biometrics/
-chat/route -- `orion/substrate/prediction_error.py`), and predicted_shift now
-names whichever domain's prediction-error is trending fastest, instead of a
-hand-tuned `SelfStateV1` dimension. Both are supplied by the caller as
-already-computed dicts (`prediction_error_by_domain`,
+is now the inverse of aggregate prediction-error volatility across the real,
+live Predictive-Processing domains (`orion/substrate/prediction_error.py`),
+and predicted_shift now names whichever domain's prediction-error is trending
+fastest, instead of a hand-tuned `SelfStateV1` dimension. Both are supplied by
+the caller as already-computed dicts (`prediction_error_by_domain`,
 `prediction_error_trend_by_domain`) -- this function stays a pure formatter/
 aggregator over them, matching its own "no I/O, no store coupling" design for
 every other input here. `self_state_present`/`self_state` are gone from both
 this signature and `AttentionSelfModelV1` -- not deprecated in place, removed
 (this repo's own "kill means kill" convention: no fallback to the thing being
 killed).
+
+**2026-07-25: sixth domain added, `bus_synaptic`.** The original five domains
+were execution/transport/biometrics/chat/route, but `transport` was excluded
+from `ACTIVE_INFERENCE_DOMAINS` (see that constant's docstring) as confirmed
+dead -- a real, bounded replacement now exists: `bus_synaptic`, built on top
+of the bus-synaptic-graph arc. `ACTIVE_INFERENCE_DOMAINS` now covers
+execution/biometrics/chat/route/bus_synaptic (five active domains, not six --
+the old broken `transport` domain remains present in
+`prediction_error_by_domain` when a caller supplies it, just still excluded
+from this filtered set).
 """
 
 from __future__ import annotations
@@ -60,16 +69,25 @@ DEFAULT_BROADCAST_STALE_THRESHOLD_SEC = 60.0
 # (`docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md`):
 # `transport_prediction_error` reads exactly 0.0 for 100% of a real 8h
 # window (`BUS_OBSERVER_STREAMS` only watches 2 real Redis Streams), so
-# averaging it in with the other four real, varying domains systematically
-# inflates confidence by a fixed, mechanical amount every tick -- harmless
-# while this formula fired on 0.04% of ticks, not harmless once it fires on
-# nearly all of them. Re-include `transport` here once a real, bounded,
-# prediction-error-shaped transport signal exists -- tracked as the
-# reversal condition against PR #1323's bus-synaptic-graph work, not before.
+# averaging it in with the other domains systematically inflates confidence
+# by a fixed, mechanical amount every tick.
+#
+# **`bus_synaptic` added 2026-07-25 -- this is the reversal condition named
+# above, now satisfied.** PR #1377 built a real, bounded, prediction-error-
+# shaped transport signal on top of the bus-synaptic-graph arc (PR #1323
+# onward): `bus_synaptic_prediction_error()` aggregates live EWMA/z-score
+# edges from the `orion_bus_synapse` FalkorDB graph, written continuously by
+# `services/orion-bus-mirror`. Confirmed live before adding here (2026-07-25,
+# 2h real window, `substrate_field_state`): 3534/3534 ticks (100% coverage --
+# better than execution/chat/route's near-0% coverage) with real variance
+# (min=0.17, max=1.0, mean=0.30), not the old `transport` domain's flat 0.0.
+# The old `transport` domain itself (`transport_prediction_error()`, narrow
+# 2-Redis-Streams scope) remains excluded and unfixed -- `bus_synaptic` is an
+# additive replacement candidate sitting alongside it, not a repair of it.
 # This constant does NOT affect the pre-existing branch-gated
 # `confidence`/`confidence_basis` fields below, which keep their original
 # (unfiltered, all-domains) formula unchanged -- additive only.
-ACTIVE_INFERENCE_DOMAINS = frozenset({"execution", "biometrics", "chat", "route"})
+ACTIVE_INFERENCE_DOMAINS = frozenset({"execution", "biometrics", "chat", "route", "bus_synaptic"})
 
 
 def _round_or_none(value: float | None, digits: int = 4) -> float | None:
@@ -194,11 +212,11 @@ def reduce_attention_self_model(
     default) reproduces today's narrative byte-for-byte.
 
     `prediction_error_by_domain` is an optional, caller-supplied snapshot of
-    the current raw `prediction_error` value for each of the five real
-    Predictive-Processing domains (`{"execution": 0.0001, "transport": 0.0,
-    "biometrics": 0.0459, "chat": ..., "route": ...}` -- keys are whatever
-    the caller has data for; missing domains are simply absent, not
-    defaulted to 0.0). Drives `confidence` in the `field_salience_only`
+    the current raw `prediction_error` value for each real Predictive-
+    Processing domain (`{"execution": 0.0001, "transport": 0.0,
+    "biometrics": 0.0459, "chat": ..., "route": ..., "bus_synaptic": 0.30}` --
+    keys are whatever the caller has data for; missing domains are simply
+    absent, not defaulted to 0.0). Drives `confidence` in the `field_salience_only`
     branch (see `_aggregate_prediction_error_confidence`). Omitting this
     argument falls back to the pre-existing
     `field_attention_frame.dominant_targets[].confidence_score` mean.

--- a/orion/substrate/tests/test_attention_self_model.py
+++ b/orion/substrate/tests/test_attention_self_model.py
@@ -387,6 +387,31 @@ class TestUnconditionalPredictionErrorConfidence:
         # exclusion -- confirms they are computed independently, not aliased.
         assert model.confidence != model.prediction_error_confidence
 
+    def test_bus_synaptic_included_in_domain_set(self) -> None:
+        # 2026-07-25: bus_synaptic is the reversal condition for the old
+        # transport exclusion -- a real, bounded signal now exists. When
+        # present in the caller's dict, it must be counted (5 domains, not
+        # 4), unlike transport which stays excluded even when supplied.
+        # {execution: 0.0001, biometrics: 0.0459, chat: 0.0, route: 0.0,
+        #  bus_synaptic: 0.30} -> mean = 0.0692 -> confidence = 0.9308
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(bus_synaptic=0.30),
+        )
+        assert model.prediction_error_confidence == pytest.approx(1.0 - 0.0692, abs=1e-4)
+        assert "bus_synaptic" in model.prediction_error_confidence_basis
+        assert "5 ACTIVE_INFERENCE_DOMAINS" in model.prediction_error_confidence_basis
+        assert "transport" not in model.prediction_error_confidence_basis
+
+    def test_only_bus_synaptic_data_is_sufficient_alone(self) -> None:
+        # Unlike transport (permanently excluded even alone), bus_synaptic
+        # alone must produce a real confidence value, not honestly-absent.
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain={"bus_synaptic": 0.5},
+        )
+        assert model.prediction_error_confidence == pytest.approx(0.5, abs=1e-4)
+
 
 def test_reference_tick_defaults_to_field_frame_generated_at() -> None:
     field_frame = _field_frame(generated_at=NOW)

--- a/scripts/analysis/measure_ast_hot_reducer.py
+++ b/scripts/analysis/measure_ast_hot_reducer.py
@@ -6,7 +6,7 @@ scaffolded-roadmap-design.md`. Replays the REAL, pure production reducer
 (`reduce_attention_self_model`, `orion/substrate/attention_self_model.py`)
 over real historical Postgres data for its inputs (`substrate_attention_
 frames` -> `FieldAttentionFrameV1`, `substrate_attention_broadcast_log` ->
-`AttentionBroadcastProjectionV1`, `substrate_field_state` -> the five
+`AttentionBroadcastProjectionV1`, `substrate_field_state` -> the
 Active-Inference domains' raw `prediction_error`), joined by nearest-
 preceding timestamp with the field lane's own tick cadence driving the
 replay (it is the highest-frequency real signal, per the Phase 1 design).
@@ -103,7 +103,7 @@ logger = logging.getLogger("orion.analysis.ast_hot_reducer")
 DEFAULT_WINDOW_HOURS: float = 48.0
 MAX_ROWS: int = 200_000
 
-# The five real, live Predictive-Processing domains
+# The real, live Predictive-Processing domains
 # (`orion/substrate/prediction_error.py`), keyed by their FieldStateV1 node
 # id. `node:substrate.transport` is included despite its documented
 # structurally-narrow scope (`services/orion-substrate-runtime/README.md`'s
@@ -117,6 +117,12 @@ PREDICTION_ERROR_DOMAIN_NODES: dict[str, str] = {
     "biometrics": "node:substrate.biometrics",
     "chat": "node:substrate.chat",
     "route": "node:substrate.route",
+    # Sixth domain, added 2026-07-25 (PR #1377): real EWMA/z-score anomaly
+    # signal aggregated over the live bus synaptic graph (orion_bus_synapse),
+    # written by services/orion-substrate-runtime/app/worker.py::_bus_synaptic_tick.
+    # Confirmed live before adding here: real, varying error values (not
+    # degenerate) across ~200 real edges per tick.
+    "bus_synaptic": "node:substrate.bus_synaptic",
 }
 
 # Trend window, in field_state ticks, split into two equal halves (recent vs
@@ -160,8 +166,9 @@ class ReplayTick:
 
 
 def extract_prediction_error_by_domain(field_state_payload: dict) -> dict[str, float]:
-    """Pull the current raw `prediction_error` value for each of the five
-    real domains out of one `FieldStateV1.node_vectors` payload. Only
+    """Pull the current raw `prediction_error` value for each real domain
+    (`PREDICTION_ERROR_DOMAIN_NODES`) out of one `FieldStateV1.node_vectors`
+    payload. Only
     includes a domain if its node and channel are actually present in this
     payload -- missing, not defaulted to 0.0, so a genuinely absent domain
     doesn't silently masquerade as "confirmed calm" in the aggregate.
@@ -214,13 +221,17 @@ def compute_prediction_error_trend(
     methodology and numbers:
     `docs/superpowers/specs/2026-07-23-predicted-shift-reversion-finding.md`.
 
-    **Validated on biometrics only, applied to all five domains.** No
+    **Validated on biometrics only, applied to all domains.** No
     independent data exists yet for execution/transport/chat/route --
     applying the same reversion sign to them is a reasoned extrapolation
-    (all five domains are computed the same way, as deltas between
+    (those domains are computed the same way, as deltas between
     successive states from discrete events -- turns, exec steps, tool
     calls -- so the same spike-and-settle dynamic is plausible), not an
-    independently confirmed one. In practice this mostly matters for
+    independently confirmed one. `bus_synaptic` (added 2026-07-25) is a
+    different computation shape (live EWMA/z-score edges, not a
+    successive-state delta) and is even less covered by this
+    extrapolation -- also unvalidated, not just unconfirmed by analogy. In
+    practice this mostly matters for
     biometrics anyway (it wins the cross-domain argmax the overwhelming
     majority of the time in live replay -- see the reducer script's own
     report), but a future pass should back-test the other four domains
@@ -437,7 +448,7 @@ def fetch_field_attention_rows(conn, since: datetime) -> tuple[list[tuple[dateti
 
 
 def fetch_field_state_rows(conn, since: datetime) -> tuple[list[tuple[datetime, dict]], bool]:
-    """Raw `FieldStateV1` snapshots -- the source of the five Active-
+    """Raw `FieldStateV1` snapshots -- the source of the Active-
     Inference domains' `prediction_error` (see `PREDICTION_ERROR_DOMAIN_
     NODES`/`extract_prediction_error_by_domain`). Replaces
     `fetch_self_state_rows` (removed 2026-07-23, same producer-killed reason
@@ -690,7 +701,7 @@ def render_report(
         "Read-only. No writes, no events, no flag/config changes. Replays the real "
         "`reduce_attention_self_model` production function over historical "
         "`substrate_attention_frames` (field lane, drives cadence), "
-        "`substrate_field_state` (five Active-Inference domains' `prediction_error`), "
+        "`substrate_field_state` (Active-Inference domains' `prediction_error`), "
         "and `substrate_attention_broadcast_log` rows, all joined by nearest-preceding "
         "timestamp.",
         "",

--- a/scripts/analysis/tests/test_measure_ast_hot_reducer.py
+++ b/scripts/analysis/tests/test_measure_ast_hot_reducer.py
@@ -77,6 +77,17 @@ class TestExtractPredictionErrorByDomain:
         out = mod.extract_prediction_error_by_domain(payload)
         assert out == {"execution": 0.1, "biometrics": 0.5}
 
+    def test_extracts_bus_synaptic_sixth_domain(self) -> None:
+        # 2026-07-25: bus_synaptic added to PREDICTION_ERROR_DOMAIN_NODES
+        # (PR #1377's node:substrate.bus_synaptic) -- must extract like any
+        # other domain, no special-casing needed given the generic
+        # dict-driven extraction loop.
+        assert "bus_synaptic" in mod.PREDICTION_ERROR_DOMAIN_NODES
+        assert mod.PREDICTION_ERROR_DOMAIN_NODES["bus_synaptic"] == "node:substrate.bus_synaptic"
+        payload = _field_state_payload(BASE, bus_synaptic=0.3)
+        out = mod.extract_prediction_error_by_domain(payload)
+        assert out == {"bus_synaptic": 0.3}
+
     def test_missing_node_vectors_yields_empty_dict(self) -> None:
         assert mod.extract_prediction_error_by_domain({}) == {}
 

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -418,6 +418,18 @@ restarts. **Do not wire any consumer to `node:substrate.bus_synaptic`** (e.g. fo
 `prediction_error_confidence`, PR #1329) until the sanity-check pass has run against real
 accumulated history, not just this first live sample.
 
+**Sanity-check pass cleared, 2026-07-25/26: first consumer wired.** A 2h real-window query
+against `substrate_field_state` (not the first-sample check above) found 3534/3534 ticks (100%
+coverage) with real, non-degenerate variance (min=0.17, max=1.0, mean=0.30) — better coverage
+than 3 of the original 5 `prediction_error` domains at time of writing. On that basis,
+`orion/substrate/attention_self_model.py`'s `ACTIVE_INFERENCE_DOMAINS` frozenset now includes
+`"bus_synaptic"` (five active domains: execution, biometrics, chat, route, bus_synaptic), feeding
+`prediction_error_confidence`. This is a different consumer than `orion-equilibrium-service`'s
+transport metacog gate (PRs #1385/#1387, wired separately, same node). The still-broken `transport`
+domain (`transport_prediction_error()`) remains excluded and unfixed — see
+`docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`'s
+2026-07-25 revision for the full caveat.
+
 **Fixed 2026-07-25 (same day, follow-up): the 5 new env keys above weren't reaching the
 container.** Same class of gotcha already documented for `SUBSTRATE_STORE_BACKEND`/`FALKORDB_URI`
 in this service's `.env_example` (not elsewhere in this README) — `docker-compose.yml` passes env vars through via an explicit


### PR DESCRIPTION
## Summary

- A separate concurrent session built `bus_synaptic_prediction_error()` (PR #1377) on top of this session's bus-synaptic-graph arc, writing real EWMA/z-score anomaly values to `node:substrate.bus_synaptic`, gated off by default and enabled live 2026-07-25 (PR #1380).
- Live-verified before wiring: 2h real Postgres window against `substrate_field_state` shows 3534/3534 ticks (100% coverage) with real, non-degenerate variance (min=0.17, max=1.0, mean=0.30) — better coverage than 3 of the original 5 domains.
- Added `"bus_synaptic"` to `attention_self_model.py`'s `ACTIVE_INFERENCE_DOMAINS` frozenset (5 active domains now: execution/biometrics/chat/route/bus_synaptic) and to `measure_ast_hot_reducer.py`'s `PREDICTION_ERROR_DOMAIN_NODES`.
- Purely additive — the still-broken `transport` domain remains excluded and unfixed, and this is a different consumer than `orion-equilibrium-service`'s transport metacog gate (PRs #1385/#1387, wired separately to the same node).
- Updated the AST/HOT design spec and substrate-runtime README with dated revision sections, and swept 5 stale "five domains" mentions in `measure_ast_hot_reducer.py` left over from adding the sixth entry (including a report-string literal that would have silently undercounted in generated output — caught by a review subagent pass).

## Outcome moved

`prediction_error_confidence`, the AST/HOT self-model's aggregate surprise-based confidence field, now incorporates a live, well-covered sixth Active-Inference instrument instead of only the four originally-healthy domains (execution/biometrics/chat/route — transport was already known-dead).

## Current architecture

`orion/substrate/attention_self_model.py::reduce_attention_self_model()` produces `AttentionSelfModelV1` (attended target, why, confidence, predicted shift) — pure, no I/O, no live bus wiring yet (per the Sentience Striving Program charter's "measure before minting" rule). Its only real caller is the replay/measurement script `scripts/analysis/measure_ast_hot_reducer.py`. `ACTIVE_INFERENCE_DOMAINS` gates which domains feed the unconditional `prediction_error_confidence` field; it excluded `transport` (confirmed dead, flat 0.0 for an 8h window) and had no sixth-domain candidate until PR #1377 built one on the bus-synaptic-graph arc.

## Architecture touched

- `orion/substrate/attention_self_model.py` — `ACTIVE_INFERENCE_DOMAINS` frozenset + docstrings.
- `scripts/analysis/measure_ast_hot_reducer.py` — `PREDICTION_ERROR_DOMAIN_NODES` dict + docstring sweep.
- Design docs (spec revision, README note).

## Files changed

- `orion/substrate/attention_self_model.py`: added `bus_synaptic` to `ACTIVE_INFERENCE_DOMAINS`, documented the reversal-condition satisfaction.
- `orion/substrate/tests/test_attention_self_model.py`: two new tests (`test_bus_synaptic_included_in_domain_set`, `test_only_bus_synaptic_data_is_sufficient_alone`).
- `scripts/analysis/measure_ast_hot_reducer.py`: added `bus_synaptic` entry to `PREDICTION_ERROR_DOMAIN_NODES`; swept 5 stale "five domains" mentions (module docstring, dict comment, `extract_prediction_error_by_domain` docstring, trend-validation comment, generated report-string literal).
- `scripts/analysis/tests/test_measure_ast_hot_reducer.py`: one new test (`test_extracts_bus_synaptic_sixth_domain`).
- `docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`: new dated revision section.
- `services/orion-substrate-runtime/README.md`: note that the sanity-check gate cleared and the first consumer is now wired.

## Schema / bus / API changes

- Added: none (no schema change — `bus_synaptic` was already a valid dict key produced upstream by PR #1377; this patch only changes which keys `ACTIVE_INFERENCE_DOMAINS` includes).
- Removed: none.
- Renamed: none.
- Behavior changed: `reduce_attention_self_model()`'s `prediction_error_confidence`/`prediction_error_confidence_basis` now include `bus_synaptic` when present in the caller's `prediction_error_by_domain` dict. No live production caller exists yet (only the replay script), so no live behavior change beyond that script's own output.
- Compatibility notes: purely additive; the pre-existing unfiltered `confidence`/`confidence_basis` field is unaffected by `ACTIVE_INFERENCE_DOMAINS` and unchanged by this patch.

## Env/config changes

- None. No `.env_example` changes required.

## Tests run

```text
PYTHONPATH="." /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest orion/substrate/tests/test_attention_self_model.py scripts/analysis/tests/test_measure_ast_hot_reducer.py -q
52 passed
```

## Evals run

None — this repo has no dedicated eval harness for `orion/substrate/attention_self_model.py` or `scripts/analysis/measure_ast_hot_reducer.py` beyond their own test suites; the replay script itself functions as the measurement/eval tool and was run manually against live Postgres data as part of the pre-wiring sanity check (see Summary).

## Docker/build/smoke checks

Not applicable — no runtime/service/Docker changes. `reduce_attention_self_model()` has no live bus wiring; this patch only changes a pure-function frozenset and a replay script's lookup dict.

## Review findings fixed

- Finding: 5 stale "five domains" mentions left in `scripts/analysis/measure_ast_hot_reducer.py` after adding the sixth `bus_synaptic` entry to `PREDICTION_ERROR_DOMAIN_NODES` — including a literal string baked into the generated markdown report (`report.md`) that would have silently undercounted going forward.
  - Fix: swept all 5 spots (module docstring, dict comment, `extract_prediction_error_by_domain` docstring, trend-validation comment noting `bus_synaptic` is a different computation shape and even less validated by the existing biometrics-only backtest, and the report-string literal).
  - Evidence: `grep -n "five" scripts/analysis/measure_ast_hot_reducer.py` returns 0 matches post-fix; full test suite re-run after the fix, 52/52 still pass.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: low
- Concern: `bus_synaptic` is a different computation shape (live EWMA/z-score edges read fresh each tick) than the other 4 active domains (deltas between successive discrete-event states), so the existing reversion-trend extrapolation (validated on biometrics only) is even less applicable to it than to execution/chat/route.
- Mitigation: documented explicitly in the trend-computation docstring; no consumer currently relies on `bus_synaptic`'s trend value for anything live.

## PR link

(filled in below)