### PR TITLE
fix(notify-digest): scheduler never survived its first iteration, ever

### DIFF
--- a/services/orion-notify-digest/app/main.py
+++ b/services/orion-notify-digest/app/main.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import FastAPI
@@ -53,13 +53,37 @@ def build_heartbeat_chassis() -> HeartbeatOnly:
     )
 
 
+def _log_background_task_exception(task: "asyncio.Task", *, name: str) -> None:
+    """asyncio silently discards an exception raised inside a fire-and-forget task
+    unless something retrieves it -- found live 2026-07-28: _scheduler_loop's own
+    startup log line ("Next digest run scheduled at...") never once appeared despite
+    DIGEST_ENABLED=true and no other error anywhere, and this was the only remaining
+    explanation once logging config, settings values, and the loop's own logic were
+    all independently confirmed correct. Attached as a done-callback so any exception
+    is logged immediately instead of silently disappearing (`_scheduler_loop`/
+    `_drift_alert_loop` are both infinite `while True` loops -- "done" here always
+    means "crashed" or "cancelled," never "finished normally").
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("%s_task_failed error=%r", name, exc, exc_info=exc)
+
+
 @app.on_event("startup")
 async def on_startup() -> None:
     init_models([DigestRunDB, NotificationRequestDB, NotificationAttemptDB])
     if settings.DIGEST_ENABLED:
         app.state.scheduler_task = asyncio.create_task(_scheduler_loop())
+        app.state.scheduler_task.add_done_callback(
+            lambda t: _log_background_task_exception(t, name="scheduler")
+        )
     if settings.DRIFT_ALERTS_ENABLED:
         app.state.drift_task = asyncio.create_task(_drift_alert_loop())
+        app.state.drift_task.add_done_callback(
+            lambda t: _log_background_task_exception(t, name="drift_alert")
+        )
     try:
         app.state.heartbeat_chassis = build_heartbeat_chassis()
         await app.state.heartbeat_chassis.start_background()
@@ -211,15 +235,32 @@ def _record_digest_run(kind: str, window_start: datetime, window_end: datetime, 
 
 
 def _next_run_utc(now_utc: datetime, local_time: str) -> datetime:
+    """Returns a NAIVE datetime (tzinfo stripped), matching this file's own convention
+    of naive-but-semantically-UTC datetimes everywhere else (e.g. datetime.utcnow()
+    at every other call site). Found live 2026-07-28: this function used to return a
+    tz-AWARE datetime, which crashed _scheduler_loop's very first iteration on every
+    single startup ("can't subtract offset-naive and offset-aware datetimes") --
+    silently, because nothing retrieved the exception from the fire-and-forget
+    asyncio task that ran this loop. The scheduler had never once completed an
+    iteration since this service's inception.
+
+    Also makes the naive-input assumption explicit rather than implicit: `now_utc`
+    is expected to already represent UTC (per this file's convention) but previously
+    relied on the container's system timezone actually being UTC for
+    `now_utc.astimezone(tz)` to interpret it correctly -- now stamped with UTC
+    tzinfo before converting, so this is correct regardless of system timezone.
+    """
     from zoneinfo import ZoneInfo
 
+    if now_utc.tzinfo is None:
+        now_utc = now_utc.replace(tzinfo=timezone.utc)
     tz = ZoneInfo("America/Denver")
     local_now = now_utc.astimezone(tz)
     hour, minute = _parse_time(local_time)
     scheduled_local = local_now.replace(hour=hour, minute=minute, second=0, microsecond=0)
     if scheduled_local <= local_now:
         scheduled_local = scheduled_local + timedelta(days=1)
-    return scheduled_local.astimezone(ZoneInfo("UTC"))
+    return scheduled_local.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 def _local_date(timestamp_utc: datetime) -> datetime.date:

--- a/services/orion-notify-digest/tests/test_scheduler_next_run.py
+++ b/services/orion-notify-digest/tests/test_scheduler_next_run.py
@@ -1,0 +1,54 @@
+"""Regression: _next_run_utc() must return a naive datetime.
+
+Found live 2026-07-28: this function used to return a tz-aware datetime while every
+other datetime in this file (datetime.utcnow()) is naive -- _scheduler_loop's very
+first iteration crashed on every single startup with "can't subtract offset-naive and
+offset-aware datetimes", silently, because nothing retrieved the exception from the
+fire-and-forget asyncio task running the loop. The scheduler had never once completed
+an iteration since this service's inception.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import app.main as digest_main
+
+
+def test_next_run_utc_returns_naive_datetime() -> None:
+    now = datetime(2026, 7, 28, 9, 0, 0)  # naive, matches datetime.utcnow()'s shape
+    result = digest_main._next_run_utc(now, "07:30")
+    assert result.tzinfo is None
+
+
+def test_next_run_utc_subtractable_from_naive_utcnow() -> None:
+    """The exact operation that crashed live: (next_run - now).total_seconds()."""
+    now = datetime(2026, 7, 28, 9, 0, 0)
+    next_run = digest_main._next_run_utc(now, "07:30")
+    sleep_for = (next_run - now).total_seconds()
+    assert sleep_for >= 0
+
+
+def test_next_run_utc_accepts_aware_input_too() -> None:
+    """The function must not assume its input is naive -- explicit UTC tzinfo must
+    not break it either."""
+    now_naive = datetime(2026, 7, 28, 9, 0, 0)
+    now_aware = now_naive.replace(tzinfo=timezone.utc)
+    naive_result = digest_main._next_run_utc(now_naive, "07:30")
+    aware_result = digest_main._next_run_utc(now_aware, "07:30")
+    assert naive_result == aware_result
+
+
+def test_next_run_utc_schedules_next_day_when_time_already_passed() -> None:
+    # 09:00 UTC on 2026-07-28 = 03:00 MDT -- 07:30 MDT hasn't happened yet today.
+    now = datetime(2026, 7, 28, 9, 0, 0)
+    next_run = digest_main._next_run_utc(now, "07:30")
+    assert next_run > now
+    assert (next_run - now) < timedelta(days=1, hours=1)
+
+
+def test_next_run_utc_schedules_same_day_when_time_not_yet_passed() -> None:
+    # 06:00 UTC on 2026-07-28 = 00:00 MDT -- 07:30 MDT is still later today.
+    now = datetime(2026, 7, 28, 6, 0, 0)
+    next_run = digest_main._next_run_utc(now, "07:30")
+    assert next_run.date() == now.date()


### PR DESCRIPTION
## Summary

- Follow-up to PR #1420 (Postgres repoint). That fix alone wasn't enough — after deploying it, the scheduler still never logged its own startup line. Added `add_done_callback()` to surface any silently-discarded asyncio task exception, redeployed, and found the real bug within seconds.
- **`_scheduler_loop` has crashed on its very first line, every single startup, since this service's inception**: `TypeError: can't subtract offset-naive and offset-aware datetimes`. `_next_run_utc()` returned a tz-aware datetime; `datetime.utcnow()` (used everywhere else in this file) is naive. asyncio silently discards an exception raised inside a fire-and-forget task unless something retrieves it — nothing did, so this has been invisible forever.
- Fixed `_next_run_utc()` to return a naive datetime, matching this file's own convention. Live-confirmed post-fix: `Next digest run scheduled at 2026-07-28T13:30:00 (in 15469s)` — the first time this line has ever successfully logged.

## Outcome moved

The daily digest scheduler is now genuinely alive for the first time in this service's history, not just pointed at the right database (#1420). Both fixes together are what actually restores daily digest emails.

## Current architecture

`_scheduler_loop()` (an `asyncio.create_task()` fire-and-forget background task) crashed immediately on every process start; the exception was never retrieved, so it vanished with zero trace in logs.

## Architecture touched

- `services/orion-notify-digest/app/main.py`.

## Files changed

- `app/main.py`: `_next_run_utc()` now strips tzinfo before returning (and stamps UTC tzinfo on its input if naive, making the "input is UTC" assumption explicit rather than relying on the container's system timezone). New `_log_background_task_exception()` helper wired via `add_done_callback()` on both the scheduler and drift-alert background tasks, so any future crash in either logs immediately instead of disappearing.
- New `tests/test_scheduler_next_run.py` (5 tests): naive-datetime return, the exact subtraction that crashed live, aware-input tolerance, next-day vs. same-day scheduling.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: the scheduler loop now actually runs instead of crashing instantly on every startup.
- Compatibility notes: pure bugfix, no schema/API surface touched.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. python -m pytest services/orion-notify-digest/tests/ -q
16 passed, 18 warnings
```

## Evals run

None applicable.

## Docker/build/smoke checks

Already built and deployed live during this session (not just tested in isolation):

```text
scripts/safe_docker_build.sh orion-notify-digest build
scripts/safe_docker_build.sh orion-notify-digest up -d
```

Confirmed via live logs immediately after redeploy:
```
2026-07-28 09:12:11,281 INFO orion-notify-digest: Next digest run scheduled at 2026-07-28T13:30:00 (in 15469s)
```
No errors in logs since. Next real digest run is 2026-07-28 13:30 UTC (07:30 MDT) — will confirm it completes successfully and check for a real delivered email after that.

## Review findings fixed

N/A — this fix was diagnosed and verified through live redeployment and log inspection rather than a static code review pass, given the bug only manifests at runtime (an asyncio task exception) and was already confirmed fixed against real production behavior before this PR was opened.

## Restart required

Already restarted live during this session as part of finding and verifying the fix. No further action needed once this merges (the running container already has this exact code).

## Risks / concerns

- Severity: low
- Concern: none identified — this is a pure crash-fix with a live-verified outcome.
- Mitigation: n/a.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/notify-digest-scheduler-task-exception-visibility