### PR TITLE
chore(hub): Mode/Recall Profile cleanup + debug panel modal refactor

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-29-hub-mode-cleanup-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-29-hub-mode-cleanup-pr.md
@@ -1,0 +1,114 @@
+# PR Report: Orion Hub Mode/Recall Profile cleanup + debug panel modal refactor
+
+## Summary
+
+- Killed 7 Hub chat "Mode" dropdown options (Auto, Grounded Small, Brain, Council, Agent Claude - Opus/Sonnet/Haiku); Orion remains the default, alongside Quick/Story/Agent.
+- Wired Recall Profile to auto-follow Mode: Orion mode leaves `recall_profile` unset (backend default resolution); any other mode forces `assist.light.v1`.
+- Killed "Auto" and "biographical.v1" from the Recall Profile dropdown.
+- Refactored the Hub "Debug Panel" section: removed the outer accordion (rows always visible) and converted all 9 row headers (Memory, Agent Trace, Autonomy Runtime, Chat Stance, Substrate Review, Self Experiments, Autonomy Readiness, Recall Canary, Cognitive Review) from inline dropdown-expand to opening their modal directly. Added a real modal for Autonomy Readiness (previously had none). Resized all 10 debug-panel-adjacent modals to `75vw x 75vh` centered.
+- Fixed two review findings: missing Escape-key handler for the new Autonomy Readiness modal, and a stray chat-feed "Open debug" button that still used the abandoned inline-expand pattern instead of opening the modal.
+
+## Outcome moved
+
+The Hub Mode/Recall Profile surface went from 12 dropdown options (several dead-end or redundant) down to a coherent 4+7 set with real, traceable behavior. Debug panel navigation changed from a two-level accordion (outer section + per-row inline expand, duplicated by a separate "Modal" button doing the same thing) to a single consistent interaction: click a row, get its content in a large modal.
+
+## Current architecture
+
+- `services/orion-hub/templates/index.html` renders the Hub chat UI; Mode/Compute/Recall Mode/Recall Profile selects live in a settings strip above the chat input. The "Debug Panel" section further down is a single `id="runtimeDebugPanel"` accordion nesting 9 sub-panel rows, each historically with its own inline-expand toggle *and* a separate "Modal" button doing largely the same thing.
+- `services/orion-hub/static/js/app.js` owns `HUB_MODE_SPECS` (Mode -> verb/lane/fcc-model mapping), `applyHubModeSelection()` (Mode change handler), and one `toggle*Panel()` + `open*Modal()` pair per debug-panel row.
+- `services/orion-hub/scripts/main.py` server-renders `{{HUB_AGENT_CLAUDE_MODE_OPTIONS}}` into the Mode select when `HUB_AGENT_CLAUDE_ENABLED` is set.
+- Discovered mid-task (not previously documented in this form): "Orion" Mode and the `chat_general` cognition verb are two different pipelines — Orion routes through `orion.hub.turn_orchestrator.run_unified_turn()` (harness-governed unified turn), not the verb-dispatch path. Static-trace only (not live-verified): the harness's own recall-profile resolution (`services/orion-cortex-exec/app/recall_utils.py::resolve_runtime_default_profile`) falls through to a hardcoded `"agent"` `runtime_mode` default when nothing upstream sets `ctx["mode"]`, which resolves to `chat.general.v1`. Left as `UNVERIFIED` per house rules — did not pull a live trace to confirm before scoping this PR, since the user redirected mid-investigation to a different concrete ask (mode/recall-profile linkage + debug panel modals) rather than continuing that thread.
+
+## Architecture touched
+
+- `services/orion-hub/templates/index.html`: Mode select, Recall Profile select, entire Debug Panel section markup, 10 modal dialog shells (resized), new Autonomy Readiness modal shell.
+- `services/orion-hub/static/js/app.js`: `HUB_MODE_SPECS`, `applyHubModeSelection`, new `setRecallProfileAutoState`, `normalizeRecallProfileDisplay` guard, 9 `toggle*Panel` functions, new `openAutonomyReadinessModal`/`closeAutonomyReadinessModal`/`ensureAutonomyReadinessModalRootOnBody`, `syncDebugModalScrollLock`, global Escape-key handler, one stray inline-expand button in the autonomy chat-feed summary card.
+- `services/orion-hub/scripts/main.py`: removed dead `{{HUB_AGENT_CLAUDE_MODE_OPTIONS}}` template-fill block (placeholder no longer exists in the template).
+
+## Files changed
+
+- `services/orion-hub/templates/index.html`: Mode/Recall Profile option pruning, Debug Panel accordion removal, Autonomy Readiness modal added, 10 modal dialogs resized to 75vw/75vh.
+- `services/orion-hub/static/js/app.js`: Mode spec pruning, Mode->Recall-Profile auto-linkage, 9 toggle->modal redirects, new Autonomy Readiness modal JS, Escape-key + stray-button fixes.
+- `services/orion-hub/scripts/main.py`: removed dead agent-claude Mode-option template-fill code (backend `HUB_AGENT_CLAUDE_ENABLED` feature itself untouched, see Non-goals below).
+- `services/orion-hub/tests/test_agent_trace_debug_panel.py`, `test_autonomy_runtime_ui_panel.py`, `test_chat_stance_debug_panel.py`, `test_memory_review_ui.py`: updated string-snapshot assertions to match the new dialog class/id/option set.
+- `services/orion-hub/tests/test_llm_route_selector.py`: updated one stale assertion, added 3 new tests covering the surviving Mode option set, the pruned Recall Profile option set, and the new `setRecallProfileAutoState` wiring.
+
+## Schema / bus / API changes
+
+None. This is pure Hub frontend + one dead-code removal in the template renderer.
+
+## Env/config changes
+
+None.
+
+## Non-goals (explicitly scoped out)
+
+- Did **not** remove the deeper "Agent Claude" backend (`HUB_AGENT_CLAUDE_ENABLED` setting, `agent_claude_input.py`, `fcc_claude_bridge.py`, and their tests) — only its Mode-dropdown surface. That backend has real, separate infrastructure (a whole FCC Claude Bridge) that may be reachable outside the Hub Mode dropdown; killing it outright was a much larger, unrequested change.
+- Did **not** sweep the now-permanently-hidden inline debug-panel body/caret DOM left behind by the toggle-to-modal conversion (8 of 9 rows). Several of these (confirmed: `autonomyDebugBody`) are still load-bearing — the Autonomy Runtime modal copies its content via `innerHTML` on open — so a blanket deletion would have broken a working modal. Flagged as a follow-up, not fixed here.
+- Did not live-verify whether Orion mode's recall profile actually resolves to `chat.general.v1` at runtime (see Current architecture) — static trace only.
+
+## Tests run
+
+```
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-hub/tests -q -p no:cacheprovider
+# Branch:   31 failed, 1032 passed, 5 skipped
+# Baseline (git stash to clean main, same command): 31 failed, 1028 passed, 5 skipped
+# Diff: 0 branch-only failures (no regressions). All 31 failures pre-exist on main,
+# unrelated to this change (DB/fixture-dependent tests, one unrelated JS-string
+# assertion) -- confirmed via git-stash baseline comparison, not assumed.
+```
+
+Targeted re-run after review-finding fixes:
+```
+python -m pytest services/orion-hub/tests/test_autonomy_runtime_ui_panel.py \
+  services/orion-hub/tests/test_llm_route_selector.py \
+  services/orion-hub/tests/test_chat_stance_debug_panel.py \
+  services/orion-hub/tests/test_agent_trace_debug_panel.py -q
+# 71 passed, 3 failed (same 3 pre-existing context_exec_agent_bridge failures)
+```
+
+## Evals run
+
+None — this service has no eval harness for Hub UI interaction; not something this narrow a UI cleanup would warrant standing one up for.
+
+## Docker/build/smoke checks
+
+Not run. This is a static template/JS change with no new dependencies, ports, env keys, or compose wiring; Docker rebuild is not required for these files to take effect (Hub serves `templates/`/`static/` directly). Manual browser verification of the modal interactions was not performed in this session — flagging per house rule rather than claiming UI verification that didn't happen.
+
+## Review findings fixed
+
+- Finding: New `autonomyReadinessModalRoot` modal had no Escape-key handler while every sibling debug-panel modal did.
+  - Fix: Added an `Escape` branch calling `closeAutonomyReadinessModal()` alongside the other modal branches in the global keydown handler.
+  - Evidence: `services/orion-hub/static/js/app.js`, keydown handler now has 18 modal branches (was 17), same pattern as the other 8 debug-panel-row modals.
+
+- Finding: A chat-feed "Open debug" shortcut in the autonomy summary card still directly un-hid the old inline `autonomyDebugBody`/caret instead of opening the new modal — an inconsistent leftover from the toggle-to-modal refactor.
+  - Fix: Replaced the 3-line manual un-hide with a single `openAutonomyDebugModal()` call, matching every other entry point into that content.
+  - Evidence: `services/orion-hub/static/js/app.js` around the `createAutonomySummaryPanel`-style builder (~line 7814).
+
+- Finding (not fixed, scoped out): 8 of 9 converted rows still carry permanently-hidden inline body/caret DOM that's dead from a user-interaction standpoint but, in at least one case, still load-bearing as a data source for its modal.
+  - Disposition: left in place; documented as a follow-up requiring per-row verification before any deletion.
+
+## Restart required
+
+```text
+No restart required.
+```
+Hub serves `templates/index.html` and `static/js/app.js` directly; changes take effect on next page load (may need a hard refresh / cache-bust if the browser cached the old `app.js`).
+
+## Risks / concerns
+
+- Severity: Low
+  Concern: The new `w-[75vw] h-[75vh]` modal sizing has no min-width/min-height floor, so on very small viewports the dialogs shrink proportionally with no safety clamp.
+  Mitigation: This was an explicit, deliberate user request ("cover 75% of the screen"); noted as a known trade-off rather than fixed, since a floor wasn't asked for and Hub is not currently used on small/mobile viewports as far as this session could determine.
+
+- Severity: Low
+  Concern: 8 of 9 converted debug-panel rows retain now-unreachable inline body/caret markup and the `update*Panel()` functions still write into it every time new data arrives, for no visible benefit.
+  Mitigation: None applied this PR; flagged as a follow-up. A blanket sweep needs per-row verification since at least `autonomyDebugBody` is still read by its modal's open function.
+
+- Severity: Info
+  Concern: Whether Orion mode's recall profile genuinely resolves to `chat.general.v1` at runtime was traced statically only, not live-verified, mid-conversation before the user redirected to the concrete Mode/Recall-Profile/debug-panel asks actually implemented here.
+  Mitigation: None needed for this PR's scope (Orion mode's *behavior* wasn't changed, only what recall_profile override the UI sends) — noted for whoever picks up that thread next.
+
+## PR link
+
+Not pushed / no PR opened yet — pending user confirmation before pushing to the remote per repo convention.

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -184,16 +184,6 @@ def render_hub_index_html(*, memory_pool_ok: bool | None = None) -> str:
     rendered = rendered.replace("{{HUB_AITOWN_TAB_NAV}}", aitown_nav)
     rendered = rendered.replace("{{HUB_AITOWN_PANEL}}", aitown_panel)
 
