### PR TITLE
feat(world-pulse): close disclosed Postgres gap, wire real bus_synaptic surprise

### DIFF
--- a/services/orion-world-pulse/.env_example
+++ b/services/orion-world-pulse/.env_example
@@ -10,6 +10,15 @@ ORION_BUS_URL=redis://100.92.216.81:6379/0
 # Bus-native SystemHealthV1 heartbeat cadence (orion:system:health).
 HEARTBEAT_INTERVAL_SEC=10
 
+# Real, ambient bus_synaptic surprise signal for the curiosity readonly-fetch capability
+# gate (orion/autonomy/capability_policy.py's domain_surprise_score) and its own
+# ActionOutcomeRefV1.surprise -- see docs/superpowers/specs/2026-07-24-efe-capability-
+# gate-design.md. Same Postgres (conjourney) DSN orion-cortex-exec/orion-spark-concept-
+# induction already use for this exact key, reused for consistency. Shipped ON by
+# default, matching that convention; leave blank to opt this service back out (it has no
+# other Postgres dependency, so blank keeps it fully inert).
+ORION_ACTION_OUTCOME_DB_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+
 WORLD_PULSE_ENABLED=true
 WORLD_PULSE_DRY_RUN=false
 WORLD_PULSE_FETCH_ENABLED=true

--- a/services/orion-world-pulse/app/services/curiosity.py
+++ b/services/orion-world-pulse/app/services/curiosity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from typing import Awaitable, Callable
 
 from orion.autonomy.capability_policy import CapabilityEvaluationContext, evaluate_capability
@@ -14,10 +15,56 @@ from orion.schemas.world_pulse import (
     CuriosityFollowupV1,
     SectionCoverageV1,
 )
+from orion.substrate.bus_synaptic_surprise import latest_bus_synaptic_prediction_error
 
 logger = logging.getLogger("orion-world-pulse.curiosity")
 
 _READONLY_CAPABILITY = "web.fetch.readonly"
+
+# Lazy, cached Postgres engine for the real ambient bus_synaptic surprise signal -- only
+# built if ORION_ACTION_OUTCOME_DB_URL is configured (see app/settings.py). This module
+# has no other Postgres dependency, so an unconfigured URL keeps
+# _default_bus_synaptic_surprise_source() inert (always None), matching this codebase's
+# established fail-open convention (orion/spark/concept_induction/bus_worker.py's
+# ConceptWorker._get_surprise_engine()) -- but unlike that class's own per-instance
+# attribute, this is a genuine process-wide module global: FastAPI runs sync route
+# handlers in a threadpool (services/orion-world-pulse/app/routers/runs.py's
+# world_pulse_run), so concurrent requests can reach this check-then-set from different
+# threads of the same process. Guarded with a lock (found in review) so two concurrent
+# first-callers can't both build and leak a real Postgres engine.
+_surprise_engine: object | None = None
+_surprise_engine_lock = threading.Lock()
+
+
+def _get_surprise_engine():
+    from app.settings import settings
+
+    if not settings.action_outcome_db_url:
+        return None
+    global _surprise_engine
+    if _surprise_engine is None:
+        with _surprise_engine_lock:
+            if _surprise_engine is None:
+                from sqlalchemy import create_engine
+
+                _surprise_engine = create_engine(settings.action_outcome_db_url, pool_pre_ping=True)
+    return _surprise_engine
+
+
+def _default_bus_synaptic_surprise_source() -> float | None:
+    """Real `surprise_source` used automatically when a caller doesn't supply one --
+    see `build_curiosity_followups`/`_gate_open` below. Fail-open: any exception here
+    (DB down, engine unbuildable) degrades to `None`, never raises into a real
+    world-pulse run.
+    """
+    engine = _get_surprise_engine()
+    if engine is None:
+        return None
+    try:
+        return latest_bus_synaptic_prediction_error(engine)
+    except Exception:
+        logger.warning("world_pulse_bus_synaptic_surprise_fetch_failed", exc_info=True)
+        return None
 
 
 def _synthetic_goal(run_id: str) -> GoalProposalV1:
