### PR TITLE
feat: repeatable prediction_error domain audit script + curiosity seed-source visibility

### DIFF
--- a/scripts/analysis/audit_prediction_error_domain.py
+++ b/scripts/analysis/audit_prediction_error_domain.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Repeatable single-domain audit for `orion/substrate/prediction_error.py`'s Active-Inference
+domains (or any other node carrying a `prediction_error` metadata field in
+`substrate_field_state`).
+
+Operationalizes CLAUDE.md's metric-quality-gate step 4 ("live-data sanity check") after two real,
+distinct failures were found the same day (2026-07-26) by hand, not by process:
+
+1. `bus_synaptic_prediction_error()` had a mathematically permanent ~0.27 floor --
+   `mean(|z|)` for a calm, standard-normal-distributed z-score population has expected value
+   `sqrt(2/pi)`, not 0, so the domain could never read "genuinely calm" no matter how quiet the
+   real mesh was. Caught by recovering the underlying pre-aggregation statistic from the
+   already-persisted value and checking its theoretical rest point by hand (PR #1391).
+2. `node:substrate.route`'s `prediction_error` was silently decaying to zero via a generic
+   field-digester staleness-decay loop that should never have applied to it (`prediction_error`
+   is designed elsewhere to be an undecayed raw snapshot). Caught by pulling the raw history and
+   noticing an exact geometric ratio (0.92) between every successive value for 48+ hours straight
+   (PR #1393).
+
+Both directions of failure -- a metric that can never look calm, and a metric that looks calm for
+a fake reason -- were only found by recovering real numbers from what was already persisted, not
+by re-deriving from code alone. This script mechanizes the two checks that judgment call relies
+on so the next domain doesn't need the same hand-archaeology:
+
+1. **Distributional sanity** -- does it read degenerate (always-0, always-1, zero variance)?
+2. **Decay-artifact detection** -- is there a suspiciously exact geometric ratio between
+   consecutive non-zero values sustained over many ticks? (The exact signature the route bug had.)
+
+This does not replace judgment or a live theory-anchor check (CLAUDE.md step 3) -- it only
+mechanizes the parts that are mechanizable. A clean report here is necessary, not sufficient,
+before trusting a domain.
+
+Run:
+    python scripts/analysis/audit_prediction_error_domain.py bus_synaptic
+    python scripts/analysis/audit_prediction_error_domain.py route --window-hours 48
+    python scripts/analysis/audit_prediction_error_domain.py --node-id node:athena --window-hours 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import logging
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("orion.analysis.prediction_error_domain_audit")
+
+DEFAULT_WINDOW_HOURS: float = 24.0
+MAX_ROWS: int = 200_000
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+# Decay-artifact detection: a run of consecutive ratios this close together (relative
+# tolerance) is treated as suspicious. 1e-9 is tight enough that real, independent
+# fresh measurements essentially never land this close by chance, but loose enough to
+# survive float round-tripping through jsonb.
+_RATIO_TOLERANCE = 1e-9
+# A run this long crosses from "could be coincidence" to "mechanically certain" -- the
+# route bug ran for 48+ hours (~86,000+ ticks at 2s cadence); 20 is a conservative floor
+# that still catches a decay bug early, long before it becomes a multi-day incident.
+_MIN_SUSPICIOUS_RUN_LENGTH = 20
+# Below this many samples, a fraction-based flag (e.g. "100% exactly 0.0") is
+# trivially true of almost any tiny window and shouldn't be reported with the
+# same confidence as a real finding over a representative sample.
+_MIN_SAMPLES_FOR_DISTRIBUTION_FLAGS = 10
+
+
+@dataclass
+class DomainSample:
+    observed_at: datetime
+    value: float
+
+
+@dataclass
+class DistributionReport:
+    n: int
+    mean: float
+    median: float
+    min_value: float
+    max_value: float
+    stdev: float
+    frac_exact_zero: float
+    frac_exact_one: float
+    distinct_values: int
+
+
+@dataclass
+class DecayArtifactReport:
+    longest_suspicious_run: int
+    suspicious_ratio: Optional[float]
+    run_start: Optional[datetime]
+    run_end: Optional[datetime]
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Exercised directly by unit tests with synthetic data.
+# ===========================================================================
+
+
+def compute_distribution(samples: list[DomainSample]) -> Optional[DistributionReport]:
+    if not samples:
+        return None
+    values = [s.value for s in samples]
+    return DistributionReport(
+        n=len(values),
+        mean=statistics.mean(values),
+        median=statistics.median(values),
+        min_value=min(values),
+        max_value=max(values),
+        stdev=statistics.pstdev(values) if len(values) > 1 else 0.0,
+        frac_exact_zero=sum(1 for v in values if v == 0.0) / len(values),
+        frac_exact_one=sum(1 for v in values if v == 1.0) / len(values),
+        distinct_values=len(set(values)),
+    )
+
+
+def detect_decay_artifact(samples: list[DomainSample]) -> DecayArtifactReport:
+    """Walk consecutive (prev, curr) pairs where both are nonzero and look for a long
+    run of near-identical ratios -- the exact signature a per-tick multiplicative decay
+    leaves behind (route's real bug: ratio == 0.92 every single tick, unbroken, for
+    48+ hours). A handful of matching ratios can happen by coincidence; a long
+    unbroken run cannot -- independent real measurements don't repeat a ratio to 9
+    decimal places dozens of times in a row.
+
+    A ratio of exactly 1.0 is deliberately excluded and never counted toward a run:
+    that means the value is genuinely held flat (unchanged), the CORRECT behavior for
+    a hold-until-stale channel post the 2026-07-26 decay.py fix -- not a decay bug.
+    Found live via this script's own first real smoke test: a 249-tick run of ratio
+    1.000000 on a genuinely calm bus_synaptic stretch was a false positive before this
+    exclusion existed.
+    """
+    best_run = 0
+    best_ratio: Optional[float] = None
+    best_start: Optional[datetime] = None
+    best_end: Optional[datetime] = None
+
+    current_run = 0
+    current_ratio: Optional[float] = None
+    current_start: Optional[datetime] = None
+
+    for prev, curr in zip(samples, samples[1:]):
+        if prev.value == 0.0 or curr.value == 0.0:
+            current_run, current_ratio, current_start = 0, None, None
+            continue
+        ratio = curr.value / prev.value
+        # ratio == 1.0 means the value is genuinely held flat (unchanged) --
+        # the CORRECT behavior for a hold-until-stale channel, not decay.
+        # Skip this transition WITHOUT resetting current_run/current_ratio:
+        # review caught that resetting here creates a false-negative -- a
+        # single held-flat tick landing in the middle of an otherwise-
+        # continuous real decay run would fragment it into two shorter
+        # sub-runs, potentially hiding a genuine bug below the detection
+        # threshold. A flat tick should be invisible to run continuity, not
+        # break it.
+        if abs(ratio - 1.0) <= _RATIO_TOLERANCE:
+            continue
+        if current_ratio is not None and abs(ratio - current_ratio) <= _RATIO_TOLERANCE:
+            current_run += 1
+        else:
+            current_run = 1
+            current_ratio = ratio
+            current_start = prev.observed_at
+        if current_run > best_run:
+            best_run = current_run
+            best_ratio = current_ratio
+            best_start = current_start
+            best_end = curr.observed_at
+
+    return DecayArtifactReport(
+        longest_suspicious_run=best_run,
+        suspicious_ratio=best_ratio,
+        run_start=best_start,
+        run_end=best_end,
+    )
+
+
+def render_report(domain_label: str, node_id: str, dist: Optional[DistributionReport],
+                   decay: DecayArtifactReport, window_hours: float) -> str:
+    lines = [
+        f"# prediction_error domain audit: {domain_label} ({node_id})",
+        f"window: last {window_hours}h",
+        "",
+    ]
+    if dist is None:
+        lines.append("NO DATA in this window -- cannot audit. Widen --window-hours or check node_id.")
+        return "\n".join(lines)
+
+    lines.append(
+        f"n={dist.n} mean={dist.mean:.5f} median={dist.median:.5f} "
+        f"min={dist.min_value:.5g} max={dist.max_value:.5g} stdev={dist.stdev:.5f}"
+    )
+    lines.append(
+        f"frac exactly 0.0={dist.frac_exact_zero*100:.1f}%  "
+        f"frac exactly 1.0={dist.frac_exact_one*100:.1f}%  "
+        f"distinct values={dist.distinct_values}"
+    )
+    lines.append("")
+
+    if dist.n < _MIN_SAMPLES_FOR_DISTRIBUTION_FLAGS:
+        lines.append(
+            f"NOTE: only {dist.n} sample(s) in this window (below "
+            f"{_MIN_SAMPLES_FOR_DISTRIBUTION_FLAGS}) -- distribution flags below are unreliable "
+            f"with this little data (e.g. a single 0.0 tick trivially reads 'ALWAYS ZERO'). "
+            f"Widen --window-hours before trusting them."
+        )
+    degenerate_flags = []
+    if dist.stdev == 0.0:
+        degenerate_flags.append("ZERO VARIANCE -- every value in this window is identical.")
+    if dist.frac_exact_zero > 0.99:
+        degenerate_flags.append("ALWAYS ZERO -- >99% of ticks read exactly 0.0.")
+    if dist.frac_exact_one > 0.5:
+        degenerate_flags.append("MOSTLY SATURATED -- >50% of ticks read exactly 1.0.")
+    if degenerate_flags:
+        lines.append("DISTRIBUTION FLAGS:")
+        lines.extend(f"  - {f}" for f in degenerate_flags)
+    else:
+        lines.append("Distribution: not obviously degenerate by these checks.")
+    lines.append("")
+
+    if decay.longest_suspicious_run >= _MIN_SUSPICIOUS_RUN_LENGTH:
+        lines.append(
+            f"DECAY ARTIFACT SUSPECTED: {decay.longest_suspicious_run} consecutive ticks held an "
+            f"identical ratio of {decay.suspicious_ratio:.6f} between {decay.run_start} and "
+            f"{decay.run_end}. This is the exact signature of a mechanical per-tick "
+            f"multiplicative decay (route's real 2026-07-26 bug: ratio 0.92, unbroken, for "
+            f"48+ hours) -- a value this consistent is not a real, independently-arriving "
+            f"measurement. Check field-digester's NODE_DECAY_CHANNELS for this channel before "
+            f"trusting it."
+        )
+    else:
+        lines.append(
+            f"No decay artifact detected (longest matching-ratio run: "
+            f"{decay.longest_suspicious_run}, threshold: {_MIN_SUSPICIOUS_RUN_LENGTH})."
+        )
+
+    return "\n".join(lines)
+
+
+# ===========================================================================
+# I/O layer.
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        conn.close()
+        return None
+    return conn
+
+
+def fetch_samples(conn, node_id: str, since: datetime) -> list[DomainSample]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT generated_at, field_json->'node_vectors'->%s->>'prediction_error'
+            FROM substrate_field_state
+            WHERE generated_at > %s
+            ORDER BY generated_at ASC
+            LIMIT %s
+            """,
+            (node_id, since, MAX_ROWS),
+        )
+        rows = cur.fetchall()
+    samples: list[DomainSample] = []
+    for observed_at, raw in rows:
+        if raw is None:
+            continue
+        try:
+            samples.append(DomainSample(observed_at=observed_at, value=float(raw)))
+        except (TypeError, ValueError):
+            continue
+    return samples
+
+
+def resolve_node_id(domain: Optional[str], node_id: Optional[str]) -> tuple[str, str]:
+    if node_id:
+        return node_id, node_id
+    if not domain:
+        raise SystemExit("must pass either a domain name or --node-id")
+    # scripts/analysis/ has no __init__.py -- load by file path, same pattern
+    # scripts/analysis/tests/test_measure_ast_hot_reducer.py already uses,
+    # rather than a package-style import that isn't reliably importable here.
+    try:
+        module_path = Path(__file__).resolve().parent / "measure_ast_hot_reducer.py"
+        spec = importlib.util.spec_from_file_location("measure_ast_hot_reducer", module_path)
+        mod = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        sys.modules.setdefault("measure_ast_hot_reducer", mod)
+        spec.loader.exec_module(mod)
+        PREDICTION_ERROR_DOMAIN_NODES = mod.PREDICTION_ERROR_DOMAIN_NODES
+    except Exception:
+        logger.warning("could not load PREDICTION_ERROR_DOMAIN_NODES", exc_info=True)
+        PREDICTION_ERROR_DOMAIN_NODES = {}
+    resolved = PREDICTION_ERROR_DOMAIN_NODES.get(domain)
+    if resolved is None:
+        known = ", ".join(sorted(PREDICTION_ERROR_DOMAIN_NODES)) or "(none importable)"
+        raise SystemExit(
+            f"unknown domain {domain!r} -- not in PREDICTION_ERROR_DOMAIN_NODES "
+            f"(scripts/analysis/measure_ast_hot_reducer.py). Known: {known}. "
+            f"Pass --node-id directly for anything else."
+        )
+    return domain, resolved
+
+
+def run(domain: Optional[str], node_id_arg: Optional[str], window_hours: float, postgres_uri: str) -> int:
+    domain_label, node_id = resolve_node_id(domain, node_id_arg)
+    conn = open_readonly_connection(postgres_uri)
+    if conn is None:
+        return 1
+    try:
+        since = datetime.now(timezone.utc) - timedelta(hours=window_hours)
+        samples = fetch_samples(conn, node_id, since)
+    finally:
+        conn.close()
+
+    dist = compute_distribution(samples)
+    decay = detect_decay_artifact(samples)
+    print(render_report(domain_label, node_id, dist, decay, window_hours))
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Repeatable live-data sanity + decay-artifact audit for one prediction_error domain."
+    )
+    parser.add_argument(
+        "domain", nargs="?", default=None,
+        help="domain name from PREDICTION_ERROR_DOMAIN_NODES (e.g. bus_synaptic, route)",
+    )
+    parser.add_argument(
+        "--node-id", type=str, default=None,
+        help="raw node_id to audit directly (e.g. node:athena), bypassing the domain lookup",
+    )
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"how far back to look in substrate_field_state (default {DEFAULT_WINDOW_HOURS})",
+    )
+    parser.add_argument(
+        "--postgres-uri", type=str, default=DEFAULT_POSTGRES_URI,
+        help="read-only Postgres DSN (default: in-cluster orion-athena-sql-db)",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    return run(args.domain, args.node_id, args.window_hours, args.postgres_uri)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_audit_prediction_error_domain.py
+++ b/scripts/analysis/tests/test_audit_prediction_error_domain.py
@@ -1,0 +1,161 @@
+"""Unit tests for audit_prediction_error_domain.py's pure layer (no DB access).
+
+Both regression cases mirror the two real 2026-07-26 bugs this script exists to
+mechanize detection of: bus_synaptic's calm-floor bias (distribution never reads
+near-zero) and route's decay artifact (an exact geometric ratio sustained for
+48+ hours)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "audit_prediction_error_domain.py"
+_spec = importlib.util.spec_from_file_location("audit_prediction_error_domain", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["audit_prediction_error_domain"] = mod
+_spec.loader.exec_module(mod)
+
+DomainSample = mod.DomainSample
+compute_distribution = mod.compute_distribution
+detect_decay_artifact = mod.detect_decay_artifact
+render_report = mod.render_report
+
+BASE = datetime(2026, 7, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _samples(values: list[float]) -> list[DomainSample]:
+    return [
+        DomainSample(observed_at=BASE + timedelta(seconds=2 * i), value=v)
+        for i, v in enumerate(values)
+    ]
+
+
+def test_compute_distribution_empty_returns_none() -> None:
+    assert compute_distribution([]) is None
+
+
+def test_compute_distribution_basic_stats() -> None:
+    report = compute_distribution(_samples([0.0, 0.5, 1.0]))
+    assert report is not None
+    assert report.n == 3
+    assert report.mean == 0.5
+    assert report.min_value == 0.0
+    assert report.max_value == 1.0
+    assert report.frac_exact_zero == 1 / 3
+    assert report.frac_exact_one == 1 / 3
+    assert report.distinct_values == 3
+
+
+def test_zero_variance_detected() -> None:
+    report = compute_distribution(_samples([0.27, 0.27, 0.27, 0.27]))
+    assert report is not None
+    assert report.stdev == 0.0
+    assert report.distinct_values == 1
+
+
+def test_always_zero_detected() -> None:
+    report = compute_distribution(_samples([0.0] * 100))
+    assert report is not None
+    assert report.frac_exact_zero == 1.0
+
+
+def test_no_decay_artifact_in_real_looking_noise() -> None:
+    # Independent-looking values -- no two consecutive ratios should match to
+    # 9 decimal places, so no suspicious run should be detected.
+    values = [0.1, 0.34, 0.02, 0.5, 0.19, 0.61, 0.03, 0.44, 0.12, 0.29]
+    report = detect_decay_artifact(_samples(values))
+    assert report.longest_suspicious_run < 20
+
+
+def test_decay_artifact_detected_matching_route_bug_shape() -> None:
+    """Reproduces route's real bug shape: a starting value multiplied by an
+    exact 0.92 ratio every tick, unbroken, for far longer than the detection
+    threshold -- this is the case the script exists to catch."""
+    values = [0.5]
+    for _ in range(49):
+        values.append(values[-1] * 0.92)
+    report = detect_decay_artifact(_samples(values))
+    assert report.longest_suspicious_run >= 20
+    assert report.suspicious_ratio is not None
+    assert abs(report.suspicious_ratio - 0.92) < 1e-9
+
+
+def test_decay_run_resets_when_a_real_value_breaks_it() -> None:
+    """A genuine fresh measurement in the middle of a decay run must reset the
+    run counter -- otherwise a single real event masks an ongoing decay bug
+    instead of correctly splitting it into two shorter, sub-threshold runs."""
+    decaying = [0.5]
+    for _ in range(10):
+        decaying.append(decaying[-1] * 0.92)
+    # A real event resets the value, then decay resumes with a fresh ratio.
+    decaying.append(0.9)
+    for _ in range(10):
+        decaying.append(decaying[-1] * 0.92)
+    report = detect_decay_artifact(_samples(decaying))
+    # Each sub-run is only 10 long -- below the 20-tick suspicious threshold,
+    # even though 20+ total decay-like transitions occurred across the series.
+    assert report.longest_suspicious_run < 20
+
+
+def test_zero_values_do_not_count_as_a_ratio_step() -> None:
+    """A transition into or out of exact 0.0 must not be treated as a ratio
+    (division by/into zero is meaningless here, not a decay signal)."""
+    values = [0.5, 0.0, 0.5, 0.0, 0.5]
+    report = detect_decay_artifact(_samples(values))
+    assert report.longest_suspicious_run == 0
+    assert report.suspicious_ratio is None
+
+
+def test_held_flat_value_is_not_a_decay_artifact() -> None:
+    """Regression test for a real false positive caught by this script's own
+    first live smoke test: a long run of ratio==1.0 (value genuinely
+    unchanged, e.g. a hold-until-stale channel sitting calm) must NOT be
+    flagged -- that is the correct post-decay.py-fix behavior, not decay."""
+    report = detect_decay_artifact(_samples([0.264] * 249))
+    assert report.longest_suspicious_run == 0
+    assert report.suspicious_ratio is None
+
+
+def test_a_single_held_flat_tick_does_not_fragment_a_real_decay_run() -> None:
+    """Regression test for a review-caught false negative: a single ratio==1.0
+    tick landing in the middle of an otherwise-continuous 0.92 decay run must
+    NOT reset run continuity. Before this fix, one flat blip could fragment
+    a genuinely long decay run into two shorter sub-runs, each potentially
+    falling below the detection threshold and hiding a real bug."""
+    values = [0.5]
+    for _ in range(19):
+        values.append(values[-1] * 0.92)
+    values.append(values[-1])  # one flat (ratio == 1.0) tick, mid-run
+    for _ in range(19):
+        values.append(values[-1] * 0.92)
+    report = detect_decay_artifact(_samples(values))
+    # 38 real 0.92 transitions total, uninterrupted by the flat blip -- must
+    # still cross the 20-tick threshold as a single run, not two 19-tick ones.
+    assert report.longest_suspicious_run >= 20
+    assert report.suspicious_ratio is not None
+    assert abs(report.suspicious_ratio - 0.92) < 1e-9
+
+
+def test_small_sample_caveat_shown_before_degenerate_flags() -> None:
+    """Review-caught gap: a single 0.0 sample trivially reads 'ALWAYS ZERO'
+    (100% of 1 tick), which would be misleading without a caveat that the
+    sample size is too small to trust. A newly-added domain with sparse
+    history should not be reported as confidently degenerate off one tick."""
+    samples = _samples([0.0])
+    dist = compute_distribution(samples)
+    decay = detect_decay_artifact(samples)
+    report = render_report("new_domain", "node:substrate.new_domain", dist, decay, window_hours=1.0)
+    assert "only 1 sample" in report
+    assert "unreliable" in report
+
+
+def test_representative_sample_size_has_no_caveat() -> None:
+    samples = _samples([0.0] * 50)
+    dist = compute_distribution(samples)
+    decay = detect_decay_artifact(samples)
+    report = render_report("calm_domain", "node:substrate.calm_domain", dist, decay, window_hours=1.0)
+    assert "unreliable" not in report

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -1821,6 +1821,28 @@ class BiometricsSubstrateWorker:
             attention_frame=attention_frame,
             config=config,
         )
+        if seeds:
+            # Visibility, 2026-07-26: which source/node actually won a budget
+            # slot this tick. _prediction_error_candidates() (orion/substrate/
+            # endogenous_curiosity.py) iterates every substrate node generically
+            # -- a new node with a `prediction_error` metadata field joins this
+            # consumer automatically, with no code change and no announcement
+            # here otherwise (this is exactly how bus_synaptic started feeding
+            # this tick the moment PR #1377 wrote to its node, and exactly how
+            # the old broken transport domain went unnoticed winning slots for
+            # weeks). Cheap, best-effort, never raises.
+            try:
+                sources = [
+                    f"{next((n.split(':', 1)[1] for n in (sig.notes or []) if n.startswith('source:')), 'unknown')}"
+                    f"={sig.focal_node_refs[0] if sig.focal_node_refs else '-'}"
+                    for sig in seeds
+                ]
+                logger.info(
+                    "substrate_endogenous_curiosity_seed_sources sources=%s",
+                    ",".join(sources)[:500],
+                )
+            except Exception:
+                logger.exception("substrate_endogenous_curiosity_seed_source_log_failed")
         if not seeds:
             try:
                 self._store.save_endogenous_curiosity_candidates([])

--- a/services/orion-substrate-runtime/tests/test_worker_endogenous_curiosity_tick.py
+++ b/services/orion-substrate-runtime/tests/test_worker_endogenous_curiosity_tick.py
@@ -221,3 +221,69 @@ def test_endogenous_curiosity_persist_failure_does_not_break_tick(monkeypatch):
     ) as evaluator_cls:
         evaluator_cls.return_value.evaluate.return_value = run_result
         worker._endogenous_curiosity_tick()  # must not raise
