### PR TITLE
feat: drive OrionTissue viz with 3 live-verified substrate signals

### DIFF
--- a/docs/superpowers/specs/2026-07-28-spark-introspector-retirement-and-honest-substrate-convergence.md
+++ b/docs/superpowers/specs/2026-07-28-spark-introspector-retirement-and-honest-substrate-convergence.md
@@ -127,3 +127,66 @@ reducer had no other real input either).
 4. Retire for real (not just stop citing) in `channels.yaml`: `orion:self:inner_features`, `orion:self:phi_reward`, `orion:spark:telemetry`, `orion:spark:introspect:candidate`. `orion:spark:state:snapshot` stays.
 
 Runs independently, not gating the above: orion-heartbeat's redundant-ceiling question (3a), the vector-host cola-conditional question (3c).
+
+---
+
+## 7. Honest signal selection for the OrionTissue visualizer page (2026-07-28, same day, separate chat session)
+
+Section 6 relocated the OrionTissue page (`services/orion-vector-host/app/static/`) and PR #1421
+(merged separately) fixed its four headline stats' *labels* (embedding_similarity/novelty_zscore/
+polarity_diff/mean_abs_activation, no invented mood taxonomy). This section covers a further
+decision: those four numbers, while honestly labeled, have "no independent theory anchor
+connecting them to reasoning quality, mood, or wellbeing" by the page's own disclosed copy —
+they're real tensor summary statistics, not a good driver for a display meant to show
+substrate-wide state. Replaced as the page's four driving/displayed metrics with real,
+brain-frame-derived signals, **only after each candidate was individually live-verified against
+real running data**, not assumed:
+
+**Confirmed real, wired in:**
+- `honesty_metrics` / `prediction_error_confidence` — 0.7929–0.9935 over a real 2-minute window.
+  Required a real fix along the way: the initial wiring passed `AttentionBroadcastProjectionV1`
+  (`load_attention_broadcast()`) as the confidence source, which has no `prediction_error_confidence`
+  field at all — the region silently emitted nothing. The real object,
+  `AttentionSelfModelV1`/`reduce_attention_self_model()`, had **never been called live anywhere in
+  this codebase** (only by offline analysis scripts) — computing it live in `_brain_frame_tick()`
+  from the already-fetched node snapshot (zero extra I/O) was the actual fix, not a rename.
+- `frame.spotlight.coalition_stability` (`AttentionBroadcastProjectionV1.coalition_stability_score`)
+  — 0.3–0.9 over a real 7-minute window (`substrate_attention_broadcast_log`). Already exposed on
+  the existing self-brain frame schema; no new wiring needed.
+- `field_anomaly` / mood-arc encoder `recon_loss` (orion-field-digester's `app/anomaly_scorer.py`,
+  the real windowed sequence-autoencoder from section 2b) — confirmed a genuine anomalous→calm
+  state transition (~0.012, 4-15x the encoder's own threshold → ~0.00012, below it) across two
+  checks roughly an hour apart. New bus subscriber added in `orion-substrate-runtime`
+  (`_field_channel_anomaly_listener_loop`), consuming the already-live, already-published
+  `orion:field_channel:anomaly_score` channel (previously consumed only by
+  `orion-equilibrium-service`'s metacog gate).
+
+**Checked and rejected, with the live numbers that killed each one:**
+- `self_state` — zero producer since the 2026-07-22 SelfStateV1 burn
+  (`orion-consolidation-runtime/app/store.py` confirms `substrate_self_state` has had no writer
+  since). Would never emit a region at all.
+- `node_kind` region max — pinned 0.9687–1.0 over a live 2-minute window (only one node kind,
+  "concept," is populated right now beyond the prediction-error tracker nodes and 3 golden seed
+  concepts — the graph has too little kind-diversity for this to be a real signal today).
+- `lane` region aggregate, both directions — `max()` reads a flat constant 0.4 whenever backlog=0
+  and lag≤60s (the common case), and additionally masks a real incident: `chat_grammar` has read
+  exactly 0.0 (lag_sec≈254000, ~70 hours stale) for the entire observation window, invisible under
+  `max()`. Switching to `min()` doesn't fix this — it just relocates the pin to that same dead
+  lane's 0.0, permanently, for as long as the lane stays down. (Separately: a reducer lane being
+  dead for 70+ hours in production is a real finding, unrelated to this viz task, not yet
+  investigated further here.)
+- raw `bus_synaptic` `gap_zscore` — not independent. `bus_synaptic_prediction_error()` is already
+  built directly from these same FalkorDB edge z-scores, and `bus_synaptic` is already one of the
+  5 domains feeding `honesty_metrics`. Using both would double-count the same underlying signal
+  under two different names.
+- `substrate_attention_frames`' `overall_salience` (general field lane) — also pinned at exactly
+  `1.0` across every sample checked.
+
+Implementation: PR branch `feat/honest-ekg-honesty-metrics`. Files touched: `orion/schemas/
+brain_frame.py` (dimension Literal), `orion/bus/channels.yaml` (new consumer),
+`services/orion-substrate-runtime/app/{settings,worker,brain_frame_producer}.py`,
+`services/orion-vector-host/app/static/{index.html,tissue_viz.js}`, plus tests for both new
+region functions and the new bus listener. All three signals verified live end-to-end through
+the real Tailscale Serve routing (`/spark/ui` page → absolute-path fetch → routes to orion-hub's
+root, not vector-host — confirmed via `tailscale serve status` and a live curl through the real
+domain), not just unit tests.

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -226,7 +226,7 @@ channels:
     # measurement, consumer owns the trigger-sensitivity knob).
     schema_id: "FieldChannelAnomalyScoreV1"
     producer_services: ["orion-field-digester"]
-    consumer_services: ["orion-equilibrium-service"]
+    consumer_services: ["orion-equilibrium-service", "orion-substrate-runtime"]
     stability: "experimental"
     since: "2026-07-21"
 

--- a/orion/schemas/brain_frame.py
+++ b/orion/schemas/brain_frame.py
@@ -13,7 +13,9 @@ class BrainRegionV1(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    dimension: Literal["node_kind", "lane", "self_state", "lattice_layer", "honesty_metrics"]
+    dimension: Literal[
+        "node_kind", "lane", "self_state", "lattice_layer", "honesty_metrics", "field_anomaly"
+    ]
     region_id: str
     label: str
     intensity: float = Field(ge=0.0, le=1.0)

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -184,6 +184,9 @@ EMBODIMENT_CHANNEL_INTENT=orion:embodiment:intent
 EMBODIMENT_CHANNEL_PERCEPTION=orion:embodiment:perception
 EMBODIMENT_DRIVES_STATE_CHANNEL=orion:memory:drives:state
 DRIVES_AUDIT_CHANNEL=orion:memory:drives:audit
+# Consumed for the brain-frame field_anomaly dimension. Producer: orion-field-digester's
+# mood-arc reconstruction-error scorer (app/anomaly_scorer.py).
+FIELD_CHANNEL_ANOMALY_SCORE_CHANNEL=orion:field_channel:anomaly_score
 # Formerly wrote DriveEngine drive_state/drive_audit into the substrate graph
 # (snapshot_source="drive_state"). Chat stance / Mind measurement SoR is Postgres
 # drive_audits. Default off. Enabling only restores graph writes — not stance reads.

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -605,24 +605,58 @@ Retention: `SELF_STATE_RETENTION_HOURS=72`, pruned hourly.
 ## Brain Frames
 
 `SubstrateBrainFrameV1` snapshots are persistent, visual readouts of substrate state at
-5-second intervals (configurable). Frames assemble _regions_ from four independent signal
-sources:
+5-second intervals (configurable). Frames assemble _regions_ from independent signal sources,
+each individually live-verified against real running data before being wired in (2026-07-28):
 
-| Dimension | Source | Computation | Stored | Signal |
-|-----------|--------|-------------|--------|--------|
-| `node_kind` | graph | max activation per node category | yes | category-wise activation peaks |
-| `lane` | health | freshness + backlog over reducers | yes | lane health composite |
-| `self_state` | field digester | 13-dim projection output | yes | field-computed signal dimensions |
-| `honesty_metrics` | active inference | prediction_error_confidence (no transform) | yes | model confidence: 0.0–1.0 |
+| Dimension | Source | Computation | Live-verified variance |
+|-----------|--------|-------------|-------------------------|
+| `node_kind` | graph | max activation per node category | **Ceiling-pinned** (0.9687–1.0 over 2min) — display only, not a good driver |
+| `lane` | reducer health | freshness + backlog composite | **Pinned regardless of `max()`/`min()`** — a dead reducer lane (`chat_grammar`, 70h+ stale) is either masked (`max`) or becomes a permanent floor (`min`) |
+| `self_state` | Postgres `substrate_self_state` | 13-dim projection read | **Dead.** Zero producer since the 2026-07-22 SelfStateV1 burn (confirmed in `orion-consolidation-runtime/app/store.py`) — this dimension never emits a region |
+| `honesty_metrics` | Active Inference | `prediction_error_confidence`, no transform beyond clamp+threshold | **Real, live.** 0.7929–0.9935 over a real 2-minute window |
+| `field_anomaly` | mood-arc encoder (orion-field-digester) | `recon_loss`, calibrated against live-observed range | **Real, live.** Confirmed a genuine anomalous→calm state transition (~0.012 → 0.00012, both real ticks) |
 
-**Honesty metrics: no transformation.** `prediction_error_confidence` from active inference
-(`orion/substrate/prediction_error.py`, computed unconditionally per domain) is clamped to
-[0.0, 1.0] and thresholded into state ("firing" >0.7, "steady" 0.4–0.7, "starving" ≤0.4).
-Real computation lives upstream in active inference; this layer is a direct read + display pass.
+**`honesty_metrics` / `prediction_error_confidence`:** computed live in `_brain_frame_tick()`
+by calling `orion.substrate.attention_self_model.reduce_attention_self_model()` — a pure
+function that, before this wiring, was called only by offline analysis scripts
+(`scripts/analysis/measure_ast_hot_reducer.py`), never in any live service. Its
+`prediction_error_by_domain` input is built by `_brain_frame_prediction_error_by_domain()`
+from the same node snapshot the tick already fetches for `node_kind` regions (zero extra
+I/O) — reading back the `metadata['prediction_error']` that `_write_prediction_error_node()`
+durably upserts per Active-Inference domain (`node:substrate.<domain>`,
+`SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true`). An earlier version of this wiring passed
+`AttentionBroadcastProjectionV1` (`load_attention_broadcast()`) instead — a real object, but
+one with no `prediction_error_confidence` field at all, so the region silently never emitted
+until this was caught and fixed.
+
+**`field_anomaly` / mood-arc encoder:** `_field_channel_anomaly_listener_loop()` subscribes to
+`orion:field_channel:anomaly_score` (producer: `orion-field-digester`'s
+`app/anomaly_scorer.py`, a real trained sequence autoencoder — `orion/mood_arc/fit_encoder.py`
+— run against live field-channel pressures) and caches the latest `FieldChannelAnomalyScoreV1`.
+`recon_loss` has no natural [0,1] range and a ratio against the encoder's own
+threshold/`recon_error_p95` saturates near-immediately (live-checked: threshold=0.000895,
+`recon_error_p95≈0.0003`, while a real 2-minute window of `recon_loss` read
+4–15x the threshold on every tick) — `_FIELD_ANOMALY_RECON_LOSS_FLOOR`/`_CEILING` in
+`brain_frame_producer.py` are disclosed, live-observed calibration constants instead
+(floor just above the encoder's real threshold, ceiling with headroom above the observed max),
+not an invented squashing formula.
+
+**Dropped candidates, all live-checked before being rejected:** `self_state` (dead producer),
+`node_kind`/`lane` region aggregates via both `max()` and `min()` (ceiling/floor-pinned against
+real data — `max()` masks a genuinely dead lane, `min()` just relocates the pin to that same
+dead lane), raw `bus_synaptic` `gap_zscore` (not independent — it's already one of
+`honesty_metrics`' 5 input domains). Full trace, including the live numbers behind each
+rejection: `docs/superpowers/specs/2026-07-28-spark-introspector-retirement-and-honest-
+substrate-convergence.md`.
 
 Frames live in `substrate_brain_frame_log` (24-hour retention, 5s cadence) and are exposed
-read-only via orion-hub's `/api/self-brain/frames/` endpoints. Frontend renders regions as
-circles (node graph view) + sparklines (EKG view) per dimension.
+read-only via orion-hub's `/api/self-brain/frames/` endpoints. The Self-Brain tab renders all
+five dimensions above (including the pinned/dead ones, disclosed as such); `services/orion-
+vector-host`'s substrate-state page (`/spark/ui`) renders only the three live-verified signals
+(`honesty_metrics`, `field_anomaly`, plus `frame.spotlight.coalition_stability` --
+`AttentionBroadcastProjectionV1.coalition_stability_score`, confirmed 0.3–0.9 real variance
+over a 7-minute window, already exposed on the frame's existing `spotlight` field with no new
+wiring needed).
 
 **Frame storage / sampling:** Full node/edge graph samples are included (best-effort
 decoration, no continuity guarantee across frames). Regions are the trackable spine.

--- a/services/orion-substrate-runtime/app/brain_frame_producer.py
+++ b/services/orion-substrate-runtime/app/brain_frame_producer.py
@@ -212,6 +212,53 @@ def _honesty_regions(attention_payload: Any | None, now: datetime) -> list[Brain
     ]
 
 
+# Calibration for _field_anomaly_regions()'s intensity normalization.
+# recon_loss (mood-arc encoder reconstruction error) has no natural [0,1]
+# range, and a ratio against the encoder's own threshold/recon_error_p95
+# saturates at the ceiling almost immediately -- live-checked 2026-07-28,
+# threshold=0.000895 (threshold_multiplier=3.0, so recon_error_p95≈0.0003),
+# while a live 2-minute window of recon_loss read [0.0037, 0.0139], i.e.
+# 4-15x the threshold on every tick. FLOOR sits just above that live
+# threshold (below-threshold reads near-calm); CEILING is set with headroom
+# above the observed live max, not tightly against it. Both are disclosed,
+# live-observed calibration constants, not an invented squashing formula --
+# revisit if live data shows this saturating in practice.
+_FIELD_ANOMALY_RECON_LOSS_FLOOR = 0.001
+_FIELD_ANOMALY_RECON_LOSS_CEILING = 0.02
+
+
+def _field_anomaly_regions(field_anomaly: Any | None, now: datetime) -> list[BrainRegionV1]:
+    """Create a brain region from the mood-arc encoder's reconstruction-error
+    anomaly score (orion-field-digester, independent of both honesty_metrics
+    and spotlight.coalition_stability -- different model, different inputs).
+    """
+    if field_anomaly is None:
+        return []
+
+    recon_loss = getattr(field_anomaly, "recon_loss", None)
+    if recon_loss is None:
+        return []
+
+    span = _FIELD_ANOMALY_RECON_LOSS_CEILING - _FIELD_ANOMALY_RECON_LOSS_FLOOR
+    intensity = _clamp01((float(recon_loss) - _FIELD_ANOMALY_RECON_LOSS_FLOOR) / span)
+    anomalous = bool(getattr(field_anomaly, "anomalous", False))
+    state_val = "firing" if anomalous else ("steady" if intensity > 0.1 else "starving")
+
+    return [
+        BrainRegionV1(
+            dimension="field_anomaly",
+            region_id="field_anomaly:reconstruction",
+            label="Field Anomaly",
+            intensity=intensity,
+            state=state_val,
+            node_count=1,
+            as_of=now,
+            stale=False,
+            detail={"recon_loss": float(recon_loss)},
+        )
+    ]
+
+
 def _spotlight(attention, now, cadence_sec) -> BrainSpotlightV1 | None:
     if attention is None:
         return None
@@ -263,7 +310,8 @@ def assemble_brain_frame(
     lane_health: Mapping[str, Any],
     self_state: Mapping[str, Any] | None,
     attention: Any | None,
-    attention_payload: Any | None,
+    attention_payload: Any | None = None,
+    field_anomaly: Any | None = None,
     settings: Any,
     now: datetime,
     tick_seq: int,
@@ -277,6 +325,7 @@ def assemble_brain_frame(
         + _lane_regions(lane_health or {}, now, firing, starving)
         + _self_state_regions(self_state, now, float(settings.brain_frame_self_state_cadence_sec))
         + _honesty_regions(attention_payload, now)
+        + _field_anomaly_regions(field_anomaly, now)
     )
     node_samples, edge_samples = _samples(
         nodes, list(edges), settings.brain_frame_sample_nodes, settings.brain_frame_sample_edges

--- a/services/orion-substrate-runtime/app/settings.py
+++ b/services/orion-substrate-runtime/app/settings.py
@@ -208,6 +208,11 @@ class Settings(BaseSettings):
     drives_audit_channel: str = Field(
         "orion:memory:drives:audit", alias="DRIVES_AUDIT_CHANNEL"
     )
+    # Consumed for the brain-frame honesty_metrics/field_anomaly dimensions.
+    # Producer: orion-field-digester's mood-arc reconstruction-error scorer.
+    field_channel_anomaly_score_channel: str = Field(
+        "orion:field_channel:anomaly_score", alias="FIELD_CHANNEL_ANOMALY_SCORE_CHANNEL"
+    )
     # Formerly materialized DriveEngine drive_state/drive_audit into the substrate
     # graph (snapshot_source="drive_state"). Chat stance / Mind measurement SoR is
     # Postgres drive_audits (bus → sql-writer). Default off. Enabling this only

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -19,6 +19,7 @@ from orion.schemas.biometrics_projection import (
 from orion.schemas.grammar import GrammarEventV1
 from orion.schemas.harness_finalize import HarnessPostTurnClosureV1
 from orion.schemas.reduction_receipt import ReductionReceiptV1
+from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
 from orion.substrate.biometrics_loop.constants import (
     ACTIVE_NODE_PRESSURE_PROJECTION_ID,
     GRAMMAR_CURSOR_NAME,
@@ -86,6 +87,18 @@ _TRUTHY = {"1", "true", "yes", "on"}
 _DRIVE_STATE_MAX_AGE_SEC = 300.0
 # Fixed signal until HarnessPostTurnClosureV1 carries surprise_level_at_draft.
 _HARNESS_CLOSURE_UNRESOLVED_ERROR = 0.65
+# node_id -> domain key, matching the fixed identities _write_prediction_error_node()
+# upserts to and the domain names orion.substrate.attention_self_model expects in
+# prediction_error_by_domain. node:substrate.harness_closure is intentionally
+# excluded -- it is not one of that reducer's recognized domains.
+_PREDICTION_ERROR_DOMAIN_NODE_IDS = {
+    "node:substrate.execution": "execution",
+    "node:substrate.transport": "transport",
+    "node:substrate.biometrics": "biometrics",
+    "node:substrate.chat": "chat",
+    "node:substrate.route": "route",
+    "node:substrate.bus_synaptic": "bus_synaptic",
+}
 
 
 def _prediction_error_nodes_enabled() -> bool:
@@ -244,6 +257,12 @@ class BiometricsSubstrateWorker:
         # tension_kinds). Independent of the embodiment C producer above.
         self._latest_drive_audit: DriveAuditV1 | None = None
         self._latest_drive_audit_at: datetime | None = None
+        # FieldChannelAnomalyScoreV1 cached off the bus for the brain-frame
+        # field_anomaly dimension -- mood-arc encoder reconstruction error over
+        # live field-channel pressures, independent of the honesty_metrics
+        # (active-inference) and spotlight (coalition_stability) signals.
+        self._latest_field_anomaly: FieldChannelAnomalyScoreV1 | None = None
+        self._latest_field_anomaly_at: datetime | None = None
         self._brain_frame_seq: int = 0
 
     @property
@@ -315,6 +334,18 @@ class BiometricsSubstrateWorker:
                 asyncio.create_task(
                     self._perception_ingest_loop(),
                     name="substrate-embodiment-perception-ingest",
+                )
+            )
+        # Field-channel anomaly listener: caches the latest mood-arc encoder
+        # reconstruction-error reading for the brain-frame field_anomaly
+        # dimension. Read-only display signal, no feature flag beyond bus
+        # availability -- rides on the same s.brain_frame_enabled gate that
+        # already governs whether anything consumes the cached value.
+        if self._bus is not None:
+            self._tasks.append(
+                asyncio.create_task(
+                    self._field_channel_anomaly_listener_loop(),
+                    name="substrate-field-channel-anomaly-listener",
                 )
             )
 
@@ -1239,6 +1270,55 @@ class BiometricsSubstrateWorker:
             except Exception:
                 logger.exception("substrate_drive_state_materialize_failed")
 
+    async def _field_channel_anomaly_listener_loop(self) -> None:
+        """Subscribe to the field-channel anomaly-score channel and cache the
+        latest FieldChannelAnomalyScoreV1.
+
+        Mirrors _drive_state_listener_loop. Producer: orion-field-digester's
+        mood-arc reconstruction-error scorer (app/anomaly_scorer.py), an
+        independent third signal alongside honesty_metrics (active-inference
+        prediction error) and spotlight.coalition_stability (GWT-dispatch
+        lane) -- different model, different inputs (field-channel pressures,
+        not domain prediction-error or attention-coalition tracking).
+        """
+        channel = self._settings.field_channel_anomaly_score_channel
+        logger.info("substrate_field_channel_anomaly_listener subscribing channel=%s", channel)
+        try:
+            async with self._bus.subscribe(channel) as pubsub:
+                while not self._stop.is_set():
+                    try:
+                        msg = await asyncio.wait_for(
+                            pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
+                            timeout=1.2,
+                        )
+                    except asyncio.TimeoutError:
+                        continue
+                    except asyncio.CancelledError:
+                        break
+                    if not msg or msg.get("type") not in ("message", "pmessage"):
+                        continue
+                    try:
+                        self._cache_field_channel_anomaly_message(msg)
+                    except Exception:
+                        logger.exception("substrate_field_channel_anomaly_handle_failed")
+        except asyncio.CancelledError:
+            raise
+        finally:
+            logger.info("substrate_field_channel_anomaly_listener stopped channel=%s", channel)
+
+    def _cache_field_channel_anomaly_message(self, raw_msg: dict[str, Any]) -> None:
+        decoded = self._bus.codec.decode(raw_msg.get("data"))
+        if not decoded.ok:
+            logger.warning("substrate_field_channel_anomaly_decode_failed: %s", decoded.error)
+            return
+        try:
+            score = FieldChannelAnomalyScoreV1.model_validate(decoded.envelope.payload or {})
+        except ValueError as exc:
+            logger.error("substrate_field_channel_anomaly_invalid err=%s", exc)
+            return
+        self._latest_field_anomaly = score
+        self._latest_field_anomaly_at = datetime.now(timezone.utc)
+
     async def _drive_audit_listener_loop(self) -> None:
         """Subscribe to the drive-audit channel and cache the latest DriveAuditV1.
 
@@ -1589,6 +1669,33 @@ class BiometricsSubstrateWorker:
             logger.exception("brain_frame_self_state_load_failed")
             return None
 
+    def _brain_frame_prediction_error_by_domain(self, nodes: Iterable[Any]) -> dict:
+        """Read each Active-Inference domain's latest prediction_error off the
+        already-fetched node snapshot -- zero extra I/O.
+
+        ``_write_prediction_error_node()`` durably upserts one fixed-identity
+        ``ConceptNodeV1`` per domain (``node:substrate.<domain>``,
+        ``metadata['prediction_error']``) every tick it fires
+        (``SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true``). Those nodes are
+        already part of the same graph snapshot ``assemble_brain_frame()``
+        uses for node_kind regions, so this just reads them back rather than
+        making a second store round-trip.
+        """
+        out: dict[str, float] = {}
+        for node in nodes:
+            node_id = str(getattr(node, "node_id", "") or "")
+            domain = _PREDICTION_ERROR_DOMAIN_NODE_IDS.get(node_id)
+            if domain is None:
+                continue
+            md = getattr(node, "metadata", None) or {}
+            value = md.get("prediction_error")
+            if value is not None:
+                try:
+                    out[domain] = float(value)
+                except (TypeError, ValueError):
+                    continue
+        return out
+
     def _brain_frame_tick(self):
         """Assemble + persist one brain frame. Returns the frame or None."""
         s = self._settings
@@ -1617,13 +1724,40 @@ class BiometricsSubstrateWorker:
                 logger.exception("brain_frame_attention_load_failed")
 
             now = datetime.now(timezone.utc)
+
+            # AttentionSelfModelV1 (carries the unconditional
+            # prediction_error_confidence field the honesty_metrics brain-frame
+            # dimension reads) has no live producer anywhere in this codebase --
+            # reduce_attention_self_model() was, until this call, only ever
+            # invoked by offline analysis scripts (scripts/analysis/
+            # measure_ast_hot_reducer.py). Compute it live here from real,
+            # already-available inputs rather than passing the narrower
+            # AttentionBroadcastProjectionV1 (`attention` above), which has no
+            # prediction_error_confidence field at all.
+            attention_self_model = None
+            try:
+                from orion.substrate.attention_self_model import (
+                    reduce_attention_self_model,
+                )
+
+                attention_self_model = reduce_attention_self_model(
+                    broadcast=attention,
+                    field_frame=None,
+                    now=now,
+                    prediction_error_by_domain=self._brain_frame_prediction_error_by_domain(nodes)
+                    or None,
+                )
+            except Exception:
+                logger.exception("brain_frame_attention_self_model_failed")
+
             frame = assemble_brain_frame(
                 nodes=nodes,
                 edges=edges,
                 lane_health=self._brain_frame_lane_health(),
                 self_state=self._brain_frame_self_state(),
                 attention=attention,
-                attention_payload=attention,
+                attention_payload=attention_self_model,
+                field_anomaly=self._latest_field_anomaly,
                 settings=s,
                 now=now,
                 tick_seq=self._brain_frame_seq,

--- a/services/orion-substrate-runtime/tests/test_brain_frame_producer.py
+++ b/services/orion-substrate-runtime/tests/test_brain_frame_producer.py
@@ -365,4 +365,81 @@ def test_honesty_regions_included_in_frame():
     honesty = {r.region_id: r for r in frame.regions if r.dimension == "honesty_metrics"}
     assert len(honesty) == 1
     assert honesty["honesty:confidence"].intensity == 0.8
-    assert honesty["honesty:confidence"].state == "firing"
+
+
+def _field_anomaly(recon_loss, anomalous=True):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(recon_loss=recon_loss, anomalous=anomalous)
+
+
+def test_field_anomaly_regions_with_none_input():
+    from datetime import datetime, timezone
+
+    from app.brain_frame_producer import _field_anomaly_regions
+
+    now = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+    assert _field_anomaly_regions(None, now) == []
+
+
+def test_field_anomaly_regions_below_floor_reads_near_zero():
+    """Live-observed 2026-07-28: recon_loss=0.00012 (below the encoder's own
+    0.000895 threshold, i.e. genuinely calm) must read near 0, not pinned by
+    an off calibration."""
+    from datetime import datetime, timezone
+
+    from app.brain_frame_producer import _field_anomaly_regions
+
+    now = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+    regions = _field_anomaly_regions(_field_anomaly(0.00012, anomalous=False), now)
+    assert len(regions) == 1
+    assert regions[0].intensity == 0.0
+    assert regions[0].state == "starving"
+
+
+def test_field_anomaly_regions_mid_range_has_real_spread():
+    """Live-observed 2026-07-28: recon_loss in [0.0037, 0.0139] over a real
+    2-minute window must map to genuinely different intensities, not a
+    ceiling/floor pin (the exact failure mode found and rejected for
+    node_kind max() and lane min()/max())."""
+    from datetime import datetime, timezone
+
+    from app.brain_frame_producer import _field_anomaly_regions
+
+    now = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+    low = _field_anomaly_regions(_field_anomaly(0.0037), now)[0].intensity
+    high = _field_anomaly_regions(_field_anomaly(0.0139), now)[0].intensity
+    assert 0.0 < low < high < 1.0
+
+
+def test_field_anomaly_regions_anomalous_flag_drives_state():
+    from datetime import datetime, timezone
+
+    from app.brain_frame_producer import _field_anomaly_regions
+
+    now = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+    regions = _field_anomaly_regions(_field_anomaly(0.015, anomalous=True), now)
+    assert regions[0].state == "firing"
+
+
+def test_field_anomaly_regions_included_in_frame():
+    from datetime import datetime, timezone
+
+    from app.brain_frame_producer import assemble_brain_frame
+
+    now = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+    frame = assemble_brain_frame(
+        nodes=[_node("t1", "tension", 0.9, 0.9)],
+        edges=[],
+        lane_health={"cursor_lag_by_reducer": {}, "pending_backlog_by_reducer": {}, "quarantine_by_reducer": {}},
+        self_state=None,
+        attention=None,
+        attention_payload=None,
+        field_anomaly=_field_anomaly(0.01),
+        settings=_settings(),
+        now=now,
+        tick_seq=11,
+    )
+    fa = {r.region_id: r for r in frame.regions if r.dimension == "field_anomaly"}
+    assert len(fa) == 1
+    assert fa["field_anomaly:reconstruction"].detail["recon_loss"] == 0.01

--- a/services/orion-substrate-runtime/tests/test_brain_frame_worker.py
+++ b/services/orion-substrate-runtime/tests/test_brain_frame_worker.py
@@ -41,6 +41,8 @@ def _worker():
     )
     w._store = MagicMock()
     w._brain_frame_seq = 0
+    w._latest_field_anomaly = None
+    w._latest_field_anomaly_at = None
     return w
 
 

--- a/services/orion-substrate-runtime/tests/test_field_channel_anomaly_listener.py
+++ b/services/orion-substrate-runtime/tests/test_field_channel_anomaly_listener.py
@@ -1,0 +1,121 @@
+"""Unit tests for the field-channel-anomaly bus listener and the
+prediction_error_by_domain extractor added to wire real
+prediction_error_confidence / field_anomaly into brain frames.
+
+Constructs the worker via __new__, mirroring test_embodiment_c_hook.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SUBSTRATE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SUBSTRATE_ROOT))
+
+from app.worker import BiometricsSubstrateWorker
+
+from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
+
+
+def _make_worker(monkeypatch) -> BiometricsSubstrateWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused/unused")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._settings = settings_mod.get_settings()
+    worker._bus = MagicMock()
+    worker._latest_field_anomaly = None
+    worker._latest_field_anomaly_at = None
+    return worker
+
+
+def _score_payload(**overrides) -> dict:
+    payload = {
+        "correlation_id": "corr-1",
+        "encoder_id": "mood-arc-encoder:v3",
+        "encoder_version": "v3",
+        "recon_loss": 0.012,
+        "recon_error_p95": 0.0003,
+        "threshold_multiplier": 3.0,
+        "threshold": 0.0009,
+        "anomalous": True,
+        "window_start": "2026-07-28T20:00:00+00:00",
+        "window_end": "2026-07-28T20:01:00+00:00",
+        "window_size": 30,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_cache_field_channel_anomaly_stores_valid_score(monkeypatch):
+    worker = _make_worker(monkeypatch)
+    bus = MagicMock()
+    bus.codec.decode.return_value = MagicMock(
+        ok=True, envelope=SimpleNamespace(payload=_score_payload())
+    )
+    worker._bus = bus
+
+    worker._cache_field_channel_anomaly_message({"data": b"irrelevant, decode is mocked"})
+
+    assert isinstance(worker._latest_field_anomaly, FieldChannelAnomalyScoreV1)
+    assert worker._latest_field_anomaly.recon_loss == 0.012
+    assert worker._latest_field_anomaly_at is not None
+
+
+def test_cache_field_channel_anomaly_fails_open_on_bad_decode(monkeypatch):
+    worker = _make_worker(monkeypatch)
+    bus = MagicMock()
+    bus.codec.decode.return_value = MagicMock(ok=False, error="boom")
+    worker._bus = bus
+
+    worker._cache_field_channel_anomaly_message({"data": b"garbage"})
+    assert worker._latest_field_anomaly is None
+
+
+def test_cache_field_channel_anomaly_fails_open_on_invalid_payload(monkeypatch):
+    worker = _make_worker(monkeypatch)
+    bus = MagicMock()
+    bus.codec.decode.return_value = MagicMock(
+        ok=True, envelope=SimpleNamespace(payload={"not": "a valid score"})
+    )
+    worker._bus = bus
+
+    worker._cache_field_channel_anomaly_message({"data": b"irrelevant"})
+    assert worker._latest_field_anomaly is None
+
+
+def _node(node_id, prediction_error=None):
+    return SimpleNamespace(node_id=node_id, metadata={"prediction_error": prediction_error})
+
+
+def test_prediction_error_by_domain_reads_fixed_nodes(monkeypatch):
+    worker = _make_worker(monkeypatch)
+    nodes = [
+        _node("node:substrate.execution", 0.001),
+        _node("node:substrate.biometrics", 0.002),
+        _node("node:substrate.bus_synaptic", 1.0),
+        _node("node:substrate.harness_closure", 0.65),  # not a recognized domain
+        _node("sub-concept-seed-orion", None),  # unrelated node, no prediction_error
+    ]
+    out = worker._brain_frame_prediction_error_by_domain(nodes)
+    assert out == {"execution": 0.001, "biometrics": 0.002, "bus_synaptic": 1.0}
+
+
+def test_prediction_error_by_domain_empty_when_no_nodes(monkeypatch):
+    worker = _make_worker(monkeypatch)
+    assert worker._brain_frame_prediction_error_by_domain([]) == {}
+
+
+def test_prediction_error_by_domain_skips_missing_values(monkeypatch):
+    worker = _make_worker(monkeypatch)
+    nodes = [_node("node:substrate.execution", None)]
+    assert worker._brain_frame_prediction_error_by_domain(nodes) == {}

--- a/services/orion-vector-host/README.md
+++ b/services/orion-vector-host/README.md
@@ -38,6 +38,34 @@ Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
 | `VECTOR_HOST_GPT_TURN_COLLECTION` | `orion_chat_gpt_turns` | Collection for ChatGPT imported turn embeddings. |
 | `VECTOR_HOST_EMBED_ROLES` | `["user","assistant"]` | Chat roles to embed from history. |
 
+## Substrate Brain State page (`/spark/ui`)
+
+Relocated 2026-07-28 from the retired `orion-spark-introspector` service (see
+`docs/superpowers/specs/2026-07-28-spark-introspector-retirement-and-honest-substrate-
+convergence.md`). Still contains OrionTissue's own real decay/diffusion tensor physics
+(`app/tissue_feed.py`, `orion/spark/orion_tissue.py`) exposed via `GET /api/tissue/state` and
+`WS /ws/tissue` -- fed by real per-turn embedding deltas, honestly labeled
+(`embedding_similarity`/`novelty_zscore`/`polarity_diff`/`mean_abs_activation`, no invented
+mood taxonomy).
+
+**The page itself (`app/static/index.html` + `tissue_viz.js`) no longer displays those four
+tensor stats.** They're real but theory-orphaned (no independent link to reasoning quality,
+mood, or wellbeing) and, unlike the three signals below, weren't independently verified to
+resist saturation before being wired into a visual driver. The page's synthwave visualizer
+(kept as-is -- same grid/sun/hue mechanics) is now driven by three real signals it polls from
+orion-hub's `GET /api/self-brain/frames/tail` every 5s (`BRAIN_FRAME_INTERVAL_SEC`), each
+individually live-verified against real running data before being wired in:
+
+| Signal | Source | Live-verified range |
+|--------|--------|----------------------|
+| Prediction Confidence | `honesty_metrics` region, `orion-substrate-runtime` | 0.79–0.99 (2min real window) |
+| Coalition Stability | `frame.spotlight.coalition_stability` | 0.3–0.9 (7min real window) |
+| Field Anomaly | `field_anomaly` region, mood-arc encoder recon_loss | confirmed real anomalous→calm transition |
+
+Full candidate-rejection trace (why `self_state`, `node_kind`/`lane` `max()`/`min()`, and raw
+`bus_synaptic` `gap_zscore` were checked and dropped) lives in
+`services/orion-substrate-runtime/README.md`'s Brain Frames section and the spec doc above.
+
 ## Smoke Tests
 
 1) **Semantic path**  

--- a/services/orion-vector-host/app/static/index.html
+++ b/services/orion-vector-host/app/static/index.html
@@ -1,21 +1,28 @@
 <!-- Relocated 2026-07-28 from services/orion-spark-introspector/app/static/
      as part of the spark-introspector retirement (docs/superpowers/specs/
      2026-07-28-spark-introspector-retirement-and-honest-substrate-
-     convergence.md). Backing WS payload now comes from orion-vector-host's
-     app/tissue_feed.py (real OrionTissue physics, fed from real per-turn
-     embedding deltas), not the old phi_encoder/SelfState pipeline.
+     convergence.md).
 
-     2026-07-28, second pass: the relocation kept honest disclaimer copy in
-     the (collapsed, easy to miss) explanation panel but left the headline
-     labels (INNER STATE/VALENCE/AROUSAL) and tissue_viz.js's invented mood
-     taxonomy (LUCID FLOW/COLD ANALYSIS/MANIC CREATIVITY/etc., and
-     Integrated-Resourced/Stress-Conflict style "implications") completely
-     unchanged from the pre-retirement page. That's the actual content the
-     retirement was supposed to remove -- threshold-derived psychology
-     labels over four tensor summary statistics, no theory anchor. Both are
-     gone now: labels renamed to what each number literally is, and the
-     invented-category logic deleted from tissue_viz.js rather than
-     softened with another disclaimer. -->
+     2026-07-28, second pass: renamed labels to what each number literally
+     is (embedding_similarity/novelty_zscore/polarity_diff/mean_abs_activation)
+     and deleted the invented mood-taxonomy logic from tissue_viz.js.
+
+     2026-07-28, third pass: those four OrionTissue tensor-summary stats are
+     themselves real but theory-orphaned (the page's own prior copy admitted
+     "no independent theory anchor connecting them to reasoning quality,
+     mood, or wellbeing"). Replaced as the page's driving/displayed metrics
+     with four signals pulled from SubstrateBrainFrameV1 (orion-substrate-
+     runtime, persisted to substrate_brain_frame_log, read via orion-hub's
+     GET /api/self-brain/frames/tail -- see that service's README "Brain
+     Frames" section): peak node-kind activation, lane health, peak
+     self-state dimension score, and prediction_error_confidence from active
+     inference (the one field here with an explicit theory anchor and zero
+     transform beyond clamp+threshold). Polled every 5s (BRAIN_FRAME_INTERVAL_SEC
+     default), not pushed -- this page's own WS (`tissue_feed.py`) still runs
+     and still reports real per-turn OrionTissue embedding-drift ticks (id/
+     timestamp only, see conn-status), it just no longer drives the four
+     headline numbers or the visualizer. See services/orion-vector-host/
+     README.md and orion-substrate-runtime/README.md for the full account. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -75,17 +82,16 @@
 <body>
     <div id="ui-layer">
         <div id="top-header">
-            <div id="mood-label">ORIONTISSUE TENSOR STATE</div>
+            <div id="mood-label">SUBSTRATE BRAIN STATE</div>
             <div id="mood-value">WAITING FOR SIGNAL...</div>
         </div>
 
         <div id="settings-container">
             <button id="gear-btn">⚙️</button>
             <div id="settings-menu">
-                <div style="font-size:10px; color:#666; margin-bottom:5px;">SYSTEM CONTROLS</div>
-                <div class="menu-item"><button id="btn-test-signal" class="menu-btn">⚡ TRIGGER TEST PULSE</button></div>
-                <div style="font-size:10px; color:#666; margin-top:10px; border-top:1px solid #333; padding-top:5px;">
-                    CONNECTION: <span id="conn-status" style="color:#f00">OFFLINE</span>
+                <div style="font-size:10px; color:#666; margin-bottom:5px;">SYSTEM STATUS</div>
+                <div style="font-size:10px; color:#666; margin-top:5px; padding-top:5px;">
+                    BRAIN FRAME POLL: <span id="conn-status" style="color:#f00">OFFLINE</span>
                 </div>
             </div>
         </div>
@@ -94,43 +100,32 @@
 
         <div id="bottom-area">
             <div id="stats-row">
-                <div class="stat-box"><span class="stat-label" title="1 - cosine_distance(embedding, this channel's running expectation), or a variance-based fallback">EMBEDDING SIMILARITY</span><span id="val-similarity" class="stat-val" style="color: #0f0;">0.00</span></div>
-                <div class="stat-box"><span class="stat-label" title="Rolling z-score of cosine distance between the latest stimulus and expectation, sigmoid-squashed to [0,1]">NOVELTY Z-SCORE</span><span id="val-novelty" class="stat-val" style="color: #ff0;">0.00</span></div>
-                <div class="stat-box"><span class="stat-label" title="mean(tensor channel 0) - mean(tensor channel 1) -- a sign convention chosen at stimulus-construction time">POLARITY DIFF</span><span id="val-polarity" class="stat-val" style="color: #0ff;">0.00</span></div>
-                <div class="stat-box"><span class="stat-label" title="mean(abs(tensor)) across the full 16x16x8 grid">MEAN |ACTIVATION|</span><span id="val-activation" class="stat-val" style="color: #f0f;">0.00</span></div>
+                <div class="stat-box"><span class="stat-label" title="1 - mean(prediction_error) across execution/biometrics/chat/route/bus_synaptic Active-Inference domains, unconditional, no transform beyond clamp">PREDICTION CONFIDENCE</span><span id="val-confidence" class="stat-val" style="color: #0f0;">0.00</span></div>
+                <div class="stat-box"><span class="stat-label" title="AttentionBroadcastProjectionV1.coalition_stability_score -- how stable the current GWT-dispatch coalition selection is">COALITION STABILITY</span><span id="val-coalition" class="stat-val" style="color: #0ff;">0.00</span></div>
+                <div class="stat-box"><span class="stat-label" title="mood-arc encoder (orion/mood_arc/) reconstruction error over live field-channel pressures, calibrated against its own live-observed range">FIELD ANOMALY</span><span id="val-anomaly" class="stat-val" style="color: #f0f;">0.00</span></div>
             </div>
-            <div id="ekg-tagline">— Live readout of OrionTissue's decay/diffusion tensor —</div>
-            <div id="meta-row">ID: <span id="val-id">-</span> | TS: <span id="val-ts">-</span></div>
-            <div id="turn-effect-box" class="hidden" title="">
-                <div class="stat-label">LAST TURN EFFECT</div>
-                <span id="turn-effect-user" class="turn-effect-line"></span>
-                <span id="turn-effect-assistant" class="turn-effect-line"></span>
-                <span id="turn-effect-turn" class="turn-effect-line"></span>
-            </div>
+            <div id="ekg-tagline">— Live readout of three independent substrate signals —</div>
+            <div id="meta-row">FRAME: <span id="val-id">-</span> | TS: <span id="val-ts">-</span></div>
 
             <div id="info-toggle-row">▼ SYSTEM INTERNALS EXPLANATION ▼</div>
 
             <div id="explanation-panel">
                 <h3>LIVE VALUES</h3>
                 <table class="diag-table">
-                    <thead><tr><th>METRIC</th><th>VALUE</th><th>FORMULA</th></tr></thead>
+                    <thead><tr><th>METRIC</th><th>VALUE</th><th>SOURCE</th></tr></thead>
                     <tbody>
-                        <tr><td>Embedding similarity</td><td id="diag-sim-val" class="diag-val">-</td><td>1 - cosine_distance(embedding, expectation)</td></tr>
-                        <tr><td>Novelty z-score</td><td id="diag-nov-val" class="diag-val">-</td><td>sigmoid(zscore(cosine_distance))</td></tr>
-                        <tr><td>Polarity diff</td><td id="diag-pol-val" class="diag-val">-</td><td>mean(T[...,0]) - mean(T[...,1])</td></tr>
-                        <tr><td>Mean |activation|</td><td id="diag-act-val" class="diag-val">-</td><td>mean(abs(T)) across the full grid</td></tr>
+                        <tr><td>Prediction confidence</td><td id="diag-confidence-val" class="diag-val">-</td><td>1 - mean(prediction_error), 5 Active-Inference domains (orion/substrate/attention_self_model.py)</td></tr>
+                        <tr><td>Coalition stability</td><td id="diag-coalition-val" class="diag-val">-</td><td>AttentionBroadcastProjectionV1.coalition_stability_score (GWT-dispatch lane)</td></tr>
+                        <tr><td>Field anomaly</td><td id="diag-anomaly-val" class="diag-val">-</td><td>mood-arc encoder recon_loss, normalized against live-observed range (orion-field-digester)</td></tr>
                     </tbody>
                 </table>
 
                 <h3>WHAT THIS ACTUALLY IS</h3>
                 <div class="edu-text">
-                    <p>This panel visualizes <span class="edu-highlight">OrionTissue</span>, a real 16x16x8 decay+diffusion tensor (<code>orion/spark/orion_tissue.py</code>) fed by how far each turn's real text embedding drifts from a recent running average of prior embeddings. It is a live physics simulation of embedding-space drift over time, not a readout of reasoning, feelings, or "thoughts."</p>
+                    <p>This panel polls <code>GET /api/self-brain/frames/tail</code> (orion-hub, backed by <code>SubstrateBrainFrameV1</code> in <code>orion-substrate-runtime</code>, persisted every 5s) and displays three independently-sourced, independently-verified real signals -- not a fused "consciousness meter." Each has a different producer, a different model, and a different input: Active-Inference prediction error across five live domains; the GWT-dispatch attention lane's own coalition-selection stability; and a trained sequence-autoencoder's reconstruction error over live field-channel pressures.</p>
                 </div>
                 <div class="edu-text">
-                    <p>The four numbers above are computed directly from that tensor's own state (<code>OrionTissue.phi()</code>) -- real and traceable, not injected from a self-report or a hand-tuned formula. They are named for what they literally are (a channel difference, a mean absolute activation, a cosine similarity, a z-score) rather than for what they might resemble. None of the four have an independent theory anchor connecting them to reasoning quality, mood, or wellbeing -- treat them as tensor summary statistics, not a cognitive or emotional assessment.</p>
-                </div>
-                <div class="edu-text">
-                    <p>2026-07-28: this page replaced an earlier version of itself that drove these same four numbers from a SelfState-anchored formula confirmed to fall back to a fake "calm" default on the majority of ticks, while this exact page's copy described it as visualizing "how the AI is thinking" and letting you "diagnose the system's mental health." A same-day follow-up found the relocated page had kept an invented mood-label taxonomy (LUCID FLOW / COLD ANALYSIS / MANIC CREATIVITY / etc., threshold-derived from the four scalars) and STATE/IMPLICATION table columns (Integrated-Resourced / Stress-Conflict) completely unchanged -- both deleted rather than re-labeled. Kept here as a disclosed correction, not scrubbed from history.</p>
+                    <p>2026-07-28: this page previously drove its four headline numbers from OrionTissue's own decay/diffusion tensor stats (embedding_similarity/novelty_zscore/polarity_diff/mean_abs_activation) -- real, but with "no independent theory anchor connecting them to reasoning quality, mood, or wellbeing" by the prior version's own disclosed copy. Replaced with the three signals above after live-verifying each candidate individually: <code>self_state</code> (a fourth candidate) turned out to have zero producer since a 2026-07-22 burn and was dropped; <code>node_kind</code>/<code>lane</code> region aggregates (both <code>max()</code> and <code>min()</code>) turned out to be either ceiling- or floor-pinned against real live data and were dropped; raw <code>bus_synaptic</code> gap_zscore was dropped as non-independent (it's already a direct input to prediction confidence, domain #5 of 5). Full trace: <code>docs/superpowers/specs/2026-07-28-spark-introspector-retirement-and-honest-substrate-convergence.md</code>.</p>
                 </div>
             </div>
         </div>

--- a/services/orion-vector-host/app/static/tissue_viz.js
+++ b/services/orion-vector-host/app/static/tissue_viz.js
@@ -2,15 +2,33 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 // --- STATE ---
-// Field names match the wire schema directly (embedding_similarity/
-// novelty_zscore/polarity_diff/mean_abs_activation) -- see
-// orion/spark/orion_tissue.py's phi() docstring for what each literally is.
+// 2026-07-28: replaced OrionTissue's own WS-pushed embedding-drift stats
+// (embedding_similarity/novelty_zscore/polarity_diff/mean_abs_activation --
+// real, but "no independent theory anchor connecting them to reasoning
+// quality, mood, or wellbeing" per this page's own prior disclosed copy)
+// with three independently-sourced, independently-verified real signals,
+// polled from orion-hub's GET /api/self-brain/frames/tail (backed by
+// SubstrateBrainFrameV1, orion-substrate-runtime, persisted every 5s):
+//   - confidence: 1 - mean(prediction_error) across 5 Active-Inference
+//     domains (honesty_metrics region, unconditional)
+//   - coalition: AttentionBroadcastProjectionV1.coalition_stability_score
+//     (frame.spotlight, GWT-dispatch lane)
+//   - anomaly: mood-arc encoder reconstruction error over live field-channel
+//     pressures, calibrated against its own live-observed range
+//     (field_anomaly region)
+// Each was live-verified individually before being wired in here -- see
+// docs/superpowers/specs/2026-07-28-spark-introspector-retirement-and-honest-
+// substrate-convergence.md for the candidates that were checked and dropped
+// (self_state: dead, zero producer; node_kind/lane max() and min(): both
+// ceiling/floor-pinned against real data; raw bus_synaptic gap_zscore:
+// not independent of confidence, already one of its 5 domains).
 const state = {
-    similarity: 0.5, novelty: 0.0, polarity: 0.5, activation: 0.0,
-    targetSimilarity: 0.5, targetNovelty: 0.0, targetPolarity: 0.5, targetActivation: 0.0,
-    lastUpdate: 0, metadata: {}, correlationId: null, timestamp: null
+    confidence: 0.5, coalition: 0.5, anomaly: 0.0,
+    targetConfidence: 0.5, targetCoalition: 0.5, targetAnomaly: 0.0,
+    lastUpdate: 0, frameId: null, timestamp: null
 };
-const INTERPOLATION_SPEED = 0.05; 
+const INTERPOLATION_SPEED = 0.05;
+const POLL_INTERVAL_MS = 5000; // matches BRAIN_FRAME_INTERVAL_SEC default
 
 // --- DOM ---
 const elMoodValue = document.getElementById('mood-value');
@@ -19,10 +37,6 @@ const elGearBtn = document.getElementById('gear-btn');
 const elSettingsMenu = document.getElementById('settings-menu');
 const elInfoToggle = document.getElementById('info-toggle-row');
 const elExplanation = document.getElementById('explanation-panel');
-const elTurnEffectBox = document.getElementById('turn-effect-box');
-const elTurnEffectUser = document.getElementById('turn-effect-user');
-const elTurnEffectAssistant = document.getElementById('turn-effect-assistant');
-const elTurnEffectTurn = document.getElementById('turn-effect-turn');
 
 // --- UI LOGIC ---
 elGearBtn.addEventListener('click', (e) => { e.stopPropagation(); elSettingsMenu.classList.toggle('visible'); });
@@ -32,109 +46,70 @@ elInfoToggle.addEventListener('click', () => {
     elInfoToggle.innerText = elExplanation.classList.contains('visible') ? "▲ HIDE INTERNALS ▲" : "▼ SYSTEM INTERNALS EXPLANATION ▼";
 });
 
-// --- WEBSOCKET ---
-class WSClient {
-    constructor() { this.ws = null; this.reconnectDelay = 1000; }
+// --- BRAIN FRAME POLL ---
+class BrainFramePoller {
+    constructor() { this.timer = null; this.consecutiveFailures = 0; }
     setConnected(isConnected) {
-        elConnStatus.innerText = isConnected ? "ONLINE" : "OFFLINE";
+        elConnStatus.innerText = isConnected ? "LIVE" : "STALE";
         elConnStatus.style.color = isConnected ? "#0f0" : "#f00";
     }
-    connect() {
-        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const host = window.location.host;
-        let path = window.location.pathname;
-        if (path.endsWith('/')) path = path.slice(0, -1);
-        if (path.endsWith('/ui')) path = path.slice(0, -3);
-        if (!path.startsWith('/')) path = '/' + path;
-        const wsUrl = `${protocol}//${host}${path}/ws/tissue`;
-        
-        this.ws = new WebSocket(wsUrl);
-        this.ws.onopen = () => { this.setConnected(true); this.reconnectDelay = 1000; };
-        this.ws.onmessage = (event) => {
-            try {
-                const data = JSON.parse(event.data);
-                if (data.type === "tissue.update") { this.handleUpdate(data); }
-            } catch (e) { console.error("Parse error:", e); }
-        };
-        this.ws.onclose = () => { this.setConnected(false); setTimeout(() => this.connect(), this.reconnectDelay); };
+    start() {
+        this.poll();
+        this.timer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
     }
-    handleUpdate(data) {
-        if (!data.stats) return;
-        state.targetSimilarity = data.stats.embedding_similarity;
-        state.targetNovelty = data.stats.novelty_zscore;
-        state.targetPolarity = data.stats.polarity_diff;
-        state.targetActivation = data.stats.mean_abs_activation;
-        state.correlationId = data.correlation_id;
-        state.timestamp = data.timestamp;
-        state.metadata = data.metadata || {};
+    async poll() {
+        try {
+            const res = await fetch('/api/self-brain/frames/tail?limit=1');
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json();
+            const frames = data.frames || [];
+            if (!frames.length) {
+                this.consecutiveFailures += 1;
+                this.setConnected(false);
+                return;
+            }
+            this.consecutiveFailures = 0;
+            this.setConnected(true);
+            this.handleFrame(frames[frames.length - 1]);
+        } catch (e) {
+            this.consecutiveFailures += 1;
+            this.setConnected(false);
+            console.error("Brain frame poll error:", e);
+        }
+    }
+    handleFrame(frame) {
+        const regions = frame.regions || [];
+        const honesty = regions.find((r) => r.dimension === 'honesty_metrics');
+        const anomaly = regions.find((r) => r.dimension === 'field_anomaly');
+        const coalitionScore = frame.spotlight ? frame.spotlight.coalition_stability : null;
+
+        if (honesty) state.targetConfidence = honesty.intensity;
+        if (anomaly) state.targetAnomaly = anomaly.intensity;
+        if (coalitionScore !== null && coalitionScore !== undefined) state.targetCoalition = coalitionScore;
+
+        state.frameId = frame.frame_id;
+        state.timestamp = frame.generated_at;
         this.updateDOM();
     }
     updateDOM() {
-        document.getElementById('val-id').innerText = (state.correlationId || "NULL").substring(0, 8) + '...';
+        document.getElementById('val-id').innerText = (state.frameId || "NULL").substring(0, 12) + '...';
         document.getElementById('val-ts').innerText = state.timestamp || "-";
-        document.getElementById('val-similarity').innerText = state.targetSimilarity.toFixed(2);
-        document.getElementById('val-novelty').innerText = state.targetNovelty.toFixed(2);
-        document.getElementById('val-polarity').innerText = state.targetPolarity.toFixed(2);
-        document.getElementById('val-activation').innerText = state.targetActivation.toFixed(2);
+        document.getElementById('val-confidence').innerText = state.targetConfidence.toFixed(2);
+        document.getElementById('val-coalition').innerText = state.targetCoalition.toFixed(2);
+        document.getElementById('val-anomaly').innerText = state.targetAnomaly.toFixed(2);
         this.updateMoodText();
         this.updateDiagnosticsTable();
-        this.updateTurnEffect();
     }
-    // 2026-07-28: this used to map the four scalars onto an invented mood
-    // taxonomy (LUCID FLOW / COLD ANALYSIS / MANIC CREATIVITY / etc.,
-    // threshold-derived, no theory anchor -- see index.html's disclosed
-    // correction). Deleted rather than relabeled: there is no honest
-    // one-word summary of four unrelated tensor statistics to substitute.
-    // The raw values in the stats row and diagnostics table are the actual
-    // signal; this just shows them literally instead of interpreting them.
     updateMoodText() {
-        const s = state.targetSimilarity, n = state.targetNovelty, p = state.targetPolarity, a = state.targetActivation;
-        elMoodValue.innerText = `sim ${s.toFixed(2)} · nov ${n.toFixed(2)} · pol ${p.toFixed(2)} · act ${a.toFixed(2)}`;
+        const c = state.targetConfidence, s = state.targetCoalition, a = state.targetAnomaly;
+        elMoodValue.innerText = `conf ${c.toFixed(2)} · coal ${s.toFixed(2)} · anom ${a.toFixed(2)}`;
         elMoodValue.style.color = "#0ff";
         elMoodValue.style.textShadow = "0 0 10px #0ff";
     }
     updateDiagnosticsTable() {
-        document.getElementById('diag-sim-val').innerText = state.targetSimilarity.toFixed(2);
-        document.getElementById('diag-nov-val').innerText = state.targetNovelty.toFixed(2);
-        document.getElementById('diag-pol-val').innerText = state.targetPolarity.toFixed(2);
-        document.getElementById('diag-act-val').innerText = state.targetActivation.toFixed(2);
-    }
-    updateTurnEffect() {
-        if (!elTurnEffectBox) return;
-        const meta = state.metadata || {};
-        const snapshotMeta = meta.spark_state_snapshot && meta.spark_state_snapshot.metadata
-            ? meta.spark_state_snapshot.metadata
-            : {};
-        const turnEffect = meta.turn_effect || snapshotMeta.turn_effect || null;
-        const summary = meta.turn_effect_summary || snapshotMeta.turn_effect_summary || null;
-        const evidence = meta.turn_effect_evidence || snapshotMeta.turn_effect_evidence || null;
-        if (!turnEffect) {
-            elTurnEffectBox.classList.add('hidden');
-            elTurnEffectUser.innerText = "";
-            elTurnEffectAssistant.innerText = "";
-            elTurnEffectTurn.innerText = "";
-            elTurnEffectBox.title = "";
-            return;
-        }
-        const fmt = (val) => (typeof val === 'number' ? val.toFixed(2) : null);
-        const fmtLine = (label, payload) => {
-            if (!payload) return "";
-            const v = fmt(payload.valence);
-            const e = fmt(payload.energy);
-            const c = fmt(payload.coherence);
-            const n = fmt(payload.novelty);
-            const parts = [];
-            if (v !== null) parts.push(`v=${v}`);
-            if (e !== null) parts.push(`e=${e}`);
-            if (c !== null) parts.push(`c=${c}`);
-            if (n !== null) parts.push(`n=${n}`);
-            return parts.length ? `${label}: ${parts.join(' ')}` : "";
-        };
-        elTurnEffectUser.innerText = fmtLine("user", turnEffect.user);
-        elTurnEffectAssistant.innerText = fmtLine("assistant", turnEffect.assistant);
-        elTurnEffectTurn.innerText = fmtLine("turn", turnEffect.turn);
-        elTurnEffectBox.title = JSON.stringify({ turn_effect: turnEffect, summary, evidence }, null, 2);
-        elTurnEffectBox.classList.remove('hidden');
+        document.getElementById('diag-confidence-val').innerText = state.targetConfidence.toFixed(2);
+        document.getElementById('diag-coalition-val').innerText = state.targetCoalition.toFixed(2);
+        document.getElementById('diag-anomaly-val').innerText = state.targetAnomaly.toFixed(2);
     }
 }
 
@@ -149,33 +124,40 @@ class SynthwaveVisualizer {
         this.plane = new THREE.Mesh(geo, mat);
         this.plane.rotation.x = -Math.PI / 2;
         this.scene.add(this.plane);
-        
+
         const sunGeo = new THREE.SphereGeometry(30, 32, 32);
         this.sunMat = new THREE.MeshBasicMaterial({ color: 0xffaa00, wireframe: true, transparent: true, opacity: 0.8, side: THREE.DoubleSide });
         this.sun = new THREE.Mesh(sunGeo, this.sunMat);
         this.sun.position.set(0, 10, -85);
         this.scene.add(this.sun);
-        
+
         const inGeo = new THREE.SphereGeometry(14, 32, 32);
         const inMat = new THREE.MeshBasicMaterial({ color: 0xff4400, transparent: true, opacity: 0.9 });
         this.innerSun = new THREE.Mesh(inGeo, inMat);
         this.sun.add(this.innerSun);
         this.vertexStore = geo.attributes.position.array.slice();
     }
+    // Mapping (2026-07-28): only 3 independent real signals exist for 4 visual
+    // channels. confidence drives both chaos and hue via different curves --
+    // this is the same real number applied twice, not a 4th invented signal.
+    //   chaos = 1 - confidence        (uncertain -> more turbulent grid)
+    //   amp   = 1 + (1-coalition)*6   (unstable attention coalition -> bigger wave amplitude)
+    //   speed = 1 + anomaly*6         (elevated field anomaly -> faster tempo)
+    //   hue   = 0.9 + confidence*0.6  (confidence -> color band)
     update(dt) {
-        const speed = 1.0 + (state.activation * 6.0);
+        const speed = 1.0 + (state.anomaly * 6.0);
         this.runTime += dt * speed;
         const pos = this.plane.geometry.attributes.position.array;
-        const chaos = Math.max(0.1, 1.0 - state.similarity);
-        const amp = 1.0 + (state.novelty * 6.0);
-        const hue = 0.9 + (state.polarity * 0.6);
-        
+        const chaos = Math.max(0.1, 1.0 - state.confidence);
+        const amp = 1.0 + ((1.0 - state.coalition) * 6.0);
+        const hue = 0.9 + (state.confidence * 0.6);
+
         for (let i = 0; i < pos.length; i += 3) {
             const ox = this.vertexStore[i], oy = this.vertexStore[i+1];
             const sy = oy - this.runTime;
             const wx = Math.sin(sy * 0.1 + this.runTime * 0.5) * 3.0 + Math.cos(sy * 0.05) * 5.0;
             pos[i] = ox + (wx * chaos);
-            
+
             let z = Math.sin(ox*0.1)*Math.cos(sy*0.1)*4.0 + Math.sin(ox*0.3+sy*0.3)*2.0 + Math.sin(ox*0.8+this.runTime)*Math.cos(sy*0.9)*(chaos*2.0);
             const dist = Math.abs(ox);
             let rf = 0.0;
@@ -187,11 +169,11 @@ class SynthwaveVisualizer {
         this.sunMat.color.setHSL((hue+0.1)%1, 1, 0.6);
         this.innerSun.material.color.setHSL(hue%1, 1, 0.5);
         this.sun.rotation.y += dt*0.1; this.sun.rotation.z -= dt*0.05;
-        this.sun.scale.setScalar(1 + Math.sin(this.runTime*2)*0.05*state.activation);
+        this.sun.scale.setScalar(1 + Math.sin(this.runTime*2)*0.05*state.anomaly);
     }
 }
 
-const ws = new WSClient(); ws.connect();
+const poller = new BrainFramePoller(); poller.start();
 const ren = new THREE.WebGLRenderer({antialias:true}); ren.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(ren.domElement);
 const scn = new THREE.Scene();
@@ -201,19 +183,11 @@ const clk = new THREE.Clock();
 function anim() {
     requestAnimationFrame(anim);
     const dt = clk.getDelta();
-    state.similarity += (state.targetSimilarity-state.similarity)*INTERPOLATION_SPEED;
-    state.novelty += (state.targetNovelty-state.novelty)*INTERPOLATION_SPEED;
-    state.polarity += (state.targetPolarity-state.polarity)*INTERPOLATION_SPEED;
-    state.activation += (state.targetActivation-state.activation)*INTERPOLATION_SPEED;
+    state.confidence += (state.targetConfidence-state.confidence)*INTERPOLATION_SPEED;
+    state.coalition += (state.targetCoalition-state.coalition)*INTERPOLATION_SPEED;
+    state.anomaly += (state.targetAnomaly-state.anomaly)*INTERPOLATION_SPEED;
     viz.update(dt);
     ren.render(scn, cam);
 }
 window.addEventListener('resize', ()=>{ cam.aspect=window.innerWidth/window.innerHeight; cam.updateProjectionMatrix(); ren.setSize(window.innerWidth, window.innerHeight); });
 anim();
-
-// Test Pulse
-const btn = document.getElementById('btn-test-signal');
-if(btn) btn.addEventListener('click', async () => {
-    let p = window.location.pathname; if(p.endsWith('/')) p=p.slice(0,-1); if(p.endsWith('/ui')) p=p.slice(0,-3); if(!p.startsWith('/')) p='/'+p;
-    await fetch(p+'/api/test-pulse', {method:"POST"});
-});


### PR DESCRIPTION
## Summary

- Replace OrionTissue page's 4 theory-orphaned tensor stats with 3 real signals from `SubstrateBrainFrameV1`, each individually live-verified against real running data before being wired in
- Fixed a real bug: `honesty_metrics` was wired to the wrong object (`AttentionBroadcastProjectionV1`, no `prediction_error_confidence` field) — now computes the real `AttentionSelfModelV1` live, which had never been called outside offline analysis scripts before this
- New `field_anomaly` brain-frame dimension, sourced from orion-field-digester's mood-arc encoder via a new bus subscriber in orion-substrate-runtime
- Checked and rejected 5 other candidate signals with live data, not assumption (see below)

## Outcome moved

The OrionTissue synthwave visualizer (`/spark/ui`) now renders honest, independently-sourced, independently-verified substrate state instead of tensor summary statistics with no theory anchor. Same visual mechanics, real inputs.

## Current architecture

Brain frames (`orion-substrate-runtime`, 5s cadence) already had `node_kind`/`lane`/`self_state` dimensions plus a `honesty_metrics` dimension merged earlier today (PR #1429) — but that dimension was silently empty in production because it was wired to the wrong object type.

## Architecture touched

### Real bug fix: honesty_metrics never actually fired
`_brain_frame_tick()` was passing `attention` (`AttentionBroadcastProjectionV1`, the narrow GWT-dispatch-lane object, loaded via `load_attention_broadcast()`) as `attention_payload`. That schema has no `prediction_error_confidence` field — confirmed live: deployed and pulled 5 consecutive frames, `honesty_metrics` region was `[]` every time.

Root cause: the object that *does* carry `prediction_error_confidence` — `AttentionSelfModelV1`, computed by `orion.substrate.attention_self_model.reduce_attention_self_model()` — had **never been called live anywhere in this codebase**. Its own module docstring says so explicitly ("Read-only. This module has no bus consumer/producer wiring"); the only two callers were offline analysis scripts (`scripts/analysis/measure_ast_hot_reducer.py`, `measure_attention_reason_branch_starvation.py`).

Fixed by computing it live in `_brain_frame_tick()`:
- New `_brain_frame_prediction_error_by_domain()` reads each Active-Inference domain's `prediction_error` off the **already-fetched** node snapshot (the fixed `node:substrate.<domain>` nodes `_write_prediction_error_node()` durably upserts) — zero extra I/O.
- Calls `reduce_attention_self_model(broadcast=attention, field_frame=None, prediction_error_by_domain=...)` to get the real object.
- Verified live post-fix: confidence read `0.7968` immediately, matching a hand-computed check against the raw domain values pulled directly from FalkorDB (`bus_synaptic=1.0`, others near-zero → `1-mean≈0.7968`). Redeployed and polled a real 2-minute window: **0.7929–0.9935**, genuine variance, not pinned.

### New signal: field_anomaly (mood-arc encoder)
- `orion-field-digester`'s `app/anomaly_scorer.py` runs a real trained sequence autoencoder (`orion/mood_arc/fit_encoder.py`, "encoder_id=mood-arc-encoder:v3") against live field-channel pressures, publishing `FieldChannelAnomalyScoreV1` on `orion:field_channel:anomaly_score` — previously consumed only by `orion-equilibrium-service`'s metacog gate, not persisted anywhere queryable.
- New `_field_channel_anomaly_listener_loop()` in `orion-substrate-runtime` subscribes and caches the latest score (mirrors the existing `_drive_state_listener_loop` pattern exactly).
- `recon_loss` has no natural [0,1] range and a ratio against the encoder's own threshold/`recon_error_p95` saturates almost immediately (live-checked: `threshold=0.000895`, `recon_error_p95≈0.0003`, while a real 2-minute window of `recon_loss` read 4–15x the threshold on every tick). `_FIELD_ANOMALY_RECON_LOSS_FLOOR`/`_CEILING` are disclosed, live-observed calibration constants instead (floor just above the encoder's real threshold, ceiling with headroom above the observed max) — not an invented squashing formula.
- Confirmed live: caught a genuine anomalous→calm state transition across two checks ~50 minutes apart (`recon_loss` ~0.012, 4-15x threshold → ~0.00012, below the threshold — both real ticks, not a formula artifact).

### Candidates checked and rejected, with the live numbers that killed each one
- **`self_state`**: zero producer since the 2026-07-22 SelfStateV1 burn (`orion-consolidation-runtime/app/store.py` confirms `substrate_self_state` has had no writer since). Would never emit a region.
- **`node_kind` region max**: pinned `0.9687–1.0` over a live 2-minute window — the graph currently only has one populated node_kind ("concept") beyond a handful of seed/tracker nodes.
- **`lane` region aggregate, both directions**: `max()` reads a flat constant `0.4` whenever backlog=0 and lag≤60s (the common case), and masks a real incident — `chat_grammar` has read exactly `0.0` (lag_sec≈254000, ~70h stale) for the entire observation window. `min()` doesn't fix this, it just relocates the pin to that same dead lane's `0.0` permanently.
- **raw `bus_synaptic` `gap_zscore`**: not independent — `bus_synaptic_prediction_error()` is already built directly from these same edges, and `bus_synaptic` is already one of `honesty_metrics`' 5 input domains.
- **`overall_salience`** (general field lane): also pinned at exactly `1.0` across every sample checked.

### Frontend
- `services/orion-vector-host/app/static/tissue_viz.js`: replaced the WS-driven 4-stat pipeline with a 5s poll against `GET /api/self-brain/frames/tail` (matches `BRAIN_FRAME_INTERVAL_SEC`). Visualizer's speed/chaos/amp/hue formulas remapped to the 3 real signals — `confidence` drives both `chaos` and `hue` via different curves (same real number applied twice, not a 4th invented signal, documented inline).
- `services/orion-vector-host/app/static/index.html`: stat row, diagnostics table, and explanation panel rewritten for the 3 new signals with real formula/source citations. Removed the `turn-effect-box` (tied to `SparkStateSnapshotV1` metadata, whose only real producer is the spark-introspector service already slated for deletion per the retirement doc) and the now-unused test-pulse button.

## Files changed

- `orion/schemas/brain_frame.py`: add `field_anomaly` to the dimension Literal
- `orion/bus/channels.yaml`: add `orion-substrate-runtime` as a consumer of `orion:field_channel:anomaly_score`
- `services/orion-substrate-runtime/app/settings.py`: new `field_channel_anomaly_score_channel` setting
- `services/orion-substrate-runtime/app/worker.py`: new listener loop + cache handler, `_brain_frame_prediction_error_by_domain()`, live `reduce_attention_self_model()` call in `_brain_frame_tick()`
- `services/orion-substrate-runtime/app/brain_frame_producer.py`: `_field_anomaly_regions()`, `attention_payload`/`field_anomaly` params on `assemble_brain_frame()`
- `services/orion-substrate-runtime/.env_example`: new `FIELD_CHANNEL_ANOMALY_SCORE_CHANNEL` key
- `services/orion-substrate-runtime/README.md`, `services/orion-vector-host/README.md`: document the final architecture, live-verification results, and rejected candidates
- `docs/superpowers/specs/2026-07-28-spark-introspector-retirement-and-honest-substrate-convergence.md`: new §7 documenting this signal-selection pass
- Tests: `test_brain_frame_producer.py` (+field_anomaly cases, fixed pre-existing `attention_payload` kwarg gap), `test_brain_frame_worker.py` (fixture fix), new `test_field_channel_anomaly_listener.py`
- `services/orion-vector-host/app/static/{index.html,tissue_viz.js}`: full frontend rewrite for the 3 real signals

## Schema / bus / API changes

- **Added**: `BrainRegionV1.dimension` now accepts `"field_anomaly"`
- **Added consumer**: `orion-substrate-runtime` now consumes `orion:field_channel:anomaly_score` (pre-existing channel, new consumer only)
- **No breaking changes**: `attention_payload` and `field_anomaly` params on `assemble_brain_frame()` both default to `None`, backward compatible

## Env/config changes

- Added: `FIELD_CHANNEL_ANOMALY_SCORE_CHANNEL` (default `orion:field_channel:anomaly_score`)
- `.env_example` updated: yes
- local `.env` synced: yes, via `python scripts/sync_local_env_from_example.py orion-substrate-runtime`

## Tests run

```
services/orion-substrate-runtime/tests/test_brain_frame_producer.py .................... [24 passed]
services/orion-substrate-runtime/tests/test_field_channel_anomaly_listener.py ...... [6 passed]
services/orion-substrate-runtime/tests/test_brain_frame_worker.py ...... [6 passed]
services/orion-hub/tests/test_self_brain_routes.py (from earlier PR #1429, still green)
```

Also ran the full `orion-substrate-runtime` test suite (196 tests) in a throwaway venv: 16 pre-existing failures reproduced identically against the unmodified `main` branch (verified directly, not assumed) — confirmed unrelated to this patch, out of scope here.

## Docker/build/smoke checks

Both services rebuilt and redeployed live via `scripts/safe_docker_build.sh` from this worktree during development, not just unit-tested:
- `orion-substrate-runtime`: redeployed twice (once for the honesty_metrics fix, once for field_anomaly); confirmed via container logs (`brain_frame_tick_completed regions=7`, no errors) and direct Postgres/FalkorDB queries showing real signal variance over time
- `orion-vector-host`: redeployed; confirmed new `index.html`/`tissue_viz.js` served correctly
- End-to-end verified through the **real Tailscale Serve routing**, not just localhost: `tailscale serve status` confirmed `/spark` → vector-host, `/` → orion-hub; a live curl through the real tailnet domain (`https://athena.tail348bbe.ts.net/spark/ui`) confirmed the page loads with the new header, and a curl to the absolute-path fetch the frontend JS uses (`/api/self-brain/frames/tail`) confirmed it correctly resolves to orion-hub, not vector-host

## Review findings fixed

None yet — review not run in this session (implementation done via live-data-driven iteration with the user directing each step, not a standalone autonomous patch). Recommend running the code-review skill before merge.

## Restart required

```
No restart required — both services were already redeployed live during development.
```

If deploying to a different environment:
```bash
scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
scripts/safe_docker_build.sh orion-vector-host up -d --build
```

## Risks / concerns

- Severity: Low
- Concern: `field_anomaly`'s calibration constants (`_FIELD_ANOMALY_RECON_LOSS_FLOOR`/`_CEILING`) are based on a live-observed range from a single ~2-minute + ~1-hour-later sampling window, not a long-term statistical study. If `recon_loss`'s real distribution shifts significantly (e.g. after an encoder retrain), the intensity mapping may need recalibration.
- Mitigation: constants are disclosed and documented inline with their exact provenance (not hidden magic numbers), making them easy to find and adjust. `detail.recon_loss` is also carried on the region unmodified, so the raw value remains inspectable regardless of calibration drift.

- Severity: Low
- Concern: The 70-hour-stale `chat_grammar` reducer lane (found as a side effect of live-checking the `lane` signal, not fixed here) is a real, separate operational issue.
- Mitigation: flagged explicitly in the PR description and the spec doc; out of scope for this patch, needs its own investigation.

## PR link

(pending — see command output)