### PR TITLE
feat(concept-atlas): wire topic-foundry mention edges into Falkor, retire dead kg:edge:ingest bus channel

### DIFF
--- a/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md
@@ -18,6 +18,20 @@ per `docs/superpowers/specs/2026-07-16-falkordb-property-graph-routing-design.md
 below. Live-verified: Concept Atlas's concept graph persists in FalkorDB
 across Hub restarts, not just Hub process memory.
 
+**Update (2026-07-28):** extended to ingest topic-foundry's `mentions`-predicate typed edges
+(`app/services/kg_edges.py`, real LLM-enriched entity extractions) as `EntityNodeV1` +
+`associated_with` edges from the owning topic's concept node, resolved via a new
+`segment_topic_id_map` (segment_id → topic_id) built from the same `GET /segments` fetch this
+route already made. This retires `orion:kg:edge:ingest.v1`, the bus channel that data used to
+publish to for zero live consumers (confirmed dead as of 2026-07-17, see that channel's former
+`orion/bus/channels.yaml` comment) — the same data now reaches a real consumer via
+`GET /kg/edges` instead of a second, unconsumed bus channel. `asks_about`/`claims_about`/
+`next_step` predicates are explicitly out of scope: no `SubstrateNodeKindV1` fits their shape
+yet, and minting one wasn't part of this patch. Known gap, not fixed here: Concept Atlas's own
+Hub-tab routes (`_concept_nodes()` and friends) filter to `node_kind == "concept"`, so the new
+entity nodes are real and generically substrate-visible but don't appear in the existing UI —
+see `services/orion-hub/README.md` §5.5 for the same note.
+
 Scope decided by Juniper: replace concept-induction's NLP extractor with the
 already-built, already-unsupervised `orion-topic-foundry` clustering
 pipeline, fix the concept-identity merge bug, add a thin typed-edge layer on

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -381,18 +381,14 @@ channels:
     stability: "experimental"
     since: "2026-01-08"
 
-  - name: "orion:kg:edge:ingest.v1"
-    kind: "event"
-    schema_id: "KgEdgeIngestV1"
-    producer_services: ["orion-topic-foundry"]
-    # orion-rdf-writer removed 2026-07-17: Fuseki is being decommissioned, and
-    # this channel was never actually consumed by it (not in settings.py's
-    # get_all_subscribe_channels()). orion-graphdb was never a real service
-    # either -- no directory under services/. No live consumer as of this
-    # change; orion-topic-foundry still publishes (kg_edges.py).
-    consumer_services: []
-    stability: "experimental"
-    since: "2026-01-08"
+  # "orion:kg:edge:ingest.v1" (KgEdgeIngestV1) removed 2026-07-28: had zero
+  # live consumers since at least 2026-07-17 (orion-rdf-writer never
+  # actually subscribed; orion-graphdb never existed as a real service --
+  # see git history for that removal). orion-topic-foundry's kg_edges.py no
+  # longer publishes it either -- the same typed edges now reach a real
+  # consumer via GET /kg/edges, pulled into the live Falkor substrate graph
+  # by orion-hub/scripts/concept_atlas_routes.py. See
+  # orion/substrate/adapters/topic_foundry.py's module docstring.
 
   - name: "orion:llm:reply*"
     kind: "result"

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -632,7 +632,6 @@ from orion.schemas.graph_compression import (
     GraphCompressionRegionMaterializedV1,
 )
 from orion.schemas.topic_foundry import (
-    KgEdgeIngestV1,
     TopicFoundryDriftAlertV1,
     TopicFoundryEnrichCompleteV1,
     TopicFoundryRunCompleteV1,
@@ -1131,7 +1130,6 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "TopicFoundryRunCompleteV1": TopicFoundryRunCompleteV1,
     "TopicFoundryEnrichCompleteV1": TopicFoundryEnrichCompleteV1,
     "TopicFoundryDriftAlertV1": TopicFoundryDriftAlertV1,
-    "KgEdgeIngestV1": KgEdgeIngestV1,
     "WorkflowScheduleSpecV1": WorkflowScheduleSpecV1,
     "WorkflowExecutionPolicyV1": WorkflowExecutionPolicyV1,
     "WorkflowDispatchRequestV1": WorkflowDispatchRequestV1,

--- a/orion/schemas/topic_foundry.py
+++ b/orion/schemas/topic_foundry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -50,22 +50,11 @@ class TopicFoundryDriftAlertV1(BaseModel):
     created_at: datetime
 
 
-class KgEdgeIngestItemV1(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    edge_id: UUID
-    segment_id: UUID
-    subject: str
-    predicate: str
-    object: str
-    confidence: float
-    created_at: datetime
-
-
-class KgEdgeIngestV1(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    run_id: UUID
-    model_id: UUID
-    model_name: str
-    edges: List[KgEdgeIngestItemV1]
+# KgEdgeIngestItemV1 / KgEdgeIngestV1 (bus envelope for the retired
+# orion:kg:edge:ingest.v1 channel) removed 2026-07-28 -- zero live consumers
+# ever subscribed. The same underlying data (topic-foundry's typed
+# mention/asks_about/claims_about/next_step edges) now reaches a real
+# consumer via GET /kg/edges (KgEdgeRecord in
+# services/orion-topic-foundry/app/models.py), pulled by
+# orion-hub/scripts/concept_atlas_routes.py into the live Falkor substrate
+# graph. See orion/substrate/adapters/topic_foundry.py's module docstring.

--- a/orion/substrate/adapters/topic_foundry.py
+++ b/orion/substrate/adapters/topic_foundry.py
@@ -1,22 +1,38 @@
 """Pure conversion of orion-topic-foundry run output into cognitive-substrate records.
 
 Phase 2 of docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md.
+Mention-edge -> EntityNodeV1 mapping added 2026-07-28 (see that spec's dated
+revision note) as part of retiring topic-foundry's dead `orion:kg:edge:ingest.v1`
+bus publish (zero live consumers, orion-rdf-writer/orion-graphdb per
+`orion/bus/channels.yaml`'s own former comment) in favor of routing the same
+already-computed, LLM-enriched typed edges through this already-live Falkor
+ingestion path instead of a second, unconsumed bus channel.
 
 This module intentionally mirrors the construction patterns used by the sibling
 adapter `orion/substrate/adapters/concept_induction.py::map_concept_profile_to_substrate`
 (provenance via `_common.make_provenance`, temporal via `_common.make_temporal`,
 evidence-node + `supports`-edge pairing, `co_occurs_with` edges built from shared
 context). It does not perform any HTTP calls or bus I/O — callers are responsible
-for fetching topic-foundry's `/topics`, `/topics/{topic_id}/keywords`, and
-`segments.jsonl`-derived data and passing it in as plain Python data (dicts or
-objects with matching attributes).
+for fetching topic-foundry's `/topics`, `/topics/{topic_id}/keywords`,
+`segments.jsonl`-derived data, and (as of the mention-edge addition) `/kg/edges`
+data, and passing it in as plain Python data (dicts or objects with matching
+attributes).
 
 Wiring this adapter into a live producer/consumer/registry is explicitly out of
 scope for this phase — see the spec's Phase 6/7/8 for where that happens.
+
+Known limitation, not fixed here: `services/orion-hub/scripts/concept_atlas_routes.py`'s
+network/god-node/typed-relation-classification views all filter to
+`node_kind == "concept"` explicitly. The `EntityNodeV1` records this module now
+emits are real, written to the store, and generically visible to any consumer
+that iterates the full node set (e.g. `orion/substrate/endogenous_curiosity.py`)
+-- but they will not appear in Concept Atlas's existing Hub UI until those
+routes are widened to include entity nodes, a separate follow-up.
 """
 
 from __future__ import annotations
 
+import hashlib
 import itertools
 from collections.abc import Mapping as ABCMapping
 from datetime import datetime
@@ -24,6 +40,7 @@ from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from orion.core.schemas.cognitive_substrate import (
     ConceptNodeV1,
+    EntityNodeV1,
     EvidenceNodeV1,
     NodeRefV1,
     SubstrateEdgeV1,
@@ -43,6 +60,14 @@ MAX_KEYWORDS_PER_TOPIC = 20
 MAX_SEGMENTS_FOR_COOCCURRENCE = 5000
 MAX_TOPICS_PER_SEGMENT = 20
 MAX_COOCCURRENCE_EDGES = 2000
+# Belt-and-suspenders: in practice this adapter never sees more than
+# topic_foundry_client.py's own MAX_KG_EDGES_LIMIT (500, no pagination loop)
+# mention edges per call -- that client-side cap is the real ceiling on a
+# single ingestion call, set well below this one. Kept here anyway so this
+# module's own worst-case bound doesn't silently depend on a caller-side
+# constant it can't see.
+MAX_MENTION_EDGES = 2000
+MAX_ENTITY_LABEL_LENGTH = 120
 
 # HDBSCAN's noise/outlier bucket. Never a real cluster — always excluded.
 OUTLIER_TOPIC_ID = -1
@@ -72,6 +97,8 @@ def map_topic_foundry_run_to_substrate(
     keywords_by_topic: Optional[Mapping[int, Sequence[str]]] = None,
     segment_topic_map: Optional[Mapping[Any, Iterable[int]]] = None,
     topic_embeddings: Optional[Mapping[int, Sequence[float]]] = None,
+    mention_edges: Optional[Sequence[Any]] = None,
+    segment_topic_id_map: Optional[Mapping[str, int]] = None,
     observed_at: Optional[datetime] = None,
     anchor_scope: str = "world",
     subject_ref: Optional[str] = None,
@@ -101,6 +128,26 @@ def map_topic_foundry_run_to_substrate(
             (list of floats), if the caller has one available. If absent for a
             given topic, `concept_embedding` is simply omitted from that
             node's metadata — never fabricated.
+        mention_edges: sequence of dict-or-object-like items with `segment_id`
+            (str/UUID), `object` (str, the mentioned entity's raw text), and
+            `confidence` (float) — matching `GET /kg/edges?predicate=mentions`
+            items (`KgEdgeRecord` in
+            services/orion-topic-foundry/app/models.py). Only `predicate ==
+            "mentions"` edges are meaningful here; the caller is expected to
+            have already filtered to that predicate (this function does not
+            re-filter by predicate itself, since callers may pass an
+            already-scoped list). Other kg_edges predicates
+            (`asks_about`/`claims_about`/`next_step`) have no corresponding
+            substrate node kind yet and are deliberately out of scope — see
+            module docstring.
+        segment_topic_id_map: mapping of `segment_id` (str) -> `topic_id`
+            (int), used to resolve which topic concept a mention edge's
+            source segment belongs to. Distinct from `segment_topic_map`
+            above (which is keyed by an arbitrary window/bucket, not
+            segment_id, and used only for `co_occurs_with` counting). A
+            mention whose segment_id has no entry here, or whose resolved
+            topic was filtered out (below `min_doc_count`, or the outlier
+            bucket), is silently skipped — never fabricates a topic link.
         observed_at: timestamp for the run; defaults to "now" (via
             `_common.make_temporal`) if not supplied.
         anchor_scope: defaults to "world" per the spec — organically-clustered
@@ -111,10 +158,12 @@ def map_topic_foundry_run_to_substrate(
 
     Returns:
         A `SubstrateGraphRecordV1` with one `ConceptNodeV1` (+ backing
-        `EvidenceNodeV1` and `supports` edge) per real topic, and free
+        `EvidenceNodeV1` and `supports` edge) per real topic, free
         `co_occurs_with` `SubstrateEdgeV1` records between topics that share a
-        segment/window. Never raises — malformed or empty input degrades to an
-        empty (but valid) record.
+        segment/window, and (when `mention_edges` is supplied) one
+        `EntityNodeV1` per distinct mentioned entity plus an `associated_with`
+        edge from the owning topic's concept node. Never raises — malformed or
+        empty input degrades to an empty (but valid) record.
     """
     run_id_str = str(run_id) if run_id is not None else "unknown-run"
     graph_id = f"sub-graph-topicfoundry-{run_id_str}"
@@ -138,6 +187,8 @@ def map_topic_foundry_run_to_substrate(
             keywords_by_topic=keywords_by_topic or {},
             segment_topic_map=segment_topic_map or {},
             topic_embeddings=topic_embeddings or {},
+            mention_edges=mention_edges or [],
+            segment_topic_id_map=segment_topic_id_map or {},
             observed_at=observed_at,
             anchor_scope=anchor_scope,
             subject_ref=subject_ref,
@@ -157,6 +208,15 @@ def _derive_label(label: Optional[str], keywords: Sequence[str], topic_id: int) 
     return f"topic_{topic_id}"
 
 
+def _entity_node_id(run_id_str: str, normalized_label: str) -> str:
+    # Entity labels are freeform extracted text (arbitrary unicode, length,
+    # punctuation) -- not safe to slugify directly into a node_id. A short
+    # stable hash keeps ids bounded and collision-safe within one run without
+    # needing to sanitize the label itself.
+    digest = hashlib.sha1(normalized_label.encode("utf-8")).hexdigest()[:16]
+    return f"sub-entity-topicfoundry-{run_id_str}-{digest}"
+
+
 def _build(
     *,
     run_id_str: str,
@@ -165,6 +225,8 @@ def _build(
     keywords_by_topic: Mapping[int, Sequence[str]],
     segment_topic_map: Mapping[Any, Iterable[int]],
     topic_embeddings: Mapping[int, Sequence[float]],
+    mention_edges: Sequence[Any],
+    segment_topic_id_map: Mapping[str, int],
     observed_at: Optional[datetime],
     anchor_scope: str,
     subject_ref: Optional[str],
@@ -337,6 +399,82 @@ def _build(
                     producer="topic_foundry_adapter",
                 ),
                 metadata={"co_occurrence_count": count, "run_id": run_id_str},
+            )
+        )
+
+    # Mention edges: kg_edges.py's real, LLM-enriched "mentions" triples
+    # (subject=model_name, predicate="mentions", object=entity text),
+    # resolved to the topic concept their source segment belongs to. One
+    # EntityNodeV1 per distinct normalized entity label (deduped within this
+    # run), one `associated_with` edge per (topic, entity) pair. A mention
+    # whose segment isn't in segment_topic_id_map, or whose resolved topic
+    # was filtered out above (noise/outlier), is silently skipped -- never
+    # fabricates a topic link that doesn't exist.
+    entity_node_ids: dict[str, str] = {}  # normalized label -> node_id, dedup within this run
+    mention_pairs_seen: set[tuple[int, str]] = set()  # (topic_id, normalized label), dedup edges
+    mention_items = list(mention_edges)[:MAX_MENTION_EDGES]
+    for raw_mention in mention_items:
+        segment_id = _get(raw_mention, "segment_id")
+        entity_text = _get(raw_mention, "object")
+        confidence_raw = _get(raw_mention, "confidence", 0.5)
+        if segment_id is None or not entity_text:
+            continue
+        topic_id = segment_topic_id_map.get(str(segment_id))
+        if topic_id is None or topic_id not in accepted:
+            continue
+        normalized_label = " ".join(str(entity_text).strip().split())[:MAX_ENTITY_LABEL_LENGTH]
+        if not normalized_label:
+            continue
+        try:
+            mention_confidence = min(1.0, max(0.0, float(confidence_raw)))
+        except (TypeError, ValueError):
+            mention_confidence = 0.5
+
+        entity_key = normalized_label.lower()
+        entity_node_id = entity_node_ids.get(entity_key)
+        if entity_node_id is None:
+            entity_node_id = _entity_node_id(run_id_str, entity_key)
+            entity_node_ids[entity_key] = entity_node_id
+            nodes.append(
+                EntityNodeV1(
+                    node_id=entity_node_id,
+                    anchor_scope=anchor_scope,
+                    subject_ref=subject_ref,
+                    promotion_state="proposed",
+                    temporal=temporal,
+                    provenance=make_provenance(
+                        source_kind="topic_foundry.mention",
+                        source_channel=source_channel,
+                        producer="topic_foundry_adapter",
+                    ),
+                    entity_type="unknown",
+                    label=normalized_label,
+                    signals=SubstrateSignalBundleV1(confidence=mention_confidence, salience=0.0),
+                    metadata={"run_id": run_id_str, "source": "orion-topic-foundry"},
+                )
+            )
+
+        pair_key = (topic_id, entity_key)
+        if pair_key in mention_pairs_seen:
+            continue
+        mention_pairs_seen.add(pair_key)
+        edges.append(
+            SubstrateEdgeV1(
+                source=NodeRefV1(
+                    node_id=f"sub-concept-topicfoundry-{run_id_str}-{topic_id}", node_kind="concept"
+                ),
+                target=NodeRefV1(node_id=entity_node_id, node_kind="entity"),
+                predicate="associated_with",
+                temporal=temporal,
+                confidence=mention_confidence,
+                salience=0.0,
+                provenance=make_provenance(
+                    source_kind="topic_foundry.mention",
+                    source_channel=source_channel,
+                    producer="topic_foundry_adapter",
+                    evidence_refs=[str(segment_id)],
+                ),
+                metadata={"run_id": run_id_str, "segment_id": str(segment_id)},
             )
         )
 

--- a/orion/substrate/reconcile.py
+++ b/orion/substrate/reconcile.py
@@ -140,6 +140,20 @@ class SubstrateIdentityResolver:
             return None
         if node.node_kind == "hypothesis":
             return None
+        if node.node_kind == "entity":
+            # Added 2026-07-28 alongside topic_foundry.py's mention-edge ->
+            # EntityNodeV1 wiring: without an identity key here, every
+            # ingestion tick (the topic-foundry scheduler runs daily by
+            # default) would create a brand-new entity node for the same
+            # real-world entity, since the adapter's own node_id is
+            # deliberately run-scoped (a hash of run_id + label). Keyed by
+            # normalized label only (matching `_legacy_concept_key`'s own
+            # label-based precedent) -- not `entity_type`, since every
+            # current producer leaves that at the schema default
+            # ("unknown") and keying on it would just fragment identity for
+            # no benefit until a real typed-entity producer exists.
+            label = str(getattr(node, "label", "")).strip().lower()
+            return f"entity|{scope}|{subject}|label:{label}" if label else None
         return None
 
     def _concept_embedding_match_key(self, node: BaseSubstrateNodeV1, *, scope: str, subject: str) -> str | None:

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -454,6 +454,27 @@ tab (`GET /concept-atlas`, backed by `GET /api/substrate/concepts/summary` and `
 | Manual topic-foundry ingestion | `POST /api/substrate/concepts/ingest-topic-foundry` (`concept_atlas_routes.py`) | operator-triggered, no flag |
 | Typed relation classification (supports/contradicts/refines) | `concept_atlas_routes.py::_classify_typed_concept_relations()`, called from the ingestion route above | runs automatically as part of ingestion, capped at `_RELATION_CLASSIFICATION_PAIR_CAP=10` pairs/call — see `services/orion-hub/scripts/concept_relation_classifier.py` for the real LLM classifier |
 | Autonomous scheduled training + ingestion | `main.py`'s `substrate_topic_foundry_scheduler_task`, calling `concept_atlas_routes.py::trigger_topic_foundry_training_run()` then the ingestion route above | `SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED` (**`true`** — flipped on live 2026-07-17; shipped disabled by default, real compute cost), interval `SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_INTERVAL_SEC` (`86400`), window `SUBSTRATE_TOPIC_FOUNDRY_WINDOW_DAYS` (`30`) |
