### PR TITLE
feat(field-digester): replace dead world_pulse transport signal with bus_synaptic

### DIFF
--- a/config/field/orion_field_topology.v1.yaml
+++ b/config/field/orion_field_topology.v1.yaml
@@ -58,16 +58,45 @@ edges:
       memory_pressure: pressure
       reasoning_load: reasoning_pressure
 
+  # 2026-07-26: stream_backlog_pressure/delivery_confidence/stream_backlog_health
+  # removed from this edge -- confirmed live degenerate (confidence/
+  # available_capacity pinned at exactly 0.85 with zero variance, pressure
+  # pinned at exactly 0.00082, over a 2h real window). Source: the narrow
+  # 2-Redis-Stream "world_pulse" census (BUS_OBSERVER_STREAMS), already
+  # documented dead in docs/superpowers/specs/2026-07-24-bus-vitality-field-
+  # signal-brainstorm.md and docs/notes/2026-07-12-metrics-swamp-arsonist-
+  # review.md. catalog_drift_pressure/observer_failure_pressure are a
+  # separate, independently-fixed metric (PR #1373) and kept as-is.
   - source_id: node:athena
     target_id: capability:transport
     edge_type: node_capability
     weight: 0.85
     channel_map:
-      stream_backlog_pressure: pressure
       catalog_drift_pressure: contract_pressure
       observer_failure_pressure: reliability_pressure
-      delivery_confidence: confidence
-      stream_backlog_health: available_capacity
+
+  # 2026-07-26: real mesh-wide transport signal, replacing the removed
+  # world_pulse-derived pressure above. node:substrate.bus_synaptic is not a
+  # physical host (unlike node:athena/atlas/circe/prometheus above) -- it's
+  # the Active-Inference domain node written by services/orion-substrate-
+  # runtime/app/worker.py::_bus_synaptic_tick via a receipt into
+  # substrate_reduction_receipts, consumed into this service's own
+  # substrate_field_state through the same generic prediction_signal
+  # perturbation path (app/ingest/state_deltas.py) the other 5 Active-
+  # Inference domains already use -- not a shared table/row between the two
+  # services (orion-substrate-runtime never touches substrate_field_state
+  # directly). Confirmed live: 100% tick coverage over the same 2h window
+  # used to confirm the edge above was dead. confidence/available_capacity
+  # are intentionally NOT mapped here -- apply_diffusion()'s existing derived-fallback formula
+  # (max(0, 1-pressure) / max(0, 1-0.5*pressure)) already produces them from
+  # this real pressure value once no direct edge claims those channels, so
+  # they get a genuine derivation instead of a second fabricated constant.
+  - source_id: node:substrate.bus_synaptic
+    target_id: capability:transport
+    edge_type: node_capability
+    weight: 0.85
+    channel_map:
+      prediction_error: pressure
 
   - source_id: node:athena
     target_id: capability:orchestration

--- a/docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md
+++ b/docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md
@@ -290,6 +290,20 @@ avoid colliding with "Idea 1-6" below, which are a separate, earlier set of cand
   own dedicated design doc and its own metric-quality-gate pass before implementation starts, not a
   green light from brainstorm output alone.
 
+## Resolved, 2026-07-26 (separate from the Missing Questions below)
+
+`capability:transport`'s `pressure`/`confidence`/`available_capacity` (fed by
+`stream_backlog_pressure`/`delivery_confidence`/`stream_backlog_health` from the same narrow
+world_pulse census this doc already calls dead) were confirmed live degenerate — `confidence`/
+`available_capacity` pinned at exactly 0.85 with zero variance, `pressure` pinned at exactly
+0.00082, over a 2h real window. Replaced with a new `node:substrate.bus_synaptic -> capability:
+transport` edge (`prediction_error -> pressure`) in `config/field/orion_field_topology.v1.yaml`,
+relying on `apply_diffusion()`'s existing derived-fallback formula for `confidence`/
+`available_capacity` rather than fabricating a second constant. This is **separate** from the
+Missing Questions bullet below about `catalog_drift_pressure`'s consumers (Idea 1,
+already-shipped PR #1373) — that question remains genuinely open; this fix touched a different
+part of the same capability's vector.
+
 ## Missing questions
 
 Carried from the original brainstorm, still unresolved:

