### PR TITLE
fix(hub): bus_synaptic trigger notifier used a schema that doesn't exist

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1714,7 +1714,7 @@ channels:
   - name: "orion:notify:in_app"
     kind: "event"
     schema_id: "HubNotificationEvent"
-    producer_services: ["orion-notify"]
+    producer_services: ["orion-notify", "orion-hub"]
     consumer_services: ["orion-hub"]
     stability: "experimental"
     since: "2026-02-01"

--- a/services/orion-hub/scripts/bus_synaptic_trigger_notifier.py
+++ b/services/orion-hub/scripts/bus_synaptic_trigger_notifier.py
@@ -12,11 +12,29 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+from uuid import uuid4
 
 from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.schemas.notify import HubNotificationEvent
 
 logger = logging.getLogger("orion-hub.bus_synaptic_notifier")
+
+
+def _source_ref() -> ServiceRef:
+    """Build the producer identity from hub settings, with a safe fallback.
+
+    Mirrors bus_publish.py's _source_ref() -- hub settings require the full
+    operator env, so fall back to defaults for import-safety in bare test
+    processes rather than duplicating a shared helper across two unrelated
+    modules.
+    """
+    try:
+        from scripts.settings import settings
+
+        return ServiceRef(name=settings.SERVICE_NAME, version=settings.SERVICE_VERSION, node=settings.NODE_NAME)
+    except Exception:
+        return ServiceRef(name="hub", version="0.3.0", node="athena")
 
 
 class BusSynapticTriggerNotifier:
@@ -114,26 +132,29 @@ class BusSynapticTriggerNotifier:
         reason = payload.get("reason", "")
 
         notification = HubNotificationEvent(
-            kind="info",
+            notification_id=uuid4(),
+            created_at=datetime.now(timezone.utc),
+            severity="warning",
+            event_kind="bus_synaptic.transport_trigger",
+            source_service="orion-hub",
             title="Bus Anomaly Detected",
-            summary=f"Inter-service RPC prediction error: {error_value}",
-            body=(
+            body_text=(
                 f"The bus synaptic transport trigger has fired.\n"
                 f"Prediction error: {error_value}\n"
                 f"This indicates real inter-service RPC anomalies detected via FalkorDB graph analysis.\n"
                 f"Reason: {reason}\n"
                 f"Check orion-equilibrium-service logs for details."
             ),
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            dismissible=True,
-            priority="normal",
+        )
+
+        envelope = BaseEnvelope(
+            kind="notify.in_app.v1",
+            source=_source_ref(),
+            payload=notification.model_dump(mode="json"),
         )
 
         try:
-            await self._bus.publish(
-                self.notify_channel,
-                notification.model_dump(mode="json"),
-            )
+            await self._bus.publish(self.notify_channel, envelope)
             logger.info(
                 "bus_synaptic_trigger_notification published: error=%s",
                 error_value,

--- a/services/orion-hub/tests/test_bus_synaptic_trigger_notifier.py
+++ b/services/orion-hub/tests/test_bus_synaptic_trigger_notifier.py
@@ -1,0 +1,80 @@
+"""Regression test for the bus_synaptic transport trigger notifier.
+
+Prior to this fix, _handle_metacog_trigger built a HubNotificationEvent
+using a stale field vocabulary (kind/summary/body/timestamp/dismissible/
+priority) that never matched the real schema (notification_id/created_at/
+severity/event_kind/source_service/title/body_text), and published the raw
+dict instead of a BaseEnvelope -- so every real trigger raised a 5-field
+pydantic ValidationError and was silently swallowed by the handler's own
+try/except, live in production. This test constructs a real trigger
+payload and asserts the notifier both publishes without raising and
+produces a wire payload that HubNotificationEvent.model_validate() accepts.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.codec import DecodeResult
+from orion.schemas.notify import HubNotificationEvent
+
+from scripts.bus_synaptic_trigger_notifier import BusSynapticTriggerNotifier
+
+
+def _trigger_decode_result() -> DecodeResult:
+    envelope = BaseEnvelope(
+        kind="metacog.trigger.v1",
+        source=ServiceRef(name="orion-equilibrium-service", version="0.1.0", node="athena"),
+        payload={
+            "trigger_kind": "transport",
+            "reason": "bus_synaptic anomaly detected",
+            "upstream": {
+                "evidence_source": "bus_synaptic_prediction_error",
+                "error": 0.87,
+            },
+        },
+    )
+    return DecodeResult(envelope=envelope, raw={}, ok=True)
+
+
+@pytest.mark.asyncio
+async def test_bus_synaptic_trigger_publishes_valid_notification_envelope() -> None:
+    notifier = BusSynapticTriggerNotifier(notify_channel="orion:notify:in_app")
+    notifier._bus = MagicMock()
+    notifier._bus.codec.decode = MagicMock(return_value=_trigger_decode_result())
+    notifier._bus.publish = AsyncMock()
+
+    await notifier._handle_metacog_trigger({"data": b"irrelevant, decode is mocked"})
+
+    notifier._bus.publish.assert_awaited_once()
+    channel, published = notifier._bus.publish.await_args.args
+    assert channel == "orion:notify:in_app"
+    assert isinstance(published, BaseEnvelope)
+
+    # The actual regression check: this used to raise ValidationError with
+    # 5 missing fields for every real trigger.
+    event = HubNotificationEvent.model_validate(published.payload)
+    assert event.event_kind == "bus_synaptic.transport_trigger"
+    assert event.severity == "warning"
+    assert event.source_service == "orion-hub"
+    assert "0.87" in (event.body_text or "")
+
+
+@pytest.mark.asyncio
+async def test_bus_synaptic_trigger_ignores_non_transport_triggers() -> None:
+    notifier = BusSynapticTriggerNotifier(notify_channel="orion:notify:in_app")
+    notifier._bus = MagicMock()
+    envelope = BaseEnvelope(
+        kind="metacog.trigger.v1",
+        source=ServiceRef(name="orion-equilibrium-service", version="0.1.0", node="athena"),
+        payload={"trigger_kind": "reasoning", "upstream": {}},
+    )
+    notifier._bus.codec.decode = MagicMock(return_value=DecodeResult(envelope=envelope, raw={}, ok=True))
+    notifier._bus.publish = AsyncMock()
+
+    await notifier._handle_metacog_trigger({"data": b"irrelevant, decode is mocked"})
+
+    notifier._bus.publish.assert_not_awaited()


### PR DESCRIPTION
## Summary
- `bus_synaptic_trigger_notifier.py` was live-failing every real trigger: `ERROR - bus_synaptic_notifier_handle_failed: 5 validation errors for HubNotificationEvent` (notification_id, created_at, severity, event_kind, source_service all missing).
- Root cause: it built `HubNotificationEvent` with a stale field vocabulary (`kind`/`summary`/`body`/`timestamp`/`dismissible`/`priority`) that doesn't exist on the real schema, and published the raw dict directly instead of wrapping it in a `BaseEnvelope` the way every other real producer of this channel does (`services/orion-notify/app/main.py`).
- Fix: correct field names matching `orion/schemas/notify.py`'s `HubNotificationEvent`, wrap in `BaseEnvelope` per the reference producer pattern, add a local `_source_ref()` helper mirroring `bus_publish.py`'s.
- Also fixed a pre-existing doc gap found along the way: `channels.yaml` didn't list `orion-hub` as a producer of `orion:notify:in_app` even though this notifier always has been.

## Outcome moved
Every real bus_synaptic transport anomaly trigger will now actually produce an in-app notification instead of silently raising and being swallowed by the handler's own try/except.

## Files changed
- `services/orion-hub/scripts/bus_synaptic_trigger_notifier.py`: fixed schema field mapping, added envelope wrapping.
- `services/orion-hub/tests/test_bus_synaptic_trigger_notifier.py`: new regression test (didn't exist before).
- `orion/bus/channels.yaml`: added `orion-hub` to `orion:notify:in_app`'s `producer_services`.

## Tests run
```
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-hub/tests/test_bus_synaptic_trigger_notifier.py -q
2 passed, 14 warnings in 2.50s
python -m py_compile services/orion-hub/scripts/bus_synaptic_trigger_notifier.py   # clean
```

## Docker/build/smoke checks
```
scripts/safe_docker_build.sh orion-hub up -d --build   # rebuilt + restarted clean
docker logs orion-athena-hub --since 20s  # notifier subscribed cleanly, no errors
curl http://localhost:8080/health  # {"status":"ok","service":"hub"}
```
Real trigger firing depends on a live bus_synaptic anomaly (not something to force safely in production) — correctness is verified via the regression test constructing the actual production payload shape plus a clean deploy with no startup errors.

## Review findings fixed
- Reviewed by orion-repo-agent subagent: verified severity/event_kind/source_service values against real conventions elsewhere in the repo (not invented), verified the test mirrors the true production call shape (DecodeResult/BaseEnvelope construction cross-checked against orion/core/bus/codec.py and the real instantiation site in main.py), confirmed the one real consumer (notification_cache.py) expects exactly what this now publishes, confirmed no other call sites need updating. One suggested follow-up (channels.yaml producer_services gap) applied in this same PR.

## Restart required
Already deployed and verified live as part of this fix — no further restart needed.

## Risks / concerns
- Severity: low
- Concern: real-trigger end-to-end verification depends on a live anomaly firing, not directly forced in this session
- Mitigation: regression test exercises the exact production payload shape and schema validation that was failing; deploy confirmed clean with no startup errors