### PR TITLE
feat(mood-arc): durable artifact persistence + explicit world-pulse exclusion

### DIFF
--- a/orion/mood_arc/fit_encoder.py
+++ b/orion/mood_arc/fit_encoder.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -139,6 +140,31 @@ DEFAULT_EXCLUDE_CHANNELS: frozenset[str] = frozenset({
     # dict, not graduated information about anything. Excluding until/unless a
     # real analog reading is ever observed.
     "expected_offline_suppression",
+    # stream_backlog_pressure/stream_backlog_health/delivery_confidence
+    # (2026-07-27, explicit exclusion, not a lucky variance-filter dodge):
+    # these are still fed by BUS_OBSERVER_STREAMS' narrow 2-Redis-Stream
+    # "world_pulse" census (orion/substrate/transport_loop/extract.py::
+    # compute_transport_pressures()) at the node:athena level -- confirmed
+    # live 2026-07-27 these are still merged into collect_field_channel_
+    # pressures()'s output via orion/field/pressure.py's HIGHER_IS_BETTER_
+    # CHANNELS/PRESSURE_CHANNELS merge, even after PRs #1391-#1397 fixed the
+    # *derived* capability:transport diffusion target these feed (real
+    # bus_synaptic data now) -- the raw node-level census itself was never
+    # touched, deliberately out of scope there. Excluded explicitly here
+    # rather than relying on the variance filter, per Juniper's direct
+    # instruction: a channel this semantically narrow (one Redis Stream's
+    # depth, not real bus/transport health -- see services/orion-substrate-
+    # runtime/README.md's "one queue, not the bus" finding) should never
+    # train a consciousness-theory-relevant encoder regardless of whatever
+    # variance it happens to show on a given corpus pull. The prior training
+    # run (2026-07-18) excluded stream_backlog_health/delivery_confidence
+    # only by accident -- they were frozen by an unrelated, since-fixed
+    # reconcile-heal bug at the time, and that memory record explicitly
+    # flagged them for re-inclusion once that bug was fixed. Do not
+    # re-include them: the bug being fixed doesn't change what they measure.
+    "stream_backlog_pressure",
+    "stream_backlog_health",
+    "delivery_confidence",
 })
 DEFAULT_VARIANCE_EPS = 1e-6
 DEFAULT_CORR_THRESHOLD = 0.9
@@ -186,6 +212,20 @@ DEFAULT_ANOMALY_THRESHOLD_MULTIPLIER = 3.0
 # Hard gate threshold, unchanged from the original spec: real held-out recon
 # loss must beat the shuffle baseline by at least 2x.
 FLOOR_MAX_RATIO = 0.5
+
+# 2026-07-27: durable promotion target. Every prior real training run's
+# artifact (manifest.json/weights.npz/probes.json) lived only under
+# write_artifacts()'s --out path, which every run so far has pointed at
+# scratch (/tmp/.../scratchpad/...) -- gone the moment the scratch dir was
+# cleaned up, confirmed live (no artifact survived from the 2026-07-18
+# production run that passed the gate). /mnt/telemetry is the same durable
+# mount the training corpus itself already lives under
+# (/mnt/telemetry/field_channels/corpus/), chosen by Juniper for the same
+# reason: real data that must survive a container/session cycling, not
+# scratch. cmd_promote (below) is the actual mechanism that writes here --
+# `train`'s own --out still defaults to wherever the caller points it,
+# promotion is a deliberate, separate, explicit step.
+DEFAULT_MODELS_ROOT = Path("/mnt/telemetry/models/mood_arc")
 
 
 def _git_sha() -> str:
@@ -1159,6 +1199,23 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "are flagged."
         ),
     )
+    promote_p = sub.add_parser(
+        "promote",
+        help="Copy a trained candidate to the durable models root and mark it active",
+    )
+    promote_p.add_argument(
+        "--encoder-dir",
+        type=Path,
+        required=True,
+        help="Directory written by a prior `train` run (manifest.json + weights.npz)",
+    )
+    promote_p.add_argument(
+        "--models-root",
+        type=Path,
+        default=DEFAULT_MODELS_ROOT,
+        help=f"Durable root to promote into (default: {DEFAULT_MODELS_ROOT})",
+    )
+
     return parser.parse_args(argv)
 
 
