### PR TITLE
feat(execution-dispatch): real surprise signal from bus_synaptic_prediction_error

### DIFF
--- a/docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md
+++ b/docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md
@@ -4,6 +4,8 @@
 **Status:** Implementation, this session
 **Mode:** Thin patch. Implements P2 of the motor-nerve series (P0/P1/P6 merged) — re-grounded against live code, not the original brainstorm-level P2 section, which assumed a `felt_state_reader` lane and a flag-flip that turn out to be wrong.
 
+**Superseded, 2026-07-28**: `surprise=0.0` below was an honest placeholder, not a bug — but it is no longer what this service emits. `services/orion-execution-dispatch-runtime` now reads a real value from `bus_synaptic_prediction_error()` (see `services/orion-execution-dispatch-runtime/README.md`'s Experience-loop section and `docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md`). Every other `ActionOutcomeEmitV1` producer in the repo still emits the binary success/fail proxy this doc describes — kept here as the accurate historical record for those.
+
 ## Arsonist summary
 
 P1 gave Layer 9 a real send path: `orion-execution-dispatch-runtime` now dispatches real cortex-exec calls and records results in `substrate_dispatch_results`. Nothing downstream of that knows it happened. Zero references to `episode_journal`, `action_outcome`, or any journaling/memory call exist anywhere in `services/orion-execution-dispatch-runtime/`. An autonomous action today produces a database row nothing reads and nothing narrates.

--- a/docs/superpowers/specs/2026-07-24-efe-capability-gate-design.md
+++ b/docs/superpowers/specs/2026-07-24-efe-capability-gate-design.md
@@ -22,11 +22,17 @@ here; see Non-goals).
 
 **Three real, load-bearing findings this design is built on, each independently verified:**
 
-1. `ActionOutcomeRefV1.surprise` is not usable as an epistemic-value signal — every real call
-   site computes it as a binary success/fail proxy, and live data confirms it reads exactly
-   `0.0` across all 12 real rows since the Postgres rebuild. Ruled out; flagged in the
+1. `ActionOutcomeRefV1.surprise` is not usable as an epistemic-value signal for most emitters
+   — every call site that existed at the time this finding was written computes it as a
+   binary success/fail proxy, and live data confirmed it read exactly `0.0` across all 12
+   real rows since the Postgres rebuild. Ruled out for those emitters; flagged in the
    field's own docstring (`orion/autonomy/models.py`) so nobody reuses it under the wrong