--- a/services/orion-field-digester/tests/test_diffusion_provenance.py
+++ b/services/orion-field-digester/tests/test_diffusion_provenance.py
@@ -344,3 +344,29 @@ def test_derived_formula_still_falls_back_when_direct_edge_contributes_nothing_t
     # Fallback to the derived formula, not hard-floored at 0.0.
     assert tgt["confidence"] == max(0.0, 1.0 - 0.5 * 0.765)
     assert tgt["available_capacity"] == max(0.0, 1.0 - 0.765)
+
+
+def test_bus_synaptic_edge_drives_capability_transport_pressure() -> None:
+    """2026-07-26: node:athena's stream_backlog_pressure/delivery_confidence/
+    stream_backlog_health -> capability:transport mappings were removed
+    (confirmed live degenerate -- pinned at exactly 0.85/0.00082 with zero
+    variance over a 2h real window, fed by the narrow world_pulse census).
+    Replaced with node:substrate.bus_synaptic's real prediction_error ->
+    pressure, config/field/orion_field_topology.v1.yaml. confidence/
+    available_capacity are deliberately not mapped directly -- they must
+    come from the existing derived-fallback formula instead."""
+    edge = FieldEdgeV1(
+        source_id="node:substrate.bus_synaptic",
+        target_id="capability:transport",
+        edge_type="node_capability",
+        weight=0.85,
+        channel_map={"prediction_error": "pressure"},
+    )
+    state = _state([edge], {"node:substrate.bus_synaptic": {"prediction_error": 0.4}})
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    tgt = state.capability_vectors["capability:transport"]
+    assert tgt["pressure"] == 0.34  # 0.4 * 0.85 * 1.0
+    assert tgt["confidence"] == max(0.0, 1.0 - 0.5 * 0.34)
+    assert tgt["available_capacity"] == max(0.0, 1.0 - 0.34)


### PR DESCRIPTION
## Summary