+| Mention-edge → entity ingestion (added 2026-07-28) | Same ingestion route above, additionally calls `topic_foundry_client.py::fetch_mention_edges_for_run()` (`GET /kg/edges?predicate=mentions`) and passes the result into `map_topic_foundry_run_to_substrate`'s `mention_edges`/`segment_topic_id_map` params | no flag, runs unconditionally as part of ingestion; degrades to zero entities on fetch failure, same as the segments fetch |
+
+**Mention edges — real, LLM-enriched entity data that used to go nowhere (2026-07-28):**
+topic-foundry's `kg_edges.py::generate_edges_for_run()` computes real typed edges
+(`mentions`/`asks_about`/`claims_about`/`next_step`) from each segment's LLM-enriched
+`meaning` field, but used to publish them on `orion:kg:edge:ingest.v1`, a bus channel with
+zero live consumers (`orion-rdf-writer` never actually subscribed; `orion-graphdb` never
+existed as a real service — see `orion/bus/channels.yaml`'s former comment on that channel).
+That publish is now retired outright. Only the `mentions` predicate is wired into the
+substrate graph so far (as `EntityNodeV1` + `associated_with` edges from the mentioning
+topic's concept node) — `asks_about`/`claims_about`/`next_step` have no corresponding
+substrate node kind yet and are out of scope until/unless that's designed. The edges
+themselves still persist in topic-foundry's own Postgres and remain queryable via its
+`GET /edges`/`GET /kg/edges` API regardless of this wiring.
+
+**Known limitation:** `_concept_nodes()` and the other Concept Atlas Hub-tab helpers in
+`concept_atlas_routes.py` explicitly filter to `node_kind == "concept"`. The `EntityNodeV1`
+records mention-edge ingestion writes are real and generically visible to any consumer that
+iterates the full substrate node set (e.g. `orion/substrate/endogenous_curiosity.py`), but
+they will not appear in the Concept Atlas Hub UI's network/god-node views until those routes
+are widened to include entity nodes — a separate follow-up, not done here.
 
 **Surfaced into live cognition two ways**, not as permanent context bloat — only when
 salient:

--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -31,6 +31,7 @@ from .topic_foundry_client import (
     TopicFoundryClientError,
     create_dataset,
     create_model,
+    fetch_mention_edges_for_run,
     fetch_run_topics_and_keywords,
     fetch_segments_for_run,
     list_datasets,
@@ -290,6 +291,7 @@ class _CountingSubstrateStore:
         self._inner = inner
         self.concepts_written = 0
         self.evidence_nodes_written = 0
+        self.entities_written = 0
         self.edges_written = 0
 
     def __getattr__(self, name: str) -> Any:
@@ -302,6 +304,8 @@ class _CountingSubstrateStore:
             self.concepts_written += 1
         elif kind == "evidence":
             self.evidence_nodes_written += 1
+        elif kind == "entity":
+            self.entities_written += 1
 
     def upsert_edge(self, *, identity_key: str, edge: Any) -> None:
         self._inner.upsert_edge(identity_key=identity_key, edge=edge)
@@ -701,16 +705,29 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
     ``segment_topic_map`` (no ``co_occurs_with`` edges produced for this
     call) rather than aborting the route -- concept/evidence node ingestion
     below is independent of it.
+
+    ``segment_topic_id_map`` (added 2026-07-28, ``segment_id -> topic_id``)
+    is built from the same ``GET /segments`` fetch above -- no extra network
+    call. It resolves ``GET /kg/edges?predicate=mentions`` results (fetched
+    separately below) to the topic concept each mentioned entity belongs to.
+    This is topic-foundry's real, LLM-enriched entity-mention data, which
+    used to go out on the now-retired ``orion:kg:edge:ingest.v1`` bus channel
+    (zero live consumers -- see ``orion/substrate/adapters/topic_foundry.py``
+    module docstring) and now feeds ``EntityNodeV1`` construction directly
+    here instead. A mentions-fetch failure degrades to an empty list (no
+    entity nodes/edges produced for this call) rather than aborting the
+    route, same contract as the segments fetch above.
     """
     store = _get_substrate_store()
     if store is None:
-        return _unavailable("substrate_store_unavailable", concepts_written=0, edges_written=0)
+        return _unavailable("substrate_store_unavailable", concepts_written=0, entities_written=0, edges_written=0)
 
     base_url = str(getattr(settings, "TOPIC_FOUNDRY_BASE_URL", "") or "").strip()
     if not base_url:
         return _unavailable(
             "topic_foundry_base_url_not_configured",
             concepts_written=0,
+            entities_written=0,
             edges_written=0,
         )
 
@@ -722,6 +739,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             "topic_foundry_fetch_failed",
             str(exc),
             concepts_written=0,
+            entities_written=0,
             edges_written=0,
         )
     except Exception as exc:  # pragma: no cover - defensive, never let a client bug 500 this route
@@ -730,6 +748,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             "topic_foundry_unexpected_error",
             str(exc),
             concepts_written=0,
+            entities_written=0,
             edges_written=0,
         )
 
@@ -738,6 +757,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
     keywords_by_topic = fetched["keywords_by_topic"]
 
     segment_topic_map: dict[str, list[int]] = {}
+    segment_topic_id_map: dict[str, int] = {}
     segments_fetched = 0
     try:
         segments = fetch_segments_for_run(base_url, run_id)
@@ -745,6 +765,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
         for seg in segments:
             topic_id = seg.get("topic_id")
             start_at = seg.get("start_at")
+            segment_id = seg.get("segment_id")
             if topic_id is None or start_at is None:
                 continue
             try:
@@ -753,6 +774,8 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
                 continue
             if topic_id_int == _OUTLIER_TOPIC_ID:
                 continue
+            if segment_id is not None:
+                segment_topic_id_map[str(segment_id)] = topic_id_int
             day_bucket = _day_bucket_from_timestamp(start_at)
             if day_bucket is None:
                 continue
@@ -761,12 +784,30 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
         logger.warning(
             "concept_atlas_ingest_topic_foundry_segments_fetch_failed run_id=%s error=%s", run_id, exc
         )
-        # Degrade to empty segment_topic_map -- co_occurs_with edges just
-        # won't be produced for this ingestion call; concept/evidence node
+        # Degrade to empty segment_topic_map/segment_topic_id_map --
+        # co_occurs_with edges and mention-derived entity edges just won't
+        # be produced for this ingestion call; concept/evidence node
         # ingestion below proceeds normally regardless.
     except Exception as exc:  # pragma: no cover - defensive, never let a client bug abort the route
         logger.warning(
             "concept_atlas_ingest_topic_foundry_segments_unexpected_error run_id=%s error=%s", run_id, exc
+        )
+
+    mention_edges: list[dict[str, Any]] = []
+    mentions_fetched = 0
+    try:
+        mention_edges = fetch_mention_edges_for_run(base_url, run_id)
+        mentions_fetched = len(mention_edges)
+    except TopicFoundryClientError as exc:
+        logger.warning(
+            "concept_atlas_ingest_topic_foundry_mentions_fetch_failed run_id=%s error=%s", run_id, exc
+        )
+        # Degrade to empty mention_edges -- no entity nodes/edges produced
+        # for this call; concept/evidence/co_occurs_with ingestion above is
+        # independent of it.
+    except Exception as exc:  # pragma: no cover - defensive, never let a client bug abort the route
+        logger.warning(
+            "concept_atlas_ingest_topic_foundry_mentions_unexpected_error run_id=%s error=%s", run_id, exc
         )
 
     try:
@@ -777,6 +818,8 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             topics=topics,
             keywords_by_topic=keywords_by_topic,
             segment_topic_map=segment_topic_map,
+            mention_edges=mention_edges,
+            segment_topic_id_map=segment_topic_id_map,
         )
     except Exception as exc:  # pragma: no cover - the adapter itself never raises, but don't trust across the boundary
         logger.warning("concept_atlas_ingest_topic_foundry_adapter_failed run_id=%s error=%s", run_id, exc)
@@ -785,6 +828,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             str(exc),
             run_id=run_id,
             concepts_written=0,
+            entities_written=0,
             edges_written=0,
         )
 
@@ -794,6 +838,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             run_id=run_id,
             topics_fetched=len(topics),
             concepts_written=0,
+            entities_written=0,
             edges_written=0,
         )
 
@@ -818,6 +863,7 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
             run_id=run_id,
             concepts_written=counting_store.concepts_written,
             evidence_nodes_written=counting_store.evidence_nodes_written,
+            entities_written=counting_store.entities_written,
             edges_written=counting_store.edges_written,
         )
 
@@ -844,9 +890,11 @@ def concept_atlas_ingest_topic_foundry() -> dict[str, Any]:
         "topics_fetched": len(topics),
         "concepts_written": counting_store.concepts_written,
         "evidence_nodes_written": counting_store.evidence_nodes_written,
+        "entities_written": counting_store.entities_written,
         "edges_written": counting_store.edges_written,
         "segments_fetched": segments_fetched,
         "segment_topic_map_buckets": len(segment_topic_map),
+        "mentions_fetched": mentions_fetched,
         "typed_edges_written": typed_edges_written,
     }
 

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -631,10 +631,11 @@ async def startup_event():
                         concept_atlas_routes_runtime.concept_atlas_ingest_topic_foundry
                     )
                     logger.info(
-                        "substrate_topic_foundry_scheduler_ingest_tick available=%s run_id=%s concepts_written=%s edges_written=%s typed_edges_written=%s",
+                        "substrate_topic_foundry_scheduler_ingest_tick available=%s run_id=%s concepts_written=%s entities_written=%s edges_written=%s typed_edges_written=%s",
                         ingest_summary.get("available"),
                         ingest_summary.get("run_id"),
                         ingest_summary.get("concepts_written"),
+                        ingest_summary.get("entities_written"),
                         ingest_summary.get("edges_written"),
                         ingest_summary.get("typed_edges_written"),
                     )

--- a/services/orion-hub/scripts/topic_foundry_client.py
+++ b/services/orion-hub/scripts/topic_foundry_client.py
@@ -315,6 +315,53 @@ def fetch_segments_for_run(
     return result
 
 
+# Mirrors GET /kg/edges's own API ceiling (`ge=1, le=500` on the route).
+MAX_KG_EDGES_LIMIT = 500
+
+
+def fetch_mention_edges_for_run(
+    base_url: str,
+    run_id: str,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    limit: int = MAX_KG_EDGES_LIMIT,
+) -> list[dict[str, Any]]:
+    """Return `KgEdgeRecord` dicts for `run_id` filtered to `predicate=mentions`
+    (`GET /kg/edges`) -- topic-foundry's real, LLM-enriched entity-mention
+    triples, added 2026-07-28 to feed `EntityNodeV1` construction in
+    `orion.substrate.adapters.topic_foundry.map_topic_foundry_run_to_substrate`
+    (see that module's docstring for why: the old `orion:kg:edge:ingest.v1`
+    bus publish this data used to go out on had zero live consumers).
+
+    Same degrade-not-abort contract as `fetch_segments_for_run`: raises
+    `TopicFoundryClientError` on network/HTTP/parse failure or a malformed
+    response; an empty `items` list (a real run with zero mentions) is not an
+    error. No pagination loop -- `limit` matches the API's own ceiling, so a
+    run with more than 500 mention edges only gets the first page (API's
+    default `sort_by=created_at, sort_dir=desc` -- no `total` field on this
+    endpoint to compare against, unlike `/segments`, so truncation here is
+    silent by construction, not just by omission).
+    """
+    url = f"{base_url.rstrip('/')}/kg/edges"
+    try:
+        resp = requests.get(
+            url,
+            params={"run_id": run_id, "predicate": "mentions", "limit": limit},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except requests.RequestException as exc:
+        raise TopicFoundryClientError(f"topic_foundry_kg_edges_request_failed: {exc}") from exc
+    except ValueError as exc:
+        raise TopicFoundryClientError(f"topic_foundry_kg_edges_invalid_json: {exc}") from exc
+
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if items is None:
+        raise TopicFoundryClientError("topic_foundry_kg_edges_malformed_response")
+    return [item for item in items if isinstance(item, dict)]
+
+
 def fetch_run_topics_and_keywords(
     base_url: str,
     *,

--- a/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
+++ b/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
@@ -155,6 +155,30 @@ def _segments_payload_empty(run_id: str = FAKE_RUN_ID) -> dict[str, Any]:
     return {"run_id": run_id, "items": [], "limit": 1000, "offset": 0, "total": 0}
 
 
+def _kg_edges_payload_empty(run_id: str = FAKE_RUN_ID) -> dict[str, Any]:
+    # Shaped like KgEdgeListPage (services/orion-topic-foundry/app/models.py).
+    return {"run_id": run_id, "items": [], "limit": 500, "offset": 0}
+
+
+def _kg_edges_payload_mentions(run_id: str = FAKE_RUN_ID) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "items": [
+            {
+                "edge_id": "44444444-4444-4444-4444-444444444444",
+                "segment_id": "seg-0a",
+                "subject": "m",
+                "predicate": "mentions",
+                "object": "Juniper Feld",
+                "confidence": 0.6,
+                "created_at": "2026-07-15T09:00:01Z",
+            }
+        ],
+        "limit": 500,
+        "offset": 0,
+    }
+
+
 def _make_fake_get(
     *,
     topics_payload: dict[str, Any],
@@ -162,6 +186,8 @@ def _make_fake_get(
     unreachable: bool = False,
     segments_payload: Optional[dict[str, Any]] = None,
     segments_unreachable: bool = False,
+    kg_edges_payload: Optional[dict[str, Any]] = None,
+    kg_edges_unreachable: bool = False,
 ):
     calls: list[tuple[str, Optional[dict[str, Any]]]] = []
 
@@ -176,6 +202,10 @@ def _make_fake_get(
         if "/topics/" in url and url.endswith("/keywords"):
             topic_id = int(url.rsplit("/", 2)[1])
             return _FakeResponse(200, _keywords_payload(topic_id))
+        if url.endswith("/kg/edges"):
+            if kg_edges_unreachable:
+                raise requests.exceptions.ConnectionError("connection refused")
+            return _FakeResponse(200, kg_edges_payload if kg_edges_payload is not None else _kg_edges_payload_empty(run_id))
         if url.endswith("/segments"):
             if segments_unreachable:
                 raise requests.exceptions.ConnectionError("connection refused")
@@ -658,6 +688,60 @@ def test_client_no_completed_run_raises_client_error(monkeypatch: pytest.MonkeyP
         tfc.fetch_run_topics_and_keywords(FAKE_BASE_URL)
 
 
+def test_client_fetch_mention_edges_filters_by_predicate_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    seen_params: dict[str, Any] = {}
+
+    def fake_get(url: str, params=None, timeout=None):
+        assert url.endswith("/kg/edges")
+        seen_params.update(params or {})
+        return _FakeResponse(200, _kg_edges_payload_mentions())
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    result = tfc.fetch_mention_edges_for_run(FAKE_BASE_URL, FAKE_RUN_ID)
+    assert seen_params["predicate"] == "mentions"
+    assert seen_params["run_id"] == FAKE_RUN_ID
+    assert len(result) == 1
+    assert result[0]["object"] == "Juniper Feld"
+
+
+def test_client_fetch_mention_edges_empty_items_is_not_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url: str, params=None, timeout=None):
+        return _FakeResponse(200, _kg_edges_payload_empty())
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    assert tfc.fetch_mention_edges_for_run(FAKE_BASE_URL, FAKE_RUN_ID) == []
+
+
+def test_client_fetch_mention_edges_malformed_response_raises_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url: str, params=None, timeout=None):
+        return _FakeResponse(200, {"run_id": FAKE_RUN_ID})  # missing "items"
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    with pytest.raises(tfc.TopicFoundryClientError):
+        tfc.fetch_mention_edges_for_run(FAKE_BASE_URL, FAKE_RUN_ID)
+
+
+def test_client_fetch_mention_edges_request_failure_raises_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import topic_foundry_client as tfc
+
+    def fake_get(url: str, params=None, timeout=None):
+        raise requests.exceptions.ConnectionError("connection refused")
+
+    monkeypatch.setattr(tfc.requests, "get", fake_get)
+    with pytest.raises(tfc.TopicFoundryClientError):
+        tfc.fetch_mention_edges_for_run(FAKE_BASE_URL, FAKE_RUN_ID)
+
+
 # --- post-ingestion typed-relation classification step -----------------------
 #
 # Covers the additive post-ingestion step added to
@@ -977,6 +1061,160 @@ def test_ingest_segments_fetch_failure_still_ingests_concepts(
     snapshot = store.snapshot()
     co_occurs_edges = [e for e in snapshot.edges.values() if e.predicate == "co_occurs_with"]
     assert co_occurs_edges == []
+
+
+# --- mention edges (GET /kg/edges) -> EntityNodeV1 / associated_with, added 2026-07-28 ---
+
+
+def test_ingest_mention_edges_produce_entity_nodes_and_associated_with_edges(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, calls = _make_fake_get(
+        topics_payload=_topics_payload_normal(),
+        segments_payload=_segments_payload_same_day(),
+        kg_edges_payload=_kg_edges_payload_mentions(),
+    )
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["mentions_fetched"] == 1
+    assert body["entities_written"] == 1
+
+    kg_edges_calls = [
+        (url, params) for url, params in calls if url.endswith("/kg/edges")
+    ]
+    assert len(kg_edges_calls) == 1
+    assert kg_edges_calls[0][1]["predicate"] == "mentions"
+
+    snapshot = store.snapshot()
+    entity_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "entity"]
+    assert len(entity_nodes) == 1
+    assert entity_nodes[0].label == "Juniper Feld"
+
+    associated_edges = [e for e in snapshot.edges.values() if e.predicate == "associated_with"]
+    assert len(associated_edges) == 1
+    assert associated_edges[0].source.node_id == f"sub-concept-topicfoundry-{FAKE_RUN_ID}-0"
+    assert associated_edges[0].target.node_id == entity_nodes[0].node_id
+
+
+def test_ingest_cross_run_same_entity_label_merges_to_one_durable_entity(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for the identity-resolution gap found in review 2026-07-28:
+    orion/substrate/reconcile.py::canonical_node_key had no branch for
+    node_kind == "entity", so EntityNodeV1's own node_id (run-scoped, a hash
+    of run_id + label) meant every ingestion tick created a brand-new entity
+    node for the same real-world mentioned entity -- unbounded duplication on
+    a scheduler that runs daily by default. Mirrors
+    test_ingest_cross_run_same_label_merges_to_one_durable_concept's shape.
+    """
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    run_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    run_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+    def _segments_payload(run_id: str) -> dict[str, Any]:
+        return {
+            "run_id": run_id,
+            "items": [{"segment_id": "seg-a", "topic_id": 0, "start_at": "2026-07-15T09:00:00Z"}],
+            "limit": 1000,
+            "offset": 0,
+            "total": 1,
+        }
+
+    def _kg_edges_payload(run_id: str) -> dict[str, Any]:
+        return {
+            "run_id": run_id,
+            "items": [
+                {
+                    "edge_id": "44444444-4444-4444-4444-444444444444",
+                    "segment_id": "seg-a",
+                    "subject": "m",
+                    "predicate": "mentions",
+                    # Deliberately different case/whitespace across runs --
+                    # normalization must still collapse this to one entity.
+                    "object": "Juniper Feld" if run_id == run_a else "  juniper feld ",
+                    "confidence": 0.6,
+                    "created_at": "2026-07-15T09:00:01Z",
+                }
+            ],
+            "limit": 500,
+            "offset": 0,
+        }
+
+    def _ingest_run(run_id: str) -> dict[str, Any]:
+        fake_get, _calls = _make_fake_get(
+            topics_payload=_topics_payload_normal(),
+            run_id=run_id,
+            segments_payload=_segments_payload(run_id),
+            kg_edges_payload=_kg_edges_payload(run_id),
+        )
+        _patch_topic_foundry_client(monkeypatch, fake_get)
+        r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["available"] is True
+        assert body["entities_written"] == 1
+        return body
+
+    _ingest_run(run_a)
+    _ingest_run(run_b)
+
+    snapshot = store.snapshot()
+    entity_nodes = [n for n in snapshot.nodes.values() if n.node_kind == "entity"]
+    assert len(entity_nodes) == 1, (
+        f"expected one durable entity after cross-run ingest, got {len(entity_nodes)}: "
+        f"{[n.node_id for n in entity_nodes]}"
+    )
+
+    associated_edges = [e for e in snapshot.edges.values() if e.predicate == "associated_with"]
+    assert len(associated_edges) == 1, (
+        f"expected one durable associated_with edge after cross-run ingest, got "
+        f"{len(associated_edges)}"
+    )
+    assert associated_edges[0].target.node_id == entity_nodes[0].node_id
+
+
+def test_ingest_mentions_fetch_failure_still_ingests_concepts(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mentions-fetch failure must degrade to no entity nodes/edges, not
+    abort the route -- concept/evidence/co_occurs_with ingestion above is
+    independent of it (same contract as the segments-fetch failure test)."""
+    from orion.substrate.store import InMemorySubstrateGraphStore
+
+    store = InMemorySubstrateGraphStore()
+    fake_get, _calls = _make_fake_get(
+        topics_payload=_topics_payload_normal(),
+        segments_payload=_segments_payload_same_day(),
+        kg_edges_unreachable=True,
+    )
+    _patch_topic_foundry_client(monkeypatch, fake_get)
+    _patch_base_url(monkeypatch, FAKE_BASE_URL)
+    _patch_store(monkeypatch, store)
+
+    r = client.post("/api/substrate/concepts/ingest-topic-foundry")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is True
+    assert body["mentions_fetched"] == 0
+    assert body["entities_written"] == 0
+    # co_occurs_with (unaffected by the mentions failure) still produced.
+    snapshot = store.snapshot()
+    co_occurs_edges = [e for e in snapshot.edges.values() if e.predicate == "co_occurs_with"]
+    assert len(co_occurs_edges) == 1
 
 
 def test_ingest_co_occurs_with_edge_clears_classification_threshold(

--- a/services/orion-topic-foundry/README.md
+++ b/services/orion-topic-foundry/README.md
@@ -39,6 +39,22 @@ Also publishes a bus-native `SystemHealthV1` heartbeat to `orion:system:health` 
 - `GET /kg/edges?run_id=...&q=...&predicate=...&limit=...&offset=...` — list KG edges with filters.
 - `GET /events?limit=...&offset=...&kind=...` — list recent run/enrich/drift alert events.
 
+**KG edges: bus publish retired 2026-07-28, HTTP consumption is now the only live path.**
+`app/services/kg_edges.py::generate_edges_for_run()` computes real, LLM-enriched typed edges
+(`mentions`/`asks_about`/`claims_about`/`next_step`) from each run's enriched segments and
+persists them to Postgres (this is what `GET /edges`/`GET /kg/edges` above serve) — that part
+is unchanged. It used to *also* publish every batch on `orion:kg:edge:ingest.v1`
+(`KgEdgeIngestV1`), but that channel had zero live consumers going back to at least
+2026-07-17 (`orion-rdf-writer` never actually subscribed to it despite being declared as one;
+`orion-graphdb` never existed as a real service at all). The publish call, the channel
+declaration in `orion/bus/channels.yaml`, and the `KgEdgeIngestV1`/`KgEdgeIngestItemV1`
+schemas are all removed as of this date — `orion-hub`'s Concept Atlas ingestion now pulls
+`mentions`-predicate edges directly via `GET /kg/edges` instead (see
+`services/orion-hub/README.md` §5.5 and `orion/substrate/adapters/topic_foundry.py`'s module
+docstring). `asks_about`/`claims_about`/`next_step` are unaffected by any of this (they never
+had a bus consumer either, and still don't) — they remain queryable via the two GET routes
+above, just not wired into the substrate graph yet.
+
 ## Required env vars
 - `SERVICE_NAME`, `SERVICE_VERSION`, `NODE_NAME`, `LOG_LEVEL`
 - `PORT`

--- a/services/orion-topic-foundry/app/services/bus_events.py
+++ b/services/orion-topic-foundry/app/services/bus_events.py
@@ -7,7 +7,6 @@ from typing import Any, Optional
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.schemas.topic_foundry import (
-    KgEdgeIngestV1,
     TopicFoundryDriftAlertV1,
     TopicFoundryEnrichCompleteV1,
     TopicFoundryRunCompleteV1,
@@ -21,7 +20,8 @@ logger = logging.getLogger("topic-foundry.bus")
 RUN_COMPLETE_CHANNEL = "orion:topic:foundry:run:complete.v1"
 ENRICH_COMPLETE_CHANNEL = "orion:topic:foundry:enrich:complete.v1"
 DRIFT_ALERT_CHANNEL = "orion:topic:foundry:drift:alert.v1"
-KG_EDGE_INGEST_CHANNEL = "orion:kg:edge:ingest.v1"
+# KG_EDGE_INGEST_CHANNEL ("orion:kg:edge:ingest.v1") retired 2026-07-28 --
+# zero live consumers. See kg_edges.py::generate_edges_for_run's comment.
 
 
 def _safe_run(coro) -> None:
@@ -91,15 +91,6 @@ class TopicFoundryBusPublisher:
             self._publish(
                 DRIFT_ALERT_CHANNEL,
                 "topic.foundry.drift.alert.v1",
-                payload.model_dump(mode="json"),
-            )
-        )
-
-    def publish_kg_edges(self, payload: KgEdgeIngestV1) -> None:
-        _safe_run(
-            self._publish(
-                KG_EDGE_INGEST_CHANNEL,
-                "kg.edge.ingest.v1",
                 payload.model_dump(mode="json"),
             )
         )

--- a/services/orion-topic-foundry/app/services/kg_edges.py
+++ b/services/orion-topic-foundry/app/services/kg_edges.py
@@ -6,9 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 from uuid import UUID, uuid4
 
-from app.services.bus_events import get_bus_publisher
 from app.storage.repository import fetch_model, fetch_run, fetch_segments, replace_edges_for_run, utc_now
-from orion.schemas.topic_foundry import KgEdgeIngestItemV1, KgEdgeIngestV1
 
 
 logger = logging.getLogger("topic-foundry.kg-edges")
@@ -20,7 +18,6 @@ def generate_edges_for_run(run_id: UUID, *, min_confidence: float = 0.2) -> int:
         return 0
     model_row = fetch_model(UUID(run_row["model_id"]))
     model_name = model_row["name"] if model_row else "unknown"
-    model_id = UUID(run_row["model_id"])
 
     segments = fetch_segments(run_id, has_enrichment=True)
     edges: List[Dict[str, Any]] = []
@@ -29,7 +26,16 @@ def generate_edges_for_run(run_id: UUID, *, min_confidence: float = 0.2) -> int:
 
     replace_edges_for_run(run_id=run_id, edges=edges)
     _write_edge_artifacts(run_row, edges)
-    _publish_edge_batch(edges, run_id=run_id, model_id=model_id, model_name=model_name)
+    # Bus publish (orion:kg:edge:ingest.v1) retired 2026-07-28 -- zero live
+    # consumers (orion-rdf-writer never actually subscribed; orion-graphdb
+    # never existed as a real service). These edges now reach a real
+    # consumer via GET /kg/edges, pulled by
+    # orion-hub/scripts/concept_atlas_routes.py into the live Falkor
+    # substrate graph instead (see
+    # orion/substrate/adapters/topic_foundry.py's module docstring). Rows
+    # still persist to Postgres (replace_edges_for_run above) and remain
+    # queryable via GET /edges and /kg/edges -- only the dead broadcast is
+    # gone.
     return len(edges)
 
 
@@ -141,26 +147,3 @@ def _write_edge_artifacts(run_row: Dict[str, Any], edges: List[Dict[str, Any]]) 
     with edges_path.open("w", encoding="utf-8") as handle:
         for edge in edges:
             handle.write(json.dumps(edge, default=str) + "\n")
-
-
-def _publish_edge_batch(edges: List[Dict[str, Any]], *, run_id: UUID, model_id: UUID, model_name: str) -> None:
-    if not edges:
-        return
-    payload = KgEdgeIngestV1(
-        run_id=run_id,
-        model_id=model_id,
-        model_name=model_name,
-        edges=[
-            KgEdgeIngestItemV1(
-                edge_id=edge["edge_id"],
-                segment_id=edge["segment_id"],
-                subject=edge["subject"],
-                predicate=edge["predicate"],
-                object=edge["object"],
-                confidence=edge["confidence"],
-                created_at=edge["created_at"],
-            )
-            for edge in edges
-        ],
-    )
-    get_bus_publisher().publish_kg_edges(payload)

--- a/services/orion-topic-foundry/tests/test_kg_edges.py
+++ b/services/orion-topic-foundry/tests/test_kg_edges.py
@@ -1,0 +1,127 @@
+"""Tests for kg_edges.py's typed-edge generation.
+
+Regression coverage for the 2026-07-28 retirement of the
+`orion:kg:edge:ingest.v1` bus publish (zero live consumers -- see
+orion/bus/channels.yaml's former comment and
+orion/substrate/adapters/topic_foundry.py's module docstring): edges are
+still computed and persisted to Postgres/artifacts, they just no longer go
+out on the bus. `app.services.bus_events`/`get_bus_publisher` are no longer
+imported by this module at all -- these tests both exercise the surviving
+compute/persist path and act as a regression guard against that import
+reappearing.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from app.services import kg_edges
+
+
+FAKE_RUN_ID = UUID("11111111-1111-1111-1111-111111111111")
+FAKE_MODEL_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _run_row(run_id: UUID = FAKE_RUN_ID, model_id: UUID = FAKE_MODEL_ID) -> dict:
+    # No "artifact_paths" key -- _write_edge_artifacts degrades to a no-op
+    # (early "if not run_dir: return"), keeping this test filesystem-free.
+    return {"run_id": str(run_id), "model_id": str(model_id)}
+
+
+def _segment(segment_id, *, entities=None, questions=None, claims=None, next_steps=None) -> dict:
+    return {
+        "segment_id": str(segment_id),
+        "meaning": {
+            "entities": entities or [],
+            "questions": questions or [],
+            "claims": claims or [],
+            "next_steps": next_steps or [],
+        },
+    }
+
+
+def test_kg_edges_module_no_longer_imports_bus_publisher() -> None:
+    """Direct regression guard for the retirement: the removed
+    `from app.services.bus_events import get_bus_publisher` import (and the
+    KgEdgeIngestV1/KgEdgeIngestItemV1 schema imports) must not reappear.
+    """
+    assert not hasattr(kg_edges, "get_bus_publisher")
+    assert not hasattr(kg_edges, "KgEdgeIngestV1")
+    assert not hasattr(kg_edges, "KgEdgeIngestItemV1")
+    assert not hasattr(kg_edges, "_publish_edge_batch")
+
+
+def test_generate_edges_for_run_returns_zero_for_missing_run(monkeypatch) -> None:
+    monkeypatch.setattr(kg_edges, "fetch_run", lambda run_id: None)
+    assert kg_edges.generate_edges_for_run(FAKE_RUN_ID) == 0
+
+
+def test_generate_edges_for_run_computes_and_persists_edges(monkeypatch) -> None:
+    segment_id = uuid4()
+    persisted: dict = {}
+
+    monkeypatch.setattr(kg_edges, "fetch_run", lambda run_id: _run_row())
+    monkeypatch.setattr(kg_edges, "fetch_model", lambda model_id: {"name": "test-model"})
+    monkeypatch.setattr(
+        kg_edges,
+        "fetch_segments",
+        lambda run_id, has_enrichment=True: [
+            _segment(segment_id, entities=["Juniper Feld", "Orion"], questions=["what next?"])
+        ],
+    )
+
+    def fake_replace(*, run_id, edges):
+        persisted["run_id"] = run_id
+        persisted["edges"] = edges
+
+    monkeypatch.setattr(kg_edges, "replace_edges_for_run", fake_replace)
+
+    count = kg_edges.generate_edges_for_run(FAKE_RUN_ID)
+
+    # 2 "mentions" (confidence 0.6) + 1 "asks_about" (confidence 0.5), all
+    # at/above the default min_confidence=0.2 floor.
+    assert count == 3
+    assert persisted["run_id"] == FAKE_RUN_ID
+    predicates = sorted(edge["predicate"] for edge in persisted["edges"])
+    assert predicates == ["asks_about", "mentions", "mentions"]
+    mention_objects = sorted(
+        edge["object"] for edge in persisted["edges"] if edge["predicate"] == "mentions"
+    )
+    assert mention_objects == ["juniper feld", "orion"]
+
+
+def test_generate_edges_for_run_filters_below_min_confidence(monkeypatch) -> None:
+    segment_id = uuid4()
+
+    monkeypatch.setattr(kg_edges, "fetch_run", lambda run_id: _run_row())
+    monkeypatch.setattr(kg_edges, "fetch_model", lambda model_id: {"name": "test-model"})
+    monkeypatch.setattr(
+        kg_edges,
+        "fetch_segments",
+        lambda run_id, has_enrichment=True: [_segment(segment_id, questions=["asks_about is 0.5 confidence"])],
+    )
+    monkeypatch.setattr(kg_edges, "replace_edges_for_run", lambda *, run_id, edges: None)
+
+    # min_confidence above asks_about's fixed 0.5 confidence -- must filter it out.
+    count = kg_edges.generate_edges_for_run(FAKE_RUN_ID, min_confidence=0.6)
+    assert count == 0
+
+
+def test_generate_edges_for_run_missing_model_degrades_to_unknown(monkeypatch) -> None:
+    segment_id = uuid4()
+    persisted: dict = {}
+
+    monkeypatch.setattr(kg_edges, "fetch_run", lambda run_id: _run_row())
+    monkeypatch.setattr(kg_edges, "fetch_model", lambda model_id: None)
+    monkeypatch.setattr(
+        kg_edges,
+        "fetch_segments",
+        lambda run_id, has_enrichment=True: [_segment(segment_id, entities=["x"])],
+    )
+    monkeypatch.setattr(
+        kg_edges, "replace_edges_for_run", lambda *, run_id, edges: persisted.update(edges=edges)
+    )
+
+    count = kg_edges.generate_edges_for_run(FAKE_RUN_ID)
+    assert count == 1
+    assert persisted["edges"][0]["subject"] == "unknown"

--- a/tests/test_cognitive_substrate_topic_foundry_adapter.py
+++ b/tests/test_cognitive_substrate_topic_foundry_adapter.py
@@ -241,3 +241,148 @@ def test_observed_at_and_subject_ref_propagate() -> None:
     concept_nodes = [n for n in out.nodes if n.node_kind == "concept"]
     assert concept_nodes[0].subject_ref == "project:orion_sapienform"
     assert concept_nodes[0].temporal.observed_at == ts
+
+
+# --- mention_edges -> EntityNodeV1 / associated_with, added 2026-07-28 ---
+
+
+def test_mention_edge_produces_entity_node_and_associated_with_edge() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=[{"segment_id": "seg-a", "object": "Juniper Feld", "confidence": 0.6}],
+        segment_topic_id_map={"seg-a": 0},
+    )
+    entity_nodes = [n for n in out.nodes if n.node_kind == "entity"]
+    assert len(entity_nodes) == 1
+    assert entity_nodes[0].label == "Juniper Feld"
+
+    mention_edges = [e for e in out.edges if e.predicate == "associated_with"]
+    assert len(mention_edges) == 1
+    edge = mention_edges[0]
+    assert edge.source.node_id == "sub-concept-topicfoundry-run-1-0"
+    assert edge.target.node_id == entity_nodes[0].node_id
+    assert edge.confidence == pytest.approx(0.6)
+
+
+def test_mention_edge_deduplicates_entity_by_normalized_label() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=[
+            {"segment_id": "seg-a", "object": "Juniper Feld", "confidence": 0.6},
+            {"segment_id": "seg-a", "object": "  juniper feld  ", "confidence": 0.9},
+        ],
+        segment_topic_id_map={"seg-a": 0},
+    )
+    entity_nodes = [n for n in out.nodes if n.node_kind == "entity"]
+    assert len(entity_nodes) == 1, "differently-cased/whitespaced same entity must dedupe to one node"
+    mention_edges = [e for e in out.edges if e.predicate == "associated_with"]
+    assert len(mention_edges) == 1, "duplicate (topic, entity) pair must not produce a second edge"
+
+
+def test_mention_edge_for_outlier_or_below_floor_topic_is_skipped() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=[
+            {"segment_id": "seg-outlier", "object": "should not appear", "confidence": 0.6},
+            {"segment_id": "seg-thin", "object": "also should not appear", "confidence": 0.6},
+        ],
+        segment_topic_id_map={"seg-outlier": -1, "seg-thin": 2},  # -1 excluded, topic 2 below min_doc_count
+    )
+    assert not [n for n in out.nodes if n.node_kind == "entity"]
+    assert not [e for e in out.edges if e.predicate == "associated_with"]
+
+
+def test_mention_edge_with_unmapped_segment_is_skipped() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=[{"segment_id": "seg-unknown", "object": "orphan mention", "confidence": 0.6}],
+        segment_topic_id_map={},  # no entry for seg-unknown
+    )
+    assert not [n for n in out.nodes if n.node_kind == "entity"]
+    assert not [e for e in out.edges if e.predicate == "associated_with"]
+
+
+def test_no_mention_edges_is_a_no_op() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+    )
+    assert not [n for n in out.nodes if n.node_kind == "entity"]
+
+
+def test_mention_edges_cap_bounds_worst_case_work() -> None:
+    from orion.substrate.adapters.topic_foundry import MAX_MENTION_EDGES
+
+    over_cap = MAX_MENTION_EDGES + 50
+    mention_edges = [
+        {"segment_id": "seg-a", "object": f"entity-{i}", "confidence": 0.5} for i in range(over_cap)
+    ]
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=mention_edges,
+        segment_topic_id_map={"seg-a": 0},
+    )
+    entity_nodes = [n for n in out.nodes if n.node_kind == "entity"]
+    assert len(entity_nodes) == MAX_MENTION_EDGES
+
+
+def test_malformed_mention_edge_is_skipped_not_raised() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=[
+            {"segment_id": None, "object": "no segment id", "confidence": 0.5},
+            {"segment_id": "seg-a", "object": "", "confidence": 0.5},
+            {"segment_id": "seg-a", "object": "not a real number", "confidence": "garbage"},
+        ],
+        segment_topic_id_map={"seg-a": 0},
+    )
+    # The third item has a real entity string, just an unparseable confidence
+    # (defaults to 0.5) -- it should still produce a node/edge; the first two
+    # are genuinely unusable (no segment_id / empty object) and are skipped.
+    entity_nodes = [n for n in out.nodes if n.node_kind == "entity"]
+    assert len(entity_nodes) == 1
+    assert entity_nodes[0].label == "not a real number"
+
+
+def test_mention_edge_label_truncated_to_max_length() -> None:
+    from orion.substrate.adapters.topic_foundry import MAX_ENTITY_LABEL_LENGTH
+
+    over_length = "x" * (MAX_ENTITY_LABEL_LENGTH + 50)
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=[{"segment_id": "seg-a", "object": over_length, "confidence": 0.5}],
+        segment_topic_id_map={"seg-a": 0},
+    )
+    entity_nodes = [n for n in out.nodes if n.node_kind == "entity"]
+    assert len(entity_nodes) == 1
+    assert len(entity_nodes[0].label) == MAX_ENTITY_LABEL_LENGTH
+
+
+def test_mention_edge_confidence_out_of_range_is_clamped() -> None:
+    out = map_topic_foundry_run_to_substrate(
+        run_id="run-1",
+        topics=_topics(),
+        keywords_by_topic=_keywords_by_topic(),
+        mention_edges=[
+            {"segment_id": "seg-a", "object": "too high", "confidence": 1.5},
+            {"segment_id": "seg-a", "object": "too low", "confidence": -3.0},
+        ],
+        segment_topic_id_map={"seg-a": 0},
+    )
+    confidences = sorted(e.confidence for e in out.edges if e.predicate == "associated_with")
+    assert confidences == [0.0, 1.0]


