### PR TITLE
fix(orion-actions): mark scheduled workflow runs completed/failed for real

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-29-workflow-schedule-completion-status-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-29-workflow-schedule-completion-status-pr.md
@@ -1,0 +1,91 @@
+## Summary
+
+- `services/orion-actions`'s workflow scheduler (the daily 06:00 `chat_history_compactor` digest and every other scheduled workflow it drives) could never report a confirmed success: `mark_dispatch_succeeded()` existed but was never called anywhere in the repo, so every dispatched run sat forever at `status="dispatched"`.
+- `_derive_analytics()`'s health formula treated "0 confirmed successes, 0 confirmed failures" as `health="healthy"` — the exact bug a user spotted in the Hub UI: `"healthy"` next to `"0/5 recent succeeded"`.
+- `_dispatch_scheduled_workflow` now blocks on an RPC reply from cortex-orch (same pattern already used by `_run_journal`/`_dispatch_scheduled_skill(wait_for_result=True)` in the same file) instead of firing the trigger and forgetting it, and threads `run_id`/`schedule_id` into the dispatch payload for correlation.
+- The scheduler's claim loop now calls `mark_dispatch_succeeded`/`mark_dispatch_failed` based on the real RPC outcome, and no longer re-raises past one failed dispatch (previously a single bad dispatch could abort the rest of the batch and skip `evaluate_attention_signals` for every sibling schedule in the same tick).
+- Health formula hardened: a schedule with recent runs but zero confirmed successes now reports `"degraded"`, not `"healthy"`.
+
+## Outcome moved
+
+The scheduler can now actually distinguish "this workflow ran and succeeded" from "we published a trigger and have no idea what happened" — a distinction it never made before. The Hub schedule panel's health badge and `N/5 recent succeeded` trend text will now agree with each other.
+
+## Current architecture
+
+`services/orion-actions/app/workflow_schedule_store.py` (`WorkflowScheduleStore`) persists `WorkflowScheduleRecordV1`/`WorkflowScheduleRunRecordV1` rows and derives a `WorkflowScheduleAnalyticsV1` (health/trend) on read. `services/orion-actions/app/main.py`'s `_scheduler_loop` (inside `lifespan`) calls `claim_due()` on a 45s tick, dispatches each due schedule to `orion-cortex-orch` over the bus, and was supposed to record the outcome back onto the run — but the success half of that loop was never wired.
+
+## Architecture touched
+
+`services/orion-actions` only — no cross-service contract change. No new bus channel, no new schema, no new env key.
+
+## Files changed
+
+- `services/orion-actions/app/main.py`: `_dispatch_scheduled_workflow` now does an RPC round-trip (reply_to + `_actions_rpc_bus.rpc_request`, timeout = `settings.actions_exec_timeout_seconds`) instead of a fire-and-forget publish, and threads `run_id`/`schedule_id` into `workflow_request["scheduled_dispatch"]`. The claim loop in `_scheduler_loop` now calls `mark_dispatch_succeeded` on success and `continue`s (rather than `raise`s) past a failed dispatch after calling `mark_dispatch_failed`.
+- `services/orion-actions/app/workflow_schedule_store.py`: `_derive_analytics()`'s degraded-health condition gained `or len(success) == 0`, so "no confirmed success among recent runs" is no longer indistinguishable from "healthy".
+- `services/orion-actions/tests/test_workflow_schedule_store.py`: two new regression tests — `test_stuck_dispatched_run_is_not_reported_healthy` (verified red against pre-fix `_derive_analytics`) and `test_confirmed_success_reports_healthy`.
+
+## Schema / bus / API changes
+
+- Added: none.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `_dispatch_scheduled_workflow` now blocks on a bus RPC reply instead of a non-blocking publish; `WorkflowScheduleAnalyticsV1.health` can now read `"degraded"` in a case that previously read `"healthy"`.
+- Compatibility notes: no payload shape changes; `scheduled_dispatch` gained two new keys (`schedule_id`, `run_id`) that no existing consumer reads yet, so this is additive.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: not applicable, no new keys.
+- local `.env` synced: not applicable.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+/mnt/scripts/Orion-Sapienform/orion_dev/bin/python -m pytest services/orion-actions/tests -q --tb=short
+102 passed, 68 warnings in 3.97s
+```
+
+Ran from the fix worktree using the main checkout's `orion_dev` venv (no venv exists per-worktree; `scripts/test_service.sh` documents this as the expected fallback path). Also hand-verified the two new tests fail against the pre-fix `_derive_analytics` (stashed the store.py change, reran, confirmed `AssertionError: assert 'healthy' != 'healthy'`, then restored the fix) before treating them as real regression coverage.
+
+## Evals run
+
+None — this service has no eval harness (`services/orion-actions/evals/` does not exist) and the change is a scheduler-bookkeeping bug fix, not a quality/behavior surface an eval would meaningfully score. Gate tests above are the appropriate coverage for this seam.
+
+## Docker/build/smoke checks
+
+Not run. This changes runtime dispatch behavior (an RPC round-trip replaces a fire-and-forget publish) inside `orion-actions`'s scheduler loop, which only fires on the real 45s scheduler tick against a live bus and a live `orion-cortex-orch` — not exercisable via `docker compose config` or a static smoke. The nested closure this touches (`_dispatch_scheduled_workflow`, inside `lifespan`) is imported and its containing `lifespan` function is exercised (compiled + partially invoked) by an existing test (`test_journal_actions.py::test_action_dedupe_try_acquire_is_thread_safe_under_concurrent_callers`, which starts `_scheduler_loop`), confirming no syntax/import errors, but that test does not drive a real claim/dispatch/RPC cycle. Recommend a live smoke on next restart: trigger a one-shot scheduled workflow, confirm the Hub schedule panel shows a `"completed"` run and `health="healthy"` after it finishes.
+
+## Review findings fixed
+
+- Finding: Sequential blocking dispatch could stall the scheduler tick for up to ~40 minutes (`batch_size=10 × timeout=240s`) under a cortex-orch outage, delaying every other daily-cadence check in the same loop iteration (goal archive, daily pulse, world pulse, metacog, journal) and re-claiming of newly-due schedules.
+  - Fix: not fixed in this patch — documented below as a known, disclosed risk rather than solved with added concurrency (`asyncio.gather`) whose thread-safety against the shared `_actions_rpc_bus` wasn't independently verified for concurrent in-flight RPCs. Deferred as a follow-up.
+  - Evidence: reviewer traced `settings.actions_exec_timeout_seconds` (240.0s default, `settings.py:90`) and `settings.actions_workflow_schedule_claim_batch_size` (10 default, `settings.py:164`) against the sequential `for claimed in ...` loop.
+- Finding: The new `len(success) == 0` degraded-health branch also fires during the normal in-flight window of every routine dispatch (between `claim_due()` persisting `status="dispatched"` and the RPC reply landing), not only genuinely stuck runs.
+  - Fix: not fixed — confirmed cosmetic-only. `evaluate_attention_signals()` only treats `"degraded"` as an active attention condition when `recent_failure_count >= 2`, which is `0` during this window, so no false notification/page fires. Left as documented behavior rather than adding a separate `"pending"` health state (would require touching the frontend's health enum and the schema's `Literal[...]`, disproportionate to a cosmetic dashboard flash).
+  - Evidence: reviewer traced `evaluate_attention_signals()` (`workflow_schedule_store.py` ~280) and confirmed the `recent_failure_count >= 2` gate.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-actions/.env \
+  -f services/orion-actions/docker-compose.yml \
+  up -d --build orion-actions
+```
+
+## Risks / concerns
+
+- Severity: Moderate.
+  Concern: cortex-orch slowness/outage now delays the scheduler's own tick (up to ~40 min worst case) instead of the old fire-and-forget publish, which was near-instant regardless of downstream health.
+  Mitigation: in practice, claimed batches for this scheduler are typically size 1 (daily-cadence jobs rarely stack 10-deep), so worst-case exposure is uncommon. A follow-up could dispatch claimed items concurrently via `asyncio.gather`, but that needs the shared `_actions_rpc_bus`'s concurrent-RPC safety verified first rather than assumed.
+- Severity: Low.
+  Concern: schedule health can show a transient `"degraded"` for the ~seconds-to-minutes an RPC is in flight, even on a run that ultimately succeeds.
+  Mitigation: confirmed no false attention/notification fires from this (gated at `recent_failure_count >= 2`); purely a dashboard-view cosmetic.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/workflow-schedule-completion-status

