### PR TITLE
fix(notify): use real compose service keys instead of directory-name hostnames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions check-substrate-projection-schema-drift bus-core-health-watchdog worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
+.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions check-substrate-projection-schema-drift check-service-hostname-refs bus-core-health-watchdog worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
 
 SERVICE ?=
 ARGS ?=
@@ -78,6 +78,17 @@ check-env-compose-parity:
 # fail-closed, but that gap should be loud in CI, not silent).
 check-journal-dispatch-registry:
 	@python scripts/check_journal_dispatch_registry.py
+
+# Repo-wide gate: flags any services/*/.env_example URL that hardcodes another
+# service's services/<dirname> directory name as an HTTP hostname instead of its
+# real Docker Compose service key. Found live 2026-07-28 -- that directory-name
+# style hostname only resolves by accident (depends on container_name:
+# ${PROJECT}-<name> happening to equal orion-<name>, i.e. PROJECT having no host
+# suffix); it silently broke orion-notify-digest's daily email since inception,
+# plus 15 other references across 11 other services. The compose service key is
+# the one hostname Docker's default network guarantees regardless of PROJECT.
+check-service-hostname-refs:
+	@python scripts/check_service_hostname_refs.py
 
 # Report-only: flags orion-actions daily cadences (Daily Pulse, World Pulse, Daily
 # Metacog, and Daily Journal -- which has no env var of its own and reuses Daily

