### PR TITLE
feat(scripts): host-level disk threshold watchdog -> Hub Pending Attention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions check-substrate-projection-schema-drift bus-core-health-watchdog worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
+.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions check-substrate-projection-schema-drift bus-core-health-watchdog disk-threshold-watchdog worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
 
 SERVICE ?=
 ARGS ?=
@@ -119,6 +119,24 @@ bus-core-health-watchdog:
 		$(if $(UNHEALTHY_STREAK_THRESHOLD),--unhealthy-streak-threshold $(UNHEALTHY_STREAK_THRESHOLD),) \
 		$(if $(RESTART_COUNT_THRESHOLD),--restart-count-threshold $(RESTART_COUNT_THRESHOLD),) \
 		$(if $(RESTART_WINDOW_MINUTES),--restart-window-minutes $(RESTART_WINDOW_MINUTES),)
+
+# Host-level disk-usage threshold watchdog for /mnt/docker, /mnt/scripts, and
+# /mnt/telemetry (each a distinct physical mount on this host). Publishes an
+# orion-notify /attention/request (Hub Pending Attention card) the first time
+# any monitored path crosses --threshold-pct (default 90), debounced via local
+# state so it doesn't refire every tick while already confirmed-notified and
+# still breached -- but DOES retry every tick if the prior notify attempt
+# never actually confirmed success (orion-notify down/unreachable), so a
+# breach can never be silently swallowed. See scripts/disk_threshold_watchdog.py's
+# docstring for the full design and scripts/README.md for cron install
+# instructions. Requires PYTHONPATH=. (it imports orion.notify.client) and
+# orion-notify reachable at NOTIFY_BASE_URL.
+disk-threshold-watchdog:
+	@PYTHONPATH=. python3 scripts/disk_threshold_watchdog.py $(if $(PATHS),--paths $(PATHS),) \
+		$(if $(THRESHOLD_PCT),--threshold-pct $(THRESHOLD_PCT),) \
+		$(if $(PROJECT),--project $(PROJECT),) \
+		$(if $(TELEMETRY_ROOT),--telemetry-root $(TELEMETRY_ROOT),) \
+		$(if $(NOTIFY_BASE_URL),--notify-base-url $(NOTIFY_BASE_URL),)
 
 # Reconciled worktree view -- path, branch, merged-into-main status, open PR,
 # disk size -- regardless of which of this repo's several worktree location