-    if bool(getattr(settings, "HUB_AGENT_CLAUDE_ENABLED", False)):
-        agent_claude_mode_options = (
-            '<option value="agent_claude_opus">Agent Claude - Opus</option>'
-            '<option value="agent_claude_sonnet">Agent Claude - Sonnet</option>'
-            '<option value="agent_claude_haiku">Agent Claude - Haiku</option>'
-        )
-    else:
-        agent_claude_mode_options = ""
-    rendered = rendered.replace("{{HUB_AGENT_CLAUDE_MODE_OPTIONS}}", agent_claude_mode_options)
-
     proposal_review_panel = ""
     proposal_review_script = ""
     if bool(getattr(settings, "HUB_PROPOSAL_REVIEW_ENABLED", False)):

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -180,9 +180,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const presenceClearButton = document.getElementById('presenceClearButton');
   const recallModeSelect = document.getElementById('recallModeSelect');
   const recallProfileSelect = document.getElementById('recallProfileSelect');
-  const runtimeDebugPanelToggle = document.getElementById('runtimeDebugPanelToggle');
-  const runtimeDebugPanelBody = document.getElementById('runtimeDebugPanelBody');
-  const runtimeDebugPanelCaret = document.getElementById('runtimeDebugPanelCaret');
   const memoryPanelToggle = document.getElementById('memoryPanelToggle');
   const memoryPanelCaret = document.getElementById('memoryPanelCaret');
   const memoryPanelBody = document.getElementById('memoryPanelBody');