--- a/scripts/check_service_hostname_refs.py
+++ b/scripts/check_service_hostname_refs.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Flag .env_example URLs that reference another service by its directory name
+instead of its real Docker Compose service key.
+
+Context: found live 2026-07-28 -- services/orion-notify-digest/.env_example hardcoded
+NOTIFY_SERVICE_URL=http://orion-notify:7140 since inception. That hostname has never
+resolved on any host where PROJECT (used for container_name: ${PROJECT}-notify) has a
+suffix -- e.g. this host's PROJECT=orion-athena gives container_name=orion-athena-notify,
+never orion-notify. The daily digest scheduler crashed silently on every send for the
+service's entire existence because of this, on top of two other independent bugs in the
+same path (#1420 Postgres URI, #1423 scheduler datetime crash).
+
+Docker Compose's default bridge network always attaches a DNS alias equal to the
+declared `services:` key (e.g. "notify" for orion-notify), regardless of PROJECT or
+container_name -- the same convention every mainstream container orchestrator uses
+(Kubernetes Service DNS, ECS Service Discovery, Nomad Consul integration all resolve
+by the declared logical service name, never by an instance/container name). That
+compose service key is the only portable hostname; this script catches the specific,
+now-recurring mistake of using the services/<dirname> directory name instead (found in
+5 places across this repo as of 2026-07-28: orion-notify-digest, orion-execution-
+dispatch-runtime, orion-security-watcher, orion-world-pulse x2).
+
+Usage:
+    python scripts/check_service_hostname_refs.py
+    python scripts/check_service_hostname_refs.py --json
+    python scripts/check_service_hostname_refs.py --report-only
+
+Exit codes: 0 = no directory-name-as-hostname references found (or --report-only).
+            1 = at least one .env_example hardcodes a service directory name as a
+                hostname where the real compose service key differs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SERVICES_DIR = _REPO_ROOT / "services"
+
+_URL_HOST_RE = re.compile(r"https?://([a-z0-9][a-z0-9\-]*[a-z0-9]):(\d+)")
+
+
+class _ComposeTagTolerantLoader:
+    """yaml.SafeLoader that ignores Compose-specific tags (e.g. `!override`, `!reset`)
+    instead of raising -- this script only needs the `services:` keys, not merge
+    semantics, so the underlying scalar/sequence/mapping value is enough."""
+
+    _loader_cls: type | None = None
+
+    @classmethod
+    def get(cls) -> type:
+        if cls._loader_cls is None:
+            import yaml
+
+            class _Loader(yaml.SafeLoader):
+                pass
+
+            def _construct_undefined(loader: "yaml.SafeLoader", node: "yaml.Node") -> object:
+                if isinstance(node, yaml.MappingNode):
+                    return loader.construct_mapping(node)
+                if isinstance(node, yaml.SequenceNode):
+                    return loader.construct_sequence(node)
+                return loader.construct_scalar(node)
+
+            _Loader.add_constructor(None, _construct_undefined)
+            cls._loader_cls = _Loader
+        return cls._loader_cls
+
+
+def _compose_service_key(service_dir: Path) -> str | None:
+    """Resolve service_dir's real compose service key. Single-service files (the norm
+    in this repo) are unambiguous. Multi-service files are resolved the same way
+    scripts/check_service_env_compose_parity.py's _select_service_block() does: by
+    exact dirname match or by the "orion-"-stripped suffix (services/orion-topic-
+    foundry's compose key is "topic-foundry", alongside a second unrelated service
+    "topic-foundry-chat-corpus-builder" in the same file) -- without this, a
+    multi-service compose file was silently treated as unresolvable and completely
+    skipped, letting a real violation (orion-notify-digest's TOPIC_FOUNDRY_URL) pass
+    the gate uncaught. Confirmed live 2026-07-28 via code review."""
+    compose_path = service_dir / "docker-compose.yml"
+    if not compose_path.is_file():
+        return None
+    import yaml
+
+    compose = yaml.load(compose_path.read_text(encoding="utf-8"), Loader=_ComposeTagTolerantLoader.get()) or {}
+    services = compose.get("services") or {}
+    if not services:
+        return None
+    if len(services) == 1:
+        return next(iter(services))
+
+    dirname = service_dir.name
+    suffix = re.sub(r"^orion-", "", dirname)
+    candidates = [name for name in services if name in (dirname, suffix)]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def _service_keys_by_dirname() -> dict[str, str]:
+    keys: dict[str, str] = {}
+    if not _SERVICES_DIR.is_dir():
+        return keys
+    for entry in sorted(_SERVICES_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        key = _compose_service_key(entry)
+        if key:
+            keys[entry.name] = key
+    return keys
+
+
+def _find_violations(dirname_to_key: dict[str, str]) -> list[dict[str, str]]:
+    violations: list[dict[str, str]] = []
+    for service_dir in sorted(_SERVICES_DIR.iterdir()):
+        env_example = service_dir / ".env_example"
+        if not env_example.is_file():
+            continue
+        for lineno, line in enumerate(env_example.read_text(encoding="utf-8").splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            for match in _URL_HOST_RE.finditer(stripped):
+                host = match.group(1)
+                real_key = dirname_to_key.get(host)
+                if real_key is None or real_key == host:
+                    continue
+                violations.append(
+                    {
+                        "file": str(env_example.relative_to(_REPO_ROOT)),
+                        "line": str(lineno),
+                        "hostname_used": host,
+                        "real_compose_service_key": real_key,
+                    }
+                )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose.")
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="always exit 0, even if violations are found (report but don't gate).",
+    )
+    args = parser.parse_args(argv)
+
+    dirname_to_key = _service_keys_by_dirname()
+    violations = _find_violations(dirname_to_key)
+
+    if args.json:
+        print(json.dumps({"violations": violations}))
+    elif violations:
+        print(
+            f"check_service_hostname_refs: {len(violations)} reference(s) use a service "
+            f"directory name as a hostname instead of its real compose service key:"
+        )
+        for v in violations:
+            print(
+                f"    {v['file']}:{v['line']}: uses \"{v['hostname_used']}\" -- "
+                f"real compose service key is \"{v['real_compose_service_key']}\""
+            )
+    else:
+        print("check_service_hostname_refs: OK -- no directory-name-as-hostname references found.")
+
+    if violations and not args.report_only:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-context-exec/.env_example
+++ b/services/orion-context-exec/.env_example
@@ -87,7 +87,12 @@ CONTEXT_EXEC_RECALL_TIMEOUT_SEC=35
 CONTEXT_EXEC_ALLOWED_LLM_PROFILES=chat,quick,agent,metacog
 CONTEXT_EXEC_DEFAULT_LLM_PROFILE=chat
 CONTEXT_EXEC_LLM_PROFILE_FALLBACK_ENABLED=false
-CONTEXT_EXEC_LLM_GATEWAY_URL=http://orion-llm-gateway:8210
+# 2026-07-28: was http://orion-llm-gateway:8210 -- that hostname only resolves by
+# accident on hosts where orion-llm-gateway was deployed before PROJECT got a host
+# suffix (container_name: ${PROJECT}-llm-gateway). The compose service key
+# ("llm-gateway") is the only hostname Docker's default network guarantees regardless
+# of PROJECT.
+CONTEXT_EXEC_LLM_GATEWAY_URL=http://llm-gateway:8210
 CONTEXT_EXEC_LLM_GATEWAY_TIMEOUT_SEC=5
 CONTEXT_EXEC_LLM_TIMEOUT_SEC=120
 CONTEXT_EXEC_AGENT_REPL_MAX_STEPS=32

--- a/services/orion-context-exec/app/settings.py
+++ b/services/orion-context-exec/app/settings.py
@@ -156,7 +156,7 @@ class ContextExecSettings(BaseSettings):
         alias="CONTEXT_EXEC_LLM_PROFILE_FALLBACK_ENABLED",
     )
     context_exec_llm_gateway_url: str = Field(
-        "http://orion-llm-gateway:8210",
+        "http://llm-gateway:8210",
         alias="CONTEXT_EXEC_LLM_GATEWAY_URL",
     )
     context_exec_llm_gateway_timeout_sec: float = Field(

--- a/services/orion-cortex-orch/.env_example
+++ b/services/orion-cortex-orch/.env_example
@@ -117,8 +117,13 @@ TOPIC_FOUNDRY_TIMEOUT_SEC=3.0
 TOPIC_FOUNDRY_LABELS_CACHE_TTL_SEC=3600.0
 
 # --- Orion Mind (HTTP to services/orion-mind; Hub enables via context.metadata mind_enabled only through Orch) ---
-# Hostname must match the Mind container on app-net: ${PROJECT:-orion}-mind (e.g. orion-mind or orion-athena-mind).
-ORION_MIND_BASE_URL=http://orion-mind:6611
+# 2026-07-28: use the compose service key ("mind"), not a directory/container-name
+# guess -- Docker's default network always aliases the declared services: key
+# regardless of PROJECT, unlike container_name: ${PROJECT:-orion}-mind which varies
+# per host. orion-mind's own compose file also declares explicit orion-mind/
+# orion-athena-mind aliases as a belt-and-suspenders workaround for the same issue,
+# but "mind" is the one hostname guaranteed not to depend on either.
+ORION_MIND_BASE_URL=http://mind:6611
 # Outer HTTP timeout for POST /v1/mind/run; must exceed Mind wall time (e.g. 210s > 180s).
 ORION_MIND_TIMEOUT_SEC=210
 MIND_N_LOOPS_DEFAULT=1

--- a/services/orion-execution-dispatch-runtime/.env_example
+++ b/services/orion-execution-dispatch-runtime/.env_example
@@ -47,7 +47,10 @@ ORION_DISPATCH_RISK_CAP_ADVISORY_ONLY=true
 # reducer) sees them the same way it already sees curiosity-fetch outcomes --
 # same channel orion-spark-concept-induction already produces onto.
 BUS_ACTION_OUTCOME_OUT=orion:autonomy:action:outcome
-NOTIFY_URL=http://orion-notify:7140
+# 2026-07-28: was http://orion-notify:7140 -- never resolves once PROJECT has a host
+# suffix (container_name: ${PROJECT}-notify). The compose service key ("notify") is
+# the portable hostname.
+NOTIFY_URL=http://notify:7140
 NOTIFY_API_TOKEN=
 LOG_LEVEL=INFO
 EXECUTION_DISPATCH_RUNTIME_PORT=8121

--- a/services/orion-execution-dispatch-runtime/app/settings.py
+++ b/services/orion-execution-dispatch-runtime/app/settings.py
@@ -79,7 +79,7 @@ class Settings(BaseSettings):
     action_outcome_channel: str = Field(
         "orion:autonomy:action:outcome", alias="BUS_ACTION_OUTCOME_OUT"
     )
-    notify_url: str = Field("http://orion-notify:7140", alias="NOTIFY_URL")
+    notify_url: str = Field("http://notify:7140", alias="NOTIFY_URL")
     notify_api_token: str | None = Field(None, alias="NOTIFY_API_TOKEN")
     log_level: str = Field("INFO", alias="LOG_LEVEL")
 

--- a/services/orion-fcc/.env_example
+++ b/services/orion-fcc/.env_example
@@ -16,7 +16,10 @@ FCC_INTERNAL_PORT=8082
 FCC_CONFIG_DIR=${HOME}/.fcc
 
 # Upstream LLM gateway as seen from inside the fcc container (overrides ~/.fcc/.env LLAMACPP_BASE_URL)
-FCC_LLAMACPP_BASE_URL=http://orion-llm-gateway:8210/v1
+# 2026-07-28: was http://orion-llm-gateway:8210/v1 -- that hostname only resolves by
+# accident (see orion-llm-gateway's container_name: ${PROJECT}-llm-gateway, which
+# varies per host). "llm-gateway" is the compose service key, guaranteed portable.
+FCC_LLAMACPP_BASE_URL=http://llm-gateway:8210/v1
 
 FCC_OPEN_BROWSER=false
 FCC_LOG_FILE=/tmp/fcc-server.log

--- a/services/orion-fcc/README.md
+++ b/services/orion-fcc/README.md
@@ -9,7 +9,7 @@ Anthropic-compatible **FCC proxy** (`free-claude-code` `fcc-server`) as a manage
 | **`~/.fcc/.env`** | **Single operator contract** — `MODEL_*`, `GITHUB_PAT`, `FIRECRAWL_API_KEY`, `AITOWN_*`, `ANTHROPIC_AUTH_TOKEN`, etc. Template: `config/fcc.env_example` |
 | **`services/orion-fcc/.env`** | **Thin service surface only** — published port, config mount path, container networking override for `LLAMACPP_BASE_URL`. **No secrets.** |
 
-`fcc-server` loads `~/.fcc/.env` from the mounted volume. Compose `environment:` vars (e.g. `FCC_LLAMACPP_BASE_URL` → `LLAMACPP_BASE_URL`) override file values **only inside the container** so bridge-network routing to `orion-llm-gateway` works without editing your secrets file.
+`fcc-server` loads `~/.fcc/.env` from the mounted volume. Compose `environment:` vars (e.g. `FCC_LLAMACPP_BASE_URL` → `LLAMACPP_BASE_URL`) override file values **only inside the container** so bridge-network routing to `llm-gateway` (orion-llm-gateway's compose service key) works without editing your secrets file.
 
 ## Topology
 
@@ -50,7 +50,7 @@ curl -fsS http://127.0.0.1:8082/health
 |-----|---------|---------|
 | `FCC_PORT` | `8082` | Host-published port |
 | `FCC_CONFIG_DIR` | `${HOME}/.fcc` | Mount source for operator FCC config |
-| `FCC_LLAMACPP_BASE_URL` | `http://orion-llm-gateway:8210/v1` | Container upstream override |
+| `FCC_LLAMACPP_BASE_URL` | `http://llm-gateway:8210/v1` | Container upstream override |
 | `FCC_OPEN_BROWSER` | `false` | Suppress admin UI browser open |
 | `FCC_LOG_FILE` | `/tmp/fcc-server.log` | Server log path (writable; config mount stays ro) |
 

--- a/services/orion-fcc/docker-compose.yml
+++ b/services/orion-fcc/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - FCC_OPEN_BROWSER=${FCC_OPEN_BROWSER:-false}
       - FCC_LOG_FILE=${FCC_LOG_FILE:-/tmp/fcc-server.log}
       # Container-only upstream override (pydantic env beats ~/.fcc/.env). Secrets stay in ~/.fcc/.env.
-      - LLAMACPP_BASE_URL=${FCC_LLAMACPP_BASE_URL:-http://orion-llm-gateway:8210/v1}
+      - LLAMACPP_BASE_URL=${FCC_LLAMACPP_BASE_URL:-http://llm-gateway:8210/v1}
       - PORT=${FCC_INTERNAL_PORT:-8082}
     volumes:
       - ${FCC_CONFIG_DIR:-${HOME}/.fcc}:/root/.fcc:ro

--- a/services/orion-fcc/entrypoint.sh
+++ b/services/orion-fcc/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-GATEWAY_URL="${FCC_LLAMACPP_BASE_URL:-http://orion-llm-gateway:8210/v1}"
+GATEWAY_URL="${FCC_LLAMACPP_BASE_URL:-http://llm-gateway:8210/v1}"
 GATEWAY_HEALTH="${GATEWAY_URL%/v1}/health"
 
 if [ -z "${FCC_SKIP_GATEWAY_WAIT:-}" ]; then

--- a/services/orion-llm-gateway/.env_example
+++ b/services/orion-llm-gateway/.env_example
@@ -21,14 +21,19 @@ ORION_DEFAULT_LLM_MODEL=Active-GGUF-Model
 LLM_DEFAULT_PROFILE_NAME=
 LLM_PROFILES_CONFIG_PATH=/app/config/llm_profiles.yaml
 
-ORION_LLM_VLLM_URL=http://orion-vllm-host:8000
-ORION_LLM_OLLAMA_URL=http://orion-ollama-host:11434
+# 2026-07-28: these three were http://orion-vllm-host:8000 / orion-ollama-host:11434 /
+# orion-llama-cola-host:8004 -- directory-name-style hostnames that only resolve by
+# accident, if at all, depending on whether PROJECT has a host suffix at deploy time.
+# The compose service key (vllm-host / ollama-host / llama-cola-host) is the only
+# hostname Docker's default network guarantees regardless of PROJECT.
+ORION_LLM_VLLM_URL=http://vllm-host:8000
+ORION_LLM_OLLAMA_URL=http://ollama-host:11434
 ORION_LLM_OLLAMA_USE_OPENAI=false
 
 # Legacy fallback only (route-table mode is primary now).
 # ORION_LLM_LLAMACPP_URL=http://100.121.214.30:7005
 
-ORION_LLM_LLAMA_COLA_URL=http://orion-llama-cola-host:8004
+ORION_LLM_LLAMA_COLA_URL=http://llama-cola-host:8004
 ORION_LLM_INCLUDE_EMBEDDINGS=false
 ORION_VECTOR_LATENT_COLLECTION=orion_latent_store
 

--- a/services/orion-notify-digest/.env_example
+++ b/services/orion-notify-digest/.env_example
@@ -22,7 +22,14 @@ HEARTBEAT_INTERVAL_SEC=10
 # (notify_digest_runs, notify_attempts) and never touches the real notify_requests table.
 POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
 
-NOTIFY_SERVICE_URL=http://orion-notify:7140
+# 2026-07-28: was http://orion-notify:7140 since inception -- never a valid hostname on
+# any host where PROJECT (used for container_name: ${PROJECT}-notify) has a host suffix,
+# e.g. this host's PROJECT=orion-athena gives container_name=orion-athena-notify. The only
+# hostname that resolves regardless of PROJECT is the compose *service* name ("notify" in
+# services/orion-notify/docker-compose.yml), which Docker's default bridge network always
+# aliases in addition to container_name. Confirmed live: today's 07:30 local digest run
+# failed with NameResolutionError on "orion-notify" even after the #1420/#1423 fixes landed.
+NOTIFY_SERVICE_URL=http://notify:7140
 NOTIFY_API_TOKEN=
 
 DIGEST_ENABLED=true
@@ -32,7 +39,12 @@ DIGEST_RECIPIENT_GROUP=juniper_primary
 DIGEST_RUN_ON_START=false
 
 # Topic Foundry (optional)
-TOPIC_FOUNDRY_URL=http://orion-topic-foundry:8615
+# 2026-07-28: was http://orion-topic-foundry:8615 -- the exact same directory-name-as-
+# hostname mistake this file's NOTIFY_SERVICE_URL had (see comment above). Real compose
+# service key is "topic-foundry"; found live-broken (still consumed by app/main.py and
+# app/digest.py for the digest's topic summary/drift section) during PR review of the
+# NOTIFY_SERVICE_URL fix.
+TOPIC_FOUNDRY_URL=http://topic-foundry:8615
 TOPIC_FOUNDRY_MODEL_NAME=
 TOPICS_WINDOW_MINUTES=30
 TOPICS_MAX_TOPICS=20

--- a/services/orion-notify-digest/app/settings.py
+++ b/services/orion-notify-digest/app/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
 
     POSTGRES_URI: str = Field("sqlite:////data/notify.db", alias="POSTGRES_URI")
 
-    NOTIFY_SERVICE_URL: str = Field("http://orion-notify:7140", alias="NOTIFY_SERVICE_URL")
+    NOTIFY_SERVICE_URL: str = Field("http://notify:7140", alias="NOTIFY_SERVICE_URL")
     NOTIFY_API_TOKEN: Optional[str] = Field(None, alias="NOTIFY_API_TOKEN")
 
     DIGEST_ENABLED: bool = Field(True, alias="DIGEST_ENABLED")

--- a/services/orion-notify-digest/tests/test_notify_service_url.py
+++ b/services/orion-notify-digest/tests/test_notify_service_url.py
@@ -1,0 +1,56 @@
+"""Regression: NOTIFY_SERVICE_URL must use a hostname that actually resolves.
+
+Found live 2026-07-28: NOTIFY_SERVICE_URL defaulted to http://orion-notify:7140 since
+this service's inception. That hostname is neither orion-notify's Docker Compose
+service key (`notify`) nor its container_name (`${PROJECT}-notify`, e.g.
+orion-athena-notify on this host) -- it has never resolved on any host where PROJECT
+has a suffix. The 07:30 local digest run failed with NameResolutionError even after
+the #1420 (Postgres) and #1423 (scheduler crash) fixes landed, because this was a
+third, independent bug in the same delivery path.
+
+The compose *service* name is the only alias Docker's default bridge network attaches
+regardless of PROJECT, so that's what this asserts against -- parsed live from
+orion-notify's own compose file rather than hardcoded, so this fails loudly if that
+service is ever renamed instead of silently going stale.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import app.settings as digest_settings
+
+NOTIFY_COMPOSE_PATH = (
+    Path(__file__).resolve().parents[3] / "services" / "orion-notify" / "docker-compose.yml"
+)
+
+
+def _notify_compose_service_name() -> str:
+    """Real YAML parsing rather than a hand-rolled regex, so this doesn't silently
+    mis-parse if orion-notify's compose file ever gains a comment/blank line before
+    its first service key, or a Compose-specific tag (e.g. `!override`) -- same
+    tag-tolerant loader as scripts/check_service_hostname_refs.py."""
+    import yaml
+
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    def _construct_undefined(loader: "yaml.SafeLoader", node: "yaml.Node") -> object:
+        if isinstance(node, yaml.MappingNode):
+            return loader.construct_mapping(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node)
+        return loader.construct_scalar(node)
+
+    _Loader.add_constructor(None, _construct_undefined)
+
+    compose = yaml.load(NOTIFY_COMPOSE_PATH.read_text(encoding="utf-8"), Loader=_Loader) or {}
+    services = compose.get("services") or {}
+    assert len(services) == 1, f"expected exactly one service in {NOTIFY_COMPOSE_PATH}, found {list(services)}"
+    return next(iter(services))
+
+
+def test_notify_service_url_default_uses_resolvable_compose_service_name() -> None:
+    service_name = _notify_compose_service_name()
+    settings = digest_settings.Settings()
+    assert settings.NOTIFY_SERVICE_URL == f"http://{service_name}:7140"

--- a/services/orion-notify/.env_example
+++ b/services/orion-notify/.env_example
@@ -19,7 +19,11 @@ HEARTBEAT_INTERVAL_SEC=10
 NOTIFY_IN_APP_ENABLED=true
 NOTIFY_IN_APP_CHANNEL=orion:notify:in_app
 
-SQL_WRITER_API_URL=http://orion-sql-writer:8220
+# 2026-07-28: was http://orion-sql-writer:8220 -- never resolves once PROJECT has a
+# host suffix (container_name: ${PROJECT}-sql-writer). The compose service key
+# ("sql-writer") is the portable hostname; live-verified reachable from this
+# container (curl http://sql-writer:8220/health -> 200) on 2026-07-28.
+SQL_WRITER_API_URL=http://sql-writer:8220
 POLICY_RULES_PATH=/app/app/policy/rules.yaml
 
 # Email transport (SMTP)

--- a/services/orion-notify/app/settings.py
+++ b/services/orion-notify/app/settings.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     NOTIFY_IN_APP_ENABLED: bool = Field(True, alias="NOTIFY_IN_APP_ENABLED")
     NOTIFY_IN_APP_CHANNEL: str = Field("orion:notify:in_app", alias="NOTIFY_IN_APP_CHANNEL")
 
-    SQL_WRITER_API_URL: str = Field("http://orion-sql-writer:8220", alias="SQL_WRITER_API_URL")
+    SQL_WRITER_API_URL: str = Field("http://sql-writer:8220", alias="SQL_WRITER_API_URL")
     POLICY_RULES_PATH: str = Field("/app/app/policy/rules.yaml", alias="POLICY_RULES_PATH")
 
     NOTIFY_EMAIL_SMTP_HOST: str = Field("", alias="NOTIFY_EMAIL_SMTP_HOST")

--- a/services/orion-security-watcher/.env_example
+++ b/services/orion-security-watcher/.env_example
@@ -45,7 +45,9 @@ SECURITY_SNAPSHOT_DIR=/mnt/telemetry/orion-security/alerts
 
 # notifications
 NOTIFY_MODE=inline          # inline | none (later: bus_only when you split)
-NOTIFY_SERVICE_URL=http://orion-notify:7140
+# 2026-07-28: was http://orion-notify:7140 -- never resolves once PROJECT has a host
+# suffix. The compose service key ("notify") is the portable hostname.
+NOTIFY_SERVICE_URL=http://notify:7140
 NOTIFY_API_TOKEN=
 NOTIFY_EMAIL_ENABLED=true
 NOTIFY_EMAIL_SMTP_HOST=smtp.yourprovider.com

--- a/services/orion-security-watcher/app/settings.py
+++ b/services/orion-security-watcher/app/settings.py
@@ -52,7 +52,7 @@ class Settings(BaseSettings):
     NOTIFY_MODE: str = Field("inline", alias="NOTIFY_MODE")
 
     # Notify service
-    NOTIFY_SERVICE_URL: str = Field("http://orion-notify:7140", alias="NOTIFY_SERVICE_URL")
+    NOTIFY_SERVICE_URL: str = Field("http://notify:7140", alias="NOTIFY_SERVICE_URL")
     NOTIFY_API_TOKEN: str = Field("", alias="NOTIFY_API_TOKEN")
 
     # Email config

--- a/services/orion-self-experiments/.env_example
+++ b/services/orion-self-experiments/.env_example
@@ -19,7 +19,9 @@ HEARTBEAT_INTERVAL_SEC=10
 # Context-exec dispatch (bus transport; requires orion-context-exec + orion-bus)
 SELF_EXPERIMENTS_DISPATCH_ENABLED=true
 SELF_EXPERIMENTS_CONTEXT_EXEC_DISPATCH_TRANSPORT=bus
-SELF_EXPERIMENTS_CONTEXT_EXEC_URL=http://orion-context-exec:8096
+# 2026-07-28: was http://orion-context-exec:8096 -- never resolves once PROJECT has a
+# host suffix. The compose service key ("context-exec") is the portable hostname.
+SELF_EXPERIMENTS_CONTEXT_EXEC_URL=http://context-exec:8096
 SELF_EXPERIMENTS_CONTEXT_EXEC_REQUEST_CHANNEL=orion:exec:request:ContextExecService
 SELF_EXPERIMENTS_CONTEXT_EXEC_TIMEOUT_SECONDS=90
 SELF_EXPERIMENTS_MAX_DISPATCH_ATTEMPTS=2

--- a/services/orion-self-experiments/app/settings.py
+++ b/services/orion-self-experiments/app/settings.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
         alias="SELF_EXPERIMENTS_CONTEXT_EXEC_DISPATCH_TRANSPORT",
     )
     self_experiments_context_exec_url: str = Field(
-        "http://orion-context-exec:8096",
+        "http://context-exec:8096",
         alias="SELF_EXPERIMENTS_CONTEXT_EXEC_URL",
     )
     self_experiments_context_exec_request_channel: str = Field(

--- a/services/orion-social-room-bridge/.env_example
+++ b/services/orion-social-room-bridge/.env_example
@@ -51,7 +51,14 @@ SOCIAL_BRIDGE_CALLSYNE_POLL_LIMIT=20
 # Polling remains disabled by default. /api/bridge/messages is POST-only and must not be used for reads.
 SOCIAL_BRIDGE_CALLSYNE_POLL_PATH=/api/bridge/messages
 
-HUB_BASE_URL=http://orion-hub:8080
+# 2026-07-28: was http://orion-hub:8080 -- orion-hub runs with network_mode: host (see
+# services/orion-hub/docker-compose.yml), so it has NO bridge-network alias under any
+# name; unlike every other service in this file's history of the same mistake, this
+# one isn't fixable by switching to the compose service key. The only way to reach it
+# from a bridge-networked container is the Docker bridge gateway IP (this host's is
+# 172.18.0.1 -- live-verified working; orion-notify's NOTIFY_HUB_URL already uses the
+# same pattern). That gateway IP is itself host-specific, not a universal constant.
+HUB_BASE_URL=http://172.18.0.1:8080
 HUB_CHAT_PATH=/api/chat
 HUB_TIMEOUT_SEC=120
 

--- a/services/orion-social-room-bridge/app/settings.py
+++ b/services/orion-social-room-bridge/app/settings.py
@@ -57,6 +57,10 @@ class Settings(BaseSettings):
     social_bridge_callsyne_poll_limit: int = Field(20, alias="SOCIAL_BRIDGE_CALLSYNE_POLL_LIMIT")
     social_bridge_callsyne_poll_path: str = Field("/api/bridge/messages", alias="SOCIAL_BRIDGE_CALLSYNE_POLL_PATH")
 
+    # 2026-07-28: this default never resolves -- orion-hub runs with network_mode:
+    # host, so it has no bridge-network alias under any name. Every real deployment
+    # must override HUB_BASE_URL via .env with a host-reachable address (e.g. the
+    # Docker bridge gateway IP; see .env_example's comment).
     hub_base_url: str = Field("http://orion-hub:8080", alias="HUB_BASE_URL")
     hub_chat_path: str = Field("/api/chat", alias="HUB_CHAT_PATH")
     hub_timeout_sec: float = Field(120.0, alias="HUB_TIMEOUT_SEC")

--- a/services/orion-thought/.env_example
+++ b/services/orion-thought/.env_example
@@ -79,7 +79,9 @@ CHANNEL_ATTENTION_SALIENCE_TRACE=orion:attention:salience:trace
 # (that key lives on the orion-mind service, not here) AND orion-thought can reach
 # ORION_MIND_BASE_URL. Verify both operationally at rollout.
 ORION_THOUGHT_MIND_ENRICHMENT_ENABLED=true
-ORION_MIND_BASE_URL=http://orion-mind:6611
+# 2026-07-28: use the compose service key ("mind"), not a directory/container-name
+# guess -- see orion-cortex-orch/.env_example's ORION_MIND_BASE_URL comment for why.
+ORION_MIND_BASE_URL=http://mind:6611
 # Budget: orion-mind runs 3 sequential LLM phases (semantic → appraisal → stance),
 # each capped by MIND_LLM_TIMEOUT_SEC (default 60s, on the orion-mind service).
 # WALL_MS must stay >= ~3× that (180000) or synthesis is cut off mid-pipeline and

--- a/services/orion-thought/app/settings.py
+++ b/services/orion-thought/app/settings.py
@@ -145,7 +145,7 @@ class ThoughtSettings(BaseSettings):
     # stay >= MIND_ENRICHMENT_MIN_VIABLE_WALL_MS and the HTTP read timeout must
     # exceed the wall (so Mind's own fail-open result is returned, not aborted).
     mind_enrichment_enabled: bool = Field(False, alias="ORION_THOUGHT_MIND_ENRICHMENT_ENABLED")
-    mind_base_url: str = Field("http://orion-mind:6611", alias="ORION_MIND_BASE_URL")
+    mind_base_url: str = Field("http://mind:6611", alias="ORION_MIND_BASE_URL")
     mind_timeout_sec: float = Field(210.0, alias="ORION_THOUGHT_MIND_TIMEOUT_SEC")
     mind_wall_ms: int = Field(180_000, alias="ORION_THOUGHT_MIND_WALL_MS")
     mind_router_profile: str = Field("default", alias="ORION_THOUGHT_MIND_ROUTER_PROFILE")

--- a/services/orion-vector-host/.env_example
+++ b/services/orion-vector-host/.env_example
@@ -38,8 +38,11 @@ VECTOR_HOST_CHAT_TURN_COLLECTION=orion_chat_turns
 VECTOR_HOST_GPT_MESSAGE_COLLECTION=orion_chat_gpt
 VECTOR_HOST_GPT_TURN_COLLECTION=orion_chat_gpt_turns
 
-ORION_LLM_VLLM_URL=http://orion-vllm-host:8000
-ORION_LLM_LLAMA_COLA_URL=http://orion-llama-cola-host:8004
+# 2026-07-28: use the compose service keys (vllm-host / llama-cola-host), not
+# directory/container-name guesses -- see orion-llm-gateway/.env_example's matching
+# comment for why.
+ORION_LLM_VLLM_URL=http://vllm-host:8000
+ORION_LLM_LLAMA_COLA_URL=http://llama-cola-host:8004
 
 VECTOR_HOST_EMBED_CONNECT_TIMEOUT_SEC=10
 VECTOR_HOST_EMBED_READ_TIMEOUT_SEC=60

--- a/services/orion-world-pulse/.env_example
+++ b/services/orion-world-pulse/.env_example
@@ -83,6 +83,8 @@ WORLD_PULSE_SITUATION_BRIEF_CHANNEL=orion:world_pulse:situation:brief:upsert
 WORLD_PULSE_SITUATION_CHANGE_CHANNEL=orion:world_pulse:situation:change:emit
 
 # Optional Notify endpoint for non-hub publish paths.
-WORLD_PULSE_NOTIFY_URL=http://orion-notify:7140
-NOTIFY_URL=http://orion-notify:7140
+# 2026-07-28: was http://orion-notify:7140 -- never resolves once PROJECT has a host
+# suffix. The compose service key ("notify") is the portable hostname.
+WORLD_PULSE_NOTIFY_URL=http://notify:7140
+NOTIFY_URL=http://notify:7140
 NOTIFY_API_TOKEN=

--- a/services/orion-world-pulse/app/settings.py
+++ b/services/orion-world-pulse/app/settings.py
@@ -132,9 +132,9 @@ class Settings(BaseSettings):
         alias="WORLD_PULSE_SITUATION_CHANGE_CHANNEL",
     )
 
-    notify_url: str = Field("http://orion-notify:7140", validation_alias=AliasChoices("WORLD_PULSE_NOTIFY_URL", "NOTIFY_URL"))
+    notify_url: str = Field("http://notify:7140", validation_alias=AliasChoices("WORLD_PULSE_NOTIFY_URL", "NOTIFY_URL"))
     notify_api_token: str | None = Field(None, alias="NOTIFY_API_TOKEN")
-    actions_url: str = Field("http://orion-actions:8110", alias="ACTIONS_URL")
+    actions_url: str = Field("http://actions:8110", alias="ACTIONS_URL")
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary

- `orion-notify-digest`'s daily email never arrived this morning despite #1420 (Postgres URI) and #1423 (scheduler crash) landing earlier today: `NOTIFY_SERVICE_URL=http://orion-notify:7140` has never resolved on this host — `PROJECT=orion-athena` means `orion-notify`'s real container is `orion-athena-notify`, and Docker's default network only guarantees resolution by the compose **service key** (`notify`), not a directory-name guess.
- Added `scripts/check_service_hostname_refs.py`, a repo-wide gate that parses every `services/*/docker-compose.yml` for its real service key and flags any `services/*/.env_example` URL hardcoding a `orion-<dirname>`-style hostname instead. It found the same mistake in **16 places across 12 services** (context-exec, cortex-orch, execution-dispatch-runtime, fcc, llm-gateway, notify, notify-digest, security-watcher, self-experiments, thought, vector-host, world-pulse).
- Fixed every hostname to the real compose service key, updated matching `app/settings.py` Field defaults, synced all live `.env` files, and rebuilt/redeployed every affected running container. Live-verified each restarts healthy with no `NameResolutionError`.
- `orion-social-room-bridge`'s `HUB_BASE_URL` is a deliberate exception: `orion-hub` runs `network_mode: host`, so it has no bridge-network alias under any name. Documented the real working pattern (Docker bridge gateway IP, matching `orion-notify`'s already-correct `NOTIFY_HUB_URL`) instead of a service-key swap that would not have fixed it.
- Code review caught two things the first pass missed: `orion-notify-digest`'s own `TOPIC_FOUNDRY_URL` had the identical bug (also fixed, also live), and the gate script had a false-negative on multi-service compose files (fixed by reusing `check_service_env_compose_parity.py`'s suffix-matching service selection).
- Manually triggered today's digest after redeploying; email sent successfully (`notification_id=c9ce4d99-4870-4e2f-8138-7f70adee5099`).

## Outcome moved

`orion-notify-digest`'s daily email now actually sends — first successful send in the service's history. 15 other latent, same-shape hostname bugs across the fleet are fixed and gated against recurrence via `make check-service-hostname-refs`.

## Current architecture

Every one of these services hardcoded a target's `services/<dirname>` directory name as its HTTP hostname (e.g. `http://orion-notify:7140`). That only resolves by accident, depending on `container_name: ${PROJECT}-<name>` happening to equal `orion-<name>` — true only on hosts where `PROJECT` has no host suffix. This host's `PROJECT=orion-athena`.

## Architecture touched

12 services' `.env_example` + matching `app/settings.py` defaults; `orion-fcc` additionally touches `entrypoint.sh`, `docker-compose.yml`, `README.md` (same one variable, 4 files). New `scripts/check_service_hostname_refs.py` gate + `Makefile` target. New regression test `services/orion-notify-digest/tests/test_notify_service_url.py`.

## Files changed

- `services/{context-exec,cortex-orch,execution-dispatch-runtime,fcc,llm-gateway,notify,notify-digest,security-watcher,self-experiments,social-room-bridge,thought,vector-host,world-pulse}/.env_example` and matching `app/settings.py`: directory-name hostname → real compose service key (or, for `social-room-bridge`'s host-networked `orion-hub` target, the documented gateway-IP pattern).
- `services/orion-fcc/{entrypoint.sh,docker-compose.yml,README.md}`: same `FCC_LLAMACPP_BASE_URL` fix mirrored across all 4 places it's duplicated.
- `scripts/check_service_hostname_refs.py`: new repo-wide gate.
- `Makefile`: new `check-service-hostname-refs` target.
- `services/orion-notify-digest/tests/test_notify_service_url.py`: regression test, parses `orion-notify`'s real compose key live rather than hardcoding it.

## Schema / bus / API changes

None.

## Env/config changes

- Changed keys (value only, not renamed): `NOTIFY_SERVICE_URL`, `NOTIFY_URL`, `WORLD_PULSE_NOTIFY_URL`, `CONTEXT_EXEC_LLM_GATEWAY_URL`, `FCC_LLAMACPP_BASE_URL`, `ORION_LLM_VLLM_URL`, `ORION_LLM_OLLAMA_URL`, `ORION_LLM_LLAMA_COLA_URL`, `SQL_WRITER_API_URL`, `SELF_EXPERIMENTS_CONTEXT_EXEC_URL`, `ORION_MIND_BASE_URL`, `TOPIC_FOUNDRY_URL` (notify-digest), `HUB_BASE_URL`.
- `.env_example` updated: yes, all 12 services (13 counting orion-fcc's extra files).
- Local `.env` synced: yes, every service with a live `.env` on this host.
- Skipped keys requiring operator action: none — all changes are drop-in value corrections, no new keys.

## Tests run

```text
PYTHONPATH=. python -m pytest services/orion-notify-digest/tests -q
17 passed, 18 warnings
python scripts/check_service_hostname_refs.py
check_service_hostname_refs: OK -- no directory-name-as-hostname references found.
```

## Evals run

None applicable (config-value gate, not a scoring/quality surface).

## Docker/build/smoke checks

Rebuilt and redeployed live via `scripts/safe_docker_build.sh` for every currently-running affected service: `orion-notify`, `orion-notify-digest`, `orion-llm-gateway`, `orion-cortex-orch`, `orion-fcc`, `orion-security-watcher`, `orion-self-experiments`, `orion-thought`, `orion-vector-host`, `orion-world-pulse`, `orion-execution-dispatch-runtime`. All confirmed `Up`/`healthy` post-restart with no `NameResolutionError` in logs. `orion-context-exec` is not currently deployed on this host (code fixed, no live redeploy applicable). `orion-social-room-bridge` needed no redeploy — its live `.env` already had the correct gateway-IP value; only the stale `.env_example` template was wrong.

Manually triggered `orion-notify-digest`'s digest send post-fix (`docker exec ... run_digest_now(...)`): succeeded, `notification_id=c9ce4d99-4870-4e2f-8138-7f70adee5099`.

## Review findings fixed

- Finding: `orion-notify-digest`'s own `TOPIC_FOUNDRY_URL` had the identical directory-name-hostname bug, live-broken and actively consumed by the digest's topic summary/drift section.
  - Fix: `http://orion-topic-foundry:8615` → `http://topic-foundry:8615` in `.env_example` and live `.env`; redeployed.
  - Evidence: container healthy post-redeploy, no `NameResolutionError`.
- Finding: `check_service_hostname_refs.py` returned `None` (skip) for any target with a multi-service `docker-compose.yml`, which is exactly why the `TOPIC_FOUNDRY_URL` bug above slipped past the gate's first version (`orion-topic-foundry`'s compose file declares two services).
  - Fix: reused `check_service_env_compose_parity.py`'s dirname/suffix service-selection logic instead of bailing on ambiguity.
  - Evidence: `python -c "..._compose_service_key(Path('services/orion-topic-foundry'))"` now returns `topic-foundry`; full gate re-run still reports clean after the corresponding `.env_example` fix.
- Finding: gate only scans `.env_example`, not `app/settings.py` — missed `orion-world-pulse`'s `ACTIONS_URL` (same bug, currently unused/no consumer).
  - Fix: corrected the value directly (`http://orion-actions:8110` → `http://actions:8110`); left `settings.py`-scanning as an explicit scope decision rather than building a second regex scanner in this same patch (noted below).
  - Evidence: `grep actions_url services/orion-world-pulse/app/` confirms no live consumer today, so no redeploy-verifiable behavior change; value is now correct for if/when one is added.
- Finding: new regression test used a hand-rolled regex to parse `orion-notify`'s compose file instead of real YAML parsing.
  - Fix: switched to the same tag-tolerant YAML loader pattern used in the gate script.
  - Evidence: `17 passed` after the change.

## Restart required

No further restart required — every affected running service was already rebuilt and redeployed live during this session.

## Risks / concerns

- Severity: low
- Concern: the gate script only scans `.env_example`, not `app/settings.py` Field defaults, so a future fix that updates one but not the other won't be caught automatically.
- Mitigation: documented as a known gap in the review; `orion-world-pulse`'s `ACTIONS_URL` (the one instance found) was fixed by hand. Follow-up: extend the gate to also scan `settings.py` defaults if this class of drift recurs.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1426