--- a/services/orion-actions/app/main.py
+++ b/services/orion-actions/app/main.py
@@ -1697,12 +1697,15 @@ async def lifespan(app: FastAPI):
 
     async def _dispatch_scheduled_workflow(claimed: ClaimedSchedule) -> None:
         entry = claimed.schedule
+        run = claimed.run
         workflow_request = dict(entry.workflow_request or {})
         policy = dict(workflow_request.get("execution_policy") or {})
         policy["invocation_mode"] = "immediate"
         workflow_request["execution_policy"] = policy
         workflow_request["scheduled_dispatch"] = {
             "request_id": entry.request_id,
+            "schedule_id": entry.schedule_id,
+            "run_id": run.run_id,
             "source": "orion-actions",
             "scheduled_label": (entry.next_run_at.isoformat() if entry.next_run_at else "scheduled"),
         }
@@ -1723,11 +1726,23 @@ async def lifespan(app: FastAPI):
         payload["verb"] = None
         payload["route_intent"] = "none"
         payload["mode"] = "brain"
-        await dispatch_cortex_request(
-            bus=hunter.bus,
-            channel=settings.cortex_request_channel,
-            envelope=env.model_copy(update={"payload": payload}),
+        # Block on the reply (mirrors _run_journal/_dispatch_scheduled_skill) instead of
+        # firing and forgetting -- callers need the real downstream ok/error to record
+        # run status; a bare publish can't tell success from a workflow that never ran.
+        reply_channel = new_reply_channel("orion:cortex:result")
+        rpc_env = env.model_copy(update={"payload": payload, "reply_to": reply_channel})
+        msg = await _actions_rpc_bus.rpc_request(
+            settings.cortex_request_channel,
+            rpc_env,
+            reply_channel=reply_channel,
+            timeout_sec=float(settings.actions_exec_timeout_seconds),
         )
+        decoded = _actions_rpc_bus.codec.decode(msg.get("data"))
+        if not decoded.ok or decoded.envelope is None:
+            raise RuntimeError(f"cortex_orch_decode_failed:{decoded.error}")
+        orch_payload = decoded.envelope.payload if isinstance(decoded.envelope.payload, dict) else {}
+        if not orch_payload.get("ok", False):
+            raise RuntimeError(f"scheduled_workflow_failed:{orch_payload.get('error') or orch_payload.get('status')}")
 
     async def _handle_workflow_schedule(env: BaseEnvelope) -> None:
         try:
@@ -2129,21 +2144,30 @@ async def lifespan(app: FastAPI):
                     dispatch_env = BaseEnvelope(kind=WORKFLOW_TRIGGER_KIND, source=src, correlation_id=str(uuid4()), payload={})
                     try:
                         await _dispatch_scheduled_workflow(claimed)
-                        await _audit(
-                            dispatch_env,
-                            status="dispatched",
-                            event_id=claimed.schedule.request_id,
-                            action_name="workflow.dispatch.v1",
-                            extra={
-                                "schedule_id": claimed.schedule.schedule_id,
-                                "workflow_id": claimed.schedule.workflow_id,
-                                "notify_on": claimed.schedule.execution_policy.notify_on,
-                                "next_run_utc": claimed.schedule.next_run_at.isoformat() if claimed.schedule.next_run_at else None,
-                            },
-                        )
                     except Exception as exc:
                         workflow_schedule_store.mark_dispatch_failed(run_id=claimed.run.run_id, schedule_id=claimed.schedule.schedule_id, error=str(exc), now_utc=now_utc)
-                        raise
+                        logger.exception(
+                            "scheduled_workflow_dispatch_failed schedule_id=%s run_id=%s",
+                            claimed.schedule.schedule_id,
+                            claimed.run.run_id,
+                        )
+                        # Don't let one failed schedule abort the rest of this batch or
+                        # skip evaluate_attention_signals below -- each claimed slot is
+                        # independent.
+                        continue
+                    workflow_schedule_store.mark_dispatch_succeeded(run_id=claimed.run.run_id, schedule_id=claimed.schedule.schedule_id, now_utc=now_utc)
+                    await _audit(
+                        dispatch_env,
+                        status="dispatched",
+                        event_id=claimed.schedule.request_id,
+                        action_name="workflow.dispatch.v1",
+                        extra={
+                            "schedule_id": claimed.schedule.schedule_id,
+                            "workflow_id": claimed.schedule.workflow_id,
+                            "notify_on": claimed.schedule.execution_policy.notify_on,
+                            "next_run_utc": claimed.schedule.next_run_at.isoformat() if claimed.schedule.next_run_at else None,
+                        },
+                    )
                 signals = workflow_schedule_store.evaluate_attention_signals(
                     now_utc=now_utc,
                     overdue_min_seconds=settings.actions_workflow_attention_overdue_min_seconds,

--- a/services/orion-actions/app/workflow_schedule_store.py
+++ b/services/orion-actions/app/workflow_schedule_store.py
@@ -229,7 +229,10 @@ class WorkflowScheduleStore:
             health = "idle"
         elif (len(failures) >= 2 and len(success) == 0) or (is_overdue and len(success) == 0):
             health = "failing"
-        elif len(failures) >= 1 or is_overdue:
+        elif len(failures) >= 1 or is_overdue or len(success) == 0:
+            # len(success) == 0 here means every recent run is still sitting at
+            # "dispatched" (or some other non-terminal status) -- no confirmed
+            # success and no confirmed failure. That's not the same as healthy.
             health = "degraded"
         else:
             health = "healthy"

--- a/services/orion-actions/tests/test_workflow_schedule_store.py
+++ b/services/orion-actions/tests/test_workflow_schedule_store.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 from app.workflow_schedule_metrics import WorkflowScheduleMetrics
 from app.workflow_schedule_store import WorkflowScheduleStore
-from orion.schemas.workflow_execution import WorkflowDispatchRequestV1, WorkflowScheduleManageRequestV1, WorkflowScheduleUpdatePatchV1
+from orion.schemas.workflow_execution import (
+    WorkflowDispatchRequestV1,
+    WorkflowScheduleManageRequestV1,
+    WorkflowScheduleUpdatePatchV1,
+)
 
 
 def test_resolve_path_whitespace_fallback_stays_tmp() -> None:
@@ -183,6 +187,48 @@ def test_attention_signals_dedupe_and_recovery(tmp_path):
     recovered = store.evaluate_attention_signals(now_utc=datetime(2026, 3, 25, 6, 5, tzinfo=timezone.utc), reminder_cooldown_seconds=9999)
     assert len(recovered) == 1
     assert recovered[0].transition == "recovered"
+
+
+def _analytics_for(store: WorkflowScheduleStore, schedule_id: str, *, now_utc: datetime):
+    listed = store.apply_management(WorkflowScheduleManageRequestV1(operation="list", request_id="m-list"), now_utc=now_utc)
+    assert listed.ok is True
+    row = next(item for item in listed.schedules if item.schedule_id == schedule_id)
+    assert row.analytics is not None
+    return row.analytics
+
+
+def test_stuck_dispatched_run_is_not_reported_healthy(tmp_path):
+    # A claimed run that never gets mark_dispatch_succeeded/mark_dispatch_failed
+    # called on it must not be reported "healthy" just because there's also no
+    # recorded failure -- "no signal yet" is not the same as "confirmed good".
+    store = WorkflowScheduleStore(str(tmp_path / "schedules.json"))
+    created = store.upsert_from_dispatch(_dispatch("r1"))
+    assert created is not None
+    claimed = store.claim_due(now_utc=datetime(2026, 3, 24, 6, 1, tzinfo=timezone.utc))
+    assert len(claimed) == 1
+
+    analytics = _analytics_for(store, created.schedule_id, now_utc=datetime(2026, 3, 24, 6, 2, tzinfo=timezone.utc))
+    assert analytics.recent_success_count == 0
+    assert analytics.recent_failure_count == 0
+    assert analytics.health != "healthy"
+
+
+def test_confirmed_success_reports_healthy(tmp_path):
+    store = WorkflowScheduleStore(str(tmp_path / "schedules.json"))
+    created = store.upsert_from_dispatch(_dispatch("r1"))
+    assert created is not None
+    claimed = store.claim_due(now_utc=datetime(2026, 3, 24, 6, 1, tzinfo=timezone.utc))
+    assert len(claimed) == 1
+    store.mark_dispatch_succeeded(
+        run_id=claimed[0].run.run_id,
+        schedule_id=claimed[0].schedule.schedule_id,
+        now_utc=datetime(2026, 3, 24, 6, 2, tzinfo=timezone.utc),
+    )
+
+    analytics = _analytics_for(store, created.schedule_id, now_utc=datetime(2026, 3, 24, 6, 3, tzinfo=timezone.utc))
+    assert analytics.recent_success_count == 1
+    assert analytics.recent_failure_count == 0
+    assert analytics.health == "healthy"
 
 
 def test_structured_error_metrics_increment(tmp_path):


### PR DESCRIPTION
## Summary

- Orion's own internal workflow scheduler (`orion-actions`) — the daily 06:00 `chat_history_compactor` digest job and every other scheduled workflow it drives — could never report a confirmed success: `mark_dispatch_succeeded()` existed but was dead code, never called anywhere in the repo. Every dispatched run sat forever at `status="dispatched"`.
- The health formula in `_derive_analytics()` treated "0 confirmed successes, 0 confirmed failures" as `health="healthy"` — the exact confusing state a user spotted in the Hub UI: `"healthy"` next to `"0/5 recent succeeded"`.
- `_dispatch_scheduled_workflow` now blocks on an RPC reply from cortex-orch (same pattern already used by `_run_journal`/`_dispatch_scheduled_skill(wait_for_result=True)` in the same file) instead of firing the trigger and forgetting it.
- The claim loop now calls `mark_dispatch_succeeded`/`mark_dispatch_failed` based on the real outcome, and no longer aborts the rest of a dispatch batch when one schedule fails.
- Health formula hardened so "no confirmed success yet" reports `"degraded"`, not `"healthy"`.

Full PR report with review findings, risks, and test evidence: `docs/superpowers/pr-reports/2026-07-29-workflow-schedule-completion-status-pr.md`.

## Test plan

- [x] `pytest services/orion-actions/tests -q` — 102 passed
- [x] Two new regression tests verified red-before-green against the pre-fix code
- [x] Independent code review (subagent) — 2 non-blocking findings, both documented as disclosed risks in the PR report
- [ ] Live smoke on next restart: trigger a one-shot scheduled workflow, confirm Hub schedule panel shows `"completed"` + `health="healthy"` after it finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)