### PR TITLE
fix(substrate): correct bus_synaptic calm-floor bias in prediction_error

### DIFF
--- a/docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md
+++ b/docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md
@@ -256,3 +256,29 @@ aggregate, it does not audit or fix the remaining two-and-a-half compromised dom
 
 Also unchanged by this patch: the silent-timeout blind spot (Patch B / `harness_rpc_timeout`)
 remains open — `bus_synaptic`'s real coverage does not by itself detect a silently-hung turn.
+
+## Revision, 2026-07-26 (`bus_synaptic` calm-floor bias found and fixed)
+
+The 2026-07-25 revision above checked `bus_synaptic`'s live-data non-degeneracy (real variance,
+100% coverage) but not its commensurability with the other four active domains -- whether its
+"calm" reading is actually comparable to their genuine-zero rest state. It wasn't:
+`bus_synaptic_prediction_error()` computed `mean(|zscore|) / 3.0`, and `mean(|Z|)` for a calm,
+~N(0,1)-distributed population has expected value `sqrt(2/pi) ≈ 0.798`, not 0. Confirmed against
+the same 2h real window this revision's numbers came from: recovered raw `mean(|z|)` values had a
+median of 0.7995 (essentially exactly this constant), and the domain never read below ~0.17
+regardless of real mesh conditions. Folded into the unweighted `prediction_error_confidence` mean,
+this silently depressed confidence whenever the mesh had any traffic at all -- in this window,
+confidence with `bus_synaptic` included (~0.927) vs. without it (~0.989) differed almost entirely
+because of this artifact, not real surprise.
+
+Fixed in `orion/substrate/prediction_error.py::bus_synaptic_prediction_error()` by subtracting the
+theoretical calm floor before saturating (same 3.0 ceiling, unchanged). Re-validated against the
+same real window under the corrected formula: median drops to 0.0 (55.8% of ticks read `<0.01`),
+real spikes up to ~0.98 preserved. `orion-equilibrium-service`'s transport metacog gate
+(PRs #1385/#1387) is unaffected -- its `error_threshold` default (`1.0`, the saturation ceiling)
+is reached under both the old and new formula only at raw `mean(|z|) >= 3.0`, an identical fire
+condition.
+
+This does not change Item 3's other caveats (transport miscalibration, route subnormal float,
+`execution_load`/`reasoning_load` substrate) -- those remain open. It is a correction to this
+same revision's own claim that the sanity-check pass had cleared `bus_synaptic`, not a new item.

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from orion.schemas.biometrics_projection import NodeBiometricsProjectionV1
@@ -16,6 +17,18 @@ _THRESHOLD = 0.30
 # Reuses the zscore_threshold=3.0 convention already live in
 # services/orion-hub/scripts/bus_synaptic_graph_routes.py's anomalies() route.
 _BUS_SYNAPTIC_ZSCORE_SATURATION = 3.0
+
+# 2026-07-26: floor-bias fix. mean(|z|) over a batch of ~N(0,1)-distributed
+# z-scores does NOT rest at 0 when traffic is genuinely calm -- E[|Z|] for a
+# standard normal is sqrt(2/pi), not 0, because averaging absolute values of a
+# zero-mean distribution can't average to zero. Confirmed live (2026-07-26,
+# 2h real window, 3527 ticks, values recovered from the *unfixed* aggregate):
+# median mean(|z|) was 0.7995, essentially exactly this constant, and the
+# aggregate NEVER read below ~0.51 raw (0.17 post-saturation) across the whole
+# window. Subtracted out below so this domain can genuinely rest near 0 like
+# its four siblings (execution/biometrics/chat/route), instead of permanently
+# reporting "moderately surprised" regardless of real mesh conditions.
+_BUS_SYNAPTIC_CALM_FLOOR = math.sqrt(2.0 / math.pi)
 
 
 def _mean(values: list[float]) -> float:
@@ -301,7 +314,21 @@ def bus_synaptic_prediction_error(edge_zscores: list[float]) -> float:
     ``zscore_threshold=3.0`` convention already live in
     ``services/orion-hub/scripts/bus_synaptic_graph_routes.py``'s ``anomalies()``
     route rather than inventing a new calibration.
