### PR TITLE
analysis: measure whether z-score normalization fixes Layer 5 attention monoculture

### DIFF
--- a/docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md
+++ b/docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md
@@ -182,3 +182,92 @@ already persisted, no new plumbing needed to read them). Then run the Missing Qu
 pass against real stored data before writing any reducer code. That single measurement script is the
 actual next deliverable; everything else in this doc is scoped and blocked behind its result — same
 discipline the generative-triggers spec already models for its own open questions.
+
+**Superseded by the 2026-07-28 update below** — see that section for the corrected priority order.
+This "Recommended next patch" is not wrong on its own terms, but it is no longer the top of the
+queue: it names the wrong prerequisite. The real blocker is not "does the metacog series have a
+genuine rest state," it's "does the arena this reducer's output would compete in even arbitrate
+fairly" — and a same-day measurement found it does not.
+
+## 2026-07-28 update — the arbitration layer, not the reducer, is the real blocker
+
+Same-day follow-up, same Juniper conversation that produced this doc. Before answering this doc's
+own Missing Questions 1-2 and building the trend reducer, the conversation traced every
+"competition/arbitration" mechanism in this codebase looking for where the reducer's output should
+"feed forward" (Missing Question 3). It found the same architectural disease in all three places
+checked: real inputs feeding a hand-picked fixed-weight linear score, never calibrated against real
+outcomes, so one channel permanently or near-permanently dominates because nothing normalizes for one
+channel being structurally noisier or more saturating than the others.
+
+**1. Old drives system (retired).** `dominant_drive=relational` monoculture: 96% of ticks pre-fix,
+~31.65% post-fix (`orion/autonomy/drives_and_autonomy_retrospective.md`).
+
+**2. Proposal/policy pipeline.** `orion/proposals/scoring.py::proposal_priority()` is
+`base_priority + 0.4*match_score + 0.2*urgency + 0.1*confidence` — fixed, uncalibrated coefficients.
+`orion/feedback/builder.py::build_feedback_frame()` genuinely records real outcomes
+(`FeedbackFrameV1`, real `outcome_status`/`outcome_score`, real field-pressure deltas) — but a
+repo-wide grep for writes to `base_priority`/`base_risk`/`dimension_weights` found only static config
+reads, never a write-back from feedback. The loop observes but never learns.
+
+**3. Layer 5 attention (the canonical, most-upstream competition layer)** —
+`orion/attention/field_attention/{scoring,selectors}.py`, live via `orion-attention-runtime`
+(`ENABLE_ATTENTION_RUNTIME=true`), explicitly named in `orion/sentience_striving_program/README.md`
+as the reason the drives system was made redundant. That charter's own §6 item 5 already ran
+`scripts/analysis/measure_emergent_clustering_probe.py` against 127,936 real
+`substrate_attention_frames` rows and found `select_system_targets`'s `field:recent_perturbations`
+target (`orion/attention/field_attention/selectors.py:128-140`,
+`salience = min(1.0, recent_perturbation_count / 10.0)`) wins top-1 in ~99.98% of ticks — the same
+"noisiest wins" shape as the drives pathology, on a different signal.
+
+**Converged direction (Juniper's own call):** don't build a new candidate producer — a metacog trend
+reducer, or anything else — into an arena that already can't arbitrate fairly. Fix the arbitration
+first, at the most canonical layer (Layer 5 attention), by normalizing each channel against its own
+real historical distribution before comparing magnitudes for top-1-winner selection. The charter's
+own §7 rule applies directly: "Measure before minting. Every new signal gets a read-only instrument
+and real historical replay before it gates anything live." So: measure whether normalization would
+actually fix the monoculture, using real data, before writing any live-scoring code.
+
+### Real measurement results (`scripts/analysis/measure_attention_salience_normalization.py`, run 2026-07-28)
+
+Read-only script, same `substrate_attention_frames` table, run fresh against 127,644 real rows
+spanning 2026-07-25T20:18Z → 2026-07-28T20:34Z (72.3h). Per CLAUDE.md's metric-quality-gate rule
+("re-run it every time, even for a metric that seems obviously fine"), the 99.98% figure above was
+**not** reused — the raw baseline was recomputed fresh in this same run:
+
+- **Raw baseline, re-verified fresh: `field:recent_perturbations` wins top-1 in 100.00% of ticks**
+  (127,644 / 127,644) — slightly *worse* than the 99.98% figure cited above, not the same number
+  restated. Its full-history stddev is `0.000000` (mean `1.0000`) — a mathematically exact
+  degenerate/saturated channel, not merely "very concentrated."
+- **Per-channel z-score normalization was computed** (each channel normalized against its own
+  full-history mean/stddev). `field:recent_perturbations` has zero variance, so it is
+  **structurally undefined under z-scoring** — division by ~0, excluded from the normalized ranking
+  entirely, not merely "loses" a fair comparison.
+- **After excluding it, the normalized top-1 winner distribution is:** `node:atlas` 55.17% (70,417
+  ticks), `node:circe` 15.84%, `capability:llm_inference` 15.24%, `node:athena` 9.86%,
+  `capability:orchestration` 2.23%, `capability:transport` 1.65%, `capability:storage` 0.01%.
+- **Classification: `NOT_MET_MONOCULTURE_SHIFTED`.** Normalization does not diversify the winner
+  distribution — it relocates the monoculture to a different single channel (`node:atlas`, 55.17%,
+  still above this measurement's 50% monoculture threshold). Two honest findings, both reported by
+  the script rather than left implicit: (a) any apparent "improvement" here is a mechanical
+  side-effect of `field:recent_perturbations` being disqualified by divide-by-~0, not evidence that
+  z-scoring is doing real calibration work on real variance; (b) the "fix" as measured just moves
+  who wins, it does not make the arena fair.
+
+**Corrected recommendation:** this doc's original "Recommended next patch" (build
+`scripts/analysis/measure_metacog_trend_baseline.py` and proceed toward the trend reducer) is now
+**sequenced behind** a higher-priority prerequisite: fixing Layer 5 attention's monoculture is the
+real blocking issue, not building a new candidate producer. Any new producer — including the trend
+reducer this doc proposes — would compete in the same broken arena and either get drowned out (if
+its signal is calmer than the saturating channels) or add another uncalibrated fixed-weight input to
+the same disease (if it's wired in as another hand-tuned score). The measurement above also shows the
+naive fix (plain per-channel z-scoring) is **not sufficient by itself** — it needs a real design pass
+(e.g. excluding degenerate channels honestly instead of accidentally, a genuine multi-way calibration
+rather than winner-take-all-on-a-different-channel, or a different normalization shape entirely) before
+it is safe to build, let alone flip live. That design pass is out of scope for this measurement run and
+requires its own explicit proposal-mode sign-off per `orion/sentience_striving_program/README.md`'s
+charter and root CLAUDE.md §0A's cognition-loop rule — not decided here.
+
+This doc's Missing Questions 1-2 and the trend-reducer build itself are not cancelled, just
+re-sequenced: they remain the right next step for metacog specifically, but only after (or in
+parallel with, if scoped as a fully separate consumer of attention output) the arbitration-layer
+question above gets its own resolution.

--- a/scripts/analysis/measure_attention_salience_normalization.py
+++ b/scripts/analysis/measure_attention_salience_normalization.py
@@ -1,0 +1,871 @@
+#!/usr/bin/env python3
+"""Read-only measurement: would per-channel z-score normalization diversify
+Layer 5 attention's top-1-winner selection over real history?
+
+Session context (2026-07-28, Juniper conversation): tonight's investigation
+found the same "noisiest wins" arbitration disease in three places in this
+codebase -- old drives system (retired, 96% `dominant_drive=relational`
+monoculture pre-fix), the proposal/policy pipeline (`orion/proposals/
+scoring.py::proposal_priority()`, fixed-weight linear blend, never
+calibrated against `orion/feedback/builder.py`'s real recorded outcomes),
+and Layer 5 attention (`orion/attention/field_attention/{scoring,
+selectors}.py`, live via `orion-attention-runtime`). The Sentience Striving
+Program charter (`orion/sentience_striving_program/README.md`) §6 item 5 ran
+`measure_emergent_clustering_probe.py` and found `select_system_targets`'s
+`field:recent_perturbations` target (`orion/attention/field_attention/
+selectors.py:128-140`, `salience = min(1.0, recent_perturbation_count /
+10.0)`) wins top-1 in ~99.98% of ticks by saturating to ~1.0 under the
+field's near-constant real perturbation rate -- structurally out-competing
+every other target almost always, because nothing normalizes for one
+channel being noisier/more-saturating than the others before comparing raw
+magnitudes.
+
+Juniper's converged direction: before writing a single line of live scoring
+code, MEASURE whether per-channel normalization (z-scoring each channel
+against its own real historical distribution before ranking) would actually
+fix this, per the charter's own §7 rule ("Measure before minting. Every new
+signal gets a read-only instrument and real historical replay before it
+gates anything live.") This script is that instrument.
+
+**Verified table (not assumed, re-checked fresh this run, not cited from a
+prior write-up):** same `substrate_attention_frames` Postgres table (
+`frame_json` jsonb column) that `measure_emergent_clustering_probe.py`
+already reads, written by `services/orion-attention-runtime/app/
+store.py::save_attention_frame()`. Row count and time range are queried
+live at the top of every run -- see "real data span" in the report, not a
+hardcoded prior number. CLAUDE.md's metric-quality-gate rule requires
+re-verifying a claim every time a build depends on it, not trusting a past
+write-up, even one from three days ago.
+
+## Disclosed scoping decisions
+
+1. **Data-access pattern, target parsing, and absence convention are reused
+   from `measure_emergent_clustering_probe.py`** (same read-only-session
+   contract, same `dominant_targets ∪ capability_targets` merge, same
+   "absence in a tick's list == 0.0 salience" convention -- a target absent
+   from a tick fell below the live policy's `min_salience=0.10`, not a
+   missing observation). Duplicated here rather than imported, matching
+   this directory's existing convention (`measure_emergent_clustering_
+   probe.py`'s own docstring: "Connection contract mirrors
+   measure_ast_hot_reducer.py / measure_capability_salience_coupling.py
+   exactly" -- every sibling script in `scripts/analysis/` is self-
+   contained, none import each other as library code; only their test
+   files load a sibling module by path for unit testing).
+
+2. **Single measurement window, not the emergent-clustering probe's A/B
+   split.** That script's two-window design exists to check whether
+   *clustering structure* recurs across time (a similarity-between-windows
+   question). This script asks a different question -- "does normalizing
+   against a channel's own historical distribution change who wins top-1"
+   -- which only needs ONE historical distribution per channel to normalize
+   against. Uses the full real available history in
+   `substrate_attention_frames` (same table, same ~72h retention) as that
+   one measurement window, since a larger sample gives a more stable
+   per-channel mean/stddev estimate than an arbitrarily-shortened window
+   would, and the emergent-clustering probe already establishes that a
+   single global full-history read is exactly how the existing 99.98%
+   baseline figure was computed (`full_history_top1` in that script). This
+   script's own baseline table is computed fresh, independently, over
+   whatever real span is available at run time -- not copy-pasted from
+   that script's prior output.
+
+3. **Normalization method: z-score against the channel's own full-history
+   series (absence-inclusive), not min-max or an EWMA band.** Justification:
+   this is the same normalization shape `orion-substrate-runtime`'s
+   `_grammar_reducer_poll_loop()` already uses live for `gap_zscore` bus-
+   synaptic anomaly detection (a real, working precedent for "z-score a
+   channel against its own history before treating a raw magnitude as
+   meaningful"), and it directly answers the question this measurement was
+   commissioned to answer: does *this* channel's *this* tick's value stand
+   out relative to *its own* normal range. An **existing-mechanism check**
+   was run before choosing this (CLAUDE.md metric quality gate step 5):
+   `orion/signals/normalization.py::EwmaBand` already implements a
+   different per-metric normalizer (EWMA mean/deviation band mapped to
+   [0,1]) used live by the organ-signal-gateway signal adapters -- a real,
+   running alternative. Not reused here because (a) it is stateful/online
+   (built for a live per-tick updating consumer, not a one-shot replay over
+   already-stored history) and (b) this measurement needs the option to
+   report "this channel could not be normalized at all" (near-zero
+   variance) as an explicit, visible finding, which a bounded-to-[0,1] EWMA
+   band would silently absorb rather than surface. Named here so the
+   choice is a disclosed decision, not silence about an existing option.
+   The per-channel z-score series is built the SAME way
+   `measure_emergent_clustering_probe.py::align_series` already builds a
+   per-target salience series (absence -> 0.0, aligned to tick order) --
+   this script's z-score is computed on exactly that same series shape.
+
+4. **Degenerate-variance handling is a first-class, reported finding, not a
+   silently-produced number.** If a channel's full-history raw series has
+   near-zero variance (same `DEGENERATE_VARIANCE_EPS = 1e-12` threshold
+   `measure_emergent_clustering_probe.py::pearson_correlation` already
+   uses), its z-score is undefined at every tick and it is EXCLUDED from
+   the normalized top-1 ranking entirely -- it cannot win under normalized
+   comparison, not because it "loses" a real z-score comparison, but
+   because no z-score could be computed for it at all. This is reported as
+   its own explicit table entry (`DEGENERATE (excluded)`), and if the
+   channel that was previously the raw-ranking's dominant winner turns out
+   to be exactly this degenerate channel, that is called out explicitly as
+   its own finding: any subsequent share drop is a mechanical side-effect
+   of disqualification-by-division-by-~0, not evidence that normalization
+   is doing real calibration work. This script also checks, separately,
+   whether the normalized ranking just relocates the monoculture to a
+   *different* single channel (a `MONOCULTURE_SHIFTED` finding) rather than
+   genuinely diversifying -- trading one "always wins" channel for another
+   is not success.
+
+5. **Classification** (`classify_normalization_effect`): explicit numeric
+   bands, see that function's docstring for the exact thresholds and
+   reasoning -- disclosed, not hidden in an if/else, same discipline as
+   `measure_emergent_clustering_probe.py::classify_similarity`.
+
+6. **This script is strictly read-only.** It opens a read-only Postgres
+   session (refuses to proceed if the session cannot be forced read-only,
+   same contract as every sibling `measure_*` script), performs SELECT-only
+   queries against `substrate_attention_frames`, and writes only to
+   `/tmp/measure-attention-salience-normalization/`. It does NOT import,
+   read as executable, modify, or write back to
+   `orion/attention/field_attention/scoring.py`, `selectors.py`, any other
+   live-running code path, or any database table. If this measurement
+   supports normalization as a real fix, implementing it is an explicit,
+   separate, larger patch requiring its own proposal-mode sign-off per
+   `orion/sentience_striving_program/README.md`'s charter and root
+   CLAUDE.md §0A's cognition-loop rule -- not a next step folded into this
+   script or this run.
+
+Run:
+    python scripts/analysis/measure_attention_salience_normalization.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("orion.analysis.attention_salience_normalization")
+
+DEGENERATE_VARIANCE_EPS: float = 1e-12
+MIN_TOTAL_ROWS: int = 200
+MAX_ROWS: int = 200_000
+MONOCULTURE_SHARE_THRESHOLD: float = 0.5
+MEANINGFUL_DIVERSITY_SHARE: float = 0.10
+DIVERSIFICATION_DROP_THRESHOLD: float = 0.30
+
+OUTPUT_DIR = Path("/tmp/measure-attention-salience-normalization")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+CSV_PATH = OUTPUT_DIR / "ticks.csv"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Reused parsing shape from
+# measure_emergent_clustering_probe.py (see module docstring #1), plus new
+# per-channel z-score / normalized-ranking logic.
+# ===========================================================================
+
+
+def _parse_target_list(raw: Any) -> list[dict]:
+    """Parse a raw `frame_json->'dominant_targets'` or `->'capability_targets'`
+    value (possibly a JSON string, possibly malformed, possibly None) into a
+    list of dict entries. Never raises."""
+    try:
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            raw = json.loads(raw)
+        if not isinstance(raw, list):
+            return []
+        return [e for e in raw if isinstance(e, dict)]
+    except Exception:
+        return []
+
+
+def extract_target_salience_map(dominant_raw: Any, capability_raw: Any) -> dict[str, float]:
+    """Merge one tick's `dominant_targets` and `capability_targets` raw JSON
+    into a single {target_id: salience_score} map. Same convention as
+    `measure_emergent_clustering_probe.py::extract_target_salience_map`.
+    Never raises."""
+    result: dict[str, float] = {}
+    for entry in _parse_target_list(dominant_raw):
+        tid = entry.get("target_id")
+        if not isinstance(tid, str):
+            continue
+        try:
+            score = float(entry.get("salience_score", 0.0))
+        except (TypeError, ValueError):
+            score = 0.0
+        result[tid] = score
+    for entry in _parse_target_list(capability_raw):
+        tid = entry.get("target_id")
+        if not isinstance(tid, str) or tid in result:
+            continue
+        try:
+            score = float(entry.get("salience_score", 0.0))
+        except (TypeError, ValueError):
+            score = 0.0
+        result[tid] = score
+    return result
+
+
+def build_target_universe(raw_maps: list[dict[str, float]]) -> list[str]:
+    seen: set[str] = set()
+    for m in raw_maps:
+        seen.update(m.keys())
+    return sorted(seen)
+
+
+def align_series(raw_maps: list[dict[str, float]], target_ids: list[str]) -> dict[str, list[float]]:
+    """Per-target salience_score series aligned to `raw_maps`' tick order.
+    Absence in a tick's map -> 0.0."""
+    series: dict[str, list[float]] = {t: [] for t in target_ids}
+    for m in raw_maps:
+        for t in target_ids:
+            series[t].append(float(m.get(t, 0.0)))
+    return series
+
+
+def channel_mean_std(values: list[float]) -> tuple[float, float, bool]:
+    """(mean, stddev, is_degenerate). Population stddev (matches
+    `pearson_correlation`'s own variance convention -- no Bessel correction,
+    since this is a description of the observed full-history population, not
+    an inference from a sample of a larger unseen population). Degenerate iff
+    variance <= DEGENERATE_VARIANCE_EPS (near-constant / flat series -- e.g.
+    a saturating channel that sits at ~1.0 almost every tick)."""
+    n = len(values)
+    if n == 0:
+        return 0.0, 0.0, True
+    mean = sum(values) / n
+    variance = sum((v - mean) ** 2 for v in values) / n
+    if variance <= DEGENERATE_VARIANCE_EPS:
+        return mean, 0.0, True
+    return mean, math.sqrt(variance), False
+
+
+def compute_zscore_series(
+    target_ids: list[str], raw_series: dict[str, list[float]]
+) -> tuple[dict[str, list[Optional[float]]], dict[str, tuple[float, float, bool]]]:
+    """Per-channel z-score series, z[i] = (raw[i] - mean) / std, computed
+    against that channel's OWN full-history raw series (see module docstring
+    #3). A degenerate channel (near-zero variance) gets an all-`None` series
+    -- never a fabricated 0.0 or an artificially clamped value, since there
+    is no real deviation to measure. Returns (z_series_by_target,
+    stats_by_target) where stats_by_target[t] = (mean, std, is_degenerate)."""
+    z_series: dict[str, list[Optional[float]]] = {}
+    stats: dict[str, tuple[float, float, bool]] = {}
+    for t in target_ids:
+        values = raw_series[t]
+        mean, std, degenerate = channel_mean_std(values)
+        stats[t] = (mean, std, degenerate)
+        if degenerate:
+            z_series[t] = [None] * len(values)
+        else:
+            z_series[t] = [(v - mean) / std for v in values]
+    return z_series, stats
+
+
+def top1_winner_raw(target_map: dict[str, float]) -> Optional[str]:
+    """The single highest-raw-salience target_id for one tick. Deterministic
+    tie-break: highest score, then alphabetical target_id. Same shape as
+    `measure_emergent_clustering_probe.py::top1_winner`."""
+    if not target_map:
+        return None
+    return sorted(target_map.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]
+
+
+def top1_winner_distribution_raw(raw_maps: list[dict[str, float]]) -> Counter:
+    counter: Counter = Counter()
+    for m in raw_maps:
+        winner = top1_winner_raw(m)
+        if winner is not None:
+            counter[winner] += 1
+    return counter
+
+
+def top1_winner_distribution_normalized(
+    target_ids: list[str], z_series: dict[str, list[Optional[float]]], n_ticks: int
+) -> tuple[Counter, int]:
+    """Per-tick argmax over defined (non-None) z-scores only -- a degenerate
+    channel is structurally excluded from ever winning here (module
+    docstring #4), not scored as a real loser. Deterministic tie-break:
+    highest z, then alphabetical target_id. Returns (winner_counter,
+    n_ticks_with_no_defined_z) -- the second value is a real coverage gap
+    (every channel degenerate at that tick), reported explicitly rather than
+    silently dropped."""
+    counter: Counter = Counter()
+    n_no_winner = 0
+    for i in range(n_ticks):
+        candidates = [
+            (t, z_series[t][i]) for t in target_ids if z_series[t][i] is not None
+        ]
+        if not candidates:
+            n_no_winner += 1
+            continue
+        winner = sorted(candidates, key=lambda kv: (-kv[1], kv[0]))[0][0]
+        counter[winner] += 1
+    return counter, n_no_winner
+
+
+def classify_normalization_effect(
+    raw_top1: Counter,
+    raw_n: int,
+    norm_top1: Counter,
+    norm_n: int,
+) -> str:
+    """Explicit classification bands for "would per-channel z-score
+    normalization diversify Layer 5 attention's top-1 winner selection."
+    These exact numbers are a disclosed scoping decision for THIS
+    measurement (module docstring #5), not asserted as universally correct.
+
+    Note: whether the raw winner is itself a degenerate (near-zero-variance)
+    channel does NOT change which band this function returns -- these bands
+    only classify the resulting winner-frequency shift. The "is the raw
+    dominant channel structurally disqualified vs. genuinely out-competed"
+    distinction is a separate, additional finding rendered in
+    `render_report`'s "Honest findings" section, deliberately kept out of
+    the classification verdict itself so degeneracy-driven relocation still
+    reads as `NOT_MET_MONOCULTURE_SHIFTED`, not silently as `MET`.
+
+    - `INSUFFICIENT_DATA`: fewer than MIN_TOTAL_ROWS real ticks, or the
+      normalized ranking had zero valid (non-degenerate-only) ticks to rank.
+      Too little real structure to judge either way.
+    - `NOT_MET`: the normalized top-1 winner's share of valid ticks is still
+      >= MONOCULTURE_SHARE_THRESHOLD (0.5) AND it is the SAME target_id that
+      won the raw ranking. Normalization did not change who wins; more than
+      half of ticks still go to one channel.
+    - `NOT_MET_MONOCULTURE_SHIFTED`: the normalized top-1 winner's share is
+      still >= MONOCULTURE_SHARE_THRESHOLD (0.5) but it is a DIFFERENT
+      target_id than the raw winner. Normalization relocated the monoculture
+      to a different single channel rather than diversifying it -- this is
+      explicitly NOT treated as success, even though the raw dominant
+      channel's own share dropped, because one channel still wins more than
+      half of all ticks.
+    - `MET`: the normalized top-1 winner's share drops by at least
+      DIVERSIFICATION_DROP_THRESHOLD (0.30, absolute) relative to the raw
+      top-1 winner's share, AND at least two distinct channels each hold
+      >= MEANINGFUL_DIVERSITY_SHARE (0.10) of valid ticks under the
+      normalized ranking. Both a real share drop AND real multi-channel
+      diversity are required -- a share drop alone could still leave one new
+      channel dominant (see MONOCULTURE_SHIFTED above).
+    - `AMBIGUOUS`: falls in neither MET nor NOT_MET/NOT_MET_MONOCULTURE_
+      SHIFTED bands (e.g. a real but partial share drop that doesn't clear
+      the 0.30 threshold, or clears it without producing real multi-channel
+      diversity) -- reported plainly rather than forced into a verdict.
+    """
+    if raw_n < MIN_TOTAL_ROWS or norm_n == 0:
+        return "INSUFFICIENT_DATA"
+
+    raw_winner, raw_count = raw_top1.most_common(1)[0] if raw_top1 else (None, 0)
+    raw_share = raw_count / raw_n if raw_n else 0.0
+
+    norm_winner, norm_count = norm_top1.most_common(1)[0] if norm_top1 else (None, 0)
+    norm_share = norm_count / norm_n if norm_n else 0.0
+
+    n_meaningful_normalized = sum(
+        1 for _, c in norm_top1.items() if (c / norm_n) >= MEANINGFUL_DIVERSITY_SHARE
+    )
+
+    if norm_share >= MONOCULTURE_SHARE_THRESHOLD:
+        if norm_winner == raw_winner:
+            return "NOT_MET"
+        return "NOT_MET_MONOCULTURE_SHIFTED"
+
+    if (raw_share - norm_share) >= DIVERSIFICATION_DROP_THRESHOLD and n_meaningful_normalized >= 2:
+        return "MET"
+
+    return "AMBIGUOUS"
+
+
+# ===========================================================================
+# I/O layer -- psycopg2 read-only. Connection contract mirrors
+# measure_emergent_clustering_probe.py / measure_ast_hot_reducer.py exactly
+# (refuses a non-read-only session).
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_frame_time_range(conn) -> tuple[Optional[datetime], Optional[datetime], int]:
+    if conn is None:
+        return None, None, 0
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT min(generated_at), max(generated_at), count(*) FROM substrate_attention_frames")
+            row = cur.fetchone()
+    except Exception:
+        logger.error("failed to fetch substrate_attention_frames time range", exc_info=True)
+        return None, None, 0
+    if not row:
+        return None, None, 0
+    min_ts, max_ts, count = row
+    if min_ts is not None and min_ts.tzinfo is None:
+        min_ts = min_ts.replace(tzinfo=timezone.utc)
+    if max_ts is not None and max_ts.tzinfo is None:
+        max_ts = max_ts.replace(tzinfo=timezone.utc)
+    return min_ts, max_ts, int(count or 0)
+
+
+def fetch_target_rows(
+    conn, start: datetime, end: datetime, max_rows: int = MAX_ROWS
+) -> tuple[list[tuple[datetime, Any, Any]], bool]:
+    """Real historical rows in [start, end], ASC by generated_at. Each row:
+    (generated_at, dominant_targets_raw, capability_targets_raw)."""
+    if conn is None:
+        return [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT generated_at, frame_json->'dominant_targets', frame_json->'capability_targets'
+                FROM substrate_attention_frames
+                WHERE generated_at >= %s AND generated_at <= %s
+                ORDER BY generated_at ASC
+                LIMIT %s
+                """,
+                (start, end, max_rows),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch substrate_attention_frames rows", exc_info=True)
+        return [], False
+    out: list[tuple[datetime, Any, Any]] = []
+    for ts, dom_raw, cap_raw in rows:
+        if ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        out.append((ts, dom_raw, cap_raw))
+    return out, len(rows) >= max_rows
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def write_ticks_csv(
+    path: Path,
+    raw_maps: list[dict[str, float]],
+    timestamps: list[datetime],
+    target_ids: list[str],
+    z_series: dict[str, list[Optional[float]]],
+) -> None:
+    import csv
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        header = ["generated_at"]
+        for t in target_ids:
+            header.append(f"raw:{t}")
+            header.append(f"z:{t}")
+        writer.writerow(header)
+        for i, (ts, m) in enumerate(zip(timestamps, raw_maps)):
+            row = [ts.isoformat()]
+            for t in target_ids:
+                row.append(f"{m.get(t, 0.0):.4f}")
+                z = z_series[t][i]
+                row.append("n/a" if z is None else f"{z:.4f}")
+            writer.writerow(row)
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.4f}"
+
+
+def render_report(
+    *,
+    global_window_label: str,
+    total_rows: int,
+    n_ticks: int,
+    target_ids: list[str],
+    stats: dict[str, tuple[float, float, bool]],
+    raw_top1: Counter,
+    norm_top1: Counter,
+    norm_valid_n: int,
+    n_no_winner: int,
+    classification: str,
+    caveats: list[str],
+) -> str:
+    lines = [
+        "# Attention Salience Normalization Probe -- Would Z-Scoring Diversify Layer 5's Top-1 Winner?",
+        "",
+        "Read-only. No writes, no events, no flag/config changes, no edits to "
+        "`orion/attention/field_attention/{scoring,selectors}.py` or any other live "
+        "code path. Runs a fresh per-channel z-score normalization over real "
+        "`substrate_attention_frames` history and asks: does normalizing each "
+        "channel against its own historical distribution before ranking change who "
+        "wins top-1, and does it actually diversify the winner distribution or just "
+        "relocate the monoculture to a different channel? Session context: "
+        "2026-07-28 Juniper conversation, same three-places-same-disease finding "
+        "documented in `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-"
+        "trend-reducer-design.md`'s 2026-07-28 update section.",
+        "",
+        f"- Real data span (queried fresh this run): {global_window_label}",
+        f"- Total `substrate_attention_frames` rows in span: {total_rows}",
+        f"- Real ticks used (rows with a parseable target list): {n_ticks}",
+        f"- Target universe observed (dominant_targets ∪ capability_targets): {len(target_ids)} "
+        f"({', '.join(f'`{t}`' for t in target_ids)})",
+        "",
+        "## Per-channel full-history stats (the normalization baseline)",
+        "",
+        "| target_id | mean (raw salience) | stddev | status |",
+        "| --- | --- | --- | --- |",
+    ]
+    for t in target_ids:
+        mean, std, degenerate = stats[t]
+        status = "DEGENERATE (near-zero variance -- excluded from normalized ranking)" if degenerate else "normal"
+        lines.append(f"| `{t}` | {mean:.4f} | {std:.6f} | {status} |")
+
+    degenerate_channels = {t for t, (_, _, d) in stats.items() if d}
+
+    lines.extend(
+        [
+            "",
+            "## Winner-frequency table: raw magnitude ranking (BEFORE normalization)",
+            "",
+            f"Full-history top-1 winner per tick, same closest-real-analog-to-`dominant_drive` "
+            f"definition as `measure_emergent_clustering_probe.py::top1_winner` "
+            f"(highest raw `salience_score`, tie-break alphabetical target_id).",
+            "",
+            "| target_id | ticks won (top-1) | share |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for target_id, count in raw_top1.most_common():
+        share = count / n_ticks if n_ticks else 0.0
+        lines.append(f"| `{target_id}` | {count} | {share * 100:.2f}% |")
+    raw_winner, raw_count = raw_top1.most_common(1)[0] if raw_top1 else (None, 0)
+    raw_share = raw_count / n_ticks if n_ticks else 0.0
+
+    lines.extend(
+        [
+            "",
+            "## Winner-frequency table: per-channel z-score ranking (AFTER normalization)",
+            "",
+            f"Per-tick argmax over defined (non-degenerate) z-scores only. "
+            f"`{n_no_winner}` of `{n_ticks}` ticks had NO defined z anywhere (every "
+            f"channel degenerate at that tick) and are excluded from the "
+            f"`{norm_valid_n}`-tick denominator below, not silently folded in.",
+            "",
+            "| target_id | ticks won (top-1, normalized) | share (of valid ticks) |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for target_id, count in norm_top1.most_common():
+        share = count / norm_valid_n if norm_valid_n else 0.0
+        lines.append(f"| `{target_id}` | {count} | {share * 100:.2f}% |")
+    norm_winner, norm_count = norm_top1.most_common(1)[0] if norm_top1 else (None, 0)
+    norm_share = norm_count / norm_valid_n if norm_valid_n else 0.0
+
+    lines.extend(
+        [
+            "",
+            "## Honest findings",
+            "",
+        ]
+    )
+    if raw_winner is not None and raw_winner in degenerate_channels:
+        lines.append(
+            f"- **The raw-ranking dominant channel (`{raw_winner}`, {raw_share*100:.2f}% share) "
+            f"is itself DEGENERATE (near-zero variance).** Any share drop reported below is a "
+            f"mechanical side-effect of that channel being structurally disqualified from the "
+            f"normalized ranking (divide-by-~0), NOT evidence that z-score normalization is doing "
+            f"real calibration work on real variance. This is exactly the scenario module "
+            f"docstring #4 warned to check for explicitly rather than silently produce a "
+            f"misleading number."
+        )
+    else:
+        lines.append(
+            f"- The raw-ranking dominant channel (`{raw_winner}`, {raw_share*100:.2f}% share) has "
+            f"real, non-degenerate variance in its own history -- any share drop below reflects a "
+            f"real change in relative ranking under normalization, not a disqualification artifact."
+        )
+
+    if norm_winner is not None and norm_winner != raw_winner and norm_share >= MONOCULTURE_SHARE_THRESHOLD:
+        lines.append(
+            f"- **Monoculture relocated, not fixed.** Under normalization, a DIFFERENT single "
+            f"channel (`{norm_winner}`) now wins {norm_share*100:.2f}% of valid ticks -- still "
+            f"above the {MONOCULTURE_SHARE_THRESHOLD*100:.0f}% monoculture threshold used by this "
+            f"script. Normalization changed WHO wins, not WHETHER one channel structurally "
+            f"dominates."
+        )
+    elif norm_winner is not None and norm_winner == raw_winner and norm_share >= MONOCULTURE_SHARE_THRESHOLD:
+        lines.append(
+            f"- **Same channel still wins under normalization.** `{norm_winner}` remains the "
+            f"top-1 winner at {norm_share*100:.2f}% of valid ticks even after z-scoring."
+        )
+    elif norm_winner is not None:
+        lines.append(
+            f"- Under normalization, the top channel (`{norm_winner}`) holds {norm_share*100:.2f}% "
+            f"of valid ticks -- below the {MONOCULTURE_SHARE_THRESHOLD*100:.0f}% monoculture "
+            f"threshold."
+        )
+
+    lines.extend(
+        [
+            "",
+            f"## Classification: **{classification}**",
+            "",
+        ]
+    )
+    lines.extend(
+        {
+            "INSUFFICIENT_DATA": [
+                f"Fewer than {MIN_TOTAL_ROWS} real ticks were available, or normalization "
+                "produced zero valid (non-degenerate-only) ticks to rank. Too little real "
+                "structure to judge either way.",
+            ],
+            "NOT_MET": [
+                "The same channel wins under both raw and normalized ranking, at or above a "
+                f"{MONOCULTURE_SHARE_THRESHOLD*100:.0f}% share. Z-score normalization, as "
+                "specified here, does NOT diversify Layer 5's top-1 winner selection on real "
+                "current data.",
+            ],
+            "NOT_MET_MONOCULTURE_SHIFTED": [
+                "A different channel wins under normalization, but it still holds >= "
+                f"{MONOCULTURE_SHARE_THRESHOLD*100:.0f}% of valid ticks. Normalization relocates "
+                "the monoculture rather than fixing the underlying disease -- explicitly NOT "
+                "treated as success by this script's classification bands.",
+            ],
+            "MET": [
+                "The normalized top-1 winner's share drops by at least "
+                f"{DIVERSIFICATION_DROP_THRESHOLD*100:.0f} percentage points relative to the raw "
+                "winner's share, AND at least two distinct channels each hold real (>= "
+                f"{MEANINGFUL_DIVERSITY_SHARE*100:.0f}%) share under the normalized ranking. Real "
+                "evidence that per-channel z-score normalization would diversify who wins.",
+            ],
+            "AMBIGUOUS": [
+                "The share drop and/or resulting diversity fall between the NOT_MET/"
+                "NOT_MET_MONOCULTURE_SHIFTED and MET bands -- reported plainly rather than forced "
+                "into either verdict.",
+            ],
+        }.get(classification, ["(no narrative for this classification)"])
+    )
+    lines.append("")
+
+    lines.extend(["## Coverage caveats", ""])
+    if caveats:
+        lines.extend(f"- {c}" for c in caveats)
+    else:
+        lines.append("- none")
+    lines.append("")
+
+    lines.extend(
+        [
+            "## Explicit scope boundary",
+            "",
+            "This script is a measurement only. It did NOT modify "
+            "`orion/attention/field_attention/scoring.py`, `selectors.py`, any other live "
+            "scoring/selector code path, or any database table. If this measurement's "
+            "classification is MET, implementing per-channel normalization in the live scoring "
+            "path is a separate, larger patch requiring its own explicit proposal-mode sign-off "
+            "per `orion/sentience_striving_program/README.md`'s charter and root CLAUDE.md "
+            "§0A's cognition-loop rule -- not a next step taken by this run.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def run() -> int:
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    progress = ProgressLog(PROGRESS_PATH)
+    caveats: list[str] = []
+
+    progress.emit("connect", percent=0.0, processed=0, total=0)
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        caveats.append("postgres unavailable or not read-only; nothing measured")
+        progress.close()
+        print("ERROR: could not open a read-only postgres connection; see log")
+        return 2
+
+    min_ts, max_ts, total_rows = fetch_frame_time_range(conn)
+    progress.emit("time range fetched", percent=5.0, processed=total_rows, total=total_rows)
+
+    if min_ts is None or max_ts is None or total_rows < MIN_TOTAL_ROWS:
+        caveats.append(
+            f"insufficient real substrate_attention_frames history (rows={total_rows}, "
+            f"min_required={MIN_TOTAL_ROWS}); cannot run a meaningful probe"
+        )
+        try:
+            conn.close()
+        except Exception:
+            pass
+        progress.close()
+        report = render_report(
+            global_window_label="n/a (insufficient data)",
+            total_rows=total_rows, n_ticks=0, target_ids=[], stats={},
+            raw_top1=Counter(), norm_top1=Counter(), norm_valid_n=0, n_no_winner=0,
+            classification="INSUFFICIENT_DATA", caveats=caveats,
+        )
+        REPORT_PATH.write_text(report, encoding="utf-8")
+        print(report)
+        return 2
+
+    global_label = f"{min_ts.isoformat()} -> {max_ts.isoformat()} ({(max_ts - min_ts).total_seconds() / 3600.0:.1f}h)"
+
+    all_rows, truncated = fetch_target_rows(conn, min_ts, max_ts, MAX_ROWS)
+    if truncated:
+        caveats.append(
+            f"history truncated at MAX_ROWS={MAX_ROWS} -- fetch is ORDER BY generated_at ASC, "
+            "so truncation keeps the OLDEST rows and drops the newest. Not triggered at current "
+            "real data volume as of this run."
+        )
+    progress.emit("history fetched", percent=25.0, processed=len(all_rows), total=len(all_rows))
+
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+    all_timestamps = [ts for ts, _, _ in all_rows]
+    all_raw_maps = [extract_target_salience_map(d, c) for _, d, c in all_rows]
+    target_ids = build_target_universe(all_raw_maps)
+    n_ticks = len(all_raw_maps)
+    progress.emit("target universe built", percent=40.0, processed=n_ticks, total=n_ticks)
+
+    if not target_ids or n_ticks == 0:
+        caveats.append("no target_ids observed in real history; cannot compute normalization")
+        report = render_report(
+            global_window_label=global_label, total_rows=total_rows, n_ticks=n_ticks,
+            target_ids=[], stats={}, raw_top1=Counter(), norm_top1=Counter(),
+            norm_valid_n=0, n_no_winner=0, classification="INSUFFICIENT_DATA", caveats=caveats,
+        )
+        REPORT_PATH.write_text(report, encoding="utf-8")
+        progress.close()
+        print(report)
+        return 2
+
+    raw_series = align_series(all_raw_maps, target_ids)
+    raw_top1 = top1_winner_distribution_raw(all_raw_maps)
+    progress.emit("raw baseline computed", percent=55.0, processed=n_ticks, total=n_ticks)
+
+    z_series, stats = compute_zscore_series(target_ids, raw_series)
+    progress.emit("z-scores computed", percent=75.0, processed=n_ticks, total=n_ticks)
+
+    norm_top1, n_no_winner = top1_winner_distribution_normalized(target_ids, z_series, n_ticks)
+    norm_valid_n = n_ticks - n_no_winner
+    progress.emit("normalized ranking computed", percent=90.0, processed=1, total=1)
+
+    degenerate_channels = {t for t, (_, _, d) in stats.items() if d}
+    if degenerate_channels:
+        caveats.append(
+            f"{len(degenerate_channels)} of {len(target_ids)} channel(s) had near-zero "
+            f"full-history variance and were excluded from normalized ranking: "
+            f"{sorted(degenerate_channels)}"
+        )
+    if n_no_winner:
+        caveats.append(
+            f"{n_no_winner} of {n_ticks} ticks had no defined z-score anywhere (every observed "
+            f"channel was degenerate or absent at that tick) and were excluded from the "
+            f"normalized-ranking denominator"
+        )
+
+    classification = classify_normalization_effect(raw_top1, n_ticks, norm_top1, norm_valid_n)
+
+    write_ticks_csv(CSV_PATH, all_raw_maps, all_timestamps, target_ids, z_series)
+    report = render_report(
+        global_window_label=global_label, total_rows=total_rows, n_ticks=n_ticks,
+        target_ids=target_ids, stats=stats, raw_top1=raw_top1, norm_top1=norm_top1,
+        norm_valid_n=norm_valid_n, n_no_winner=n_no_winner, classification=classification,
+        caveats=caveats,
+    )
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    progress.emit("done", percent=100.0, processed=1, total=1)
+    progress.close()
+
+    print(report)
+    print(f"\nartifacts: {REPORT_PATH}, {CSV_PATH}, {PROGRESS_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only probe: would per-channel z-score normalization diversify "
+        "Layer 5 attention's top-1-winner selection over real history?"
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    build_arg_parser().parse_args(argv)
+    return run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_measure_attention_salience_normalization.py
+++ b/scripts/analysis/tests/test_measure_attention_salience_normalization.py
@@ -1,0 +1,313 @@
+"""Deterministic unit tests for measure_attention_salience_normalization.py.
+
+No DB, no network. Everything here is pure: JSON-target-list parsing, series
+alignment, per-channel mean/stddev, z-score series, normalized-ranking
+argmax, and the classification bands all operate on plain synthetic data.
+Same sibling-module-by-file-path loading pattern as
+test_measure_emergent_clustering_probe.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections import Counter
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "measure_attention_salience_normalization.py"
+_spec = importlib.util.spec_from_file_location("measure_attention_salience_normalization", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_attention_salience_normalization"] = mod
+_spec.loader.exec_module(mod)
+
+
+# ===========================================================================
+# extract_target_salience_map -- pure JSON parsing, must never raise.
+# ===========================================================================
+
+
+def test_extract_target_salience_map_merges_dominant_and_capability() -> None:
+    dominant = [
+        {"target_id": "node:athena", "salience_score": 0.7},
+        {"target_id": "capability:transport", "salience_score": 0.5},
+    ]
+    capability = [{"target_id": "capability:transport", "salience_score": 0.5}]
+    result = mod.extract_target_salience_map(dominant, capability)
+    assert result == {"node:athena": 0.7, "capability:transport": 0.5}
+
+
+def test_extract_target_salience_map_handles_json_string() -> None:
+    dominant = '[{"target_id": "node:athena", "salience_score": 0.42}]'
+    result = mod.extract_target_salience_map(dominant, None)
+    assert result == {"node:athena": 0.42}
+
+
+def test_extract_target_salience_map_none_never_raises() -> None:
+    assert mod.extract_target_salience_map(None, None) == {}
+
+
+def test_extract_target_salience_map_malformed_never_raises() -> None:
+    assert mod.extract_target_salience_map("{not valid json", "also not valid") == {}
+    assert mod.extract_target_salience_map(
+        [{"target_id": "node:athena", "salience_score": "garbage"}], None
+    ) == {"node:athena": 0.0}
+
+
+# ===========================================================================
+# build_target_universe / align_series
+# ===========================================================================
+
+
+def test_build_target_universe_sorted_dedup() -> None:
+    raw_maps = [{"b": 0.1, "a": 0.2}, {"c": 0.3}]
+    assert mod.build_target_universe(raw_maps) == ["a", "b", "c"]
+
+
+def test_align_series_absence_is_zero() -> None:
+    raw_maps = [{"a": 0.5}, {"b": 0.9}, {"a": 0.2, "b": 0.1}]
+    series = mod.align_series(raw_maps, ["a", "b"])
+    assert series["a"] == [0.5, 0.0, 0.2]
+    assert series["b"] == [0.0, 0.9, 0.1]
+
+
+# ===========================================================================
+# channel_mean_std -- degenerate-variance detection.
+# ===========================================================================
+
+
+def test_channel_mean_std_normal_series() -> None:
+    mean, std, degenerate = mod.channel_mean_std([0.1, 0.2, 0.3, 0.4, 0.5])
+    assert abs(mean - 0.3) < 1e-9
+    assert std > 0.0
+    assert degenerate is False
+
+
+def test_channel_mean_std_flat_series_is_degenerate() -> None:
+    mean, std, degenerate = mod.channel_mean_std([1.0, 1.0, 1.0, 1.0])
+    assert abs(mean - 1.0) < 1e-9
+    assert std == 0.0
+    assert degenerate is True
+
+
+def test_channel_mean_std_empty_series_is_degenerate() -> None:
+    mean, std, degenerate = mod.channel_mean_std([])
+    assert degenerate is True
+
+
+def test_channel_mean_std_near_constant_saturated_channel_is_degenerate() -> None:
+    """The real repo finding this script exists to check: a channel that
+    saturates to ~1.0 and stays there (field:recent_perturbations-shaped)
+    must be flagged degenerate, not treated as having real variance."""
+    values = [1.0] * 999 + [0.9999999999999]
+    mean, std, degenerate = mod.channel_mean_std(values)
+    assert degenerate is True
+
+
+# ===========================================================================
+# compute_zscore_series
+# ===========================================================================
+
+
+def test_compute_zscore_series_normal_channel() -> None:
+    target_ids = ["a"]
+    raw_series = {"a": [0.0, 1.0, 2.0, 3.0, 4.0]}
+    z_series, stats = mod.compute_zscore_series(target_ids, raw_series)
+    mean, std, degenerate = stats["a"]
+    assert degenerate is False
+    assert abs(mean - 2.0) < 1e-9
+    # z-scores should be symmetric around zero for a linear ramp.
+    assert abs(sum(z_series["a"])) < 1e-9
+    assert all(v is not None for v in z_series["a"])
+
+
+def test_compute_zscore_series_degenerate_channel_is_all_none() -> None:
+    target_ids = ["a"]
+    raw_series = {"a": [1.0, 1.0, 1.0, 1.0]}
+    z_series, stats = mod.compute_zscore_series(target_ids, raw_series)
+    assert stats["a"][2] is True  # degenerate
+    assert z_series["a"] == [None, None, None, None]
+
+
+def test_compute_zscore_series_multi_channel_independent() -> None:
+    target_ids = ["a", "b"]
+    raw_series = {
+        "a": [0.0, 1.0, 2.0],
+        "b": [1.0, 1.0, 1.0],  # degenerate
+    }
+    z_series, stats = mod.compute_zscore_series(target_ids, raw_series)
+    assert stats["a"][2] is False
+    assert stats["b"][2] is True
+    assert all(v is not None for v in z_series["a"])
+    assert z_series["b"] == [None, None, None]
+
+
+# ===========================================================================
+# top1_winner_raw / top1_winner_distribution_raw
+# ===========================================================================
+
+
+def test_top1_winner_raw_picks_highest_score() -> None:
+    assert mod.top1_winner_raw({"a": 0.5, "b": 0.9, "c": 0.3}) == "b"
+
+
+def test_top1_winner_raw_deterministic_tiebreak_alphabetical() -> None:
+    assert mod.top1_winner_raw({"z": 0.5, "a": 0.5}) == "a"
+
+
+def test_top1_winner_raw_empty_map_is_none() -> None:
+    assert mod.top1_winner_raw({}) is None
+
+
+def test_top1_winner_distribution_raw_counts() -> None:
+    raw_maps = [{"a": 0.9}, {"a": 0.8}, {"b": 0.99}]
+    dist = mod.top1_winner_distribution_raw(raw_maps)
+    assert dist["a"] == 2
+    assert dist["b"] == 1
+
+
+# ===========================================================================
+# top1_winner_distribution_normalized -- the core new logic.
+# ===========================================================================
+
+
+def test_top1_winner_distribution_normalized_picks_highest_z() -> None:
+    target_ids = ["a", "b"]
+    # a: mean 1, std 1 -> z = [-1, 0, 1]
+    # b: mean 0, std 1 -> z = [1, 0, -1]  (b wins tick 0, tie tick 1, a wins tick 2)
+    z_series = {
+        "a": [-1.0, 0.0, 1.0],
+        "b": [1.0, 0.0, -1.0],
+    }
+    dist, n_no_winner = mod.top1_winner_distribution_normalized(target_ids, z_series, 3)
+    assert n_no_winner == 0
+    assert dist["b"] == 1  # tick 0
+    assert dist["a"] == 2  # tick 1 (tiebreak alphabetical -> a), tick 2
+
+
+def test_top1_winner_distribution_normalized_excludes_degenerate_channel() -> None:
+    """A degenerate channel (all-None z-series) must never win -- even if its
+    raw value would have been highest every tick under the old ranking."""
+    target_ids = ["saturated", "real"]
+    z_series = {
+        "saturated": [None, None, None],
+        "real": [-0.5, 0.2, 1.0],
+    }
+    dist, n_no_winner = mod.top1_winner_distribution_normalized(target_ids, z_series, 3)
+    assert n_no_winner == 0
+    assert "saturated" not in dist
+    assert dist["real"] == 3
+
+
+def test_top1_winner_distribution_normalized_all_degenerate_tick_has_no_winner() -> None:
+    target_ids = ["a", "b"]
+    z_series = {
+        "a": [None, 0.5],
+        "b": [None, -0.5],
+    }
+    dist, n_no_winner = mod.top1_winner_distribution_normalized(target_ids, z_series, 2)
+    assert n_no_winner == 1
+    assert dist["a"] == 1
+
+
+# ===========================================================================
+# classify_normalization_effect -- explicit documented bands.
+# ===========================================================================
+
+
+def test_classify_normalization_effect_insufficient_data_too_few_rows() -> None:
+    raw = Counter({"a": 100})
+    norm = Counter({"a": 100})
+    result = mod.classify_normalization_effect(raw, 100, norm, 100)
+    assert result == "INSUFFICIENT_DATA"
+
+
+def test_classify_normalization_effect_insufficient_data_zero_valid_normalized_ticks() -> None:
+    raw = Counter({"a": 1000})
+    norm = Counter()
+    result = mod.classify_normalization_effect(raw, 1000, norm, 0)
+    assert result == "INSUFFICIENT_DATA"
+
+
+def test_classify_normalization_effect_not_met_same_winner_still_dominant() -> None:
+    raw = Counter({"a": 900, "b": 100})
+    norm = Counter({"a": 800, "b": 200})
+    result = mod.classify_normalization_effect(raw, 1000, norm, 1000)
+    assert result == "NOT_MET"
+
+
+def test_classify_normalization_effect_monoculture_shifted() -> None:
+    """This is the real live finding this script produced against
+    substrate_attention_frames on 2026-07-28: raw dominant channel is
+    degenerate, gets excluded, but a DIFFERENT single channel takes over at
+    >= 50% share under normalization -- not a fix, a relocation."""
+    raw = Counter({"field:recent_perturbations": 1000})
+    norm = Counter({"node:atlas": 552, "node:circe": 200, "capability:llm_inference": 150, "node:athena": 98})
+    result = mod.classify_normalization_effect(raw, 1000, norm, 1000)
+    assert result == "NOT_MET_MONOCULTURE_SHIFTED"
+
+
+def test_classify_normalization_effect_met_real_diversification() -> None:
+    raw = Counter({"a": 900, "b": 100})
+    norm = Counter({"a": 300, "b": 250, "c": 250, "d": 200})
+    result = mod.classify_normalization_effect(raw, 1000, norm, 1000)
+    assert result == "MET"
+
+
+def test_classify_normalization_effect_ambiguous_partial_drop_no_real_diversity() -> None:
+    # Winner's share drops from 90% to 45% (a real 0.45 drop, clears the 0.30
+    # threshold) AND stays below the 0.5 monoculture threshold, but the
+    # remaining 55% is spread thin enough that only ONE channel (the winner
+    # itself) clears the 10% meaningful-diversity bar -- not "at least two
+    # distinct channels", so this must land in AMBIGUOUS, not MET.
+    raw = Counter({"a": 270, "b": 30})
+    norm = Counter({"a": 135, "b": 27, "c": 27, "d": 27, "e": 27, "f": 27, "g": 27, "h": 3})
+    result = mod.classify_normalization_effect(raw, 300, norm, 300)
+    assert result == "AMBIGUOUS"
+
+
+# ---------------------------------------------------------------------------
+# Exact-boundary conditions -- the code uses `>=` (inclusive) everywhere for
+# MONOCULTURE_SHARE_THRESHOLD, DIVERSIFICATION_DROP_THRESHOLD, and
+# MEANINGFUL_DIVERSITY_SHARE. These tests pin that inclusive behavior down so
+# a future accidental `>` edit gets caught instead of silently flipping the
+# verdict at the exact boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_classify_normalization_effect_norm_share_exactly_at_monoculture_threshold() -> None:
+    # norm_share == 0.5 exactly (the MONOCULTURE_SHARE_THRESHOLD) must still
+    # count as a monoculture (inclusive >=), not fall through to MET/AMBIGUOUS.
+    raw = Counter({"a": 900, "b": 100})
+    norm = Counter({"a": 500, "b": 500})
+    result = mod.classify_normalization_effect(raw, 1000, norm, 1000)
+    assert result == "NOT_MET"
+
+
+def test_classify_normalization_effect_drop_clears_diversification_threshold() -> None:
+    # (raw_share - norm_share) clears DIVERSIFICATION_DROP_THRESHOLD (0.30)
+    # with norm_share below the monoculture threshold and >= 2 meaningful
+    # channels -> must count as MET (the code's comparison is inclusive >=).
+    # Counts are chosen as exact dyadic fractions (denominator 1600, a power
+    # of two) specifically so raw_share/norm_share/drop are bit-exact in IEEE
+    # float -- 700/1000-style decimal fractions are NOT exactly representable
+    # in binary float (e.g. `0.7 - 0.4 == 0.29999999999999993`, not `0.3`),
+    # so pinning this test to a literal boundary of "== 0.30" would be
+    # testing float-rounding noise, not the `>=` comparison this test exists
+    # to cover. Verified: raw_share=0.75, norm_share=0.4375, drop=0.3125.
+    raw = Counter({"a": 1200, "b": 400})  # raw_share = 0.75
+    norm = Counter({"a": 700, "b": 500, "c": 400})  # norm_share = 0.4375, drop = 0.3125
+    result = mod.classify_normalization_effect(raw, 1600, norm, 1600)
+    assert result == "MET"
+
+
+def test_classify_normalization_effect_channel_share_exactly_at_meaningful_diversity_bar() -> None:
+    # A second channel at exactly MEANINGFUL_DIVERSITY_SHARE (0.10) must count
+    # toward the "at least two distinct channels" MET requirement (inclusive
+    # >=), not be excluded for landing exactly on the boundary.
+    raw = Counter({"a": 900, "b": 100})  # raw_share = 0.90
+    norm = Counter({"a": 450, "b": 100, "c": 90, "d": 90, "e": 90, "f": 90, "g": 90})
+    # norm_share = 0.45 (< 0.5), drop = 0.45 (>= 0.30); meaningful channels:
+    # a=45% and b=10% exactly -> 2 channels clear the >=10% bar, c-g at 9% each do not.
+    result = mod.classify_normalization_effect(raw, 1000, norm, 1000)
+    assert result == "MET"


### PR DESCRIPTION
## Summary

- New read-only measurement script `scripts/analysis/measure_attention_salience_normalization.py`: pulls real historical `FieldAttentionFrameV1` rows from Postgres `substrate_attention_frames` (same table/columns `measure_emergent_clustering_probe.py` already reads), re-verifies the top-1-winner monoculture baseline fresh (does not trust the prior 99.98% write-up), then computes a per-channel z-score of each target against its own full-history mean/stddev and recomputes top-1-winner under that normalized comparison.
- Explicit, documented handling for the degenerate-variance case: a channel with near-zero historical variance (division-by-~0) is excluded from the normalized ranking rather than silently scored — and the script separately flags when the *raw dominant* channel is exactly this degenerate case, so a share drop isn't misread as real calibration.
- New five-band classification (`classify_normalization_effect`): `INSUFFICIENT_DATA` / `NOT_MET` / `NOT_MET_MONOCULTURE_SHIFTED` / `MET` / `AMBIGUOUS`, with `NOT_MET_MONOCULTURE_SHIFTED` specifically catching "normalization just relocated the monoculture to a different single channel" rather than treating any share drop as success.
- 29 new deterministic unit tests (`scripts/analysis/tests/test_measure_attention_salience_normalization.py`), including exact-boundary tests for all three thresholds (using dyadic fractions to avoid float-rounding false negatives at the `>=` boundaries).
- New dated section in `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md` ("2026-07-28 update — the arbitration layer, not the reducer, is the real blocker") folding in the real measurement results and re-sequencing the doc's original "Recommended next patch" behind this higher-priority prerequisite.
- Strictly read-only: no writes to Postgres, no import of or edit to `orion/attention/field_attention/{scoring,selectors}.py` or any other live-running code path.

## Outcome moved

Answers, with real numbers, whether per-channel z-score normalization (the naive fix for Layer 5 attention's "noisiest wins" monoculture, named as the converged direction from tonight's investigation into the same disease recurring across drives/proposal-scoring/attention) would actually work — before any live-scoring code gets written. It does not: it relocates the monoculture rather than fixing it.

## Current architecture

`orion/attention/field_attention/selectors.py::select_system_targets` computes `field:recent_perturbations`' salience as `min(1.0, recent_perturbation_count / 10.0)`, which saturates under the field's near-constant real perturbation rate. `measure_emergent_clustering_probe.py` (Sentience Striving Program charter §6 item 5) previously found this wins top-1 in ~99.98% of ticks. Nothing in this codebase normalizes any arbitration channel (drives, proposal/policy scoring, or Layer 5 attention) against its own historical distribution before comparing raw magnitudes — all three use fixed-weight/raw-magnitude comparisons never calibrated against outcomes.

## Architecture touched

Analysis-script + docs only. No service, schema, bus, or config changes.

## Files changed

- `scripts/analysis/measure_attention_salience_normalization.py` (new): the read-only measurement instrument.
- `scripts/analysis/tests/test_measure_attention_salience_normalization.py` (new): deterministic unit tests for all pure logic in the script above.
- `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md` (modified): new dated section with the real measurement results; original content preserved, not rewritten.

## Schema / bus / API changes

None.

## Env/config changes

None. No `.env_example` changes; local `.env` sync not applicable.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest scripts/analysis/tests/ -q
282 passed in 1.30s
```

(29 new tests for this script; 253 pre-existing sibling tests unaffected.)

## Evals run

No dedicated eval harness for `scripts/analysis/`; this script *is* the measurement/eval artifact per this directory's own convention (see `scripts/analysis/README.md` — other scripts in this directory follow the same "measurement script is the deliverable" shape, e.g. `measure_autonomy_gate.py`).

## Docker/build/smoke checks

Not applicable — no service/runtime changes. The script itself was run live against the real database (see below) as its own smoke test.

## Live measurement results (real data, run 2026-07-28)

Run against real Postgres (`substrate_attention_frames`, 127,861 rows, 2026-07-25T20:18Z → 2026-07-28T20:39Z, ~72.3h):

- **Raw baseline, re-verified fresh (not cited from the prior write-up):** `field:recent_perturbations` wins top-1 in **100.00%** of ticks (worse than the previously-cited 99.98%). Its full-history stddev is exactly `0.000000` — a mathematically exact degenerate/saturated channel.
- **Z-score normalization:** `field:recent_perturbations` is structurally undefined under z-scoring (division by ~0) — excluded from the normalized ranking entirely, not merely outcompeted.
- **Normalized winner distribution:** `node:atlas` 55.18% (70,557 ticks), `node:circe` 15.81%, `capability:llm_inference` 15.21%, `node:athena` 9.90%, `capability:orchestration` 2.23%, `capability:transport` 1.65%, `capability:storage` 0.01%.
- **Classification: `NOT_MET_MONOCULTURE_SHIFTED`.** Normalization does not diversify the winner distribution — it relocates the monoculture to a different single channel, still above this script's 50% monoculture threshold.

Artifacts from the run: `/tmp/measure-attention-salience-normalization/{report.md,ticks.csv,progress.log}` (local, not committed — matches this repo's `/tmp/<script-name>/` convention).

## Review findings fixed

- Finding: unused `degenerate_channels` parameter in `classify_normalization_effect()` — read but never referenced in the function body.
  - Fix: removed the parameter from the function signature, the one caller in `run()`, and all 9 test call sites; added a docstring note clarifying that degeneracy-vs-genuine-competition is deliberately a separate "Honest findings" narrative in the report, not folded into the classification verdict itself.
  - Evidence: `git diff` shows the signature and all call sites updated consistently; full test suite re-run clean after the change (282 passed).
- Finding: missing exact-boundary tests for the three classification thresholds (`MONOCULTURE_SHARE_THRESHOLD=0.5`, `DIVERSIFICATION_DROP_THRESHOLD=0.30`, `MEANINGFUL_DIVERSITY_SHARE=0.10`) — a future `>=` → `>` edit could silently flip verdicts at the boundary without a test catching it.
  - Fix: added 3 new boundary tests. One required switching from decimal fractions (e.g. `700/1000`) to dyadic fractions (denominator a power of two) after discovering `0.7 - 0.4 == 0.29999999999999993` in IEEE float, not `0.3` — pinning a literal `== 0.30` boundary would have tested float-rounding noise, not the actual `>=` comparison; documented this in the test's own comment.
  - Evidence: `scripts/analysis/tests/test_measure_attention_salience_normalization.py::test_classify_normalization_effect_{norm_share_exactly_at_monoculture_threshold,drop_clears_diversification_threshold,channel_share_exactly_at_meaningful_diversity_bar}`, all passing.

Review was run via a subagent against the live diff and the live database independently (not just re-checking my own claims); its full report is summarized above.

## Restart required

No restart required. No service or runtime behavior changed.

## Risks / concerns

- Severity: low
- Concern: the measurement itself is a negative result (naive z-scoring does not fix the monoculture) — no further action is scoped or implied by this PR. The doc explicitly says a real design pass (e.g. principled handling of degenerate channels, genuine multi-way calibration) would need its own proposal-mode sign-off before any live-scoring change, per this repo's Sentience Striving Program charter and CLAUDE.md §0A.
- Mitigation: none needed — this is by design. No live code was touched; explicitly confirmed in both the script's own scope-boundary section and this PR description.

## PR link

(added by `gh pr create` below)