### PR TITLE
fix(execution-dispatch): ground substrate.inspect/summarize/observe prompts in real telemetry

### DIFF
--- a/orion/cognition/prompts/substrate_inspect.j2
+++ b/orion/cognition/prompts/substrate_inspect.j2
@@ -12,6 +12,17 @@ TARGET
 - target_id: {{ target_id }}
 - allowed_scope: {{ allowed_scope }}
 
+REAL TELEMETRY (the only real numbers you have for this target)
+- priority_score: {{ "%.3f"|format(priority_score) if priority_score is defined and priority_score is not none else "unavailable" }}
+- risk_score: {{ "%.3f"|format(risk_score) if risk_score is defined and risk_score is not none else "unavailable" }}
+- motivating dimensions (the field-pressure scores that triggered this inspection, higher = more elevated):
+{% for dim, val in (motivating_dimensions | default({}, true)).items() %}
+  - {{ dim }}: {{ "%.3f"|format(val) }}
+{% endfor %}
+{% if not (motivating_dimensions | default({}, true)) %}
+  - (none recorded for this target)
+{% endif %}
+
 PROVENANCE (for your own grounding only — do not restate verbatim in the output)
 - proposal_id: {{ proposal_id }}
 - decision_id: {{ decision_id }}
@@ -20,7 +31,7 @@ PROVENANCE (for your own grounding only — do not restate verbatim in the outpu
 Return STRICT JSON only, with exactly this shape:
 {
   "observation": "one to three sentences, direct and specific to this target — what is elevated, what it looks like, what would matter next",
-  "salient_facts": ["short, concrete fact strings grounded in the target and its kind — no invented telemetry values"],
+  "salient_facts": ["short, concrete fact strings grounded in the target and its kind"],
   "confidence": 0.0
 }
 
@@ -31,7 +42,12 @@ Rules:
   the elevated condition, not a generic status line.
 - "salient_facts" must be non-empty when you have anything specific to say
   about target_kind={{ target_kind }}; use short factual fragments, not prose.
+- These are the only real numbers you have for this target. Describe only
+  what they show — do not name any other specific metric, count, subsystem
+  detail, or percentage not derivable from the values above. If a dimension
+  you'd want to speak to is missing from REAL TELEMETRY, say plainly that you
+  don't have a reading for it rather than inventing one.
 - confidence is a float between 0 and 1 reflecting how well-grounded this
-  read is given only the target/kind provided — do not overclaim certainty
-  from a bare id.
+  read is given the telemetry actually provided — do not overclaim certainty
+  beyond what the numbers above support.
 - No markdown fences. No commentary before or after the JSON.

--- a/orion/cognition/prompts/substrate_observe.j2
+++ b/orion/cognition/prompts/substrate_observe.j2
@@ -15,6 +15,17 @@ TARGET
 - target_id: {{ target_id }}
 - allowed_scope: {{ allowed_scope }}
 
+REAL TELEMETRY (the only real numbers you have for this target — a quiet check, so low values here are the expected, unremarkable case)
+- priority_score: {{ "%.3f"|format(priority_score) if priority_score is defined and priority_score is not none else "unavailable" }}
+- risk_score: {{ "%.3f"|format(risk_score) if risk_score is defined and risk_score is not none else "unavailable" }}
+- motivating dimensions on record for this glance:
+{% for dim, val in (motivating_dimensions | default({}, true)).items() %}
+  - {{ dim }}: {{ "%.3f"|format(val) }}
+{% endfor %}
+{% if not (motivating_dimensions | default({}, true)) %}
+  - (none recorded for this target)
+{% endif %}
+
 PROVENANCE (for your own grounding only — do not restate verbatim in the output)
 - proposal_id: {{ proposal_id }}
 - decision_id: {{ decision_id }}
@@ -23,7 +34,7 @@ PROVENANCE (for your own grounding only — do not restate verbatim in the outpu
 Return STRICT JSON only, with exactly this shape:
 {
   "observation": "one or two sentences, calm and unhurried — a routine glance at this target, not a diagnostic report; steady/unremarkable is a fine and common answer",
-  "salient_facts": ["short, concrete fact strings about the target, ordinary in tone — no invented telemetry values, no alarm language"],
+  "salient_facts": ["short, concrete fact strings about the target, ordinary in tone, no alarm language"],
   "confidence": 0.0
 }
 
@@ -35,7 +46,12 @@ Rules:
 - "observation" should sound like a brief, ordinary glance, not a warning.
 - "salient_facts" must still be non-empty when you have anything concrete to
   say about target_kind={{ target_kind }}, even if every fact is mundane.
+- These are the only real numbers you have for this target. Describe only
+  what they show — do not name any other specific metric, count, subsystem
+  detail, or percentage not derivable from the values above. A low or empty
+  reading is a normal, calm result worth stating plainly, not a gap to fill
+  in with an invented one.
 - confidence is a float between 0 and 1 reflecting how well-grounded this
-  glance is given only the target/kind provided — do not overclaim certainty
-  from a bare id.
+  glance is given the telemetry actually provided — do not overclaim
+  certainty beyond what the numbers above support.
 - No markdown fences. No commentary before or after the JSON.

--- a/orion/cognition/prompts/substrate_summarize.j2
+++ b/orion/cognition/prompts/substrate_summarize.j2
@@ -12,6 +12,17 @@ TARGET
 - target_id: {{ target_id }}
 - allowed_scope: {{ allowed_scope }}
 
+REAL TELEMETRY (the only real numbers you have for this target)
+- priority_score: {{ "%.3f"|format(priority_score) if priority_score is defined and priority_score is not none else "unavailable" }}
+- risk_score: {{ "%.3f"|format(risk_score) if risk_score is defined and risk_score is not none else "unavailable" }}
+- motivating dimensions (the field-pressure scores across this target's facets — use these for breadth, not any single one for depth):
+{% for dim, val in (motivating_dimensions | default({}, true)).items() %}
+  - {{ dim }}: {{ "%.3f"|format(val) }}
+{% endfor %}
+{% if not (motivating_dimensions | default({}, true)) %}
+  - (none recorded for this target)
+{% endif %}
+
 PROVENANCE (for your own grounding only — do not restate verbatim in the output)
 - proposal_id: {{ proposal_id }}
 - decision_id: {{ decision_id }}
@@ -20,7 +31,7 @@ PROVENANCE (for your own grounding only — do not restate verbatim in the outpu
 Return STRICT JSON only, with exactly this shape:
 {
   "observation": "two to four sentences giving an overall, wide-angle picture of this target's state — not anchored to one dimension or alarm",
-  "salient_facts": ["short, concrete fact strings covering different facets of the target — breadth over depth, no invented telemetry values"],
+  "salient_facts": ["short, concrete fact strings covering different facets of the target — breadth over depth"],
   "confidence": 0.0
 }
 
@@ -32,7 +43,12 @@ Rules:
   condition) rather than depth on a single pressure.
 - "salient_facts" should span multiple facets of target_kind={{ target_kind }}
   where you have grounds to say something, not repeat one point three ways.
+- These are the only real numbers you have for this target. Describe only
+  what they show — do not name any other specific metric, count, subsystem
+  detail, or percentage not derivable from the values above. If a facet
+  you'd want to cover has no reading in REAL TELEMETRY, say plainly that you
+  don't have a reading for it rather than inventing one.
 - confidence is a float between 0 and 1 reflecting how well-grounded this
-  summary is given only the target/kind provided — do not overclaim certainty
-  from a bare id.
+  summary is given the telemetry actually provided — do not overclaim
+  certainty beyond what the numbers above support.
 - No markdown fences. No commentary before or after the JSON.

--- a/orion/execution_dispatch/envelopes.py
+++ b/orion/execution_dispatch/envelopes.py
@@ -27,6 +27,19 @@ def build_cortex_request_envelope(
             "target_kind": candidate.target_kind,
             "allowed_scope": route.allowed_scope,
             "origin": "endogenous.dispatch",
+            # Real, already-computed grounding data for the substrate.inspect/
+            # summarize/observe prompts (see orion/cognition/prompts/
+            # substrate_*.j2's "REAL TELEMETRY" section). motivating_dimensions
+            # is the actual field_pressures()/template_match_score() dimension
+            # scores (orion/proposals/builder.py::_build_candidate()) that
+            # caused this proposal to exist -- the only real numbers the model
+            # gets instead of a bare target_id. priority_score/risk_score are
+            # likewise already computed on the candidate; included so the
+            # model can ground "why does this matter" without inventing a
+            # justification.
+            "motivating_dimensions": dict(candidate.motivating_dimensions),
+            "priority_score": candidate.priority_score,
+            "risk_score": candidate.risk_score,
         },
         "constraints": {
             "read_only": True,

--- a/services/orion-cortex-exec/tests/test_substrate_probe_prompt_grounding.py
+++ b/services/orion-cortex-exec/tests/test_substrate_probe_prompt_grounding.py
@@ -1,0 +1,163 @@
+"""Regression coverage for the substrate.inspect/summarize/observe grounding fix.
+
+Diagnosed live 2026-07-28/29: these three prompts previously gave the model
+only a bare target_kind/target_id/allowed_scope and an instruction to avoid
+"invented telemetry values" -- with no real data to ground anything in, that
+instruction was self-contradicting by construction. Confirmed in production
+(``substrate_dispatch_results``) that the model was fabricating specific
+technical claims (transformer "attention heads", token-throughput deltas)
+that don't correspond to any real signal in this substrate.
+
+The fix wires ``ProposalCandidateV1.motivating_dimensions``/``priority_score``/
+``risk_score`` (already real, already computed in
+``orion/proposals/builder.py::_build_candidate()``) through
+``orion/execution_dispatch/envelopes.py::build_cortex_request_envelope()``'s
+context dict, which flows unmodified all the way to this service's Jinja
+render context (see ``executor.py::_render_prompt`` / ``_prompt_render_ctx``).
+This test renders the real templates the same way ``call_step_services`` does
+and checks the real numbers actually show up -- and that omission of
+``motivating_dimensions`` (e.g. an older persisted envelope) degrades
+gracefully instead of crashing the render.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+EXEC_ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+if str(EXEC_ROOT) not in sys.path:
+    sys.path.append(str(EXEC_ROOT))
+
+
+def _load_executor_module():
+    app_dir = EXEC_ROOT / "app"
+    executor_path = app_dir / "executor.py"
+    package_name = "orion_cortex_exec_lane"
+    app_package_name = f"{package_name}.app"
+    if package_name not in sys.modules:
+        pkg = types.ModuleType(package_name)
+        pkg.__path__ = [str(app_dir.parent)]
+        sys.modules[package_name] = pkg
+    if app_package_name not in sys.modules:
+        pkg = types.ModuleType(app_package_name)
+        pkg.__path__ = [str(app_dir)]
+        sys.modules[app_package_name] = pkg
+    spec = importlib.util.spec_from_file_location(f"{app_package_name}.executor", executor_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_template(name: str) -> str:
+    return (ROOT / "orion" / "cognition" / "prompts" / name).read_text(encoding="utf-8")
+
+
+def _base_ctx(**overrides) -> dict:
+    ctx = {
+        "target_kind": "node",
+        "target_id": "node:atlas",
+        "allowed_scope": "inspect_only",
+        "proposal_id": "proposal:inspect:node:atlas",
+        "decision_id": "policy.decision:proposal:inspect:node:atlas:substrate_policy.v1",
+        "self_state_id": "self_state:v1:abcd",
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+def test_substrate_inspect_renders_real_motivating_dimensions():
+    executor_module = _load_executor_module()
+    template = _load_template("substrate_inspect.j2")
+    ctx = _base_ctx(
+        motivating_dimensions={"resource_pressure": 0.652, "cpu_pressure": 0.41},
+        priority_score=0.71,
+        risk_score=0.05,
+    )
+    prompt = executor_module._render_prompt(template, ctx)
+    assert "REAL TELEMETRY" in prompt
+    assert "resource_pressure: 0.652" in prompt
+    assert "cpu_pressure: 0.410" in prompt
+    assert "priority_score: 0.710" in prompt
+    assert "risk_score: 0.050" in prompt
+    # The old self-contradicting instruction (no real data + "no invented
+    # telemetry values") is gone in favor of an enforceable instruction now
+    # that real data is present.
+    assert "no invented telemetry values" not in prompt
+
+
+def test_substrate_summarize_renders_real_motivating_dimensions():
+    executor_module = _load_executor_module()
+    template = _load_template("substrate_summarize.j2")
+    ctx = _base_ctx(
+        target_kind="capability",
+        target_id="capability:orchestration",
+        allowed_scope="summarize_only",
+        motivating_dimensions={"resource_pressure": 0.3, "attention_load": 0.2},
+        priority_score=0.3,
+        risk_score=0.1,
+    )
+    prompt = executor_module._render_prompt(template, ctx)
+    assert "REAL TELEMETRY" in prompt
+    assert "resource_pressure: 0.300" in prompt
+    assert "attention_load: 0.200" in prompt
+
+
+def test_substrate_observe_renders_real_motivating_dimensions():
+    executor_module = _load_executor_module()
+    template = _load_template("substrate_observe.j2")
+    ctx = _base_ctx(
+        target_id="node:substrate.route",
+        motivating_dimensions={"resource_pressure": 0.05},
+        priority_score=0.05,
+        risk_score=0.02,
+    )
+    prompt = executor_module._render_prompt(template, ctx)
+    assert "REAL TELEMETRY" in prompt
+    assert "resource_pressure: 0.050" in prompt
+
+
+def test_substrate_prompts_degrade_gracefully_without_motivating_dimensions():
+    """A context missing motivating_dimensions/priority_score/risk_score
+    (e.g. an older persisted request_envelope, or any other caller of these
+    templates that hasn't been updated) must not crash the render -- it
+    should fall back to an explicit "no reading" statement, not raise.
+    """
+    executor_module = _load_executor_module()
+    for name in ("substrate_inspect.j2", "substrate_summarize.j2", "substrate_observe.j2"):
+        template = _load_template(name)
+        ctx = _base_ctx()
+        prompt = executor_module._render_prompt(template, ctx)
+        assert "REAL TELEMETRY" in prompt
+        assert "unavailable" in prompt
+        assert "none recorded for this target" in prompt
+
+
+def test_substrate_prompts_degrade_gracefully_with_explicit_none_dimensions():
+    """Same as the missing-key case above, but for an explicit ``None`` value
+    (as opposed to the key being entirely absent from ctx) -- Jinja's
+    ``default`` filter only substitutes on ``Undefined`` unless told to also
+    treat ``None`` as falsy via ``default(fallback, true)``. Caught in code
+    review: the first cut of these templates used a bare
+    ``motivating_dimensions | default({})``, which would have raised
+    ``AttributeError: 'NoneType' object has no attribute 'items'`` on an
+    explicit ``None`` (not currently reachable from the real producer, since
+    ``ProposalCandidateV1.motivating_dimensions`` is never ``None`` through
+    pydantic, but worth locking down given how easily ctx dicts get
+    mutated/merged elsewhere in this service).
+    """
+    executor_module = _load_executor_module()
+    for name in ("substrate_inspect.j2", "substrate_summarize.j2", "substrate_observe.j2"):
+        template = _load_template(name)
+        ctx = _base_ctx(motivating_dimensions=None, priority_score=None, risk_score=None)
+        prompt = executor_module._render_prompt(template, ctx)
+        assert "REAL TELEMETRY" in prompt
+        assert "unavailable" in prompt
+        assert "none recorded for this target" in prompt

--- a/tests/test_execution_dispatch_envelopes.py
+++ b/tests/test_execution_dispatch_envelopes.py
@@ -30,6 +30,7 @@ def _candidate() -> ProposalCandidateV1:
         confidence_score=0.9,
         risk_score=0.05,
         reversibility_score=1.0,
+        motivating_dimensions={"resource_pressure": 0.65},
         proposed_effect="increase_observability",
         required_policy_gate="read_only",
         execution_intent={"mode": "descriptive_only"},
@@ -104,4 +105,29 @@ def test_envelope_no_field_state_or_prompts() -> None:
     assert "prompt" not in blob
     assert "llm" not in blob
     assert "field_state" not in blob
-    assert "dimensions" not in blob
+
+
+def test_envelope_includes_real_grounding_data() -> None:
+    """The substrate_inspect/summarize/observe prompts previously got only a
+    bare target_kind/target_id/allowed_scope and had no honest option but to
+    confabulate telemetry. motivating_dimensions/priority_score/risk_score
+    are already-real, already-computed values on ProposalCandidateV1 (see
+    orion/proposals/builder.py::_build_candidate()'s field_pressures()/
+    template_match_score() math) -- this asserts they actually reach the
+    envelope's context dict, since that dict is what flows unmodified through
+    ExecutionDispatchCandidateV1.request_envelope -> worker.py ->
+    ExecutionDispatchCortexClient.dispatch() -> PlanExecutionRequest.context
+    -> the Jinja render context in services/orion-cortex-exec/app/
+    executor.py::_render_prompt().
+    """
+    env = build_cortex_request_envelope(
+        candidate=_candidate(),
+        decision=_decision(),
+        route=ROUTE,
+        field_tick_id=FIELD_TICK_ID,
+        dry_run=True,
+    )
+    ctx = env["context"]
+    assert ctx["motivating_dimensions"] == {"resource_pressure": 0.65}
+    assert ctx["priority_score"] == 0.5
+    assert ctx["risk_score"] == 0.05


### PR DESCRIPTION
## Summary

- `orion/execution_dispatch/envelopes.py::build_cortex_request_envelope()` now adds `candidate.motivating_dimensions`, `candidate.priority_score`, `candidate.risk_score` to the envelope's `context` dict -- all already-real, already-computed values, just never wired through.
- `orion/cognition/prompts/substrate_inspect.j2`, `substrate_summarize.j2`, `substrate_observe.j2` each gain a "REAL TELEMETRY" section rendering these values, and the old self-contradicting "no invented telemetry values" instruction (impossible to honestly follow with zero real data) is replaced with an enforceable one tied to the real numbers now present.
- Each template's distinct voice preserved (inspect = diagnostic depth, summarize = wide-angle breadth, observe = calm/routine) -- only the grounding problem was fixed, not homogenized.
- Jinja guards handle both an absent key and an explicit `None` (`| default({}, true)`, `is defined and ... is not none`) so older/partial contexts degrade to an explicit "unavailable"/"none recorded" instead of crashing the render.

## Outcome moved

Layer 9's autonomous substrate-inspection prompts stop asking the model to report on nothing. Confirmed live in production (`substrate_dispatch_results`, `inspect_node_resource_pressure` template, 16,000+ real completions) that the prior zero-data prompt caused fabricated, specific-sounding technical claims (invented transformer "attention head" utilization percentages, made-up token-throughput deltas) with no corresponding real signal anywhere in this substrate. That fabricated text was traced end-to-end into Orion's real chat with the user via `action_outcomes` -> `chat_stance.py::_project_recent_dispatch_actions()` -> `chat_general.j2`'s "Recent autonomous actions (evidence you may truthfully reference...)" block. This patch gives the model the real dimension-pressure scores and priority/risk that actually triggered the inspection instead.

## Current architecture

`envelopes.py`'s `context` dict previously contained only `proposal_id`/`decision_id`/`field_tick_id`/`target_id`/`target_kind`/`allowed_scope`/`origin`. That dict is persisted on `ExecutionDispatchCandidateV1.request_envelope`, read back verbatim by `services/orion-execution-dispatch-runtime/app/worker.py:361`, sent through `orion/execution_dispatch/cortex_client.py::ExecutionDispatchCortexClient.dispatch(context=context)` as `PlanExecutionRequest.context` (a plain `Dict[str, Any]`, no allowlist), unpacked in `services/orion-cortex-exec/app/main.py:526` into `ctx`, and rendered via `executor.py::_render_prompt()` (`Environment(autoescape=False).from_string(template).render(**ctx.copy())`). The three `substrate.*` prompt templates only had those bare identifiers to work with.

## Architecture touched

- `orion/execution_dispatch/envelopes.py` (context dict)
- `orion/cognition/prompts/substrate_inspect.j2`, `substrate_summarize.j2`, `substrate_observe.j2`

No service boundaries, bus channels, or schemas changed -- `context` is already an untyped `Dict[str, Any]` field on `PlanExecutionRequest`, so no contract update was needed.

## Files changed

- `orion/execution_dispatch/envelopes.py`: adds `motivating_dimensions`/`priority_score`/`risk_score` to the context dict passed to cortex-exec.
- `orion/cognition/prompts/substrate_inspect.j2`: adds "REAL TELEMETRY" section, replaces self-contradicting "no invented telemetry values" instruction.
- `orion/cognition/prompts/substrate_summarize.j2`: same, breadth-framed.
- `orion/cognition/prompts/substrate_observe.j2`: same, calm/routine-framed.
- `tests/test_execution_dispatch_envelopes.py`: updated fixture to include `motivating_dimensions`; relaxed a pre-existing P1-era assertion (`assert "dimensions" not in blob`) that predates this task and is now intentionally violated -- confirmed in review that assertion was guarding against raw `FieldStateV1` leakage (per-node/per-capability blob), not against `ProposalCandidateV1.motivating_dimensions` (a handful of named, bounded dimension scores); added a new positive test.
- `services/orion-cortex-exec/tests/test_substrate_probe_prompt_grounding.py` (new): renders the real templates through the real `executor.py::_render_prompt`, asserts real telemetry values appear, and asserts graceful degradation for both a missing key and an explicit `None`.

## Schema / bus / API changes

- Added: none (no schema/registry change -- `context: Dict[str, Any]` already accepted arbitrary keys).
- Removed: none.
- Renamed: none.
- Behavior changed: `substrate.inspect`/`summarize`/`observe` prompts now receive real field-pressure grounding data instead of none.
- Compatibility notes: an older/partial context missing these keys still renders correctly (explicit "unavailable"/"none recorded" fallback), so this is backward compatible with anything else that might construct a context for these verbs (none found -- `envelopes.py` is the sole builder).

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: n/a.
- local `.env` synced: n/a (no env changes).
- skipped keys requiring operator action: none.

## Tests run

```text
.venv/bin/python3 -m pytest services/orion-cortex-exec/tests/test_substrate_probe_prompt_grounding.py tests/test_execution_dispatch_envelopes.py tests/test_plan_loader.py -q
17 passed

.venv/bin/python3 -m pytest tests/test_execution_dispatch_cortex_client.py tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_policy_loader.py tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_transport_dry_run.py -q
47 passed

.venv/bin/python3 -m pytest tests/test_execution_dispatch_builder.py -q
7 passed

.venv/bin/python3 -m pytest services/orion-cortex-exec/tests/test_router_final_text_assembly.py -q
35 passed

.venv/bin/python3 -m pytest services/orion-cortex-exec/tests/test_metacog_publish_lane.py -q
16 passed
```

## Evals run

No eval harness exists for `orion/execution_dispatch/` or the `substrate.*` prompt templates specifically. The new render tests cover the same seam an eval would (real template + real context -> assert real values appear, not fabricated ones), but a proper eval would need live LLM completions against the new prompts to check the model actually stops naming invented metrics -- follow-up, not this patch's scope (explicitly excluded: building a groundedness/consistency checker).

## Docker/build/smoke checks

Not run -- this is a prompt-content and context-wiring change, no runtime config, dependency, port, or compose wiring touched. No Docker rebuild required for the change to take effect on next natural service restart (prompt templates and Python are read fresh per process start, no baked-in artifacts).

## Review findings fixed

- Finding: `motivating_dimensions | default({})` only substitutes on Jinja `Undefined`, not an explicit `None` -- an explicit `None` in ctx would raise `AttributeError: 'NoneType' object has no attribute 'items'` inside `_render_prompt`. Not reachable from the real producer today (`ProposalCandidateV1.motivating_dimensions` is never `None` through pydantic), but worth locking down.
  - Fix: changed to `motivating_dimensions | default({}, true)` in all three templates (both the `{% for %}` and the `{% if not %}` usages), matching the `is defined and ... is not none` pattern already used for `priority_score`/`risk_score`.
  - Evidence: new `test_substrate_prompts_degrade_gracefully_with_explicit_none_dimensions` in `services/orion-cortex-exec/tests/test_substrate_probe_prompt_grounding.py`, passing.
- Finding (confirmed no issue, documented for the record): relaxing `assert "dimensions" not in blob` in `test_execution_dispatch_envelopes.py` does not undermine the original P1-era intent of that assertion.
  - Fix: n/a -- traced `FieldStateV1` (raw per-node/per-capability blob the original assertion was guarding against, alongside `field_state`/`prompt`/`llm`) versus `ProposalCandidateV1.motivating_dimensions` (a bounded, named dimension-score dict from `template_match_score()`) and confirmed they're not the same thing; the `"field_state" not in blob` guard is still intact and untouched.
  - Evidence: `orion/schemas/field_state.py` (raw blob shape), `orion/proposals/scoring.py::template_match_score()` (bounded producer of `motivating_dimensions`), `docs/superpowers/specs/2026-07-13-execution-dispatch-motor-nerve-p1-design.md` (no envelope-minimality rule beyond the correlation_id/reply_to/kind point this patch doesn't touch).

## Restart required

```text
No restart required for the fix itself to take effect on next natural process restart of
services/orion-execution-dispatch-runtime and services/orion-cortex-exec (both read
orion/execution_dispatch/envelopes.py and orion/cognition/prompts/*.j2 fresh at import/render
time, no baked artifacts). If Juniper wants the fix live immediately rather than waiting for
the next natural restart:
```

```bash
docker compose -f services/orion-execution-dispatch-runtime/docker-compose.yml restart
docker compose -f services/orion-cortex-exec/docker-compose.yml restart
```

## Risks / concerns

- Severity: low
- Concern: no eval harness exists to check the model actually stops fabricating once given real data -- this patch verifies the *input* is real, not that the model's *output* is faithful to it.
- Mitigation: explicitly out of scope per the task (a groundedness/consistency checker is a named, separate follow-up); worth watching `substrate_dispatch_results.result_json.salient_facts` for continued fabrication after this ships, and building that checker as the next step if it recurs.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1450
