### PR TITLE
fix(vector-host): drop double /spark prefix breaking Cognitive EKG via Tailscale

### DIFF
--- a/services/orion-vector-host/app/main.py
+++ b/services/orion-vector-host/app/main.py
@@ -693,14 +693,16 @@ app = FastAPI(
 
 # --- OrionTissue read model / EKG UI ---------------------------------------
 # New home for the "Cognitive EKG" surface (2026-07-28, spark-introspector
-# retirement). Mounted under /spark to match the path convention the old
-# service used, so an operator-level reverse-proxy repoint (spark-
-# introspector's container port -> this service's port for the /spark/*
-# prefix) is the only remaining step outside this repo -- the actual
-# proxy/ingress config that resolved /spark/ui to spark-introspector's
-# container was not found anywhere in this repo (not orion-hub, not deploy/),
-# so it is operator infra this changeset cannot edit directly. See the PR
-# description for the exact repoint this requires.
+# retirement). Routes are UNPREFIXED here on purpose: the operator's
+# Tailscale Serve mount (`/spark -> http://127.0.0.1:8320`) strips the
+# `/spark` prefix before forwarding -- confirmed live via
+# `/spark/spark/ui` returning 200 and `/spark/health` (an existing
+# unprefixed route) already working. Mounting this router under its own
+# `/spark` prefix double-counted that segment and 404'd every request.
+# The frontend (tissue_viz.js, index.html) is unaffected -- it derives
+# WS/fetch URLs from the browser's visible `window.location.pathname`,
+# which still shows the full `/spark/...` path regardless of how the
+# proxy forwards internally.
 spark_router = APIRouter()
 
 
@@ -760,8 +762,8 @@ async def spark_test_pulse() -> Dict[str, Any]:
     return {"status": "broadcast_sent", "payload": payload}
 
 
-app.include_router(spark_router, prefix="/spark")
-app.mount("/spark/static", StaticFiles(directory="app/static"), name="spark_static")
+app.include_router(spark_router)
+app.mount("/static", StaticFiles(directory="app/static"), name="spark_static")
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- The Cognitive EKG routes shipped in #1413 were mounted under an app-internal `/spark` prefix, but the operator's Tailscale Serve mount (`/spark -> 127.0.0.1:8320`) already strips that prefix before forwarding — so every request 404'd inside the app despite the proxy config being correct.
- Confirmed live via the real tailnet URL: `/spark/spark/ui` returned 200 pre-fix (double-prefix survives one strip), `/spark/ui` alone did not, `/spark/health` (already unprefixed) worked fine — proving the strip behavior directly rather than assuming it.
- Fix: `app.include_router(spark_router)` (no prefix) and static mount moved from `/spark/static` to `/static`. Frontend needed no changes — it derives WS/fetch URLs from the browser's visible `window.location.pathname`, which still shows the full `/spark/...` path regardless of backend-internal routing.

## Outcome moved
`/spark/ui`, `/spark/static/tissue_viz.js`, and `/spark/api/tissue/state` all now return 200 through the real Tailscale-fronted URL (verified post-deploy, not just locally). The Cognitive EKG panel in Hub's iframe should render instead of showing `{"detail": "Not Found"}`.

## Files changed
- `services/orion-vector-host/app/main.py`: removed the app-internal `/spark` prefix from route/mount registration.

## Tests run
```
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-vector-host/tests/ -q
9 passed, 1 warning in 0.93s
```

## Docker/build/smoke checks
```
scripts/safe_docker_build.sh orion-vector-host up -d --build   # rebuilt + restarted clean

# Live verification against the real tailnet URL, before and after:
curl https://athena.tail348bbe.ts.net/spark/ui              # 404 -> 200
curl https://athena.tail348bbe.ts.net/spark/static/tissue_viz.js  # 404 -> 200
curl https://athena.tail348bbe.ts.net/spark/api/tissue/state      # 404 -> 200
```

## Review findings fixed
- Reviewed by orion-repo-agent subagent: checked for route collisions (none), stale internal `/spark`-prefixed references elsewhere in the repo (none), and reverse-routing on the renamed static mount (no consumers, safe). No blocking findings. One cosmetic nit (unchanged `name="spark_static"` on the mount) left as-is, not worth the extra diff.

## Restart required
Already deployed and verified live as part of this fix — no further restart needed.

## Risks / concerns
- Severity: low
- Concern: none identified
- Mitigation: n/a