### PR DESCRIPTION
## Summary

- topic-foundry's `kg_edges.py::generate_edges_for_run()` computes real, LLM-enriched typed edges (`mentions`/`asks_about`/`claims_about`/`next_step`) from chat segments, but only ever published them on `orion:kg:edge:ingest.v1` — a bus channel with zero live consumers (`orion-rdf-writer` never actually subscribed, even before Fuseki decommission; `orion-graphdb` never existed as a real service, confirmed via git history).
- Instead of building a new bus consumer, this routes the `mentions` predicate into `orion-hub`'s already-live, already-scheduled Falkor substrate ingestion path instead: new `fetch_mention_edges_for_run()` client call (`GET /kg/edges`, an existing endpoint, no new API) feeds `map_topic_foundry_run_to_substrate()`, which now emits `EntityNodeV1` + `associated_with` edges from the owning topic's concept node.
- `asks_about`/`claims_about`/`next_step` are explicitly out of scope — no substrate node kind fits their shape yet.
- The dead bus publish is retired outright (`_publish_edge_batch`, `publish_kg_edges`, `KgEdgeIngestV1`/`KgEdgeIngestItemV1`, the `channels.yaml` declaration, the schema registry entry) — not left running unconsumed.
- Code review caught one real blocking bug before push (see Review findings below) and fixed it with a regression test.