-   assumption again.
+   assumption. **Update, 2026-07-28**: `services/orion-execution-dispatch-runtime` is now a
+   real exception — its rows carry a genuine `bus_synaptic_prediction_error()` value, not
+   the proxy (see that service's README, "Experience loop" section). This does not change
+   this design's own approach (still building `domain_surprise_score` on
+   `NormalizationContext` over `prediction_error.py`'s domains, per Missing Question 1) —
+   noted here so this finding doesn't read as still-universally-true.
 2. **This design never reads, writes, persists, or validates against `GoalProposalV1`,
    `drive_origin`, or `required_drive_origins`, anywhere, for any reason.** An earlier draft
    proposed coexistence with and validation against the halted drives gate — both wrong, both

--- a/orion/autonomy/models.py
+++ b/orion/autonomy/models.py
@@ -165,15 +165,22 @@ class FetchedArticleRefV1(BaseModel):
 
 
 class ActionOutcomeRefV1(BaseModel):
-    """`surprise` is NOT a real epistemic-uncertainty/prediction-error signal despite the
-    name -- confirmed 2026-07-24 by tracing every real call site
-    (`orion/autonomy/episode_fetch.py`, `orion/autonomy/policy_act.py`): it is always a
-    binary success/fail proxy (`0.0 if success else 1.0`, or a hardcoded `1.0` for "found
-    vs not found"), never a continuous measure of anything. Live data confirms it: every
-    real `action_outcomes` row observed post-2026-07-23-rebuild reads exactly `0.0`.
-    Do not reuse this field as an Active-Inference/epistemic-value term in any new design
-    (see `docs/superpowers/specs/2026-07-24-efe-capability-gate-design.md` for the design
-    this was ruled out of) -- it is redundant with `success`, not an independent signal.
+    """`surprise` is a mix of one real signal and several fake ones -- check the emitter
+    before trusting a row. Confirmed 2026-07-24 by tracing every call site that existed at
+    the time (`orion/autonomy/episode_fetch.py`, `orion/autonomy/policy_act.py`,
+    `orion/autonomy/curiosity_reuse.py`): all three are a binary success/fail proxy
+    (`0.0 if success else 1.0`, or a hardcoded `1.0` for "found vs not found"), never a
+    continuous measure of anything -- do not reuse this field as an Active-
+    Inference/epistemic-value term for those emitters' rows (see
+    `docs/superpowers/specs/2026-07-24-efe-capability-gate-design.md` for the design this
+    was ruled out of there).
+
+    As of 2026-07-28, `services/orion-execution-dispatch-runtime` is a genuine exception:
+    its rows carry a real, continuous value from `bus_synaptic_prediction_error()`
+    (`orion/substrate/prediction_error.py`, live-fixed for a calm-floor bias in PR #1391),
+    not a success/fail proxy. That emitter is identifiable by `kind` values
+    `inspect`/`summarize`/`observe`/`noop` (`ExecutionDispatchCandidateV1.dispatch_kind`) --
+    everything else emitting onto this same route is still the fake proxy described above.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -82,6 +82,28 @@ A publish failure here is caught and logged, never raises out of the tick —
 emit is attempted, so an unreachable bus loses only chat-visible narration,
 never the underlying record.
 
+**`surprise` is a real signal, not the honest placeholder it started as
+(2026-07-13).** Every other `ActionOutcomeEmitV1` producer in the repo
+(`orion/autonomy/episode_fetch.py`, `policy_act.py`, `curiosity_reuse.py`)
+still emits a binary success/fail proxy — see
+`orion/autonomy/models.py::ActionOutcomeRefV1`'s docstring. This service is
+the one exception: `surprise` is read live off `substrate_field_state`'s
+`node:substrate.bus_synaptic` node (`ExecutionDispatchRuntimeStore.
+latest_bus_synaptic_prediction_error()`), i.e.
+`bus_synaptic_prediction_error()` (`orion/substrate/prediction_error.py`,
+already generic across the whole bus mesh, already fixed once for a
+calm-floor bias in PR #1391). Falls back to `0.0` if the node hasn't been
+written yet, the field is older than `_BUS_SYNAPTIC_STALENESS_HORIZON_SEC`
+(reuses `PressureConfig().prediction_error_decay_horizon_seconds`, 30 min —
+`prediction_error` is a deliberately undecayed raw snapshot, see
+`services/orion-field-digester/app/digestion/decay.py`, so a frozen value
+from a stalled upstream tick must not be presented as live), or the read
+fails — fail-open, never blocks emitting the outcome itself. See
+`docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md`
+(original placeholder) and
+`docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md`
+(why `bus_synaptic` is the domain to build on) for the full history.
+
 ## Status vocabulary
 
 `ExecutionDispatchCandidateV1.dispatch_status`:

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -12,8 +12,16 @@ from sqlalchemy.engine import Engine
 from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
 from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.substrate.pressure import PressureConfig
 
 logger = logging.getLogger("orion.execution_dispatch.runtime.store")
+
+# Reuses the same horizon `orion/substrate/endogenous_curiosity.py`'s
+# `_prediction_error_staleness_decay()` applies to this identical undecayed raw
+# field, rather than inventing a fresh number -- see
+# `latest_bus_synaptic_prediction_error()`'s docstring for why this method treats
+# a stale row as absent (None) instead of partially decaying it.
+_BUS_SYNAPTIC_STALENESS_HORIZON_SEC = PressureConfig().prediction_error_decay_horizon_seconds
 
 
 class ExecutionDispatchRuntimeStore:
@@ -338,6 +346,72 @@ class ExecutionDispatchRuntimeStore:
                 {"today_start": today_start_utc},
             ).mappings().first()
         return float(row["total_risk"]) if row else 0.0
+
+    def latest_bus_synaptic_prediction_error(self) -> float | None:
+        """Real, live surprise signal for `ActionOutcomeEmitV1.surprise` -- replaces the
+        hardcoded `0.0` this service previously emitted (a disclosed, honest placeholder
+        per docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md, not a
+        bug, but never a real signal either).
+
+        Reads `orion/substrate/prediction_error.py::bus_synaptic_prediction_error()`'s
+        already-written output off `substrate_field_state` (`node:substrate.bus_synaptic`'s
+        `prediction_error` field) -- populated by `orion-field-digester`'s
+        `state_deltas.py` (`target_kind == "prediction_signal"`, `mode="replace"`), not
+        directly by `orion-substrate-runtime`, which only publishes the perturbation that
+        triggers that write. Chosen over the other four domains (execution/biometrics/chat/
+        route) because it is generic across the whole bus mesh rather than scoped to one
+        reducer, and because it already went through a real live-data sanity check (PR #1391
+        fixed a ~0.27 calm-floor bias found by recovering real numbers, not by eyeballing
+        variance -- see that PR and
+        docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md).
+        Edge-count cold-start filtering (`count < ~5` unreliable per
+        `services/orion-bus-mirror/README.md`) already happens upstream, in
+        `orion-substrate-runtime`'s `_bus_synaptic_tick`, before this value is ever written --
+        not re-done here.
+
+        **Staleness guard**: `prediction_error` was deliberately made an undecayed raw
+        snapshot (removed from `NODE_DECAY_CHANNELS` 2026-07-26, per
+        `services/orion-field-digester/app/digestion/decay.py`) -- it sits at whatever was
+        last written until the next perturbation, and does not self-correct if the writing
+        tick stalls or the producing service goes down. This module has already been burned
+        twice by trusting an undecayed/mis-decayed field at face value (`node:substrate.route`
+        decaying unopposed for 48h; the bus_synaptic calm-floor bug). `orion/substrate/
+        endogenous_curiosity.py::_prediction_error_staleness_decay()` guards the same raw
+        field for its own consumer by age-decaying it; this method instead treats a row
+        older than `_BUS_SYNAPTIC_STALENESS_HORIZON_SEC` as unavailable (`None`) rather than
+        partially decaying it -- a single scalar has no good "partially stale" representation,
+        and honest absence is the same choice #1379's design doc already made for this field.
+
+        Returns `None` (not `0.0`) when the node is absent, stale, or unparseable, so the
+        caller can tell "no real signal available" apart from "genuinely calm" -- collapsing
+        those would recreate exactly the degenerate-zero failure mode this patch exists to fix.
+        """
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    """
+                    SELECT field_json -> 'node_vectors' -> 'node:substrate.bus_synaptic'
+                           ->> 'prediction_error' AS value,
+                           generated_at
+                    FROM substrate_field_state
+                    ORDER BY generated_at DESC
+                    LIMIT 1
+                    """
+                )
+            ).mappings().first()
+        if not row or row["value"] is None:
+            return None
+        generated_at = row["generated_at"]
+        if generated_at is not None:
+            if generated_at.tzinfo is None:
+                generated_at = generated_at.replace(tzinfo=timezone.utc)
+            age_seconds = (datetime.now(timezone.utc) - generated_at).total_seconds()
+            if age_seconds > _BUS_SYNAPTIC_STALENESS_HORIZON_SEC:
+                return None
+        try:
+            return float(row["value"])
+        except (TypeError, ValueError):
+            return None
 
     def recent_dispatch_result_statuses(self, limit: int = 10) -> list[str]:
         """Kept, not removed: no longer called by worker.py's theater tripwire

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -434,7 +434,26 @@ class ExecutionDispatchRuntimeWorker:
         curiosity-fetch ones. Never lets a publish failure raise out of
         the tick -- an unreachable bus must not lose a result that's
         already durably recorded via save_dispatch_result above.
+
+        `surprise` was a hardcoded `0.0` placeholder (2026-07-13, honest,
+        disclosed, never a real signal). Now reads the real, live
+        `bus_synaptic_prediction_error()` value off `substrate_field_state`
+        (`self._store.latest_bus_synaptic_prediction_error()`) -- generic
+        across the whole bus mesh, already fixed once for a calm-floor bias
+        (PR #1391). Falls back to `0.0` if the node isn't written yet or the
+        query fails, same as before this patch -- this is a real-signal
+        upgrade, not a new hard dependency; a fetch failure here must not
+        block emitting the outcome itself.
         """