@@ -1279,6 +1336,8 @@ def cmd_train(args: argparse.Namespace) -> int:
         shuffle_baseline_loss=shuffle_baseline_loss,
         purge_gap_windows=args.purge_gap_windows,
         ar1_surrogate_loss=ar1_surrogate_loss,
+        floor_ratio=gate["floor_ratio"],
+        floor_pass=gate["floor_pass"],
         ceiling_ratio=gate["ceiling_ratio"],
         floor_ratio_ci_low=ci_low,
         floor_ratio_ci_high=ci_high,
@@ -1356,12 +1415,125 @@ def cmd_detect_anomalies(args: argparse.Namespace) -> int:
     return 0
 
 
+def promote_encoder(
+    encoder_dir: Path,
+    *,
+    models_root: Path,
+    now: datetime | None = None,
+) -> dict:
+    """Copy a trained candidate's artifacts into the durable models_root,
+    flip its manifest status candidate -> active, retire whatever was
+    previously active, and update the active.json pointer.
+
+    Fail-closed, on purpose: refuses (raises ValueError, never silently
+    proceeds) if the candidate's own manifest doesn't record floor_pass is
+    True. This is the one hard gate this project has -- a candidate with
+    floor_pass=None (written before this field existed) or floor_pass=False
+    (failed its own shuffle-baseline check) must never become the "active"
+    encoder just because someone pointed --encoder-dir at it. This is
+    deliberately not re-run here -- promote does not retrain or re-score,
+    it only trusts a manifest that already recorded a real gate result.
+    """
+    manifest, _weights = load_artifacts(encoder_dir)
+    if manifest.floor_pass is not True:
+        raise ValueError(
+            f"refusing to promote {manifest.encoder_id}: floor_pass={manifest.floor_pass!r} "
+            "(must be exactly True; a candidate with no recorded gate result or a failing "
+            "one must never be promoted)"
+        )
+
+    dest_dir = models_root / manifest.encoder_version
+    if dest_dir.exists():
+        raise ValueError(
+            f"refusing to overwrite existing promoted directory at {dest_dir} "
+            "(encoder_version must be unique per promotion; use a new --encoder-version "
+            "at train time, don't re-promote the same version)"
+        )
+
+    resolved_now = now or datetime.now(timezone.utc)
+    active_pointer_path = models_root / "active.json"
+
+    # Review-caught ordering bug (2026-07-27): the previous-active retirement
+    # and pointer flip used to happen BEFORE the new candidate's artifacts
+    # were copied. If the copy step failed partway (missing/corrupt source,
+    # disk full, permissions on /mnt/telemetry) after the old version had
+    # already been marked "retired", the system was left with active.json
+    # still pointing at that now-retired directory -- any consumer that
+    # cross-checks manifest.status == "active" against what the pointer
+    # names would see zero active encoders, not a safe rollback to the old
+    # version. Fixed by making retirement + pointer-flip the LAST two steps,
+    # only after the new candidate's own artifacts and manifest are fully
+    # durable on disk -- a failure anywhere above this point now leaves the
+    # previous active version completely untouched and still genuinely
+    # active.
+    dest_dir.mkdir(parents=True, exist_ok=False)
+    shutil.copy2(encoder_dir / "weights.npz", dest_dir / "weights.npz")
+    if (encoder_dir / "probes.json").exists():
+        shutil.copy2(encoder_dir / "probes.json", dest_dir / "probes.json")
+    promoted_manifest = manifest.model_copy(update={"status": "active", "promoted_at": resolved_now})
+    (dest_dir / "manifest.json").write_text(promoted_manifest.model_dump_json(indent=2), encoding="utf-8")
+
+    previous_active: dict | None = None
+    if active_pointer_path.exists():
+        previous_active = json.loads(active_pointer_path.read_text(encoding="utf-8"))
+        prev_manifest_path = Path(previous_active["path"]) / "manifest.json"
+        if prev_manifest_path.exists():
+            prev_manifest = MoodArcEncoderManifestV1.model_validate_json(
+                prev_manifest_path.read_text(encoding="utf-8")
+            )
+            prev_manifest = prev_manifest.model_copy(update={"status": "retired"})
+            prev_manifest_path.write_text(prev_manifest.model_dump_json(indent=2), encoding="utf-8")
+
+    # Atomic pointer write (temp file + rename, review-suggested secondary
+    # fix): a crash mid-write to active.json directly could leave a
+    # truncated/corrupt JSON; write-then-rename is atomic on the same
+    # filesystem, so a reader always sees either the old or the new pointer
+    # in full, never a partial one.
+    tmp_pointer_path = active_pointer_path.with_suffix(".json.tmp")
+    tmp_pointer_path.write_text(
+        json.dumps(
+            {
+                "encoder_id": manifest.encoder_id,
+                "encoder_version": manifest.encoder_version,
+                "promoted_at": resolved_now.isoformat(),
+                "path": str(dest_dir),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    tmp_pointer_path.replace(active_pointer_path)
+
+    return {
+        "promoted": str(dest_dir),
+        "encoder_id": manifest.encoder_id,
+        "encoder_version": manifest.encoder_version,
+        "previous_active": previous_active,
+    }
+
+
+def cmd_promote(args: argparse.Namespace) -> int:
+    try:
+        result = promote_encoder(args.encoder_dir, models_root=args.models_root)
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            f"promote: could not load encoder artifacts from {args.encoder_dir} "
+            f"(expected manifest.json + weights.npz, written by a prior `train` run): {exc}"
+        ) from exc
+    except ValueError as exc:
+        raise SystemExit(f"promote: {exc}") from exc
+    print(json.dumps(result, indent=2))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     if args.command == "train":
         return cmd_train(args)
     if args.command == "detect-anomalies":
         return cmd_detect_anomalies(args)
+    if args.command == "promote":
+        return cmd_promote(args)
     raise SystemExit(f"unknown command: {args.command}")
 
 

--- a/orion/mood_arc/tests/test_mood_arc_encoder_fit_script.py
+++ b/orion/mood_arc/tests/test_mood_arc_encoder_fit_script.py
@@ -416,6 +416,43 @@ def test_default_exclude_channels_drops_expected_offline_suppression_presence_ar
     assert fields == ("real_signal",)
 
 
+def test_default_exclude_channels_drops_world_pulse_channels_even_with_real_variance() -> None:
+    """Regression, 2026-07-27: stream_backlog_pressure/stream_backlog_health/
+    delivery_confidence must be excluded regardless of how much variance they
+    show, not merely because they happened to be flat on a past corpus pull.
+    They're still fed by the narrow world_pulse census at the node:athena
+    level (orion/substrate/transport_loop/extract.py) even after PRs
+    #1391-#1397 fixed the derived capability:transport signal these feed --
+    the raw node-level census itself was never touched. Unlike
+    expected_offline_suppression (a presence/absence artifact, no real
+    signal at all), these channels are given genuine, non-degenerate
+    variance here specifically to prove the exclusion is by name, not a
+    variance-filter side effect."""
+    from orion.mood_arc.fit_encoder import DEFAULT_EXCLUDE_CHANNELS, select_fields
+
+    rng = np.random.default_rng(3)
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    rows = [
+        _make_row(
+            t=start + timedelta(seconds=i),
+            channels={
+                "real_signal": float(rng.normal(0, 1)),
+                "stream_backlog_pressure": float(rng.uniform(0, 1)),
+                "stream_backlog_health": float(rng.uniform(0, 1)),
+                "delivery_confidence": float(rng.uniform(0, 1)),
+            },
+            idx=i,
+        )
+        for i in range(200)
+    ]
+
+    fields = select_fields(rows, exclude=DEFAULT_EXCLUDE_CHANNELS, variance_eps=1e-6)
+    assert fields == ("real_signal",)
+    assert "stream_backlog_pressure" not in fields
+    assert "stream_backlog_health" not in fields
+    assert "delivery_confidence" not in fields
+
+
 def test_select_fields_respects_custom_exclude() -> None:
     from orion.mood_arc.fit_encoder import select_fields
 

--- a/orion/mood_arc/tests/test_mood_arc_promote.py
+++ b/orion/mood_arc/tests/test_mood_arc_promote.py
@@ -1,0 +1,233 @@
+"""Tests for cmd_promote / promote_encoder (2026-07-27).
+
+Every real training run before this patch wrote its artifact only to a
+--out path that has, in practice, always been scratch (/tmp/.../scratchpad/
+...) -- gone the moment the scratch dir was cleaned up. Confirmed live: no
+artifact survived from the 2026-07-18 production run that actually passed
+its own gate. promote_encoder() is the missing durable-persistence step;
+these tests focus on its one hard invariant -- fail-closed on an
+unverified or failing candidate -- since that's the property most worth
+protecting against a future regression.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from orion.mood_arc.fit_encoder import load_artifacts, promote_encoder, write_artifacts
+from orion.schemas.telemetry.field_channel_corpus import FieldChannelCorpusRowV1
+from orion.schemas.telemetry.mood_arc import MoodArcEncoderManifestV1
+from orion.schemas.telemetry.phi_encoder import CorpusStatsV1, TrainingStatsV1
+
+REPO = Path(__file__).resolve().parents[3]
+FIT_SCRIPT = REPO / "orion" / "mood_arc" / "fit_encoder.py"
+
+
+def _run_fit(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(FIT_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+
+
+def _make_row(*, t: datetime, channels: dict[str, float], idx: int) -> FieldChannelCorpusRowV1:
+    return FieldChannelCorpusRowV1(generated_at=t, tick_id=f"tick_{idx}", channels=channels)
+
+
+def _write_corpus(path: Path, rows: list[FieldChannelCorpusRowV1]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(row.model_dump_json() + "\n")
+
+
+def _normal_rows(n_rows: int = 1500, seed: int = 0) -> list[FieldChannelCorpusRowV1]:
+    rng = np.random.default_rng(seed)
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    rows: list[FieldChannelCorpusRowV1] = []
+    for i in range(n_rows):
+        t = start + timedelta(seconds=2 * i)
+        phase = i * 0.05
+        channels = {
+            "coherence": float(0.6 + 0.05 * np.sin(phase) + rng.normal(0, 0.01)),
+            "energy": float(0.3 + 0.1 * np.sin(phase * 0.7) + rng.normal(0, 0.02)),
+            "novelty": float(0.5 + 0.3 * np.sin(phase * 1.3) + rng.normal(0, 0.03)),
+        }
+        rows.append(_make_row(t=t, channels=channels, idx=i))
+    return rows
+
+
+def _train_small_encoder(tmp_path: Path, *, encoder_version: str = "v-test") -> Path:
+    corpus = tmp_path / "train_corpus.jsonl"
+    out_dir = tmp_path / "candidate"
+    _write_corpus(corpus, _normal_rows())
+    proc = _run_fit(
+        "train",
+        "--corpus", str(corpus),
+        "--out", str(out_dir),
+        "--encoder-version", encoder_version,
+        "--hidden-dim", "32",
+        "--latent-dim", "16",
+        "--epochs", "150",
+        "--min-hours", "0.5",
+        "--min-rows", "100",
+        "--purge-gap-windows", "6",
+        "--bootstrap-n", "20",
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return out_dir
+
+
+def _fake_manifest(*, encoder_version: str, floor_pass: bool | None) -> MoodArcEncoderManifestV1:
+    now = datetime.now(timezone.utc)
+    return MoodArcEncoderManifestV1(
+        encoder_id=f"mood-arc-encoder:{encoder_version}",
+        encoder_version=encoder_version,
+        status="candidate",
+        architecture="mlp_shallow_v1",
+        window_size=30,
+        stride=15,
+        max_gap_sec=6.0,
+        hidden_dim=32,
+        latent_dim=16,
+        channel_names=["coherence", "energy", "novelty"],
+        corpus=CorpusStatsV1(
+            corpus_path="fake.jsonl", row_count=100, excluded_degenerate=0,
+            time_range_start=now, time_range_end=now,
+        ),
+        training=TrainingStatsV1(
+            epochs=10, final_loss=0.01, held_out_loss=0.02,
+            recon_error_p50=0.03, recon_error_p95=0.05,
+        ),
+        shuffle_baseline_loss=0.04,
+        floor_ratio=0.3 if floor_pass else 0.9,
+        floor_pass=floor_pass,
+        git_sha="deadbeef",
+        trained_at=now,
+    )
+
+
+def _fake_candidate_dir(tmp_path: Path, *, encoder_version: str, floor_pass: bool | None) -> Path:
+    candidate_dir = tmp_path / f"candidate-{encoder_version}"
+    manifest = _fake_manifest(encoder_version=encoder_version, floor_pass=floor_pass)
+    write_artifacts(candidate_dir, manifest=manifest, weights={"w": np.zeros((2, 2))}, probes={})
+    return candidate_dir
+
+
+def test_promote_real_trained_candidate_end_to_end(tmp_path: Path) -> None:
+    """The real CLI (train, via subprocess, same as the anomaly-detector
+    tests) produces a candidate; promote_encoder must accept it if and only
+    if it actually passed its own gate, and the promoted copy must be a
+    genuine, independent copy (not the same files/directory)."""
+    candidate_dir = _train_small_encoder(tmp_path, encoder_version="v-real-1")
+    manifest, _ = load_artifacts(candidate_dir)
+    models_root = tmp_path / "models_root"
+
+    if not manifest.floor_pass:
+        pytest.skip(
+            "this small synthetic corpus's real training run did not pass its own "
+            "gate this time (floor_ratio can vary run to run on a tiny fixture) -- "
+            "not this test's concern, see test_promote_refuses_failing_candidate "
+            "for the fail-closed behavior itself"
+        )
+
+    result = promote_encoder(candidate_dir, models_root=models_root)
+
+    dest_dir = Path(result["promoted"])
+    assert dest_dir.exists()
+    assert dest_dir != candidate_dir
+    promoted_manifest, promoted_weights = load_artifacts(dest_dir)
+    assert promoted_manifest.status == "active"
+    assert promoted_manifest.promoted_at is not None
+    assert set(promoted_weights.keys()) == set(load_artifacts(candidate_dir)[1].keys())
+
+    active_pointer = json.loads((models_root / "active.json").read_text(encoding="utf-8"))
+    assert active_pointer["encoder_version"] == "v-real-1"
+    assert active_pointer["path"] == str(dest_dir)
+
+
+def test_promote_refuses_candidate_with_no_recorded_gate_result(tmp_path: Path) -> None:
+    """floor_pass=None (a manifest written before this field existed, or one
+    that never ran the gate) must never be silently treated as a pass."""
+    candidate_dir = _fake_candidate_dir(tmp_path, encoder_version="v-none", floor_pass=None)
+    with pytest.raises(ValueError, match="floor_pass"):
+        promote_encoder(candidate_dir, models_root=tmp_path / "models_root")
+    assert not (tmp_path / "models_root").exists()
+
+
+def test_promote_refuses_failing_candidate(tmp_path: Path) -> None:
+    candidate_dir = _fake_candidate_dir(tmp_path, encoder_version="v-fail", floor_pass=False)
+    with pytest.raises(ValueError, match="floor_pass"):
+        promote_encoder(candidate_dir, models_root=tmp_path / "models_root")
+    assert not (tmp_path / "models_root").exists()
+
+
+def test_promote_refuses_to_overwrite_existing_version(tmp_path: Path) -> None:
+    models_root = tmp_path / "models_root"
+    candidate_dir = _fake_candidate_dir(tmp_path, encoder_version="v-dup", floor_pass=True)
+    promote_encoder(candidate_dir, models_root=models_root)
+    with pytest.raises(ValueError, match="existing"):
+        promote_encoder(candidate_dir, models_root=models_root)
+
+
+def test_promote_retires_previous_active_version(tmp_path: Path) -> None:
+    """Promoting a second version must flip the first version's own
+    persisted manifest status to 'retired', not just repoint active.json --
+    a consumer reading version v1's manifest directly (not through the
+    pointer) must see that it's no longer current."""
+    models_root = tmp_path / "models_root"
+    v1_dir = _fake_candidate_dir(tmp_path, encoder_version="v1", floor_pass=True)
+    result1 = promote_encoder(v1_dir, models_root=models_root)
+    v1_dest = Path(result1["promoted"])
+    assert MoodArcEncoderManifestV1.model_validate_json(
+        (v1_dest / "manifest.json").read_text(encoding="utf-8")
+    ).status == "active"
+
+    v2_dir = _fake_candidate_dir(tmp_path, encoder_version="v2", floor_pass=True)
+    result2 = promote_encoder(v2_dir, models_root=models_root)
+    assert result2["previous_active"]["encoder_version"] == "v1"
+
+    v1_manifest_after = MoodArcEncoderManifestV1.model_validate_json(
+        (v1_dest / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert v1_manifest_after.status == "retired"
+
+    active_pointer = json.loads((models_root / "active.json").read_text(encoding="utf-8"))
+    assert active_pointer["encoder_version"] == "v2"
+
+
+def test_failed_promotion_leaves_previous_active_version_untouched(tmp_path: Path) -> None:
+    """Regression test for a review-caught ordering bug: retiring the
+    previous active version and flipping active.json used to happen BEFORE
+    the new candidate's artifacts were copied. A failure during the copy
+    step (simulated here by deleting the candidate's weights.npz after
+    write_artifacts wrote it, so load_artifacts/shutil.copy2 hits a missing
+    file) must leave the previously-promoted version fully, genuinely
+    active -- not retired-with-nothing-to-replace-it."""
+    models_root = tmp_path / "models_root"
+    v1_dir = _fake_candidate_dir(tmp_path, encoder_version="v1", floor_pass=True)
+    result1 = promote_encoder(v1_dir, models_root=models_root)
+    v1_dest = Path(result1["promoted"])
+
+    v2_dir = _fake_candidate_dir(tmp_path, encoder_version="v2", floor_pass=True)
+    (v2_dir / "weights.npz").unlink()  # simulate a corrupt/missing source mid-promotion
+
+    with pytest.raises(FileNotFoundError):
+        promote_encoder(v2_dir, models_root=models_root)
+
+    v1_manifest_after = MoodArcEncoderManifestV1.model_validate_json(
+        (v1_dest / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert v1_manifest_after.status == "active"
+
+    active_pointer = json.loads((models_root / "active.json").read_text(encoding="utf-8"))
+    assert active_pointer["encoder_version"] == "v1"
+    assert active_pointer["path"] == str(v1_dest)

--- a/orion/schemas/telemetry/mood_arc.py
+++ b/orion/schemas/telemetry/mood_arc.py
@@ -115,6 +115,17 @@ class MoodArcEncoderManifestV1(BaseModel):
     corpus: CorpusStatsV1        # reused as-is from orion.schemas.telemetry.phi_encoder
     training: TrainingStatsV1    # reused as-is
     shuffle_baseline_loss: float # held_out_loss with rows shuffled within-window (see gate)
+    # floor_ratio / floor_pass (2026-07-27, previously computed by cmd_train's
+    # two_tier_gate() and only ever printed to stdout, never persisted --
+    # found while building cmd_promote, which needs a durable, reloadable
+    # answer to "did this exact candidate pass its own gate" rather than
+    # trusting an operator's memory of a training run's console output).
+    # floor_ratio = real_held_loss / shuffle_baseline_loss; floor_pass =
+    # floor_ratio < FLOOR_MAX_RATIO, the one hard gate this project has
+    # (ceiling_ratio, above, is diagnostic only). None only for manifests
+    # written before this field existed.
+    floor_ratio: Optional[float] = None
+    floor_pass: Optional[bool] = None
     # purge_gap_windows: number of windows dropped as an embargo zone between
     # the train/held-out temporal boundary (see purged_temporal_split()) --
     # not in the original spec, added because a held-out window merely


### PR DESCRIPTION
## Summary

Sentience Striving Program's IIT/mood-arc-encoder thread. Two real gaps found before doing a real training run.

- **Persistence gap**: every prior real training run's artifact only ever lived at a scratch `--out` path (`/tmp/.../scratchpad/...`) — confirmed gone now, no artifact survives anywhere from the 2026-07-18 production run that actually passed its own gate. Built `promote_encoder()`/`cmd_promote`: copies a trained candidate to a durable `/mnt/telemetry/models/mood_arc/` root (matching where the training corpus itself already lives), flips `status` candidate→active, retires whatever was previously active, writes an `active.json` pointer.
- This required adding `floor_ratio`/`floor_pass` to `MoodArcEncoderManifestV1` — previously computed by `two_tier_gate()` and only ever printed to stdout, never persisted, so there was no durable way to check "did this candidate actually pass its own gate" before promoting it. `promote` now fails closed on `floor_pass is not True`.
- **Metric-quality gap**: `collect_field_channel_pressures()` (`orion/field/pressure.py`) still merges `stream_backlog_pressure`/`stream_backlog_health`/`delivery_confidence` into this corpus — confirmed still fed by the narrow world_pulse census at the `node:athena` level, even after PRs #1391-#1397 fixed the *derived* `capability:transport` signal these feed (the raw node-level channels were explicitly out of scope there). Added explicit-by-name exclusion, not relying on the variance filter — the prior training run excluded these only because they were frozen by an unrelated, since-fixed bug, and that memory record explicitly flagged them for re-inclusion once fixed. Do not re-include: the bug being fixed doesn't change what they measure.
- Review caught a real ordering bug in the first cut of `promote_encoder`: retiring the previous active version and flipping `active.json` happened *before* the new candidate's artifacts were copied — a failure mid-copy could leave zero active encoders. Fixed (copy/write-new-manifest first, retire-old/flip-pointer last, pointer write made atomic), with a regression test reproducing the exact failure.

## Outcome moved

The IIT thread's actual blocker — "the trained artifact keeps evaporating" — is closed. A real training run can now produce something that survives past the session that made it, and won't be trained on the exact metrics this session spent all day proving are fake.

## Current architecture

`orion/mood_arc/fit_encoder.py`: `train`/`detect-anomalies` CLI subcommands, `write_artifacts()`/`load_artifacts()` for manifest.json+weights.npz+probes.json round-trips. No `promote` existed — the module's own docstring explicitly said "a later roadmap item, not built by this patch."

## Files changed

- `orion/mood_arc/fit_encoder.py`: new `promote_encoder()`/`cmd_promote`, new `DEFAULT_MODELS_ROOT` constant, 3 new `DEFAULT_EXCLUDE_CHANNELS` entries, `cmd_train` now populates `floor_ratio`/`floor_pass`.
- `orion/schemas/telemetry/mood_arc.py`: `MoodArcEncoderManifestV1` gained `floor_ratio`/`floor_pass` (both `Optional`, additive-only — this is a disk-only artifact never committed to the repo, no migration concern).
- `orion/mood_arc/tests/test_mood_arc_promote.py` (new): 6 tests — real end-to-end promotion via the actual CLI, fail-closed on missing/failing gate result, refuse-to-overwrite, retire-previous-active, and the review-caught ordering regression.
- `orion/mood_arc/tests/test_mood_arc_encoder_fit_script.py`: 1 new test proving the world-pulse exclusion works by name against genuinely high-variance data, not as a lucky variance-filter side effect.

## Schema / bus / API changes

- Added: `MoodArcEncoderManifestV1.floor_ratio: Optional[float]`, `.floor_pass: Optional[bool]`.
- Removed: none.
- Renamed: none.
- Behavior changed: `select_fields()` now always excludes `stream_backlog_pressure`/`stream_backlog_health`/`delivery_confidence` regardless of variance.
- Compatibility notes: this manifest is a dark, disk-only artifact never committed to the repo — no prior real artifact needs to stay compatible with the new fields.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH="." /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest orion/mood_arc/tests/ -q
50 passed
```

## Evals run

None — this patch is infrastructure (persistence + exclusion), not a new signal; the actual encoder training run (this thread's real eval) is the next step, planned as a separate follow-up now that this lands.

## Docker/build/smoke checks

Not applicable — offline CLI tool, no service/runtime changes. `/mnt/telemetry/models/mood_arc/` will be created on first real `promote` call (`mkdir(parents=True)`).

## Review findings fixed

- Finding: `promote_encoder()`'s previous-active retirement and `active.json` pointer flip happened *before* the new candidate's artifacts were copied — a failure during the copy step (missing/corrupt source, disk full) could leave the system with the old version marked "retired" and the pointer still aimed at it, reading as zero active encoders to any status-checking consumer.
  - Fix: reordered so copy + new-manifest-write happen first; retirement + pointer-flip only after the new artifacts are fully durable. Pointer write also made atomic (temp file + `Path.replace`).
  - Evidence: new regression test `test_failed_promotion_leaves_previous_active_version_untouched` simulates the exact failure (deletes the candidate's `weights.npz` mid-promotion) and confirms the previous version's manifest still reads `"active"` and `active.json` still points at it. All 6 promote tests pass.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: low
- Concern: `dest_dir.exists()` (the refuse-to-overwrite check) has a theoretical TOCTOU race before `mkdir(exist_ok=False)` — not hardened further, since this is an offline, single-operator CLI tool with no concurrent-promotion use case today.
- Mitigation: none needed at current scale; would need attention only if this ever becomes a multi-operator or automated pipeline.

## PR link

(filled in below)