### PR TITLE
fix(field-attention): replace saturated recent_perturbation caps with EWMA baseline

### DIFF
--- a/orion/attention/field_attention/selectors.py
+++ b/orion/attention/field_attention/selectors.py
@@ -10,6 +10,10 @@ from orion.attention.field_attention.scoring import (
     urgency_score,
     weighted_pressure,
 )
+from orion.field.pressure import (
+    RECENT_PERTURBATION_EWMA_MIN_SAMPLES,
+    RECENT_PERTURBATION_ZSCORE_SATURATION,
+)
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 from orion.schemas.field_state import FieldStateV1
 
@@ -129,10 +133,29 @@ def select_system_targets(
     field: FieldStateV1,
     policy: FieldAttentionPolicyV1,
 ) -> list[FieldAttentionTargetV1]:
+    """Surfaces ``field:recent_perturbations`` as a system attention target
+    when recent perturbation activity is elevated relative to this mesh's
+    own recent baseline.
+
+    2026-07-28: was ``min(1.0, count / 10.0)`` -- live-confirmed permanently
+    saturated at 1.0 (real steady-state count is ~100-118 in the 60s window,
+    5-10x past the old cap), so this target used to report maximum salience
+    on essentially every tick regardless of whether anything was actually
+    unusual. Now scores ``field.recent_perturbation_zscore`` (EWMA baseline
+    maintained by apply_perturbations() -- see field_state.py's
+    recent_perturbation_ewma* docstring), same fix shape as
+    bus_synaptic_prediction_error's calm-floor correction: reused, not
+    reinvented. A below-baseline dip (negative zscore) is clamped to 0 --
+    "quieter than usual" isn't a reason to attend here, only "busier than
+    usual" is.
+    """
     count = len(field.recent_perturbations)
     if count == 0:
         return []
