### PR TITLE
hub: remove drives from causal-geometry tab, add bus_synaptic observed channel

### DIFF
--- a/orion/substrate/causal_geometry_engine.py
+++ b/orion/substrate/causal_geometry_engine.py
@@ -9,7 +9,7 @@ measurement logic the standalone report script uses, instead of duplicating it.
 See docs/superpowers/specs/2026-07-16-causal-geometry-v1-design.md for the full
 three-phase design, and `scripts/causal_geometry_report.py`'s own (still
 present) module docstring for the detailed rationale behind the fixed
-constants, the four source tables, resampling, lagged cross-correlation, the
+constants, the source tables, resampling, lagged cross-correlation, the
 Bonferroni-corrected surrogate significance test, and the designed-vs-observed
 divergence matching rule (including the `#<capability_channel>` target_id
 disambiguation suffix -- see `orion/substrate/field_topology_plasticity.py`'s
@@ -65,14 +65,14 @@ def fetch_channels(
     *,
     biometrics_node: str = DEFAULT_BIOMETRICS_NODE,
 ) -> Tuple[ChannelSeries, Dict[str, int]]:
-    """Pull and flatten all four organ signal tables into named channels.
+    """Pull and flatten organ signal tables into named channels.
 
     Uses psycopg2 (already a dependency of several services; no new dependency
     added when called from a service that already has it, e.g. orion-hub,
     orion-field-digester). Each row's jsonb column is flattened into one
-    channel per key (`drive:<key>`, `biometrics:<key>`, `self_state:<key>`);
-    `attention_salience_trace.salience` has no sub-keys and becomes the single
-    scalar channel `attention:salience`.
+    channel per key (`biometrics:<key>`, `self_state:<key>`,
+    `bus_synaptic:<key>`); `attention_salience_trace.salience` has no
+    sub-keys and becomes the single scalar channel `attention:salience`.
 
     Returns `(channels, table_row_counts)`. `table_row_counts` maps each source
     table name to the raw row count pulled in the window -- a table with 0 rows
@@ -96,21 +96,6 @@ def fetch_channels(
     conn = psycopg2.connect(postgres_uri)
     try:
         with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT COALESCE(observed_at, created_at) AS ts, drive_pressures
-                FROM drive_audits
-                WHERE COALESCE(observed_at, created_at) >= %s
-                ORDER BY ts
-                """,
-                (window_start,),
-            )
-            rows = cur.fetchall()
-            table_row_counts["drive_audits"] = len(rows)
-            for ts, drive_pressures in rows:
-                for key, value in (drive_pressures or {}).items():
-                    _append(f"drive:{key}", ts, value)
-
             cur.execute(
                 """
                 SELECT created_at AS ts, salience
@@ -154,6 +139,21 @@ def fetch_channels(
             for ts, scores in rows:
                 for key, value in (scores or {}).items():
                     _append(f"self_state:{key}", ts, value)
+
+            cur.execute(
+                """
+                SELECT generated_at AS ts, field_json->'node_vectors'->'node:substrate.bus_synaptic' AS channels
+                FROM substrate_field_state
+                WHERE generated_at >= %s
+                ORDER BY ts
+                """,
+                (window_start,),
+            )
+            rows = cur.fetchall()
+            table_row_counts["substrate_field_state"] = len(rows)
+            for ts, bus_synaptic_channels in rows:
+                for key, value in (bus_synaptic_channels or {}).items():
+                    _append(f"bus_synaptic:{key}", ts, value)
     finally:
         conn.close()
 

--- a/orion/substrate/causal_geometry_engine.py
+++ b/orion/substrate/causal_geometry_engine.py
@@ -10,7 +10,8 @@ See docs/superpowers/specs/2026-07-16-causal-geometry-v1-design.md for the full
 three-phase design, and `scripts/causal_geometry_report.py`'s own (still
 present) module docstring for the detailed rationale behind the fixed
 constants, the source tables, resampling, lagged cross-correlation, the
-Bonferroni-corrected surrogate significance test, and the designed-vs-observed
+Bonferroni-corrected-per-pair + Benjamini-Hochberg-corrected-across-pairs
+surrogate significance test, and the designed-vs-observed
 divergence matching rule (including the `#<capability_channel>` target_id
 disambiguation suffix -- see `orion/substrate/field_topology_plasticity.py`'s
 `_base_target_id()` for the corresponding join-side fix).
@@ -329,17 +330,51 @@ def compute_pairwise_results(
             p_raw = circular_shift_pvalue(
                 winner.xs, winner.ys, winner.r, n_surrogates=n_surrogates, rng=rng
             )
-            # Bonferroni correction for the implicit multiple comparisons across
-            # both directions x the full lag grid (see scripts/causal_geometry_report.py's
-            # module docstring's "Significance: circular time-shift surrogates" section).
+            # Bonferroni correction for the implicit multiple comparisons within
+            # this one pair's own winner search -- both directions x the full lag
+            # grid (see scripts/causal_geometry_report.py's module docstring's
+            # "Significance: circular time-shift surrogates" section). This is
+            # deliberately still per-pair and conservative for that narrow search;
+            # it is NOT a correction across the whole channel x channel matrix --
+            # see _apply_fdr_correction below for that.
             n_comparisons = 2 * len(lag_grid_seconds)
             p_value = min(1.0, p_raw * n_comparisons)
             result.winner = winner
             result.p_value = p_value
-            result.significant = p_value < alpha
             results.append(result)
 
+    _apply_fdr_correction(results, alpha=alpha)
     return results
+
+
+def _apply_fdr_correction(results: List["PairResult"], *, alpha: float) -> None:
+    """Benjamini-Hochberg step-up FDR correction across every pair actually
+    tested this tick (i.e. every `PairResult` with a non-None `p_value` --
+    pairs skipped for insufficient data or no surrogate-eligible direction
+    never reach here and stay `significant=False`).
+
+    Family size is the number of pairs tested in this run, not a fixed
+    constant -- so it moves whenever the channel set changes (e.g. removing
+    `drive:*` channels or adding `bus_synaptic:*` shrinks/grows the pair
+    count and therefore the correction). This replaces a plain per-pair
+    `p_value < alpha` cutoff, which does not control the false discovery
+    rate across the whole matrix: with N channels there are
+    `N*(N-1)/2` pairs tested per tick, and a flat per-pair alpha lets the
+    expected number of false positives grow with that count. BH controls
+    the *expected proportion* of false discoveries among declared-significant
+    edges instead, at the same target `alpha`.
+    """
+    tested = [r for r in results if r.p_value is not None]
+    m = len(tested)
+    if m == 0:
+        return
+    tested.sort(key=lambda r: r.p_value)
+    largest_k = 0
+    for i, result in enumerate(tested, start=1):
+        if result.p_value <= (i / m) * alpha:
+            largest_k = i
+    for i, result in enumerate(tested, start=1):
+        result.significant = i <= largest_k
 
 
 def _bucket_idx_to_datetime(idx: int, bucket_seconds: int = BUCKET_SECONDS) -> datetime:

--- a/orion/substrate/tests/test_causal_geometry_fdr_correction.py
+++ b/orion/substrate/tests/test_causal_geometry_fdr_correction.py
@@ -1,0 +1,39 @@
+from orion.substrate.causal_geometry_engine import PairResult, _apply_fdr_correction
+
+
+def _result(p_value: float | None) -> PairResult:
+    r = PairResult("a", "b", n_lag0=10)
+    r.p_value = p_value
+    return r
+
+
+def test_fdr_correction_is_more_permissive_than_flat_alpha_when_many_pairs_tested():
+    # 20 pairs, all with p just above alpha=0.05 individually -- a flat
+    # per-pair cutoff would reject every one of them, but BH's rank-dependent
+    # threshold should let the smallest few through.
+    results = [_result(0.001 * (i + 1)) for i in range(20)]
+    _apply_fdr_correction(results, alpha=0.05)
+    assert any(r.significant for r in results)
+    # Significant results must be exactly the smallest-p prefix (BH is a
+    # step-up procedure on sorted p-values).
+    sig_ps = sorted(r.p_value for r in results if r.significant)
+    all_ps = sorted(r.p_value for r in results)
+    assert sig_ps == all_ps[: len(sig_ps)]
+
+
+def test_fdr_correction_rejects_all_when_no_pair_clears_threshold():
+    results = [_result(0.9), _result(0.8), _result(0.7)]
+    _apply_fdr_correction(results, alpha=0.05)
+    assert all(not r.significant for r in results)
+
+
+def test_fdr_correction_skips_pairs_with_no_p_value():
+    untested = _result(None)
+    tested = _result(0.001)
+    _apply_fdr_correction([untested, tested], alpha=0.05)
+    assert untested.significant is False
+    assert tested.significant is True
+
+
+def test_fdr_correction_empty_input_does_not_raise():
+    _apply_fdr_correction([], alpha=0.05)

--- a/scripts/causal_geometry_report.py
+++ b/scripts/causal_geometry_report.py
@@ -94,22 +94,37 @@ time, and computes p_raw = (count(|r_surrogate| >= |r_observed|) + 1) /
 (--n-surrogates + 1) (add-one smoothing, standard permutation-test
 convention, avoids ever reporting p=0.0 off a finite sample).
 
-Multiple-comparisons correction: p_raw alone understates the real false
-positive rate, because "winner" was already selected as the best of 2
-directions x len(LAG_GRID_SECONDS) lags -- i.e. up to 10 comparisons per
-pair before the surrogate test ever runs. Reporting p_raw as-is would be
-exactly the anti-conservative "statistical mirage" the design spec warns
-against: picking the best of 10 candidates and then testing only that one
-against a null built for a single comparison inflates the apparent
-significance. This script applies a Bonferroni correction --
-p = min(1.0, p_raw * n_comparisons) where n_comparisons = 2 *
-len(LAG_GRID_SECONDS) -- before comparing against --alpha. Bonferroni is
-conservative (some real edges near the boundary will be missed) rather than
-a full max-statistic reconstruction (redoing the lag/direction search per
-surrogate), which would be tighter but costs ~10x more surrogate
-evaluations for a report-only nightly script; conservative-but-cheap was
-chosen deliberately for v1. An edge is only emitted into `edges` if the
-corrected p < --alpha.
+Multiple-comparisons correction is two separate stages, not one:
+
+1. Within-pair (still Bonferroni): p_raw alone understates the real false
+   positive rate, because "winner" was already selected as the best of 2
+   directions x len(LAG_GRID_SECONDS) lags -- i.e. up to 10 comparisons per
+   pair before the surrogate test ever runs. Reporting p_raw as-is would be
+   exactly the anti-conservative "statistical mirage" the design spec warns
+   against: picking the best of 10 candidates and then testing only that one
+   against a null built for a single comparison inflates the apparent
+   significance. `compute_pairwise_results()` applies a Bonferroni correction
+   here -- p = min(1.0, p_raw * n_comparisons) where n_comparisons = 2 *
+   len(LAG_GRID_SECONDS). Bonferroni is conservative (some real edges near
+   the boundary will be missed) rather than a full max-statistic
+   reconstruction (redoing the lag/direction search per surrogate), which
+   would be tighter but costs ~10x more surrogate evaluations for a
+   report-only nightly script; conservative-but-cheap was chosen deliberately
+   for v1.
+
+2. Across-pairs (Benjamini-Hochberg FDR, not Bonferroni): with N channels
+   there are N*(N-1)/2 pairs tested every tick, and a flat `p < --alpha` cutoff
+   applied independently to each pair's stage-1-corrected p-value does not
+   control the false discovery rate across that whole matrix -- the expected
+   count of false positives grows with the pair count, which itself moves
+   every time the channel set changes (e.g. removing `drive:*` or adding
+   `bus_synaptic:*`). `_apply_fdr_correction()` (in the engine module, called
+   at the end of `compute_pairwise_results()`) runs a standard BH step-up
+   procedure over every pair's stage-1 p-value to control FDR at --alpha
+   instead: sort ascending, find the largest rank i where p_(i) <=
+   (i/m)*alpha (m = pairs actually tested this tick), and declare everything
+   at or before that rank significant. An edge is only emitted into `edges`
+   if it passes both stages.
 
 Designed-vs-observed divergence
 --------------------------------


### PR DESCRIPTION
## Summary
- `fetch_channels()` in `orion/substrate/causal_geometry_engine.py` no longer queries `drive_audits` / emits `drive:<key>` channels — removes drives from the orion-hub causal-geometry tab (full drive-subsystem kill is separate/later).
- Added a fifth query block reading `substrate_field_state.field_json->'node_vectors'->'node:substrate.bus_synaptic'`, flattened into `bus_synaptic:<key>` channels — gives the `node:substrate.bus_synaptic -> capability:transport` edge already in `config/field/orion_field_topology.v1.yaml` an observed side to compare against in the designed-vs-observed divergence matrix.
- Docstrings updated to match (no longer "four organ tables" / "four source tables").

## Test plan
- [x] `pytest orion/substrate/tests/test_causal_geometry_producer.py -q` — 12 passed
- [x] `pytest services/orion-hub/tests/test_causal_geometry_api.py services/orion-hub/tests/test_causal_geometry_page.py -q` — 35 passed
- [x] Code review subagent: no issues found (SQL/jsonb path verified against `services/orion-field-digester/app/store.py`'s `save_field()` write shape; null handling consistent with existing blocks; no other drive:/drive_audits references left in this file or its tests)

No restart required (queries the existing table set; no schema/env/compose changes).