### PR TITLE
feat: bus_synaptic transport trigger operator notifications + eval fixes

### DIFF
--- a/services/orion-equilibrium-service/evals/run_bus_synaptic_poll_e2e_eval.py
+++ b/services/orion-equilibrium-service/evals/run_bus_synaptic_poll_e2e_eval.py
@@ -87,15 +87,24 @@ async def main():
     logger.info(f"Injecting bus_synaptic prediction_error=1.2 into FalkorDB...")
     graph = Graph(redis_client, settings.falkordb_substrate_graph)
     try:
-        # Update or create the node
+        # Update or create the node - use direct property update
         query = """
-        MERGE (n:SubstrateNode { node_id: "node:substrate.bus_synaptic" })
+        MATCH (n:SubstrateNode {node_id: "node:substrate.bus_synaptic"})
         SET n.prediction_error = 1.2
-        SET n.last_updated = datetime()
         RETURN n.node_id, n.prediction_error
         """
         result = graph.query(query)
-        logger.info(f"✓ Node updated: {result.result_set}")
+        if result.result_set:
+            logger.info(f"✓ Node updated: {result.result_set}")
+        else:
+            # If node doesn't exist, create it
+            logger.info("Node not found, creating new SubstrateNode...")
+            create_query = """
+            CREATE (n:SubstrateNode {node_id: "node:substrate.bus_synaptic", prediction_error: 1.2})
+            RETURN n.node_id, n.prediction_error
+            """
+            create_result = graph.query(create_query)
+            logger.info(f"✓ Node created: {create_result.result_set}")
     except Exception as e:
         logger.error(f"✗ Failed to update FalkorDB node: {e}")
         return False


### PR DESCRIPTION
## Summary

Follow-up to PR #1401: Wire bus_synaptic transport trigger into orion-hub's notification system + fix E2E eval FalkorDB query compatibility.

Delivers operator visibility when real inter-service RPC anomalies are detected.

## Outcome moved

- ✅ Operators see real-time notifications in orion-hub when bus_synaptic transport triggers fire
- ✅ Notifications include error value, reason, links to logs
- ✅ E2E eval ready to run for full pipeline validation + timing metrics

## Architecture touched

**orion-hub:**
- New `BusSynapticTriggerNotifier` subscribes to `orion:equilibrium:metacog:trigger`
- Filters for `trigger_kind=transport` + `evidence_source=bus_synaptic_prediction_error`
- Publishes `HubNotificationEvent` to `orion:notify:in_app`
- Integrated into hub startup/shutdown lifecycle

**orion-equilibrium-service:**
- Fixed E2E eval FalkorDB query (removed Cypher datetime() call)
- Now uses MATCH + SET with CREATE fallback
- Ready to inject test anomaly and verify full pipeline

## Files changed

- `services/orion-hub/scripts/bus_synaptic_trigger_notifier.py`: NEW - notification bridge
- `services/orion-hub/scripts/main.py`: Wire notifier into lifecycle
- `services/orion-equilibrium-service/evals/run_bus_synaptic_poll_e2e_eval.py`: FalkorDB query fix

## Tests run

- ✅ Unit tests: 6 test methods (mocked, local)
- ⏳ E2E eval: Ready to run in Docker environment

To run E2E:
```bash
cd services/orion-equilibrium-service && python3 evals/run_bus_synaptic_poll_e2e_eval.py
```

## Restart required

orion-hub must restart to pick up notifier wiring.

---

**Commits on this PR:**
1. 928cf1584 - feat: wire bus_synaptic transport trigger notification into orion-hub
2. 800497e - fix: remove datetime() from FalkorDB query (Cypher compat)

Builds directly on top of merged PR #1401.