### PR TITLE
fix(hub): fix debug-panel modal stacking, remove Cognition Packs/Verb Routing

### DIFF
--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -3699,15 +3699,15 @@ document.addEventListener("DOMContentLoaded", () => {
     ensureDebugPanelModalRootOnBody();
     debugPanelModalRoot.style.position = 'fixed';
     debugPanelModalRoot.style.inset = '0';
-    debugPanelModalRoot.style.zIndex = '2147483646';
+    debugPanelModalRoot.style.zIndex = '2147483640';
     if (debugPanelModalBackdrop) {
       debugPanelModalBackdrop.style.position = 'fixed';
       debugPanelModalBackdrop.style.inset = '0';
-      debugPanelModalBackdrop.style.zIndex = '2147483646';
+      debugPanelModalBackdrop.style.zIndex = '2147483640';
     }
     if (debugPanelModalDialog) {
       debugPanelModalDialog.style.position = 'fixed';
-      debugPanelModalDialog.style.zIndex = '2147483647';
+      debugPanelModalDialog.style.zIndex = '2147483641';
     }
     debugPanelModalRoot.classList.remove('hidden');
     debugPanelModalRoot.setAttribute('aria-hidden', 'false');

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -2356,7 +2356,7 @@
 
   <div
     id="agentTraceModal"
-    class="hidden fixed inset-0 z-50 bg-gray-950/80 backdrop-blur-sm"
+    class="hidden fixed inset-0 z-[2147483646] bg-gray-950/80 backdrop-blur-sm"
     aria-hidden="true"
   >
     <div class="fixed left-1/2 top-1/2 flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl">
@@ -2525,9 +2525,9 @@
     </div>
   </div>
 
-  <div id="debugPanelModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483646;" aria-hidden="true">
-    <div id="debugPanelModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483646;"></div>
-    <div id="debugPanelModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483647;">
+  <div id="debugPanelModalRoot" class="hidden fixed inset-0 z-[120] pointer-events-auto" style="position: fixed; inset: 0; z-index: 2147483640;" aria-hidden="true">
+    <div id="debugPanelModalBackdrop" class="fixed inset-0 z-[120] bg-black/85 backdrop-blur-sm" style="position: fixed; inset: 0; z-index: 2147483640;"></div>
+    <div id="debugPanelModalDialog" class="fixed left-1/2 top-1/2 z-[121] flex w-[75vw] h-[75vh] max-w-none -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl" style="position: fixed; z-index: 2147483641;">
       <div class="flex items-center justify-between border-b border-gray-800 px-5 py-4">
         <div class="text-xs uppercase tracking-[0.24em] text-gray-300">Debug Panel</div>
         <button
@@ -2860,40 +2860,10 @@
           <div id="socialInspectionPanelSummary" class="grid grid-cols-1 gap-2 text-[11px] text-gray-300"></div>
         </div>
 
-        <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3 space-y-3">
-          <div class="flex items-center justify-between">
-            <div class="text-xs uppercase tracking-wide text-gray-500">Cognition Packs</div>
-          </div>
-          <div id="packContainer" class="flex flex-wrap gap-2"></div>
-
-          <div class="flex items-center justify-between pt-2 border-t border-gray-700">
-            <div class="text-xs uppercase tracking-wide text-gray-500">Verb Routing</div>
-
-            <div class="flex items-center gap-2">
-              <button id="clearButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Clear</button>
-              <button id="copyButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Copy</button>
-            </div>
-          </div>
-
-          <div class="relative">
-            <button id="verbSelectTrigger" class="w-full flex items-center justify-between bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-2 border border-gray-700">
-              <span id="verbSelectLabel" class="text-sm text-gray-300">Select verbs…</span>
-              <span class="text-gray-400">▾</span>
-            </button>
-
-            <div id="verbDropdown" class="hidden absolute mt-2 w-full bg-gray-900 border border-gray-700 rounded-lg shadow-xl z-20">
-              <div class="flex items-center justify-between px-3 py-2 border-b border-gray-800 gap-2">
-                <div class="text-[10px] uppercase tracking-wide text-gray-500">Available Verbs</div>
-                <div class="flex items-center gap-2">
-                  <label class="text-[10px] text-gray-400 flex items-center gap-1">
-                    <input id="verbActiveOnlyToggle" type="checkbox" class="h-3 w-3 text-indigo-600 rounded bg-gray-700 border-gray-600" checked />
-                    Active only
-                  </label>
-                  <button id="clearVerbs" class="text-[10px] text-gray-400 hover:text-white">Clear</button>
-                </div>
-              </div>
-              <div id="verbList" class="max-h-56 overflow-y-auto p-2 space-y-1"></div>
-            </div>
+        <div class="bg-gray-900/40 border border-gray-700 rounded-xl p-3">
+          <div class="flex items-center justify-end gap-2">
+            <button id="clearButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Clear</button>
+            <button id="copyButton" class="text-xs bg-gray-800 hover:bg-gray-700 text-gray-200 rounded-lg px-3 py-1 border border-gray-700">Copy</button>
           </div>
         </div>
           </div>

--- a/services/orion-hub/tests/test_llm_route_selector.py
+++ b/services/orion-hub/tests/test_llm_route_selector.py
@@ -404,3 +404,52 @@ def test_debug_panel_is_single_card_wrapping_all_rows_in_one_modal() -> None:
     assert "function openDebugPanelModal()" in app_js
     assert "function closeDebugPanelModal()" in app_js
     assert "debugPanelOpenModal.addEventListener('click'" in app_js
+
+
+def test_debug_panel_modal_z_index_is_below_all_per_item_modals() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    app_js = APP_JS.read_text(encoding="utf-8")
+
+    # The outer wrapping modal must sit strictly below the shared per-item
+    # modal tier (2147483646/647) so a nested modal (e.g. Memory, Agent
+    # Trace) opened from within it always paints on top, regardless of
+    # DOM-append order or click sequence.
+    assert 'id="debugPanelModalRoot"' in html
+    debug_root = html.split('id="debugPanelModalRoot"', 1)[1].split(">", 1)[0]
+    assert "z-index: 2147483640" in debug_root
+    debug_dialog = html.split('id="debugPanelModalDialog"', 1)[1].split(">", 1)[0]
+    assert "z-index: 2147483641" in debug_dialog
+    assert "debugPanelModalRoot.style.zIndex = '2147483640';" in app_js
+    assert "debugPanelModalDialog.style.zIndex = '2147483641';" in app_js
+
+    # Every per-item modal (including Agent Trace, which previously used a
+    # much lower z-50 and could never out-stack the wrapping modal) sits at
+    # or above the shared 2147483646/647 tier, strictly above the wrapper.
+    for modal_id in (
+        "memoryDebugModalDialog",
+        "autonomyDebugModalDialog",
+        "chatStanceDebugModalDialog",
+        "substrateReviewModalDialog",
+        "selfExperimentsModalDialog",
+        "autonomyReadinessModalDialog",
+        "recallCanaryModalDialog",
+        "cognitiveReviewModalDialog",
+    ):
+        section = html.split(f'id="{modal_id}"', 1)[1].split(">", 1)[0]
+        assert "z-index: 2147483647" in section, f"{modal_id} not above debug panel wrapper"
+    agent_trace_section = html.split('id="agentTraceModal"', 1)[1].split(">", 1)[0]
+    assert "z-50" not in agent_trace_section
+    assert "z-[2147483646]" in agent_trace_section
+
+
+def test_debug_panel_no_longer_shows_cognition_packs_or_verb_routing() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    modal_shell = html.split('id="debugPanelModalRoot"', 1)[1].split('id="autonomyDebugModalRoot"', 1)[0]
+    assert "Cognition Packs" not in modal_shell
+    assert "Verb Routing" not in modal_shell
+    assert 'id="packContainer"' not in modal_shell
+    assert 'id="verbSelectTrigger"' not in modal_shell
+    assert 'id="verbDropdown"' not in modal_shell
+    # Clear/Copy conversation controls (not verb/pack routing) are kept.
+    assert 'id="clearButton"' in modal_shell
+    assert 'id="copyButton"' in modal_shell


### PR DESCRIPTION
## Summary

Follow-up to #1447/#1448 (both already merged). Two real bugs found after #1448 landed on `main`:

- Memory and Agent Trace's per-item modals didn't visibly open when triggered from inside the new outer Debug Panel modal. Root cause: the outer wrapper shared the exact same top-tier z-index (2147483646/647) as every per-item modal it contains, so depending on DOM-append order the wrapper could paint on top even after the nested modal's `hidden` class was removed. Agent Trace was worse — its modal was still on the old `z-50` class, unrelated to the shared scheme, so it could never out-stack the wrapper at all.
  - Fix: lowered the outer wrapper to a strictly-lower z-index tier (2147483640/641) so any per-item modal always renders above it regardless of order; bumped Agent Trace's modal to the shared tier.
- Removed the "Cognition Packs" and "Verb Routing" sections (pack selector, verb multi-select) from the debug panel per request. Kept the Clear/Copy conversation buttons that shared the same card, since those aren't pack/verb routing.

## Test plan

- [x] `pytest services/orion-hub/tests -q` — 1033 passed, 31 failed, 5 skipped — identical failure set to the pre-existing baseline (0 regressions)
- [x] Re-rendered `render_hub_index_html()` directly to confirm the template still parses cleanly and the removed elements are actually gone from output
- [x] Added test coverage: z-index tiering (outer wrapper below the shared per-item tier, Agent Trace bumped off z-50), and Cognition Packs/Verb Routing removed while Clear/Copy are kept
- [ ] Manual browser verification was not performed this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)