### PR TITLE
fix(hub): repoint transport gates at real bus_synaptic data, fix dead nesting bug

### DIFF
--- a/config/substrate-lattice/transport_lattice_policy.v1.yaml
+++ b/config/substrate-lattice/transport_lattice_policy.v1.yaml
@@ -11,7 +11,20 @@ dimension_weights:
 
 # channel → dimension, thresholds, action ceiling
 channels:
-  stream_backlog_pressure:
+  # Renamed from stream_backlog_pressure 2026-07-27 (PRs #1391-#1396): that
+  # channel was fed by a narrow 2-Redis-Stream "world_pulse" census, not real
+  # bus traffic, already retired. bus_synaptic_pressure is capability:transport's
+  # real, mesh-wide successor (config/field/orion_field_topology.v1.yaml).
+  # Thresholds carried over unchanged from the old channel -- Juniper's explicit
+  # call: the old gate effectively never fired (frozen near-zero for its whole
+  # life, plus a separate dict-nesting bug in substrate_lattice_routes.py that
+  # meant it read a nonexistent key regardless), so there's no real prior
+  # behavior to preserve continuity with. bus_synaptic's real distribution
+  # saturates at 1.0 for ~14% of ticks (6h live sample, 2026-07-27) -- these
+  # thresholds will make this gate active far more often than the old one ever
+  # was; that is treated as the honest signal the old gate never gave, not a
+  # miscalibration to chase.
+  bus_synaptic_pressure:
     dimension: delivery_integrity
     watch_at: 0.25
     summarize_at: 0.50

--- a/services/orion-hub/scripts/substrate_lattice_routes.py
+++ b/services/orion-hub/scripts/substrate_lattice_routes.py
@@ -482,12 +482,35 @@ def _compute_gates(chain: dict[str, Any]) -> list[dict[str, Any]]:
     transport = chain.get("transport", {})
     m3 = transport.get("m3", {})
     m3_receipts = transport.get("m3_receipts", {})
+    m4 = transport.get("m4", {})
     m5 = transport.get("m5", {})
     l9 = transport.get("l9", {})
 
     m3_status = m3.get("status", "missing")
     m3_values = m3.get("values", {}) if m3_status != "missing" else {}
     buses = m3_values.get("buses", {})
