### PR TITLE
feat(substrate): retire transport_prediction_error's live write

### DIFF
--- a/docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md
+++ b/docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md
@@ -304,3 +304,21 @@ condition.
 This does not change Item 3's other caveats (transport miscalibration, route subnormal float,
 `execution_load`/`reasoning_load` substrate) -- those remain open. It is a correction to this
 same revision's own claim that the sanity-check pass had cleared `bus_synaptic`, not a new item.
+
+## Revision, 2026-07-26 (`transport` domain retired, not merely excluded)
+
+Item 3's transport caveat (2026-07-25 revision above: "real signal, calibrated ~1,000x off the
+system's actual operating range") is resolved differently than route's -- not repaired, retired.
+`transport_prediction_error()`'s live write was removed entirely from
+`services/orion-substrate-runtime/app/worker.py::_transport_tick()`
+(`docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md`,
+implemented after Juniper's explicit go-ahead following proposal mode). It was never just an
+AST/HOT-side exclusion problem: the same dead `node:substrate.transport` node kept winning real
+curiosity-candidate budget slots in `orion/substrate/endogenous_curiosity.py`, a live,
+autonomy-adjacent rung-5 consumer that iterates every substrate node generically -- confirmed
+pinned at `signal_strength=1.0` across 1,428 candidate sets over a 24h window (2026-07-16).
+`bus_synaptic` is the real successor there too, and required no new wiring in that consumer.
+
+Item 3's metric-quality-gate pass now needs to clear two domains, not three: route (its own
+subnormal-float caveat separately fixed the same day, see the 2026-07-26 revision above) and
+`execution_load`/`reasoning_load` substrate, still open.

--- a/docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md
+++ b/docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md
@@ -1,6 +1,15 @@
 # Retire `transport_prediction_error()` / `node:substrate.transport` — `bus_synaptic` is the real transport signal now — design spec
 
-Status: **design mode, not implemented.** Written per CLAUDE.md's proposal-mode rule (this touches
+Status: **IMPLEMENTED, 2026-07-26.** Juniper gave explicit go-ahead after this proposal-mode doc.
+`services/orion-substrate-runtime/app/worker.py::_transport_tick()`'s prediction_error write was
+removed; `endogenous_curiosity.py`'s generic node iteration already carries `bus_synaptic` with no
+new wiring, confirming this doc's own core claim. See `services/orion-substrate-runtime/README.md`'s
+"RETIRED, 2026-07-26" section and the AST/HOT design spec's matching revision for the live writeup.
+Recommended-next-patch steps 1-4 below were all completed; `transport_prediction_error()` was kept
+(not deleted) per step 3's "cheapest" option, unused by any live caller.
+
+Original proposal-mode status, preserved below for the record: **design mode, not implemented.**
+Written per CLAUDE.md's proposal-mode rule (this touches
 `orion/substrate/endogenous_curiosity.py`, a rung-5 autonomy-adjacent cognition-loop consumer).
 Juniper explicitly asked for this doc before any code changes, after flagging that the old
 `transport` Active-Inference domain is illegitimate and `bus_synaptic` is the real signal.

--- a/orion/substrate/endogenous_curiosity.py
+++ b/orion/substrate/endogenous_curiosity.py
@@ -43,12 +43,22 @@ HARD_BUDGET_CEILING = 8
 
 # Prediction-error staleness ceiling. `metadata["prediction_error"]` is a raw
 # snapshot (never decays on its own; see `pressure.py::prediction_error_pressure()`'s
-# docstring) written by the transport reducer whenever `transport_prediction_error()`
-# fires. Left unguarded, a node that was surprising once is "sustained prediction
+# docstring). Left unguarded, a node that was surprising once is "sustained prediction
 # error" forever and, since candidates sort strongest-first, wins the bounded
 # per-cycle budget on every tick. Live-confirmed 2026-07-16: `node:substrate.transport`
 # held `signal_strength=1.0` identically across all 1,428 persisted candidate sets
-# over the prior 24h (path live since 2026-07-02, not dormant).
+# over the prior 24h (path live since 2026-07-02, not dormant) -- written by the
+# transport reducer whenever `transport_prediction_error()` fired.
+#
+# **Resolved 2026-07-26, not just decayed away:** `transport_prediction_error()`'s
+# write was removed entirely from `services/orion-substrate-runtime/app/worker.py
+# ::_transport_tick()` (docs/superpowers/specs/2026-07-26-transport-domain-
+# retirement-bus-synaptic-successor-design.md) -- it was a narrow, known-fake
+# "world_pulse" census, not real bus traffic, and this staleness ceiling was only
+# ever a mitigation for it, not a fix. `node:substrate.bus_synaptic` is the real
+# mesh-wide successor and already flows into this same generic node iteration
+# with zero code change here. This staleness-decay guard remains load-bearing
+# for every other node this function reads, not specifically for transport.
 #
 # Deliberately NOT switched to reading `dynamic_pressure` directly, unlike the
 # sibling fix in `attention_broadcast.py::_node_salience()` (PR #1061):

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -85,7 +85,23 @@ def transport_prediction_error(
     prev: TransportBusProjectionV1,
     curr: TransportBusProjectionV1,
 ) -> float:
-    """0-1 surprise score: how much did transport bus health change this batch?"""
+    """0-1 surprise score: how much did transport bus health change this batch?
+
+    **Retired from live use 2026-07-26** (docs/superpowers/specs/2026-07-26-
+    transport-domain-retirement-bus-synaptic-successor-design.md). This diffs
+    stream_backlog_health/delivery_confidence/stream_backlog_pressure -- fields
+    fed by BUS_OBSERVER_STREAMS' narrow 2-Redis-Stream "world_pulse" census, not
+    real inter-service bus traffic. Already excluded from attention_self_model
+    .py's ACTIVE_INFERENCE_DOMAINS as known-dead; `services/orion-substrate-
+    runtime/app/worker.py::_transport_tick()` no longer calls this function
+    live -- bus_synaptic_prediction_error() (below) is the real, mesh-wide
+    successor, already flowing into every consumer this fed. Kept here (not
+    deleted) though it now has zero callers anywhere in the repo, live or
+    offline -- checked: measure_transport_bus_signal_history.py and measure_
+    transport_biometrics_prediction_error_correlation.py only mention this
+    function's name in prose docstrings, they read persisted values directly
+    from Postgres, no import. Do not wire this back into a live tick.
+    """
     deltas: list[float] = []
     for bus_id, curr_bus in curr.buses.items():
         prev_bus = prev.buses.get(bus_id)

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -458,6 +458,29 @@ saturation ceiling, which both the old and new formulas only reach at raw `mean(
 identical fire condition before and after this fix, confirmed by reading
 `services/orion-equilibrium-service/app/settings.py` and its `.env_example` (both `1.0`).
 
+**RETIRED, 2026-07-26: `transport_prediction_error()`'s live write removed entirely.** Following
+Juniper's explicit go-ahead after proposal mode
+(`docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md`),
+`_transport_tick()` (`app/worker.py`) no longer computes or writes `node:substrate.transport`'s
+`prediction_error` -- the narrow `world_pulse`-census instrument documented above was not just
+excluded from `attention_self_model.py`'s `ACTIVE_INFERENCE_DOMAINS`, it kept winning real
+curiosity-candidate budget slots in `orion/substrate/endogenous_curiosity.py` (confirmed pinned at
+`signal_strength=1.0` for 1,428 candidate sets over 24h, 2026-07-16 -- see that module's own
+comment, now updated to note resolution). `bus_synaptic_prediction_error()` is the real successor
+and required zero new wiring in that consumer: `endogenous_curiosity.py`'s node iteration is
+already fully generic, so `bus_synaptic` was already flowing into it before this patch. Checked and
+confirmed unaffected by removing this write: reducer-health/cursor tracking (`record_success`/
+`_advance_cursor`, driven by `last_id` from real event processing, not by this block),
+`_log_transport_incident_signals()` (a separate, still-running diagnostic logger),
+`catalog_drift_pressure`/`observer_failure_pressure` (fed by a different function,
+`compute_transport_pressures()`, and still live in `config/field/orion_field_topology.v1.yaml`'s
+`capability:transport` edge per PR #1394). `transport_prediction_error()` itself is kept (not
+deleted) though review confirmed it has zero callers anywhere in the repo now -- the two analysis
+scripts this doc originally credited (`measure_transport_bus_signal_history.py`,
+`measure_transport_biometrics_prediction_error_correlation.py`) only name it in prose, they read
+persisted values directly from Postgres. Review also caught one dead read: `prev_projection =
+load_projection()` was only ever consumed by the removed call, deleted alongside it.
+
 **Fixed 2026-07-25 (same day, follow-up): the 5 new env keys above weren't reaching the
 container.** Same class of gotcha already documented for `SUBSTRATE_STORE_BACKEND`/`FALKORDB_URI`
 in this service's `.env_example` (not elsewhere in this README) — `docker-compose.yml` passes env vars through via an explicit

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -45,7 +45,6 @@ from orion.substrate.prediction_error import (
     chat_prediction_error,
     execution_prediction_error,
     route_prediction_error,
-    transport_prediction_error,
 )
 from orion.substrate.transport_loop.pipeline import (
     empty_transport_projection,
@@ -2110,7 +2109,10 @@ class BiometricsSubstrateWorker:
             loaded = self._store.load_transport_bus_projection(TRANSPORT_BUS_PROJECTION_ID)
             return loaded or empty_transport_projection(now=now)
 
-        prev_projection = load_projection()
+        # 2026-07-26: prev_projection removed here -- it was only ever read by
+        # the now-removed transport_prediction_error(prev_projection,
+        # curr_projection) call below. Keeping it would be a wasted Postgres
+        # read every tick for a value nobody consumes (review caught this).
 
         def process_batch(batch: list[GrammarEventV1]) -> None:
             process_transport_grammar_events(
@@ -2131,22 +2133,32 @@ class BiometricsSubstrateWorker:
         if last_id is not None:
             curr_projection = load_projection()
             _log_transport_incident_signals(curr_projection)
-            error = transport_prediction_error(prev_projection, curr_projection)
-            if error > 0.0:
-                self._store.save_receipt(
-                    _prediction_error_receipt(
-                        reducer_key="transport_bus",
-                        node_id="node:substrate.transport",
-                        prediction_error=error,
-                        now=now,
-                    )
-                )
-                self._write_prediction_error_node(
-                    node_id="node:substrate.transport",
-                    error=error,
-                    now=now,
-                    reducer_key="transport_bus",
-                    contributing_id=last_id,
-                )
+            # 2026-07-26: node:substrate.transport's prediction_error write REMOVED
+            # (docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-
+            # synaptic-successor-design.md). transport_prediction_error() itself
+            # (orion/substrate/prediction_error.py) is a narrow 2-Redis-Stream
+            # "world_pulse" census, not real bus traffic, already excluded from
+            # attention_self_model.py's ACTIVE_INFERENCE_DOMAINS -- but the write
+            # here kept running regardless, and orion/substrate/endogenous_
+            # curiosity.py's generic node iteration kept reading it, once pinned
+            # at signal_strength=1.0 for a full 24h (2026-07-16, see that module's
+            # comment) and winning real curiosity-candidate budget slots on a fake
+            # signal. bus_synaptic_prediction_error() (node:substrate.bus_synaptic)
+            # already flows into that same consumer automatically -- no new wiring
+            # needed there, killing this write is the entire change. Everything
+            # else in this reducer (event processing, projection state, incident
+            # logging above, catalog_drift_pressure/observer_failure_pressure via
+            # config/field/orion_field_topology.v1.yaml's still-live edge) is
+            # unaffected -- confirmed via _grammar_reducer_poll_loop that reducer-
+            # health/cursor tracking is driven by last_id, not by this block.
+            # transport_prediction_error() itself is kept, not deleted -- review
+            # confirmed it has zero callers anywhere in the repo now, live or
+            # offline (the two analysis scripts this comment originally claimed
+            # used it, measure_transport_bus_signal_history.py and measure_
+            # transport_biometrics_prediction_error_correlation.py, only mention
+            # its name in prose docstrings -- both read persisted values
+            # straight out of Postgres, no import). Kept anyway as the cheapest
+            # option (deleting it buys nothing and risks a future script
+            # wanting it for genuine historical replay).
 
         return last_id

--- a/services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py
+++ b/services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py
@@ -169,7 +169,10 @@ def test_write_prediction_error_node_preserves_dynamics_state_on_rewrite(monkeyp
     """Regression test: _write_prediction_error_node's docstring says it "writes
     a single node under a fixed identity_key so re-writes collapse" -- i.e. the
     same node_id is upserted repeatedly (see worker.py's _execution_tick /
-    _transport_tick callers, both using a fixed node_id every cycle). Now that
+    _route_tick callers, both using a fixed node_id every cycle -- _transport_tick
+    no longer calls this helper as of 2026-07-26, see docs/superpowers/specs/
+    2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md).
+    Now that
     falkor_codec.py always includes dynamic_pressure/dormant/etc in every
     upsert's SET clause, a naive re-write that doesn't carry forward the
     dynamics engine's already-computed state would durably reset it to


### PR DESCRIPTION
## Summary

Implements PR #1392's proposal-mode design doc after explicit go-ahead.

- `transport_prediction_error()` is a narrow, known-fake "world_pulse" 2-Redis-Stream census, not real bus traffic — already excluded from `attention_self_model.py`'s `ACTIVE_INFERENCE_DOMAINS`, but its tick kept running and its node kept winning real curiosity-candidate budget slots in `orion/substrate/endogenous_curiosity.py` (confirmed pinned at `signal_strength=1.0` across 1,428 candidate sets over 24h, 2026-07-16) because that consumer iterates every substrate node generically.
- Removed the prediction_error computation/write from `_transport_tick()` (`services/orion-substrate-runtime/app/worker.py`). Everything else in that reducer (event processing, projection state, `_log_transport_incident_signals()`, `catalog_drift_pressure`/`observer_failure_pressure` via the still-live topology edge from PR #1394) is untouched.
- `bus_synaptic_prediction_error()` required zero new wiring in `endogenous_curiosity.py` — its node iteration is already fully generic, so `bus_synaptic` was already flowing in before this patch.
- `transport_prediction_error()` is kept (not deleted), but review found and corrected an overclaim about why: the two analysis scripts this comment originally credited don't actually import it — corrected in all three places it appeared.
- Review also caught and fixed a dead variable (`prev_projection`, a now-unused Postgres read every tick) and confirmed no other live consumer breaks via a fresh repo-wide grep.

## Outcome moved

The dead `transport` domain can no longer silently win real curiosity-candidate budget slots on a fake signal — closes the 2026-07-16 incident class permanently rather than just mitigating it via staleness decay.

## Current architecture

`_transport_tick()` (`REDUCER_SPECS[2]`) processes real transport grammar events, maintains `TransportBusProjectionV1`, and until this patch also computed/wrote a prediction_error signal from a narrow, already-known-dead census.

## Architecture touched

`services/orion-substrate-runtime/app/worker.py` only for code; docs updated to match.

## Files changed

- `services/orion-substrate-runtime/app/worker.py`: removed the prediction_error computation/write and the now-dead `prev_projection` read; removed the unused `transport_prediction_error` import.
- `services/orion-substrate-runtime/tests/test_worker_falkor_routed_store.py`: updated a stale docstring reference (named `_transport_tick` as a "fixed node_id" example — no longer true).
- `orion/substrate/prediction_error.py`: retirement docstring on `transport_prediction_error()`.
- `orion/substrate/endogenous_curiosity.py`: comment-only update noting the 2026-07-16 incident is resolved, not just decayed.
- `services/orion-substrate-runtime/README.md`, the AST/HOT design spec, and the proposal doc itself: dated revisions / status update to IMPLEMENTED.

## Schema / bus / API changes

- Added: none.
- Removed: `node:substrate.transport`'s `prediction_error` metadata stops being refreshed (ages out via existing staleness decay).
- Renamed: none.
- Behavior changed: `_transport_tick()` no longer writes a prediction_error signal. `endogenous_curiosity.py`'s candidate generation no longer sees a (fake) contribution from `node:substrate.transport`.
- Compatibility notes: `catalog_drift_pressure`/`observer_failure_pressure` (a separate function, separate topology edge) unaffected.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH="services/orion-substrate-runtime" /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest \
  services/orion-substrate-runtime/tests/ -q --ignore=services/orion-substrate-runtime/tests/test_grammar_consumer_integration.py
16 failed, 162 passed
```
(16 failures confirmed identical — same test names, same error types — to the pre-existing baseline on a clean main clone; not introduced by this patch.)