-    salience = min(1.0, count / 10.0)
+    zscore = field.recent_perturbation_zscore
+    if zscore is None or field.recent_perturbation_ewma_n < RECENT_PERTURBATION_EWMA_MIN_SAMPLES:
+        return []
+    salience = min(1.0, max(0.0, zscore) / RECENT_PERTURBATION_ZSCORE_SATURATION)
     if salience < policy.thresholds.min_salience:
         return []
     return [
@@ -145,7 +168,9 @@ def select_system_targets(
             urgency_score=0.0,
             confidence_score=0.0,
             dominant_channels={},
-            reasons=[f"recent field perturbation count is {count}"],
+            reasons=[
+                f"recent field perturbation count is {count} (z={zscore:.2f} vs baseline)"
+            ],
             evidence_refs=[f"field:{field.tick_id}"],
             suggested_observation_mode=observation_mode_for(salience, policy),
         )

--- a/orion/field/pressure.py
+++ b/orion/field/pressure.py
@@ -82,6 +82,30 @@ def clamp01(x: float) -> float:
     return max(0.0, min(1.0, float(x)))
 
 
+# Shared by this module's recent_perturbation_count channel and
+# orion/attention/field_attention/selectors.py's select_system_targets --
+# both score the same field.recent_perturbation_zscore (see field_state.py's
+# recent_perturbation_ewma* docstring for why this replaced a fixed count
+# cap). Reuses the z>=3.0 "anomalous" convention already live in
+# services/orion-hub/scripts/bus_synaptic_graph_routes.py's anomalies()
+# route and orion/substrate/prediction_error.py's
+# _BUS_SYNAPTIC_ZSCORE_SATURATION, rather than inventing a new calibration.
+RECENT_PERTURBATION_ZSCORE_SATURATION = 3.0
+
+# Cold-start reliability floor for field.recent_perturbation_zscore, same
+# concept as services/orion-bus-mirror/README.md's documented "count < ~5 is
+# unreliable" floor for gap_zscore (orion/substrate/prediction_error.py's
+# bus_synaptic_prediction_error() puts that same filtering responsibility on
+# its caller, not the aggregation function -- same split here). Confirmed by
+# hand: orion.bus.ewma.compute_ewma_update's variance estimate is built from
+# a single prior sample after the first update, so a tiny early delta over a
+# near-zero variance floor produces a wildly inflated z (simulated
+# 2026-07-28: z=1000 on the *second* observation for a steady 1-unit/tick
+# ramp). Below this many samples, treat the zscore as not yet trustworthy --
+# absent/no-signal, not a fake reading.
+RECENT_PERTURBATION_EWMA_MIN_SAMPLES = 5
+
+
 def collect_field_channel_pressures(
     field: FieldStateV1,
 ) -> tuple[dict[str, float], dict[str, str]]:
@@ -124,16 +148,34 @@ def collect_field_channel_pressures(
     # a direct diff against orion/self_state/scoring.py's original), a real
     # regression since orion-field-digester's field_channel_corpus.v1 rows
     # and orion/mood_arc/fit_encoder.py's explicit by-name exclusion both
-    # depend on this key being present. Restored verbatim, including the
-    # original 2026-07-16 saturating-counter fix history: field.recent_
-    # perturbations used to be capped to the last 20 distinct labels EVER
-    # seen (saturating this to 1.0 within a few ticks and pinning it there
-    # forever); orion-field-digester's apply_perturbations now prunes it to a
-    # rolling 60s wall-clock window instead, so this count reflects genuinely
-    # recent activity and decays back down once a burst passes.
+    # depend on this key being present.
+    #
+    # 2026-07-28 correction to that restoration: the "n / 20.0" cap it
+    # restored was itself live-confirmed saturated. field.recent_perturbations
+    # is correctly pruned to a rolling 60s window (2026-07-16 fix, still
+    # correct -- verified live 2026-07-28 that nothing older than ~59s
+    # survives), but real steady-state mesh traffic fills that window to
+    # ~100-118 distinct labels, 5-10x past the old /20.0 cap -- so this
+    # channel read pinned at 1.0 under completely normal operation, not just
+    # during bursts. Now scores deviation from this mesh's own recent
+    # baseline instead of an absolute count (field.recent_perturbation_zscore,
+    # maintained by apply_perturbations() -- see field_state.py's
+    # recent_perturbation_ewma* docstring). zscore is None on the first tick
+    # after a cold start (no baseline yet) or after upgrade from a
+    # persisted-but-older FieldStateV1 -- leaving the key absent that tick is
+    # correct ("no empty-shell cognition": absent beats a fake 0.0), it
+    # populates from the next tick onward. Also gated on
+    # RECENT_PERTURBATION_EWMA_MIN_SAMPLES -- see that constant's docstring
+    # for why an early zscore isn't trustworthy yet either.
     n = len(field.recent_perturbations)
-    if n > 0:
-        out["recent_perturbation_count"] = clamp01(min(1.0, n / 20.0))
+    if (
+        n > 0
+        and field.recent_perturbation_zscore is not None
+        and field.recent_perturbation_ewma_n >= RECENT_PERTURBATION_EWMA_MIN_SAMPLES
+    ):
+        out["recent_perturbation_count"] = clamp01(
+            max(0.0, field.recent_perturbation_zscore) / RECENT_PERTURBATION_ZSCORE_SATURATION
+        )
     return out, provenance
 
 

--- a/orion/schemas/field_state.py
+++ b/orion/schemas/field_state.py
@@ -56,6 +56,47 @@ class FieldStateV1(BaseModel):
     # list) -- an immediate, one-tick reset, not gated by window expiry --
     # and it repopulates normally from there.
     recent_perturbation_at: list[datetime] = Field(default_factory=list)
+    # Baseline-relative recent_perturbation salience (2026-07-28): fixes a
+    # live-confirmed saturation bug -- both self_state/scoring's old
+    # count/10.0 salience and this file's neighboring recent_perturbation_count
+    # channel (orion/field/pressure.py, count/20.0) turned out to be
+    # permanently pinned at their 1.0 ceiling under real live traffic (steady
+    # state observed 2026-07-28 was ~100-118 distinct labels in the 60s
+    # window above, 5-10x past both fixed caps) -- an absolute magic-number
+    # cap can't discriminate a real burst from normal mesh churn once normal
+    # churn already exceeds the cap. Same EWMA-baseline-vs-z-score
+    # methodology as bus_synaptic_prediction_error's gap_zscore (orion/bus/
+    # ewma.py::compute_ewma_update, reused not reimplemented), applied here
+    # to the recent_perturbations *count* itself rather than per-edge timing.
+    # Updated once per apply_perturbations() call (services/orion-field-
+    # digester/app/digestion/perturbation.py) using this tick's post-prune
+    # len(recent_perturbations) as the observed value. zscore is None on the
+    # very first call (recent_perturbation_ewma_n becomes 1 that same tick,
+    # with no prior baseline to compare against yet) and numeric from the
+    # second call onward -- same "no empty-shell cognition" rule
+    # compute_ewma_update already documents for its own first-observation
+    # case.
+    #
+    # Known accepted limitation (not fixed by
+    # orion/field/pressure.py::RECENT_PERTURBATION_EWMA_MIN_SAMPLES, which
+    # only guards the separate few-sample variance-noise problem): on any
+    # genuinely fresh FieldStateV1 -- first-ever deploy, or a store
+    # wipe/migration (not hypothetical here; see the 2026-07-23 Postgres
+    # disk-death incident that required a full re-feed) -- both
+    # recent_perturbations and this EWMA baseline start from empty together,
+    # so the reading stays elevated for the first several minutes of real
+    # wall-clock time regardless of whether anything is actually anomalous
+    # (hand-simulated: still >0.6 at tick 34 of a steady 3-labels/2s-tick
+    # baseline). This is a smaller, time-boxed, self-healing recurrence of
+    # the same failure shape this fix otherwise kills for the steady-state
+    # (i.e. normal, long-running-service) case, which is genuinely fixed and
+    # independently verified. Accepted rather than engineered away here to
+    # keep this patch thin -- a real follow-up would need to gate on
+    # elapsed wall-clock time since state init, not just sample count.
+    recent_perturbation_ewma: float = 0.0
+    recent_perturbation_ewma_var: float = 0.0
+    recent_perturbation_ewma_n: int = 0
+    recent_perturbation_zscore: float | None = None
     # Decay/injection-interval mismatch fix (2026-07-17): keyed node_id ->
     # channel -> the wall-clock timestamp of that channel's last real write
     # from apply_perturbations() (services/orion-field-digester/app/

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -383,6 +383,20 @@ first place. Full reasoning and phased detail:
    `select_system_targets`' formula itself needs the same delta-gating/normalization
    discipline the O1-O3 drives fixes applied to `DriveEngine` before this probe's numbers can
    be trusted as representative of the *node/capability* coalition structure specifically.
+   **2026-07-28 update: the second option above shipped in PR #1433.** Independently
+   rediscovered live (steady-state `recent_perturbations` window occupancy of ~100-118, 5-10x
+   past the old `/10.0` cap) before this write-up was found via search-before-editing —
+   `select_system_targets`' formula is no longer `min(1.0, count / 10.0)`; it now scores a
+   z-score against a per-tick EWMA baseline of the count
+   (`orion/schemas/field_state.py::recent_perturbation_zscore`,
+   `orion/bus/ewma.py::compute_ewma_update`), same methodology as
+   `bus_synaptic_prediction_error`'s `gap_zscore`. This fixes the structural "always saturates"
+   cause of the 99.98% figure above, but **that number itself is now stale, not re-verified**:
+   the fix was validated with unit tests and hand-simulation against realistic tick dynamics,
+   not by re-running this probe script against live post-deploy data. Re-running
+   `--window-hours 24 --gap-hours 12` after this ships is the honest next step before treating
+   the monoculture-differentiation item as closed — a lower dominant-target percentage is
+   expected, not guaranteed.
 6. **Revisit `capability_policy.py`'s coupling to live salience** — only after item 3 closes
    the `drive_origin` dependency and item 2's field-native attention is proven, not assumed.
    At this point the actual mechanism is a real open choice, not a given: a salience-to-

--- a/services/orion-field-digester/app/digestion/perturbation.py
+++ b/services/orion-field-digester/app/digestion/perturbation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from orion.bus.ewma import compute_ewma_update
 from orion.schemas.field_state import FieldStateV1
 
 from app.ingest.state_deltas import Perturbation
@@ -39,6 +40,19 @@ RECENT_PERTURBATION_WINDOW_SECONDS = 60.0
 # hold ~900 entries; this just bounds worst-case unbounded growth from a
 # runaway producer bug so the list can never grow without limit.
 RECENT_PERTURBATION_MAX_ENTRIES = 2000
+
+# Baseline-relative salience fix (2026-07-28): see field_state.py's
+# recent_perturbation_ewma* docstring for the live evidence (both consumers
+# of the raw count were permanently saturated). apply_perturbations() runs
+# once per digestion tick (RECEIPT_POLL_INTERVAL_SEC, default 2s) regardless
+# of real traffic, so this is a fixed-cadence EWMA, not per-event like
+# orion-bus-mirror's alpha=0.2 (which updates once per real edge
+# observation). alpha=0.02 targets an effective baseline window of
+# ~2/alpha-1 ~= 99 ticks ~= 3.3 minutes at the default tick cadence -- long
+# enough to smooth past a single burst without being so slow it can't track
+# a genuine multi-minute regime shift (e.g. sustained deploy/backfill
+# activity vs. quiet baseline).
+RECENT_PERTURBATION_RATE_EWMA_ALPHA = 0.02
 
 def apply_perturbations(
     state: FieldStateV1,
@@ -95,7 +109,27 @@ def apply_perturbations(
             state.recent_perturbations.append(p.label)
             state.recent_perturbation_at.append(ts)
     _prune_recent_perturbations(state, now=ts)
+    _update_recent_perturbation_baseline(state)
     return state
+
+
+def _update_recent_perturbation_baseline(state: FieldStateV1) -> None:
+    """EWMA-baseline the post-prune recent_perturbations count so consumers
+    (orion/field/pressure.py, orion/attention/field_attention/selectors.py)
+    can score deviation from *this mesh's own recent normal*, instead of an
+    absolute magic-number cap that real traffic already exceeds at steady
+    state -- see field_state.py's recent_perturbation_ewma* docstring."""
+    update = compute_ewma_update(
+        prev_ewma=state.recent_perturbation_ewma,
+        prev_variance=state.recent_perturbation_ewma_var,
+        prev_count=state.recent_perturbation_ewma_n,
+        value=float(len(state.recent_perturbations)),
+        alpha=RECENT_PERTURBATION_RATE_EWMA_ALPHA,
+    )
+    state.recent_perturbation_ewma = update.ewma
+    state.recent_perturbation_ewma_var = update.variance
+    state.recent_perturbation_zscore = update.zscore
+    state.recent_perturbation_ewma_n += 1
 
 
 def _prune_recent_perturbations(state: FieldStateV1, *, now: datetime) -> None:

--- a/services/orion-field-digester/tests/test_perturbation_recency.py
+++ b/services/orion-field-digester/tests/test_perturbation_recency.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from orion.schemas.field_state import FieldStateV1
-from orion.field.pressure import collect_field_channel_pressures
 
 from app.digestion.perturbation import (
     RECENT_PERTURBATION_WINDOW_SECONDS,
@@ -22,23 +21,29 @@ def _perturbation(label: str) -> Perturbation:
     return Perturbation(node_id="node:athena", channel="cortex_exec_step_load", intensity=0.1, label=label)
 
 
+# NOTE: this file covers recent_perturbations/recent_perturbation_at list
+# pruning only. The count itself used to be read straight off
+# collect_field_channel_pressures() as an absolute-count-vs-fixed-cap value;
+# that got replaced 2026-07-28 by a baseline-relative EWMA/zscore
+# (services/orion-field-digester/tests/test_recent_perturbation_baseline.py)
+# after the fixed cap was live-confirmed to saturate under real steady-state
+# traffic. The list-pruning behavior below is unrelated to that change and
+# still applies unmodified.
+
+
 def test_more_than_old_cap_within_one_instant_does_not_saturate_forever() -> None:
     # Regression guard for the original bug: the OLD mechanism hard-capped
     # recent_perturbations to the last 20 distinct labels EVER seen, with no
-    # expiry -- once 20 distinct labels had ever arrived, recent_perturbation_count
-    # was permanently pinned at 1.0, even if the burst that produced them was
-    # a one-off and nothing followed for hours. This test applies 40 distinct
+    # expiry -- once 20 distinct labels had ever arrived, the list stopped
+    # growing and never emptied, even if the burst that produced them was a
+    # one-off and nothing followed for hours. This test applies 40 distinct
     # perturbations at a single instant (`now` fixed), then advances well past
-    # the new window and applies nothing further -- the count must decay back
-    # toward 0, which the old mechanism could never do.
+    # the new window and applies nothing further -- the list must empty back
+    # out, which the old mechanism could never do.
     state = _empty_state("tick_burst")
     burst = [_perturbation(f"delta_{i}") for i in range(40)]
     apply_perturbations(state, burst, now=BASE)
-
-    # Immediately after the burst, the window is still fresh -- saturated is
-    # expected and correct (a genuine burst of real, current activity).
-    channels, _ = collect_field_channel_pressures(state)
-    assert channels["recent_perturbation_count"] == 1.0
+    assert len(state.recent_perturbations) == 40
 
     # Advance well past the window with no further activity. A tick still
     # runs (apply_perturbations is called every tick regardless of whether
@@ -47,26 +52,20 @@ def test_more_than_old_cap_within_one_instant_does_not_saturate_forever() -> Non
     later = BASE + timedelta(seconds=RECENT_PERTURBATION_WINDOW_SECONDS + 30)
     apply_perturbations(state, [], now=later)
 
-    channels_later, _ = collect_field_channel_pressures(state)
-    assert channels_later.get("recent_perturbation_count", 0.0) < 1.0
     assert state.recent_perturbations == []
     assert state.recent_perturbation_at == []
 
 
-def test_quiet_baseline_rate_does_not_saturate_within_a_window() -> None:
+def test_quiet_baseline_rate_stays_well_under_the_old_cap() -> None:
     # Real observed quiet-baseline rate (substrate_field_applied_deltas,
     # 2026-07-16 20:28-21:10 UTC): ~6-10 distinct applied deltas/minute.
     # Simulated here as one new distinct label every 6 seconds across a
-    # single 60s window (10 total) -- must NOT saturate to 1.0, unlike the
-    # old last-20-ever cap which would have hit 1.0 within ~2 minutes of any
-    # sustained traffic and then stayed there permanently.
+    # single 60s window (10 total).
     state = _empty_state("tick_baseline")
     for i in range(10):
         ts = BASE + timedelta(seconds=6 * i)
         apply_perturbations(state, [_perturbation(f"baseline_{i}")], now=ts)
 
-    channels, _ = collect_field_channel_pressures(state)
-    assert channels["recent_perturbation_count"] < 1.0
     assert len(state.recent_perturbations) == 10
 
 

--- a/services/orion-field-digester/tests/test_recent_perturbation_baseline.py
+++ b/services/orion-field-digester/tests/test_recent_perturbation_baseline.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from orion.field.pressure import (
+    RECENT_PERTURBATION_EWMA_MIN_SAMPLES,
+    collect_field_channel_pressures,
+)
+from orion.schemas.field_state import FieldStateV1
+
+from app.digestion.perturbation import apply_perturbations
+from app.ingest.state_deltas import Perturbation
+
+BASE = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+TICK_SECONDS = 2.0
+
+
+def _empty_state(tick_id: str) -> FieldStateV1:
+    return FieldStateV1(generated_at=BASE, tick_id=tick_id)
+
+
+def _tick(state: FieldStateV1, n_labels: int, *, tick_index: int, prefix: str = "p") -> None:
+    """Apply n_labels new distinct perturbations at BASE + tick_index * TICK_SECONDS."""
+    at = BASE + timedelta(seconds=TICK_SECONDS * tick_index)
+    perturbations = [
+        Perturbation(
+            node_id="node:athena",
+            channel="cortex_exec_step_load",
+            intensity=0.1,
+            label=f"{prefix}_{tick_index}_{i}",
+        )
+        for i in range(n_labels)
+    ]
+    apply_perturbations(state, perturbations, now=at)
+
+
+def test_first_tick_has_no_baseline_yet() -> None:
+    # Regression guard for the bus_synaptic_prediction_error class of bug:
+    # a metric that varies but is never validated against its true rest
+    # state. Here the true "no signal yet" state is an ABSENT channel, not
+    # a fake 0.0 or a fake 1.0 -- there's no baseline on the very first
+    # observation (orion.bus.ewma.compute_ewma_update's own documented
+    # behavior).
+    state = _empty_state("tick_0")
+    _tick(state, 5, tick_index=0)
+    assert state.recent_perturbation_zscore is None
+    assert state.recent_perturbation_ewma_n == 1
+    channels, _ = collect_field_channel_pressures(state)
+    assert "recent_perturbation_count" not in channels
+
+
+def test_cold_start_samples_below_min_do_not_produce_a_reading() -> None:
+    # Confirmed by hand (2026-07-28): the shared EWMA utility's z-score is
+    # wildly unreliable for the first few samples (z=1000 on the second
+    # observation for a steady 1-unit/tick ramp, since variance is
+    # estimated from a single prior point). Below
+    # RECENT_PERTURBATION_EWMA_MIN_SAMPLES, the channel must stay absent
+    # even though a numeric zscore already exists on state.
+    state = _empty_state("tick_cold")
+    for i in range(RECENT_PERTURBATION_EWMA_MIN_SAMPLES - 1):
+        _tick(state, 5 + i, tick_index=i)
+    assert state.recent_perturbation_ewma_n == RECENT_PERTURBATION_EWMA_MIN_SAMPLES - 1
+    assert state.recent_perturbation_zscore is not None
+    channels, _ = collect_field_channel_pressures(state)
+    assert "recent_perturbation_count" not in channels
+
+
+def test_steady_baseline_does_not_saturate_even_past_the_old_fixed_caps() -> None:
+    # The actual live bug this fixes: real steady-state traffic (observed
+    # live 2026-07-28: ~100-118 distinct labels/60s window) already blew
+    # past both the old count/10.0 (selectors.py) and count/20.0
+    # (pressure.py) fixed caps, pinning both permanently at 1.0.
+    #
+    # Simulated here as a constant rate of 3 new distinct labels every 2s
+    # tick -- the window itself naturally converges to ~93 entries once
+    # entries start expiring past the 60s mark (tick ~30), well past both
+    # old caps. Run long enough (150 ticks = 300s of simulated time) for the
+    # EWMA baseline to catch up to that new steady window size too --
+    # hand-verified via direct simulation that the reading is already <0.1
+    # by this point, monotonically decreasing from its ramp-up peak. Once
+    # past cold start, "always ~93" must read as this mesh's genuine normal
+    # (near 0), not as permanent maximum surprise.
+    state = _empty_state("tick_steady")
+    for i in range(150):
+        _tick(state, 3, tick_index=i)
+    assert state.recent_perturbation_ewma_n >= RECENT_PERTURBATION_EWMA_MIN_SAMPLES
+    assert len(state.recent_perturbations) > 20  # comfortably past both old fixed caps (10, 20)
+    channels, _ = collect_field_channel_pressures(state)
+    assert channels["recent_perturbation_count"] < 0.3
+
+
+def test_genuine_burst_above_established_baseline_is_flagged() -> None:
+    # Establish a GENUINELY settled baseline first, not just "past the
+    # RECENT_PERTURBATION_EWMA_MIN_SAMPLES cold-start gate" -- 5-9 samples in
+    # is nowhere near enough for either the 60s recent_perturbations window
+    # or the alpha=0.02 EWMA to have converged (hand-verified: a 20-tick
+    # "baseline" here reads ~0.97 with NO burst at all, purely from the
+    # window/EWMA still ramping up from empty -- that variant of this test
+    # would have passed even with the burst line deleted, so it wasn't
+    # actually testing burst detection). 150 ticks matches
+    # test_steady_baseline_does_not_saturate_even_past_the_old_fixed_caps's
+    # already-verified convergence point (~0.095 by then).
+    state = _empty_state("tick_burst_after_baseline")
+    for i in range(150):
+        _tick(state, 3, tick_index=i)
+    pre_burst_channels, _ = collect_field_channel_pressures(state)
+    pre_burst_reading = pre_burst_channels["recent_perturbation_count"]
+    assert pre_burst_reading < 0.3  # confirms the baseline really is settled
+
+    _tick(state, 300, tick_index=150, prefix="burst")
+
+    channels, _ = collect_field_channel_pressures(state)
+    assert channels["recent_perturbation_count"] > 0.5
+    assert channels["recent_perturbation_count"] > pre_burst_reading
+
+
+def test_burst_does_not_pin_the_reading_forever() -> None:
+    # The actual regression the old mechanism could never satisfy: after a
+    # burst, once activity returns to normal, the reading must come back
+    # down (the EWMA baseline has partially absorbed the burst, and the
+    # burst's own labels eventually age out of the 60s window), not stay
+    # pinned at its post-burst high forever. Hand-verified via direct
+    # simulation: with this baseline/burst/recovery shape, the reading is
+    # back at its pre-burst level (in this case exactly 0.0) within 80s of
+    # the burst ending.
+    state = _empty_state("tick_burst_recovers")
+    for i in range(150):
+        _tick(state, 3, tick_index=i)
+    burst_index = 150
+    _tick(state, 300, tick_index=burst_index, prefix="burst")
+    channels_at_burst, _ = collect_field_channel_pressures(state)
+    burst_reading = channels_at_burst.get("recent_perturbation_count", 0.0)
+    assert burst_reading > 0.9  # confirms the burst itself was actually flagged
+
+    for j in range(1, 40):
+        _tick(state, 3, tick_index=burst_index + j)
+    channels_after, _ = collect_field_channel_pressures(state)
+    recovered_reading = channels_after.get("recent_perturbation_count", 0.0)
+
+    assert recovered_reading < burst_reading

--- a/tests/test_attention_field_selectors.py
+++ b/tests/test_attention_field_selectors.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.attention.field_attention.policy import load_attention_policy
+from orion.attention.field_attention.selectors import select_system_targets
+from orion.field.pressure import RECENT_PERTURBATION_EWMA_MIN_SAMPLES
+from orion.schemas.field_state import FieldStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_attention_policy(REPO / "config" / "attention" / "field_attention_policy.v1.yaml")
+
+BASE = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _field(
+    *,
+    recent_perturbations: list[str],
+    zscore: float | None,
+    ewma_n: int,
+) -> FieldStateV1:
+    return FieldStateV1(
+        generated_at=BASE,
+        tick_id="tick_test",
+        recent_perturbations=recent_perturbations,
+        recent_perturbation_zscore=zscore,
+        recent_perturbation_ewma_n=ewma_n,
+    )
+
+
+def test_no_recent_perturbations_yields_no_target() -> None:
+    field = _field(recent_perturbations=[], zscore=5.0, ewma_n=10)
+    assert select_system_targets(field, POLICY) == []
+
+
+def test_no_baseline_yet_yields_no_target() -> None:
+    # count > 0 but the EWMA has never observed a second sample -- there is
+    # no baseline to be anomalous against (compute_ewma_update's own
+    # documented first-observation behavior).
+    field = _field(recent_perturbations=["a"], zscore=None, ewma_n=1)
+    assert select_system_targets(field, POLICY) == []
+
+
+def test_below_cold_start_min_samples_yields_no_target() -> None:
+    # A numeric zscore already exists, but with too few samples the
+    # variance estimate is unreliable (hand-verified: z=1000 on the second
+    # observation for a steady ramp) -- must not be trusted yet.
+    field = _field(
+        recent_perturbations=["a", "b"],
+        zscore=50.0,
+        ewma_n=RECENT_PERTURBATION_EWMA_MIN_SAMPLES - 1,
+    )
+    assert select_system_targets(field, POLICY) == []
+
+
+def test_below_baseline_deviation_is_not_salient() -> None:
+    # Quieter than usual isn't "surprising" in the sense this target cares
+    # about -- only busier-than-usual bursts should attend here.
+    field = _field(
+        recent_perturbations=["a"],
+        zscore=-2.0,
+        ewma_n=RECENT_PERTURBATION_EWMA_MIN_SAMPLES,
+    )
+    assert select_system_targets(field, POLICY) == []
+
+
+def test_elevated_deviation_below_min_salience_threshold_yields_no_target() -> None:
+    field = _field(
+        recent_perturbations=["a"],
+        zscore=0.1,  # salience = 0.1/3.0 ~= 0.033, below policy's min_salience 0.10
+        ewma_n=RECENT_PERTURBATION_EWMA_MIN_SAMPLES,
+    )
+    assert select_system_targets(field, POLICY) == []
+
+
+def test_genuine_burst_produces_a_system_target() -> None:
+    field = _field(
+        recent_perturbations=[f"label_{i}" for i in range(93)],
+        zscore=4.5,  # past the 3.0 saturation point
+        ewma_n=RECENT_PERTURBATION_EWMA_MIN_SAMPLES,
+    )
+    targets = select_system_targets(field, POLICY)
+    assert len(targets) == 1
+    target = targets[0]
+    assert target.target_id == "field:recent_perturbations"
+    assert target.target_kind == "system"
+    assert target.salience_score == 1.0  # saturates at zscore >= 3.0
+    assert "93" in target.reasons[0]


### PR DESCRIPTION
## Summary

- Live-confirmed both consumers of `FieldStateV1.recent_perturbations` were permanently pinned at their ceiling under completely normal traffic: `select_system_targets`'s `count/10.0` and `collect_field_channel_pressures`'s `count/20.0`, real steady state is ~100-118 in the 60s window (5-10x past both).
- Replaced both fixed caps with a z-score against a per-tick EWMA baseline of the count, reusing `orion/bus/ewma.py::compute_ewma_update` (the same methodology already proven for `bus_synaptic_prediction_error`'s `gap_zscore`) instead of reinventing it.
- Added a cold-start `RECENT_PERTURBATION_EWMA_MIN_SAMPLES=5` gate after hand-verifying the shared EWMA utility produces wildly unreliable z-scores on the first few samples (z=1000 on the second-ever observation for a steady ramp).
- New `FieldStateV1` fields are additive with safe defaults (`extra="forbid"` model, backward-compatible with old persisted rows, same precedent as the existing `recent_perturbation_at` field).

## Outcome moved

`field:recent_perturbations`'s attention salience and the `recent_perturbation_count` pressure channel now discriminate real bursts from normal mesh churn, instead of reading "maximum surprise" essentially always.

## Current architecture

`recent_perturbations` is correctly pruned to a rolling 60s wall-clock window (2026-07-16 fix, confirmed still correct live). Two consumers read `len(...)` off an absolute fixed cap:
- `orion/attention/field_attention/selectors.py::select_system_targets` — `salience = min(1.0, count/10.0)`
- `orion/field/pressure.py::collect_field_channel_pressures` — `recent_perturbation_count = clamp01(min(1.0, n/20.0))`

Both caps predate any live-traffic calibration.

## Architecture touched

- `orion/schemas/field_state.py`: 4 new `FieldStateV1` fields (EWMA state).
- `services/orion-field-digester/app/digestion/perturbation.py`: producer, updates the EWMA once per tick after pruning.
- `orion/field/pressure.py` / `orion/attention/field_attention/selectors.py`: consumers, now z-score-based.

## Files changed

- `orion/schemas/field_state.py`: adds `recent_perturbation_ewma`, `recent_perturbation_ewma_var`, `recent_perturbation_ewma_n`, `recent_perturbation_zscore`, with a documented known-limitation note (cold-start-after-restart ramp, see Risks below).
- `services/orion-field-digester/app/digestion/perturbation.py`: new `_update_recent_perturbation_baseline()`, `RECENT_PERTURBATION_RATE_EWMA_ALPHA=0.02`.
- `orion/field/pressure.py`: `RECENT_PERTURBATION_ZSCORE_SATURATION=3.0` (reuses the existing z>=3.0 anomaly convention already live elsewhere), `RECENT_PERTURBATION_EWMA_MIN_SAMPLES=5`, rewritten `recent_perturbation_count` block.
- `orion/attention/field_attention/selectors.py`: `select_system_targets` rewritten to use the zscore + gate, imports the two shared constants from `pressure.py`.
- `services/orion-field-digester/tests/test_perturbation_recency.py`: trimmed two assertions that tested the now-removed absolute-count semantics; kept list-pruning assertions unchanged.
- `services/orion-field-digester/tests/test_recent_perturbation_baseline.py` (new): cold-start, min-samples gating, steady-state-does-not-saturate, burst-is-flagged (against a genuinely converged baseline), burst-recovers-not-pinned-forever.
- `tests/test_attention_field_selectors.py` (new): consumer-side gating/scaling tests for `select_system_targets`.

## Schema / bus / API changes

- Added: `FieldStateV1.recent_perturbation_ewma`, `.recent_perturbation_ewma_var`, `.recent_perturbation_ewma_n`, `.recent_perturbation_zscore` (all with safe defaults).
- Removed: nothing.
- Renamed: nothing.
- Behavior changed: `recent_perturbation_count` channel and `field:recent_perturbations` attention target salience are now baseline-relative instead of absolute-count-capped.
- Compatibility notes: additive fields on an `extra="forbid"` model, verified an old persisted row (missing these keys) loads fine with defaults. No bus channel or registry changes needed — same schema version (`field.state.v1`), same precedent as the 2026-07-16 `recent_perturbation_at` addition.

## Env/config changes

None.

## Tests run

```text
pytest services/orion-field-digester/tests tests/test_attention_field_selectors.py orion/bus/tests/test_ewma.py -q
173 passed
```
Also ran the broader field/attention/hub regression surface (`test_field_state_schemas.py`, `test_attention_frame_builder.py`, `test_field_deterministic_replay.py`, `test_field_digestion_rules.py`, `test_field_topology_reconciliation.py`, hub field-channel-glossary/debug-api tests, substrate-runtime field/attention-tagged tests) -- all pass except one pre-existing failure (`test_channels_endpoint_returns_35_entries`, confirmed failing identically on unmodified `main`, unrelated to this patch).

## Evals run

No eval harness exists for this seam; none added (thin numeric fix, covered by the deterministic tests above).

## Docker/build/smoke checks

Not applicable -- pure Python logic change, no runtime/config/dependency surface touched. Live production data (not a smoke test) was used up front to diagnose the bug via `curl http://localhost:8080/api/substrate/field/latest` against the running `orion-athena-hub` container.

## Review findings fixed

- Finding: `field_state.py`'s docstring said "zscore is None until `recent_perturbation_ewma_n >= 1`", which is imprecise (after the *first* call `ewma_n` is already 1 while zscore is still `None`; zscore only becomes numeric from the second call).
  - Fix: reworded to state the exact per-call semantics.
  - Evidence: `orion/schemas/field_state.py` comment above the new fields.
- Finding: `test_genuine_burst_above_established_baseline_is_flagged`'s 20-tick "baseline" wasn't actually converged (hand-simulation showed ~0.97 with no burst at all, purely from ramp-up) -- the test would have passed even with the burst deleted, and this also surfaces a real, smaller-scope residual gap: a genuinely fresh `FieldStateV1` (first deploy, or a store wipe like the 2026-07-23 Postgres disk-death incident) reads elevated for several minutes regardless of real activity, which `RECENT_PERTURBATION_EWMA_MIN_SAMPLES` does not protect against (it only guards the separate few-sample variance-noise problem).
  - Fix: rewrote the test to establish a genuinely-settled 150-tick baseline first (asserting the pre-burst reading is actually low before injecting the burst), matching the already-verified convergence point. Documented the cold-start-after-restart gap explicitly in `field_state.py` as an accepted, time-boxed, self-healing known limitation rather than silently leaving it unaddressed.
  - Evidence: `services/orion-field-digester/tests/test_recent_perturbation_baseline.py::test_genuine_burst_above_established_baseline_is_flagged`, `orion/schemas/field_state.py` known-limitation comment.

## Restart required

```text
No restart required for this branch to be reviewed/merged. Once merged and deployed,
services/orion-field-digester (producer) and any process importing
orion.attention.field_attention.selectors / orion.field.pressure (consumers) should be
restarted to pick up the new EWMA fields -- the schema change is backward compatible so
this is not urgent, but stale-in-memory instances won't populate the new fields until
restarted.
```

## Risks / concerns

- Severity: low
- Concern: cold-start-after-restart transient -- a genuinely fresh `FieldStateV1` reads elevated for several minutes of real wall-clock time regardless of actual activity (the EWMA min-samples gate only guards the separate small-sample variance-noise problem, not this ramp-up window).
- Mitigation: documented explicitly in `orion/schemas/field_state.py`; bounded (self-heals within minutes) and does not affect the steady-state (i.e. normal long-running-service) case, which is the one the live production evidence showed was actually broken. A real follow-up would gate on elapsed wall-clock time since state init rather than sample count alone -- left out of this patch to keep it thin.

## PR link

(created by this command)