## Outcome moved

Topic-foundry's richer, LLM-enriched entity-mention data now reaches a real consumer instead of broadcasting into a channel nobody listens to. `orion-topic-foundry`'s `kg_edges.py` also goes from zero test coverage to 5 tests.

## Current architecture

Two parallel topic-foundry → substrate paths existed: (1) `concept_atlas_ingest_topic_foundry()` in `orion-hub`, HTTP-pulling topics/keywords/segments into Falkor via `map_topic_foundry_run_to_substrate` — live, scheduler-driven, working. (2) `kg_edges.py`'s bus publish — real compute, real Postgres persistence, but the bus broadcast itself had no consumer.

## Architecture touched

- `orion/substrate/adapters/topic_foundry.py` — pure adapter, new `mention_edges`/`segment_topic_id_map` params, `EntityNodeV1` + `associated_with` edge construction.
- `orion/substrate/reconcile.py` — new `entity` branch in `canonical_node_key` (the review-caught fix).
- `services/orion-hub/scripts/{topic_foundry_client.py,concept_atlas_routes.py,main.py}` — new HTTP fetch, route wiring, `entities_written`/`mentions_fetched` counters.
- `services/orion-topic-foundry/app/services/{kg_edges.py,bus_events.py}` — dead publish removed.
- `orion/schemas/topic_foundry.py`, `orion/schemas/registry.py`, `orion/bus/channels.yaml` — dead schema/channel removed.