+        try:
+            surprise = self._store.latest_bus_synaptic_prediction_error()
+        except Exception:
+            logger.warning(
+                "execution_dispatch_bus_synaptic_surprise_fetch_failed dispatch_id=%s",
+                candidate.dispatch_id,
+                exc_info=True,
+            )
+            surprise = None
         try:
             emit = ActionOutcomeEmitV1(
                 subject=ACTION_OUTCOME_SUBJECT,
@@ -442,7 +461,7 @@ class ExecutionDispatchRuntimeWorker:
                 kind=candidate.dispatch_kind,
                 summary=summary[:ACTION_OUTCOME_SUMMARY_MAX_CHARS],
                 success=success,
-                surprise=0.0,
+                surprise=surprise if surprise is not None else 0.0,
                 observed_at=observed_at,
             )
             env = BaseEnvelope(

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -286,6 +286,79 @@ def test_sum_risk_dispatched_today_zero_when_no_row(monkeypatch) -> None:
     monkeypatch.setattr(store, "_engine", fake_engine)
 
     assert store.sum_risk_dispatched_today() == 0.0
+
+
+def test_latest_bus_synaptic_prediction_error_returns_real_value(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "value": "0.1675",
+        "generated_at": datetime.now(timezone.utc),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.latest_bus_synaptic_prediction_error() == 0.1675
+
+
+def test_latest_bus_synaptic_prediction_error_none_when_no_row(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = None
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.latest_bus_synaptic_prediction_error() is None
+
+
+def test_latest_bus_synaptic_prediction_error_none_when_node_absent(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "value": None,
+        "generated_at": datetime.now(timezone.utc),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.latest_bus_synaptic_prediction_error() is None
+
+
+def test_latest_bus_synaptic_prediction_error_none_when_stale(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    stale_generated_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "value": "0.1675",
+        "generated_at": stale_generated_at,
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.latest_bus_synaptic_prediction_error() is None
+
+
+def test_latest_bus_synaptic_prediction_error_none_when_unparseable(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "value": "not-a-float",
+        "generated_at": datetime.now(timezone.utc),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.latest_bus_synaptic_prediction_error() is None
 
 
 def test_recent_dispatch_result_statuses_returns_ordered_list(monkeypatch) -> None:

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -183,6 +183,7 @@ def _patch_bus_and_client(monkeypatch, outcomes: dict[str, object]) -> MagicMock
 async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(
@@ -215,6 +216,7 @@ async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None
 async def test_send_one_emits_action_outcome_on_success(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(
@@ -234,12 +236,58 @@ async def test_send_one_emits_action_outcome_on_success(monkeypatch) -> None:
     assert env.payload["kind"] == "inspect"
     assert env.payload["summary"] == "steady state observed"
     assert env.payload["success"] is True
+    assert env.payload["surprise"] == 0.1675
+
+
+@pytest.mark.asyncio
+async def test_send_one_action_outcome_surprise_falls_back_to_zero_when_unavailable(
+    monkeypatch,
+) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=None)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    fake_bus = _patch_bus_and_client(
+        monkeypatch,
+        {"dispatch:1": {"result": {"final_text": '{"observation": "steady"}'}}},
+    )
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+
+    _, env = fake_bus.publish.await_args.args
+    assert env.payload["surprise"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_send_one_action_outcome_surprise_falls_back_to_zero_on_fetch_error(
+    monkeypatch,
+) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(
+        side_effect=RuntimeError("db unreachable")
+    )
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    fake_bus = _patch_bus_and_client(
+        monkeypatch,
+        {"dispatch:1": {"result": {"final_text": '{"observation": "steady"}'}}},
+    )
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+
+    _, env = fake_bus.publish.await_args.args
+    assert env.payload["surprise"] == 0.0
 
 
 @pytest.mark.asyncio
 async def test_send_one_emits_action_outcome_on_empty_observation(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(monkeypatch, {"dispatch:1": {"result": {"final_text": ""}}})
@@ -257,6 +305,7 @@ async def test_send_one_emits_action_outcome_on_empty_observation(monkeypatch) -
 async def test_send_one_emits_action_outcome_on_rpc_failure(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(monkeypatch, {"dispatch:1": RuntimeError("rpc timed out")})
@@ -281,6 +330,7 @@ async def test_send_one_re_emits_action_outcome_on_idempotent_replay(monkeypatch
     # this same replay branch, so there'd be no other chance to retry it.
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
         return_value={
@@ -307,6 +357,7 @@ async def test_send_one_re_emits_action_outcome_on_idempotent_replay(monkeypatch
 async def test_send_one_action_outcome_publish_failure_does_not_raise(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     fake_bus = _patch_bus_and_client(
@@ -327,6 +378,7 @@ async def test_send_one_action_outcome_publish_failure_does_not_raise(monkeypatc
 async def test_send_one_action_outcome_summary_is_truncated(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     long_observation = "x" * 5000
@@ -346,6 +398,7 @@ async def test_send_one_action_outcome_summary_is_truncated(monkeypatch) -> None
 async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(monkeypatch, {"dispatch:1": RuntimeError("rpc timed out")})
@@ -365,6 +418,7 @@ async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeyp
 async def test_send_prepared_candidates_empty_observation_status_empty(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(monkeypatch, {"dispatch:1": {"result": {"final_text": ""}}})
@@ -388,6 +442,7 @@ async def test_send_prepared_candidates_respects_per_tick_budget(monkeypatch) ->
         update={"limits": worker._policy.limits.model_copy(update={"max_dispatches_per_tick": 1})}
     )
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
@@ -419,6 +474,7 @@ async def test_send_prepared_candidates_stops_at_first_candidate_exceeding_remai
     worker = _make_worker(monkeypatch)
     worker._settings.orion_dispatch_max_risk_per_day = 0.10
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
@@ -453,6 +509,7 @@ async def test_send_prepared_candidates_sends_all_when_cumulative_risk_fits_budg
     )
     worker._settings.orion_dispatch_max_risk_per_day = 1.0
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
@@ -492,6 +549,7 @@ async def test_send_prepared_candidates_skips_non_prepared_without_consuming_per
     )
     worker._settings.orion_dispatch_max_risk_per_day = 1.0
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
@@ -523,6 +581,7 @@ async def test_send_prepared_candidates_zero_risk_candidate_still_spends_the_flo
     )
     worker._settings.orion_dispatch_max_risk_per_day = worker_mod.MINIMUM_REAL_RISK_FLOOR
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
@@ -554,6 +613,7 @@ async def test_send_one_replays_existing_result_without_resending(monkeypatch) -
     # tick must NOT fire a second real cortex-exec RPC for it.
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
         return_value={
@@ -578,6 +638,7 @@ async def test_send_one_replays_existing_result_without_resending(monkeypatch) -
 async def test_send_one_replays_existing_failed_result_without_resending(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
         return_value={
@@ -626,6 +687,7 @@ async def test_send_prepared_candidates_skips_when_tripwire_active(monkeypatch) 
         ["empty"] * 6 + ["success"] * 4, maxlen=worker_mod.THEATER_TRIPWIRE_WINDOW
     )
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._notify.send = MagicMock()
     _patch_bus_and_client(monkeypatch, {})
@@ -646,6 +708,7 @@ async def test_send_prepared_candidates_tripwire_stays_tripped_across_calls(monk
         ["empty"] * 6 + ["success"] * 4, maxlen=worker_mod.THEATER_TRIPWIRE_WINDOW
     )
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     worker._store.save_dispatch_result = MagicMock()
     worker._notify.send = MagicMock()
     _patch_bus_and_client(monkeypatch, {})
@@ -662,6 +725,7 @@ async def test_send_prepared_candidates_tripwire_stays_tripped_across_calls(monk
 async def test_send_prepared_candidates_noop_when_nothing_prepared(monkeypatch) -> None:
     worker = _make_worker(monkeypatch)
     worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1675)
     frame = _frame_with_candidates(_candidate("dispatch:1", status="blocked"))
 
     updated = await worker._send_prepared_candidates(frame)


### PR DESCRIPTION
## Summary

- `action_outcomes.surprise` (emitted by `orion-execution-dispatch-runtime`) was a hardcoded `0.0` placeholder since 2026-07-13 — honest, disclosed, never a real signal.
- Replaces it with a real read of `bus_synaptic_prediction_error()`'s already-computed output (PR #1377, calm-floor fixed PR #1391) off `substrate_field_state`'s `node:substrate.bus_synaptic` node — no new tracker, no new table, reuses an existing generic instrument.
- Review found a real gap (missing staleness check on an intentionally-undecayed raw field) — fixed in the same patch: values older than the shared prediction-error decay horizon (30 min, `PressureConfig`) are treated as unavailable, not silently served stale.
- Updated `orion/autonomy/models.py`'s `ActionOutcomeRefV1` docstring, this service's README, and two historical spec docs (`2026-07-13-autonomy-experience-loop-p2-design.md`, `2026-07-24-efe-capability-gate-design.md`) so the "surprise is always fake" finding those docs made no longer reads as universally true.

## Outcome moved

`action_outcomes` rows from this service now carry a genuine, continuous, already-live-validated surprise value instead of a constant `0.0` — the exact "flat/degenerate metric" failure the Sentience Striving Program's metric-quality gate exists to catch.

## Current architecture

`_emit_action_outcome()` in `services/orion-execution-dispatch-runtime/app/worker.py` built `ActionOutcomeEmitV1` with `surprise=0.0` unconditionally, for every dispatch outcome (success/empty/failed).

## Architecture touched

- `services/orion-execution-dispatch-runtime/app/store.py`: new `latest_bus_synaptic_prediction_error()`.
- `services/orion-execution-dispatch-runtime/app/worker.py`: `_emit_action_outcome()` now fetches and uses that value, fail-open to `0.0`.

## Files changed

- `services/orion-execution-dispatch-runtime/app/store.py`: new store method, raw SQL against `substrate_field_state`, staleness-guarded.
- `services/orion-execution-dispatch-runtime/app/worker.py`: wires the fetch into `_emit_action_outcome`, wrapped in try/except.
- `orion/autonomy/models.py`: `ActionOutcomeRefV1` docstring updated — this emitter is now the one real exception to the "surprise is a fake success/fail proxy" rule.
- `services/orion-execution-dispatch-runtime/README.md`: "Experience loop" section documents the real signal + staleness guard.
- `docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md`: superseded-note added, historical content untouched.
- `docs/superpowers/specs/2026-07-24-efe-capability-gate-design.md`: finding 1 updated to note this exception, doesn't change the design's own approach.
- `tests/test_execution_dispatch_runtime_store.py`: 5 new tests (real value, no row, null field, stale, unparseable).
- `tests/test_execution_dispatch_runtime_worker.py`: existing tests updated to mock the new store method; 2 new tests for None/exception fallback; success-path test now asserts the real surprise value propagates.

## Schema / bus / API changes

- Added: none (no schema/table change — reads an existing column via a new JSON path).
- Removed: none.
- Renamed: none.
- Behavior changed: `ActionOutcomeEmitV1.surprise` for this emitter's rows is now a real float instead of a hardcoded `0.0`.
- Compatibility notes: fail-open — any read failure or stale/absent data falls back to the old `0.0` behavior.

## Env/config changes

- None. No `.env_example`/`.env` changes needed.

## Tests run

```text
PYTHONPATH=. python -m pytest tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_runtime_worker.py services/orion-execution-dispatch-runtime/tests/test_theater_tripwire.py -q
51 passed, 2 warnings in 2.48s
```

## Evals run

None applicable — no eval harness exists for this service; this is a data-quality fix to an emitted field, not a new behavior needing behavioral eval.

## Docker/build/smoke checks

Not run — no runtime config, port, dependency, or compose wiring changed (`orion` package is already fully copied into this service's image; `orion.substrate.pressure` needs no new dependency).

## Review findings fixed

- Finding: No staleness check — `prediction_error` is a deliberately undecayed raw snapshot (per `orion-field-digester`'s `decay.py`), so a stalled upstream tick could silently serve an arbitrarily old value as "live" surprise, repeating a failure class this repo has already been burned by twice (`node:substrate.route` decay-to-zero, bus_synaptic calm-floor bug).
  - Fix: Added `_BUS_SYNAPTIC_STALENESS_HORIZON_SEC` (reuses `PressureConfig().prediction_error_decay_horizon_seconds`), treats rows older than the horizon as unavailable (`None` → falls back to `0.0`), mirroring `endogenous_curiosity.py`'s staleness-decay convention for this same raw field but choosing honest-absence over partial decay for a single scalar.
  - Evidence: New test `test_latest_bus_synaptic_prediction_error_none_when_stale`.
- Finding (minor): docstrings didn't mention that cold-start edge-count filtering already happens upstream (in `orion-substrate-runtime`'s `_bus_synaptic_tick`), making this patch hard to self-audit without chasing the write path across three services.
  - Fix: Added an explicit note in the store method's docstring.
  - Evidence: `services/orion-execution-dispatch-runtime/app/store.py`, `latest_bus_synaptic_prediction_error()` docstring.
- Finding (cosmetic, verified not present): reviewer flagged possible misattribution of which service performs the actual Postgres write (field-digester, not substrate-runtime) — checked, the docstring already correctly attributes this to field-digester's `state_deltas.py`; no change needed.

## Restart required

```bash
docker restart orion-athena-execution-dispatch-runtime
```

## Risks / concerns

- Severity: low
- Concern: this is the only `ActionOutcomeEmitV1` producer with a real `surprise` value; any downstream consumer that reads `action_outcomes.surprise` generically (without checking `kind`) could now see a mix of real floats and fake success/fail proxies from other emitters.
- Mitigation: documented explicitly in `orion/autonomy/models.py::ActionOutcomeRefV1`'s docstring, identifiable by `kind` (`inspect`/`summarize`/`observe`/`noop`).

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/wire-bus-synaptic-surprise-action-outcomes