--- a/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-pr.md
@@ -1,0 +1,283 @@
+# PR report — host-level disk threshold watchdog -> Hub Pending Attention
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1425
+Branch: `chore/disk-threshold-watchdog`
+Status: **DONE**
+
+## Summary
+
+- `/mnt/docker`, `/mnt/scripts/`, and `/mnt/telemetry` (three distinct
+  physical mounts on this host, confirmed via `df -h`) had no threshold
+  monitoring that surfaced a breach anywhere an operator would actually
+  see it.
+- Added `scripts/disk_threshold_watchdog.py`: a standalone, host-level
+  (non-containerized), cron-run script that checks `shutil.disk_usage()`
+  per path and, the first time a path crosses `--threshold-pct` (default
+  90), fires `orion-notify`'s `POST /attention/request` -- the same
+  mechanism `orion-mesh-guardian` already uses -- which lands as a Hub
+  Pending Attention card.
+- Mirrors the pattern already proven and code-reviewed in
+  `scripts/bus_core_health_watchdog.py`: pure `evaluate_path()` for the
+  threshold/debounce logic, `flock`-guarded atomic state writes to survive
+  overlapping cron invocations, distinct exit codes (0/1/2/3) so a
+  monitoring wrapper can tell "breach detected" apart from "tooling
+  failure" apart from "watchdog bug."
+- Live-verified end to end against the real running `orion-notify`: real
+  `attention_request` calls landed with `status: "pending"`, confirmed via
+  `GET /attention`, then ack'd/dismissed to clean up smoke-test noise.
+- A high-effort code-review subagent (`orion-repo-agent`) found one
+  **critical** bug before merge: a failed/unconfirmed notify call was
+  being persisted as "already notified," so a breach that first occurred
+  while `orion-notify` was down would never retry -- no Pending Attention
+  card would ever land for the entire duration of the outage, exactly the
+  failure window this feature exists to survive. Fixed and live-reproduced
+  (see below).
+
+## Outcome moved
+
+Previously: nothing watched host disk usage on these three mounts. Now: a
+cron-run script that checks all three independently every 15 minutes,
+publishes a real Hub Pending Attention card on first breach, debounces
+repeat notification while already confirmed, and -- critically -- retries
+on every subsequent tick if the prior notify attempt never actually
+succeeded, rather than silently going quiet.
+
+## Current architecture
+
+No prior disk-threshold monitoring existed. Two lookalikes were
+investigated and ruled out during design:
+
+- `skills.storage.disk_health_snapshot.v1`
+  (`orion/cognition/verbs/skills.storage.disk_health_snapshot.v1.yaml`) --
+  a reactive cognition skill, goal-driven, invoked by Orion's own autonomy
+  loop on demand, not a threshold watchdog.
+- `resource_pressure`/`cpu_pressure`/`gpu_pressure` (Scarcity Economy) --
+  Orion's internal cognitive-economy signal feeding drives, not an
+  operator infra alert. Wrong layer entirely.
+
+`orion.notify.client.NotifyClient.attention_request()` ->
+`orion-notify`'s `POST /attention/request` -> Hub Pending Attention is the
+real, live, proven mechanism, already used by `orion-mesh-guardian`
+(`services/orion-mesh-guardian/app/attention.py`) and the Fuseki recover
+job.
+
+## Architecture touched
+
+Host-level only. No new service, no schema/bus contract change, no Docker
+container. `NotifyClient`/`ChatAttentionRequest`
+(`orion/schemas/notify.py`, `orion/notify/client.py`) reused as-is.
+`PendingAttentionCardV1` (`orion/schemas/attention_salience.py`) was
+considered and ruled out -- it's hard-locked to `source:
+Literal["cognitive_loop"]` with `extra="forbid"`, a different subsystem
+entirely.
+
+## Files changed
+
+- `scripts/disk_threshold_watchdog.py` (new): the watchdog.
+  `measure_path()` (never raises), `evaluate_path()` (pure
+  threshold/debounce/retry state machine), `_publish_attention()` (returns
+  whether orion-notify actually confirmed), `run()` (flock-guarded
+  read-evaluate-write cycle), `main()` (CLI + exit codes).
+- `tests/test_disk_threshold_watchdog.py` (new, 35 tests): pure-logic
+  tests for every state transition (breach/recovery/re-breach,
+  error/ok/error, breach->error), concurrency-lock tests, `load_state`
+  corruption-resilience tests, and -- added during the review-fix pass --
+  explicit retry-on-failed-notify regression tests mirroring the real
+  `NotifyClient` contract (`NotificationAccepted(ok=False, ...)`, not an
+  exception).
+- `Makefile`: new `disk-threshold-watchdog` target (sets `PYTHONPATH=.`,
+  since this script imports `orion.notify.client`, unlike
+  `bus_core_health_watchdog.py` which deliberately imports nothing from
+  `orion.*`).
+- `scripts/README.md`: new "Disk Threshold Watchdog" discoverability
+  section -- description, usage, expected output, one-time `chown`
+  prerequisite (same `root:root` 755 gotcha confirmed live for the
+  bus-core watchdog's telemetry directory), and the crontab install line.
+
+## Schema / bus / API changes
+
+None. Reuses `ChatAttentionRequest`/`NotifyClient.attention_request()` as
+is -- no new bus channel, no schema registry change, no
+`PendingAttentionCardV1` widening.
+
+## Env/config changes
+
+None added. Reads `$PROJECT`/`$TELEMETRY_ROOT`/`$NOTIFY_BASE_URL`/
+`$NOTIFY_API_TOKEN` (existing keys) purely as CLI-flag defaults,
+overridable via `--project`/`--telemetry-root`/`--notify-base-url`/
+`--notify-api-token`/`--paths`/`--threshold-pct`/`--state-file`.
+
+## Tests run
+
+```text
+source venv/bin/activate && python -m py_compile scripts/disk_threshold_watchdog.py
+=> OK
+
+PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py -q
+=> 35 passed
+
+PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py tests/test_bus_core_health_watchdog.py -q
+=> 84 passed
+
+git diff --check
+=> clean
+```
+
+## Evals run
+
+None applicable -- deterministic gate-style script (matches AGENTS.md
+section 11's "Gate tests" category, same as `bus_core_health_watchdog.py`),
+not a quality/behavior measurement needing an eval harness.
+
+## Docker/build/smoke checks
+
+No Docker involved -- host-level script, nothing to build.
+
+Live smoke against the real host and real running `orion-notify` (port
+7140):
+
+```text
+$ PYTHONPATH=. python3 scripts/disk_threshold_watchdog.py --threshold-pct 90 --json
+disk_threshold_watchdog: /mnt/docker status=ok used=79.6%   (/dev/sda)
+disk_threshold_watchdog: /mnt/scripts status=ok used=6.0%   (/dev/sde1)
+disk_threshold_watchdog: /mnt/telemetry status=ok used=18.6% (/dev/sdf1)
+exit: 0
+```
+
+Forced-breach end-to-end (threshold-pct=0): 3 real `attention_request`
+calls landed in `orion-notify`'s `/attention` list with `status:
+"pending"`, confirmed via `GET /attention`, then ack'd/dismissed via
+`POST /attention/{id}/ack` to clean up.
+
+Retry-on-failure regression, reproduced live against an unreachable
+notify port (`--notify-base-url http://127.0.0.1:1`) both BEFORE and
+AFTER the fix:
+
+```text
+BEFORE FIX:
+  tick 1 (notify unreachable): last_status=breached persisted, notify attempted
+  tick 2 (notify still unreachable): NO notify attempt at all -- silently swallowed
+
+AFTER FIX:
+  tick 1 (notify unreachable): last_status=breached, notified=false persisted
+  tick 2 (notify still unreachable): notify RETRIED for all 3 paths, notified=false
+  tick 3 (notify now reachable): notify RETRIED, notified=true persisted
+  tick 4 (still breached): no retry -- already confirmed notified
+```
+
+## Review findings fixed
+
+Code review (`orion-repo-agent`, high effort) against
+`/mnt/scripts/Orion-Sapienform-disk-threshold-watchdog`:
+
+- **Finding (CRITICAL)**: `_publish_attention()` discarded
+  `NotifyClient.attention_request()`'s return value entirely, and `run()`
+  persisted the debounce transition to "breached"/"notified" before the
+  notify call even happened. The real `NotifyClient` never raises on
+  network failure -- it catches everything internally and returns
+  `NotificationAccepted(ok=False, ...)`. So a breach occurring while
+  `orion-notify` is down would get `last_status="breached"` committed on
+  tick 1, and tick 2 would see `status == prev_status` and never retry --
+  permanently silent, zero Pending Attention card, for the entire outage.
+  Live-reproduced by the reviewer against a mocked unreachable client.
+  - **Fix**: `_publish_attention()` now returns `bool(result.ok)` (False
+    on both exception and `ok=False`). `evaluate_path()` now tracks a
+    separate `notified` field per path, only ever set `True` by `run()`
+    after a confirmed-successful call; `should_notify` fires on a status
+    transition OR whenever the current bad status has `notified != True`,
+    so a failed/unconfirmed attempt retries every subsequent tick until it
+    succeeds.
+  - **Evidence**:
+    `test_evaluate_path_repeated_breach_retries_if_previous_notify_never_confirmed`,
+    `test_evaluate_path_repeated_error_retries_if_previous_notify_never_confirmed`,
+    `test_run_retries_notify_next_tick_when_notify_returns_ok_false`,
+    `test_run_stops_retrying_once_a_notify_attempt_succeeds` -- plus the
+    live before/after reproduction above against a real unreachable port.
+- **Finding (MEDIUM)**: the one existing test claiming to cover "notify
+  unreachable" (`test_run_notify_failure_does_not_crash_watchdog`) used
+  `side_effect = RuntimeError(...)`, which the real client never actually
+  raises -- it gave false confidence for exactly the broken scenario.
+  - **Fix**: `_fake_notify()` now defaults to mirroring the real contract
+    (`MagicMock(ok=True/False)`, not an exception); the exception-path
+    test is kept (still valid coverage for `_publish_attention`'s
+    `except` branch) alongside new `ok=False`-based tests that match the
+    realistic failure mode.
+  - **Evidence**: see tests listed above.
+- **Finding (LOW, fixed)**: the Makefile target's comment pointed to a
+  `scripts/README.md` cron-install section that didn't exist yet.
+  - **Fix**: added the actual crontab line plus the one-time `chown`
+    prerequisite (same gotcha class already documented for the bus-core
+    watchdog) to `scripts/README.md`.
+  - **Evidence**: confirmed live -- `/mnt/telemetry/orion-athena/` is
+    `root:root` 755 on this host, same as documented for
+    `bus_core_health_watchdog.py`.
+- **Finding (MEDIUM, accepted not fixed)**: `_StateLock` wraps the full
+  per-path loop including the `orion-notify` HTTP call (up to 10s timeout
+  per path), unlike `bus_core_health_watchdog.py`'s lock which only ever
+  guards fast local I/O (its one blocking call, `docker inspect`, happens
+  outside the lock, and its alert path is a local file write, not a
+  network call). During a slow/hanging (not just refusing) `orion-notify`,
+  an overlapping cron tick that can't acquire the lock skips cleanly
+  rather than measuring disk at all for that tick.
+  - **Not fixed**: a correct two-phase lock (measure+decide under lock,
+    notify outside, re-lock to commit outcome) is real complexity for a
+    lower-severity, cron-cadence-dependent (default every 15 min, not
+    every 1 min like bus-core-watchdog) risk. The reviewer explicitly
+    assessed this as shippable with a documented follow-up rather than
+    blocking.
+  - **Mitigation**: documented here and in the script's own docstring; a
+    future patch could split measurement from notification if the
+    every-15-min cadence proves too coarse in practice.
+- **Finding (MINOR, informational, accepted)**: `run()` does a single
+  `_atomic_write_json` after the full per-path loop rather than per-item
+  like the sibling script. If `measure_path`/`evaluate_path`/
+  `_publish_attention` ever raised unexpectedly partway through a
+  multi-path tick (not currently reachable given `measure_path`'s
+  documented "never raises" contract), in-memory progress for paths
+  already processed that tick would be lost. Reviewer noted this fails in
+  the safe direction (duplicate notify next tick, not silently dropped) --
+  not urgent.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+This is a new, standalone host-level script -- nothing to restart. It
+only becomes live once the crontab line in `scripts/README.md`'s "Disk
+Threshold Watchdog" section is installed by hand (host crontab is shared
+infrastructure, deliberately not modified automatically).
+
+**Exact install commands (report only, not run by this session):**
+
+```bash
+sudo mkdir -p /mnt/telemetry/orion-athena/disk-watchdog
+sudo chown "$(whoami)":"$(whoami)" /mnt/telemetry/orion-athena/disk-watchdog
+
+crontab -e
+# then paste:
+*/15 * * * * cd /mnt/scripts/Orion-Sapienform && make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
+```
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `/mnt/docker` is already at ~80% used on this host today. At
+  the default `--threshold-pct 90`, this won't fire immediately, but it's
+  close enough that a real card is plausible soon after this ships --
+  expected behavior, not a bug, flagging so it isn't mistaken for a
+  smoke-test artifact when it lands.
+- Severity: medium (documented, not blocking)
+- Concern: `_StateLock` holds across the notify HTTP call (see Review
+  Findings above) -- a slow/hanging (not refusing) `orion-notify` could
+  cause a skipped measurement tick under overlapping cron runs. Low
+  real-world likelihood at the default 15-minute cadence.
+- Severity: low
+- Concern: every-15-minute cron cadence assumes cron itself is running --
+  same inherited gap as every other cron-based gate in this repo
+  (`bus_core_health_watchdog.py`, `check_concept_relation_digest_liveness.py`).
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1425