+
+
+def test_seed_sources_logged_for_visibility(monkeypatch, caplog):
+    """2026-07-26 visibility fix: which source/node won a budget slot this
+    tick must be logged. This is the generic node-iteration property that let
+    bus_synaptic join this consumer automatically (PR #1377) with zero code
+    change here -- and the same property that let the old broken transport
+    domain go unnoticed winning slots for weeks. A new signal source joining
+    silently should at least be loggable, not just silently invisible."""
+    worker = _make_worker(monkeypatch, enabled=True)
+    fake_store = MagicMock()
+    fake_store.snapshot.return_value = SimpleNamespace(
+        nodes={"node:substrate.bus_synaptic": _graph_node("node:substrate.bus_synaptic", 0.7)}
+    )
+    seed = SimpleNamespace(
+        signal_type="curiosity_candidate",
+        notes=["endogenous_seed", "source:prediction_error"],
+        focal_node_refs=["node:substrate.bus_synaptic"],
+        signal_strength=0.7,
+        confidence=0.7,
+    )
+    decision = SimpleNamespace(outcome="invoke", chosen_task_type="evidence_gap_scan")
+    run_result = SimpleNamespace(signals=[seed], decision=decision)
+
+    with patch(
+        "orion.substrate.graphdb_store.build_substrate_store_from_env",
+        return_value=fake_store,
+    ), patch(
+        "orion.substrate.endogenous_curiosity.endogenous_curiosity_candidates",
+        return_value=[seed],
+    ), patch(
+        "orion.substrate.frontier_curiosity.FrontierCuriosityEvaluator"
+    ) as evaluator_cls:
+        evaluator_cls.return_value.evaluate.return_value = run_result
+        with caplog.at_level("INFO"):
+            worker._endogenous_curiosity_tick()
+
+    assert any(
+        "substrate_endogenous_curiosity_seed_sources" in r.message
+        and "prediction_error=node:substrate.bus_synaptic" in r.message
+        for r in caplog.records
+    )
+
+
+def test_seed_source_logging_failure_does_not_break_tick(monkeypatch):
+    """A malformed/mocked signal missing focal_node_refs (as several existing
+    fixtures in this file do) must not crash the tick -- the visibility log
+    is best-effort."""
+    worker = _make_worker(monkeypatch, enabled=True)
+    fake_store = MagicMock()
+    fake_store.snapshot.return_value = SimpleNamespace(nodes={})
+    seed = SimpleNamespace(signal_type="curiosity_candidate", notes=["endogenous_seed"])
+    decision = SimpleNamespace(outcome="invoke", chosen_task_type="evidence_gap_scan")
+    run_result = SimpleNamespace(signals=[seed], decision=decision)
+
+    with patch(
+        "orion.substrate.graphdb_store.build_substrate_store_from_env",
+        return_value=fake_store,
+    ), patch(
+        "orion.substrate.endogenous_curiosity.endogenous_curiosity_candidates",
+        return_value=[seed],
+    ), patch(
+        "orion.substrate.frontier_curiosity.FrontierCuriosityEvaluator"
+    ) as evaluator_cls:
+        evaluator_cls.return_value.evaluate.return_value = run_result
+        worker._endogenous_curiosity_tick()  # must not raise


