### PR TITLE
fix(substrate): stop SubstrateDynamicsEngine.tick() clobbering externally-owned metadata

### DIFF
--- a/orion/substrate/dynamics.py
+++ b/orion/substrate/dynamics.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
 
 from .activation import ActivationConfig, decay_activation, seed_activation
+from .falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
 from .pressure import (
     PressureConfig,
     contradiction_amplification,
@@ -170,7 +171,26 @@ class SubstrateDynamicsEngine:
                 )
                 updated_signal = node.signals.model_copy(update={"activation": activation_bundle})
                 updated_node = node.model_copy(update={"signals": updated_signal, "metadata": metadata})
-                self._store.upsert_node(identity_key=identity_by_node_id.get(node_id), node=updated_node)
+                # skip_metadata_keys: this engine reads prediction_error purely
+                # to SEED pressure (prediction_error_pressure() above) -- it
+                # never computes prediction_error/contributing_turn_ids
+                # itself and must not re-persist whatever (possibly stale)
+                # copy happened to be in this tick's start-of-loop snapshot.
+                # Confirmed live 2026-07-29: this write guard fires on
+                # activation decay alone, which changes on essentially every
+                # node every tick, far more often than an external writer
+                # like bus_synaptic's 30s cadence -- without this guard,
+                # this engine's own frequent re-writes durably clobbered a
+                # real writer's fresh values, freezing node:substrate.
+                # bus_synaptic's prediction_error at a stale 1.0 for 3+
+                # hours and causing real false "Bus Anomaly Detected"
+                # alerts downstream. See falkor_codec.
+                # EXTERNALLY_OWNED_METADATA_KEYS's docstring for the full trace.
+                self._store.upsert_node(
+                    identity_key=identity_by_node_id.get(node_id),
+                    node=updated_node,
+                    skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS,
+                )
 
             if activation_changed:
                 activation_updates.append(

--- a/orion/substrate/falkor_codec.py
+++ b/orion/substrate/falkor_codec.py
@@ -152,6 +152,33 @@ DYNAMICS_ENGINE_OWNED_METADATA_KEYS: tuple[str, ...] = (
     "dormancy_updated_at",
 )
 
+# The reverse-direction ownership problem, confirmed live 2026-07-29 as a real
+# bug (not theoretical): SubstrateDynamicsEngine.tick() (orion/substrate/
+# dynamics.py) reads `prediction_error` off a node purely to SEED pressure
+# (prediction_error_pressure()) but was re-persisting the ENTIRE metadata dict
+# -- including prediction_error/contributing_turn_ids, fields it does not own
+# and never computes -- via its own upsert_node() call. Its write guard fires
+# on activation decay alone (which changes on essentially every node, every
+# tick, unconditionally), far more often than an external writer like
+# bus_synaptic's 30s tick -- so dynamics.py's frequent re-writes of whatever
+# was in its own start-of-tick snapshot functionally "won" the race almost
+# always, durably re-locking a stale prediction_error value even while the
+# real external writer kept succeeding and logging correct, fresh values.
+# Confirmed live: node:substrate.bus_synaptic frozen at prediction_error=1.0
+# for 3+ hours despite bus_synaptic_tick_completed logging real, varying,
+# non-saturated values every 30s the entire time -- and this same frozen
+# value was independently polled by orion-equilibrium-service's own
+# bus_synaptic metacog trigger, producing real false "Bus Anomaly Detected"
+# alerts. Expressed as RAW metadata dict keys (matching how a caller like
+# dynamics.py naturally thinks about node.metadata), NOT the encoded Cypher
+# property names -- `contributing_turn_ids` becomes `contributing_turn_ids_json`
+# only once encode_node_properties() runs; FalkorSubstrateStore.upsert_node()
+# is responsible for translating this raw-key set into the encoded property
+# names it actually needs to exclude from the SET clause.
+EXTERNALLY_OWNED_METADATA_KEYS: frozenset[str] = frozenset(
+    {"prediction_error", "contributing_turn_ids"}
+)
+
 
 def _safe_float(value: Any, *, default: float | None) -> float | None:
     """Tolerant numeric coercion matching the `.get(key) or default` pattern

--- a/orion/substrate/falkor_store.py
+++ b/orion/substrate/falkor_store.py
@@ -508,16 +508,82 @@ class FalkorSubstrateStore:
     def get_edge_id_by_identity(self, identity_key: str) -> str | None:
         return self._cache.get_edge_id_by_identity(identity_key)
 
-    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: BaseSubstrateNodeV1,
+        skip_metadata_keys: frozenset[str] | None = None,
+    ) -> None:
+        """``skip_metadata_keys`` (raw ``node.metadata`` key names, e.g.
+        ``falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS``) excludes those keys
+        from BOTH the Cypher SET clause (so an existing value on the graph is
+        left untouched, not overwritten with this call's copy) AND the local
+        in-process cache update (so the cache doesn't diverge from the graph
+        by caching this call's stale copy instead of the real value already
+        there). Confirmed live 2026-07-29 as a real bug, not theoretical: a
+        caller with no reason to know the current value of a field it
+        doesn't own (SubstrateDynamicsEngine.tick() re-persisting
+        `prediction_error` purely because activation decay triggered its
+        write guard) durably clobbered a different writer's fresh values --
+        `node:substrate.bus_synaptic` frozen at `prediction_error=1.0` for
+        3+ hours despite the real writer succeeding every 30s the whole
+        time, which independently caused false "Bus Anomaly Detected"
+        alerts via orion-equilibrium-service's own poll of the same frozen
+        value. See falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring
+        for the full trace.
+
+        **Known, bounded race, same shape as the cache-swap race documented
+        on ``_hydrate_from_durable()`` above**: the ``self._cache.get_node_by_id()``
+        read used to build the skip-preserving merge isn't lock-protected. A
+        second concurrent ``upsert_node()`` call landing between that read
+        and this call's own ``self._cache.upsert_node(...)`` could still
+        leave the *local cache* (not the durable Falkor graph -- the Cypher
+        SET-clause exclusion is unconditional and independent of this cache
+        read) briefly holding a stale copy of a skipped key. Self-heals the
+        same way: this write still bumps ``self._write_generation``, so the
+        next ``snapshot()`` call detects the mismatch and re-hydrates from
+        durable Falkor, which is unaffected by this narrow window.
+        """
         if getattr(node, "node_kind", None) not in ("concept", "evidence"):
             raise ValueError(
                 "FalkorSubstrateStore durable writes support concept and evidence nodes only; "
                 f"got node_kind={getattr(node, 'node_kind', None)!r}"
             )
         node = _with_sanitized_metadata(node)
+
+        cache_node = node
+        skip_encoded_keys: set[str] = set()
+        if skip_metadata_keys:
+            existing_cached = self._cache.get_node_by_id(node.node_id)
+            merged_metadata = dict(node.metadata or {})
+            existing_metadata = (existing_cached.metadata or {}) if existing_cached is not None else {}
+            for key in skip_metadata_keys:
+                if key in existing_metadata:
+                    merged_metadata[key] = existing_metadata[key]
+                else:
+                    # No cached copy to fall back on -- an honest "unknown"
+                    # (key absent) beats caching this caller's own unverified
+                    # guess for a field it doesn't own. Review finding
+                    # 2026-07-29: without this, a cache miss (e.g. mid-
+                    # rehydrate) would leave the LOCAL cache holding the
+                    # caller's copy for a field the durable Cypher write
+                    # deliberately skipped -- cache/durable divergence until
+                    # the next generation-triggered rehydrate.
+                    merged_metadata.pop(key, None)
+            cache_node = node.model_copy(update={"metadata": merged_metadata})
+            # Translate raw metadata keys into the encoded Cypher property
+            # names actually present in the SET clause -- contributing_turn_ids
+            # becomes contributing_turn_ids_json only once
+            # encode_node_properties() runs (see _dynamics_properties_from_metadata,
+            # and test_externally_owned_metadata_keys_translation_matches_real_encoding
+            # for the drift guard on this hardcoded translation).
+            for key in skip_metadata_keys:
+                skip_encoded_keys.add("contributing_turn_ids_json" if key == "contributing_turn_ids" else key)
+
         params = encode_node_properties(node, identity_key)
         label = node_label_for_kind(str(node.node_kind))
-        assignments = _set_assignments("n", params, skip={"node_id"})
+        assignments = _set_assignments("n", params, skip={"node_id"} | skip_encoded_keys)
         cypher = (
             f"MERGE (n:SubstrateNode:{label} {{node_id: $node_id}}) "
             f"SET {assignments} "
@@ -528,7 +594,7 @@ class FalkorSubstrateStore:
         except Exception as exc:
             logger.error("falkor_substrate_upsert_node_failed node_id=%s error=%s", node.node_id, exc)
             raise
-        self._cache.upsert_node(identity_key=identity_key, node=node)
+        self._cache.upsert_node(identity_key=identity_key, node=cache_node)
         self._write_generation += 1
 
     def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None:

--- a/orion/substrate/graphdb_store.py
+++ b/orion/substrate/graphdb_store.py
@@ -197,7 +197,32 @@ LIMIT 1
             return cached
         return self._get_canonical_id(identity_key=identity_key, identity_kind="edge")
 
-    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: BaseSubstrateNodeV1,
+        skip_metadata_keys: frozenset[str] | None = None,
+    ) -> None:
+        """``skip_metadata_keys``: same contract as FalkorSubstrateStore's
+        (not the live backend -- SUBSTRATE_STORE_BACKEND=falkor in
+        production -- kept consistent for interface parity and in case this
+        backend is ever reactivated). This store's DELETE+INSERT WHERE
+        pattern replaces every property on every call, so "leave untouched"
+        isn't expressible the same way Falkor's partial Cypher SET is;
+        best-effort merge instead, reading the existing node first and
+        carrying its current value forward for any skipped key."""
+        if skip_metadata_keys:
+            existing = self.get_node_by_id(node.node_id)
+            if existing is not None:
+                merged_metadata = dict(node.metadata or {})
+                existing_metadata = existing.metadata or {}
+                for key in skip_metadata_keys:
+                    if key in existing_metadata:
+                        merged_metadata[key] = existing_metadata[key]
+                    else:
+                        merged_metadata.pop(key, None)
+                node = node.model_copy(update={"metadata": merged_metadata})
         node_iri = self._node_iri(node.node_id)
         payload_json = json.dumps(node.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
         metadata_json = json.dumps(node.metadata or {}, ensure_ascii=False, sort_keys=True)

--- a/orion/substrate/routed_store.py
+++ b/orion/substrate/routed_store.py
@@ -47,9 +47,17 @@ class RoutedSubstrateGraphStore:
     def get_edge_id_by_identity(self, identity_key: str) -> str | None:
         return self._primary.get_edge_id_by_identity(identity_key)
 
-    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
-        self._primary.upsert_node(identity_key=identity_key, node=node)
-        self._shadow_write("upsert_node", identity_key=identity_key, node=node)
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: BaseSubstrateNodeV1,
+        skip_metadata_keys: frozenset[str] | None = None,
+    ) -> None:
+        self._primary.upsert_node(identity_key=identity_key, node=node, skip_metadata_keys=skip_metadata_keys)
+        self._shadow_write(
+            "upsert_node", identity_key=identity_key, node=node, skip_metadata_keys=skip_metadata_keys
+        )
 
     def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None:
         self._primary.upsert_edge(identity_key=identity_key, edge=edge)

--- a/orion/substrate/store.py
+++ b/orion/substrate/store.py
@@ -44,7 +44,13 @@ class SubstrateGraphStore(Protocol):
     def get_node_id_by_identity(self, identity_key: str) -> str | None: ...
     def get_edge_id_by_identity(self, identity_key: str) -> str | None: ...
     def get_identity_key_by_node_id(self, node_id: str) -> str | None: ...
-    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None: ...
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: BaseSubstrateNodeV1,
+        skip_metadata_keys: frozenset[str] | None = None,
+    ) -> None: ...
     def upsert_edge(self, *, identity_key: str, edge: SubstrateEdgeV1) -> None: ...
     def snapshot(self) -> MaterializedSubstrateGraphState: ...
 
@@ -92,7 +98,29 @@ class InMemorySubstrateGraphStore:
     def get_identity_key_by_node_id(self, node_id: str) -> str | None:
         return self._identity_key_by_node_id.get(node_id)
 
-    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: BaseSubstrateNodeV1,
+        skip_metadata_keys: frozenset[str] | None = None,
+    ) -> None:
+        """``skip_metadata_keys``: same contract as FalkorSubstrateStore's
+        (see that implementation's docstring) -- preserve whatever's already
+        stored for these metadata keys instead of overwriting with this
+        call's copy, so a test double backed by this in-memory store
+        exercises the same "don't clobber a field you don't own" behavior."""
+        if skip_metadata_keys:
+            existing = self._nodes.get(node.node_id)
+            if existing is not None:
+                merged_metadata = dict(node.metadata or {})
+                existing_metadata = existing.metadata or {}
+                for key in skip_metadata_keys:
+                    if key in existing_metadata:
+                        merged_metadata[key] = existing_metadata[key]
+                    else:
+                        merged_metadata.pop(key, None)
+                node = node.model_copy(update={"metadata": merged_metadata})
         self._nodes[node.node_id] = node
         if identity_key:
             self._node_identity_index[identity_key] = node.node_id

--- a/orion/substrate/tests/test_dynamics.py
+++ b/orion/substrate/tests/test_dynamics.py
@@ -43,10 +43,18 @@ class _CountingStore(InMemorySubstrateGraphStore):
     def __init__(self) -> None:
         super().__init__()
         self.upsert_node_calls: list[str] = []
+        self.skip_metadata_keys_calls: list[frozenset[str] | None] = []
 
-    def upsert_node(self, *, identity_key: str | None, node: BaseSubstrateNodeV1) -> None:
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: BaseSubstrateNodeV1,
+        skip_metadata_keys: frozenset[str] | None = None,
+    ) -> None:
         self.upsert_node_calls.append(node.node_id)
-        super().upsert_node(identity_key=identity_key, node=node)
+        self.skip_metadata_keys_calls.append(skip_metadata_keys)
+        super().upsert_node(identity_key=identity_key, node=node, skip_metadata_keys=skip_metadata_keys)
 
 
 def _engine_with(store: InMemorySubstrateGraphStore, *, activations: dict[str, float], pressures: dict[str, float]) -> SubstrateDynamicsEngine:
@@ -81,6 +89,70 @@ def test_tick_rewrites_node_when_activation_changes() -> None:
 
     assert store.upsert_node_calls == [node.node_id]
     assert len(result.activation_updates) == 1
+
+
+def test_tick_passes_externally_owned_keys_to_skip_metadata_keys() -> None:
+    """Regression test for the live bug confirmed 2026-07-29: tick()'s write
+    guard fires on activation decay alone (essentially every node, every
+    tick), and must never re-persist prediction_error/contributing_turn_ids
+    -- fields it only ever READS (to seed pressure), never computes. See
+    falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring for the full
+    incident (node:substrate.bus_synaptic frozen at a stale prediction_error
+    for 3+ hours, causing real false "Bus Anomaly Detected" alerts)."""
+    from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
+
+    store = _CountingStore()
+    node = _steady_node(activation=0.3, pressure=0.0)
+    store.upsert_node(identity_key="identity-1", node=node)
+    store.upsert_node_calls.clear()
+    store.skip_metadata_keys_calls.clear()
+
+    engine = _engine_with(store, activations={node.node_id: 0.5}, pressures={node.node_id: 0.0})
+    engine.tick(now=_NOW)
+
+    assert store.upsert_node_calls == [node.node_id]
+    assert store.skip_metadata_keys_calls == [EXTERNALLY_OWNED_METADATA_KEYS]
+
+
+def test_tick_does_not_clobber_externally_owned_prediction_error() -> None:
+    """The actual end-to-end regression, reproducing the real race: a node's
+    prediction_error is updated by a genuinely EXTERNAL writer (bus_synaptic's
+    own tick, in the real incident) WHILE this engine's tick() is in flight --
+    i.e. after this engine's own snapshot() was taken (top of tick()) but
+    before its own upsert_node() call runs. The external writer's fresher
+    value must survive; it must NOT be reverted to whatever stale copy was in
+    this engine's own start-of-tick snapshot. InMemorySubstrateGraphStore has
+    no caching layer (snapshot() always reflects the current store instantly),
+    so the race is simulated by injecting the "external write" as a side
+    effect of the already-test-only-stubbed _compute_activations call, which
+    real tick() invokes strictly after snapshot() and strictly before its own
+    upsert_node() call -- the exact window the real bug lived in.
+    """
+    store = _CountingStore()
+    node = _steady_node(activation=0.3, pressure=0.0)
+    node = node.model_copy(update={"metadata": {**node.metadata, "prediction_error": 0.9}})
+    store.upsert_node(identity_key="identity-1", node=node)
+    store.upsert_node_calls.clear()
+
+    engine = SubstrateDynamicsEngine(store=store)
+    engine._compute_pressures = lambda nodes, outgoing, tick_at: ({node.node_id: 0.0}, {})  # type: ignore[method-assign]
+
+    def _compute_activations_with_concurrent_external_write(updated_nodes, outgoing, pressures, tick_at):
+        fresher = store.get_node_by_id(node.node_id)
+        fresher = fresher.model_copy(update={"metadata": {**fresher.metadata, "prediction_error": 0.42}})
+        store.upsert_node(identity_key="identity-1", node=fresher)
+        return {node.node_id: 0.5}
+
+    engine._compute_activations = _compute_activations_with_concurrent_external_write  # type: ignore[method-assign]
+
+    engine.tick(now=_NOW)
+
+    assert store.upsert_node_calls == [node.node_id, node.node_id], "expected the external write plus this engine's own"
+    stored = store.get_node_by_id(node.node_id)
+    assert stored.metadata["prediction_error"] == 0.42, (
+        "tick() clobbered a fresher externally-written prediction_error with its own "
+        "stale snapshot-time copy -- this is the exact live bug this test guards against"
+    )
 
 
 def test_tick_rewrites_node_when_pressure_changes_even_if_activation_steady() -> None:

--- a/orion/substrate/tests/test_falkor_store.py
+++ b/orion/substrate/tests/test_falkor_store.py
@@ -1407,3 +1407,95 @@ def test_resolve_falkor_snapshot_ceiling_invalid_value_falls_back_to_shared_sett
     monkeypatch.setenv("FALKOR_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", "not-a-number")
     monkeypatch.delenv("SUBSTRATE_SNAPSHOT_FORCE_REFRESH_CEILING_SEC", raising=False)
     assert _resolve_falkor_snapshot_force_refresh_ceiling_sec() == 30.0  # shared default
+
+
+# --- skip_metadata_keys (2026-07-29 dynamics-clobber fix) -----------------
+# Review gap: the regression tests in orion/substrate/tests/test_dynamics.py
+# only exercise InMemorySubstrateGraphStore (no encode/translate step) --
+# the live FalkorSubstrateStore path (Cypher SET-clause exclusion + the raw
+# metadata key -> encoded Cypher property name translation) had zero direct
+# coverage. These tests close that gap using the same RecordingFalkorClient
+# harness the existing SET-clause tests above already use.
+
+def test_falkor_upsert_node_skip_metadata_keys_excludes_from_cypher_set_clause():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    node = _concept(
+        node_id="concept-skip-alpha",
+        metadata={
+            "dynamic_pressure": 0.1,
+            "prediction_error": 0.9,
+            "contributing_turn_ids": ["turn-1", "turn-2"],
+        },
+    )
+
+    from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
+
+    store.upsert_node(
+        identity_key="concept:skip-alpha", node=node, skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS
+    )
+
+    cypher, params = client.calls[-1]
+    assert "n.prediction_error = $prediction_error" not in cypher
+    assert "n.contributing_turn_ids_json = $contributing_turn_ids_json" not in cypher
+    # dynamic_pressure isn't in the skip set -- still a normal, unaffected write.
+    assert "n.dynamic_pressure = $dynamic_pressure" in cypher
+
+
+def test_falkor_upsert_node_skip_metadata_keys_preserves_cached_value():
+    client = RecordingFalkorClient()
+    store = FalkorSubstrateStore(
+        FalkorSubstrateStoreConfig(uri="redis://localhost:6379", graph_name="orion_substrate"),
+        client=client,
+        hydrate=False,
+    )
+    from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
+
+    fresh = _concept(node_id="concept-skip-beta", metadata={"prediction_error": 0.42})
+    store.upsert_node(identity_key="concept:skip-beta", node=fresh)  # a real writer's fresh value
+
+    stale = _concept(node_id="concept-skip-beta", metadata={"prediction_error": 0.9})
+    store.upsert_node(
+        identity_key="concept:skip-beta", node=stale, skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS
+    )
+
+    # The local in-process cache must not diverge from what the durable
+    # Cypher SET clause actually did -- both must keep the fresher 0.42, not
+    # this call's own (deliberately excluded) 0.9.
+    cached = store.get_node_by_id("concept-skip-beta")
+    assert cached.metadata["prediction_error"] == 0.42
+    cypher, params = client.calls[-1]
+    assert "n.prediction_error = $prediction_error" not in cypher
+
+
+def test_externally_owned_metadata_keys_translation_matches_real_encoding():
+    """Review gap: falkor_store.py's raw->encoded key translation is a single
+    hardcoded ternary (only contributing_turn_ids -> contributing_turn_ids_json
+    is special-cased). If EXTERNALLY_OWNED_METADATA_KEYS ever grows a key whose
+    encoded name diverges in some other way, that ternary silently stops
+    working and the exact incident this fix addresses reappears for the new
+    key, with nothing to catch it. This test fails loudly the moment that
+    drift happens, by encoding a real node through the actual production
+    function and checking every EXTERNALLY_OWNED_METADATA_KEYS member maps to
+    a property name this repo's translation logic already knows about."""
+    from orion.substrate.falkor_codec import (
+        EXTERNALLY_OWNED_METADATA_KEYS,
+        _dynamics_properties_from_metadata,
+    )
+
+    raw_metadata = {key: "sentinel" for key in EXTERNALLY_OWNED_METADATA_KEYS}
+    encoded = _dynamics_properties_from_metadata(raw_metadata)
+    known_translations = {"contributing_turn_ids": "contributing_turn_ids_json"}
+
+    for raw_key in EXTERNALLY_OWNED_METADATA_KEYS:
+        encoded_key = known_translations.get(raw_key, raw_key)
+        assert encoded_key in encoded, (
+            f"EXTERNALLY_OWNED_METADATA_KEYS contains {raw_key!r}, but the real encoded "
+            f"Cypher property name {encoded_key!r} isn't in _dynamics_properties_from_metadata()'s "
+            "output -- falkor_store.py's translation ternary needs updating to match, or the "
+            "skip_metadata_keys fix silently stops protecting this field."
+        )

--- a/orion/substrate/tests/test_routed_store.py
+++ b/orion/substrate/tests/test_routed_store.py
@@ -28,7 +28,7 @@ def _concept(node_id: str = "sub-node-r1") -> ConceptNodeV1:
 
 
 class _BoomStore(InMemorySubstrateGraphStore):
-    def upsert_node(self, *, identity_key, node):
+    def upsert_node(self, *, identity_key, node, skip_metadata_keys=None):
         raise RuntimeError("shadow boom")
 
 


### PR DESCRIPTION
## Summary

- Fixes a confirmed live bug: `node:substrate.bus_synaptic` was frozen at `prediction_error=1.0` for 3+ hours despite the real writer (`_bus_synaptic_tick`) succeeding every 30s with fresh, correctly-varying values — and this frozen value independently caused real, repeated false "Bus Anomaly Detected" alerts via `orion-equilibrium-service`'s own poll of the same node.
- Root cause: `SubstrateDynamicsEngine.tick()` is a second writer to the same node, firing far more frequently (activation decay triggers its write guard on essentially every node every tick) than the real writer, and was re-persisting `prediction_error`/`contributing_turn_ids` — fields it only ever reads, never computes — sourced from its own potentially-stale start-of-tick snapshot.
- Adds `skip_metadata_keys` to `upsert_node()` across the `SubstrateGraphStore` Protocol and all 4 implementations, symmetric to the existing `DYNAMICS_ENGINE_OWNED_METADATA_KEYS` protection (which only ever protected the other direction).

## Outcome moved

`node:substrate.bus_synaptic` (and any other node whose `dynamic_pressure` stays flat while activation keeps decaying) can no longer have its `prediction_error`/`contributing_turn_ids` silently reverted to stale snapshot data by the dynamics engine's own more-frequent writes.

## Current architecture

`orion/substrate/dynamics.py`'s `SubstrateDynamicsEngine.tick()` and `services/orion-substrate-runtime/app/worker.py`'s various `_write_prediction_error_node()` callers (bus_synaptic/execution/biometrics/chat/route ticks) both write to the same FalkorDB `SubstrateNode` records via the shared `FalkorSubstrateStore.upsert_node()`. Only one direction of "don't clobber a field you don't own" was protected before this fix.

## Architecture touched

- `orion/substrate/store.py` — `SubstrateGraphStore` Protocol + `InMemorySubstrateGraphStore`
- `orion/substrate/falkor_store.py` — `FalkorSubstrateStore` (the live backend)
- `orion/substrate/routed_store.py` — `RoutedSubstrateGraphStore` (pass-through)
- `orion/substrate/graphdb_store.py` — `GraphDBSubstrateStore` (legacy SPARQL backend, not live in production, kept for interface parity)
- `orion/substrate/falkor_codec.py` — new `EXTERNALLY_OWNED_METADATA_KEYS` constant
- `orion/substrate/dynamics.py` — `tick()` now passes the new parameter on its own write

## Files changed

- `falkor_codec.py`: new `EXTERNALLY_OWNED_METADATA_KEYS = frozenset({"prediction_error", "contributing_turn_ids"})`, documents the incident.
- `falkor_store.py`: `upsert_node()` accepts `skip_metadata_keys`, excludes those keys from both the Cypher SET clause and the local cache update; cache-miss case treats the field as "unknown" rather than caching an unverified guess (review finding fix).
- `store.py`, `routed_store.py`, `graphdb_store.py`: interface parity + (for the SPARQL backend) a best-effort equivalent merge.
- `dynamics.py`: passes `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS` on its own `upsert_node()` call.
- Tests: 2 new regression tests in `test_dynamics.py` (one directly reproduces the race and was manually verified to fail without the fix), 3 new tests in `test_falkor_store.py` closing a review-found live-backend coverage gap, 2 test doubles updated for the new interface parameter.

## Schema / bus / API changes

- Added: `upsert_node(..., skip_metadata_keys: frozenset[str] | None = None)` — optional, backward-compatible parameter across the `SubstrateGraphStore` interface.
- Removed: none.
- Renamed: none.
- Behavior changed: `SubstrateDynamicsEngine.tick()` no longer overwrites `prediction_error`/`contributing_turn_ids` on any node it writes for activation/dormancy-only reasons.
- Compatibility notes: fully additive, default `None` preserves existing behavior for every other caller.

## Env/config changes

None.

## Tests run

```
orion/substrate/tests/ (full suite): 453 passed
services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py + test_post_turn_closure_listener.py: 18 passed
```
Manually verified the core regression test fails without the fix (temporarily reverted `dynamics.py`'s change, confirmed `AssertionError: 0.9 == 0.42`, then correctly reapplied the fix).

## Evals run

No dedicated eval harness for this module; covered by the unit/regression tests above, including a test that directly reproduces the live race condition.

## Docker/build/smoke checks

Not yet deployed — this PR is code-only. Live deploy + verification against the real frozen `node:substrate.bus_synaptic` is the next step (separate from this PR, since `services/orion-substrate-runtime` needs a rebuild to pick up this `orion/` package change).

## Review findings fixed

- Finding: **[Moderate, CONFIRMED]** No test exercised the live `FalkorSubstrateStore` path (Cypher SET-clause exclusion + raw→encoded key translation) — only `InMemorySubstrateGraphStore` was covered.
  - Fix: 2 new tests using the existing `RecordingFalkorClient` harness, directly asserting on generated Cypher.
  - Evidence: `test_falkor_upsert_node_skip_metadata_keys_excludes_from_cypher_set_clause`, `test_falkor_upsert_node_skip_metadata_keys_preserves_cached_value`.
- Finding: **[Low/Moderate, CONFIRMED]** The cache-merge read isn't lock-protected against a genuinely concurrent writer, same class of race as an existing documented one in this file.
  - Fix: documented explicitly next to the existing precedent, not fixed (narrow, self-healing via the existing write-generation mechanism).
  - Evidence: docstring addition on `FalkorSubstrateStore.upsert_node()`.
- Finding: **[Low, PLAUSIBLE]** Cache/durable divergence on a cache miss — durable write correctly skips the field, but the local cache fell back to the caller's unverified copy.
  - Fix: cache miss now strips the skipped key entirely ("unknown" beats "unverified guess").
  - Evidence: updated merge logic in `falkor_store.py`, code comment explaining the fix.
- Finding: **[Design note]** The raw→encoded key translation is a single hardcoded ternary with no drift guard.
  - Fix: added a consistency test that fails loudly if `EXTERNALLY_OWNED_METADATA_KEYS` and the real encoding function ever diverge.
  - Evidence: `test_externally_owned_metadata_keys_translation_matches_real_encoding`.

## Restart required

```bash
scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
```

(orion/ is a shared package copied into the container at build time — a rebuild is required for this fix to take effect live. Not yet run as part of this PR.)

## Risks / concerns

- Severity: Low
- Concern: the legacy SPARQL/`GraphDBSubstrateStore` backend's `skip_metadata_keys` support is best-effort (full DELETE+INSERT semantics don't map as cleanly as Falkor's partial Cypher SET) and untested against a real triplestore.
- Mitigation: this backend is confirmed not live in production (`SUBSTRATE_STORE_BACKEND=falkor`); added purely for interface parity.

## PR link

(filled in by `gh pr create` output)