--- a/mesh-utilities/bootstrap/README.md
+++ b/mesh-utilities/bootstrap/README.md
@@ -41,3 +41,20 @@ sudo bash /opt/orion-bootstrap/scripts/verify-gpu.sh   # after driver install + 
 ## Keys folder policy
 - `keys/admin_authorized_keys.pub` — place one or more **public** keys (newline-separated). Appended to root's `authorized_keys`.
 - No deploy/private keys are used or stored. All outbound Git uses the forwarded agent from Carbon.
+
+## Post-bootstrap: host crontab jobs (do not skip this)
+None of the steps above touch the host crontab. This repo has several host-level jobs (disk/DB maintenance, health watchdogs) that run via plain `crontab`, not `docker-compose` and not this bootstrap script -- they do **not** come back automatically on a new machine or after a host rebuild. If this box is ever replaced or rebuilt, these must be reinstalled by hand.
+
+`scripts/README.md` is the authoritative, current list of every host-cron script this repo ships and its exact install command (search that file for "cron" or `crontab -e`) -- check there for the full and up-to-date set, since new ones get added over time and duplicating the list here would just rot. As of this writing that includes at minimum:
+- Fuseki recover/compact (`services/orion-rdf-store/README.md`)
+- Concept-relation digest (`services/orion-memory-consolidation/README.md`)
+- Bus-core crash-loop watchdog (`scripts/bus_core_health_watchdog.py`, see `scripts/README.md`)
+- Disk threshold watchdog (`scripts/disk_threshold_watchdog.py`, see `scripts/README.md`)
+
+Exact contents of the currently-live crontab on the existing host (`crontab -l`, verified 2026-07-28), as a copy-paste starting point -- **do not assume this list is complete**, cross-check against `scripts/README.md` for anything shipped since:
+```cron
+5,25,45 * * * * cd /mnt/scripts/Orion-Sapienform/services/orion-rdf-store && make recover >> /mnt/scripts/Orion-Sapienform/logs/orion-fuseki-recover.log 2>&1
+0 12 * * * cd /mnt/scripts/Orion-Sapienform/services/orion-rdf-store && SOURCE=/mnt/graphdb/rdf-store/fuseki/databases/orion make compact >> /mnt/graphdb/rdf_logs/fuseki-compact-run.log 2>&1
+*/30 * * * * PATH=/mnt/scripts/Orion-Sapienform/venv/bin:$PATH POSTGRES_URI=$(grep -m1 '^POSTGRES_URI=' /mnt/scripts/Orion-Sapienform/services/orion-hub/.env | cut -d= -f2-) make -C /mnt/scripts/Orion-Sapienform concept-relation-digest >> /mnt/scripts/Orion-Sapienform/logs/orion-concept-relation-digest.log 2>&1
+```
+Note the bus-core and disk-threshold watchdogs are documented in `scripts/README.md` with their own install lines but are **not** in the block above -- confirm against a fresh `crontab -l` on the actual current host before treating this snippet as ground truth, don't just copy it blind.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,6 +66,36 @@ bus_core_health_watchdog: orion-orion-athena-bus-core health=healthy consecutive
 bus_core_health_watchdog: OK -- no crash-loop signature.
 ```
 
+## Disk Threshold Watchdog (Hub Pending Attention on low disk)
+Nothing previously watched host disk usage on `/mnt/docker`, `/mnt/scripts/`, and `/mnt/telemetry` (three distinct physical mounts on this host, confirmed via `df -h`) and surfaced a breach anywhere an operator would see it. This script checks `shutil.disk_usage()` on each path; the first time a path crosses `--threshold-pct` (default 90), it fires one `orion-notify` `/attention/request` (the same mechanism `orion-mesh-guardian` uses), which lands as a Hub Pending Attention card. Debounced via local state so it does not refire every tick while still breached — recovery clears the debounce silently (Pending Attention cards are ack'd by a human, not auto-resolved). A path that can't be statted at all (permission error, vanished mount) also fires, at `severity=error`. Requires `PYTHONPATH=.` (imports `orion.notify.client`) and `orion-notify` reachable at `NOTIFY_BASE_URL` (default `http://localhost:7140`, the host-reachable port — not the Docker-internal hostname).
+```bash
+PYTHONPATH=. python scripts/disk_threshold_watchdog.py
+# or: make disk-threshold-watchdog
+```
+Expected output when all paths are under threshold:
+```
+disk_threshold_watchdog: /mnt/docker status=ok used=79.6%
+disk_threshold_watchdog: /mnt/scripts status=ok used=6.0%
+disk_threshold_watchdog: /mnt/telemetry status=ok used=18.6%
+disk_threshold_watchdog: OK -- all paths under threshold.
+```
+
+**One-time prerequisite** (the default state-file directory is `root:root`
+755 on this host, same class of gotcha documented for the bus-core
+watchdog above):
+```bash
+sudo mkdir -p /mnt/telemetry/orion-athena/disk-watchdog
+sudo chown "$(whoami)":"$(whoami)" /mnt/telemetry/orion-athena/disk-watchdog
+```
+
+**Cron install** (run from repo root, venv activated so `python3` resolves
+to the venv interpreter with `orion-notify`'s dependencies installed):
+```bash
+crontab -e
+# then paste:
+*/15 * * * * cd /mnt/scripts/Orion-Sapienform && make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
+```
+
 ## Daily Schedule Collision Check (orion-actions cadences)
 `services/orion-actions/.env_example` gives Daily Pulse, World Pulse, and Daily Metacog their own hour/minute pairs, but Daily Journal has no env var of its own — `services/orion-actions/app/main.py`'s `journal_should_run` call (~line 2125-2131) reuses `settings.actions_daily_pulse_hour_local`/`minute_local` verbatim, so Daily Journal always fires at the exact same local minute as Daily Pulse, by config. Two independently-LLM-generated daily artifacts landing in the same notification slot reads as duplication even though they're genuinely different pipelines. This script computes pairwise time-of-day distance across all four cadences and flags any pair within `--threshold-minutes` (default 30) of each other. Report-only by default (always exits 0); pass `--fail-on-collision` to make it a real gate.
 ```bash

--- a/scripts/disk_threshold_watchdog.py
+++ b/scripts/disk_threshold_watchdog.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Host-level disk-usage threshold watchdog for the mount points that back
+this repo's Docker images, source checkout, and telemetry corpus.
+
+Context: nothing in this repo checks disk usage on `/mnt/docker`,
+`/mnt/scripts/`, or `/mnt/telemetry` and surfaces a breach anywhere an
+operator would actually see it. Each mount is a distinct physical
+filesystem on this host (confirmed via `df -h`: `/dev/sda` -> /mnt/docker,
+`/dev/sde1` -> /mnt/scripts, `/dev/sdf1` -> /mnt/telemetry), so usage on one
+says nothing about the others -- all three are checked independently.
+
+Same category as `scripts/bus_core_health_watchdog.py` (standalone,
+host-level, cron-run, not a live service loop; pure `evaluate_path()` for
+the threshold/debounce logic; flock-guarded atomic state). The one
+deliberate difference: that script avoided `orion-notify`'s
+`/attention/request` because a bus-core crash loop can take Postgres/the
+bus down in the same incident notify might depend on. A slowly filling
+disk is not that kind of bootstrapping failure -- `orion-notify` reusing
+the same alerting path already proven live by `orion-mesh-guardian` and
+the Fuseki recover job is the right call here, and it's what actually
+lands this as a Hub Pending Attention card (the point of this script).
+
+Per monitored path, on each run:
+
+- `shutil.disk_usage(path)` gives (total, used, free); percent_used =
+  used / total * 100.
+- If percent_used >= `--threshold-pct` (default 90.0) and the path was NOT
+  already flagged as breached on the previous run, this is a new breach:
+  one `NotifyClient.attention_request()` call fires (severity "warning").
+  While a path stays breached across runs AND the notify call already
+  succeeded, no repeat notification fires (debounced via persisted state)
+  -- Hub Pending Attention cards are ack'd by a human, not auto-resolved
+  by this script, so repeat spam while waiting for an ack would be
+  actively unhelpful. Debounce state is only persisted as "notified" once
+  `NotifyClient.attention_request()` actually confirms success
+  (`NotificationAccepted.ok`) -- a failed attempt (orion-notify down,
+  unreachable, or erroring; note the real client never raises for this,
+  it returns `ok=False`) retries on every subsequent tick until it
+  succeeds, rather than being silently swallowed the moment `last_status`
+  flips to "breached". See evaluate_path()'s docstring for the full
+  rationale (found by code review, live-reproduced before the fix).
+- If `shutil.disk_usage(path)` itself raises (path missing, permission
+  denied, mount vanished) and this is a NEW error for that path, that is
+  also worth attention (a vanished mount can BE the disk problem) --
+  fires a separate "error" attention_request, same debounce/retry rule.
+- Recovery (breached -> under threshold) clears the debounce state
+  silently, no notification -- once a card is ack'd, there's nothing to
+  auto-resolve; a human already saw it.
+
+State (per-path: last status, first-breach timestamp, last percent_used,
+whether the current status was successfully notified) persists to
+`--state-file` (default `${TELEMETRY_ROOT}/${PROJECT}/disk-watchdog/
+state.json`).
+
+Concurrency: same non-blocking `flock` pattern as
+`bus_core_health_watchdog.py` guards the read-evaluate-write cycle against
+overlapping cron invocations. A run that can't acquire the lock skips
+cleanly (exit 0).
+
+Usage:
+    python scripts/disk_threshold_watchdog.py
+    python scripts/disk_threshold_watchdog.py --threshold-pct 85 --json
+    python scripts/disk_threshold_watchdog.py --paths /mnt/docker,/mnt/scripts,/mnt/telemetry
+
+Exit codes: 0 = all monitored paths under threshold (also returned if this
+                run was skipped because another run already holds the lock).
+            1 = at least one monitored path is at/over threshold, or could
+                not be statted, at check time (regardless of whether a new
+                notification fired this tick -- mirrors
+                bus_core_health_watchdog.py's exit-code contract so a
+                monitoring wrapper keying off exit code behaves the same
+                way across both scripts).
+            2 = could not complete the check for a reason outside any
+                single monitored path (a filesystem error writing state --
+                e.g. the telemetry tree not yet created/chowned on a fresh
+                host). Deliberately distinct from exit 1 so a permissions
+                failure can never be misread as "disk full."
+            3 = the watchdog itself broke on an unexpected/unhandled
+                exception (a bug in this script). Deliberately distinct
+                from both exit 1 and exit 2, same convention as
+                bus_core_health_watchdog.py.
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/disk_threshold_watchdog.py` puts scripts/ on
+# sys.path[0], which can shadow stdlib modules (same issue documented in
+# scripts/bus_core_health_watchdog.py / scripts/check_inner_state_registry.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+from orion.notify.client import NotifyClient  # noqa: E402
+
+DEFAULT_PATHS = ("/mnt/docker", "/mnt/scripts", "/mnt/telemetry")
+DEFAULT_THRESHOLD_PCT = 90.0
+
+
+def default_state_file(telemetry_root: str, project: str) -> Path:
+    return Path(telemetry_root) / project / "disk-watchdog" / "state.json"
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """mkstemp in the same directory + os.replace -- atomic on the same
+    filesystem, no torn writes if this run is interrupted mid-write."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"paths": {}}
+    try:
+        with path.open("r") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict) or not isinstance(data.get("paths"), dict):
+            raise ValueError("state file did not contain the expected {'paths': {...}} shape")
+        return data
+    except (json.JSONDecodeError, ValueError, OSError) as exc:
+        print(
+            f"disk_threshold_watchdog: WARNING -- state file {path} unreadable/corrupt "
+            f"({exc}), starting from a fresh state.",
+            file=sys.stderr,
+        )
+        return {"paths": {}}
+
+
+def measure_path(path: str) -> tuple[float | None, str | None]:
+    """Returns (percent_used, error). Exactly one is non-None.
+
+    Never raises -- a missing mount or permission error is itself a signal
+    this script reports on, not a tooling failure that should crash the run.
+    """
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError as exc:
+        return None, str(exc)
+    if usage.total <= 0:
+        return None, f"disk_usage reported non-positive total ({usage.total}) for {path}"
+    return (usage.used / usage.total) * 100.0, None
+
+
+def evaluate_path(
+    state_for_path: dict[str, Any],
+    percent_used: float | None,
+    error: str | None,
+    threshold_pct: float,
+    now: datetime,
+) -> tuple[dict[str, Any], str, bool]:
+    """Pure function: given one path's persisted state plus one fresh
+    (percent_used, error) observation, returns
+    (updated_state_for_path, status, should_notify).
+
+    status is one of "ok" / "breached" / "error". should_notify is True on a
+    transition INTO "breached" or INTO "error", AND on every subsequent tick
+    where the status is still bad but `state_for_path["notified"]` is not
+    True -- i.e. the caller (run()) never confirmed a prior notify attempt
+    actually succeeded. This is deliberate: `run()` only persists
+    `notified=True` after `NotifyClient.attention_request()` reports
+    success. A notify call that raised, or came back with `ok=False` (the
+    real `NotifyClient` never raises on network failure -- it always
+    returns `NotificationAccepted(ok=False, ...)`), must not be silently
+    treated as "handled." Without this, a breach that first occurs while
+    orion-notify is down/unreachable would be debounced into permanent
+    silence the moment `last_status` flips to "breached", even though no
+    Pending Attention card ever actually landed. Caught live during code
+    review: a mocked notify failure showed the state file committing
+    last_status="breached" on tick 1 with zero retry attempted on tick 2.
+    """
+    now_iso = now.isoformat()
+    prev_status = state_for_path.get("last_status", "ok")
+    prev_notified = bool(state_for_path.get("notified", False))
+    new_state = dict(state_for_path)
+
+    if error is not None:
+        status = "error"
+        new_state["last_error"] = error
+        new_state["last_percent_used"] = None
+    else:
+        assert percent_used is not None
+        status = "breached" if percent_used >= threshold_pct else "ok"
+        new_state["last_error"] = None
+        new_state["last_percent_used"] = percent_used
+
+    is_status_transition = status in ("breached", "error") and status != prev_status
+    should_notify = status in ("breached", "error") and (is_status_transition or not prev_notified)
+
+    if is_status_transition:
+        new_state["first_detected_at"] = now_iso
+        new_state["notified"] = False
+    elif status == "ok":
+        new_state["first_detected_at"] = None
+        new_state["notified"] = False
+    else:
+        # Status unchanged and still bad -- carry the previous notified flag
+        # forward; run() overwrites it with the real outcome of this tick's
+        # notify attempt if should_notify is True.
+        new_state["notified"] = prev_notified
+
+    new_state["last_status"] = status
+    new_state["last_check_at"] = now_iso
+    return new_state, status, should_notify
+
+
+class WatchdogLockedError(RuntimeError):
+    """Another watchdog run already holds the state-file lock -- this run
+    skips cleanly rather than racing it for the write."""
+
+
+class _StateLock:
+    """Non-blocking flock on `<state_file>.lock`, same pattern as
+    bus_core_health_watchdog.py's _StateLock -- guards against overlapping
+    cron invocations corrupting the read-evaluate-write cycle."""
+
+    def __init__(self, state_file: Path) -> None:
+        self._lock_path = state_file.with_suffix(state_file.suffix + ".lock")
+        self._fh = None
+
+    def __enter__(self) -> "_StateLock":
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(self._lock_path, "w")
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            fh.close()
+            raise WatchdogLockedError(
+                f"lock {self._lock_path} already held -- another watchdog run is in progress, skipping"
+            ) from exc
+        self._fh = fh
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        if self._fh is not None:
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            self._fh.close()
+
+
+def _publish_attention(
+    notify: NotifyClient,
+    *,
+    path: str,
+    status: str,
+    percent_used: float | None,
+    error: str | None,
+    threshold_pct: float,
+) -> bool:
+    """Returns True only if orion-notify actually confirmed the attention
+    request (`NotificationAccepted.ok`). The real `NotifyClient.
+    attention_request()` does not raise on network failure -- it catches
+    everything internally and returns `NotificationAccepted(ok=False, ...)`
+    -- so both that case AND a genuine exception (e.g. a pydantic
+    construction error) must return False here. run() uses this return
+    value, not "did the call happen," to decide whether the debounce state
+    may be marked notified -- see evaluate_path()'s docstring.
+    """
+    if status == "breached":
+        message = (
+            f"Disk usage on {path} is at {percent_used:.1f}% "
+            f"(threshold {threshold_pct:.1f}%)."
+        )
+        reason = f"[Orion disk watchdog] {path} over threshold"
+    else:
+        message = f"Could not check disk usage on {path}: {error}"
+        reason = f"[Orion disk watchdog] {path} check failed"
+
+    context = {
+        "source_service": "disk-threshold-watchdog",
+        "event_kind": "orion.disk.threshold.attention.v1",
+        "path": path,
+        "status": status,
+        "percent_used": percent_used,
+        "threshold_pct": threshold_pct,
+        "error": error,
+        "reason": reason,
+    }
+    try:
+        result = notify.attention_request(
+            message=message,
+            severity="warning" if status == "breached" else "error",
+            require_ack=True,
+            context=context,
+        )
+    except Exception as exc:  # noqa: BLE001 -- notify failure must not crash the watchdog
+        print(
+            f"disk_threshold_watchdog: WARNING -- failed to publish attention request for "
+            f"{path}: {exc}. Will retry next tick.",
+            file=sys.stderr,
+        )
+        return False
+
+    ok = bool(getattr(result, "ok", False))
+    if not ok:
+        detail = getattr(result, "detail", None)
+        print(
+            f"disk_threshold_watchdog: WARNING -- orion-notify did not confirm the attention "
+            f"request for {path} (ok=False, detail={detail!r}). Will retry next tick.",
+            file=sys.stderr,
+        )
+    return ok
+
+
+def run(
+    paths: list[str],
+    threshold_pct: float,
+    state_file: Path,
+    notify: NotifyClient,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], bool]:
+    now = now or datetime.now(timezone.utc)
+
+    with _StateLock(state_file):
+        state = load_state(state_file)
+        any_bad = False
+        for path in paths:
+            percent_used, error = measure_path(path)
+            path_state = state["paths"].get(path, {})
+            new_path_state, status, should_notify = evaluate_path(
+                path_state, percent_used, error, threshold_pct, now
+            )
+            if status != "ok":
+                any_bad = True
+            if should_notify:
+                new_path_state["notified"] = _publish_attention(
+                    notify,
+                    path=path,
+                    status=status,
+                    percent_used=percent_used,
+                    error=error,
+                    threshold_pct=threshold_pct,
+                )
+            state["paths"][path] = new_path_state
+        _atomic_write_json(state_file, state)
+
+    return state, any_bad
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--paths",
+        default=os.getenv("DISK_WATCHDOG_PATHS", ",".join(DEFAULT_PATHS)),
+        help=f"Comma-separated mount paths to check. Default: {','.join(DEFAULT_PATHS)}.",
+    )
+    parser.add_argument(
+        "--threshold-pct",
+        type=float,
+        default=float(os.getenv("DISK_WATCHDOG_THRESHOLD_PCT", DEFAULT_THRESHOLD_PCT)),
+        help=f"Percent-used threshold that triggers a breach. Default: {DEFAULT_THRESHOLD_PCT}.",
+    )
+    parser.add_argument(
+        "--project",
+        default=os.getenv("PROJECT", "orion-athena"),
+        help="Compose project name, matches $PROJECT (see .env). Used to derive the default "
+        "state-file path. Default: $PROJECT or 'orion-athena'.",
+    )
+    parser.add_argument(
+        "--telemetry-root",
+        default=os.getenv("TELEMETRY_ROOT", "/mnt/telemetry"),
+        help="Root of the telemetry tree, matches $TELEMETRY_ROOT. Default: $TELEMETRY_ROOT or /mnt/telemetry.",
+    )
+    parser.add_argument("--state-file", default=None, help="Path to the watchdog's own state JSON file.")
+    parser.add_argument(
+        "--notify-base-url",
+        default=os.getenv("NOTIFY_BASE_URL", "http://localhost:7140"),
+        help="orion-notify base URL, reachable from the host (not the Docker-internal "
+        "hostname). Default: $NOTIFY_BASE_URL or http://localhost:7140.",
+    )
+    parser.add_argument(
+        "--notify-api-token",
+        default=os.getenv("NOTIFY_API_TOKEN"),
+        help="orion-notify API token, if configured. Default: $NOTIFY_API_TOKEN.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of prose.")
+    args = parser.parse_args(argv)
+
+    paths = [p.strip() for p in args.paths.split(",") if p.strip()]
+    state_file = Path(args.state_file) if args.state_file else default_state_file(args.telemetry_root, args.project)
+    notify = NotifyClient(base_url=args.notify_base_url, api_token=args.notify_api_token, timeout=10)
+
+    try:
+        state, any_bad = run(paths, args.threshold_pct, state_file, notify)
+    except WatchdogLockedError as exc:
+        print(f"disk_threshold_watchdog: SKIPPED -- {exc}", file=sys.stderr)
+        return 0
+    except OSError as exc:
+        print(
+            f"disk_threshold_watchdog: FAILED -- could not write state file: {exc}. "
+            "Check directory ownership/permissions.",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:  # noqa: BLE001 -- deliberate catch-all, see docstring's Exit codes
+        print(
+            f"disk_threshold_watchdog: UNEXPECTED ERROR -- {type(exc).__name__}: {exc}. "
+            "This is a bug in the watchdog itself, not a real disk signal.",
+            file=sys.stderr,
+        )
+        return 3
+
+    if args.json:
+        print(json.dumps({"state_file": str(state_file), "threshold_pct": args.threshold_pct, **state}))
+    else:
+        for path in paths:
+            p_state = state["paths"].get(path, {})
+            status = p_state.get("last_status", "unknown")
+            pct = p_state.get("last_percent_used")
+            pct_str = f"{pct:.1f}%" if isinstance(pct, (int, float)) else "n/a"
+            print(f"disk_threshold_watchdog: {path} status={status} used={pct_str}")
+        print("disk_threshold_watchdog: OK -- all paths under threshold." if not any_bad else "disk_threshold_watchdog: ATTENTION -- see above.", file=sys.stderr if any_bad else sys.stdout)
+
+    return 1 if any_bad else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_disk_threshold_watchdog.py
+++ b/tests/test_disk_threshold_watchdog.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import disk_threshold_watchdog as watchdog  # noqa: E402
+
+
+def _now(offset_minutes: float = 0.0) -> datetime:
+    return datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc) + timedelta(minutes=offset_minutes)
+
+
+# ---------------------------------------------------------------------------
+# measure_path
+# ---------------------------------------------------------------------------
+
+
+def test_measure_path_returns_percent_used_for_real_path(tmp_path):
+    pct, err = watchdog.measure_path(str(tmp_path))
+    assert err is None
+    assert pct is not None
+    assert 0.0 <= pct <= 100.0
+
+
+def test_measure_path_returns_error_for_missing_path():
+    pct, err = watchdog.measure_path("/nonexistent/path/that/should/not/exist")
+    assert pct is None
+    assert err is not None
+
+
+def test_measure_path_never_raises_on_missing_path():
+    # Documented contract: measure_path never raises, only reports (None, error).
+    watchdog.measure_path("/definitely/not/a/real/mount/anywhere")
+
+
+# ---------------------------------------------------------------------------
+# evaluate_path -- pure state-transition logic
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_path_ok_when_under_threshold():
+    state, status, is_new = watchdog.evaluate_path({}, 50.0, None, 90.0, _now())
+    assert status == "ok"
+    assert is_new is False
+    assert state["last_percent_used"] == 50.0
+    assert state["first_detected_at"] is None
+
+
+def test_evaluate_path_breach_is_new_event_first_time():
+    state, status, is_new = watchdog.evaluate_path({}, 95.0, None, 90.0, _now())
+    assert status == "breached"
+    assert is_new is True
+    assert state["first_detected_at"] == _now().isoformat()
+
+
+def test_evaluate_path_repeated_breach_after_successful_notify_does_not_refire():
+    state1, _, _ = watchdog.evaluate_path({}, 95.0, None, 90.0, _now())
+    state1["notified"] = True  # simulates run() persisting a confirmed notify
+    state2, status, should_notify = watchdog.evaluate_path(state1, 96.0, None, 90.0, _now(1))
+    assert status == "breached"
+    assert should_notify is False
+    # first_detected_at carries forward from the original breach, not reset.
+    assert state2["first_detected_at"] == _now().isoformat()
+
+
+def test_evaluate_path_repeated_breach_retries_if_previous_notify_never_confirmed():
+    # notified stays False (the default) -- simulates a failed/unconfirmed
+    # publish attempt on the prior tick. Regression test for the code-review
+    # finding: a failed notify must not be silently debounced into permanent
+    # silence.
+    state1, _, _ = watchdog.evaluate_path({}, 95.0, None, 90.0, _now())
+    assert state1["notified"] is False
+    state2, status, should_notify = watchdog.evaluate_path(state1, 96.0, None, 90.0, _now(1))
+    assert status == "breached"
+    assert should_notify is True
+
+
+def test_evaluate_path_recovery_clears_breach_state_silently():
+    state1, _, _ = watchdog.evaluate_path({}, 95.0, None, 90.0, _now())
+    state1["notified"] = True
+    state2, status, should_notify = watchdog.evaluate_path(state1, 50.0, None, 90.0, _now(1))
+    assert status == "ok"
+    assert should_notify is False
+    assert state2["first_detected_at"] is None
+    assert state2["notified"] is False
+
+
+def test_evaluate_path_breach_after_recovery_fires_again():
+    state1, _, _ = watchdog.evaluate_path({}, 95.0, None, 90.0, _now())
+    state1["notified"] = True
+    state2, _, _ = watchdog.evaluate_path(state1, 50.0, None, 90.0, _now(1))
+    state3, status, should_notify = watchdog.evaluate_path(state2, 95.0, None, 90.0, _now(2))
+    assert status == "breached"
+    assert should_notify is True
+
+
+def test_evaluate_path_exactly_at_threshold_counts_as_breached():
+    _, status, _ = watchdog.evaluate_path({}, 90.0, None, 90.0, _now())
+    assert status == "breached"
+
+
+def test_evaluate_path_error_is_new_event():
+    state, status, should_notify = watchdog.evaluate_path({}, None, "permission denied", 90.0, _now())
+    assert status == "error"
+    assert should_notify is True
+    assert state["last_error"] == "permission denied"
+    assert state["last_percent_used"] is None
+
+
+def test_evaluate_path_repeated_error_after_successful_notify_does_not_refire():
+    state1, _, _ = watchdog.evaluate_path({}, None, "permission denied", 90.0, _now())
+    state1["notified"] = True
+    state2, status, should_notify = watchdog.evaluate_path(state1, None, "permission denied", 90.0, _now(1))
+    assert status == "error"
+    assert should_notify is False
+
+
+def test_evaluate_path_repeated_error_retries_if_previous_notify_never_confirmed():
+    state1, _, _ = watchdog.evaluate_path({}, None, "permission denied", 90.0, _now())
+    assert state1["notified"] is False
+    state2, status, should_notify = watchdog.evaluate_path(state1, None, "permission denied", 90.0, _now(1))
+    assert status == "error"
+    assert should_notify is True
+
+
+def test_evaluate_path_error_then_ok_then_error_fires_again():
+    state1, _, _ = watchdog.evaluate_path({}, None, "boom", 90.0, _now())
+    state1["notified"] = True
+    state2, _, _ = watchdog.evaluate_path(state1, 10.0, None, 90.0, _now(1))
+    state3, status, should_notify = watchdog.evaluate_path(state2, None, "boom again", 90.0, _now(2))
+    assert status == "error"
+    assert should_notify is True
+
+
+def test_evaluate_path_breach_directly_to_error_is_new_event():
+    # status changes from "breached" to "error" -- still a distinct new event
+    # (different failure mode), not swallowed by "already flagged."
+    state1, _, _ = watchdog.evaluate_path({}, 95.0, None, 90.0, _now())
+    state1["notified"] = True
+    state2, status, should_notify = watchdog.evaluate_path(state1, None, "mount vanished", 90.0, _now(1))
+    assert status == "error"
+    assert should_notify is True
+
+
+# ---------------------------------------------------------------------------
+# run() -- orchestration, notify wiring, debounce across ticks
+# ---------------------------------------------------------------------------
+
+
+def _fake_notify(ok: bool = True) -> MagicMock:
+    """Mirrors the real NotifyClient.attention_request() contract: it never
+    raises for a network failure, it returns NotificationAccepted(ok=...)."""
+    notify = MagicMock()
+    notify.attention_request = MagicMock(return_value=MagicMock(ok=ok, detail=None))
+    return notify
+
+
+def test_run_fires_notify_once_on_new_breach_and_writes_state(tmp_path):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify()
+
+    # threshold_pct=0 guarantees a breach against any real filesystem usage.
+    state, any_bad = watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now())
+
+    assert any_bad is True
+    assert notify.attention_request.call_count == 1
+    call_kwargs = notify.attention_request.call_args.kwargs
+    assert call_kwargs["severity"] == "warning"
+    assert call_kwargs["context"]["path"] == str(small_dir)
+    assert state_file.exists()
+    persisted = json.loads(state_file.read_text())
+    assert persisted["paths"][str(small_dir)]["last_status"] == "breached"
+    assert persisted["paths"][str(small_dir)]["notified"] is True
+
+
+def test_run_does_not_refire_notify_on_second_tick_still_breached(tmp_path):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify()
+
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now())
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now(15))
+
+    assert notify.attention_request.call_count == 1
+
+
+def test_run_retries_notify_next_tick_when_notify_returns_ok_false(tmp_path):
+    # Regression test for the code-review finding: the REAL NotifyClient
+    # never raises on network failure -- it returns ok=False. A prior
+    # version of this script treated the call as "handled" the moment it
+    # was attempted, regardless of the result, which meant a breach that
+    # first occurred while orion-notify was down/unreachable would never
+    # be retried and no Pending Attention card would ever land.
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify(ok=False)
+
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now())
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now(15))
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now(30))
+
+    assert notify.attention_request.call_count == 3
+    persisted = json.loads(state_file.read_text())
+    assert persisted["paths"][str(small_dir)]["notified"] is False
+
+
+def test_run_stops_retrying_once_a_notify_attempt_succeeds(tmp_path):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = MagicMock()
+    notify.attention_request = MagicMock(
+        side_effect=[
+            MagicMock(ok=False, detail="connection refused"),
+            MagicMock(ok=True, detail=None),
+        ]
+    )
+
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now())      # fails
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now(15))    # succeeds
+    watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now(30))    # should not retry
+
+    assert notify.attention_request.call_count == 2
+    persisted = json.loads(state_file.read_text())
+    assert persisted["paths"][str(small_dir)]["notified"] is True
+
+
+def test_run_does_not_fire_notify_when_under_threshold(tmp_path):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify()
+
+    state, any_bad = watchdog.run([str(small_dir)], 100.0, state_file, notify, now=_now())
+
+    assert any_bad is False
+    assert notify.attention_request.call_count == 0
+
+
+def test_run_fires_error_severity_for_missing_path(tmp_path):
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify()
+
+    state, any_bad = watchdog.run(
+        ["/nonexistent/definitely/not/real"], 90.0, state_file, notify, now=_now()
+    )
+
+    assert any_bad is True
+    assert notify.attention_request.call_count == 1
+    assert notify.attention_request.call_args.kwargs["severity"] == "error"
+
+
+def test_run_checks_multiple_paths_independently(tmp_path):
+    breached_dir = tmp_path / "full"
+    breached_dir.mkdir()
+    ok_dir = tmp_path / "empty"
+    ok_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify()
+
+    # Force one path to read as breached via a monkeypatched measure_path
+    # keyed by path, since we can't actually fill a real tmp filesystem.
+    original = watchdog.measure_path
+
+    def fake_measure(path):
+        if path == str(breached_dir):
+            return 99.0, None
+        return original(path)
+
+    watchdog.measure_path = fake_measure
+    try:
+        state, any_bad = watchdog.run(
+            [str(breached_dir), str(ok_dir)], 90.0, state_file, notify, now=_now()
+        )
+    finally:
+        watchdog.measure_path = original
+
+    assert any_bad is True
+    assert notify.attention_request.call_count == 1
+    persisted_paths = state["paths"]
+    assert persisted_paths[str(breached_dir)]["last_status"] == "breached"
+    assert persisted_paths[str(ok_dir)]["last_status"] == "ok"
+
+
+def test_run_notify_failure_does_not_crash_watchdog(tmp_path):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify()
+    notify.attention_request.side_effect = RuntimeError("orion-notify unreachable")
+
+    # Must not raise even though the notify call inside failed.
+    state, any_bad = watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now())
+    assert any_bad is True
+    assert state_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# locking
+# ---------------------------------------------------------------------------
+
+
+def test_state_lock_blocks_concurrent_acquisition(tmp_path):
+    state_file = tmp_path / "state.json"
+    with watchdog._StateLock(state_file):
+        with pytest.raises(watchdog.WatchdogLockedError):
+            with watchdog._StateLock(state_file):
+                pass
+
+
+def test_state_lock_is_released_after_context_exit(tmp_path):
+    state_file = tmp_path / "state.json"
+    with watchdog._StateLock(state_file):
+        pass
+    # Should not raise -- the lock was released.
+    with watchdog._StateLock(state_file):
+        pass
+
+
+def test_run_skips_cleanly_when_lock_already_held(tmp_path):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    notify = _fake_notify()
+
+    with watchdog._StateLock(state_file):
+        with pytest.raises(watchdog.WatchdogLockedError):
+            watchdog.run([str(small_dir)], 0.0, state_file, notify, now=_now())
+    # No notify call happened because run() never got past the lock.
+    assert notify.attention_request.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# load_state resilience
+# ---------------------------------------------------------------------------
+
+
+def test_load_state_returns_empty_for_missing_file(tmp_path):
+    state = watchdog.load_state(tmp_path / "does_not_exist.json")
+    assert state == {"paths": {}}
+
+
+def test_load_state_recovers_from_corrupt_json(tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text("{not valid json")
+    state = watchdog.load_state(state_file)
+    assert state == {"paths": {}}
+
+
+def test_load_state_recovers_from_wrong_shape(tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"unexpected": "shape"}))
+    state = watchdog.load_state(state_file)
+    assert state == {"paths": {}}
+
+
+# ---------------------------------------------------------------------------
+# main() CLI / exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_zero_when_all_paths_ok(tmp_path, monkeypatch):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(watchdog, "NotifyClient", lambda **kw: _fake_notify())
+
+    rc = watchdog.main(
+        ["--paths", str(small_dir), "--threshold-pct", "100", "--state-file", str(state_file)]
+    )
+    assert rc == 0
+
+
+def test_main_exits_one_when_a_path_is_breached(tmp_path, monkeypatch):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(watchdog, "NotifyClient", lambda **kw: _fake_notify())
+
+    rc = watchdog.main(
+        ["--paths", str(small_dir), "--threshold-pct", "0", "--state-file", str(state_file)]
+    )
+    assert rc == 1
+
+
+def test_main_exits_two_on_state_write_permission_error(tmp_path, monkeypatch):
+    small_dir = tmp_path / "mount"
+    small_dir.mkdir()
+    unwritable_state_file = tmp_path / "no_such_parent" / "state.json"
+    monkeypatch.setattr(watchdog, "NotifyClient", lambda **kw: _fake_notify())
+
+    def boom(*a, **kw):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(watchdog, "_atomic_write_json", boom)
+
+    rc = watchdog.main(
+        ["--paths", str(small_dir), "--threshold-pct", "100", "--state-file", str(unwritable_state_file)]
+    )
+    assert rc == 2
+
+
+def test_main_exits_three_on_unexpected_exception(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(watchdog, "NotifyClient", lambda **kw: _fake_notify())
+
+    def boom(*a, **kw):
+        raise ValueError("bug")
+
+    monkeypatch.setattr(watchdog, "run", boom)
+
+    rc = watchdog.main(["--paths", "/tmp", "--state-file", str(state_file)])
+    assert rc == 3
+
+
+def test_default_paths_include_docker_scripts_telemetry():
+    assert watchdog.DEFAULT_PATHS == ("/mnt/docker", "/mnt/scripts", "/mnt/telemetry")
+
+
+def test_default_state_file_lives_under_telemetry_root():
+    path = watchdog.default_state_file("/mnt/telemetry", "orion-athena")
+    assert str(path) == "/mnt/telemetry/orion-athena/disk-watchdog/state.json"


### PR DESCRIPTION
## Summary

- `/mnt/docker`, `/mnt/scripts/`, and `/mnt/telemetry` (three distinct physical mounts on this host, confirmed via `df -h`) had no threshold monitoring that surfaced a breach anywhere an operator would actually see it.
- Added `scripts/disk_threshold_watchdog.py`: a standalone, host-level (non-containerized), cron-run script that checks `shutil.disk_usage()` per path and, the first time a path crosses `--threshold-pct` (default 90), fires `orion-notify`'s `POST /attention/request` — the same mechanism `orion-mesh-guardian` already uses — which lands as a Hub Pending Attention card.
- Mirrors the pattern already proven and code-reviewed in `scripts/bus_core_health_watchdog.py`: pure `evaluate_path()` for the threshold/debounce logic, `flock`-guarded atomic state writes to survive overlapping cron invocations, distinct exit codes (0/1/2/3) so a monitoring wrapper can tell "breach detected" apart from "tooling failure" apart from "watchdog bug."
- Live-verified end to end against the real running `orion-notify`: real `attention_request` calls landed with `status: "pending"`, confirmed via `GET /attention`, then ack'd/dismissed to clean up smoke-test noise.
- A high-effort code-review subagent (`orion-repo-agent`) found one **critical** bug before merge: a failed/unconfirmed notify call was being persisted as "already notified," so a breach that first occurred while `orion-notify` was down would never retry — no Pending Attention card would ever land for the entire duration of the outage, exactly the failure window this feature exists to survive. Fixed and live-reproduced (see below).

## Outcome moved

Previously: nothing watched host disk usage on these three mounts. Now: a cron-run script that checks all three independently every 15 minutes, publishes a real Hub Pending Attention card on first breach, debounces repeat notification while already confirmed, and — critically — retries on every subsequent tick if the prior notify attempt never actually succeeded, rather than silently going quiet.

## Current architecture

No prior disk-threshold monitoring existed. Two lookalikes were investigated and ruled out: `skills.storage.disk_health_snapshot.v1` (a reactive cognition skill, goal-driven, not a threshold watchdog) and `resource_pressure`/`cpu_pressure`/`gpu_pressure` (Orion's internal cognitive-economy signal feeding drives, not an operator infra alert — wrong layer). `orion.notify.client.NotifyClient.attention_request()` → `orion-notify` `/attention/request` → Hub Pending Attention is the real, live, proven mechanism, already used by `orion-mesh-guardian` and the Fuseki recover job.

## Architecture touched

Host-level only. No new service, no schema/bus contract change, no Docker container. `NotifyClient`/`ChatAttentionRequest` (`orion/schemas/notify.py`, `orion/notify/client.py`) reused as-is.

## Files changed

- `scripts/disk_threshold_watchdog.py` (new): the watchdog. `measure_path()` (never raises), `evaluate_path()` (pure threshold/debounce/retry state machine), `_publish_attention()` (returns whether orion-notify actually confirmed), `run()` (flock-guarded read-evaluate-write cycle), `main()` (CLI + exit codes).
- `tests/test_disk_threshold_watchdog.py` (new, 35 tests): pure-logic tests for every state transition (breach/recovery/re-breach, error/ok/error, breach→error), concurrency-lock tests, `load_state` corruption-resilience tests, and — added during the review-fix pass — explicit retry-on-failed-notify regression tests mirroring the real `NotifyClient` contract (`NotificationAccepted(ok=False, ...)`, not an exception).
- `Makefile`: new `disk-threshold-watchdog` target (sets `PYTHONPATH=.`, since this script imports `orion.notify.client`, unlike `bus_core_health_watchdog.py` which deliberately imports nothing from `orion.*`).
- `scripts/README.md`: new "Disk Threshold Watchdog" discoverability section — description, usage, expected output, one-time `chown` prerequisite (same `root:root` 755 gotcha confirmed live for the bus-core watchdog's telemetry directory), and the crontab install line.

## Schema / bus / API changes

None. Reuses `ChatAttentionRequest`/`NotifyClient.attention_request()` as-is — no new bus channel, no schema registry change, no `PendingAttentionCardV1` widening (that schema is hard-locked to `source: Literal["cognitive_loop"]` and is a different subsystem entirely — not reusable here).

## Env/config changes

None added. Reads `$PROJECT`/`$TELEMETRY_ROOT`/`$NOTIFY_BASE_URL`/`$NOTIFY_API_TOKEN` (existing keys) purely as CLI-flag defaults, overridable via `--project`/`--telemetry-root`/`--notify-base-url`/`--notify-api-token`/`--paths`/`--threshold-pct`/`--state-file`.

## Tests run

```text
source venv/bin/activate && python -m py_compile scripts/disk_threshold_watchdog.py
=> OK

PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py -q
=> 35 passed

PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py tests/test_bus_core_health_watchdog.py -q
=> 84 passed

git diff --check
=> clean
```

## Evals run

None applicable — deterministic gate-style script (matches AGENTS.md §11's "Gate tests" category, same as `bus_core_health_watchdog.py`), not a quality/behavior measurement needing an eval harness.

## Docker/build/smoke checks

No Docker involved — host-level script, nothing to build.

Live smokes against the real host and real running `orion-notify` (port 7140):
```text
$ PYTHONPATH=. python3 scripts/disk_threshold_watchdog.py --threshold-pct 90 --json
disk_threshold_watchdog: /mnt/docker status=ok used=79.6%   (/dev/sda)
disk_threshold_watchdog: /mnt/scripts status=ok used=6.0%   (/dev/sde1)
disk_threshold_watchdog: /mnt/telemetry status=ok used=18.6% (/dev/sdf1)
exit: 0
```

Forced-breach end-to-end (threshold-pct=0): 3 real `attention_request` calls landed in `orion-notify`'s `/attention` list with `status: "pending"`, confirmed via `GET /attention`, then ack'd/dismissed via `POST /attention/{id}/ack` to clean up.

Retry-on-failure regression, reproduced live against an unreachable notify port (`--notify-base-url http://127.0.0.1:1`) both BEFORE and AFTER the fix:
```text
BEFORE FIX:
  tick 1 (notify unreachable): last_status=breached persisted, notify attempted
  tick 2 (notify still unreachable): NO notify attempt at all -- silently swallowed

AFTER FIX:
  tick 1 (notify unreachable): last_status=breached, notified=false persisted
  tick 2 (notify still unreachable): notify RETRIED for all 3 paths, notified=false
  tick 3 (notify now reachable): notify RETRIED, notified=true persisted
  tick 4 (still breached): no retry -- already confirmed notified
```

## Review findings fixed

Code review (`orion-repo-agent`, high effort) against `/mnt/scripts/Orion-Sapienform-disk-threshold-watchdog`:

- **Finding (CRITICAL)**: `_publish_attention()` discarded `NotifyClient.attention_request()`'s return value entirely, and `run()` persisted the debounce transition to "breached"/"notified" before the notify call even happened. The real `NotifyClient` never raises on network failure — it catches everything internally and returns `NotificationAccepted(ok=False, ...)`. So a breach occurring while `orion-notify` is down would get `last_status="breached"` committed on tick 1, and tick 2 would see `status == prev_status` and never retry — permanently silent, zero Pending Attention card, for the entire outage. Live-reproduced by the reviewer against a mocked unreachable client.
  - **Fix**: `_publish_attention()` now returns `bool(result.ok)` (False on both exception and `ok=False`). `evaluate_path()` now tracks a separate `notified` field per path, only ever set `True` by `run()` after a confirmed-successful call; `should_notify` fires on a status transition OR whenever the current bad status has `notified != True`, so a failed/unconfirmed attempt retries every subsequent tick until it succeeds.
  - **Evidence**: `test_evaluate_path_repeated_breach_retries_if_previous_notify_never_confirmed`, `test_evaluate_path_repeated_error_retries_if_previous_notify_never_confirmed`, `test_run_retries_notify_next_tick_when_notify_returns_ok_false`, `test_run_stops_retrying_once_a_notify_attempt_succeeds` — plus the live before/after reproduction above against a real unreachable port.
- **Finding (MEDIUM)**: the one existing test claiming to cover "notify unreachable" (`test_run_notify_failure_does_not_crash_watchdog`) used `side_effect = RuntimeError(...)`, which the real client never actually raises — it gave false confidence for exactly the broken scenario.
  - **Fix**: `_fake_notify()` now defaults to mirroring the real contract (`MagicMock(ok=True/False)`, not an exception); the exception-path test is kept (still valid coverage for `_publish_attention`'s `except` branch) alongside new `ok=False`-based tests that match the realistic failure mode.
  - **Evidence**: see tests listed above.
- **Finding (LOW, fixed)**: the Makefile target's comment pointed to a `scripts/README.md` cron-install section that didn't exist yet.
  - **Fix**: added the actual crontab line plus the one-time `chown` prerequisite (same gotcha class already documented for the bus-core watchdog) to `scripts/README.md`.
  - **Evidence**: confirmed live — `/mnt/telemetry/orion-athena/` is `root:root` 755 on this host, same as documented for `bus_core_health_watchdog.py`.
- **Finding (MEDIUM, accepted not fixed)**: `_StateLock` wraps the full per-path loop including the `orion-notify` HTTP call (up to 10s timeout per path), unlike `bus_core_health_watchdog.py`'s lock which only ever guards fast local I/O (its one blocking call, `docker inspect`, happens outside the lock, and its alert path is a local file write, not a network call). During a slow/hanging (not just refusing) `orion-notify`, an overlapping cron tick that can't acquire the lock skips cleanly rather than measuring disk at all for that tick.
  - **Not fixed**: a correct two-phase lock (measure+decide under lock, notify outside, re-lock to commit outcome) is real complexity for a lower-severity, cron-cadence-dependent (default every 15 min, not every 1 min like bus-core-watchdog) risk. The reviewer explicitly assessed this as shippable with a documented follow-up rather than blocking.
  - **Mitigation**: documented here and in the script's own docstring; a future patch could split measurement from notification if the every-15-min cadence proves too coarse in practice.
- **Finding (MINOR, informational, accepted)**: `run()` does a single `_atomic_write_json` after the full per-path loop rather than per-item like the sibling script. If `measure_path`/`evaluate_path`/`_publish_attention` ever raised unexpectedly partway through a multi-path tick (not currently reachable given `measure_path`'s documented "never raises" contract), in-memory progress for paths already processed that tick would be lost. Reviewer noted this fails in the safe direction (duplicate notify next tick, not silently dropped) — not urgent.

## Restart required

```text
No restart required.
```

This is a new, standalone host-level script — nothing to restart. It only becomes live once the crontab line in `scripts/README.md`'s "Disk Threshold Watchdog" section is installed by hand (host crontab is shared infrastructure, deliberately not modified automatically).

**Exact install commands (report only, not run by this session):**
```bash
sudo mkdir -p /mnt/telemetry/orion-athena/disk-watchdog
sudo chown "$(whoami)":"$(whoami)" /mnt/telemetry/orion-athena/disk-watchdog

crontab -e
# then paste:
*/15 * * * * make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
```

## Risks / concerns

- Severity: low
- Concern: `/mnt/docker` is already at ~80% used on this host today. At the default `--threshold-pct 90`, this won't fire immediately, but it's close enough that a real card is plausible soon after this ships — expected behavior, not a bug, flagging so it isn't mistaken for a smoke-test artifact when it lands.
- Severity: medium (documented, not blocking)
- Concern: `_StateLock` holds across the notify HTTP call (see Review Findings above) — a slow/hanging (not refusing) `orion-notify` could cause a skipped measurement tick under overlapping cron runs. Low real-world likelihood at the default 15-minute cadence.
- Severity: low
- Concern: every-15-minute cron cadence assumes cron itself is running — same inherited gap as every other cron-based gate in this repo (`bus_core_health_watchdog.py`, `check_concept_relation_digest_liveness.py`).

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/chore/disk-threshold-watchdog