## Files changed

- `orion/substrate/adapters/topic_foundry.py`: mention-edge → EntityNodeV1/associated_with mapping, capped at `MAX_MENTION_EDGES` (documented as effectively bounded lower by the client's own 500-item ceiling).
- `orion/substrate/reconcile.py`: `entity` identity-key branch (label-keyed, mirrors the concept pattern) — fixes the cross-run duplication bug review found.
- `services/orion-hub/scripts/topic_foundry_client.py`: `fetch_mention_edges_for_run()`.
- `services/orion-hub/scripts/concept_atlas_routes.py`: wires the fetch in, builds `segment_topic_id_map` from the segments fetch already happening, adds `entities_written`/`mentions_fetched` to the response and `_CountingSubstrateStore`.
- `services/orion-hub/scripts/main.py`: scheduler log line includes `entities_written`.
- `services/orion-topic-foundry/app/services/kg_edges.py`: `_publish_edge_batch` and its call site removed.
- `services/orion-topic-foundry/app/services/bus_events.py`: `publish_kg_edges`/`KG_EDGE_INGEST_CHANNEL` removed.
- `orion/schemas/topic_foundry.py`: `KgEdgeIngestV1`/`KgEdgeIngestItemV1` removed.
- `orion/schemas/registry.py`: registration removed.
- `orion/bus/channels.yaml`: `orion:kg:edge:ingest.v1` entry removed.
- `services/orion-hub/README.md`, `services/orion-topic-foundry/README.md`, `docs/superpowers/specs/2026-07-15-concept-atlas-graph-pipeline-design.md`: dated documentation of the change and its known UI limitation.
- Tests: `tests/test_cognitive_substrate_topic_foundry_adapter.py` (+9), `services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py` (+10, including the cross-run entity-merge regression test), `services/orion-topic-foundry/tests/test_kg_edges.py` (new file, 5 tests).

## Schema / bus / API changes

- **Removed:** `orion:kg:edge:ingest.v1` channel, `KgEdgeIngestV1`/`KgEdgeIngestItemV1` schemas, their registry entries.
- **Added:** no new schema — reuses `EntityNodeV1`/`associated_with` (both already existed, unused by any live producer before this).
- **Behavior changed:** `POST /api/substrate/concepts/ingest-topic-foundry` response gains `entities_written`/`mentions_fetched` fields.
- **Compatibility notes:** the removed bus channel had zero live consumers; nothing downstream depended on it. Edges still persist to topic-foundry's own Postgres and remain queryable via `GET /edges`/`GET /kg/edges` regardless of this change.

## Env/config changes

None. No new env keys; the scheduler flag this rides on (`SUBSTRATE_TOPIC_FOUNDRY_SCHEDULER_ENABLED`) already exists and defaults to `true`.

## Tests run

```text
PYTHONPATH=. pytest tests/test_cognitive_substrate_topic_foundry_adapter.py -q       → 26 passed
PYTHONPATH=. pytest orion/substrate/tests/test_reconcile.py -q                       → 9 passed
(from services/orion-hub) pytest tests/test_concept_atlas_ingest_topic_foundry.py -q → 31 passed
(from services/orion-topic-foundry) pytest tests/test_kg_edges.py -q                 → 5 passed
```
71 total, all passing. (`tests/test_concept_atlas_routes.py::test_concept_atlas_page_renders` fails identically against unmodified `main` in this environment — pre-existing, unrelated to this patch.)

## Evals run

No eval harness exists for either touched service; not applicable.

## Docker/build/smoke checks

Not run — no Docker environment available in this session. No runtime config/dependency/port changes, so a build/config check wasn't expected to be load-bearing here; flagging per CLAUDE.md rather than silently skipping.

## Review findings fixed

- Finding: `SubstrateIdentityResolver.canonical_node_key` had no branch for `node_kind == "entity"` — every ingestion tick (daily scheduler, on by default) would create a brand-new duplicate entity node for the same real-world mentioned entity, unbounded growth forever.
  - Fix: added a label-keyed `entity` branch to `canonical_node_key` (`orion/substrate/reconcile.py`), mirroring the existing concept-identity pattern.
  - Evidence: new test `test_ingest_cross_run_same_entity_label_merges_to_one_durable_entity` — two ingestion calls with the same (differently-cased) entity label produce exactly one durable entity node and one durable edge, not two orphaned pairs.
- Finding: `MAX_MENTION_EDGES=2000` in the adapter can never actually be exercised — the real ceiling is the client's own 500-item, no-pagination fetch cap.
  - Fix: documented with a comment tying the two constants together.
  - Evidence: code comment, `orion/substrate/adapters/topic_foundry.py`.
- Finding: missing test coverage for entity-label truncation and out-of-range confidence clamping.
  - Fix: two tests added (`test_mention_edge_label_truncated_to_max_length`, `test_mention_edge_confidence_out_of_range_is_clamped`).
  - Evidence: both pass.
- Noted, not changed: the single `try/except Exception` in `_build()` gives the new mention-edge loop blast radius over already-working concept/topic construction if it throws unexpectedly. Matches the adapter's existing "never raises" contract; the new loop is defensively written (every field goes through safe accessors before use). Left as a design note, not a required fix.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-topic-foundry/.env \
  -f services/orion-topic-foundry/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: low. Concern: `EntityNodeV1` records won't appear in the Concept Atlas Hub UI (network/god-node views filter to `node_kind == "concept"`). Mitigation: documented in 3 places (both service READMEs, the design spec); real, substrate-visible data regardless, generic consumers (e.g. `endogenous_curiosity.py`) already see it. Separate follow-up to widen the UI.
- Severity: low. Concern: `asks_about`/`claims_about`/`next_step` predicates still have no substrate consumer — only `mentions` is wired. Intentional scope cut (no matching node kind exists yet), not an oversight.

## PR link

(filled in by `gh pr create` output)