### PR TITLE
chore(scripts): disk watchdog follow-up — recover stranded PATH fix + monitor 5 more mounts

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-followup-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-followup-pr.md
@@ -1,6 +1,6 @@
 # PR report — disk threshold watchdog follow-up: recover stranded crontab fix + expand to 8 mounts
 
-PR: (create at https://github.com/junebug-junie/Orion-Sapienform/pull/new/chore/disk-threshold-watchdog-followup)
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1440
 Branch: `chore/disk-threshold-watchdog-followup`
 Status: **DONE**
 
@@ -199,4 +199,4 @@ primary checkout is on the merged commit).
 
 ## PR link
 
-<link>
+https://github.com/junebug-junie/Orion-Sapienform/pull/1440

--- a/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-followup-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-followup-pr.md
@@ -1,0 +1,202 @@
+# PR report — disk threshold watchdog follow-up: recover stranded crontab fix + expand to 8 mounts
+
+PR: (create at https://github.com/junebug-junie/Orion-Sapienform/pull/new/chore/disk-threshold-watchdog-followup)
+Branch: `chore/disk-threshold-watchdog-followup`
+Status: **DONE**
+
+## Summary
+
+- PR #1425 (the original disk threshold watchdog) merged into `main`
+  *before* two follow-up commits pushed to that branch landed --
+  `docs(bootstrap): flag host crontab jobs must be reinstalled on a new
+  machine` did make it into `main` (a keyword-grep on the commit message
+  falsely suggested otherwise; verified via `git merge-base
+  --is-ancestor`), but `fix(docs): disk-threshold-watchdog crontab line
+  needs venv PATH prefix` did not. GitHub does not retroactively pull in
+  commits pushed to a branch after that branch's PR has already merged.
+  Recovered by cherry-picking the missing commit onto a fresh branch off
+  current `main` (the old branch itself is stale relative to `main` by
+  ~90 unrelated files from other merged work, so opening a PR directly
+  from it would have shown a misleading diff).
+- Expanded `scripts/disk_threshold_watchdog.py`'s `DEFAULT_PATHS` from 3
+  mounts to 8: added `/` (root), `/mnt/postgres`, `/mnt/graphdb`,
+  `/mnt/storage-warm`, and `/mnt/storage-lukewarm` per Juniper's request.
+  All confirmed via `df -h` to be genuinely distinct physical filesystems
+  on this host (`/dev/mapper/ubuntu--vg-ubuntu--lv`, `/dev/sdg1`,
+  `/dev/sdg2`, `/dev/sdc`, `/dev/sdh` respectively), not bind mounts of an
+  already-monitored path.
+- Purely additive to the data, not the logic -- `evaluate_path()`,
+  `run()`, `_publish_attention()`, and the flock-guarded state machine
+  from PR #1425 (already code-reviewed, including the critical
+  retry-on-failed-notify fix) are unchanged.
+- Live crontab on this host was also directly edited (with explicit
+  operator go-ahead) to add the `PATH=`/`cd` prefixes the earlier fix
+  documented -- confirmed via `crontab -l` before and after, only the
+  disk-threshold-watchdog line touched, the other 3 jobs (fuseki
+  recover/compact, concept-relation-digest) left untouched.
+
+## Outcome moved
+
+The disk threshold watchdog now covers every distinct physical mount on
+this host, not just the original 3. The previously-documented crontab fix
+(required for the watchdog to actually run under cron rather than crash
+on `ModuleNotFoundError: No module named 'pydantic'`) is now actually
+reachable from `main`, not stranded on a closed PR's branch.
+
+## Current architecture
+
+`scripts/disk_threshold_watchdog.py` (PR #1425, merged) already
+implements the full threshold/debounce/retry/notify state machine.
+Nothing in that logic touches path count or path shape -- `DEFAULT_PATHS`
+is a flat tuple consumed only via `--paths` CLI parsing (comma-split) and
+iterated as opaque dict keys in `run()`'s per-path loop. Verified (by
+code review, see below) that no code anywhere assumes a `/mnt/...` shape
+or does prefix-matching between paths, so adding `/` and more `/mnt/*`
+mounts required zero logic changes.
+
+## Architecture touched
+
+None beyond the one script's default config and its tests/docs. No
+schema, bus, or service changes.
+
+## Files changed
+
+- `scripts/disk_threshold_watchdog.py`: `DEFAULT_PATHS` grown from 3 to 8
+  entries; module docstring's mount list and `df -h` device mapping
+  updated to match.
+- `tests/test_disk_threshold_watchdog.py`: renamed
+  `test_default_paths_include_docker_scripts_telemetry` ->
+  `test_default_paths_include_all_eight_host_mounts`, asserts the full
+  8-tuple in order.
+- `scripts/README.md`: "Disk Threshold Watchdog" section's prose and
+  expected-output example updated to all 8 paths with a fresh live
+  snapshot; also carries the recovered `PATH=` crontab fix (was already
+  correct content, just needed to actually land in `main`).
+- `docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-pr.md`:
+  carries the recovered `PATH=` fix's post-push correction note (same
+  reason as above).
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. `DEFAULT_PATHS` is a Python constant, not an env-driven value
+(`--paths`/`$DISK_WATCHDOG_PATHS` already existed as an override
+mechanism from PR #1425 and needed no changes).
+
+## Tests run
+
+```text
+source venv/bin/activate && python -m py_compile scripts/disk_threshold_watchdog.py
+=> OK
+
+PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py -q
+=> 35 passed
+
+PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py tests/test_bus_core_health_watchdog.py -q
+=> 84 passed
+
+git diff --check
+=> clean
+```
+
+## Evals run
+
+None applicable -- same deterministic gate-style script as PR #1425, no
+eval harness needed.
+
+## Docker/build/smoke checks
+
+No Docker involved. Live smoke against all 8 real mounts on this host:
+
+```text
+$ PYTHONPATH=. python3 scripts/disk_threshold_watchdog.py --threshold-pct 90 --json
+/               status=ok used=20.1%
+/mnt/docker           status=ok used=81.1%
+/mnt/scripts          status=ok used=6.8%
+/mnt/telemetry        status=ok used=18.6%
+/mnt/postgres         status=ok used=14.8%
+/mnt/graphdb          status=ok used=0.0%
+/mnt/storage-warm     status=ok used=34.1%
+/mnt/storage-lukewarm status=ok used=7.4%
+exit: 0
+```
+
+Cross-checked against `df -h` for the same 8 mounts at review time -- all
+within normal drift, no inversions or copy-paste errors between lines
+(`/mnt/graphdb`'s 0.0% vs. df's rounded 1% is expected:
+`shutil.disk_usage()`'s `used/total` differs slightly from df's
+`used/(used+avail)` reserved-blocks formula, most visible on a
+near-empty filesystem).
+
+Also directly edited and verified the live host crontab (explicit
+operator request, "put it in the cron for me" for the earlier PATH= fix):
+
+```text
+$ crontab -l | tail -3
+# alerts for disk fullness on /mnt/[docker,scripts,telemetry] -- needs the venv
+# PATH prefix because disk_threshold_watchdog.py imports orion.notify.client
+# (pydantic/requests), unlike bus_core_health_watchdog.py which is stdlib-only
+*/15 * * * * cd /mnt/scripts/Orion-Sapienform && PATH=/mnt/scripts/Orion-Sapienform/venv/bin:$PATH make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
+```
+
+Confirmed via a fully cron-simulated environment (`env -i`, minimal
+`PATH`, no inherited cwd) both broken (bare `make`, no `cd`/`PATH=`) and
+fixed, before installing the fixed line live.
+
+## Review findings fixed
+
+Code review (`orion-repo-agent`, medium effort, scoped to the additive
+mount-expansion diff since the underlying state-machine logic already got
+a full high-effort review in PR #1425):
+
+- **Finding (SHOULD FIX)**: the mount-expansion diff existed only as
+  uncommitted working-tree changes at review time, not a commit -- a
+  `git worktree remove` or accidental `git checkout --` could have
+  silently lost it with nothing to recover.
+  - **Fix**: committed (`261bb51af`) immediately after the review
+    returned.
+  - **Evidence**: `git log --oneline -1` / `git status --short` now
+    clean.
+- **Finding (informational, confirmed clean)**: verified no code path
+  anywhere in the script special-cases or prefix-matches on path shape --
+  `/` (root) and `/mnt/storage-warm`/`/mnt/storage-lukewarm` (prefix
+  substrings of each other) are all handled as opaque exact-match dict
+  keys throughout `evaluate_path()`, `run()`, `_publish_attention()`, and
+  the log-line f-string. No double-slash or malformed output for `/`.
+- **Finding (informational, confirmed clean)**: diff scope is genuinely
+  narrow -- confirmed no changes to any state-machine/locking/notify
+  logic, only the data (`DEFAULT_PATHS`) and matching docs/tests.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+Standalone host-level script, same as PR #1425. The live crontab line was
+already updated as part of this same session (see Docker/build/smoke
+checks above) -- the expanded 8-mount coverage takes effect on the next
+`*/15 * * * *` tick once this branch's code is what the crontab's
+`cd /mnt/scripts/Orion-Sapienform` resolves to (i.e. once merged and the
+primary checkout is on the merged commit).
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `/mnt/docker` remains the mount closest to the default 90%
+  threshold on this host (81-86% observed across this session) --
+  expected to be the first real Pending Attention card once this ships,
+  not a bug.
+- Severity: low
+- Concern: this is the second time in one day a commit got stranded by a
+  PR merging before a later push landed. No process gap identified beyond
+  "check `git merge-base --is-ancestor <sha> origin/main` before assuming
+  a pushed commit made it into a merged PR" -- not proposing new tooling
+  for a two-occurrence pattern, just noting it.
+
+## PR link
+
+<link>

--- a/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-pr.md
@@ -257,8 +257,21 @@ sudo chown "$(whoami)":"$(whoami)" /mnt/telemetry/orion-athena/disk-watchdog
 
 crontab -e
 # then paste:
-*/15 * * * * cd /mnt/scripts/Orion-Sapienform && make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
+*/15 * * * * cd /mnt/scripts/Orion-Sapienform && PATH=/mnt/scripts/Orion-Sapienform/venv/bin:$PATH make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
 ```
+
+**Post-push correction (2026-07-28):** the crontab line originally
+documented here omitted the `PATH=.../venv/bin:$PATH` prefix. When
+Juniper actually installed it, `make disk-threshold-watchdog` ran under
+cron's own minimal `PATH` (not an activated shell), which resolved
+`python3` to the system interpreter and crashed on
+`ModuleNotFoundError: No module named 'pydantic'` (this script imports
+`orion.notify.client`, unlike `bus_core_health_watchdog.py`, whose
+crontab line has no such requirement since it imports nothing outside the
+stdlib). Live-confirmed with `env -i PATH="/usr/bin:/bin" ... python3 -c
+"import pydantic"` failing, and the venv's `python3 -c "import pydantic"`
+succeeding. Fixed in this file and in `scripts/README.md`; the line above
+is the corrected version.
 
 ## Risks / concerns
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,18 +67,24 @@ bus_core_health_watchdog: OK -- no crash-loop signature.
 ```
 
 ## Disk Threshold Watchdog (Hub Pending Attention on low disk)
-Nothing previously watched host disk usage on `/mnt/docker`, `/mnt/scripts/`, and `/mnt/telemetry` (three distinct physical mounts on this host, confirmed via `df -h`) and surfaced a breach anywhere an operator would see it. This script checks `shutil.disk_usage()` on each path; the first time a path crosses `--threshold-pct` (default 90), it fires one `orion-notify` `/attention/request` (the same mechanism `orion-mesh-guardian` uses), which lands as a Hub Pending Attention card. Debounced via local state so it does not refire every tick while still breached — recovery clears the debounce silently (Pending Attention cards are ack'd by a human, not auto-resolved). A path that can't be statted at all (permission error, vanished mount) also fires, at `severity=error`. Requires `PYTHONPATH=.` (imports `orion.notify.client`) and `orion-notify` reachable at `NOTIFY_BASE_URL` (default `http://localhost:7140`, the host-reachable port — not the Docker-internal hostname).
+Nothing previously watched host disk usage on `/`, `/mnt/docker`, `/mnt/scripts/`, `/mnt/telemetry`, `/mnt/postgres`, `/mnt/graphdb`, `/mnt/storage-warm`, and `/mnt/storage-lukewarm` (eight distinct physical mounts on this host, confirmed via `df -h`) and surfaced a breach anywhere an operator would see it. This script checks `shutil.disk_usage()` on each path; the first time a path crosses `--threshold-pct` (default 90), it fires one `orion-notify` `/attention/request` (the same mechanism `orion-mesh-guardian` uses), which lands as a Hub Pending Attention card. Debounced via local state so it does not refire every tick while still breached — recovery clears the debounce silently (Pending Attention cards are ack'd by a human, not auto-resolved). A path that can't be statted at all (permission error, vanished mount) also fires, at `severity=error`. Requires `PYTHONPATH=.` (imports `orion.notify.client`) and `orion-notify` reachable at `NOTIFY_BASE_URL` (default `http://localhost:7140`, the host-reachable port — not the Docker-internal hostname).
 ```bash
 PYTHONPATH=. python scripts/disk_threshold_watchdog.py
 # or: make disk-threshold-watchdog
 ```
 Expected output when all paths are under threshold:
 ```
-disk_threshold_watchdog: /mnt/docker status=ok used=79.6%
-disk_threshold_watchdog: /mnt/scripts status=ok used=6.0%
+disk_threshold_watchdog: / status=ok used=20.1%
+disk_threshold_watchdog: /mnt/docker status=ok used=81.1%
+disk_threshold_watchdog: /mnt/scripts status=ok used=6.8%
 disk_threshold_watchdog: /mnt/telemetry status=ok used=18.6%
+disk_threshold_watchdog: /mnt/postgres status=ok used=14.8%
+disk_threshold_watchdog: /mnt/graphdb status=ok used=0.0%
+disk_threshold_watchdog: /mnt/storage-warm status=ok used=34.1%
+disk_threshold_watchdog: /mnt/storage-lukewarm status=ok used=7.4%
 disk_threshold_watchdog: OK -- all paths under threshold.
 ```
+Note `/mnt/docker` runs closest to the default 90% threshold on this host of the eight monitored mounts -- expect it to be first in line for a real Pending Attention card.
 
 **One-time prerequisite** (the default state-file directory is `root:root`
 755 on this host, same class of gotcha documented for the bus-core

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,12 +88,18 @@ sudo mkdir -p /mnt/telemetry/orion-athena/disk-watchdog
 sudo chown "$(whoami)":"$(whoami)" /mnt/telemetry/orion-athena/disk-watchdog
 ```
 
-**Cron install** (run from repo root, venv activated so `python3` resolves
-to the venv interpreter with `orion-notify`'s dependencies installed):
+**Cron install.** Unlike `bus-core-health-watchdog` (zero non-stdlib
+imports), this script imports `orion.notify.client` -> pydantic/requests,
+which only exist in the repo venv -- and cron runs with its own minimal
+`PATH`, not an activated shell, so a bare `make disk-threshold-watchdog`
+line resolves `python3` to the system interpreter and fails with
+`ModuleNotFoundError: No module named 'pydantic'`. The `PATH=` prefix
+below (same pattern already used by the concept-relation-digest cron
+entry) is required, not optional:
 ```bash
 crontab -e
 # then paste:
-*/15 * * * * cd /mnt/scripts/Orion-Sapienform && make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
+*/15 * * * * cd /mnt/scripts/Orion-Sapienform && PATH=/mnt/scripts/Orion-Sapienform/venv/bin:$PATH make disk-threshold-watchdog >> /mnt/scripts/Orion-Sapienform/logs/orion-disk-threshold-watchdog.log 2>&1
 ```
 
 ## Daily Schedule Collision Check (orion-actions cadences)

--- a/scripts/disk_threshold_watchdog.py
+++ b/scripts/disk_threshold_watchdog.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """Host-level disk-usage threshold watchdog for the mount points that back
-this repo's Docker images, source checkout, and telemetry corpus.
+this repo's Docker images, source checkout, databases, graph store, and
+warm/lukewarm bulk storage tiers.
 
-Context: nothing in this repo checks disk usage on `/mnt/docker`,
-`/mnt/scripts/`, or `/mnt/telemetry` and surfaces a breach anywhere an
-operator would actually see it. Each mount is a distinct physical
-filesystem on this host (confirmed via `df -h`: `/dev/sda` -> /mnt/docker,
-`/dev/sde1` -> /mnt/scripts, `/dev/sdf1` -> /mnt/telemetry), so usage on one
-says nothing about the others -- all three are checked independently.
+Context: nothing in this repo checks disk usage on `/`, `/mnt/docker`,
+`/mnt/scripts/`, `/mnt/telemetry`, `/mnt/postgres`, `/mnt/graphdb`,
+`/mnt/storage-warm`, or `/mnt/storage-lukewarm` and surfaces a breach
+anywhere an operator would actually see it. Each mount is a distinct
+physical filesystem on this host (confirmed via `df -h`: root ->
+/dev/mapper/ubuntu--vg-ubuntu--lv, `/dev/sda` -> /mnt/docker, `/dev/sde1`
+-> /mnt/scripts, `/dev/sdf1` -> /mnt/telemetry, `/dev/sdg1` ->
+/mnt/postgres, `/dev/sdg2` -> /mnt/graphdb, `/dev/sdc` ->
+/mnt/storage-warm, `/dev/sdh` -> /mnt/storage-lukewarm), so usage on one
+says nothing about the others -- all eight are checked independently.
 
 Same category as `scripts/bus_core_health_watchdog.py` (standalone,
 host-level, cron-run, not a live service loop; pure `evaluate_path()` for
@@ -102,7 +107,16 @@ if sys.path and sys.path[0] == _SCRIPT_DIR:
 
 from orion.notify.client import NotifyClient  # noqa: E402
 
-DEFAULT_PATHS = ("/mnt/docker", "/mnt/scripts", "/mnt/telemetry")
+DEFAULT_PATHS = (
+    "/",
+    "/mnt/docker",
+    "/mnt/scripts",
+    "/mnt/telemetry",
+    "/mnt/postgres",
+    "/mnt/graphdb",
+    "/mnt/storage-warm",
+    "/mnt/storage-lukewarm",
+)
 DEFAULT_THRESHOLD_PCT = 90.0
 
 

--- a/tests/test_disk_threshold_watchdog.py
+++ b/tests/test_disk_threshold_watchdog.py
@@ -428,8 +428,17 @@ def test_main_exits_three_on_unexpected_exception(tmp_path, monkeypatch):
     assert rc == 3
 
 
-def test_default_paths_include_docker_scripts_telemetry():
-    assert watchdog.DEFAULT_PATHS == ("/mnt/docker", "/mnt/scripts", "/mnt/telemetry")
+def test_default_paths_include_all_eight_host_mounts():
+    assert watchdog.DEFAULT_PATHS == (
+        "/",
+        "/mnt/docker",
+        "/mnt/scripts",
+        "/mnt/telemetry",
+        "/mnt/postgres",
+        "/mnt/graphdb",
+        "/mnt/storage-warm",
+        "/mnt/storage-lukewarm",
+    )
 
 
 def test_default_state_file_lives_under_telemetry_root():


### PR DESCRIPTION
## Summary

- **Stranded-commit recovery**: PR #1425 (disk threshold watchdog) merged into `main` before a follow-up commit (`fix(docs): disk-threshold-watchdog crontab line needs venv PATH prefix`) reached it — GitHub doesn't retroactively pull in commits pushed to a branch after that branch's PR already merged. Recovered by cherry-picking the missing commit onto a fresh branch off current `main` (the old branch itself had drifted ~90 unrelated files behind `main` from other merged work in the meantime, so a PR from it directly would've shown a misleading diff).
- **Mount expansion**: `scripts/disk_threshold_watchdog.py`'s `DEFAULT_PATHS` grows from 3 to 8: adds `/` (root), `/mnt/postgres`, `/mnt/graphdb`, `/mnt/storage-warm`, `/mnt/storage-lukewarm`. All confirmed via `df -h` as genuinely distinct physical filesystems on this host. Purely additive to data — zero changes to the already-reviewed `evaluate_path()`/`run()`/notify/locking logic from PR #1425.
- Live host crontab was also directly edited (explicit operator go-ahead) to install the recovered `PATH=`/`cd` fix — verified via `crontab -l` before/after, only the disk-threshold-watchdog line touched.

## Test plan

- [x] `PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py -q` → 35 passed
- [x] `PYTHONPATH=. python -m pytest tests/test_disk_threshold_watchdog.py tests/test_bus_core_health_watchdog.py -q` → 84 passed
- [x] Live smoke against all 8 real host mounts, cross-checked against `df -h`
- [x] Code review (`orion-repo-agent`, medium effort, scoped to the additive diff) — one SHOULD-FIX finding (uncommitted work at review time), fixed immediately; no logic issues found
- [x] Live crontab edit verified via `crontab -l` before/after

Full PR report: `docs/superpowers/pr-reports/2026-07-28-disk-threshold-watchdog-followup-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)