@@ -39,15 +86,15 @@ def _synthetic_goal(run_id: str) -> GoalProposalV1:
 
 def _resolve_domain_surprise(surprise_source: SurpriseSource | None) -> float | None:
     """Same real ambient bus_synaptic value orion/autonomy/policy_act.py's identically-named
-    helper reads -- this service currently has no Postgres access to supply a real
-    surprise_source (disclosed gap; see docs/superpowers/specs/2026-07-24-efe-capability-
-    gate-design.md), so this is always `None` today. Wired anyway so a future Postgres
-    connection here needs zero call-site changes -- just a real callable.
+    helper reads. `None` (the default -- no explicit surprise_source passed by the caller)
+    falls back to `_default_bus_synaptic_surprise_source`, this module's own real reader --
+    closing the disclosed gap this service had (no Postgres access at all) as of
+    2026-07-28. Still resolves to `None` in practice unless `ORION_ACTION_OUTCOME_DB_URL`
+    is configured for this service.
     """
-    if surprise_source is None:
-        return None
+    real_source = surprise_source or _default_bus_synaptic_surprise_source
     try:
-        return surprise_source()
+        return real_source()
     except Exception:
         return None
 
@@ -134,7 +181,11 @@ def build_curiosity_followups(
         # failure degrades to skipping this section, never failing the run.
         try:
             outcome = asyncio.run(
-                execute_readonly_fetch(req, fetch_backend=backend, surprise_source=surprise_source)
+                execute_readonly_fetch(
+                    req,
+                    fetch_backend=backend,
+                    surprise_source=surprise_source or _default_bus_synaptic_surprise_source,
+                )
             )
             followups.append(
                 CuriosityFollowupV1(

--- a/services/orion-world-pulse/app/settings.py
+++ b/services/orion-world-pulse/app/settings.py
@@ -17,6 +17,13 @@ class Settings(BaseSettings):
     orion_bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
     orion_bus_enforce_catalog: bool = Field(False, alias="ORION_BUS_ENFORCE_CATALOG")
     orion_bus_url: str = Field("redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
+    # Real, ambient bus_synaptic surprise signal for the curiosity readonly-fetch gate
+    # (orion/autonomy/capability_policy.py's domain_surprise_score) and its own
+    # ActionOutcomeRefV1.surprise -- see docs/superpowers/specs/2026-07-24-efe-capability-
+    # gate-design.md. Blank/opt-in at the code level (this service had zero Postgres
+    # dependency before this field); `.env_example` ships it filled in and ON, matching
+    # orion-cortex-exec/orion-spark-concept-induction's convention for the same key.
+    action_outcome_db_url: str = Field("", alias="ORION_ACTION_OUTCOME_DB_URL")
     # Bus-native SystemHealthV1 heartbeat cadence (orion:system:health). See
     # docs/superpowers/specs/2026-07-24-service-heartbeat-node-telemetry-design.md.
     heartbeat_interval_sec: float = Field(10.0, alias="HEARTBEAT_INTERVAL_SEC")

--- a/services/orion-world-pulse/requirements.txt
+++ b/services/orion-world-pulse/requirements.txt
@@ -6,3 +6,5 @@ pydantic==2.9.2
 pydantic-settings==2.5.2
 redis==5.0.8
 pytest==8.3.4
+sqlalchemy==2.0.36
+psycopg2-binary==2.9.10

--- a/services/orion-world-pulse/tests/test_curiosity_bus_synaptic_surprise.py
+++ b/services/orion-world-pulse/tests/test_curiosity_bus_synaptic_surprise.py
@@ -1,0 +1,78 @@
+"""Regression: curiosity.py's default bus_synaptic surprise wiring.
+
+ORION_ACTION_OUTCOME_DB_URL is optional for this service (it had no other Postgres
+dependency before 2026-07-28) -- unconfigured must degrade to None on every call, not
+raise or spin up a real connection attempt. Configured, it must actually resolve a real
+value without any caller needing to pass surprise_source explicitly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.services.curiosity as curiosity
+
+
+@pytest.fixture(autouse=True)
+def _reset_surprise_engine():
+    """Guarantees curiosity._surprise_engine is reset before AND after every test in this
+    file, regardless of test order or a mid-test failure -- a manual reset at the end of
+    each test body is order-dependent and doesn't run if the test raises (found in review:
+    one test was missing its manual reset, relying on execution order to mask it)."""
+    curiosity._surprise_engine = None
+    yield
+    curiosity._surprise_engine = None
+
+
+def test_default_source_none_when_db_url_unconfigured(monkeypatch):
+    monkeypatch.setattr("app.settings.settings.action_outcome_db_url", "")
+    assert curiosity._get_surprise_engine() is None
+    assert curiosity._default_bus_synaptic_surprise_source() is None
+
+
+def test_default_source_returns_real_value_when_configured(monkeypatch):
+    monkeypatch.setattr(
+        "app.settings.settings.action_outcome_db_url",
+        "postgresql://test:test@localhost/test",
+    )
+    with patch.object(curiosity, "latest_bus_synaptic_prediction_error", return_value=0.1675):
+        assert curiosity._default_bus_synaptic_surprise_source() == 0.1675
+
+
+def test_default_source_engine_cached_across_calls(monkeypatch):
+    monkeypatch.setattr(
+        "app.settings.settings.action_outcome_db_url",
+        "postgresql://test:test@localhost/test",
+    )
+    with patch("sqlalchemy.create_engine") as mock_create_engine:
+        mock_create_engine.return_value = MagicMock()
+        curiosity._get_surprise_engine()
+        curiosity._get_surprise_engine()
+    mock_create_engine.assert_called_once()
+
+
+def test_default_source_fails_open_on_query_error(monkeypatch):
+    monkeypatch.setattr(
+        "app.settings.settings.action_outcome_db_url",
+        "postgresql://test:test@localhost/test",
+    )
+    with patch.object(
+        curiosity, "latest_bus_synaptic_prediction_error", side_effect=RuntimeError("db down")
+    ):
+        assert curiosity._default_bus_synaptic_surprise_source() is None
+
+
+def test_resolve_domain_surprise_falls_back_to_default_when_no_explicit_source(monkeypatch):
+    with patch.object(
+        curiosity, "_default_bus_synaptic_surprise_source", return_value=0.037
+    ):
+        assert curiosity._resolve_domain_surprise(None) == 0.037
+
+
+def test_resolve_domain_surprise_prefers_explicit_source_over_default(monkeypatch):
+    with patch.object(
+        curiosity, "_default_bus_synaptic_surprise_source", return_value=0.037
+    ):
+        assert curiosity._resolve_domain_surprise(lambda: 0.9) == 0.9


### PR DESCRIPTION
## Summary

- Closes a disclosed gap from PR #1412: `orion-world-pulse`'s `curiosity.py` (readonly-fetch capability gate + gap-fill fetch) had a `surprise_source` DI seam but no Postgres access to ever supply a real value -- always `None` in production.
- Gives it one, same pattern as `orion-spark-concept-induction` (PR #1403): new `ORION_ACTION_OUTCOME_DB_URL` setting, lazy cached engine, real `_default_bus_synaptic_surprise_source()` used automatically whenever a caller doesn't pass an explicit `surprise_source`.
- Separately root-caused (no code change) why the capability gate hasn't fired since recent deploys: it only triggers on a real `world.pulse.run.result.v1` event, and none has landed recently -- a real scheduling/cadence gap, not a bug. The `CONCEPT_AUTONOMOUS_TRIGGER_ENABLED=false` log line seen earlier gates a different feature (concept/keyword extraction) and runs *after* this code path in the handler, not before it.

## Outcome moved

`orion-world-pulse`'s `journal.compose.episode`-adjacent gate and its own fetch outcomes now get the real ambient `bus_synaptic_prediction_error()` signal instead of always `None` -- the last of the three real production services (`execution-dispatch-runtime`, `concept-induction`, `world-pulse`) that needed this wiring.

## Current architecture

`curiosity.py`'s `_gate_open`/`build_curiosity_followups` accepted a `surprise_source` parameter but had no default real implementation to fall back to -- every real caller passes `None`, so `domain_surprise_score`/`ActionOutcomeRefV1.surprise` were always `None` for this service.

## Architecture touched

- `services/orion-world-pulse/app/services/curiosity.py`, `app/settings.py`, `requirements.txt`, `.env_example`.

## Files changed

- `requirements.txt`: added `sqlalchemy`/`psycopg2-binary`.
- `app/settings.py`: new `action_outcome_db_url` field (`ORION_ACTION_OUTCOME_DB_URL`), blank/opt-in at the code level.
- `app/services/curiosity.py`: new lazy-cached engine + `_default_bus_synaptic_surprise_source()`; `_resolve_domain_surprise` and the per-section `execute_readonly_fetch` call now fall back to the real default when no explicit `surprise_source` is supplied.
- `.env_example`: new key documented, shipped ON (same DSN convention as `orion-cortex-exec`/`orion-spark-concept-induction`). Live `.env` (main checkout) synced to match.
- No `docker-compose.yml` change needed -- this service's compose uses a plain `env_file: .env` (loads every key), unlike `concept-induction`'s compose (which explicitly enumerates vars and needed a real fix for this in PR #1403).
- Tests: new `services/orion-world-pulse/tests/test_curiosity_bus_synaptic_surprise.py` (6 tests).

## Schema / bus / API changes

- Added: `ORION_ACTION_OUTCOME_DB_URL` setting/env key.
- Removed: none.
- Renamed: none.
- **Behavior changed (flagging explicitly, per review)**: once this service's live `.env` has the DB URL configured, every stored `ActionOutcomeRefV1.surprise` for this service's fetch outcomes, and every `_gate_open` capability-gate decision, will carry a real ambient value instead of always `None`. Any future consumer written assuming "always `None` for this service" would see this change the day it deploys -- intentional and is the whole point of the patch, but worth naming explicitly since it touches a persisted schema field.
- Compatibility notes: fully backward-compatible at the code level (fail-open to `None` if unconfigured or on any query error); the live-data behavior change described above is real and intentional.

## Env/config changes

- Added keys: `ORION_ACTION_OUTCOME_DB_URL`.
- Removed keys: none.
- `.env_example` updated: yes, shipped ON.
- Local `.env` synced: yes (main checkout's `services/orion-world-pulse/.env`).
- Skipped keys requiring operator action: none.

## Tests run

```text
PYTHONPATH=. python -m pytest services/orion-world-pulse/tests/ -q
82 passed, 14 warnings
```

## Evals run

None applicable -- no eval harness exists for this service.

## Docker/build/smoke checks

Not run directly -- needs an image rebuild to pick up the new `sqlalchemy`/`psycopg2-binary` dependencies; no other runtime/port/compose change.

## Review findings fixed

- Finding (moderate): `_get_surprise_engine()`'s module-global lazy-init check-then-set has no lock. This service's FastAPI route (`world_pulse_run`) is a sync `def` handler run in Starlette's threadpool, so concurrent requests reach this from different threads of the same process -- unlike the `ConceptWorker._get_surprise_engine()` comparison the original comment drew (a genuine single-instance attribute, no concurrent callers), this is a real process-wide global reachable concurrently. Two simultaneous first-callers could both build and leak a real Postgres engine.
  - Fix: double-checked locking with a `threading.Lock()`.
  - Evidence: `app/services/curiosity.py` diff; existing + new tests still pass (82).
- Finding (minor/hygiene): one new test (`test_default_source_engine_cached_across_calls`) was missing its manual `curiosity._surprise_engine = None` reset at the end, relying on test execution order (and other tests' own resets) to avoid leaking a stale mock into a later test -- order-dependent, not structurally guaranteed.
  - Fix: replaced every manual reset with one `autouse` pytest fixture that resets before and after every test in the file, regardless of order or a mid-test failure.
  - Evidence: `services/orion-world-pulse/tests/test_curiosity_bus_synaptic_surprise.py` diff.
- Finding (non-issue, verified clean): the `from app.settings import settings` import inside `_get_surprise_engine()`'s function body correctly observes `monkeypatch.setattr` mutations on the real module-level singleton (no staleness); `real_source = surprise_source or _default_bus_synaptic_surprise_source`'s falsy-callable risk is not reachable given the actual type contract and only real call site (which always passes `None`, never a falsy-but-not-None value).

## Restart required

```bash
docker compose -f services/orion-world-pulse/docker-compose.yml build orion-world-pulse
docker restart orion-world-pulse
```
(needs a rebuild first for the new dependencies to be installed.)

## Risks / concerns

- Severity: low
- Concern: this service now has a live Postgres dependency it didn't have before (opt-in via env, shipped on in `.env_example`/live `.env`). A Postgres outage surfaces as warning-logged fetch failures, not crashes.
- Mitigation: entirely fail-open -- `_default_bus_synaptic_surprise_source()`/`_get_surprise_engine()` never raise into a real world-pulse run; every consumer falls back to the pre-existing `None` behavior on any failure.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/world-pulse-bus-synaptic-surprise-wiring