@@ -321,8 +318,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const selfExperimentsModalRaw = document.getElementById('selfExperimentsModalRaw');
   const autonomyReadinessPanel = document.getElementById('autonomyReadinessPanel');
   const autonomyReadinessToggle = document.getElementById('autonomyReadinessToggle');
-  const autonomyReadinessCaret = document.getElementById('autonomyReadinessCaret');
-  const autonomyReadinessBody = document.getElementById('autonomyReadinessBody');
+  const autonomyReadinessOpenModal = document.getElementById('autonomyReadinessOpenModal');
+  const autonomyReadinessModalRoot = document.getElementById('autonomyReadinessModalRoot');
+  const autonomyReadinessModalBackdrop = document.getElementById('autonomyReadinessModalBackdrop');
+  const autonomyReadinessModalDialog = document.getElementById('autonomyReadinessModalDialog');
+  const autonomyReadinessModalClose = document.getElementById('autonomyReadinessModalClose');
   const autonomyReadinessMeta = document.getElementById('autonomyReadinessMeta');
   const autonomyReadinessOverview = document.getElementById('autonomyReadinessOverview');
   const autonomyReadinessWarnings = document.getElementById('autonomyReadinessWarnings');
@@ -3032,6 +3032,7 @@ document.addEventListener("DOMContentLoaded", () => {
       || isModalVisible(substrateReviewModalRoot)
       || isModalVisible(cognitiveReviewModalRoot)
       || isModalVisible(autonomyConstitutionModalRoot)
+      || isModalVisible(autonomyReadinessModalRoot)
       || isModalVisible(agentTraceModal);
     document.body.classList.toggle('overflow-hidden', shouldLock);
   }
@@ -3676,6 +3677,40 @@ document.addEventListener("DOMContentLoaded", () => {
     syncDebugModalScrollLock();
   }
 
+  function ensureAutonomyReadinessModalRootOnBody() {
+    if (!autonomyReadinessModalRoot || !document.body) return;
+    if (autonomyReadinessModalRoot.parentElement !== document.body) {
+      document.body.appendChild(autonomyReadinessModalRoot);
+    }
+  }
+
+  function openAutonomyReadinessModal() {
+    if (!autonomyReadinessModalRoot) return;
+    ensureAutonomyReadinessModalRootOnBody();
+    autonomyReadinessModalRoot.style.position = 'fixed';
+    autonomyReadinessModalRoot.style.inset = '0';
+    autonomyReadinessModalRoot.style.zIndex = '2147483646';
+    if (autonomyReadinessModalBackdrop) {
+      autonomyReadinessModalBackdrop.style.position = 'fixed';
+      autonomyReadinessModalBackdrop.style.inset = '0';
+      autonomyReadinessModalBackdrop.style.zIndex = '2147483646';
+    }
+    if (autonomyReadinessModalDialog) {
+      autonomyReadinessModalDialog.style.position = 'fixed';
+      autonomyReadinessModalDialog.style.zIndex = '2147483647';
+    }
+    autonomyReadinessModalRoot.classList.remove('hidden');
+    autonomyReadinessModalRoot.setAttribute('aria-hidden', 'false');
+    syncDebugModalScrollLock();
+  }
+
+  function closeAutonomyReadinessModal() {
+    if (!autonomyReadinessModalRoot) return;
+    autonomyReadinessModalRoot.classList.add('hidden');
+    autonomyReadinessModalRoot.setAttribute('aria-hidden', 'true');
+    syncDebugModalScrollLock();
+  }
+
   function clearChatStanceDebugPanel() {
     lastChatStanceDebug = null;
     if (chatStanceDebugBody) chatStanceDebugBody.classList.add('hidden');
@@ -3766,10 +3801,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleChatStanceDebugPanel() {
-    if (!chatStanceDebugBody) return;
-    const nextHidden = !chatStanceDebugBody.classList.contains('hidden');
-    chatStanceDebugBody.classList.toggle('hidden', nextHidden);
-    if (chatStanceDebugCaret) chatStanceDebugCaret.textContent = nextHidden ? '▾' : '▴';
+    openChatStanceDebugModal();
   }
 
   function ensureChatStanceModalRootOnBody() {
@@ -3896,10 +3928,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleSubstrateReviewDebugPanel() {
-    if (!substrateReviewDebugBody) return;
-    const nextHidden = !substrateReviewDebugBody.classList.contains('hidden');
-    substrateReviewDebugBody.classList.toggle('hidden', nextHidden);
-    if (substrateReviewDebugCaret) substrateReviewDebugCaret.textContent = nextHidden ? '▾' : '▴';
+    openSubstrateReviewModal();
   }
 
   function clearSelfExperimentsDebugPanel() {
@@ -3911,10 +3940,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleSelfExperimentsDebugPanel() {
-    if (!selfExperimentsDebugBody) return;
-    const nextHidden = !selfExperimentsDebugBody.classList.contains('hidden');
-    selfExperimentsDebugBody.classList.toggle('hidden', nextHidden);
-    if (selfExperimentsDebugCaret) selfExperimentsDebugCaret.textContent = nextHidden ? '▾' : '▴';
+    openSelfExperimentsModal();
   }
 
   function updateSelfExperimentsDebugPanel(payload) {
@@ -4184,18 +4210,13 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function clearAutonomyReadinessPanel() {
-    if (autonomyReadinessBody) autonomyReadinessBody.classList.add('hidden');
-    if (autonomyReadinessCaret) autonomyReadinessCaret.textContent = '▾';
     if (autonomyReadinessMeta) autonomyReadinessMeta.textContent = 'No autonomy readiness snapshot loaded.';
     if (autonomyReadinessOverview) autonomyReadinessOverview.textContent = 'No data yet.';
     if (autonomyReadinessWarnings) autonomyReadinessWarnings.textContent = 'No warnings.';
   }
 
   function toggleAutonomyReadinessPanel() {
-    if (!autonomyReadinessBody) return;
-    const nextHidden = !autonomyReadinessBody.classList.contains('hidden');
-    autonomyReadinessBody.classList.toggle('hidden', nextHidden);
-    if (autonomyReadinessCaret) autonomyReadinessCaret.textContent = nextHidden ? '▾' : '▴';
+    openAutonomyReadinessModal();
   }
 
   function updateAutonomyReadinessPanel(snapshot) {
@@ -4264,10 +4285,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleRecallCanaryPanel() {
-    if (!recallCanaryBody) return;
-    const nextHidden = !recallCanaryBody.classList.contains('hidden');
-    recallCanaryBody.classList.toggle('hidden', nextHidden);
-    if (recallCanaryCaret) recallCanaryCaret.textContent = nextHidden ? '▾' : '▴';
+    openRecallCanaryModal();
   }
 
   function toggleWorldPulsePanel() {
@@ -4982,31 +5000,15 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleMemoryPanel() {
-    if (!memoryPanelBody) return;
-    const nextHidden = !memoryPanelBody.classList.contains('hidden');
-    memoryPanelBody.classList.toggle('hidden', nextHidden);
-    if (memoryPanelCaret) memoryPanelCaret.textContent = nextHidden ? '▾' : '▴';
-  }
-
-  function toggleRuntimeDebugPanel() {
-    if (!runtimeDebugPanelBody) return;
-    const nextHidden = !runtimeDebugPanelBody.classList.contains('hidden');
-    runtimeDebugPanelBody.classList.toggle('hidden', nextHidden);
-    if (runtimeDebugPanelCaret) runtimeDebugPanelCaret.textContent = nextHidden ? '▾' : '▴';
+    openMemoryDebugModal();
   }
 
   function toggleAgentTraceDebugPanel() {
-    if (!agentTraceDebugBody) return;
-    const nextHidden = !agentTraceDebugBody.classList.contains('hidden');
-    agentTraceDebugBody.classList.toggle('hidden', nextHidden);
-    if (agentTraceDebugCaret) agentTraceDebugCaret.textContent = nextHidden ? '▾' : '▴';
+    openAgentTraceModal(lastAgentTraceSummary, lastAgentTraceMeta);
   }
 
   function toggleAutonomyDebugPanel() {
-    if (!autonomyDebugBody) return;
-    const nextHidden = !autonomyDebugBody.classList.contains('hidden');
-    autonomyDebugBody.classList.toggle('hidden', nextHidden);
-    if (autonomyDebugCaret) autonomyDebugCaret.textContent = nextHidden ? '▾' : '▴';
+    openAutonomyDebugModal();
   }
 
   function isAttentionNotification(notification) {
@@ -6188,7 +6190,7 @@ document.addEventListener("DOMContentLoaded", () => {
         (typeof document !== 'undefined' && document.body && document.body.dataset.orionChatLane) ||
         'grounded_small';
       laneApi.syncRecallProfileForLane(lane);
-    } else if (!recallProfileSelect.value || recallProfileSelect.value === 'auto') {
+    } else if (currentMode !== 'orion' && (!recallProfileSelect.value || recallProfileSelect.value === 'auto')) {
       recallProfileSelect.value = 'assist.light.v1';
     }
   }
@@ -7810,9 +7812,7 @@ document.addEventListener("DOMContentLoaded", () => {
     debugButton.className = 'rounded-full border border-violet-400/40 bg-violet-500/20 px-2 py-1 text-[10px] font-semibold text-violet-100 hover:bg-violet-500/30';
     debugButton.textContent = 'Open debug';
     debugButton.addEventListener('click', () => {
-      if (autonomyDebugPanel) autonomyDebugPanel.classList.remove('hidden');
-      if (autonomyDebugBody) autonomyDebugBody.classList.remove('hidden');
-      if (autonomyDebugCaret) autonomyDebugCaret.textContent = '▴';
+      openAutonomyDebugModal();
     });
     panel.appendChild(debugButton);
     return panel;
@@ -8885,22 +8885,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const hubModeSelect = document.getElementById('hubModeSelect');
   const hubComputeSelect = document.getElementById('hubComputeSelect');
   const HUB_MODE_SPECS = {
-    auto: { mode: 'auto', verb: null, lane: null, label: 'Auto' },
     orion: { mode: 'orion', fccModelLabel: 'MODEL_SONNET', verb: null, lane: 'orion', label: 'Orion' },
-    grounded_small: { mode: 'brain', verb: null, lane: 'grounded_small', label: 'Grounded Small' },
-    brain: { mode: 'brain', verb: null, lane: 'brain', label: 'Brain' },
     quick: { mode: 'brain', verb: 'chat_quick', lane: 'quick', label: 'Quick' },
     story: { mode: 'brain', verb: 'chat_kids_story', lane: null, label: 'Story' },
     agent: { mode: 'agent', verb: null, lane: null, label: 'Agent' },
-    agent_claude_opus: { mode: 'agent-claude', fccModelLabel: 'MODEL_OPUS', verb: null, lane: null, label: 'Agent Claude - Opus', skipComputeConfirm: true },
-    agent_claude_sonnet: { mode: 'agent-claude', fccModelLabel: 'MODEL_SONNET', verb: null, lane: null, label: 'Agent Claude - Sonnet', skipComputeConfirm: true },
-    agent_claude_haiku: { mode: 'agent-claude', fccModelLabel: 'MODEL_HAIKU', verb: null, lane: null, label: 'Agent Claude - Haiku', skipComputeConfirm: true },
-    council: { mode: 'council', verb: null, lane: null, label: 'Council' },
   };
 
   function hubModeSpec(modeKey) {
-    const key = String(modeKey || hubModeSelect?.value || 'grounded_small').trim().toLowerCase();
-    return HUB_MODE_SPECS[key] || HUB_MODE_SPECS.grounded_small;
+    const key = String(modeKey || hubModeSelect?.value || 'orion').trim().toLowerCase();
+    return HUB_MODE_SPECS[key] || HUB_MODE_SPECS.orion;
   }
 
   function applyAgentClaudePayloadFields(payload) {
@@ -8917,9 +8910,33 @@ document.addEventListener("DOMContentLoaded", () => {
     payload.fcc_model_label = spec.fccModelLabel || 'MODEL_SONNET';
   }
 
+  // Recall Profile auto-follows Mode: Orion leaves recall_profile unset (backend
+  // default resolution); any other mode forces the echo-safe assist.light.v1 lane.
+  // Reuses the payload builder's pre-existing 'auto' == "no override" sentinel
+  // (see recall_profile / recall_profile_explicit below) via a synthetic option,
+  // since 'auto' is no longer a user-facing Recall Profile choice.
+  function setRecallProfileAutoState(useAutoDefault) {
+    if (!recallProfileSelect) return;
+    let autoOption = recallProfileSelect.querySelector('option[value="auto"]');
+    if (useAutoDefault) {
+      if (!autoOption) {
+        autoOption = document.createElement('option');
+        autoOption.value = 'auto';
+        autoOption.textContent = '(default)';
+        recallProfileSelect.insertBefore(autoOption, recallProfileSelect.firstChild);
+      }
+      recallProfileSelect.value = 'auto';
+      recallProfileSelect.disabled = true;
+    } else {
+      if (autoOption) autoOption.remove();
+      recallProfileSelect.disabled = false;
+      recallProfileSelect.value = 'assist.light.v1';
+    }
+  }
+
   function applyHubModeSelection(modeKey, { silent = false } = {}) {
-    const key = String(modeKey || 'grounded_small').trim().toLowerCase();
-    const spec = HUB_MODE_SPECS[key] || HUB_MODE_SPECS.grounded_small;
+    const key = String(modeKey || 'orion').trim().toLowerCase();
+    const spec = HUB_MODE_SPECS[key] || HUB_MODE_SPECS.orion;
     currentMode = spec.mode;
     modeVerbOverride = spec.verb;
     if (spec.mode === 'brain' && spec.verb === 'chat_quick') {
@@ -8928,11 +8945,10 @@ document.addEventListener("DOMContentLoaded", () => {
     if (hubModeSelect && hubModeSelect.value !== key) {
       hubModeSelect.value = key;
     }
+    setRecallProfileAutoState(key === 'orion');
     const laneApi = (typeof globalThis !== 'undefined' ? globalThis : window).OrionHubGroundedSmallLane;
     if (laneApi && typeof laneApi.setLane === 'function' && spec.lane) {
       laneApi.setLane(spec.lane);
-    } else if (laneApi && typeof laneApi.setLane === 'function' && key === 'auto') {
-      laneApi.setLane('grounded_small');
     } else if (laneApi && typeof laneApi.setLane === 'function' && key === 'orion') {
       laneApi.setLane('orion');
     }
@@ -9240,9 +9256,6 @@ document.addEventListener("DOMContentLoaded", () => {
   if (memoryDebugModalDialog) {
     memoryDebugModalDialog.addEventListener('click', (event) => event.stopPropagation());
   }
-  if (runtimeDebugPanelToggle) {
-    runtimeDebugPanelToggle.addEventListener('click', toggleRuntimeDebugPanel);
-  }
   if (agentTraceDebugToggle) {
     agentTraceDebugToggle.addEventListener('click', toggleAgentTraceDebugPanel);
   }
@@ -9390,6 +9403,28 @@ document.addEventListener("DOMContentLoaded", () => {
   }
   if (autonomyReadinessToggle) {
     autonomyReadinessToggle.addEventListener('click', toggleAutonomyReadinessPanel);
+  }
+  ensureAutonomyReadinessModalRootOnBody();
+  if (autonomyReadinessOpenModal) {
+    autonomyReadinessOpenModal.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openAutonomyReadinessModal();
+    });
+  }
+  if (autonomyReadinessModalClose) {
+    autonomyReadinessModalClose.addEventListener('click', closeAutonomyReadinessModal);
+  }
+  if (autonomyReadinessModalBackdrop) {
+    autonomyReadinessModalBackdrop.addEventListener('click', closeAutonomyReadinessModal);
+  }
+  if (autonomyReadinessModalRoot) {
+    autonomyReadinessModalRoot.addEventListener('click', (event) => {
+      if (event.target === autonomyReadinessModalRoot) closeAutonomyReadinessModal();
+    });
+  }
+  if (autonomyReadinessModalDialog) {
+    autonomyReadinessModalDialog.addEventListener('click', (event) => event.stopPropagation());
   }
   if (recallCanaryRunButton) {
     recallCanaryRunButton.addEventListener('click', async () => {
@@ -9749,6 +9784,10 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (event.key === 'Escape' && autonomyDebugModalRoot && !autonomyDebugModalRoot.classList.contains('hidden')) {
       closeAutonomyDebugModal();
+      return;
+    }
+    if (event.key === 'Escape' && autonomyReadinessModalRoot && !autonomyReadinessModalRoot.classList.contains('hidden')) {
+      closeAutonomyReadinessModal();
       return;
     }
     if (event.key === 'Escape' && chatStanceDebugModalRoot && !chatStanceDebugModalRoot.classList.contains('hidden')) {

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -259,15 +259,10 @@
               aria-label="Hub chat mode"
               title="Behavior lane: Orion unified turn, agent/council/brain routing. Social room ON forces brain mode and chat_social_room verb."
             >
-              <option value="auto">Auto</option>
               <option value="orion" selected>Orion</option>
-              <option value="grounded_small">Grounded Small</option>
-              <option value="brain">Brain</option>
               <option value="quick">Quick</option>
               <option value="story">Story</option>
               <option value="agent">Agent</option>
-              {{HUB_AGENT_CLAUDE_MODE_OPTIONS}}
-              <option value="council">Council</option>
             </select>
           </div>
           <div class="flex items-center gap-2 pt-1 border-t border-gray-700/80">
@@ -322,12 +317,14 @@
           </div>
           <div class="flex items-center gap-2">
             <label for="recallProfileSelect" class="text-gray-400">Recall Profile</label>
-            <select id="recallProfileSelect" class="bg-gray-800 text-gray-200 rounded border border-gray-700 px-2 py-1 text-xs">
-              <option value="auto">Auto</option>
+            <select
+              id="recallProfileSelect"
+              class="bg-gray-800 text-gray-200 rounded border border-gray-700 px-2 py-1 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Auto-set by Mode: Orion mode leaves this unset (backend default); any other mode forces assist.light.v1. Manual picks below override until Mode changes again."
+            >
               <option value="assist.light.v1" selected>assist.light.v1</option>
               <option value="recall.v1">recall.v1</option>
               <option value="chat.general.v1">chat.general.v1</option>
-              <option value="biographical.v1">biographical.v1</option>
               <option value="self.factual.v1">self.factual.v1</option>
               <option value="reflect.v1">reflect.v1</option>
               <option value="reflect.anchor.v1">reflect.anchor.v1</option>
@@ -418,15 +415,10 @@
         </div>
 
         <div id="runtimeDebugPanel" class="bg-gray-800/40 border border-gray-700 rounded-xl p-3 space-y-2">
-          <button
-            id="runtimeDebugPanelToggle"
-            class="w-full flex items-center justify-between text-xs text-gray-300 hover:text-white"
-            type="button"
-          >
+          <div class="w-full flex items-center justify-between text-xs text-gray-300">
             <span class="uppercase tracking-wide">Debug Panel</span>
-            <span id="runtimeDebugPanelCaret" class="text-gray-500">▾</span>
-          </button>
-          <div id="runtimeDebugPanelBody" class="hidden space-y-2 text-xs text-gray-300">
+          </div>
+          <div id="runtimeDebugPanelBody" class="space-y-2 text-xs text-gray-300">
             <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
               <div class="flex items-center justify-between gap-2">
                 <button
@@ -671,7 +663,13 @@
               type="button"
             >
               <span class="uppercase tracking-wide">Autonomy Readiness</span>
-              <span id="autonomyReadinessCaret" class="text-gray-500">▾</span>
+            </button>
+            <button
+              id="autonomyReadinessOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
             </button>
             <button
               id="autonomyConstitutionOpenModal"
@@ -680,14 +678,6 @@
             >
               Policy Matrix
             </button>
-          </div>
-          <div id="autonomyReadinessBody" class="hidden space-y-3 text-xs text-gray-300">
-            <div id="autonomyReadinessMeta" class="text-[10px] text-gray-500">Loading autonomy readiness snapshot…</div>
-            <div id="autonomyReadinessOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">No data yet.</div>
-            <div>
-              <div class="text-gray-500 mb-1">Warnings</div>
-              <div id="autonomyReadinessWarnings" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px]">No warnings.</div>
-            </div>
           </div>
         </div>
 
@@ -2708,10 +2698,10 @@
 
   <div
     id="agentTraceModal"
-    class="hidden fixed inset-0 z-50 bg-gray-950/80 backdrop-blur-sm px-4 py-6"
+    class="hidden fixed inset-0 z-50 bg-gray-950/80 backdrop-blur-sm"
     aria-hidden="true"
   >
-    <div class="mx-auto flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl">
+    <div class="fixed left-1/2 top-1/2 flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-sm font-semibold text-gray-100">Agent Trace</div>
@@ -2879,7 +2869,7 @@
 
   <div id="autonomyDebugModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="autonomyDebugModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="autonomyDebugModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="autonomyDebugModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-emerald-300">Autonomy runtime</div>
@@ -2899,9 +2889,35 @@
     </div>
   </div>
 
+  <div id="autonomyReadinessModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
+    <div id="autonomyReadinessModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
+    <div id="autonomyReadinessModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+      <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
+        <div>
+          <div class="text-xs uppercase tracking-[0.24em] text-emerald-300">Autonomy readiness</div>
+        </div>
+        <button
+          id="autonomyReadinessModalClose"
+          class="rounded-lg border border-gray-700 bg-gray-900 px-3 py-1 text-xs text-gray-200 hover:bg-gray-800"
+          type="button"
+        >
+          Close
+        </button>
+      </div>
+      <div class="min-h-0 flex-1 overflow-y-auto px-5 py-4 space-y-3 text-xs text-gray-300">
+        <div id="autonomyReadinessMeta" class="text-[10px] text-gray-500">Loading autonomy readiness snapshot…</div>
+        <div id="autonomyReadinessOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">No data yet.</div>
+        <div>
+          <div class="text-gray-500 mb-1">Warnings</div>
+          <div id="autonomyReadinessWarnings" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px]">No warnings.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div id="memoryDebugModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="memoryDebugModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="memoryDebugModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="memoryDebugModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-indigo-300">Memory / recall debug</div>
@@ -2923,7 +2939,7 @@
 
   <div id="chatStanceDebugModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="chatStanceDebugModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="chatStanceDebugModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="chatStanceDebugModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-indigo-300">Chat stance debug</div>
@@ -2991,7 +3007,7 @@
 
   <div id="substrateReviewModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="substrateReviewModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="substrateReviewModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="substrateReviewModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-cyan-300">Substrate review runtime</div>
@@ -3035,7 +3051,7 @@
 
   <div id="selfExperimentsModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="selfExperimentsModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="selfExperimentsModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="selfExperimentsModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-indigo-300">Self experiments runtime</div>
@@ -3088,7 +3104,7 @@
 
   <div id="cognitiveReviewModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="cognitiveReviewModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="cognitiveReviewModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="cognitiveReviewModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-fuchsia-300">Cognitive proposal review</div>
@@ -3127,7 +3143,7 @@
 
   <div id="recallCanaryModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="recallCanaryModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="recallCanaryModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="recallCanaryModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-indigo-300">Recall canary</div>
@@ -3196,7 +3212,7 @@
 
   <div id="autonomyConstitutionModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="autonomyConstitutionModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="autonomyConstitutionModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121] mx-auto flex w-auto max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+    <div id="autonomyConstitutionModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-cyan-300">Autonomy constitution</div>

--- a/services/orion-hub/tests/test_agent_trace_debug_panel.py
+++ b/services/orion-hub/tests/test_agent_trace_debug_panel.py
@@ -46,7 +46,7 @@ def test_memory_debug_uses_modal_driven_detail_view_with_autonomy_modal_pattern(
     assert template.index('id="memoryDebugOpenModal"') < template.index('id="memoryPanelBody"')
     assert 'id="memoryDebugModalRoot" class="hidden fixed inset-0 z-[120]' in template
     assert 'id="memoryDebugModalBackdrop" class="fixed inset-0 z-[120]' in template
-    assert 'id="memoryDebugModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121]' in template
+    assert 'id="memoryDebugModalDialog" class="fixed left-1/2 top-1/2 z-[121]' in template
     assert "function openMemoryDebugModal()" in app_js
     assert "function closeMemoryDebugModal()" in app_js
     assert "function ensureMemoryDebugModalRootOnBody()" in app_js

--- a/services/orion-hub/tests/test_autonomy_runtime_ui_panel.py
+++ b/services/orion-hub/tests/test_autonomy_runtime_ui_panel.py
@@ -212,7 +212,7 @@ def test_template_includes_fixed_high_z_autonomy_runtime_modal() -> None:
     assert 'id="autonomyDebugModalRoot"' in template
     assert 'id="autonomyDebugModalRoot" class="hidden fixed inset-0 z-[120]' in template
     assert 'id="autonomyDebugModalBackdrop" class="fixed inset-0 z-[120]' in template
-    assert 'id="autonomyDebugModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121]' in template
+    assert 'id="autonomyDebugModalDialog" class="fixed left-1/2 top-1/2 z-[121]' in template
     assert 'z-index: 2147483646' in template
     assert 'z-index: 2147483647' in template
     assert 'id="autonomyDebugOpenModal"' in template
@@ -234,7 +234,8 @@ def test_template_includes_autonomy_readiness_panel_card() -> None:
 
     assert 'id="autonomyReadinessPanel"' in template
     assert 'id="autonomyReadinessToggle"' in template
-    assert 'id="autonomyReadinessBody"' in template
+    assert 'id="autonomyReadinessOpenModal"' in template
+    assert 'id="autonomyReadinessModalRoot"' in template
     assert 'id="autonomyReadinessMeta"' in template
     assert 'id="autonomyReadinessOverview"' in template
     assert 'id="autonomyReadinessWarnings"' in template

--- a/services/orion-hub/tests/test_chat_stance_debug_panel.py
+++ b/services/orion-hub/tests/test_chat_stance_debug_panel.py
@@ -24,7 +24,7 @@ def test_template_includes_chat_stance_modal_shell() -> None:
     template = TEMPLATE_PATH.read_text(encoding="utf-8")
     assert 'id="chatStanceDebugModalRoot" class="hidden fixed inset-0 z-[120]' in template
     assert 'id="chatStanceDebugModalBackdrop" class="fixed inset-0 z-[120]' in template
-    assert 'id="chatStanceDebugModalDialog" class="fixed inset-x-4 top-8 bottom-8 z-[121]' in template
+    assert 'id="chatStanceDebugModalDialog" class="fixed left-1/2 top-1/2 z-[121]' in template
     assert 'id="chatStanceDebugModalBody"' in template
 
 
@@ -174,7 +174,7 @@ def test_thought_process_js_registers_grounded_small_lane_contract() -> None:
     template = TEMPLATE_PATH.read_text(encoding="utf-8")
     assert "global.OrionHubGroundedSmallLane" in thought_js
     assert "LANE_GROUNDED_SMALL = 'grounded_small'" in thought_js
-    assert "Grounded Small" in template
+    assert '<option value="orion" selected>Orion</option>' in template
     assert "hubModeSelect" in thought_js
     assert "options.llm_route = 'quick';" in thought_js
     assert "payload.verbs = [];" in thought_js

--- a/services/orion-hub/tests/test_llm_route_selector.py
+++ b/services/orion-hub/tests/test_llm_route_selector.py
@@ -338,4 +338,33 @@ def test_thought_process_syncs_lane_from_mode_dropdown() -> None:
     assert "hubModeSelect" in src
     assert "setLane" in src
     assert "LANE_GROUNDED_SMALL" in src
-    assert "Grounded Small" in html
+    assert '<option value="orion" selected>Orion</option>' in html
+
+
+def test_mode_dropdown_only_has_surviving_options() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    mode_select = html.split('id="hubModeSelect"', 1)[1].split("</select>", 1)[0]
+    assert 'value="orion"' in mode_select
+    assert 'value="quick"' in mode_select
+    assert 'value="story"' in mode_select
+    assert 'value="agent"' in mode_select
+    for killed_value in ("auto", "grounded_small", "brain", "council", "agent_claude_opus", "agent_claude_sonnet", "agent_claude_haiku"):
+        assert f'value="{killed_value}"' not in mode_select
+
+
+def test_recall_profile_dropdown_drops_auto_and_biographical() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    recall_select = html.split('id="recallProfileSelect"', 1)[1].split("</select>", 1)[0]
+    assert 'value="assist.light.v1" selected' in recall_select
+    assert 'value="biographical.v1"' not in recall_select
+    assert 'value="auto"' not in recall_select
+
+
+def test_recall_profile_auto_follows_mode() -> None:
+    app_js = APP_JS.read_text(encoding="utf-8")
+    assert "function setRecallProfileAutoState(useAutoDefault)" in app_js
+    assert "setRecallProfileAutoState(key === 'orion');" in app_js
+    assert "recallProfileSelect.value = 'auto';" in app_js
+    assert "recallProfileSelect.disabled = true;" in app_js
+    assert "recallProfileSelect.disabled = false;" in app_js
+    assert "recallProfileSelect.value = 'assist.light.v1';" in app_js

--- a/services/orion-hub/tests/test_memory_review_ui.py
+++ b/services/orion-hub/tests/test_memory_review_ui.py
@@ -24,7 +24,8 @@ def test_memory_js_exposes_metadata_editors_and_patch() -> None:
 
 def test_template_includes_cards_recall_profiles() -> None:
     template = (HUB_ROOT / "templates" / "index.html").read_text(encoding="utf-8")
-    assert 'value="biographical.v1"' in template
+    # biographical.v1 was intentionally dropped from the Recall Profile dropdown
+    # (the only place it appeared in this template); self.factual.v1 remains.
     assert 'value="self.factual.v1"' in template
     assert 'id="memorySubviewConsolidationDrafts"' in template
     assert 'id="memoryConsolidationDraftsPanel"' in template


### PR DESCRIPTION
## Summary

- Mode dropdown: kill Auto, Grounded Small, Brain, Council, Agent Claude Opus/Sonnet/Haiku. Orion stays default, alongside Quick/Story/Agent.
- Recall Profile now auto-follows Mode: Orion leaves `recall_profile` unset (backend default resolution), any other mode forces `assist.light.v1`.
- Recall Profile dropdown: kill Auto and biographical.v1.
- Debug Panel: remove the outer accordion (rows always visible), convert all 9 row headers (Memory, Agent Trace, Autonomy Runtime, Chat Stance, Substrate Review, Self Experiments, Autonomy Readiness, Recall Canary, Cognitive Review) from inline dropdown-expand to opening their modal directly, add a real modal for Autonomy Readiness (previously had none), resize all 10 debug-panel modals to 75vw x 75vh.
- Fix 2 review findings: missing Escape-key handler on the new Autonomy Readiness modal, and a stray chat-feed button still using the abandoned inline-expand pattern instead of the modal.

Full PR report: `docs/superpowers/pr-reports/2026-07-29-hub-mode-cleanup-pr.md`

## Non-goals

- Did not remove the deeper "Agent Claude" backend feature (settings flag, `agent_claude_input.py`, `fcc_claude_bridge.py`) — only its Mode-dropdown surface.
- Did not sweep the now-permanently-hidden inline debug-panel body/caret DOM left over from the toggle-to-modal conversion — at least one (`autonomyDebugBody`) is still load-bearing as its modal's data source, so a blanket deletion needs per-row verification first.

## Test plan

- [x] `pytest services/orion-hub/tests -q` — 1032 passed, 31 failed, 5 skipped
- [x] Confirmed 0 regressions via git-stash baseline comparison on the same command against unmodified `main` (31 failed there too, identical failure set minus 4 order-dependent/flaky tests)
- [x] Independent code review (subagent) run against the full diff; both real findings fixed, re-tested after fixes
- [ ] Manual browser verification of the new modal interactions was not performed this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)