### PR DESCRIPTION
## Summary

Items 4 and 5 of the brainstorm follow-through (bus_synaptic calm-floor fix PR #1391, route decay fix PR #1393, capability:transport replacement PR #1394).

- **New**: `scripts/analysis/audit_prediction_error_domain.py` — mechanizes the two live-data checks that judgment relied on to catch both real bugs this session, by hand: distributional sanity (degenerate: zero variance, always-0, mostly-saturated) and decay-artifact detection (a suspiciously exact, sustained geometric ratio between consecutive nonzero values — route's exact bug signature: ratio 0.92 for 48+ hours straight).
- Its own **first live smoke test caught a real bug in itself**: a held-flat run (ratio exactly 1.0) was being flagged as a decay artifact, when holding flat is the *correct* post-fix behavior, not a bug. Fixed by excluding ratio==1.0 from ever starting/extending a suspicious run.
- Review then caught a **second, subtler gap**: a single flat tick landing mid-decay-run was resetting continuity instead of being skipped, which could fragment a genuine long decay run into two shorter sub-runs, each potentially falling below the detection threshold. Fixed (skip without breaking continuity) plus a regression test reproducing the exact scenario. Also added a small-sample-size caveat since degenerate flags are meaningless on 1-2 ticks (also a review finding).
- `worker.py`'s `_endogenous_curiosity_tick()`: added a best-effort visibility log (`substrate_endogenous_curiosity_seed_sources`) naming which source/node won a candidate-budget slot each tick. `_prediction_error_candidates()` iterates every substrate node generically — this is how `bus_synaptic` joined this rung-5 cognition-loop consumer automatically the moment its node appeared (PR #1377), and how the old broken `transport` domain went unnoticed winning slots for weeks.

## Outcome moved

The next domain that turns out to have a floor-bias or decay-artifact bug can be checked with one command instead of hand-archaeology. Silent new/dead cognition-loop contributors are now loggable, not just discoverable after the fact.

## Current architecture

`orion/substrate/endogenous_curiosity.py::_prediction_error_candidates()` generically iterates every substrate node with a `prediction_error` metadata field — no domain allowlist, confirmed via code read this session. No prior tooling existed to mechanically sanity-check a domain's live distribution against the two specific failure shapes found this session (permanent floor bias, decay-to-zero artifact).

## Files changed

- `scripts/analysis/audit_prediction_error_domain.py` (new): CLI, `<domain>` or `--node-id`, `--window-hours`, `--postgres-uri`. Pure layer (`compute_distribution`, `detect_decay_artifact`) separated from I/O, matching this directory's existing convention (`measure_transport_bus_signal_history.py`).
- `scripts/analysis/tests/test_audit_prediction_error_domain.py` (new): 12 tests covering both real bug shapes plus the two review-caught gaps.
- `services/orion-substrate-runtime/app/worker.py`: visibility log line in `_endogenous_curiosity_tick()`.
- `services/orion-substrate-runtime/tests/test_worker_endogenous_curiosity_tick.py`: 2 new tests (log fires with real signal shape; malformed mock doesn't crash the tick).

## Schema / bus / API changes

None — new read-only analysis script, and a log-line addition to existing production code (no behavior change to what the tick actually does).

## Env/config changes

None.

## Tests run

```text
PYTHONPATH="." /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest scripts/analysis/tests/test_audit_prediction_error_domain.py -q
12 passed

PYTHONPATH="services/orion-substrate-runtime" /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest services/orion-substrate-runtime/tests/test_worker_endogenous_curiosity_tick.py -q
10 passed

PYTHONPATH="services/orion-substrate-runtime" /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest services/orion-substrate-runtime/tests/ -q --ignore=services/orion-substrate-runtime/tests/test_grammar_consumer_integration.py
162 passed (16 pre-existing failures confirmed identical on a clean main clone -- unrelated env/settings issues, not introduced by this patch)
```

Also live-smoke-tested the script against real Postgres data (`bus_synaptic`, `route`) — see PR conversation for full output.

## Evals run

None — the script itself functions as the eval tool going forward; validated its own correctness against real historical data during development (that's how both self-caught bugs above were found).

## Docker/build/smoke checks

Not applicable for the new script (local analysis tool, no service changes). The worker.py logging addition takes effect on next substrate-runtime deploy; purely additive (a new log line), no restart-critical behavior change.

## Review findings fixed

- Finding: `detect_decay_artifact()`'s ratio==1.0 exclusion fully reset run continuity, meaning a single held-flat tick mid-run could fragment a real decay run into two sub-runs each below the detection threshold — a demonstrated false-negative path.
  - Fix: changed the ratio==1.0 branch to skip the transition without resetting `current_run`/`current_ratio`/`current_start`.
  - Evidence: new regression test `test_a_single_held_flat_tick_does_not_fragment_a_real_decay_run` reproduces the exact scenario and passes; all 12 tests green.
- Finding: no minimum-sample-size gate before reporting distribution flags — a single 0.0 sample trivially reads "ALWAYS ZERO," which is misleading for a newly-added domain with sparse history.
  - Fix: added `_MIN_SAMPLES_FOR_DISTRIBUTION_FLAGS = 10` and a caveat line in the report when below it.
  - Evidence: `test_small_sample_caveat_shown_before_degenerate_flags`/`test_representative_sample_size_has_no_caveat` both pass.
- Finding (confirmed non-issue, not a fix): whether the worker.py visibility log's try/except could silently swallow on every real production tick — traced the full `FrontierInvocationSignalV1` pydantic contract (`notes`/`focal_node_refs` are never `None`, always a list by field default) and confirmed the log line is safe against every real signal shape; only the deliberately-malformed test mock triggers the except branch.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml \
  up -d --build
```
(For the visibility log line to take effect; the audit script needs no deploy.)

## Risks / concerns

- Severity: low
- Concern: the decay-artifact detector's `_MIN_SUSPICIOUS_RUN_LENGTH = 20` and `_RATIO_TOLERANCE = 1e-9` are judgment calls calibrated against route's specific bug shape (86,000+ ticks, ratio 0.92) — a different decay bug with a much shorter real history or a less precise ratio could still slip under this detector.
- Mitigation: documented in the module docstring as a conservative floor, not a guarantee; the script is a sanity-check aid, not a replacement for the judgment CLAUDE.md's metric-quality-gate already requires.

## PR link

(filled in below)