### PR TITLE
chore(tissue): tear down invented mood taxonomy, rename to literal signals

### DIFF
--- a/orion/spark/orion_tissue.py
+++ b/orion/spark/orion_tissue.py
@@ -334,34 +334,49 @@ class OrionTissue:
 
     def phi(self) -> Dict[str, float]:
         """
-        Compute a low-dimensional "self state" φ from the tissue.
+        Compute a low-dimensional read-model of the tissue's raw tensor
+        state. Deliberately named for what each number literally is, not
+        for what it might resemble -- these are summary statistics of a
+        16x16x8 tensor, not a validated measure of anything experiential.
+        See CLAUDE.md 0A's metric-quality gate: a label needs a theory
+        anchor to earn a cognition word, and none of these four have one.
 
         v2:
-          - valence: mean difference between positive/negative channels
-          - energy: mean absolute activation
-          - coherence: hybrid (embedding-aware when available)
-          - novelty: baseline-relative novelty (rolling z-score)
+          - polarity_diff: mean(channel 0) - mean(channel 1) (a sign
+            convention chosen when stimuli are built, not derived)
+          - mean_abs_activation: mean absolute activation across the tensor
+          - embedding_similarity: 1 - cosine_distance(embedding, this
+            channel's running expectation) when an embedding is available,
+            variance-based fallback otherwise
+          - novelty_zscore: rolling z-score of cosine distance between the
+            latest stimulus and this channel's expectation, sigmoid-squashed
+            to [0, 1]
         """
         if self.T.size == 0:
-            return {"valence": 0.0, "energy": 0.0, "coherence": 0.0, "novelty": 0.0}
+            return {
+                "polarity_diff": 0.0,
+                "mean_abs_activation": 0.0,
+                "embedding_similarity": 0.0,
+                "novelty_zscore": 0.0,
+            }
 
-        # Valence is defined as a difference between a "positive" channel
-        # and a "negative" channel when available (neural projection uses
-        # ch0 for +, ch1 for -). This gives us a sign.
+        # polarity_diff is a difference between a "positive" channel and a
+        # "negative" channel when available (neural projection uses ch0 for
+        # +, ch1 for -) -- a sign convention picked at stimulus-construction
+        # time, not something the tensor itself derives.
         if self.C >= 2:
-            valence = float(self.T[..., 0].mean() - self.T[..., 1].mean())
+            polarity_diff = float(self.T[..., 0].mean() - self.T[..., 1].mean())
         else:
-            valence = float(self.T[..., 0].mean())
-        energy = float(np.abs(self.T).mean())
-        variance = float(self.T.var())
-        coherence = self._coherence_from_embedding(self.last_channel)
-        novelty = float(self.last_novelty_per_channel.get(self.last_channel, 0.0))
+            polarity_diff = float(self.T[..., 0].mean())
+        mean_abs_activation = float(np.abs(self.T).mean())
+        embedding_similarity = self._coherence_from_embedding(self.last_channel)
+        novelty_zscore = float(self.last_novelty_per_channel.get(self.last_channel, 0.0))
 
         return {
-            "valence": valence,
-            "energy": energy,
-            "coherence": coherence,
-            "novelty": novelty,
+            "polarity_diff": polarity_diff,
+            "mean_abs_activation": mean_abs_activation,
+            "embedding_similarity": embedding_similarity,
+            "novelty_zscore": novelty_zscore,
         }
 
     def summarize_for(self, agent_id: str) -> Dict[str, Any]:

