### PR TITLE
fix(hub): correct Debug Panel to single card + one wrapping modal

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-29-hub-mode-cleanup-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-29-hub-mode-cleanup-pr.md
@@ -5,33 +5,33 @@
 - Killed 7 Hub chat "Mode" dropdown options (Auto, Grounded Small, Brain, Council, Agent Claude - Opus/Sonnet/Haiku); Orion remains the default, alongside Quick/Story/Agent.
 - Wired Recall Profile to auto-follow Mode: Orion mode leaves `recall_profile` unset (backend default resolution); any other mode forces `assist.light.v1`.
 - Killed "Auto" and "biographical.v1" from the Recall Profile dropdown.
-- Refactored the Hub "Debug Panel" section: removed the outer accordion (rows always visible) and converted all 9 row headers (Memory, Agent Trace, Autonomy Runtime, Chat Stance, Substrate Review, Self Experiments, Autonomy Readiness, Recall Canary, Cognitive Review) from inline dropdown-expand to opening their modal directly. Added a real modal for Autonomy Readiness (previously had none). Resized all 10 debug-panel-adjacent modals to `75vw x 75vh` centered.
-- Fixed two review findings: missing Escape-key handler for the new Autonomy Readiness modal, and a stray chat-feed "Open debug" button that still used the abandoned inline-expand pattern instead of opening the modal.
+- Restructured the Hub "Debug Panel" section into a single card with one "Modal" button. Clicking it opens one new 75vw x 75vh modal containing all 9 sub-panels (Memory, Agent Trace, Autonomy Runtime, Chat Stance, Substrate Review, Self Experiments, Autonomy Readiness, Recall Canary, Cognitive Review) exactly as they were — each still has its own inline expand/collapse toggle *and* its own separate per-item "Modal" button, unchanged. Added a real per-item modal for Autonomy Readiness (previously had none, only an unrelated "Policy Matrix" button). Resized all 10 debug-panel-adjacent modals (the new outer one plus the 9 existing/added per-item ones) to `75vw x 75vh` centered.
+- Note: this PR went through one full revision of the Debug Panel approach mid-review. The first pass converted each of the 9 rows' own click target from inline-expand to opening its own modal directly and removed the outer accordion. That was **not** what was wanted — the actual ask was to keep every row's existing behavior completely unchanged and only wrap the *outer* section in one new modal. The first pass was reverted in place before this PR was finalized; what's described above and in the diff is the corrected version.
+- Fixed two review findings from the (now-superseded) first pass: missing Escape-key handler, and a stray chat-feed "Open debug" button using an inconsistent pattern. Both fixes were carried forward/re-applied against the corrected structure (Escape-key branch for the new outer `debugPanelModalRoot`; the chat-feed button now opens the outer modal and expands the Autonomy Runtime row inline within it, matching the row's real behavior).
 
 ## Outcome moved
 
-The Hub Mode/Recall Profile surface went from 12 dropdown options (several dead-end or redundant) down to a coherent 4+7 set with real, traceable behavior. Debug panel navigation changed from a two-level accordion (outer section + per-row inline expand, duplicated by a separate "Modal" button doing the same thing) to a single consistent interaction: click a row, get its content in a large modal.
+The Hub Mode/Recall Profile surface went from 12 dropdown options (several dead-end or redundant) down to a coherent 4+7 set with real, traceable behavior. The Debug Panel went from an always-expanded 9-row accordion sitting permanently in the page flow to a single collapsed card; all 9 rows' existing interactions are preserved verbatim, just relocated inside one on-demand modal.
 
 ## Current architecture
 
-- `services/orion-hub/templates/index.html` renders the Hub chat UI; Mode/Compute/Recall Mode/Recall Profile selects live in a settings strip above the chat input. The "Debug Panel" section further down is a single `id="runtimeDebugPanel"` accordion nesting 9 sub-panel rows, each historically with its own inline-expand toggle *and* a separate "Modal" button doing largely the same thing.
+- `services/orion-hub/templates/index.html` renders the Hub chat UI; Mode/Compute/Recall Mode/Recall Profile selects live in a settings strip above the chat input. The "Debug Panel" section further down was a single `id="runtimeDebugPanel"` div always rendering all 9 sub-panel rows inline in the page, each with its own inline-expand toggle *and* a separate per-item "Modal" button.
 - `services/orion-hub/static/js/app.js` owns `HUB_MODE_SPECS` (Mode -> verb/lane/fcc-model mapping), `applyHubModeSelection()` (Mode change handler), and one `toggle*Panel()` + `open*Modal()` pair per debug-panel row.
 - `services/orion-hub/scripts/main.py` server-renders `{{HUB_AGENT_CLAUDE_MODE_OPTIONS}}` into the Mode select when `HUB_AGENT_CLAUDE_ENABLED` is set.
-- Discovered mid-task (not previously documented in this form): "Orion" Mode and the `chat_general` cognition verb are two different pipelines — Orion routes through `orion.hub.turn_orchestrator.run_unified_turn()` (harness-governed unified turn), not the verb-dispatch path. Static-trace only (not live-verified): the harness's own recall-profile resolution (`services/orion-cortex-exec/app/recall_utils.py::resolve_runtime_default_profile`) falls through to a hardcoded `"agent"` `runtime_mode` default when nothing upstream sets `ctx["mode"]`, which resolves to `chat.general.v1`. Left as `UNVERIFIED` per house rules — did not pull a live trace to confirm before scoping this PR, since the user redirected mid-investigation to a different concrete ask (mode/recall-profile linkage + debug panel modals) rather than continuing that thread.
+- Discovered mid-task (not previously documented in this form): "Orion" Mode and the `chat_general` cognition verb are two different pipelines — Orion routes through `orion.hub.turn_orchestrator.run_unified_turn()` (harness-governed unified turn), not the verb-dispatch path. Static-trace only (not live-verified): the harness's own recall-profile resolution (`services/orion-cortex-exec/app/recall_utils.py::resolve_runtime_default_profile`) falls through to a hardcoded `"agent"` `runtime_mode` default when nothing upstream sets `ctx["mode"]`, which resolves to `chat.general.v1`. Left as `UNVERIFIED` per house rules — did not pull a live trace to confirm before scoping this PR, since the user redirected mid-investigation to a different concrete ask (mode/recall-profile linkage + debug panel modal wrapping) rather than continuing that thread.
 
 ## Architecture touched
 
-- `services/orion-hub/templates/index.html`: Mode select, Recall Profile select, entire Debug Panel section markup, 10 modal dialog shells (resized), new Autonomy Readiness modal shell.
-- `services/orion-hub/static/js/app.js`: `HUB_MODE_SPECS`, `applyHubModeSelection`, new `setRecallProfileAutoState`, `normalizeRecallProfileDisplay` guard, 9 `toggle*Panel` functions, new `openAutonomyReadinessModal`/`closeAutonomyReadinessModal`/`ensureAutonomyReadinessModalRootOnBody`, `syncDebugModalScrollLock`, global Escape-key handler, one stray inline-expand button in the autonomy chat-feed summary card.
+- `services/orion-hub/templates/index.html`: Mode select, Recall Profile select. Debug Panel: outer card simplified to a single "Modal" button; the entire original `runtimeDebugPanelBody` (all 9 rows, byte-for-byte their original markup) relocated as-is into a new `debugPanelModalRoot` modal shell. New per-item Autonomy Readiness modal added, mirroring the Autonomy Runtime modal's copy-on-open pattern. 10 modal dialogs (the new outer one, the new Autonomy Readiness one, and the 8 pre-existing per-item ones) resized to 75vw/75vh.
+- `services/orion-hub/static/js/app.js`: `HUB_MODE_SPECS`, `applyHubModeSelection`, new `setRecallProfileAutoState`, `normalizeRecallProfileDisplay` guard. Debug panel: all 9 `toggle*Panel()` functions restored to their original inline expand/collapse behavior (unchanged from before this PR); new `openDebugPanelModal`/`closeDebugPanelModal`/`ensureDebugPanelModalRootOnBody` for the single outer modal; new `openAutonomyReadinessModal`/`closeAutonomyReadinessModal`/`ensureAutonomyReadinessModalRootOnBody` following the `autonomyDebugModal` copy-on-open pattern; `syncDebugModalScrollLock` and the global Escape-key handler both extended to cover the two new modal roots.
 - `services/orion-hub/scripts/main.py`: removed dead `{{HUB_AGENT_CLAUDE_MODE_OPTIONS}}` template-fill block (placeholder no longer exists in the template).
 
 ## Files changed
 
-- `services/orion-hub/templates/index.html`: Mode/Recall Profile option pruning, Debug Panel accordion removal, Autonomy Readiness modal added, 10 modal dialogs resized to 75vw/75vh.
-- `services/orion-hub/static/js/app.js`: Mode spec pruning, Mode->Recall-Profile auto-linkage, 9 toggle->modal redirects, new Autonomy Readiness modal JS, Escape-key + stray-button fixes.
+- `services/orion-hub/templates/index.html`: Mode/Recall Profile option pruning; Debug Panel restructured into one card + one wrapping modal around the unchanged 9-row content; Autonomy Readiness per-item modal added; 10 modal dialogs resized to 75vw/75vh.
+- `services/orion-hub/static/js/app.js`: Mode spec pruning; Mode->Recall-Profile auto-linkage; Debug Panel wrapped in one new modal with all 9 rows' original toggle behavior preserved; new Autonomy Readiness modal JS; Escape-key + scroll-lock coverage for both new modals.
 - `services/orion-hub/scripts/main.py`: removed dead agent-claude Mode-option template-fill code (backend `HUB_AGENT_CLAUDE_ENABLED` feature itself untouched, see Non-goals below).
-- `services/orion-hub/tests/test_agent_trace_debug_panel.py`, `test_autonomy_runtime_ui_panel.py`, `test_chat_stance_debug_panel.py`, `test_memory_review_ui.py`: updated string-snapshot assertions to match the new dialog class/id/option set.
-- `services/orion-hub/tests/test_llm_route_selector.py`: updated one stale assertion, added 3 new tests covering the surviving Mode option set, the pruned Recall Profile option set, and the new `setRecallProfileAutoState` wiring.
+- `services/orion-hub/tests/test_llm_route_selector.py`: added tests covering the surviving Mode option set, the pruned Recall Profile option set, the `setRecallProfileAutoState` wiring, and the single-card/single-modal Debug Panel wrapping (row content lives inside the modal, main-page card has no inline row content, each row keeps its own toggle + per-item Modal button).
 
 ## Schema / bus / API changes
 
@@ -44,7 +44,7 @@ None.
 ## Non-goals (explicitly scoped out)
 
 - Did **not** remove the deeper "Agent Claude" backend (`HUB_AGENT_CLAUDE_ENABLED` setting, `agent_claude_input.py`, `fcc_claude_bridge.py`, and their tests) — only its Mode-dropdown surface. That backend has real, separate infrastructure (a whole FCC Claude Bridge) that may be reachable outside the Hub Mode dropdown; killing it outright was a much larger, unrequested change.
-- Did **not** sweep the now-permanently-hidden inline debug-panel body/caret DOM left behind by the toggle-to-modal conversion (8 of 9 rows). Several of these (confirmed: `autonomyDebugBody`) are still load-bearing — the Autonomy Runtime modal copies its content via `innerHTML` on open — so a blanket deletion would have broken a working modal. Flagged as a follow-up, not fixed here.
+- Did **not** change any of the 9 debug-panel rows' own interaction pattern (inline toggle + separate per-item Modal button, unchanged) — only wrapped the outer section in one new modal. An earlier draft of this PR did change per-row behavior; that draft was reverted before finalizing, see Summary.
 - Did not live-verify whether Orion mode's recall profile actually resolves to `chat.general.v1` at runtime (see Current architecture) — static trace only.
 
 ## Tests run
@@ -77,16 +77,18 @@ Not run. This is a static template/JS change with no new dependencies, ports, en
 
 ## Review findings fixed
 
-- Finding: New `autonomyReadinessModalRoot` modal had no Escape-key handler while every sibling debug-panel modal did.
-  - Fix: Added an `Escape` branch calling `closeAutonomyReadinessModal()` alongside the other modal branches in the global keydown handler.
-  - Evidence: `services/orion-hub/static/js/app.js`, keydown handler now has 18 modal branches (was 17), same pattern as the other 8 debug-panel-row modals.
+An independent code-review subagent reviewed the first-pass version of this PR (per-row toggle-to-modal conversion). Two real findings from that pass were fixed at the time; both fixes were carried forward into the corrected structure below since they're still applicable:
 
-- Finding: A chat-feed "Open debug" shortcut in the autonomy summary card still directly un-hid the old inline `autonomyDebugBody`/caret instead of opening the new modal — an inconsistent leftover from the toggle-to-modal refactor.
-  - Fix: Replaced the 3-line manual un-hide with a single `openAutonomyDebugModal()` call, matching every other entry point into that content.
-  - Evidence: `services/orion-hub/static/js/app.js` around the `createAutonomySummaryPanel`-style builder (~line 7814).
+- Finding: The new outer debug-panel-wrapping modal had no Escape-key handler while every other modal did.
+  - Fix: Added an `Escape` branch calling `closeDebugPanelModal()` (and separately `closeAutonomyReadinessModal()` for the new per-item Autonomy Readiness modal) alongside the existing modal branches in the global keydown handler.
+  - Evidence: `services/orion-hub/static/js/app.js` global keydown handler.
 
-- Finding (not fixed, scoped out): 8 of 9 converted rows still carry permanently-hidden inline body/caret DOM that's dead from a user-interaction standpoint but, in at least one case, still load-bearing as a data source for its modal.
-  - Disposition: left in place; documented as a follow-up requiring per-row verification before any deletion.
+- Finding: A chat-feed "Open debug" shortcut in the autonomy summary card needs to reach into the now-modal-wrapped Autonomy Runtime row.
+  - Fix: The button now calls `openDebugPanelModal()` first, then un-hides the Autonomy Runtime row's inline body within it — matching how a user would actually reach that row by hand (open Debug Panel modal, expand the row).
+  - Evidence: `services/orion-hub/static/js/app.js`, the `debugButton` click handler in the autonomy chat-feed summary card builder (~line 7886).
+
+- Finding (from the first pass, no longer applicable): 8 of 9 rows would have carried permanently-hidden, unreachable inline body/caret DOM under the per-row-modal design.
+  - Disposition: moot — the corrected design keeps every row's original inline toggle fully live and reachable (nothing was made unreachable), since only the outer section was wrapped in a modal.
 
 ## Restart required
 
@@ -100,10 +102,6 @@ Hub serves `templates/index.html` and `static/js/app.js` directly; changes take 
 - Severity: Low
   Concern: The new `w-[75vw] h-[75vh]` modal sizing has no min-width/min-height floor, so on very small viewports the dialogs shrink proportionally with no safety clamp.
   Mitigation: This was an explicit, deliberate user request ("cover 75% of the screen"); noted as a known trade-off rather than fixed, since a floor wasn't asked for and Hub is not currently used on small/mobile viewports as far as this session could determine.
-
-- Severity: Low
-  Concern: 8 of 9 converted debug-panel rows retain now-unreachable inline body/caret markup and the `update*Panel()` functions still write into it every time new data arrives, for no visible benefit.
-  Mitigation: None applied this PR; flagged as a follow-up. A blanket sweep needs per-row verification since at least `autonomyDebugBody` is still read by its modal's open function.
 
 - Severity: Info
   Concern: Whether Orion mode's recall profile genuinely resolves to `chat.general.v1` at runtime was traced statically only, not live-verified, mid-conversation before the user redirected to the concrete Mode/Recall-Profile/debug-panel asks actually implemented here.

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -180,6 +180,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const presenceClearButton = document.getElementById('presenceClearButton');
   const recallModeSelect = document.getElementById('recallModeSelect');
   const recallProfileSelect = document.getElementById('recallProfileSelect');
+  const debugPanelOpenModal = document.getElementById('debugPanelOpenModal');
+  const debugPanelModalRoot = document.getElementById('debugPanelModalRoot');
+  const debugPanelModalBackdrop = document.getElementById('debugPanelModalBackdrop');
+  const debugPanelModalDialog = document.getElementById('debugPanelModalDialog');
+  const debugPanelModalClose = document.getElementById('debugPanelModalClose');
   const memoryPanelToggle = document.getElementById('memoryPanelToggle');
   const memoryPanelCaret = document.getElementById('memoryPanelCaret');
   const memoryPanelBody = document.getElementById('memoryPanelBody');
@@ -318,11 +323,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const selfExperimentsModalRaw = document.getElementById('selfExperimentsModalRaw');
   const autonomyReadinessPanel = document.getElementById('autonomyReadinessPanel');
   const autonomyReadinessToggle = document.getElementById('autonomyReadinessToggle');
+  const autonomyReadinessCaret = document.getElementById('autonomyReadinessCaret');
+  const autonomyReadinessBody = document.getElementById('autonomyReadinessBody');
   const autonomyReadinessOpenModal = document.getElementById('autonomyReadinessOpenModal');
   const autonomyReadinessModalRoot = document.getElementById('autonomyReadinessModalRoot');
   const autonomyReadinessModalBackdrop = document.getElementById('autonomyReadinessModalBackdrop');
   const autonomyReadinessModalDialog = document.getElementById('autonomyReadinessModalDialog');
   const autonomyReadinessModalClose = document.getElementById('autonomyReadinessModalClose');
+  const autonomyReadinessModalMeta = document.getElementById('autonomyReadinessModalMeta');
+  const autonomyReadinessModalBody = document.getElementById('autonomyReadinessModalBody');
   const autonomyReadinessMeta = document.getElementById('autonomyReadinessMeta');
   const autonomyReadinessOverview = document.getElementById('autonomyReadinessOverview');
   const autonomyReadinessWarnings = document.getElementById('autonomyReadinessWarnings');
@@ -3033,6 +3042,7 @@ document.addEventListener("DOMContentLoaded", () => {
       || isModalVisible(cognitiveReviewModalRoot)
       || isModalVisible(autonomyConstitutionModalRoot)
       || isModalVisible(autonomyReadinessModalRoot)
+      || isModalVisible(debugPanelModalRoot)
       || isModalVisible(agentTraceModal);
     document.body.classList.toggle('overflow-hidden', shouldLock);
   }
@@ -3677,6 +3687,40 @@ document.addEventListener("DOMContentLoaded", () => {
     syncDebugModalScrollLock();
   }
 
+  function ensureDebugPanelModalRootOnBody() {
+    if (!debugPanelModalRoot || !document.body) return;
+    if (debugPanelModalRoot.parentElement !== document.body) {
+      document.body.appendChild(debugPanelModalRoot);
+    }
+  }
+
+  function openDebugPanelModal() {
+    if (!debugPanelModalRoot) return;
+    ensureDebugPanelModalRootOnBody();
+    debugPanelModalRoot.style.position = 'fixed';
+    debugPanelModalRoot.style.inset = '0';
+    debugPanelModalRoot.style.zIndex = '2147483646';
+    if (debugPanelModalBackdrop) {
+      debugPanelModalBackdrop.style.position = 'fixed';
+      debugPanelModalBackdrop.style.inset = '0';
+      debugPanelModalBackdrop.style.zIndex = '2147483646';
+    }
+    if (debugPanelModalDialog) {
+      debugPanelModalDialog.style.position = 'fixed';
+      debugPanelModalDialog.style.zIndex = '2147483647';
+    }
+    debugPanelModalRoot.classList.remove('hidden');
+    debugPanelModalRoot.setAttribute('aria-hidden', 'false');
+    syncDebugModalScrollLock();
+  }
+
+  function closeDebugPanelModal() {
+    if (!debugPanelModalRoot) return;
+    debugPanelModalRoot.classList.add('hidden');
+    debugPanelModalRoot.setAttribute('aria-hidden', 'true');
+    syncDebugModalScrollLock();
+  }
+
   function ensureAutonomyReadinessModalRootOnBody() {
     if (!autonomyReadinessModalRoot || !document.body) return;
     if (autonomyReadinessModalRoot.parentElement !== document.body) {
@@ -3699,6 +3743,8 @@ document.addEventListener("DOMContentLoaded", () => {
       autonomyReadinessModalDialog.style.position = 'fixed';
       autonomyReadinessModalDialog.style.zIndex = '2147483647';
     }
+    if (autonomyReadinessModalMeta) autonomyReadinessModalMeta.textContent = autonomyReadinessMeta ? autonomyReadinessMeta.textContent : '--';
+    if (autonomyReadinessModalBody) autonomyReadinessModalBody.innerHTML = autonomyReadinessBody ? autonomyReadinessBody.innerHTML : '--';
     autonomyReadinessModalRoot.classList.remove('hidden');
     autonomyReadinessModalRoot.setAttribute('aria-hidden', 'false');
     syncDebugModalScrollLock();
@@ -3801,7 +3847,10 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleChatStanceDebugPanel() {
-    openChatStanceDebugModal();
+    if (!chatStanceDebugBody) return;
+    const nextHidden = !chatStanceDebugBody.classList.contains('hidden');
+    chatStanceDebugBody.classList.toggle('hidden', nextHidden);
+    if (chatStanceDebugCaret) chatStanceDebugCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function ensureChatStanceModalRootOnBody() {
@@ -3928,7 +3977,10 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleSubstrateReviewDebugPanel() {
-    openSubstrateReviewModal();
+    if (!substrateReviewDebugBody) return;
+    const nextHidden = !substrateReviewDebugBody.classList.contains('hidden');
+    substrateReviewDebugBody.classList.toggle('hidden', nextHidden);
+    if (substrateReviewDebugCaret) substrateReviewDebugCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function clearSelfExperimentsDebugPanel() {
@@ -3940,7 +3992,10 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleSelfExperimentsDebugPanel() {
-    openSelfExperimentsModal();
+    if (!selfExperimentsDebugBody) return;
+    const nextHidden = !selfExperimentsDebugBody.classList.contains('hidden');
+    selfExperimentsDebugBody.classList.toggle('hidden', nextHidden);
+    if (selfExperimentsDebugCaret) selfExperimentsDebugCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function updateSelfExperimentsDebugPanel(payload) {
@@ -4210,13 +4265,18 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function clearAutonomyReadinessPanel() {
+    if (autonomyReadinessBody) autonomyReadinessBody.classList.add('hidden');
+    if (autonomyReadinessCaret) autonomyReadinessCaret.textContent = '▾';
     if (autonomyReadinessMeta) autonomyReadinessMeta.textContent = 'No autonomy readiness snapshot loaded.';
     if (autonomyReadinessOverview) autonomyReadinessOverview.textContent = 'No data yet.';
     if (autonomyReadinessWarnings) autonomyReadinessWarnings.textContent = 'No warnings.';
   }
 
   function toggleAutonomyReadinessPanel() {
-    openAutonomyReadinessModal();
+    if (!autonomyReadinessBody) return;
+    const nextHidden = !autonomyReadinessBody.classList.contains('hidden');
+    autonomyReadinessBody.classList.toggle('hidden', nextHidden);
+    if (autonomyReadinessCaret) autonomyReadinessCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function updateAutonomyReadinessPanel(snapshot) {
@@ -4285,7 +4345,10 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleRecallCanaryPanel() {
-    openRecallCanaryModal();
+    if (!recallCanaryBody) return;
+    const nextHidden = !recallCanaryBody.classList.contains('hidden');
+    recallCanaryBody.classList.toggle('hidden', nextHidden);
+    if (recallCanaryCaret) recallCanaryCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function toggleWorldPulsePanel() {
@@ -5000,15 +5063,24 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function toggleMemoryPanel() {
-    openMemoryDebugModal();
+    if (!memoryPanelBody) return;
+    const nextHidden = !memoryPanelBody.classList.contains('hidden');
+    memoryPanelBody.classList.toggle('hidden', nextHidden);
+    if (memoryPanelCaret) memoryPanelCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function toggleAgentTraceDebugPanel() {
-    openAgentTraceModal(lastAgentTraceSummary, lastAgentTraceMeta);
+    if (!agentTraceDebugBody) return;
+    const nextHidden = !agentTraceDebugBody.classList.contains('hidden');
+    agentTraceDebugBody.classList.toggle('hidden', nextHidden);
+    if (agentTraceDebugCaret) agentTraceDebugCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function toggleAutonomyDebugPanel() {
-    openAutonomyDebugModal();
+    if (!autonomyDebugBody) return;
+    const nextHidden = !autonomyDebugBody.classList.contains('hidden');
+    autonomyDebugBody.classList.toggle('hidden', nextHidden);
+    if (autonomyDebugCaret) autonomyDebugCaret.textContent = nextHidden ? '▾' : '▴';
   }
 
   function isAttentionNotification(notification) {
@@ -7812,7 +7884,10 @@ document.addEventListener("DOMContentLoaded", () => {
     debugButton.className = 'rounded-full border border-violet-400/40 bg-violet-500/20 px-2 py-1 text-[10px] font-semibold text-violet-100 hover:bg-violet-500/30';
     debugButton.textContent = 'Open debug';
     debugButton.addEventListener('click', () => {
-      openAutonomyDebugModal();
+      openDebugPanelModal();
+      if (autonomyDebugPanel) autonomyDebugPanel.classList.remove('hidden');
+      if (autonomyDebugBody) autonomyDebugBody.classList.remove('hidden');
+      if (autonomyDebugCaret) autonomyDebugCaret.textContent = '▴';
     });
     panel.appendChild(debugButton);
     return panel;
@@ -9256,6 +9331,28 @@ document.addEventListener("DOMContentLoaded", () => {
   if (memoryDebugModalDialog) {
     memoryDebugModalDialog.addEventListener('click', (event) => event.stopPropagation());
   }
+  ensureDebugPanelModalRootOnBody();
+  if (debugPanelOpenModal) {
+    debugPanelOpenModal.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openDebugPanelModal();
+    });
+  }
+  if (debugPanelModalClose) {
+    debugPanelModalClose.addEventListener('click', closeDebugPanelModal);
+  }
+  if (debugPanelModalBackdrop) {
+    debugPanelModalBackdrop.addEventListener('click', closeDebugPanelModal);
+  }
+  if (debugPanelModalRoot) {
+    debugPanelModalRoot.addEventListener('click', (event) => {
+      if (event.target === debugPanelModalRoot) closeDebugPanelModal();
+    });
+  }
+  if (debugPanelModalDialog) {
+    debugPanelModalDialog.addEventListener('click', (event) => event.stopPropagation());
+  }
   if (agentTraceDebugToggle) {
     agentTraceDebugToggle.addEventListener('click', toggleAgentTraceDebugPanel);
   }
@@ -9788,6 +9885,10 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (event.key === 'Escape' && autonomyReadinessModalRoot && !autonomyReadinessModalRoot.classList.contains('hidden')) {
       closeAutonomyReadinessModal();
+      return;
+    }
+    if (event.key === 'Escape' && debugPanelModalRoot && !debugPanelModalRoot.classList.contains('hidden')) {
+      closeDebugPanelModal();
       return;
     }
     if (event.key === 'Escape' && chatStanceDebugModalRoot && !chatStanceDebugModalRoot.classList.contains('hidden')) {

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -417,355 +417,13 @@
         <div id="runtimeDebugPanel" class="bg-gray-800/40 border border-gray-700 rounded-xl p-3 space-y-2">
           <div class="w-full flex items-center justify-between text-xs text-gray-300">
             <span class="uppercase tracking-wide">Debug Panel</span>
-          </div>
-          <div id="runtimeDebugPanelBody" class="space-y-2 text-xs text-gray-300">
-            <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
-              <div class="flex items-center justify-between gap-2">
-                <button
-                  id="memoryPanelToggle"
-                  class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
-                  type="button"
-                >
-                  <span class="uppercase tracking-wide">Memory / Recall Debug</span>
-                  <span id="memoryPanelCaret" class="text-gray-500">▾</span>
-                </button>
-                <button
-                  id="memoryDebugOpenModal"
-                  class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-                  type="button"
-                >
-                  Modal
-                </button>
-              </div>
-              <div id="memoryPanelBody" class="hidden space-y-2 text-xs text-gray-300">
-            <div class="flex items-center justify-between">
-              <span class="text-gray-500">Memory used</span>
-              <span id="memoryUsedValue">--</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-gray-500">Recall count</span>
-              <span id="recallCountValue">--</span>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Backend counts</div>
-              <pre id="backendCountsValue" class="whitespace-pre-wrap break-words text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-20 overflow-y-auto">--</pre>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Memory digest (summary)</div>
-              <pre id="memoryDigestPre" class="whitespace-pre-wrap break-words text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-24 overflow-y-auto">--</pre>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Outbound routing debug</div>
-              <pre id="outboundRoutingDebug" class="whitespace-pre-wrap break-words text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-20 overflow-y-auto">--</pre>
-            </div>
-              </div>
-            </div>
-
-        <div id="agentTraceDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
-          <div class="flex items-center justify-between gap-2">
             <button
-              id="agentTraceDebugToggle"
-              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
-              type="button"
-            >
-              <span class="uppercase tracking-wide">Agent Trace</span>
-              <span id="agentTraceDebugCaret" class="text-gray-500">▾</span>
-            </button>
-            <button
-              id="agentTraceDebugOpenModal"
+              id="debugPanelOpenModal"
               class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
               type="button"
             >
               Modal
             </button>
-          </div>
-          <div id="agentTraceDebugBody" class="hidden space-y-4 text-xs text-gray-300">
-            <div id="agentTraceDebugMeta" class="text-[10px] text-gray-500">--</div>
-            <div id="agentTraceDebugOverview" class="space-y-3"></div>
-            <div>
-              <div class="text-gray-500 mb-1">Deterministic summary</div>
-              <div
-                id="agentTraceDebugSummary"
-                class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-sm text-gray-200 whitespace-pre-wrap"
-              >--</div>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Grouped tool usage</div>
-              <div id="agentTraceDebugToolGroups"></div>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Timeline</div>
-              <div id="agentTraceDebugTimeline"></div>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Raw payload</div>
-              <div id="agentTraceDebugRaw"></div>
-            </div>
-          </div>
-        </div>
-
-        <div id="autonomyDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
-          <div class="flex items-center justify-between gap-2">
-            <button
-              id="autonomyDebugToggle"
-              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
-              type="button"
-            >
-              <span class="uppercase tracking-wide">Autonomy Runtime</span>
-              <span id="autonomyDebugCaret" class="text-gray-500">▾</span>
-            </button>
-            <button
-              id="autonomyDebugOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Modal
-            </button>
-          </div>
-          <div id="autonomyDebugBody" class="hidden space-y-4 text-xs text-gray-300">
-            <div id="autonomyDebugMeta" class="text-[10px] text-gray-500">--</div>
-            <div class="flex flex-wrap items-center gap-2">
-              <button id="autonomyGoalArchiveDryRun" type="button" class="rounded-lg border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-amber-200 hover:bg-amber-500/20">Goal archive dry-run</button>
-              <button id="autonomyGoalArchiveApply" type="button" class="rounded-lg border border-rose-500/40 bg-rose-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-rose-200 hover:bg-rose-500/20">Goal archive apply</button>
-              <span id="autonomyGoalArchiveStatus" class="text-[10px] text-gray-400">Nightly job runs in orion-actions @ 03:15 local (not shown in Schedule panel).</span>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Overview</div>
-              <div id="autonomyDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Active state</div>
-              <div id="autonomyDebugState" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
-            </div>
-            <div>
-              <div id="autonomyDebugProposalsTitle" class="text-xs uppercase tracking-wide text-amber-400/80 mb-1">Active goals (non-executing)</div>
-              <div id="autonomyDebugProposals" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Stance alignment</div>
-              <div id="autonomyDebugAlignment" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Raw compact debug</div>
-              <pre id="autonomyDebugRaw" class="whitespace-pre-wrap text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2">--</pre>
-            </div>
-          </div>
-        </div>
-
-        <div id="chatStanceDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
-          <div class="flex items-center justify-between gap-2">
-            <button
-              id="chatStanceDebugToggle"
-              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
-              type="button"
-            >
-              <span class="uppercase tracking-wide">Chat Stance</span>
-              <span id="chatStanceDebugCaret" class="text-gray-500">▾</span>
-            </button>
-            <button
-              id="chatStanceDebugOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Modal
-            </button>
-          </div>
-          <div id="chatStanceDebugBody" class="hidden space-y-3 text-xs text-gray-300">
-            <div id="chatStanceDebugMeta" class="text-[10px] text-gray-500">No chat stance debug payload on this turn.</div>
-            <div id="chatStanceDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">No chat stance debug payload on this turn.</div>
-            <div>
-              <div class="text-gray-500 mb-1">Compact lineage summary</div>
-              <div id="chatStanceDebugLineage" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">--</div>
-            </div>
-            <div>
-              <div class="text-gray-500 mb-1">Raw compact JSON</div>
-              <pre id="chatStanceDebugRaw" class="whitespace-pre-wrap text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2">--</pre>
-            </div>
-          </div>
-        </div>
-
-        <div id="substrateReviewDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
-          <div class="flex items-center justify-between gap-2">
-            <button
-              id="substrateReviewDebugToggle"
-              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
-              type="button"
-            >
-              <span class="uppercase tracking-wide">Substrate Review</span>
-              <span id="substrateReviewDebugCaret" class="text-gray-500">▾</span>
-            </button>
-            <button
-              id="substrateReviewDebugOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Modal
-            </button>
-          </div>
-          <div id="substrateReviewDebugBody" class="hidden space-y-2 text-xs text-gray-300">
-            <div id="substrateReviewDebugMeta" class="text-[10px] text-gray-500">Loading substrate review runtime status…</div>
-            <div id="substrateReviewDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
-            <div class="flex items-center justify-between text-[10px] text-gray-400">
-              <a id="substrateReviewDebugStandaloneLink" href="/substrate" class="text-indigo-300 hover:text-indigo-200 underline">Open standalone /substrate</a>
-              <span>Operator bounded controls in modal</span>
-            </div>
-          </div>
-        </div>
-
-        <div id="selfExperimentsDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
-          <div class="flex items-center justify-between gap-2">
-            <button
-              id="selfExperimentsDebugToggle"
-              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
-              type="button"
-            >
-              <span class="uppercase tracking-wide">Self Experiments</span>
-              <span id="selfExperimentsDebugCaret" class="text-gray-500">▾</span>
-            </button>
-            <button
-              id="selfExperimentsDebugOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Modal
-            </button>
-            <button
-              id="selfExperimentsDebugRefresh"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Refresh
-            </button>
-          </div>
-          <div id="selfExperimentsDebugBody" class="hidden space-y-2 text-xs text-gray-300">
-            <div id="selfExperimentsDebugMeta" class="text-[10px] text-gray-500">Loading self-experiments status…</div>
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-2">
-              <input id="selfExperimentsFilterCorrelation" type="text" placeholder="correlation_id" class="rounded-lg border border-gray-700 bg-gray-900/60 px-2 py-1 text-[11px] text-gray-200" />
-              <input id="selfExperimentsFilterDate" type="text" placeholder="date (YYYY-MM-DD)" class="rounded-lg border border-gray-700 bg-gray-900/60 px-2 py-1 text-[11px] text-gray-200" />
-              <input id="selfExperimentsFilterSkill" type="text" placeholder="skill_id" class="rounded-lg border border-gray-700 bg-gray-900/60 px-2 py-1 text-[11px] text-gray-200" />
-              <button id="selfExperimentsApplyFilters" type="button" class="rounded-lg border border-gray-600 bg-gray-800/70 px-2 py-1 text-[11px] text-gray-200 hover:bg-gray-700">Apply Filters</button>
-            </div>
-            <div class="flex flex-wrap items-center gap-2">
-              <button id="selfExperimentsTriggerPulse" type="button" class="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200 hover:bg-emerald-500/20">Trigger Pulse</button>
-              <button id="selfExperimentsTriggerMetacog" type="button" class="rounded-lg border border-cyan-500/40 bg-cyan-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-cyan-200 hover:bg-cyan-500/20">Trigger Metacog</button>
-              <span id="selfExperimentsActionStatus" class="text-[10px] text-gray-400">Idle.</span>
-            </div>
-            <div id="selfExperimentsDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
-            <pre id="selfExperimentsDebugRaw" class="whitespace-pre-wrap text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-28 overflow-y-auto">--</pre>
-          </div>
-        </div>
-
-        <div id="autonomyReadinessPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
-          <div class="flex items-center justify-between gap-2">
-            <button
-              id="autonomyReadinessToggle"
-              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
-              type="button"
-            >
-              <span class="uppercase tracking-wide">Autonomy Readiness</span>
-            </button>
-            <button
-              id="autonomyReadinessOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Modal
-            </button>
-            <button
-              id="autonomyConstitutionOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Policy Matrix
-            </button>
-          </div>
-        </div>
-
-        <div id="recallCanaryPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3">
-          <div class="flex items-center justify-between gap-2">
-            <button id="recallCanaryToggle" class="flex items-center gap-2 text-left" type="button">
-              <span class="text-xs uppercase tracking-wide text-gray-400">Recall Canary</span>
-              <span id="recallCanaryCaret" class="text-[10px] text-gray-500">▾</span>
-            </button>
-            <button
-              id="recallCanaryOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Modal
-            </button>
-          </div>
-          <div id="recallCanaryBody" class="mt-3 hidden space-y-3">
-            <div id="recallCanaryStatusMeta" class="text-[10px] text-gray-500">No canary run yet.</div>
-            <div id="recallCanarySummary" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">No data yet.</div>
-            <div class="text-[10px] text-gray-500">
-              Open the Recall Canary modal to run manual canary queries, record judgments, and create review artifacts.
-            </div>
-          </div>
-        </div>
-
-        <div id="cognitiveReviewPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-3">
-          <div class="flex items-center justify-between gap-2">
-            <div class="text-xs uppercase tracking-wide text-gray-400">Cognitive Proposal Review</div>
-            <button
-              id="cognitiveReviewOpenModal"
-              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
-              type="button"
-            >
-              Modal
-            </button>
-          </div>
-          <div class="text-[10px] text-gray-500">Modal-only operator console.</div>
-        </div>
-
-        <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-3">
-          <div class="flex items-center justify-between gap-3">
-            <div>
-              <div class="text-xs uppercase tracking-wide text-gray-500">Social Inspection</div>
-              <div id="socialInspectionPanelStatus" class="text-[11px] text-gray-400 mt-1">Waiting for a social-room turn.</div>
-            </div>
-            <button id="socialInspectionOpen" type="button" class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-3 py-1.5 text-[11px] font-semibold text-indigo-200 hover:bg-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-40" disabled>Open</button>
-          </div>
-          <div id="socialInspectionBadgeRow" class="flex flex-wrap gap-2"></div>
-          <div id="socialInspectionPanelSummary" class="grid grid-cols-1 gap-2 text-[11px] text-gray-300"></div>
-        </div>
-
-        <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-3">
-          <div class="flex items-center justify-between">
-            <div class="text-xs uppercase tracking-wide text-gray-500">Cognition Packs</div>
-          </div>
-          <div id="packContainer" class="flex flex-wrap gap-2"></div>
-
-          <div class="flex items-center justify-between pt-2 border-t border-gray-700">
-            <div class="text-xs uppercase tracking-wide text-gray-500">Verb Routing</div>
-
-            <div class="flex items-center gap-2">
-              <button id="clearButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Clear</button>
-              <button id="copyButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Copy</button>
-            </div>
-          </div>
-
-          <div class="relative">
-            <button id="verbSelectTrigger" class="w-full flex items-center justify-between bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-2 border border-gray-700">
-              <span id="verbSelectLabel" class="text-sm text-gray-300">Select verbs…</span>
-              <span class="text-gray-400">▾</span>
-            </button>
-
-            <div id="verbDropdown" class="hidden absolute mt-2 w-full bg-gray-900 border border-gray-700 rounded-lg shadow-xl z-20">
-              <div class="flex items-center justify-between px-3 py-2 border-b border-gray-800 gap-2">
-                <div class="text-[10px] uppercase tracking-wide text-gray-500">Available Verbs</div>
-                <div class="flex items-center gap-2">
-                  <label class="text-[10px] text-gray-400 flex items-center gap-1">
-                    <input id="verbActiveOnlyToggle" type="checkbox" class="h-3 w-3 text-indigo-600 rounded bg-gray-700 border-gray-600" checked />
-                    Active only
-                  </label>
-                  <button id="clearVerbs" class="text-[10px] text-gray-400 hover:text-white">Clear</button>
-                </div>
-              </div>
-              <div id="verbList" class="max-h-56 overflow-y-auto p-2 space-y-1"></div>
-            </div>
-          </div>
-        </div>
           </div>
         </div>
       </div>
@@ -2776,7 +2434,7 @@
       </div>
     </div>
   </div>
-  
+
   <div id="workflowModal" class="hidden fixed inset-0 z-[68] bg-black/80 p-4 md:p-8" aria-hidden="true">
     <div class="mx-auto flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl">
       <div class="flex items-start justify-between gap-4 border-b border-gray-800 px-5 py-4">
@@ -2867,6 +2525,382 @@
     </div>
   </div>
 
+  <div id="debugPanelModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
+    <div id="debugPanelModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
+    <div id="debugPanelModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+      <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
+        <div class="text-xs uppercase tracking-[0.24em] text-gray-300">Debug Panel</div>
+        <button
+          id="debugPanelModalClose"
+          class="rounded-lg border border-gray-700 bg-gray-900 px-3 py-1 text-xs text-gray-200 hover:bg-gray-800"
+          type="button"
+        >
+          Close
+        </button>
+      </div>
+      <div class="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          <div id="runtimeDebugPanelBody" class="space-y-2 text-xs text-gray-300">
+            <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
+              <div class="flex items-center justify-between gap-2">
+                <button
+                  id="memoryPanelToggle"
+                  class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
+                  type="button"
+                >
+                  <span class="uppercase tracking-wide">Memory / Recall Debug</span>
+                  <span id="memoryPanelCaret" class="text-gray-500">▾</span>
+                </button>
+                <button
+                  id="memoryDebugOpenModal"
+                  class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+                  type="button"
+                >
+                  Modal
+                </button>
+              </div>
+              <div id="memoryPanelBody" class="hidden space-y-2 text-xs text-gray-300">
+            <div class="flex items-center justify-between">
+              <span class="text-gray-500">Memory used</span>
+              <span id="memoryUsedValue">--</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span class="text-gray-500">Recall count</span>
+              <span id="recallCountValue">--</span>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Backend counts</div>
+              <pre id="backendCountsValue" class="whitespace-pre-wrap break-words text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-20 overflow-y-auto">--</pre>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Memory digest (summary)</div>
+              <pre id="memoryDigestPre" class="whitespace-pre-wrap break-words text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-24 overflow-y-auto">--</pre>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Outbound routing debug</div>
+              <pre id="outboundRoutingDebug" class="whitespace-pre-wrap break-words text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-20 overflow-y-auto">--</pre>
+            </div>
+              </div>
+            </div>
+
+        <div id="agentTraceDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <button
+              id="agentTraceDebugToggle"
+              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
+              type="button"
+            >
+              <span class="uppercase tracking-wide">Agent Trace</span>
+              <span id="agentTraceDebugCaret" class="text-gray-500">▾</span>
+            </button>
+            <button
+              id="agentTraceDebugOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+          </div>
+          <div id="agentTraceDebugBody" class="hidden space-y-4 text-xs text-gray-300">
+            <div id="agentTraceDebugMeta" class="text-[10px] text-gray-500">--</div>
+            <div id="agentTraceDebugOverview" class="space-y-3"></div>
+            <div>
+              <div class="text-gray-500 mb-1">Deterministic summary</div>
+              <div
+                id="agentTraceDebugSummary"
+                class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-sm text-gray-200 whitespace-pre-wrap"
+              >--</div>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Grouped tool usage</div>
+              <div id="agentTraceDebugToolGroups"></div>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Timeline</div>
+              <div id="agentTraceDebugTimeline"></div>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Raw payload</div>
+              <div id="agentTraceDebugRaw"></div>
+            </div>
+          </div>
+        </div>
+
+        <div id="autonomyDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <button
+              id="autonomyDebugToggle"
+              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
+              type="button"
+            >
+              <span class="uppercase tracking-wide">Autonomy Runtime</span>
+              <span id="autonomyDebugCaret" class="text-gray-500">▾</span>
+            </button>
+            <button
+              id="autonomyDebugOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+          </div>
+          <div id="autonomyDebugBody" class="hidden space-y-4 text-xs text-gray-300">
+            <div id="autonomyDebugMeta" class="text-[10px] text-gray-500">--</div>
+            <div class="flex flex-wrap items-center gap-2">
+              <button id="autonomyGoalArchiveDryRun" type="button" class="rounded-lg border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-amber-200 hover:bg-amber-500/20">Goal archive dry-run</button>
+              <button id="autonomyGoalArchiveApply" type="button" class="rounded-lg border border-rose-500/40 bg-rose-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-rose-200 hover:bg-rose-500/20">Goal archive apply</button>
+              <span id="autonomyGoalArchiveStatus" class="text-[10px] text-gray-400">Nightly job runs in orion-actions @ 03:15 local (not shown in Schedule panel).</span>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Overview</div>
+              <div id="autonomyDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Active state</div>
+              <div id="autonomyDebugState" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
+            </div>
+            <div>
+              <div id="autonomyDebugProposalsTitle" class="text-xs uppercase tracking-wide text-amber-400/80 mb-1">Active goals (non-executing)</div>
+              <div id="autonomyDebugProposals" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Stance alignment</div>
+              <div id="autonomyDebugAlignment" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Raw compact debug</div>
+              <pre id="autonomyDebugRaw" class="whitespace-pre-wrap text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2">--</pre>
+            </div>
+          </div>
+        </div>
+
+        <div id="chatStanceDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <button
+              id="chatStanceDebugToggle"
+              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
+              type="button"
+            >
+              <span class="uppercase tracking-wide">Chat Stance</span>
+              <span id="chatStanceDebugCaret" class="text-gray-500">▾</span>
+            </button>
+            <button
+              id="chatStanceDebugOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+          </div>
+          <div id="chatStanceDebugBody" class="hidden space-y-3 text-xs text-gray-300">
+            <div id="chatStanceDebugMeta" class="text-[10px] text-gray-500">No chat stance debug payload on this turn.</div>
+            <div id="chatStanceDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">No chat stance debug payload on this turn.</div>
+            <div>
+              <div class="text-gray-500 mb-1">Compact lineage summary</div>
+              <div id="chatStanceDebugLineage" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">--</div>
+            </div>
+            <div>
+              <div class="text-gray-500 mb-1">Raw compact JSON</div>
+              <pre id="chatStanceDebugRaw" class="whitespace-pre-wrap text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2">--</pre>
+            </div>
+          </div>
+        </div>
+
+        <div id="substrateReviewDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <button
+              id="substrateReviewDebugToggle"
+              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
+              type="button"
+            >
+              <span class="uppercase tracking-wide">Substrate Review</span>
+              <span id="substrateReviewDebugCaret" class="text-gray-500">▾</span>
+            </button>
+            <button
+              id="substrateReviewDebugOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+          </div>
+          <div id="substrateReviewDebugBody" class="hidden space-y-2 text-xs text-gray-300">
+            <div id="substrateReviewDebugMeta" class="text-[10px] text-gray-500">Loading substrate review runtime status…</div>
+            <div id="substrateReviewDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
+            <div class="flex items-center justify-between text-[10px] text-gray-400">
+              <a id="substrateReviewDebugStandaloneLink" href="/substrate" class="text-indigo-300 hover:text-indigo-200 underline">Open standalone /substrate</a>
+              <span>Operator bounded controls in modal</span>
+            </div>
+          </div>
+        </div>
+
+        <div id="selfExperimentsDebugPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <button
+              id="selfExperimentsDebugToggle"
+              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
+              type="button"
+            >
+              <span class="uppercase tracking-wide">Self Experiments</span>
+              <span id="selfExperimentsDebugCaret" class="text-gray-500">▾</span>
+            </button>
+            <button
+              id="selfExperimentsDebugOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+            <button
+              id="selfExperimentsDebugRefresh"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Refresh
+            </button>
+          </div>
+          <div id="selfExperimentsDebugBody" class="hidden space-y-2 text-xs text-gray-300">
+            <div id="selfExperimentsDebugMeta" class="text-[10px] text-gray-500">Loading self-experiments status…</div>
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-2">
+              <input id="selfExperimentsFilterCorrelation" type="text" placeholder="correlation_id" class="rounded-lg border border-gray-700 bg-gray-900/60 px-2 py-1 text-[11px] text-gray-200" />
+              <input id="selfExperimentsFilterDate" type="text" placeholder="date (YYYY-MM-DD)" class="rounded-lg border border-gray-700 bg-gray-900/60 px-2 py-1 text-[11px] text-gray-200" />
+              <input id="selfExperimentsFilterSkill" type="text" placeholder="skill_id" class="rounded-lg border border-gray-700 bg-gray-900/60 px-2 py-1 text-[11px] text-gray-200" />
+              <button id="selfExperimentsApplyFilters" type="button" class="rounded-lg border border-gray-600 bg-gray-800/70 px-2 py-1 text-[11px] text-gray-200 hover:bg-gray-700">Apply Filters</button>
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+              <button id="selfExperimentsTriggerPulse" type="button" class="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200 hover:bg-emerald-500/20">Trigger Pulse</button>
+              <button id="selfExperimentsTriggerMetacog" type="button" class="rounded-lg border border-cyan-500/40 bg-cyan-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-cyan-200 hover:bg-cyan-500/20">Trigger Metacog</button>
+              <span id="selfExperimentsActionStatus" class="text-[10px] text-gray-400">Idle.</span>
+            </div>
+            <div id="selfExperimentsDebugOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
+            <pre id="selfExperimentsDebugRaw" class="whitespace-pre-wrap text-[10px] text-gray-200 bg-gray-900/60 border border-gray-700 rounded p-2 max-h-28 overflow-y-auto">--</pre>
+          </div>
+        </div>
+
+        <div id="autonomyReadinessPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <button
+              id="autonomyReadinessToggle"
+              class="flex-1 flex items-center justify-between text-xs text-gray-300 hover:text-white"
+              type="button"
+            >
+              <span class="uppercase tracking-wide">Autonomy Readiness</span>
+              <span id="autonomyReadinessCaret" class="text-gray-500">▾</span>
+            </button>
+            <button
+              id="autonomyReadinessOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+            <button
+              id="autonomyConstitutionOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Policy Matrix
+            </button>
+          </div>
+          <div id="autonomyReadinessBody" class="hidden space-y-3 text-xs text-gray-300">
+            <div id="autonomyReadinessMeta" class="text-[10px] text-gray-500">Loading autonomy readiness snapshot…</div>
+            <div id="autonomyReadinessOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">No data yet.</div>
+            <div>
+              <div class="text-gray-500 mb-1">Warnings</div>
+              <div id="autonomyReadinessWarnings" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px]">No warnings.</div>
+            </div>
+          </div>
+        </div>
+
+        <div id="recallCanaryPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3">
+          <div class="flex items-center justify-between gap-2">
+            <button id="recallCanaryToggle" class="flex items-center gap-2 text-left" type="button">
+              <span class="text-xs uppercase tracking-wide text-gray-400">Recall Canary</span>
+              <span id="recallCanaryCaret" class="text-[10px] text-gray-500">▾</span>
+            </button>
+            <button
+              id="recallCanaryOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+          </div>
+          <div id="recallCanaryBody" class="mt-3 hidden space-y-3">
+            <div id="recallCanaryStatusMeta" class="text-[10px] text-gray-500">No canary run yet.</div>
+            <div id="recallCanarySummary" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">No data yet.</div>
+            <div class="text-[10px] text-gray-500">
+              Open the Recall Canary modal to run manual canary queries, record judgments, and create review artifacts.
+            </div>
+          </div>
+        </div>
+
+        <div id="cognitiveReviewPanel" class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-3">
+          <div class="flex items-center justify-between gap-2">
+            <div class="text-xs uppercase tracking-wide text-gray-400">Cognitive Proposal Review</div>
+            <button
+              id="cognitiveReviewOpenModal"
+              class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20"
+              type="button"
+            >
+              Modal
+            </button>
+          </div>
+          <div class="text-[10px] text-gray-500">Modal-only operator console.</div>
+        </div>
+
+        <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-3">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <div class="text-xs uppercase tracking-wide text-gray-500">Social Inspection</div>
+              <div id="socialInspectionPanelStatus" class="text-[11px] text-gray-400 mt-1">Waiting for a social-room turn.</div>
+            </div>
+            <button id="socialInspectionOpen" type="button" class="rounded-lg border border-indigo-500/40 bg-indigo-500/10 px-3 py-1.5 text-[11px] font-semibold text-indigo-200 hover:bg-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-40" disabled>Open</button>
+          </div>
+          <div id="socialInspectionBadgeRow" class="flex flex-wrap gap-2"></div>
+          <div id="socialInspectionPanelSummary" class="grid grid-cols-1 gap-2 text-[11px] text-gray-300"></div>
+        </div>
+
+        <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-3">
+          <div class="flex items-center justify-between">
+            <div class="text-xs uppercase tracking-wide text-gray-500">Cognition Packs</div>
+          </div>
+          <div id="packContainer" class="flex flex-wrap gap-2"></div>
+
+          <div class="flex items-center justify-between pt-2 border-t border-gray-700">
+            <div class="text-xs uppercase tracking-wide text-gray-500">Verb Routing</div>
+
+            <div class="flex items-center gap-2">
+              <button id="clearButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Clear</button>
+              <button id="copyButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Copy</button>
+            </div>
+          </div>
+
+          <div class="relative">
+            <button id="verbSelectTrigger" class="w-full flex items-center justify-between bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-2 border border-gray-700">
+              <span id="verbSelectLabel" class="text-sm text-gray-300">Select verbs…</span>
+              <span class="text-gray-400">▾</span>
+            </button>
+
+            <div id="verbDropdown" class="hidden absolute mt-2 w-full bg-gray-900 border border-gray-700 rounded-lg shadow-xl z-20">
+              <div class="flex items-center justify-between px-3 py-2 border-b border-gray-800 gap-2">
+                <div class="text-[10px] uppercase tracking-wide text-gray-500">Available Verbs</div>
+                <div class="flex items-center gap-2">
+                  <label class="text-[10px] text-gray-400 flex items-center gap-1">
+                    <input id="verbActiveOnlyToggle" type="checkbox" class="h-3 w-3 text-indigo-600 rounded bg-gray-700 border-gray-600" checked />
+                    Active only
+                  </label>
+                  <button id="clearVerbs" class="text-[10px] text-gray-400 hover:text-white">Clear</button>
+                </div>
+              </div>
+              <div id="verbList" class="max-h-56 overflow-y-auto p-2 space-y-1"></div>
+            </div>
+          </div>
+        </div>
+          </div>
+      </div>
+    </div>
+  </div>
+
   <div id="autonomyDebugModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
     <div id="autonomyDebugModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
     <div id="autonomyDebugModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
@@ -2895,6 +2929,7 @@
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div>
           <div class="text-xs uppercase tracking-[0.24em] text-emerald-300">Autonomy readiness</div>
+          <div id="autonomyReadinessModalMeta" class="mt-1 text-[11px] text-gray-400">Loading autonomy readiness snapshot…</div>
         </div>
         <button
           id="autonomyReadinessModalClose"
@@ -2904,13 +2939,8 @@
           Close
         </button>
       </div>
-      <div class="min-h-0 flex-1 overflow-y-auto px-5 py-4 space-y-3 text-xs text-gray-300">
-        <div id="autonomyReadinessMeta" class="text-[10px] text-gray-500">Loading autonomy readiness snapshot…</div>
-        <div id="autonomyReadinessOverview" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-1">No data yet.</div>
-        <div>
-          <div class="text-gray-500 mb-1">Warnings</div>
-          <div id="autonomyReadinessWarnings" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px]">No warnings.</div>
-        </div>
+      <div class="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+        <div id="autonomyReadinessModalBody" class="text-xs text-gray-300 space-y-3"></div>
       </div>
     </div>
   </div>

--- a/services/orion-hub/tests/test_llm_route_selector.py
+++ b/services/orion-hub/tests/test_llm_route_selector.py
@@ -368,3 +368,39 @@ def test_recall_profile_auto_follows_mode() -> None:
     assert "recallProfileSelect.disabled = true;" in app_js
     assert "recallProfileSelect.disabled = false;" in app_js
     assert "recallProfileSelect.value = 'assist.light.v1';" in app_js
+
+
+def test_debug_panel_is_single_card_wrapping_all_rows_in_one_modal() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    app_js = APP_JS.read_text(encoding="utf-8")
+
+    # Main-page surface: one card, one Modal button, no inline row content.
+    panel_card = html.split('id="runtimeDebugPanel"', 1)[1].split("</div>\n        </div>", 1)[0]
+    assert 'id="debugPanelOpenModal"' in panel_card
+    assert 'id="memoryPanelToggle"' not in panel_card
+
+    # All 9 rows live inside the new modal's body, not on the main page directly.
+    modal_shell = html.split('id="debugPanelModalRoot"', 1)[1].split('id="autonomyDebugModalRoot"', 1)[0]
+    assert 'w-[75vw] h-[75vh]' in modal_shell
+    assert 'id="runtimeDebugPanelBody"' in modal_shell
+    for row_id in (
+        "memoryPanelToggle",
+        "agentTraceDebugToggle",
+        "autonomyDebugToggle",
+        "chatStanceDebugToggle",
+        "substrateReviewDebugToggle",
+        "selfExperimentsDebugToggle",
+        "autonomyReadinessToggle",
+        "recallCanaryToggle",
+        "cognitiveReviewOpenModal",
+    ):
+        assert f'id="{row_id}"' in modal_shell
+
+    # Each row still keeps its own original inline expand + its own per-item Modal button.
+    assert 'id="memoryDebugOpenModal"' in modal_shell
+    assert 'id="autonomyDebugOpenModal"' in modal_shell
+    assert "function toggleMemoryPanel()" in app_js
+    assert "memoryPanelBody.classList.toggle('hidden', nextHidden);" in app_js
+    assert "function openDebugPanelModal()" in app_js
+    assert "function closeDebugPanelModal()" in app_js
+    assert "debugPanelOpenModal.addEventListener('click'" in app_js


### PR DESCRIPTION
## Summary

PR #1447 (merged) shipped a Debug Panel restructure that changed each of the 9 row's own click behavior (inline toggle -> opening its own modal). That wasn't the actual request — the ask was to keep every row's existing behavior completely unchanged (inline expand/collapse + its own separate per-item "Modal" button) and only wrap the *outer* section in one new modal.

This PR corrects that, on top of #1447 already being on `main`:

- Reverted all 9 `toggle*Panel()` functions back to their original inline expand/collapse behavior.
- Restored the Autonomy Readiness row's inline body/caret; kept its new per-item modal (added in #1447) as an additional pop-out, mirroring the copy-on-open pattern the Autonomy Runtime modal already uses.
- Outer "Debug Panel" card is now a single row with one "Modal" button. Clicking it opens one new `debugPanelModalRoot` modal (75vw x 75vh) containing the entire original 9-row content, byte-for-byte, relocated as-is.
- Extended the Escape-key handler and scroll-lock sync to cover the two new modal roots.
- Fixed the "Open debug" chat-feed shortcut to open the new outer modal and expand the Autonomy Runtime row within it (previously would have un-hidden a row with no visible modal open).

Full PR report (updated in place, describes both the original PR #1447 changes and this correction): `docs/superpowers/pr-reports/2026-07-29-hub-mode-cleanup-pr.md`

## Test plan

- [x] `pytest services/orion-hub/tests -q` — 1032 passed, 32 failed, 5 skipped
- [x] Confirmed 0 real regressions vs a git-stash baseline comparison on unmodified `main` (31 failures there); the one delta (`test_substrate_mutation_manual_route_routing.py::test_routing_manual_apply_changes_real_live_routing_surface`) is a confirmed pre-existing flaky/order-dependent test unrelated to this repo area — passes standalone, a different test in the same file fails instead when that file is run alone
- [x] Re-rendered `render_hub_index_html()` directly to confirm the template parses cleanly with no leftover `{{...}}` placeholders after the block relocation
- [x] Added test coverage asserting the main-page Debug Panel card has no inline row content and all 9 rows' original ids/behavior live inside the new modal
- [ ] Manual browser verification of the modal interactions was not performed this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)