+
+    # 2026-07-27: pressure/contract gates below read M4's capability:transport
+    # field_vector, not M3's raw projection. Found while wiring bus_synaptic in:
+    # TransportBusProjectionV1 (orion/schemas/transport_projection.py) has NO
+    # top-level stream_backlog_pressure/contract_pressure/observer_failure_pressure
+    # fields at all -- those only exist nested under buses[bus_id][...] per
+    # TransportBusStateV1. `m3_values.get("stream_backlog_pressure")` and
+    # `m3_values.get("contract_pressure")` were reading a key that never
+    # existed at that level, always silently defaulting to 0.0/"quiet" --
+    # confirmed against the real persisted JSON, not just the schema. This was
+    # a separate, pre-existing bug, independent of the world_pulse-census
+    # degeneracy PRs #1391-#1396 fixed. M4's field_vector already carries the
+    # real values (pressure/contract_pressure/reliability_pressure), fed by
+    # config/field/orion_field_topology.v1.yaml's capability:transport edges
+    # (bus_synaptic -> pressure per PR #1394; catalog_drift_pressure ->
+    # contract_pressure and observer_failure_pressure -> reliability_pressure,
+    # both still live) -- no new query needed, this data was already being
+    # fetched into the chain and simply never read from the right place.
+    m4_status = m4.get("status", "missing")
+    m4_field_vector = (
+        (m4.get("values") or {}).get("field_vector", {}) if m4_status != "missing" else {}
+    )
 
     # --- freshness gate ---
     freshness_max_age = (
@@ -525,31 +548,44 @@ def _compute_gates(chain: dict[str, Any]) -> list[dict[str, Any]]:
 
     # --- pressure gate ---
     channels = lattice_policy.get("channels", {})
-    transport_p = float(m3_values.get("stream_backlog_pressure") or 0.0)
-    observer_p = float(m3_values.get("observer_failure_pressure") or 0.0)
-    transport_watch_at = float(
-        (channels.get("stream_backlog_pressure") or {}).get("watch_at", 0.25)
-    )
-    observer_watch_at = float(
-        (channels.get("observer_failure_pressure") or {}).get("watch_at", 0.25)
-    )
-    pressure_active = transport_p >= transport_watch_at or observer_p >= observer_watch_at
-    pressure_state = "watch" if pressure_active else "quiet"
-    pressure_reason = (
-        f"stream_backlog_pressure={transport_p:.2f} "
-        f"observer_failure_pressure={observer_p:.2f} "
-        f"(thresholds: transport={transport_watch_at}, observer={observer_watch_at})"
-    )
+    if m4_status in ("stale", "missing"):
+        # Review-caught gap, 2026-07-27: the contract gate below already guards
+        # on m4_status; this one didn't, and a stale/missing M4 was silently
+        # read as "quiet" (0.0 default) or as a real reading of whatever value
+        # last happened to be cached -- the exact failure class (stale/absent
+        # data mistaken for a genuine calm reading) this patch exists to fix.
+        # M3 and M4 have independent freshness clocks in production
+        # (substrate_transport_bus_projection.updated_at vs
+        # substrate_field_state.generated_at), so M4 going stale/missing while
+        # M3 stays fresh is a real, not just theoretical, scenario.
+        pressure_state = "unknown"
+        pressure_reason = f"pressure state unknown: M4 field vector is {m4_status}"
+    else:
+        transport_p = float(m4_field_vector.get("pressure") or 0.0)
+        observer_p = float(m4_field_vector.get("reliability_pressure") or 0.0)
+        transport_watch_at = float(
+            (channels.get("bus_synaptic_pressure") or {}).get("watch_at", 0.25)
+        )
+        observer_watch_at = float(
+            (channels.get("observer_failure_pressure") or {}).get("watch_at", 0.25)
+        )
+        pressure_active = transport_p >= transport_watch_at or observer_p >= observer_watch_at
+        pressure_state = "watch" if pressure_active else "quiet"
+        pressure_reason = (
+            f"bus_synaptic_pressure={transport_p:.2f} "
+            f"observer_failure_pressure={observer_p:.2f} "
+            f"(thresholds: transport={transport_watch_at}, observer={observer_watch_at})"
+        )
 
     # --- contract gate ---
     contract_watch_at = float(
         (channels.get("contract_pressure") or {}).get("watch_at", 0.50)
     )
-    if m3_status in ("stale", "missing"):
+    if m4_status in ("stale", "missing"):
         contract_state = "unknown"
-        contract_reason = f"contract state unknown: M3 projection is {m3_status}"
+        contract_reason = f"contract state unknown: M4 field vector is {m4_status}"
     else:
-        contract_p = float(m3_values.get("contract_pressure") or 0.0)
+        contract_p = float(m4_field_vector.get("contract_pressure") or 0.0)
         if contract_p == 0.0:
             contract_state = "quiet"
         elif contract_p >= contract_watch_at:

--- a/services/orion-hub/tests/test_substrate_lattice_routes.py
+++ b/services/orion-hub/tests/test_substrate_lattice_routes.py
@@ -203,6 +203,14 @@ def _sample_proof_chain_for_gates(
                 "values": {
                     "projection_id": "active_transport_bus_projection",
                     "stream_backlog_health": 1.0,
+                    # 2026-07-27: these two top-level keys don't exist on the real
+                    # TransportBusProjectionV1 schema (only nested under buses[...]
+                    # per TransportBusStateV1) -- kept here only because
+                    # transport_simulate()/_compute_salience() (a separate,
+                    # not-yet-fixed code path, out of scope for this patch) still
+                    # reads M3 this way. _compute_gates() no longer reads these --
+                    # it reads m4.field_vector below instead (real bug found while
+                    # wiring bus_synaptic in: this key was never real).
                     "stream_backlog_pressure": stream_backlog_pressure,
                     "contract_pressure": contract_pressure,
                     "catalog_drift_pressure": 0.0,
@@ -225,11 +233,26 @@ def _sample_proof_chain_for_gates(
                 "values": {"count": len(receipt_list), "receipts": receipt_list},
             },
             "m4": {
-                "status": "fresh",
+                # m3_status (fresh/stale) reused here rather than an independent
+                # calculation -- both lanes share the same bus_age_sec test knob,
+                # and _compute_gates' contract gate now genuinely depends on M4's
+                # freshness (it's where the value is read from), not M3's, so this
+                # must actually vary with bus_age_sec, not be hardcoded "fresh".
+                "status": m3_status,
                 "source_table": "substrate_field_state",
                 "timestamp": ts,
                 "age_sec": bus_age_sec,
-                "values": {"field_vector": {"pressure": 0.5}, "has_transport_vector": True},
+                # capability:transport's real field vector -- what _compute_gates
+                # actually reads post 2026-07-27. pressure/contract_pressure mirror
+                # the same test knobs used for M3 above so both code paths can be
+                # exercised from one fixture without a parameter per code path.
+                "values": {
+                    "field_vector": {
+                        "pressure": stream_backlog_pressure,
+                        "contract_pressure": contract_pressure,
+                    },
+                    "has_transport_vector": True,
+                },
             },
             "m5": {
                 "status": "fresh",
@@ -396,6 +419,33 @@ def test_gates_pressure_watch_when_nonzero(client) -> None:
         resp = client.get("/api/substrate-lattice/transport/gates")
     gates = {g["gate_id"]: g for g in resp.json()["gates"]}
     assert gates["pressure"]["state"] == "watch"
+
+
+def test_gates_pressure_reads_m4_field_vector_not_m3_top_level(client) -> None:
+    """Regression test, 2026-07-27: the pressure/contract gates used to read
+    m3.values.stream_backlog_pressure/contract_pressure, keys that don't exist
+    on the real TransportBusProjectionV1 schema (only nested under
+    buses[bus_id][...]) -- always silently defaulting to 0.0/"quiet"/"pass"
+    regardless of real bus state. Proves the fix by setting M3's top-level
+    keys to values that would trip the OLD (buggy) thresholds if read, while
+    M4's field_vector (what the code now actually reads) says otherwise."""
+    chain = _sample_proof_chain_for_gates(
+        stream_backlog_pressure=0.9, contract_pressure=0.9,
+    )
+    # Poison M3's top-level values -- if the code regresses to reading these,
+    # both gates would report "watch"/high; with the fix, M4 alone decides.
+    chain["transport"]["m3"]["values"]["stream_backlog_pressure"] = 0.9
+    chain["transport"]["m3"]["values"]["contract_pressure"] = 0.9
+    chain["transport"]["m4"]["values"]["field_vector"]["pressure"] = 0.0
+    chain["transport"]["m4"]["values"]["field_vector"]["contract_pressure"] = 0.0
+    with patch.object(
+        substrate_lattice_routes, "_load_transport_proof_chain", return_value=chain
+    ):
+        resp = client.get("/api/substrate-lattice/transport/gates")
+    gates = {g["gate_id"]: g for g in resp.json()["gates"]}
+    assert gates["pressure"]["state"] == "quiet"
+    assert gates["contract"]["state"] == "quiet"
+    assert "bus_synaptic_pressure=0.00" in gates["pressure"]["reason"]
 
 
 # ── _load_transport_proof_chain internals ────────────────────────
@@ -853,6 +903,39 @@ def test_gates_contract_unknown_when_m3_stale(client) -> None:
         resp = client.get("/api/substrate-lattice/transport/gates")
     gates = {g["gate_id"]: g for g in resp.json()["gates"]}
     assert gates["contract"]["state"] == "unknown"
+
+
+def test_gates_pressure_unknown_when_m4_stale(client) -> None:
+    """Regression test, 2026-07-27 (review-caught gap): the pressure gate must
+    go 'unknown' when M4 is stale/missing, exactly like the contract gate --
+    reading from a stale/missing field vector as if it were a real 'quiet' or
+    'watch' reading is the same failure class this whole patch exists to fix.
+    Poisons the pressure value high (0.9) to prove it's the staleness check
+    that suppresses it, not the value itself happening to read low."""
+    chain = _sample_proof_chain_for_gates(bus_age_sec=3600.0, freshness_threshold_sec=60)
+    chain["transport"]["m4"]["values"]["field_vector"]["pressure"] = 0.9
+    with patch.object(
+        substrate_lattice_routes, "_load_transport_proof_chain", return_value=chain
+    ):
+        resp = client.get("/api/substrate-lattice/transport/gates")
+    gates = {g["gate_id"]: g for g in resp.json()["gates"]}
+    assert gates["pressure"]["state"] == "unknown"
+
+
+def test_gates_pressure_missing_when_m4_absent(client) -> None:
+    """pressure gate is 'unknown' when M4 has no data at all (status=missing),
+    not silently defaulting to 'quiet' via the 0.0 fallback."""
+    chain = _sample_proof_chain_for_gates()
+    chain["transport"]["m4"] = {
+        "status": "missing", "source_table": "substrate_field_state",
+        "timestamp": None, "age_sec": None, "values": None,
+    }
+    with patch.object(
+        substrate_lattice_routes, "_load_transport_proof_chain", return_value=chain
+    ):
+        resp = client.get("/api/substrate-lattice/transport/gates")
+    gates = {g["gate_id"]: g for g in resp.json()["gates"]}
+    assert gates["pressure"]["state"] == "unknown"
 
 
 def test_gates_attention_pass_when_capability_transport_present(client) -> None:


### PR DESCRIPTION
## Summary

Follow-up from a "anything else using that bullshit transport" sweep across the mesh after PRs #1391-#1396.

- `services/orion-hub/scripts/substrate_lattice_routes.py`'s `/transport/gates` pressure/contract gates were reading `m3_values.get("stream_backlog_pressure"/"contract_pressure")` — but `TransportBusProjectionV1` has **no top-level fields with those names at all** (only nested under `buses[bus_id][...]` per `TransportBusStateV1`). Confirmed against a live persisted row: this key has never existed in production, so both gates have silently defaulted to `0.0`/"quiet"/"pass" since day one — a separate, pre-existing bug independent of whether the world_pulse census was ever healthy.
- Fixed by reading from **M4** (`capability:transport`'s field vector) instead — already fetched into the same chain dict, no new query needed. M4's `pressure` is fed by `node:substrate.bus_synaptic` (PR #1394's topology edge); `contract_pressure` by the still-live `catalog_drift_pressure` edge.
- Review caught a second gap in the same spirit: the pressure gate had no missing/stale-M4 guard (unlike the contract gate, which now correctly has one) — a stale or absent M4 would silently read as a real "quiet"/"watch" reading instead of "unknown." Fixed, with regression tests.
- Renamed the policy channel `stream_backlog_pressure` → `bus_synaptic_pressure` in `config/substrate-lattice/transport_lattice_policy.v1.yaml`, thresholds unchanged (0.25/0.50/0.75) — the old gate effectively never fired (frozen + the nesting bug), so there's no real prior behavior to preserve continuity with.
- **Deliberately not fixed here**: `transport_simulate()`/`_compute_salience()` has the identical structural bug (reads M3's top level via a hardcoded `_TRANSPORT_CHANNELS` dict) — left alone as a separate, lower-stakes "what-if" tool with its own scope. That dict's own comment ("MIRROR the YAML") is now stale as of this patch — disclosed here, not silently left to diverge.

## Outcome moved

The hub's transport proof-chain dashboard now shows real pressure/contract gate status instead of a value that was structurally incapable of ever being anything but "quiet"/"pass," for a reason unrelated to and predating the world_pulse degeneracy this session already fixed.

## Current architecture

`_compute_gates()` evaluates 7 gates (freshness/evidence/lineage/pressure/contract/attention/action_ceiling) from a "proof chain" dict assembled by `_load_transport_proof_chain()` across M3 (`substrate_transport_bus_projection`), M4 (`substrate_field_state`'s `capability:transport` vector), M5 (attention), L9 (dispatch).

## Files changed

- `services/orion-hub/scripts/substrate_lattice_routes.py`: pressure/contract gates repointed at M4's field vector; pressure gate gained the same stale/missing guard the contract gate already had.
- `services/orion-hub/tests/test_substrate_lattice_routes.py`: shared fixture updated to populate M4 realistically (previously hardcoded `{"pressure": 0.5}` regardless of test params); 3 new tests (nesting-bug regression, pressure-unknown-when-stale, pressure-unknown-when-missing).
- `config/substrate-lattice/transport_lattice_policy.v1.yaml`: channel renamed.

## Schema / bus / API changes

None — this is a read path fix, no schema/bus changes. `/transport/gates`' response shape is unchanged (same 7 gate_ids); only the `pressure`/`contract` gates' underlying data source and reason strings changed.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH="services/orion-hub" /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest services/orion-hub/tests/test_substrate_lattice_routes.py -q
48 passed
```

Also ran the full `services/orion-hub/tests/` suite (987 passed, 33 failed, 2 errors) — confirmed none of the 33 pre-existing failures reference `substrate_lattice`/`transport` (they're playwright-browser-missing and unrelated `app.js` content-assertion failures).

## Evals run

None — validated against a live persisted `substrate_transport_bus_projection` row and the real `TransportBusProjectionV1` schema directly, the more direct check for a dict-nesting bug than a unit-test fixture alone would give.

## Docker/build/smoke checks

Not applicable — pure route-logic fix, no service/runtime changes. Takes effect on next hub deploy.

## Review findings fixed

- Finding: pressure gate had no `m4_status in ("stale", "missing")` guard, unlike the contract gate — a stale/missing M4 would silently report "quiet"/"watch" off a 0.0-default or cached value instead of "unknown," the exact failure class this patch exists to fix.
  - Fix: added the identical guard the contract gate already has.
  - Evidence: `test_gates_pressure_unknown_when_m4_stale`/`test_gates_pressure_missing_when_m4_absent`, both pass; reviewer independently reproduced the pre-fix gap by hand against the real function before the fix landed.
- Finding (disclosed, not fixed): `_TRANSPORT_CHANNELS`'s own comment claims it mirrors the YAML policy — now stale, since only the code path this patch touches (`_compute_gates`) was updated, not `transport_simulate`'s hardcoded dict.
  - Fix: none in this PR — deliberately out of scope, disclosed in this description and the code's own new comments.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: low
- Concern: `transport_simulate`/`_compute_salience`'s identical nesting bug remains unfixed — the `/transport/simulate` "what-if" preview endpoint still silently reads a nonexistent M3 key for `stream_backlog_pressure`/`contract_pressure`.
- Mitigation: named explicitly as a follow-up; not introduced or worsened by this patch, and the fix requires deciding whether that endpoint should also move to M4-sourced data (a genuinely separate design question, not a quick copy-paste of this patch).

## PR link

(filled in below)