- `capability:transport`'s diffusion vector (`pressure`/`confidence`/`available_capacity`) confirmed live degenerate: `confidence`/`available_capacity` pinned at exactly 0.85 with zero variance, `pressure` pinned at exactly 0.00082, over a 2h real window. Source: the narrow 2-Redis-Stream "world_pulse" census (`BUS_OBSERVER_STREAMS`), already flagged dead since 2026-07-12 but never given a real replacement.
- Removed `stream_backlog_pressure`/`delivery_confidence`/`stream_backlog_health` from the `node:athena -> capability:transport` edge in `config/field/orion_field_topology.v1.yaml`. Kept `catalog_drift_pressure -> contract_pressure` and `observer_failure_pressure -> reliability_pressure` — a separate, already-independently-fixed metric (PR #1373), not part of this degeneracy.
- Added `node:substrate.bus_synaptic -> capability:transport` (`prediction_error -> pressure`). `confidence`/`available_capacity` are deliberately not mapped directly — `apply_diffusion()`'s existing derived-fallback formula (`max(0, 1-pressure)`/`max(0, 1-0.5*pressure)`) already produces them from this real pressure once no edge claims those channels directly, giving a genuine derivation instead of a second fabricated constant.
- Review subagent traced the actual cross-service mechanism and corrected an inaccurate comment: `orion-substrate-runtime` never touches `substrate_field_state` directly — it writes a receipt into `substrate_reduction_receipts`, consumed into field-digester's own `substrate_field_state` via the same generic `prediction_signal` perturbation path the other 5 Active-Inference domains already use. Not a shared table/row between the two services.
- Review also found and flagged (not fixed) a separate pre-existing bug: `capability:transport -> capability:orchestration`'s `stream_backlog_pressure` channel_map has read a never-written key since `capability:transport` was created in May 2026 — confirmed via full git history of the topology file, unaffected by this patch either way.

## Outcome moved

`capability:transport`'s field-tensor representation stops carrying a fabricated-constant confidence/pressure reading and instead reflects a real, live, mesh-wide anomaly signal.

## Current architecture

`services/orion-field-digester/app/digestion/diffusion.py::apply_diffusion()` reads `config/field/orion_field_topology.v1.yaml`'s edges each tick, applying `channel_map` entries as `contribution = clamp01(src_val * weight * diffusion_rate)` into `capability_vectors`. `edge.source_id` is a plain string lookup with no validation against the YAML's declared `nodes:` list, confirmed by reading the full function and `lattice.py`'s loader.

## Files changed

- `config/field/orion_field_topology.v1.yaml`: removed 3 dead channel_map entries, added the `node:substrate.bus_synaptic -> capability:transport` edge with explanatory comments.
- `services/orion-field-digester/tests/test_diffusion_provenance.py`: new test `test_bus_synaptic_edge_drives_capability_transport_pressure`.
- `docs/superpowers/specs/2026-07-24-bus-vitality-field-signal-brainstorm.md`: new "Resolved, 2026-07-26" section, explicitly scoped separate from the still-open `catalog_drift_pressure` consumer-audit question.

## Schema / bus / API changes

- Added: one new `FieldEdgeV1` entry in the topology config (data, not schema).
- Removed: 3 channel_map entries from an existing edge.
- Renamed: none.
- Behavior changed: `capability:transport`'s `pressure`/`confidence`/`available_capacity` now derive from `node:substrate.bus_synaptic` instead of the dead world_pulse census.
- Compatibility notes: `contract_pressure`/`reliability_pressure` on the same capability are untouched.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH="services/orion-field-digester" /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest \
  services/orion-field-digester/tests/ -q --ignore=services/orion-field-digester/tests/test_heartbeat_chassis.py
153 passed
```
(`test_heartbeat_chassis.py`'s collection error is pre-existing and unrelated, per PR #1393.)

Also verified the real topology YAML parses correctly post-edit:
```text
PYTHONPATH="services/orion-field-digester" python -c "from app.graph.lattice import load_lattice; ..."
OK 10 edges
```

## Evals run

None — validated against real historical Postgres data (the live-degeneracy confirmation query) instead, the more direct check for this class of bug.

## Docker/build/smoke checks

Not applicable — config-only change (topology YAML), no service code/schema/Docker changes. Takes effect on next field-digester deploy (reads `LATTICE_PATH` fresh each restart).

## Review findings fixed

- Finding: the new edge's comment inaccurately claimed `node:substrate.bus_synaptic` shares "the same `substrate_field_state` row/table" with field-digester, when the real mechanism is a receipt-mediated perturbation (same pattern as the other 5 Active-Inference domains), not a shared table.
  - Fix: reworded the comment to describe the actual receipt → generic `prediction_signal` perturbation path.
  - Evidence: review subagent traced both services' real code (`orion-substrate-runtime/app/worker.py`, `orion-field-digester/app/ingest/state_deltas.py`) and confirmed no `substrate_field_state` reference exists anywhere in `orion-substrate-runtime`.
- Finding (flagged, not fixed — out of scope): `capability:transport -> capability:orchestration`'s `stream_backlog_pressure` channel_map has read a never-written key since May 2026, confirmed via full git history of the topology file.
  - Fix: none in this PR — named here for a follow-up ticket, unaffected by this patch either way.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: low
- Concern: `capability:transport -> capability:orchestration`'s dead `stream_backlog_pressure` mapping (found during this review) means transport pressure still doesn't propagate into orchestration's own pressure, regardless of this fix.
- Mitigation: named as a separate follow-up; not introduced or worsened by this patch, and fixing it requires deciding what channel name that downstream edge should actually read (`pressure`, presumably) — a small, separate, well-scoped patch.

## PR link

(filled in below)