+
+    **2026-07-26: subtracts ``_BUS_SYNAPTIC_CALM_FLOOR`` before saturating.**
+    ``mean(|z|)`` does not rest at 0 for genuinely calm traffic -- see that
+    constant's docstring. Without this correction the function returned
+    values with a live-confirmed floor around 0.27 no matter how quiet the
+    mesh actually was, which silently and permanently biased
+    ``prediction_error_confidence`` downward once this domain was wired into
+    ``attention_self_model.ACTIVE_INFERENCE_DOMAINS`` (caught before any live
+    consumer existed). Now returns ``max(0, mean(|z|) - floor) / (saturation -
+    floor)``, clamped to [0, 1] -- still saturates to 1.0 at zscore 3.0
+    (unchanged ceiling), but now genuinely rests near 0 like the other four
+    domains' raw deltas.
     """
     if not edge_zscores:
         return 0.0
-    return min(1.0, _mean([abs(z) for z in edge_zscores]) / _BUS_SYNAPTIC_ZSCORE_SATURATION)
+    mean_abs_z = _mean([abs(z) for z in edge_zscores])
+    excess = max(0.0, mean_abs_z - _BUS_SYNAPTIC_CALM_FLOOR)
+    return min(1.0, excess / (_BUS_SYNAPTIC_ZSCORE_SATURATION - _BUS_SYNAPTIC_CALM_FLOOR))

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -5,6 +5,7 @@ vocabulary; see the Sentience Striving Program charter §9b item 3)."""
 
 from __future__ import annotations
 
+import math
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -514,16 +515,35 @@ class TestBusSynapticPredictionError:
             bus_synaptic_prediction_error([1.5])
         )
 