```text
PYTHONPATH="." /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest orion/substrate/tests/ -q
435 passed
```

## Evals run

None — validated against the real, already-documented 2026-07-16 incident and a fresh repo-wide grep for other consumers instead.

## Docker/build/smoke checks

Not applicable directly — requires a substrate-runtime restart to take effect (listed below).

## Review findings fixed

- Finding: `prev_projection = load_projection()` became dead code (only ever consumed by the removed call), performing a wasted Postgres read every tick.
  - Fix: deleted, with an explanatory comment.
  - Evidence: full test suite re-run post-fix, still exact 16/162 baseline.
- Finding: worker.py's comment, `prediction_error.py`'s docstring, and the README all claimed `transport_prediction_error()` was kept "for" two named analysis scripts — factually wrong, neither script imports it (both read Postgres directly, the function name only appears in prose).
  - Fix: corrected all three to state it's kept unused by any known caller, live or offline.
  - Evidence: `grep -n "^import\|^from\|transport_prediction_error"` on both scripts confirms no import.
- Finding (confirmed non-issue): whether reducer-health/cursor tracking or the two still-live transport pressures depend on the removed block.
  - Fix: none needed — traced `_grammar_reducer_poll_loop` (driven by `last_id`) and `compute_transport_pressures()` (a genuinely separate function) directly, confirmed independent.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: low
- Concern: `node:substrate.transport`'s stale prediction_error value will sit frozen (per PR #1393's decay fix) rather than actively cleared — a cosmetic leftover, not a behavioral risk, since `endogenous_curiosity.py`'s own staleness decay ages any node's contribution to zero regardless.
- Mitigation: none needed; consistent with how route's stale value is already handled post-#1393.

## PR link

(filled in below)