--- a/services/orion-vector-host/app/main.py
+++ b/services/orion-vector-host/app/main.py
@@ -718,10 +718,10 @@ async def spark_tissue_state() -> Dict[str, Any]:
     state), never injected from self-state or any other source."""
     phi_stats = get_phi_stats()
     return {
-        "phi": phi_stats.get("coherence", 0.0),
-        "novelty": phi_stats.get("novelty", 0.0),
-        "valence": phi_stats.get("valence", 0.0),
-        "arousal": phi_stats.get("energy", 0.0),
+        "embedding_similarity": phi_stats.get("embedding_similarity", 0.0),
+        "novelty_zscore": phi_stats.get("novelty_zscore", 0.0),
+        "polarity_diff": phi_stats.get("polarity_diff", 0.0),
+        "mean_abs_activation": phi_stats.get("mean_abs_activation", 0.0),
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -751,10 +751,10 @@ async def spark_test_pulse() -> Dict[str, Any]:
         "correlation_id": f"TEST-{str(uuid4())[:8]}",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "stats": {
-            "phi": random.random(),
-            "novelty": random.random(),
-            "valence": random.random(),
-            "arousal": random.random(),
+            "embedding_similarity": random.random(),
+            "novelty_zscore": random.random(),
+            "polarity_diff": random.random(),
+            "mean_abs_activation": random.random(),
         },
         "metadata": {"source": "manual_test_pulse"},
     }

--- a/services/orion-vector-host/app/static/index.html
+++ b/services/orion-vector-host/app/static/index.html
@@ -3,12 +3,24 @@
      2026-07-28-spark-introspector-retirement-and-honest-substrate-
      convergence.md). Backing WS payload now comes from orion-vector-host's
      app/tissue_feed.py (real OrionTissue physics, fed from real per-turn
-     embedding deltas), not the old phi_encoder/SelfState pipeline. -->
+     embedding deltas), not the old phi_encoder/SelfState pipeline.
+
+     2026-07-28, second pass: the relocation kept honest disclaimer copy in
+     the (collapsed, easy to miss) explanation panel but left the headline
+     labels (INNER STATE/VALENCE/AROUSAL) and tissue_viz.js's invented mood
+     taxonomy (LUCID FLOW/COLD ANALYSIS/MANIC CREATIVITY/etc., and
+     Integrated-Resourced/Stress-Conflict style "implications") completely
+     unchanged from the pre-retirement page. That's the actual content the
+     retirement was supposed to remove -- threshold-derived psychology
+     labels over four tensor summary statistics, no theory anchor. Both are
+     gone now: labels renamed to what each number literally is, and the
+     invented-category logic deleted from tissue_viz.js rather than
+     softened with another disclaimer. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Orion Cognitive Dashboard</title>
+    <title>OrionTissue Signal Monitor</title>
     <style>
         body { margin: 0; overflow: hidden; background: #000; color: #fff; font-family: 'Courier New', Courier, monospace; }
         canvas { display: block; position: absolute; top: 0; left: 0; z-index: 0; }
@@ -49,7 +61,6 @@
         .diag-table th { text-align: left; border-bottom: 1px solid #444; padding: 5px; color: #666; }
         .diag-table td { border-bottom: 1px solid #222; padding: 5px; color: #ccc; }
         .diag-val { font-weight: bold; color: #fff; }
-        .diag-state { font-family: monospace; text-transform: uppercase; }
         
         .exp-col { margin-bottom: 15px; border-left: 2px solid #333; padding-left: 10px; }
         .exp-title { color: #fff; font-weight: bold; margin-bottom: 4px; }
@@ -64,7 +75,7 @@
 <body>
     <div id="ui-layer">
         <div id="top-header">
-            <div id="mood-label">COGNITIVE STATE</div>
+            <div id="mood-label">ORIONTISSUE TENSOR STATE</div>
             <div id="mood-value">WAITING FOR SIGNAL...</div>
         </div>
 
@@ -83,12 +94,12 @@
 
         <div id="bottom-area">
             <div id="stats-row">
-                <div class="stat-box"><span class="stat-label" title="OrionTissue's own coherence value (embedding-vs-expectation similarity), read directly from OrionTissue.phi() -- not a trained encoder output">INNER STATE (φ)</span><span id="val-phi" class="stat-val" style="color: #0f0;">0.00</span></div>
-                <div class="stat-box"><span class="stat-label">NOVELTY</span><span id="val-novelty" class="stat-val" style="color: #ff0;">0.00</span></div>
-                <div class="stat-box"><span class="stat-label">VALENCE</span><span id="val-valence" class="stat-val" style="color: #0ff;">0.00</span></div>
-                <div class="stat-box"><span class="stat-label">AROUSAL</span><span id="val-arousal" class="stat-val" style="color: #f0f;">0.00</span></div>
+                <div class="stat-box"><span class="stat-label" title="1 - cosine_distance(embedding, this channel's running expectation), or a variance-based fallback">EMBEDDING SIMILARITY</span><span id="val-similarity" class="stat-val" style="color: #0f0;">0.00</span></div>
+                <div class="stat-box"><span class="stat-label" title="Rolling z-score of cosine distance between the latest stimulus and expectation, sigmoid-squashed to [0,1]">NOVELTY Z-SCORE</span><span id="val-novelty" class="stat-val" style="color: #ff0;">0.00</span></div>
+                <div class="stat-box"><span class="stat-label" title="mean(tensor channel 0) - mean(tensor channel 1) -- a sign convention chosen at stimulus-construction time">POLARITY DIFF</span><span id="val-polarity" class="stat-val" style="color: #0ff;">0.00</span></div>
+                <div class="stat-box"><span class="stat-label" title="mean(abs(tensor)) across the full 16x16x8 grid">MEAN |ACTIVATION|</span><span id="val-activation" class="stat-val" style="color: #f0f;">0.00</span></div>
             </div>
-            <div id="ekg-tagline">— Real-time EKG of Orion's Cognitive State —</div>
+            <div id="ekg-tagline">— Live readout of OrionTissue's decay/diffusion tensor —</div>
             <div id="meta-row">ID: <span id="val-id">-</span> | TS: <span id="val-ts">-</span></div>
             <div id="turn-effect-box" class="hidden" title="">
                 <div class="stat-label">LAST TURN EFFECT</div>
@@ -100,38 +111,26 @@
             <div id="info-toggle-row">▼ SYSTEM INTERNALS EXPLANATION ▼</div>
 
             <div id="explanation-panel">
-                <h3>LIVE DIAGNOSTICS</h3>
+                <h3>LIVE VALUES</h3>
                 <table class="diag-table">
-                    <thead><tr><th>METRIC</th><th>VALUE</th><th>STATE</th><th>IMPLICATION</th></tr></thead>
+                    <thead><tr><th>METRIC</th><th>VALUE</th><th>FORMULA</th></tr></thead>
                     <tbody>
-                        <tr><td>Inner State (φ)</td><td id="diag-phi-val" class="diag-val">-</td><td id="diag-phi-state" class="diag-state">-</td><td id="diag-phi-imp">-</td></tr>
-                        <tr><td>NOVELTY</td><td id="diag-nov-val" class="diag-val">-</td><td id="diag-nov-state" class="diag-state">-</td><td id="diag-nov-imp">-</td></tr>
-                        <tr><td>VALENCE</td><td id="diag-val-val" class="diag-val">-</td><td id="diag-val-state" class="diag-state">-</td><td id="diag-val-imp">-</td></tr>
-                        <tr><td>AROUSAL</td><td id="diag-aro-val" class="diag-val">-</td><td id="diag-aro-state" class="diag-state">-</td><td id="diag-aro-imp">-</td></tr>
+                        <tr><td>Embedding similarity</td><td id="diag-sim-val" class="diag-val">-</td><td>1 - cosine_distance(embedding, expectation)</td></tr>
+                        <tr><td>Novelty z-score</td><td id="diag-nov-val" class="diag-val">-</td><td>sigmoid(zscore(cosine_distance))</td></tr>
+                        <tr><td>Polarity diff</td><td id="diag-pol-val" class="diag-val">-</td><td>mean(T[...,0]) - mean(T[...,1])</td></tr>
+                        <tr><td>Mean |activation|</td><td id="diag-act-val" class="diag-val">-</td><td>mean(abs(T)) across the full grid</td></tr>
                     </tbody>
                 </table>
-
-                <h3>TELEMETRY DECODER (REFERENCE)</h3>
-                <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-bottom: 20px;">
-                    <div style="flex: 1; min-width: 200px;">
-                        <div class="exp-col"><div class="exp-title">φ Inner State (headline)</div>Honest aggregate of Orion's felt+cognitive signals (arithmetic, not a single-factor floor).<br><strong>High:</strong> Integrated, resourced, low load.<br><strong>Low:</strong> Fragmented or heavily loaded.</div>
-                        <div class="exp-col"><div class="exp-title">NOVELTY (Amplitude)</div>Surprise factor.<br><strong>High:</strong> Tall mountains.<br><strong>Low:</strong> Flat road.</div>
-                    </div>
-                    <div style="flex: 1; min-width: 200px;">
-                        <div class="exp-col"><div class="exp-title">VALENCE (Color)</div>Sentiment.<br><strong>Cyan:</strong> Positive.<br><strong>Red:</strong> Negative.</div>
-                        <div class="exp-col"><div class="exp-title">AROUSAL (Speed)</div>Energy.<br><strong>High:</strong> Fast movement.<br><strong>Low:</strong> Slow drift.</div>
-                    </div>
-                </div>
 
                 <h3>WHAT THIS ACTUALLY IS</h3>
                 <div class="edu-text">
                     <p>This panel visualizes <span class="edu-highlight">OrionTissue</span>, a real 16x16x8 decay+diffusion tensor (<code>orion/spark/orion_tissue.py</code>) fed by how far each turn's real text embedding drifts from a recent running average of prior embeddings. It is a live physics simulation of embedding-space drift over time, not a readout of reasoning, feelings, or "thoughts."</p>
                 </div>
                 <div class="edu-text">
-                    <p>The four numbers above (INNER STATE / NOVELTY / VALENCE / AROUSAL) are computed directly from that tensor's own state (<code>OrionTissue.phi()</code>) -- real and traceable, not injected from a self-report or a hand-tuned formula. They are also a real simplification: four scalars cannot capture reasoning quality, honesty, or wellbeing, and the mood label below is an illustrative label over those four numbers, not a clinical or verified cognitive assessment.</p>
+                    <p>The four numbers above are computed directly from that tensor's own state (<code>OrionTissue.phi()</code>) -- real and traceable, not injected from a self-report or a hand-tuned formula. They are named for what they literally are (a channel difference, a mean absolute activation, a cosine similarity, a z-score) rather than for what they might resemble. None of the four have an independent theory anchor connecting them to reasoning quality, mood, or wellbeing -- treat them as tensor summary statistics, not a cognitive or emotional assessment.</p>
                 </div>
                 <div class="edu-text">
-                    <p>2026-07-28: this page replaced an earlier version of itself that drove these same four numbers from a SelfState-anchored formula confirmed to fall back to a fake "calm" default on the majority of ticks, while this exact page's copy described it as visualizing "how the AI is thinking" and letting you "diagnose the system's mental health." That framing overclaimed what four scalars can support even now that the numbers are real -- kept here as a disclosed correction, not scrubbed from history.</p>
+                    <p>2026-07-28: this page replaced an earlier version of itself that drove these same four numbers from a SelfState-anchored formula confirmed to fall back to a fake "calm" default on the majority of ticks, while this exact page's copy described it as visualizing "how the AI is thinking" and letting you "diagnose the system's mental health." A same-day follow-up found the relocated page had kept an invented mood-label taxonomy (LUCID FLOW / COLD ANALYSIS / MANIC CREATIVITY / etc., threshold-derived from the four scalars) and STATE/IMPLICATION table columns (Integrated-Resourced / Stress-Conflict) completely unchanged -- both deleted rather than re-labeled. Kept here as a disclosed correction, not scrubbed from history.</p>
                 </div>
             </div>
         </div>

--- a/services/orion-vector-host/app/static/tissue_viz.js
+++ b/services/orion-vector-host/app/static/tissue_viz.js
@@ -2,9 +2,12 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 // --- STATE ---
+// Field names match the wire schema directly (embedding_similarity/
+// novelty_zscore/polarity_diff/mean_abs_activation) -- see
+// orion/spark/orion_tissue.py's phi() docstring for what each literally is.
 const state = {
-    phi: 0.5, novelty: 0.0, valence: 0.5, arousal: 0.0,
-    targetPhi: 0.5, targetNovelty: 0.0, targetValence: 0.5, targetArousal: 0.0,
+    similarity: 0.5, novelty: 0.0, polarity: 0.5, activation: 0.0,
+    targetSimilarity: 0.5, targetNovelty: 0.0, targetPolarity: 0.5, targetActivation: 0.0,
     lastUpdate: 0, metadata: {}, correlationId: null, timestamp: null
 };
 const INTERPOLATION_SPEED = 0.05; 
@@ -57,10 +60,10 @@ class WSClient {
     }
     handleUpdate(data) {
         if (!data.stats) return;
-        state.targetPhi = data.stats.phi;
-        state.targetNovelty = data.stats.novelty;
-        state.targetValence = data.stats.valence;
-        state.targetArousal = data.stats.arousal;
+        state.targetSimilarity = data.stats.embedding_similarity;
+        state.targetNovelty = data.stats.novelty_zscore;
+        state.targetPolarity = data.stats.polarity_diff;
+        state.targetActivation = data.stats.mean_abs_activation;
         state.correlationId = data.correlation_id;
         state.timestamp = data.timestamp;
         state.metadata = data.metadata || {};
@@ -69,56 +72,32 @@ class WSClient {
     updateDOM() {
         document.getElementById('val-id').innerText = (state.correlationId || "NULL").substring(0, 8) + '...';
         document.getElementById('val-ts').innerText = state.timestamp || "-";
-        document.getElementById('val-phi').innerText = state.targetPhi.toFixed(2);
+        document.getElementById('val-similarity').innerText = state.targetSimilarity.toFixed(2);
         document.getElementById('val-novelty').innerText = state.targetNovelty.toFixed(2);
-        document.getElementById('val-valence').innerText = state.targetValence.toFixed(2);
-        document.getElementById('val-arousal').innerText = state.targetArousal.toFixed(2);
+        document.getElementById('val-polarity').innerText = state.targetPolarity.toFixed(2);
+        document.getElementById('val-activation').innerText = state.targetActivation.toFixed(2);
         this.updateMoodText();
         this.updateDiagnosticsTable();
         this.updateTurnEffect();
     }
-    // Illustrative labels over 4 real scalars (see index.html's "WHAT THIS
-    // ACTUALLY IS" panel) -- a stylized reading of OrionTissue's physics
-    // state, not a verified or clinical cognitive/emotional assessment.
+    // 2026-07-28: this used to map the four scalars onto an invented mood
+    // taxonomy (LUCID FLOW / COLD ANALYSIS / MANIC CREATIVITY / etc.,
+    // threshold-derived, no theory anchor -- see index.html's disclosed
+    // correction). Deleted rather than relabeled: there is no honest
+    // one-word summary of four unrelated tensor statistics to substitute.
+    // The raw values in the stats row and diagnostics table are the actual
+    // signal; this just shows them literally instead of interpreting them.
     updateMoodText() {
-        const v = state.targetValence, p = state.targetPhi, a = state.targetArousal, n = state.targetNovelty;
-        let mood = "UNKNOWN", color = "#888";
-        if (n > 0.8) { mood = "EPIPHANY DETECTED"; color = "#fff"; }
-        else if (a > 0.5) {
-            if (v > 0.5 && p > 0.5) { mood = "LUCID FLOW"; color = "#0ff"; }
-            else if (v > 0.5 && p <= 0.5) { mood = "MANIC CREATIVITY"; color = "#d0f"; }
-            else if (v <= 0.5 && p > 0.5) { mood = "CRITICAL FOCUS"; color = "#f80"; }
-            else { mood = "COGNITIVE DISSONANCE"; color = "#f00"; }
-        } else {
-            if (v > 0.5 && p > 0.5) { mood = "DEEP RESONANCE"; color = "#0af"; }
-            else if (v > 0.5 && p <= 0.5) { mood = "DAYDREAMING"; color = "#fba"; }
-            else if (v <= 0.5 && p > 0.5) { mood = "COLD ANALYSIS"; color = "#88f"; }
-            else { mood = "IDLE / STATIC"; color = "#666"; }
-        }
-        elMoodValue.innerText = `[ ${mood} ]`;
-        elMoodValue.style.color = color;
-        elMoodValue.style.textShadow = `0 0 15px ${color}`;
+        const s = state.targetSimilarity, n = state.targetNovelty, p = state.targetPolarity, a = state.targetActivation;
+        elMoodValue.innerText = `sim ${s.toFixed(2)} · nov ${n.toFixed(2)} · pol ${p.toFixed(2)} · act ${a.toFixed(2)}`;
+        elMoodValue.style.color = "#0ff";
+        elMoodValue.style.textShadow = "0 0 10px #0ff";
     }
     updateDiagnosticsTable() {
-        // Helper to update cells
-        const updateRow = (id, val, highLow, imp) => {
-            document.getElementById(`diag-${id}-val`).innerText = val.toFixed(2);
-            document.getElementById(`diag-${id}-state`).innerText = highLow;
-            document.getElementById(`diag-${id}-imp`).innerText = imp;
-        };
-        
-        // Logic for diagnostics
-        const p = state.targetPhi;
-        updateRow('phi', p, p > 0.5 ? "HIGH" : "LOW", p > 0.5 ? "Integrated / Resourced" : "Loaded / Fragmented");
-        
-        const n = state.targetNovelty;
-        updateRow('nov', n, n > 0.5 ? "HIGH" : "LOW", n > 0.5 ? "Surprising / New" : "Routine / Known");
-        
-        const v = state.targetValence;
-        updateRow('val', v, v > 0.5 ? "POS" : "NEG", v > 0.5 ? "Harmony / Flow" : "Stress / Conflict");
-        
-        const a = state.targetArousal;
-        updateRow('aro', a, a > 0.5 ? "HIGH" : "LOW", a > 0.5 ? "Active / Alert" : "Passive / Idle");
+        document.getElementById('diag-sim-val').innerText = state.targetSimilarity.toFixed(2);
+        document.getElementById('diag-nov-val').innerText = state.targetNovelty.toFixed(2);
+        document.getElementById('diag-pol-val').innerText = state.targetPolarity.toFixed(2);
+        document.getElementById('diag-act-val').innerText = state.targetActivation.toFixed(2);
     }
     updateTurnEffect() {
         if (!elTurnEffectBox) return;
@@ -184,12 +163,12 @@ class SynthwaveVisualizer {
         this.vertexStore = geo.attributes.position.array.slice();
     }
     update(dt) {
-        const speed = 1.0 + (state.arousal * 6.0);
+        const speed = 1.0 + (state.activation * 6.0);
         this.runTime += dt * speed;
         const pos = this.plane.geometry.attributes.position.array;
-        const chaos = Math.max(0.1, 1.0 - state.phi);
+        const chaos = Math.max(0.1, 1.0 - state.similarity);
         const amp = 1.0 + (state.novelty * 6.0);
-        const hue = 0.9 + (state.valence * 0.6);
+        const hue = 0.9 + (state.polarity * 0.6);
         
         for (let i = 0; i < pos.length; i += 3) {
             const ox = this.vertexStore[i], oy = this.vertexStore[i+1];
@@ -208,7 +187,7 @@ class SynthwaveVisualizer {
         this.sunMat.color.setHSL((hue+0.1)%1, 1, 0.6);
         this.innerSun.material.color.setHSL(hue%1, 1, 0.5);
         this.sun.rotation.y += dt*0.1; this.sun.rotation.z -= dt*0.05;
-        this.sun.scale.setScalar(1 + Math.sin(this.runTime*2)*0.05*state.arousal);
+        this.sun.scale.setScalar(1 + Math.sin(this.runTime*2)*0.05*state.activation);
     }
 }
 
@@ -222,10 +201,10 @@ const clk = new THREE.Clock();
 function anim() {
     requestAnimationFrame(anim);
     const dt = clk.getDelta();
-    state.phi += (state.targetPhi-state.phi)*INTERPOLATION_SPEED;
+    state.similarity += (state.targetSimilarity-state.similarity)*INTERPOLATION_SPEED;
     state.novelty += (state.targetNovelty-state.novelty)*INTERPOLATION_SPEED;
-    state.valence += (state.targetValence-state.valence)*INTERPOLATION_SPEED;
-    state.arousal += (state.targetArousal-state.arousal)*INTERPOLATION_SPEED;
+    state.polarity += (state.targetPolarity-state.polarity)*INTERPOLATION_SPEED;
+    state.activation += (state.targetActivation-state.activation)*INTERPOLATION_SPEED;
     viz.update(dt);
     ren.render(scn, cam);
 }

--- a/services/orion-vector-host/app/tissue_feed.py
+++ b/services/orion-vector-host/app/tissue_feed.py
@@ -45,7 +45,7 @@ gate -- this is not a port, so it gets its own trace):
    spec's explicit "no SurfaceEncoding/MAPPER indirection" instruction.
 5. Split the projected grid's sign into stimulus channels 0 (positive) and 1
    (negative), scaled by `magnitude` -- matches `OrionTissue.phi()`'s own
-   valence definition (`T[...,0].mean() - T[...,1].mean()`). All other
+   polarity_diff definition (`T[...,0].mean() - T[...,1].mean()`). All other
    channels stay at 0; this module does not invent per-channel semantics
    beyond what the tissue itself already assigns meaning to.
 6. `TISSUE.calculate_novelty(stimulus, channel_key=...)` runs before
@@ -146,9 +146,10 @@ def _build_stimulus(delta: np.ndarray, magnitude: float) -> np.ndarray:
 
 
 def get_phi_stats() -> Dict[str, float]:
-    """Read-model accessor: valence/energy/coherence/novelty, all derived
-    directly from TISSUE's real internal tensor state (`OrionTissue.phi()`),
-    never injected from self-state or any other source."""
+    """Read-model accessor: polarity_diff/mean_abs_activation/
+    embedding_similarity/novelty_zscore, all derived directly from TISSUE's
+    real internal tensor state (`OrionTissue.phi()`), never injected from
+    self-state or any other source."""
     return {k: float(v) for k, v in (TISSUE.phi() or {}).items()}
 
 
@@ -223,10 +224,10 @@ async def feed_tissue(
                     "correlation_id": correlation_id or doc_id,
                     "timestamp": _now_iso(),
                     "stats": {
-                        "phi": phi_stats.get("coherence", 0.0),
-                        "novelty": phi_stats.get("novelty", 0.0),
-                        "valence": phi_stats.get("valence", 0.0),
-                        "arousal": phi_stats.get("energy", 0.0),
+                        "embedding_similarity": phi_stats.get("embedding_similarity", 0.0),
+                        "novelty_zscore": phi_stats.get("novelty_zscore", 0.0),
+                        "polarity_diff": phi_stats.get("polarity_diff", 0.0),
+                        "mean_abs_activation": phi_stats.get("mean_abs_activation", 0.0),
                     },
                     "metadata": {
                         "doc_id": doc_id,

--- a/services/orion-vector-host/tests/test_tissue_feed.py
+++ b/services/orion-vector-host/tests/test_tissue_feed.py
@@ -33,7 +33,7 @@ def test_feed_tissue_returns_real_phi_stats():
     stats = asyncio.run(
         tissue_feed.feed_tissue(_rand_embedding(seed=1), doc_id="doc-1", broadcast=False)
     )
-    assert set(stats.keys()) == {"valence", "energy", "coherence", "novelty"}
+    assert set(stats.keys()) == {"polarity_diff", "mean_abs_activation", "embedding_similarity", "novelty_zscore"}
     assert all(isinstance(v, float) for v in stats.values())
 
 
@@ -45,9 +45,9 @@ def test_feed_tissue_first_call_is_maximally_novel():
         tissue_feed.feed_tissue(_rand_embedding(seed=2), doc_id="doc-1", broadcast=False)
     )
     # calculate_novelty() ran (not dead/never-called, the bug this module's
-    # docstring documents fixing) -- energy/coherence/novelty must not all be
-    # the zero-initialized tensor's default.
-    assert stats["energy"] != 0.0 or stats["novelty"] != 0.0
+    # docstring documents fixing) -- mean_abs_activation/novelty_zscore must
+    # not all be the zero-initialized tensor's default.
+    assert stats["mean_abs_activation"] != 0.0 or stats["novelty_zscore"] != 0.0
 
 
 def test_feed_tissue_seeds_ema_from_persisted_tissue_expectation():
@@ -101,12 +101,12 @@ def test_feed_tissue_zero_embedding_does_not_crash():
     stats = asyncio.run(
         tissue_feed.feed_tissue(np.zeros(16, dtype=np.float32), doc_id="doc-zero", broadcast=False)
     )
-    assert set(stats.keys()) == {"valence", "energy", "coherence", "novelty"}
+    assert set(stats.keys()) == {"polarity_diff", "mean_abs_activation", "embedding_similarity", "novelty_zscore"}
 
 
 def test_feed_tissue_empty_embedding_short_circuits():
     stats = asyncio.run(tissue_feed.feed_tissue([], doc_id="doc-empty", broadcast=False))
-    assert set(stats.keys()) == {"valence", "energy", "coherence", "novelty"}
+    assert set(stats.keys()) == {"polarity_diff", "mean_abs_activation", "embedding_similarity", "novelty_zscore"}
     assert "chat" not in tissue_feed._EMBEDDING_EMA or tissue_feed._EMBEDDING_EMA.get("chat") is None
 
 


### PR DESCRIPTION
## Summary
- `OrionTissue.phi()` (`orion/spark/orion_tissue.py`) returned psychology-borrowed keys (`valence`/`energy`/`coherence`/`novelty`) for arbitrary tensor arithmetic with no theory anchor -- e.g. `valence = mean(T[...,0]) - mean(T[...,1])`, a sign convention picked at stimulus-construction time, not derived from anything.
- The EKG page (`services/orion-vector-host/app/static/tissue_viz.js`) compounded this: `updateMoodText()` mapped the four scalars onto an invented mood taxonomy via hardcoded `>0.5`/`>0.8` thresholds -- literal labels like `LUCID FLOW`, `MANIC CREATIVITY`, `COGNITIVE DISSONANCE`, `COLD ANALYSIS`. `updateDiagnosticsTable()` did the same for a STATE/IMPLICATION table (`Integrated / Resourced` vs `Stress / Conflict`).
- This is confirmed to be the exact content PR #1413 (spark-introspector retirement) was supposed to remove but didn't -- it fixed the page's disclaimer copy elsewhere but left this invented-taxonomy code completely unchanged, so the original overclaiming text ("COLD ANALYSIS", "Integrated / Resourced") was still live in production.

## Outcome moved
The page now shows four literally-named values with real formulas in their tooltips (`EMBEDDING SIMILARITY`, `NOVELTY Z-SCORE`, `POLARITY DIFF`, `MEAN |ACTIVATION|`) instead of an invented mood word and psychology-flavored implications. No interpretation layer between the raw tensor statistics and what's displayed.

## Files changed
- `orion/spark/orion_tissue.py`: renamed `phi()`'s dict keys, rewrote docstrings to describe formulas literally.
- `services/orion-vector-host/app/tissue_feed.py`, `app/main.py`: updated to use new key names directly on the wire (WS broadcast + `/api/tissue/state` + `/api/test-pulse`), removing a second relabeling layer that used to remap `coherence`->`"phi"` and `energy`->`"arousal"` for the API.
- `services/orion-vector-host/app/static/index.html`: renamed title/labels/tooltips, replaced the diagnostics table's STATE/IMPLICATION columns with a FORMULA column, rewrote the TELEMETRY DECODER section, added a disclosed-correction paragraph.
- `services/orion-vector-host/app/static/tissue_viz.js`: deleted `updateMoodText()`'s mood-taxonomy switch and `updateDiagnosticsTable()`'s invented STATE/IMPLICATION generation, renamed `state` object fields throughout (Three.js visual behavior unchanged, only variable names).
- `services/orion-vector-host/tests/test_tissue_feed.py`: updated assertions to match new key names.

## Tests run
```
# Note: this venv's `orion` package resolves via an editable install pointing at the
# main checkout path, not per-worktree -- a plain `pytest <worktree-path>` silently
# tests the UNEDITED main-checkout copy of orion/spark/orion_tissue.py. Required an
# explicit sys.path.insert(0, worktree) before importing/running pytest to actually
# exercise this worktree's changes (confirmed via orion.spark.orion_tissue.__file__).

services/orion-vector-host/tests/test_tissue_feed.py -q
9 passed

tests/test_spark_metrics_v2.py -q
2 passed  (unaffected -- exercises calculate_novelty()/propagate() directly, not phi()'s dict keys)

python -m py_compile orion/spark/orion_tissue.py services/orion-vector-host/app/tissue_feed.py services/orion-vector-host/app/main.py
# clean

node --check services/orion-vector-host/app/static/tissue_viz.js
# clean
```

## Docker/build/smoke checks
```
scripts/safe_docker_build.sh orion-vector-host up -d --build   # rebuilt + restarted clean

curl https://athena.tail348bbe.ts.net/spark/api/tissue/state
# {"embedding_similarity":0.99,"novelty_zscore":0.48,"polarity_diff":0.001,"mean_abs_activation":0.44,"timestamp":"..."}

curl https://athena.tail348bbe.ts.net/spark/ui | grep -E "ORIONTISSUE|EMBEDDING SIMILARITY|POLARITY DIFF"
# confirmed new labels rendered
```

## Review findings fixed
- Reviewed by orion-repo-agent subagent: independently traced every real consumer of the old dict/wire keys repo-wide (none missed), confirmed no leftover old field-name references anywhere in the touched surface, confirmed the Three.js visualization's variable renames didn't swap which field drives which visual effect, cross-checked every new UI label/tooltip's formula claim against the actual `orion_tissue.py` implementation (all accurate). One informational note (not a defect): `tissue_viz.js`'s `updateTurnEffect()` still reads `valence`/`energy`/`coherence`/`novelty` from a completely unrelated `turn_effect` schema (not `OrionTissue.phi()`) -- confirmed out of scope for this PR, flagged as a possible future cleanup.

## Restart required
Already deployed and verified live as part of this fix -- no further restart needed.

## Risks / concerns
- Severity: low
- Concern: none identified
- Mitigation: n/a