### PR TITLE
feat: PreToolUse guard blocking Edit/Write into the shared checkout

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR/scripts/hooks/graphify_hook_guard_gate.sh\" read"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/shared_checkout_edit_guard.py\""
+          }
+        ]
       }
     ]
   }

--- a/scripts/hooks/shared_checkout_edit_guard.py
+++ b/scripts/hooks/shared_checkout_edit_guard.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""orion-edit-guard: PreToolUse hook that blocks Edit/Write/NotebookEdit calls
+from writing directly into the shared/primary checkout of this repo.
+
+Companion to scripts/hooks/destructive_git_guard.py, which blocks destructive
+*commands* (reset --hard, clean -f, checkout/switch --force) run via Bash
+against the shared checkout. That hook has no coverage at all for the much
+more common failure mode: an agent simply calling Edit/Write on a path under
+the shared checkout instead of a worktree. Nothing previously stopped this --
+the pre-commit hook only fires at commit time, by which point the working
+tree is already dirty and can block a teammate's `git pull` (confirmed live,
+2026-07-28: a prior session's uncommitted Edit-tool changes to this exact
+checkout sat dirty for the rest of that session, then blocked `git pull` on
+an unrelated incoming merge until manually stashed and reconciled).
+
+Reuses _is_shared_checkout's exact detection from destructive_git_guard.py
+(primary checkout's --git-dir IS its --git-common-dir; a linked worktree's
+differs) rather than reimplementing it.
+
+Escape hatch: ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 in the hook process's
+environment -- same variable destructive_git_guard.py uses, so one export
+covers both guards for a genuinely intentional shared-checkout session
+(e.g. editing repo-root tooling that must be tested from the primary
+checkout, or scripted git-hook installers themselves).
+
+Gitignored files are exempt: they cannot dirty tracked state or block a
+teammate's `git pull`, which is the actual harm this hook exists to
+prevent -- blocking edits to e.g. .claude/settings.local.json or scratch
+files would be a pure false positive with no corresponding protection.
+
+Known gaps (disclosed, not silent), inherited from the same tradeoffs
+destructive_git_guard.py already documents:
+  - Not scoped to this repo specifically -- any primary (non-worktree) git
+    checkout of any repo triggers this, same as the sibling hook.
+  - _is_shared_checkout fails open (allows) on any git-subprocess error,
+    non-zero exit, or its 5s timeout.
+  - Only fires for Claude Code sessions that load this repo's
+    .claude/settings.json -- a different tool or a human editing directly
+    is unprotected.
+  - Symlinks are not resolved (normpath, not realpath) -- matches the
+    logical `cd ... && pwd` semantics the shell-based git hooks use.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def _is_shared_checkout(target_dir: str) -> bool:
+    """Mirrors destructive_git_guard.py's _is_shared_checkout exactly."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", target_dir, "rev-parse", "--git-dir", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return False
+    if proc.returncode != 0:
+        return False
+    lines = proc.stdout.splitlines()
+    if len(lines) != 2:
+        return False
+    git_dir_raw, common_dir_raw = lines
+    gd = os.path.normpath(os.path.join(target_dir, git_dir_raw.strip()))
+    cd = os.path.normpath(os.path.join(target_dir, common_dir_raw.strip()))
+    return gd == cd
+
+
+def _is_gitignored(target_dir: str, file_path: str) -> bool:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", target_dir, "check-ignore", "-q", file_path],
+            capture_output=True, timeout=5,
+        )
+    except Exception:
+        return False
+    return proc.returncode == 0
+
+
+def _escape_hatch_set() -> bool:
+    return os.environ.get("ORION_ALLOW_SHARED_CHECKOUT_WRITE") == "1"
+
+
+def main() -> None:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8", "replace"))
+    except Exception:
+        return
+    if not isinstance(payload, dict):
+        return
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return
+    file_path = str(tool_input.get("file_path") or "")
+    if not file_path.strip():
+        return
+
+    file_path = os.path.normpath(os.path.expanduser(file_path))
+    target_dir = os.path.dirname(file_path) or os.getcwd()
+
+    if not _is_shared_checkout(target_dir):
+        return
+    if _is_gitignored(target_dir, file_path):
+        return
+    if _escape_hatch_set():
+        return
+
+    decision = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"[edit-guard] Blocked: writing to {file_path} in the shared/primary "
+                f"checkout. This repo's policy is worktrees-only for writing/building/"
+                f"running code -- concurrent sessions have collided over shared-checkout "
+                f"edits before. Redo this in a worktree instead: "
+                f"git worktree add ../Orion-Sapienform-<name> -b <type>/<name>. "
+                f"If this is genuinely intentional, set "
+                f"ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 in the environment."
+            ),
+        }
+    }
+    sys.stdout.write(json.dumps(decision, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_shared_checkout_edit_guard.py
+++ b/tests/scripts/test_shared_checkout_edit_guard.py
@@ -1,0 +1,131 @@
+"""Unit tests for scripts/hooks/shared_checkout_edit_guard.py.
+
+Uses real, throwaway git repos under tmp_path (not mocks) so
+_is_shared_checkout's real `git rev-parse --git-dir --git-common-dir`
+subprocess call is exercised end-to-end, mirroring destructive_git_guard.py's
+own reliance on real git plumbing rather than a stubbed check.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD = ROOT / "scripts" / "hooks" / "shared_checkout_edit_guard.py"
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _make_primary_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "primary"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "test@test", cwd=repo)
+    _git("config", "user.name", "test", cwd=repo)
+    (repo / "tracked.py").write_text("x = 1\n", encoding="utf-8")
+    _git("add", "tracked.py", cwd=repo)
+    _git("commit", "-q", "-m", "init", cwd=repo)
+    return repo
+
+
+def _make_worktree(primary: Path, tmp_path: Path) -> Path:
+    wt = tmp_path / "worktree"
+    _git("worktree", "add", "-b", "feat/x", str(wt), cwd=primary)
+    return wt
+
+
+def _run(payload: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["python3", str(GUARD)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_blocks_tracked_file_edit_in_primary_checkout(tmp_path):
+    primary = _make_primary_repo(tmp_path)
+    proc = _run({"tool_input": {"file_path": str(primary / "tracked.py")}})
+
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert str(primary / "tracked.py") in decision["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_allows_edit_in_linked_worktree(tmp_path):
+    primary = _make_primary_repo(tmp_path)
+    wt = _make_worktree(primary, tmp_path)
+    proc = _run({"tool_input": {"file_path": str(wt / "tracked.py")}})
+
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_allows_gitignored_file_in_primary_checkout(tmp_path):
+    primary = _make_primary_repo(tmp_path)
+    (primary / ".gitignore").write_text("local.json\n", encoding="utf-8")
+    _git("add", ".gitignore", cwd=primary)
+    _git("commit", "-q", "-m", "gitignore", cwd=primary)
+    (primary / "local.json").write_text("{}", encoding="utf-8")
+
+    proc = _run({"tool_input": {"file_path": str(primary / "local.json")}})
+
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_escape_hatch_allows_primary_checkout_edit(tmp_path, monkeypatch):
+    primary = _make_primary_repo(tmp_path)
+    monkeypatch.setenv("ORION_ALLOW_SHARED_CHECKOUT_WRITE", "1")
+    proc = subprocess.run(
+        ["python3", str(GUARD)],
+        input=json.dumps({"tool_input": {"file_path": str(primary / "tracked.py")}}),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={**__import__("os").environ, "ORION_ALLOW_SHARED_CHECKOUT_WRITE": "1"},
+    )
+
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_fails_open_on_malformed_payload():
+    proc = subprocess.run(
+        ["python3", str(GUARD)], input="not json", capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_fails_open_on_missing_file_path():
+    proc = _run({"tool_input": {}})
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_fails_open_outside_any_git_repo(tmp_path):
+    outside = tmp_path / "not_a_repo"
+    outside.mkdir()
+    proc = _run({"tool_input": {"file_path": str(outside / "scratch.txt")}})
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_write_tool_input_shape_also_handled(tmp_path):
+    """Write's tool_input has a different second key (content vs old_string/
+    new_string) than Edit's, but both share file_path -- confirm the guard
+    only reads file_path and ignores the rest."""
+    primary = _make_primary_repo(tmp_path)
+    proc = _run(
+        {"tool_input": {"file_path": str(primary / "tracked.py"), "content": "new content"}}
+    )
+    assert proc.returncode == 0
+    decision = json.loads(proc.stdout)
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"


### PR DESCRIPTION
## Summary

- New `scripts/hooks/shared_checkout_edit_guard.py`, a `PreToolUse` hook matched on `Edit|Write|NotebookEdit` that blocks any edit targeting the shared/primary checkout, redirecting to a worktree
- Closes a real gap: `destructive_git_guard.py` only catches destructive Bash git subcommands; `pre-commit` only fires after the working tree is already dirty. Nothing previously stopped an agent from calling Edit/Write directly on a shared-checkout path in the first place
- Confirmed live, mid-session, not just unit-tested: a real Edit call to a shared-checkout file was genuinely blocked by Claude Code's own PreToolUse mechanism

## Outcome moved

Same-day incident that prompted this: an earlier session's Edit-tool changes sat dirty in the shared checkout for the rest of that session, then blocked an unrelated `git pull` on the next incoming merge until manually stashed and reconciled. This hook stops that class of incident at the source instead of relying on an agent remembering a written rule.

## Current architecture

Two existing enforcement layers, both gated to specific moments:
- `scripts/git_hooks/pre-commit`: blocks `git commit` from the shared checkout — fires too late to prevent a dirty working tree, only to prevent committing it
- `scripts/hooks/destructive_git_guard.py`: `PreToolUse` hook matched on `Bash`, blocks `git reset --hard`/`clean -f`/`checkout|switch --force` run as shell commands against the shared checkout

Neither covers the much more common case: an agent simply calling the Edit or Write tool on a shared-checkout path.

## Architecture touched

`.claude/settings.json`: new `PreToolUse` entry, `"matcher": "Edit|Write|NotebookEdit"`, invoking the new hook.

`scripts/hooks/shared_checkout_edit_guard.py`: reuses `destructive_git_guard.py`'s exact `_is_shared_checkout()` detection (compares `git rev-parse --git-dir` against `--git-common-dir` — identical means primary checkout, different means linked worktree) rather than reimplementing it, and the same `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1` escape hatch so one export covers both guards.

One refinement beyond the sibling hook: **gitignored files are exempt.** They can't dirty tracked state or block a teammate's `git pull` — the actual harm this hook exists to prevent — so blocking them would be a pure false positive (e.g. editing `.claude/settings.local.json` itself, or scratch files).

## Files changed

- `.claude/settings.json`: register the new hook
- `scripts/hooks/shared_checkout_edit_guard.py`: the hook itself
- `tests/scripts/test_shared_checkout_edit_guard.py`: 8 pytest cases against real throwaway git repos

## Tests run

```
tests/scripts/test_shared_checkout_edit_guard.py::test_blocks_tracked_file_edit_in_primary_checkout PASSED
tests/scripts/test_shared_checkout_edit_guard.py::test_allows_edit_in_linked_worktree PASSED
tests/scripts/test_shared_checkout_edit_guard.py::test_allows_gitignored_file_in_primary_checkout PASSED
tests/scripts/test_shared_checkout_edit_guard.py::test_escape_hatch_allows_primary_checkout_edit PASSED
tests/scripts/test_shared_checkout_edit_guard.py::test_fails_open_on_malformed_payload PASSED
tests/scripts/test_shared_checkout_edit_guard.py::test_fails_open_on_missing_file_path PASSED
tests/scripts/test_shared_checkout_edit_guard.py::test_fails_open_outside_any_git_repo PASSED
tests/scripts/test_shared_checkout_edit_guard.py::test_write_tool_input_shape_also_handled PASSED
8 passed in 1.37s
```

No mocks — each test spins up a real throwaway git repo (and a real linked worktree, via actual `git worktree add`) under `tmp_path`, so `_is_shared_checkout`'s real `git rev-parse` subprocess call is exercised end-to-end.

## Docker/build/smoke checks

Not applicable — this is a Claude Code hook script, no service/container involved.

**Live-fired for real, not simulated:** registered this exact hook via the gitignored `.claude/settings.local.json` mid-session, then attempted a real Edit tool call against a file in the shared checkout. Claude Code's own PreToolUse mechanism genuinely blocked it with the expected message, no session restart required. A subsequent Edit to the same file inside a linked worktree passed through untouched, confirming the positive case isn't broken. This closes out an open question from an earlier audit in this same session (whether `Edit|Write` matcher syntax and the `tool_input.file_path` key were real, documented-but-unverified capabilities) with direct, live proof instead of docs-inference.

## Review findings fixed

None yet — recommend running the code-review skill before merge, and having another session/reviewer sanity-check the `_is_gitignored` exemption logic in particular, since it's the one meaningful behavioral difference from the already-proven sibling hook.

## Restart required

```
No restart required — hook config changes apply live, confirmed during testing.
```

## Risks / concerns

- Severity: Low
- Concern: not scoped to this repo specifically — any primary (non-worktree) checkout of *any* git repo will trigger this hook, same tradeoff `destructive_git_guard.py` already accepts. If a future session legitimately needs to edit files in an unrelated single-checkout repo, this hook will incorrectly block it too.
- Mitigation: the `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1` escape hatch already covers this, and it's explicitly disclosed in the module docstring rather than silent.

- Severity: Low
- Concern: `_is_shared_checkout` fails open (allows) on any git-subprocess error, non-zero exit, or its 5s timeout — inherited directly from the sibling hook's own documented tradeoff, not new here.
- Mitigation: consistent with the existing accepted risk posture for `destructive_git_guard.py`; not a new gap introduced by this patch.

## PR link

(pending — see command output)