### PR TITLE
docs(topic-foundry): fix wrong LLM route example, document the silent default-lane fallback

### DIFF
--- a/services/orion-topic-foundry/README.md
+++ b/services/orion-topic-foundry/README.md
@@ -166,9 +166,9 @@ Example (truncated, representative):
   "service": "orion-topic-foundry",
   "version": "0.1.0",
   "node": "...",
-  "llm_enabled": false,
+  "llm_enabled": true,
   "llm_transport": "bus",
-  "llm_bus_route": "LLMGatewayService",
+  "llm_bus_route": "",
   "llm_intake_channel": "orion:exec:request:LLMGatewayService",
   "llm_reply_prefix": "orion:llm:reply",
   "segmentation_modes_supported": ["time_gap", "semantic", "hybrid", "llm_judge", "hybrid_llm"],
@@ -180,7 +180,7 @@ Example (truncated, representative):
     "embedding_source_url": "http://orion-vector-host:8320/embedding",
     "metric": "cosine",
     "min_cluster_size": 15,
-    "llm_bus_route": "LLMGatewayService"
+    "llm_bus_route": ""
   },
   "introspection": {
     "ok": true,
@@ -205,6 +205,29 @@ LLM path is considered usable when:
 1. `TOPIC_FOUNDRY_LLM_ENABLE=true` (feature enabled), and
 2. `TOPIC_FOUNDRY_LLM_USE_BUS=true` and `ORION_BUS_ENABLED=true` (transport resolves to bus).
 
+**`TOPIC_FOUNDRY_LLM_BUS_ROUTE` is a route *key* into `orion-llm-gateway`'s route table**
+(`LLM_GATEWAY_ROUTE_TABLE_JSON`, e.g. `chat`/`agent`/`metacog`/`quick` — check that gateway's
+own live env for the current real keys, they're operator-configured and can change). It is
+**not** the intake channel name — `TOPIC_FOUNDRY_LLM_INTAKE_CHANNEL` (set separately, below)
+is what carries the literal string `LLMGatewayService` in this repo's convention
+(`orion:exec:request:LLMGatewayService`). A prior version of this example set
+`TOPIC_FOUNDRY_LLM_BUS_ROUTE=LLMGatewayService` by mistake — that's the channel-name string
+sitting in the route-key field, which doesn't match any real route table key.
+
+**Leaving `TOPIC_FOUNDRY_LLM_BUS_ROUTE` blank (the actual shipped default) is not "no
+route" — it silently falls through to whatever `orion-llm-gateway`'s own
+`LLM_ROUTE_DEFAULT` is set to** (`llm_backend.py`: `route or settings.llm_route_default or
+"chat"`). Confirmed live 2026-07-28: the gateway's `LLM_ROUTE_DEFAULT=quick`, so every
+enrichment LLM call currently lands on whichever worker the `quick` route table entry points
+at — a lane picked by whatever else happens to be the global default, not one chosen for
+this workload. Set it explicitly if that's not what you want; the `metacog` route's own
+model-profile notes in `config/llm_profiles.yaml` describe it as tuned for exactly this
+shape of work ("optimized for episodic structured JSON (draft + enrich)"), but routing
+enrichment's background batch traffic onto the same dedicated lane other live,
+latency-sensitive metacog-trigger consumers use is a real capacity/contention trade-off,
+not just a config toggle — deliberately not changed here, flagging it for an operator
+decision instead.
+
 Recommended env example:
 
 ```env
@@ -212,7 +235,7 @@ TOPIC_FOUNDRY_LLM_ENABLE=true
 TOPIC_FOUNDRY_LLM_USE_BUS=true
 ORION_BUS_ENABLED=true
 ORION_BUS_URL=redis://<tailnet-redis-host>:6379/0
-TOPIC_FOUNDRY_LLM_BUS_ROUTE=LLMGatewayService
+TOPIC_FOUNDRY_LLM_BUS_ROUTE=
 TOPIC_FOUNDRY_LLM_INTAKE_CHANNEL=orion:exec:request:LLMGatewayService
 TOPIC_FOUNDRY_LLM_REPLY_PREFIX=orion:llm:reply
 TOPIC_FOUNDRY_LLM_TIMEOUT_SECS=60


### PR DESCRIPTION
## Summary

- The "recommended env example" for `TOPIC_FOUNDRY_LLM_BUS_ROUTE` in `services/orion-topic-foundry/README.md` set it to `LLMGatewayService` — not a real route table key (the live gateway route table only has `chat`/`agent`/`metacog`/`quick`). That's actually the intake *channel* name, copy-pasted into the wrong field.
- Nothing documented what actually happens with the real shipped default (blank). Confirmed live: `orion-llm-gateway`'s `LLM_ROUTE_DEFAULT=quick`, so every topic-foundry LLM call — including the real enrichment calls from PR #1414's live deploy verification — silently lands on the gateway's global default lane, not one chosen for this workload.
- Also corrected the `/capabilities` example JSON against the actual live response — it was stale in `llm_bus_route`, `llm_enabled`, and `default_metric`, not just the route field.

## Outcome moved

The README now accurately describes real routing behavior instead of a broken example nobody would have caught without live-testing it.

## Current architecture

No code touched — pure documentation fix, verified against the live running `orion-athena-topic-foundry` container and `orion-llm-gateway`'s live env, not guessed.

## Architecture touched

None (docs only).

## Files changed

- `services/orion-topic-foundry/README.md`: corrected the LLM-route example and its explanation, corrected the `/capabilities` example JSON to match live output.

## Schema / bus / API changes

None.

## Env/config changes

None. This does not change `TOPIC_FOUNDRY_LLM_BUS_ROUTE`'s actual value anywhere (still blank, still falls through to the gateway default) — it only documents that behavior honestly instead of recommending a broken value. Whether to explicitly route enrichment onto the `metacog` lane is named as a real, deliberate trade-off (capacity contention with live latency-sensitive metacog consumers on the same GPU) and left as an open operator decision, not changed here.

## Tests run

Not applicable — docs only, no code changed.

## Evals run

Not applicable.

## Docker/build/smoke checks

Not applicable — no code/config changed, nothing to rebuild. Verification was live-read-only: confirmed `llm_bus_route: ""` via `curl http://localhost:8615/capabilities` inside the running `orion-athena-topic-foundry` container, and `LLM_ROUTE_DEFAULT=quick` via `docker exec orion-llm-gateway env`.

## Review findings fixed

N/A — docs-only change, no code review dispatched.

## Restart required

```text
No restart required.
```

## Risks / concerns

None.

## PR link

(filled in below)
