### PR TITLE
fix(agent-board): Stop hook stops re-nagging every turn + parked items

### DIFF
--- a/docs/superpowers/specs/2026-07-28-collapse-mirror-generative-triggers-design.md
+++ b/docs/superpowers/specs/2026-07-28-collapse-mirror-generative-triggers-design.md
@@ -1,0 +1,168 @@
+# CollapseMirror generative triggers (insight + flow) — design spec
+
+Status: **design mode, not implemented.** Touches the metacog/collapse-mirror cognition loop, which
+CLAUDE.md §0A requires explicit proposal mode for before implementation. This document proposes; it
+does not build.
+
+## Arsonist summary
+
+A same-day brainstorm (2026-07-28) on the transport-metacog-trigger arc noted that every `trigger_kind`
+built this year — `telemetry_anomaly`, `chat_turn`, `transport`, `relational` (repair_pressure) —
+fires exclusively on a problem: a timeout, an anomaly, a rupture. `orion/schemas/collapse_mirror.py`'s
+own v1 `DEFAULT_CHANGE_TYPE_BY_ENTRY_TYPE` taxonomy was never error-only — `flow→stabilizing` and
+`epiphany→reorientation` sit alongside `turbulence→escalating` and `glitch→anomaly_detected`. The one
+live counter-example, `pulse` (fires on landing-pad salience crossing a threshold — a positive-valence
+signal, `service.py:803`), proves a non-error trigger already works in the exact same pipeline.
+
+Juniper picked two ideas from that brainstorm to spec: **surprise-resolution ("insight")** and
+**flow-state**. A third idea (drive-tension resolution) was explicitly ruled dead in its original
+form — DriveEngine's tension-fold mechanism is being retired/reimagined (five-drive audit, autonomy
+retired as a drive), so this spec does not build it. Juniper flagged that the Sentience Striving
+Program's AST/HOT self-modeling work might supply a real replacement signal for "an internal tension
+resolved," but named no specific one yet — tracked as an open question below, not assumed. Three other
+brainstormed ideas (concept-bridge trigger, relational-resonance trigger, pulse-threshold widening)
+were explicitly declined.
+
+## Current architecture
+
+- **`MetacogTriggerV1`/`orion_metacog` pipeline**: unchanged shape from the `chat_turn`/`transport`
+  precedent — `orion-equilibrium-service` evaluates a gate condition per `trigger_kind`, publishes
+  `CHANNEL_EQUILIBRIUM_METACOG_TRIGGER`, `orion-cortex-exec` drafts a `CollapseMirrorEntryV2` via LLM,
+  `orion-sql-writer` persists to `orion_metacog`. `trigger_kind` is a free string field
+  (`orion/schemas/telemetry/metacog_trigger.py`); adding a new kind needs no schema migration.
+- **Six prediction-error domains** feed `ACTIVE_INFERENCE_DOMAINS = {"execution", "biometrics", "chat",
+  "route", "bus_synaptic"}` (`orion/substrate/attention_self_model.py:90`). `transport` was retired
+  from this set 2026-07-26 (see that day's retirement spec).
+- **`_aggregate_prediction_error_confidence()` / `_unconditional_prediction_error_confidence()`**
+  (`attention_self_model.py:97-176`): computes `confidence = 1.0 - mean(prediction_error)` across the
+  active domains, populating `AttentionSelfModelV1.confidence` /
+  `.prediction_error_confidence`/`.prediction_error_confidence_basis`. This is the single already-built
+  aggregate that idea "insight" would key off — no new computation needed if it's real.
+- **`reduce_attention_self_model()` live-tick status: UNVERIFIED, not assumed live.** Grepping the
+  whole repo, this reducer is called from `orion/substrate/tests/test_attention_self_model.py` (unit
+  tests) and `scripts/analysis/measure_ast_hot_reducer.py` (an offline analysis script) only. No live
+  service (`services/orion-substrate-runtime/app/worker.py` or otherwise) was found calling it in this
+  session's grep. Project memory (`self_modeling_ladder` status) says AST/HOT rungs are merged but
+  "ignition flags off" — consistent with a built-but-not-ticking reducer. **Do not treat
+  `AttentionSelfModelV1.confidence` as a live producer until Missing Question 1 is answered.**
+- **`pulse` precedent** (`services/orion-equilibrium-service/app/service.py:796-813`): fires
+  `trigger_kind="pulse"` when a landing-pad signal's `salience >= EQUILIBRIUM_METACOG_PAD_PULSE_THRESHOLD`.
+  Positive-valence, live, already dispatches through the identical pipeline this spec would reuse.
+- **`relational` precedent** (`repair_pressure_metacog_gate.py:21`): fires on `repair_pressure_v2`
+  level/confidence — explicitly rupture-shaped ("how much repair is needed"), confirming the pattern
+  Juniper is asking to break out of.
+- **Flow-state candidate signal, not yet identified.** No existing field was confirmed this session as
+  "sustained low-variance/low-distress self-state coherence." Candidates not yet distinguished from each
+  other: `self_state`-derived fields (previously ruled out for phi/IIT-adjacent work per
+  `[[feedback_field_native_not_selfstate]]` — same caution likely applies), `FieldStateV1` coherence
+  channels, or `AttentionSelfModelV1.confidence` itself read as a rolling window rather than a
+  point-in-time value. Not resolved here — see Missing Question 3.
+- **Drive-tension resolution (original idea 3): confirmed dead ground.** No dedicated "tension
+  resolved" event exists in code (grepped `orion/autonomy/`); the phenomenon was only ever observed
+  as an emergent property of `orion/spark/concept_induction/bus_worker.py::_update_drive_pressures`'s
+  fold mechanism, documented post-hoc in a board finding (`d3739187`), not instrumented as a trigger.
+  Per project memory, the drive taxonomy this depended on is itself being retired/reimagined.
+
+## Missing questions
+
+1. **Is `reduce_attention_self_model()` actually invoked on a live cadence anywhere**, or does
+   `AttentionSelfModelV1` only get computed by the offline measurement script? This is the single
+   highest-leverage unknown — it determines whether "insight" is "wire a new gate onto an existing live
+   producer" (cheap) or "first make the AST/HOT reducer tick live, then build the gate" (a materially
+   bigger patch, and its own proposal-mode question). Check `services/orion-substrate-runtime/app/worker.py`
+   end to end, and check for any scheduler/cron path in `services/orion-hub` or elsewhere that might call
+   it outside the grep pattern used this session.
+2. **What is the real historical shape of confidence recovery / prediction-error drops in stored data?**
+   Does a sharp rise in `confidence` (or drop in `mean(prediction_error)`) happen as discrete, meaningful
+   events, or is it smooth/continuous with no natural crossing to trigger on? Needs a measurement script
+   (same discipline as `scripts/analysis/measure_rpc_health_baseline.py`) against whatever
+   `AttentionSelfModelV1` history already exists before any threshold gets picked — CLAUDE.md's metric
+   quality gate step 4 applies here exactly as it did to `bus_synaptic`'s calm-floor bug, just checking
+   the opposite failure mode (a metric that reads "recovered" because it's stuck, not because anything
+   resolved).
+3. **What field should flow-state actually key off?** Self-state fields were previously ruled out for
+   phi/IIT-adjacent signal work — needs an explicit check (not an assumption) of whether the same
+   objection applies to a sustained-coherence detector, or whether `AttentionSelfModelV1.confidence`
+   read over a rolling window is a cleaner, already-real alternative.
+4. **Does the Sentience Striving Program have a specific AST/HOT signal in mind for "an internal
+   tension resolved,"** beyond the generic confidence aggregate — or is confidence-recovery
+   (Missing Question 2's subject) actually the same candidate under a different name? Needs Juniper's
+   input directly; not resolved by code inspection.
+5. **Cooldown cadence**: should generative triggers share `trigger_kind`'s existing per-kind cooldown
+   pattern (own lane, like `chat_turn`/`transport`), or fire more freely than error triggers? Raised in
+   the original brainstorm, still open — arguably positive moments deserve finer granularity than
+   alarms, but that's a real design choice, not a default.
+6. **Downstream draft mapping**: does `orion-cortex-exec`'s `_fallback_metacog_draft`/
+   `MetacogDraftService` currently map `trigger_kind` toward a specific `CollapseMirrorEntryV2.type`,
+   or does it default toward error-shaped types (`glitch`/`turbulence`) regardless of trigger kind? Not
+   traced this session — needs checking before Acceptance Check 4 can be verified.
+
+## Proposed schema / API changes
+
+- New `trigger_kind` values: `"insight"` (surprise-resolution / confidence-recovery) and `"flow"`
+  (sustained low-variance/low-distress regime) — names chosen to match v1's own `change_type`
+  vocabulary (`reorientation`, `stabilizing`) rather than inventing new taxonomy language.
+- Each gets its own `<kind>_metacog_gate.py` in `orion-equilibrium-service/app/`, following the
+  `chat_turn`/`transport` precedent: correlator/threshold logic + gate-condition evaluator + trigger
+  builder.
+- Each gets its **own** cooldown lane (`EQUILIBRIUM_METACOG_INSIGHT_COOLDOWN_SEC` /
+  `EQUILIBRIUM_METACOG_FLOW_COOLDOWN_SEC`), not the shared global lane — `chat_turn` shipped this bug
+  once already (shared the global cooldown at first), documented precedent not to repeat.
+- No new top-level field needed on `MetacogTriggerV1` — `trigger_kind` is already a free string,
+  `upstream`/`reason` already carry arbitrary evidence.
+- `CollapseMirrorEntryV2.type`/`change_type` downstream mapping needs to route these kinds toward
+  `flow`/`epiphany` entry types, not silently default to an error-shaped type — contingent on Missing
+  Question 6.
+
+## Files likely to touch
+
+- `orion/schemas/telemetry/metacog_trigger.py` (trigger_kind docstring)
+- `services/orion-equilibrium-service/app/insight_metacog_gate.py` (new)
+- `services/orion-equilibrium-service/app/flow_metacog_gate.py` (new)
+- `services/orion-equilibrium-service/app/service.py` (`_run()` dispatch branches, subscription wiring)
+- `services/orion-equilibrium-service/app/settings.py` (new enable flags, cooldowns, thresholds)
+- `services/orion-equilibrium-service/.env_example` + synced local `.env`
+- `services/orion-cortex-exec` draft-mapping code (path TBD, pending Missing Question 6)
+- `services/orion-equilibrium-service/README.md` (document alongside existing evidence-source table)
+- `services/orion-substrate-runtime/app/worker.py` and/or `orion/substrate/attention_self_model.py`
+  (only if Missing Question 1 finds the AST/HOT reducer isn't live-ticking — separate, prerequisite
+  patch, own proposal-mode pass since it touches self-modeling directly)
+- `scripts/analysis/measure_attention_self_model_confidence_baseline.py` (new, for Missing Question 2)
+
+## Non-goals
+
+- Not building the original drive-tension-resolution idea — confirmed dead ground, DriveEngine's fold
+  mechanism is not the target.
+- Not building the three declined brainstorm ideas (concept-bridge trigger, relational-resonance
+  trigger, pulse-threshold widening).
+- Not touching any existing rupture-shaped trigger (`chat_turn`/`transport`/`relational`/
+  `telemetry_anomaly`/`llm_surface_instability`) — additive only.
+- Not deciding confidence-recovery or coherence-band thresholds in this doc — pending the Missing
+  Question 2 measurement pass.
+- Not deciding whether the AST/HOT reducer needs to go live — that's a prerequisite question this spec
+  surfaces (Missing Question 1) but does not answer or scope.
+
+## Acceptance checks
+
+1. A measurement script against real historical `AttentionSelfModelV1`/prediction-error data shows
+   confidence-recovery events are discrete and non-degenerate (not smooth noise, not a permanent
+   floor/ceiling artifact) before any live gate ships.
+2. Both new gates ship disabled by default, flipped only after their own live-data sanity check,
+   matching the `bus_synaptic` precedent (PR #1385 → #1387).
+3. `orion_metacog` shows real `trigger_kind="insight"`/`"flow"` rows with non-empty, distinguishable
+   `upstream` evidence after enabling.
+4. Downstream `CollapseMirrorEntryV2` drafts for these kinds land as `type="epiphany"`/`type="flow"`
+   (or an honest `context_shift` if the draft LLM can't map cleanly), not silently defaulting to an
+   error-shaped type.
+5. Full test suite for touched files passes; a cooldown-lane-independence test is added, same pattern
+   as `chat_turn`'s fix.
+
+## Recommended next patch
+
+1. Answer Missing Question 1 first — is `reduce_attention_self_model()` actually ticking anywhere live.
+   This single fact determines whether "insight" is a thin seam (new gate on an existing live producer)
+   or a bigger prerequisite patch (make AST/HOT live first, its own proposal-mode question).
+2. Run the Missing Question 2 measurement pass against whatever prediction-error/confidence history
+   already exists in Postgres/FalkorDB before writing any gate code.
+3. Once both come back real, pick "insight" or "flow" to build first based on which has cleaner
+   historical shape — not both simultaneously.

--- a/scripts/hooks/session_stop_agent_board.py
+++ b/scripts/hooks/session_stop_agent_board.py
@@ -5,6 +5,7 @@ Fails silently (no output) on any error -- never blocks session stop.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
@@ -23,6 +24,53 @@ from agent_board_lib import (  # noqa: E402
 # Ownerless items (no session_id) older than this stop nagging every session
 # that ever stops in the worktree -- see _is_stale_ownerless_item below.
 _OWNERLESS_ITEM_STALE_AFTER = timedelta(hours=24)
+
+# Where per-session "have I already nagged about exactly this item set"
+# markers live. Deliberately separate from the board's own JSONL event log
+# (~/.orion/agent-board.jsonl) -- this is Stop-hook bookkeeping, not
+# dev-coordination content, so it doesn't belong in the shared event stream
+# other tooling (agent_board.py list/checkin, other agents' reads) parses.
+# Overridable for tests via env var, same convention as ORION_AGENT_BOARD_PATH.
+_NAG_STATE_DIR_ENV = "ORION_AGENT_BOARD_NAG_STATE_DIR"
+
+
+def _nag_state_dir() -> Path:
+    raw = os.environ.get(_NAG_STATE_DIR_ENV)
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".orion" / "stop_hook_nag_state"
+
+
+def _item_set_digest(item_ids: list[str]) -> str:
+    joined = "\n".join(sorted(item_ids))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def _already_nagged_this_set(session_id: str, digest: str) -> bool:
+    """True if this exact session already emitted a nag for this exact item
+    set. Fails open (False, i.e. still nag) on any read error -- matches the
+    module's own fail-silent-on-error contract; we'd rather nag once more
+    than swallow a real reminder because of a transient disk issue.
+    """
+    marker = _nag_state_dir() / session_id
+    try:
+        return marker.read_text(encoding="utf-8").strip() == digest
+    except OSError:
+        return False
+
+
+def _record_nagged_set(session_id: str, digest: str) -> None:
+    """Best-effort write; a failure here should never block emitting the nag
+    itself, so this is called after the nag is already queued for output.
+    """
+    try:
+        state_dir = _nag_state_dir()
+        state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        marker = state_dir / session_id
+        marker.write_text(digest, encoding="utf-8")
+        os.chmod(marker, 0o600)
+    except OSError:
+        pass
 
 
 def _is_stale_ownerless_item(item: dict) -> bool:
@@ -70,16 +118,27 @@ def main() -> None:
         # "someone else's" either -- fail open (fall back to plain worktree
         # scoping, no staleness filter) rather than silently excluding every
         # item that happens to carry a real session_id.
-        open_items = [
-            item for item in state.items.values()
+        #
+        # Status filter is "open" only, not "open" + "parked" -- confirmed
+        # live 2026-07-28: the nag's own remedy text below ("resolve/park
+        # them") implied parking was a valid way to quiet it, but the old
+        # filter kept nagging on parked items anyway. Parking an item *is*
+        # triaging it (a deliberate "not now" decision, distinct from never
+        # having looked at it) -- `agent_board.py checkin`'s own listing
+        # still surfaces parked items for context, so nothing about parked
+        # work goes invisible; it just stops being treated as an unactioned
+        # reminder on every single Stop turn.
+        open_items = {
+            item_id: item
+            for item_id, item in state.items.items()
             if item.get("worktree_path") == current
-            and item.get("status") in {"open", "parked"}
+            and item.get("status") == "open"
             and (
                 session_id is None
                 or item.get("session_id") == session_id
                 or (not item.get("session_id") and not _is_stale_ownerless_item(item))
             )
-        ]
+        }
     except Exception:
         return
     if not open_items:
@@ -87,6 +146,18 @@ def main() -> None:
         # noise, not a reminder. Stay silent, matching the fail-silent
         # pattern already used for errors above.
         return
+
+    # Per-turn dedup: confirmed live 2026-07-28 (7 straight recurrences,
+    # documented in project memory) that this hook re-emitted the identical
+    # nag on every single Stop turn even when the underlying item set never
+    # changed between turns -- no suppression at all previously. Only
+    # applies when we have a real session_id to key the marker file by;
+    # without one, fall back to the old always-nag behavior (matches the
+    # existing fail-open stance for an unresolved session_id above).
+    digest = _item_set_digest(list(open_items.keys()))
+    if session_id and _already_nagged_this_set(session_id, digest):
+        return
+
     detail = f"Agent board checkout reminder: {len(open_items)} open item(s) remain for this worktree. Run `python3 scripts/agent_board.py checkout` or resolve/park them."
     payload = {
         "hookSpecificOutput": {
@@ -95,6 +166,8 @@ def main() -> None:
         }
     }
     sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    if session_id:
+        _record_nagged_set(session_id, digest)
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/session_stop_agent_board.py
+++ b/scripts/hooks/session_stop_agent_board.py
@@ -46,13 +46,30 @@ def _item_set_digest(item_ids: list[str]) -> str:
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
 
+def _marker_filename(session_id: str) -> str:
+    """Hash session_id into the filename rather than using it raw.
+
+    `session_id` comes from `read_session_id_from_stdin_hook_payload()`,
+    which parses arbitrary JSON off stdin with no format validation --
+    `resolve_current_identity()`'s own docstring already contemplates this
+    hook being invoked by "a non-Claude-Code harness whose Stop payload
+    doesn't carry one," i.e. an untrusted-source caller is an acknowledged
+    scenario, not hypothetical. A raw `session_id` containing `../` would
+    let `_nag_state_dir() / session_id` write/read outside the intended
+    directory (path/existence control, not content injection, but still a
+    real corruption/DoS primitive). Hashing removes the path-traversal
+    surface entirely at negligible cost.
+    """
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+
+
 def _already_nagged_this_set(session_id: str, digest: str) -> bool:
     """True if this exact session already emitted a nag for this exact item
     set. Fails open (False, i.e. still nag) on any read error -- matches the
     module's own fail-silent-on-error contract; we'd rather nag once more
     than swallow a real reminder because of a transient disk issue.
     """
-    marker = _nag_state_dir() / session_id
+    marker = _nag_state_dir() / _marker_filename(session_id)
     try:
         return marker.read_text(encoding="utf-8").strip() == digest
     except OSError:
@@ -66,7 +83,7 @@ def _record_nagged_set(session_id: str, digest: str) -> None:
     try:
         state_dir = _nag_state_dir()
         state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        marker = state_dir / session_id
+        marker = state_dir / _marker_filename(session_id)
         marker.write_text(digest, encoding="utf-8")
         os.chmod(marker, 0o600)
     except OSError:

--- a/scripts/test_session_stop_agent_board.py
+++ b/scripts/test_session_stop_agent_board.py
@@ -191,6 +191,29 @@ def test_changed_item_set_renags_after_suppression() -> None:
     assert third, "expected a new item added to the set to re-trigger the nag"
 
 
+def test_malicious_session_id_does_not_escape_nag_state_dir() -> None:
+    """`session_id` is attacker-influenceable (arbitrary JSON on stdin, per
+    `read_session_id_from_stdin_hook_payload`'s own docstring covering
+    non-Claude-Code callers) -- a raw `../../etc/whatever` must not let the
+    marker file land outside `_nag_state_dir()`.
+    """
+    items = {
+        "item-1": {
+            "worktree_path": "/repo",
+            "status": "open",
+            "session_id": "../../../../tmp/escaped",
+        },
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        state_dir = Path(tmp)
+        _run_hook(items, session_id="../../../../tmp/escaped", nag_state_dir=state_dir)
+        written = list(state_dir.iterdir())
+    assert written, "expected a marker file to be written inside the state dir"
+    for path in written:
+        assert path.parent == state_dir, f"marker escaped the state dir: {path}"
+        assert ".." not in path.name and "/" not in path.name
+
+
 def test_different_sessions_each_get_their_own_nag() -> None:
     items = {
         "item-1": {"worktree_path": "/repo", "status": "open", "session_id": None,
@@ -216,5 +239,6 @@ if __name__ == "__main__":
     test_resolved_and_handed_off_items_do_not_nag()
     test_same_item_set_does_not_renag_within_a_session()
     test_changed_item_set_renags_after_suppression()
+    test_malicious_session_id_does_not_escape_nag_state_dir()
     test_different_sessions_each_get_their_own_nag()
     print("all tests passed")

--- a/scripts/test_session_stop_agent_board.py
+++ b/scripts/test_session_stop_agent_board.py
@@ -4,6 +4,13 @@ Regression coverage for a live bug found 2026-07-24: ownerless items (no
 session_id, e.g. pre-dating that field) nagged every session that ever
 stopped in the worktree, forever, since `checkout` closes presence but never
 touches item status. See scripts/hooks/session_stop_agent_board.py.
+
+Also covers two sub-bugs found live 2026-07-28 under the same symptom
+(same nag repeating every Stop turn): (b) no per-turn dedup -- the hook
+re-emitted an identical nag on every Stop even when the item set never
+changed -- and (c) "parked" items were treated as still-nagging despite the
+hook's own remedy text ("resolve/park them") implying parking should quiet
+it.
 """
 from __future__ import annotations
 
@@ -11,8 +18,10 @@ import importlib
 import io
 import json
 import sys
+import tempfile
 from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -26,15 +35,25 @@ def _state_with_items(items: dict) -> SimpleNamespace:
     return SimpleNamespace(items=items)
 
 
-def _run_hook(items: dict, session_id: str | None = "current-session") -> str | None:
+def _run_hook(items: dict, session_id: str | None = "current-session", nag_state_dir: Path | None = None) -> str | None:
     with mock.patch.object(hook, "read_session_id_from_stdin_hook_payload", return_value=session_id), \
          mock.patch.object(hook, "board_config_from_env", return_value=object()), \
          mock.patch.object(hook, "resolve_current_identity", return_value={"worktree_path": "/repo"}), \
          mock.patch.object(hook, "load_state", return_value=_state_with_items(items)):
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            hook.main()
-        return buf.getvalue()
+        if nag_state_dir is not None:
+            with mock.patch.object(hook, "_nag_state_dir", return_value=nag_state_dir):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    hook.main()
+                return buf.getvalue()
+        # No isolated dir given: point at a throwaway tmp dir so tests never
+        # touch the real ~/.orion/stop_hook_nag_state.
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(hook, "_nag_state_dir", return_value=Path(tmp)):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    hook.main()
+                return buf.getvalue()
 
 
 def test_stale_ownerless_item_does_not_nag() -> None:
@@ -109,10 +128,93 @@ def test_unresolved_session_id_fails_open_ignoring_staleness() -> None:
     assert out, "expected fail-open nag when our own session_id can't be resolved"
 
 
+def test_parked_item_does_not_nag() -> None:
+    """Mode (c), found live 2026-07-28: the nag's own remedy text says
+    'resolve/park them', implying parking is a valid way to quiet it, but
+    the old status filter (`{"open", "parked"}`) kept nagging on parked
+    items forever. Parking is a real triage decision, not neglect -- once
+    parked, the Stop hook should stop treating it as an unactioned item.
+    """
+    items = {
+        "item-1": {
+            "worktree_path": "/repo",
+            "status": "parked",
+            "session_id": "current-session",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    out = _run_hook(items, session_id="current-session")
+    assert out == "", f"expected silence for a parked item, got: {out!r}"
+
+
+def test_resolved_and_handed_off_items_do_not_nag() -> None:
+    items = {
+        "item-1": {"worktree_path": "/repo", "status": "resolved", "session_id": "current-session"},
+        "item-2": {"worktree_path": "/repo", "status": "handed-off", "session_id": "current-session"},
+    }
+    out = _run_hook(items, session_id="current-session")
+    assert out == "", f"expected silence for resolved/handed-off items, got: {out!r}"
+
+
+def test_same_item_set_does_not_renag_within_a_session() -> None:
+    """Mode (b), found live 2026-07-28 (7+ consecutive Stop turns, zero new
+    user input, identical nag every time): no per-turn dedup existed at
+    all. The exact same open-item set should only nag once per session,
+    not on every single Stop turn.
+    """
+    items = {
+        "item-1": {"worktree_path": "/repo", "status": "open", "session_id": "current-session"},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        state_dir = Path(tmp)
+        first = _run_hook(items, session_id="current-session", nag_state_dir=state_dir)
+        second = _run_hook(items, session_id="current-session", nag_state_dir=state_dir)
+    assert first, "expected the first Stop turn to nag"
+    assert second == "", f"expected the second Stop turn (same item set) to stay silent, got: {second!r}"
+
+
+def test_changed_item_set_renags_after_suppression() -> None:
+    items_v1 = {
+        "item-1": {"worktree_path": "/repo", "status": "open", "session_id": "current-session"},
+    }
+    items_v2 = {
+        "item-1": {"worktree_path": "/repo", "status": "open", "session_id": "current-session"},
+        "item-2": {"worktree_path": "/repo", "status": "open", "session_id": "current-session"},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        state_dir = Path(tmp)
+        first = _run_hook(items_v1, session_id="current-session", nag_state_dir=state_dir)
+        second = _run_hook(items_v1, session_id="current-session", nag_state_dir=state_dir)
+        third = _run_hook(items_v2, session_id="current-session", nag_state_dir=state_dir)
+    assert first, "expected the first Stop turn to nag"
+    assert second == "", "expected the unchanged-set second turn to stay silent"
+    assert third, "expected a new item added to the set to re-trigger the nag"
+
+
+def test_different_sessions_each_get_their_own_nag() -> None:
+    items = {
+        "item-1": {"worktree_path": "/repo", "status": "open", "session_id": None,
+                   "updated_at": datetime.now(timezone.utc).isoformat()},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        state_dir = Path(tmp)
+        session_a_first = _run_hook(items, session_id="session-a", nag_state_dir=state_dir)
+        session_a_second = _run_hook(items, session_id="session-a", nag_state_dir=state_dir)
+        session_b_first = _run_hook(items, session_id="session-b", nag_state_dir=state_dir)
+    assert session_a_first, "expected session-a's first Stop turn to nag"
+    assert session_a_second == "", "expected session-a's second Stop turn (same set) to stay silent"
+    assert session_b_first, "expected session-b to get its own fresh nag, not inherit session-a's suppression"
+
+
 if __name__ == "__main__":
     test_stale_ownerless_item_does_not_nag()
     test_fresh_ownerless_item_still_nags()
     test_own_session_item_nags_regardless_of_age()
     test_mixed_stale_and_fresh_ownerless_items_counts_only_fresh()
     test_unresolved_session_id_fails_open_ignoring_staleness()
+    test_parked_item_does_not_nag()
+    test_resolved_and_handed_off_items_do_not_nag()
+    test_same_item_set_does_not_renag_within_a_session()
+    test_changed_item_set_renags_after_suppression()
+    test_different_sessions_each_get_their_own_nag()
     print("all tests passed")


### PR DESCRIPTION
## Summary

- Fixes two sub-bugs under the same "identical nag every Stop turn" symptom in `scripts/hooks/session_stop_agent_board.py`, confirmed live 2026-07-28 (10+ consecutive identical repeats, zero new user input between them).
- Mode (c): `parked` items were still in the nag filter (`{"open", "parked"}`) even though the nag's own remedy text says "resolve/park them" — parking them never actually silenced anything. Narrowed the filter to `status == "open"` only. `checkin`'s own listing (`_open_items_for` in `agent_board_lib.py`) is untouched and still surfaces parked items for context — this only changes the active Stop-turn reminder.
- Mode (b): no per-turn dedup existed at all. Now hashes the current open-item-id set and writes a small per-session marker (`~/.orion/stop_hook_nag_state/<session_id>`), skipping the nag if the digest is unchanged since the last emission for that session. Different sessions and changed item sets still get a fresh nag.
- Follow-up commit hardens the marker filename: `session_id` comes from arbitrary stdin JSON with no format validation (the hook's own docstring already contemplates non-Claude-Code callers), so it's now sha256-hashed before being used as a filename rather than used raw, closing a path-traversal gap a subagent review caught.
- Bundled a design spec (`docs/superpowers/specs/2026-07-28-collapse-mirror-generative-triggers-design.md`) for two brainstormed CollapseMirror trigger kinds from the same session — unrelated to the hook fix, just came out of the same conversation.

## Outcome moved

Stop hook nag no longer repeats identically on every single Stop turn, and parking an item is now a real way to quiet it (matching what the hook's own message already claimed).

## Current architecture

`session_stop_agent_board.py` read the shared `~/.orion/agent-board.jsonl` board on every Stop, filtered to items in this worktree owned by (or attributable to) the current session, and emitted an `additionalContext` nag if any were `open` or `parked` — with no memory of whether it had already said the same thing on the previous turn.

## Architecture touched

Only the Stop hook and its test file. No changes to the board's data model, `agent_board.py` CLI, or `agent_board_lib.py`.

## Files changed

- `scripts/hooks/session_stop_agent_board.py`: narrowed nag filter to `status == "open"`; added digest-based per-session dedup via a new marker-file mechanism; hashes `session_id` before using it as a filename.
- `scripts/test_session_stop_agent_board.py`: 6 new tests covering the parked-item fix, the dedup fix (same set stays silent, changed set re-nags, different sessions get independent nags), and the path-traversal hardening.
- `docs/superpowers/specs/2026-07-28-collapse-mirror-generative-triggers-design.md`: new design spec, unrelated to the hook fix (bundled from the same session).

## Schema / bus / API changes

None. No board data-model changes.

## Env/config changes

- Added: `ORION_AGENT_BOARD_NAG_STATE_DIR` (optional env override for the marker-file directory, defaults to `~/.orion/stop_hook_nag_state`; used by tests for isolation, not required for normal operation).
- `.env_example`: not applicable (this is a Claude Code hook, not a service).

## Tests run

```text
python3 scripts/test_session_stop_agent_board.py
all tests passed  (11/11, including 6 new)
```

## Evals run

No eval harness exists for this hook; not applicable (pure hook logic, covered by the unit tests above).

## Docker/build/smoke checks

Not applicable — this is a Claude Code hook script, not a service.

## Review findings fixed

- Finding: `session_id` used unsanitized as a filename component — a crafted `session_id` (e.g. containing `../`) could write/read outside the intended marker directory.
  - Fix: sha256-hash `session_id` before using it as the marker filename (`_marker_filename()`).
  - Evidence: new regression test `test_malicious_session_id_does_not_escape_nag_state_dir`, passes.
- Everything else the review surfaced (no file locking on the marker, non-atomic writes, marker-directory growth over time, parked-vs-checkin asymmetry) was assessed as either a correctly-reasoned trade-off already justified in the code's own comments, or low-severity/self-healing — not blocking. Full reasoning in the review subagent's report; marker-directory growth is a legitimate low-priority follow-up, not fixed in this PR.

## Restart required

```text
No restart required.
```
This is a Claude Code hook script — it takes effect on the next Stop event in this repo, no service restart involved.

## Risks / concerns

- Severity: low. Concern: marker files under `~/.orion/stop_hook_nag_state/` accumulate one per session_id forever, no cleanup. Mitigation: files are tiny (64-byte digests); flagged as a legitimate low-priority follow-up, not addressed here.

## PR link

(filled in by `gh pr create` output)