+    def test_calm_floor_reads_zero_not_positive(self) -> None:
+        """2026-07-26 floor-bias fix. mean(|z|) resting at sqrt(2/pi) (the
+        expected |Z| for a calm, standard-normal-distributed edge population)
+        must read as genuine 0.0, not the ~0.27 the pre-fix formula returned
+        for this exact input. This is the regression this patch exists to
+        prevent -- without it, this domain can never report "calm" like its
+        four siblings."""
+        calm_floor = math.sqrt(2.0 / math.pi)
+        assert bus_synaptic_prediction_error([calm_floor]) == pytest.approx(0.0, abs=1e-9)
+
+    def test_below_calm_floor_still_clamps_to_zero(self) -> None:
+        """A mean |z| below the theoretical calm floor (sampling noise on a
+        small edge count) must not go negative."""
+        assert bus_synaptic_prediction_error([0.1]) == 0.0
+
     def test_saturates_at_one_not_min_030_threshold(self) -> None:
         """Must use the 3.0 z-score saturation, not this module's 0.30
         pressure-hint-delta _THRESHOLD -- a mean |zscore| of 1.5 dividing by
         0.30 would already saturate to 1.0, destroying the distinction this
-        instrument exists to make."""
+        instrument exists to make. Expected value updated 2026-07-26 for the
+        calm-floor subtraction: (1.5 - sqrt(2/pi)) / (3.0 - sqrt(2/pi)).
+        """
         result = bus_synaptic_prediction_error([1.5])
-        assert result == pytest.approx(0.5)  # 1.5 / 3.0, not min(1.0, 1.5/0.30)
+        assert result == pytest.approx(0.3188367996970756)
 
     def test_saturates_at_one_for_large_zscore(self) -> None:
         assert bus_synaptic_prediction_error([50.0]) == 1.0
 
     def test_averages_across_multiple_edges(self) -> None:
-        assert bus_synaptic_prediction_error([0.0, 3.0]) == pytest.approx(0.5)
+        """Expected value updated 2026-07-26 for the calm-floor subtraction:
+        mean([0.0, 3.0]) = 1.5, same transform as the 1.5 case above."""
+        assert bus_synaptic_prediction_error([0.0, 3.0]) == pytest.approx(0.3188367996970756)

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -430,6 +430,27 @@ domain (`transport_prediction_error()`) remains excluded and unfixed — see
 `docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`'s
 2026-07-25 revision for the full caveat.
 
+**Corrected 2026-07-26: the sanity-check pass above was incomplete.** It checked non-degeneracy
+(step 4 of CLAUDE.md's metric-quality-gate) but skipped the theory-anchor/commensurability check
+(step 3) -- whether this domain's "calm" value is actually comparable to its four siblings'.
+It wasn't: `bus_synaptic_prediction_error()` computed `mean(|zscore|) / 3.0`, and `mean(|Z|)` for a
+calm, ~N(0,1)-distributed edge population has an expected value of `sqrt(2/pi) ≈ 0.798`, not 0 --
+averaging absolute values of a zero-mean distribution can't average to zero. Confirmed against the
+same 2h real window used above (recovering raw `mean(|z|)` from the already-stored aggregate):
+median raw `mean(|z|)` was 0.7995, essentially exactly this constant, and the reported
+`prediction_error` never read below ~0.17 across the whole window regardless of real mesh
+conditions -- a permanent floor bias silently pulling `prediction_error_confidence` down whenever
+this domain had any traffic at all, unrelated to genuine surprise. Fixed in
+`orion/substrate/prediction_error.py::bus_synaptic_prediction_error()` by subtracting this floor
+before saturating (same 3.0 ceiling, now genuinely resting near 0 when calm). Re-validated against
+the same real window under the corrected formula: median drops to 0.0 (55.8% of ticks now read
+`<0.01`), real spikes up to ~0.98 preserved -- not degenerate, matches the shape of the other four
+domains instead of permanently reporting "moderately surprised." `orion-equilibrium-service`'s
+transport metacog gate (PRs #1385/#1387) is unaffected: its `error_threshold` default is `1.0`, the
+saturation ceiling, which both the old and new formulas only reach at raw `mean(|z|) >= 3.0` --
+identical fire condition before and after this fix, confirmed by reading
+`services/orion-equilibrium-service/app/settings.py` and its `.env_example` (both `1.0`).
+
 **Fixed 2026-07-25 (same day, follow-up): the 5 new env keys above weren't reaching the
 container.** Same class of gotcha already documented for `SUBSTRATE_STORE_BACKEND`/`FALKORDB_URI`
 in this service's `.env_example` (not elsewhere in this README) — `docker-compose.yml` passes env vars through via an explicit

--- a/services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py
+++ b/services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py
@@ -97,10 +97,13 @@ def test_bus_synaptic_tick_skips_nan_and_infinite_zscores(monkeypatch):
     )
     with patch.object(worker, "_write_prediction_error_node") as write_node:
         worker._bus_synaptic_tick()
-    # Only the real 1.5 should count -- mean(1.5)/3.0 saturation = 0.5, not
-    # NaN-poisoned or maxed out by the infinite value.
+    # Only the real 1.5 should count -- not NaN-poisoned or maxed out by the
+    # infinite value. Expected value updated 2026-07-26 for the calm-floor
+    # fix (bus_synaptic_prediction_error now subtracts sqrt(2/pi) before
+    # saturating): (1.5 - sqrt(2/pi)) / (3.0 - sqrt(2/pi)), not the old
+    # mean(1.5)/3.0 = 0.5.
     write_node.assert_called_once()
-    assert write_node.call_args.kwargs["error"] == pytest.approx(0.5)
+    assert write_node.call_args.kwargs["error"] == pytest.approx(0.3188367996970756)
 
 
 def test_bus_synaptic_edge_queries_filter_stale_edges() -> None:


### PR DESCRIPTION
## Summary

- `bus_synaptic_prediction_error()` computed `mean(|zscore|)/3.0`, but `E[|Z|]` for a calm, standard-normal-distributed edge population is `sqrt(2/pi) ≈ 0.798`, not 0.
- Live-confirmed against the same 2h/3527-tick window used to justify PR #1390's merge (recovering raw `mean(|z|)` from the already-stored aggregate): median was 0.7995, essentially exactly this constant. The domain never read below ~0.17 regardless of real mesh calm.
- This silently biased `prediction_error_confidence` downward whenever the mesh had any traffic at all — found immediately after PR #1390 wired `bus_synaptic` into `ACTIVE_INFERENCE_DOMAINS`, via a metric-quality-gate theory-anchor check (CLAUDE.md step 3) that should have run before that merge.
- Fix subtracts the calm floor before saturating (same 3.0 ceiling, genuinely rests near 0 when calm). Re-validated against the same real window: median drops to 0.0 (55.8% of ticks `<0.01`), real spikes to ~0.98 preserved.
- `orion-equilibrium-service`'s transport metacog gate (PRs #1385/#1387) is unaffected — its `error_threshold` (1.0, the saturation ceiling) is reached under both formulas only at raw `mean(|z|) >= 3.0`, an identical fire condition, confirmed by reading its `settings.py`/`.env_example`.
- Review subagent caught one sibling test outside the original diff scope (`test_worker_bus_synaptic_tick.py`) that would have broken CI; fixed in the same commit.

## Outcome moved

`bus_synaptic_prediction_error()` now genuinely rests near 0 for calm traffic, matching the semantics its four sibling Active-Inference domains already have, instead of carrying a permanent ~0.27 floor bias into every aggregate confidence computation.

## Current architecture

`bus_synaptic_prediction_error(edge_zscores)` aggregates live `|zscore|` values from the bus-synaptic-graph (`orion_bus_synapse`) and was merged into `attention_self_model.py`'s `ACTIVE_INFERENCE_DOMAINS` in PR #1390 earlier today.

## Architecture touched

`orion/substrate/prediction_error.py` only — no schema, bus, or service changes.

## Files changed

- `orion/substrate/prediction_error.py`: added `_BUS_SYNAPTIC_CALM_FLOOR = sqrt(2/pi)`, subtracted before saturating in `bus_synaptic_prediction_error()`.
- `orion/substrate/tests/test_prediction_error.py`: 2 new tests (`test_calm_floor_reads_zero_not_positive`, `test_below_calm_floor_still_clamps_to_zero`), 2 existing tests' expected values recomputed for the new formula.
- `services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py`: 1 test's expected value corrected (review-subagent finding).
- `docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`: new "Revision, 2026-07-26" section.
- `services/orion-substrate-runtime/README.md`: new "Corrected 2026-07-26" section.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: `bus_synaptic_prediction_error()`'s return value for any non-saturating input changes (e.g. `f([1.5])`: `0.5` → `0.3188...`). Only currently-live consumer is `orion-equilibrium-service`'s transport metacog gate, confirmed unaffected (see Summary). `attention_self_model.py`'s `prediction_error_confidence` has no live production caller yet (only the offline replay script).
- Compatibility notes: purely a formula correction, same input/output contract (list of floats → 0-1 float).

## Env/config changes

None.

## Tests run

```text
PYTHONPATH="." /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest \
  services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py \
  orion/substrate/tests/test_prediction_error.py \
  orion/substrate/tests/test_attention_self_model.py \
  scripts/analysis/tests/test_measure_ast_hot_reducer.py -q
101 passed
```

## Evals run

None — validated instead against real historical Postgres data (see Summary), which is the more direct check for this specific bug (a distributional/statistical property, not something a unit-test fixture alone would have caught).

## Docker/build/smoke checks

Not applicable — pure-function change, no service/runtime/Docker changes.

## Review findings fixed

- Finding: `services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py::test_bus_synaptic_tick_skips_nan_and_infinite_zscores` exercises `bus_synaptic_prediction_error()` indirectly and was outside the original diff, so its hardcoded expected value (`0.5`) would have broken under the new formula.
  - Fix: updated the assertion to `pytest.approx(0.3188367996970756)`, matching the corrected formula's output for the same input.
  - Evidence: full suite re-run post-fix, 101/101 pass.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: low
- Concern: this is the second live-data-driven correction to `bus_synaptic` in two days (PR #1390 wired it in, this PR fixes a bias found immediately after). A related, separate, larger question was raised in review of this fix — whether the pre-existing `transport` domain (`transport_prediction_error()`, narrow 2-Redis-Streams scope, already known ~1000x miscalibrated) should be retired now that `bus_synaptic` supersedes it, since a live consumer (`orion/substrate/endogenous_curiosity.py`) still reads `node:substrate.transport`'s pinned-at-1.0 signal for candidate-budget scoring. That is explicitly NOT part of this PR — Juniper asked for a proposal-mode design doc first (CLAUDE.md's rule for cognition-loop-adjacent changes), which is being written separately.
- Mitigation: this PR is scoped strictly to the calm-floor formula bug; the transport-retirement question is tracked as a separate, upcoming design doc.

## PR link

(filled in below)