### PR TITLE
fix(orion-ai-town): fix engine-recovery query timeout, add Convex data compaction

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-29-aitown-convex-compaction-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-29-aitown-convex-compaction-pr.md
@@ -1,0 +1,232 @@
+# PR report: AI Town Convex engine-recovery fix + data compaction
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1452
+Branch: `fix/aitown-convex-compaction`
+
+## Summary
+
+Juniper reported AI Town was broken (couldn't move/interact) and separately
+that Orion's in-town dialogue felt transactional, not curious. The dialogue
+question was answered inline (root cause: `orion/embodiment/speech.py`'s
+`build_speech_prompt()` injects zero personality/curiosity framing and runs
+on the fastest/shallowest `chat_quick` lane — a separate, already-understood
+tradeoff, not touched by this PR). Investigating the movement/interact
+complaint led to two real, unrelated bugs:
+
+1. The engine-recovery diagnostic/recovery tooling from a prior incident
+   (`patches/orion-engine-recovery.patch`) had a query bug that made it
+   unusable at scale.
+2. The actual root cause of the reported lag: self-hosted Convex retains
+   unbounded document-revision history with no compaction, and this
+   deployment had never been restarted/compacted in ~3 weeks.
+
+## Outcome moved
+
+Live-verified on the running `orion-ai-town` deployment:
+
+| metric | before | after |
+|---|---|---|
+| `db.sqlite3` size | 23.56GB | 240MB (99% reduction) |
+| backend CPU (idle) | 123% | 0.00% |
+| backend RSS | 52.87GB | ~1.46GB |
+| OCC error rate | ~20-30/min | 0/min |
+
+All 216,460 documents round-tripped intact across every table (verified via
+`npx convex data` spot-checks and the import change-summary output).
+
+## Current architecture
+
+`services/orion-ai-town` wraps a16z's self-hosted `ai-town` — Convex backend
+(SQLite-backed, single container) + frontend + dashboard. `upstream/` is a
+gitignored local clone pinned to a SHA; repo-tracked behavior changes live as
+`.patch` files in `patches/`, applied by `scripts/apply_upstream_patches.sh`.
+No prior maintenance/compaction tooling existed. The backend container had
+been running continuously since world creation (~2026-07-06/07) with no
+restarts, and no one had previously needed to invoke the engine-recovery
+tooling from `orion-engine-recovery.patch` at any real scale.
+
+## Investigation path (for future reference)
+
+1. `docker compose logs backend` showed 84 unique errors — OCC (optimistic
+   concurrency) conflicts on `inputs`/`engines`, plus the built-in "restart
+   dead worlds" cron itself erroring repeatedly.
+2. Ran the existing `testing:debugEngineState` diagnostic (from the prior
+   engine-recovery patch) to confirm a frozen-engine theory — it **timed
+   out** ("too many system operations"), which was itself the first real
+   finding: the query used `.withIndex(eq engineId only).filter(gt number)`,
+   which can't prune the index range. It was scanning the engine's entire
+   input history (300k+ rows) instead of just the pending tail, regardless
+   of `.take()` limit. Fixed to chain `.gt('number', processed)` directly
+   into `withIndex`, matching the engine's own `loadInputs` in
+   `convex/engine/abstractGame.ts` (which already did this correctly).
+3. With the query fixed, live data showed the engine was **not** actually
+   frozen — pending backlog was 0-1, `processedInputNumber` advancing
+   normally. The frozen-engine theory (pattern-matched from the *prior*
+   incident this patch's comments describe) did not hold up under direct
+   verification, and was dropped rather than reported as fixed.
+4. User reported continued lag ("characters appearing to move but not,
+   chat timing out"). `docker stats` showed the real problem: backend
+   container at 123% CPU / 52.87GB RSS, backing a 23.5GB SQLite file.
+5. Sampled row counts per table (via a new bounded `tableGrowthSample`
+   query, using the auto `by_creation_time` index rather than a full
+   `.collect()`) — totaled only ~100-200MB of logical data. Checked the
+   singular `world` document directly (new `worldDocSizeProbe` query) —
+   4.4KB, no live unbounded-array bug. Conclusion: the 23GB was Convex's own
+   retained document-revision history, not deletable app data.
+6. Confirmed live: `VACUUM` on the stopped file only recovered ~5%
+   (23.56GB → 22.24GB after 14 minutes) — consistent with history being
+   *live* data from SQLite's point of view, not reclaimable free space.
+7. The only real fix: export (`npx convex export`, no downtime) → stop →
+   reset the SQLite file → restart → reimport (`npx convex import
+   --replace-all`). First live run of this sequence (manual, no script yet)
+   succeeded at shrinking the file but broke the live app: the reset also
+   wipes deployed Convex function code and `npx convex env` variables
+   (LLM gateway wiring), since both live in the same file. Recovered live by
+   redeploying (`npx convex dev --once`) and re-running
+   `scripts/wire_llm_gateway.sh`, then manually heartbeating the world back
+   to `running`.
+8. Built `scripts/compact_convex_data.sh` to encode the *complete* correct
+   sequence (including the two gaps found in step 7) so a future/scheduled
+   run doesn't repeat the same recovery-by-hand. Wired a daily,
+   threshold-gated (5GiB default) host crontab entry.
+
+## Architecture touched
+
+- `patches/orion-engine-recovery.patch` (upstream `convex/testing.ts` diff)
+- New `scripts/compact_convex_data.sh`
+- `README.md`, `.env_example`
+- Host crontab (not part of the git diff)
+
+## Files changed
+
+- `services/orion-ai-town/patches/orion-engine-recovery.patch`: index-range
+  fix for `debugEngineState`/`recoverFrozenEngine`; added `tableGrowthSample`
+  and `worldDocSizeProbe` read-only sizing probes.
+- `services/orion-ai-town/scripts/compact_convex_data.sh`: new — export →
+  stop → snapshot+rename → restart → redeploy functions → restore env vars →
+  reimport → heartbeat world. Threshold-gated, `--check`/`--force` flags.
+- `services/orion-ai-town/tests/test_engine_recovery_patch.py`,
+  `test_compact_convex_data_script.py`: new structural gate tests.
+- `services/orion-ai-town/README.md`: new "Maintenance: Convex data
+  compaction" section.
+- `services/orion-ai-town/.env_example`: documented (commented, optional)
+  `AITOWN_COMPACT_THRESHOLD_BYTES` / `AITOWN_COMPACT_HEALTH_TIMEOUT_SEC`.
+
+## Schema / bus / API changes
+
+- Added: two internal-only Convex diagnostic queries (`tableGrowthSample`,
+  `worldDocSizeProbe`) — not part of any bus/schema contract.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `debugEngineState`/`recoverFrozenEngine` now take an
+  optional `limit` arg and use a real indexed range scan instead of timing
+  out.
+- Compatibility notes: none needed; these are internal maintenance
+  functions, not consumed by the frontend or any other service.
+
+## Env/config changes
+
+- Added keys (optional, commented in `.env_example`):
+  `AITOWN_COMPACT_THRESHOLD_BYTES` (default 5GiB, baked into the script),
+  `AITOWN_COMPACT_HEALTH_TIMEOUT_SEC` (default 180s, baked into the script).
+- `.env_example` updated: yes.
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`:
+  yes — no changes applied (new keys are commented/optional, script's
+  existing divergence report for unrelated services is pre-existing).
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```
+/mnt/scripts/Orion-Sapienform/venv/bin/pytest services/orion-ai-town/tests/ -v
+29 passed, 1 failed (test_juniper_blurb_present_in_world_ts — requires the
+gitignored upstream/ clone, which doesn't exist in this fresh worktree;
+pre-existing/environmental, not a regression from this change).
+```
+
+## Evals run
+
+No eval harness exists for this service (infra/ops tooling, not a
+cognition-loop change). Live verification against the running deployment
+(documented above and in "Docker/build/smoke checks") served as the
+functional check.
+
+## Docker/build/smoke checks
+
+Full live run performed against the running deployment during this session
+(not a staging/test environment — this repo has no separate staging AI Town
+instance):
+
+```
+npx convex export --path <job>/export.zip           # no downtime
+docker compose stop backend
+docker cp <container>:/convex/data/db.sqlite3 <job>/db.sqlite3.pre-compact.bak
+docker run --rm -v orion-ai-town_convex-data:/data alpine \
+  mv /data/db.sqlite3 /data/db.sqlite3.pre-compact-<ts>
+docker compose start backend                         # health check passes
+npx convex dev --once                                # function redeploy
+npx convex env set --from-file <job>/env.backup       # (manual restore on
+                                                        # first run; scripted
+                                                        # for future runs)
+npx convex import --replace-all -y <job>/export.zip   # 216,460 docs restored
+npx convex run world:heartbeatWorld '{"worldId": "..."}'
+```
+
+Verified after: `docker compose ps` (healthy), `docker stats` (0.00% CPU,
+~1.46GB RSS), `npx convex data worldStatus`/`playerDescriptions` (data
+intact), `testing:debugEngineState` (engine ticking,
+`processedInputNumber` advancing, 0-1 pending).
+
+Patch chain re-verified from scratch: cloned the pinned upstream SHA fresh
+into `/tmp`, applied all 6 tracked patches in `apply_upstream_patches.sh`'s
+order (including the regenerated `orion-engine-recovery.patch`) — all apply
+cleanly with `git apply --check`.
+
+## Review findings fixed
+
+- Finding: `compact_convex_data.sh`'s rename-old-db step silently swallowed
+  failure (`mv ... || true`), so a failed rename would let the script
+  proceed as if compaction happened while the backend restarts on the same
+  bloated file.
+  - Fix: rename failure now aborts the script loudly with explicit
+    recovery instructions pointing at the export/backup.
+  - Evidence: `scripts/compact_convex_data.sh` step 4/7.
+- Finding: hardcoded `VOLUME_NAME="orion-ai-town_convex-data"` assumed
+  Compose's default project-name-prefix convention; a `COMPOSE_PROJECT_NAME`
+  override would silently target a nonexistent (auto-created, empty) volume
+  while the real data volume went untouched.
+  - Fix: volume name resolved dynamically from the running backend
+    container's actual mount via `docker inspect`.
+  - Evidence: `scripts/compact_convex_data.sh`, volume-resolution block.
+- Finding: new optional env keys weren't documented in `.env_example`.
+  - Fix: added as commented/optional entries with a pointer to the README
+    section.
+  - Evidence: `services/orion-ai-town/.env_example`.
+
+## Restart required
+
+```
+No restart required — the live deployment was already recovered and
+verified during this session (backend healthy, functions deployed, env
+restored, world running). Merging this branch only updates the tracked
+patch/script/docs to match what's already live.
+```
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the pre-compaction `npx convex env` values were not captured
+  before the *first* live compaction run (that capture step was only added
+  to the script after discovering the gap mid-session). They were restored
+  via `scripts/wire_llm_gateway.sh`'s own default (`LLM_MODEL=quick`), which
+  does not match the README's documented default (`LLM_MODEL=chat`). I
+  could not confirm which value was actually in use before the compaction.
+- Mitigation: worth an operator check of `npx convex env list` against
+  README expectations. Low blast radius either way — both are valid gateway
+  routes; this only affects which llamacpp lane NPC chat completion uses.
+  All future runs of the fixed script capture and restore the exact prior
+  values, so this is a one-time gap, not a recurring risk.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1452

--- a/services/orion-ai-town/.env_example
+++ b/services/orion-ai-town/.env_example
@@ -25,3 +25,8 @@ OLLAMA_PORT=11434
 
 # Optional SQL backend (empty = SQLite volume)
 DATABASE_URL=
+
+# Maintenance: scripts/compact_convex_data.sh (see README "Maintenance: Convex
+# data compaction"). Optional -- both have sane defaults baked into the script.
+# AITOWN_COMPACT_THRESHOLD_BYTES=5368709120
+# AITOWN_COMPACT_HEALTH_TIMEOUT_SEC=180

--- a/services/orion-ai-town/README.md
+++ b/services/orion-ai-town/README.md
@@ -132,6 +132,51 @@ docker compose config
 curl -fsS http://127.0.0.1:3210/version
 ```
 
+## Maintenance: Convex data compaction
+
+The self-hosted Convex backend retains a full document-revision history
+forever (every mutation writes a new version instead of overwriting), with
+no built-in compaction. A continuously-ticking town accumulates this
+without bound: confirmed live 2026-07-29, `db.sqlite3` reached 23.5GB after
+~3 weeks even though logical/current data across every table added up to
+only ~240MB. `VACUUM` cannot reclaim this — it only recovered ~5% (23.56GB →
+22.24GB after a 14-minute run) because none of the retained revisions are
+logically deleted from Convex's point of view.
+
+`scripts/compact_convex_data.sh` fixes this by exporting current live data,
+resetting the on-disk file, and reimporting — which starts a fresh history
+from that point while preserving the game world exactly as it was (verified
+live: 23.5GB → 240MB, all 216k+ documents round-tripped intact). It also
+redeploys Convex functions and restores `npx convex env` variables, both of
+which live in the same file and get wiped by the reset alongside the data,
+and heartbeats the default world back to `running` so nobody has to reload
+the frontend tab afterward.
+
+```bash
+# Report current db.sqlite3 size only, no changes:
+bash scripts/compact_convex_data.sh --check
+
+# Compact only if over the threshold (default 5GiB):
+bash scripts/compact_convex_data.sh
+
+# Compact regardless of current size:
+bash scripts/compact_convex_data.sh --force
+```
+
+Env overrides: `AITOWN_COMPACT_THRESHOLD_BYTES` (default `5368709120` = 5GiB),
+`AITOWN_COMPACT_HEALTH_TIMEOUT_SEC` (default `180`).
+
+Each run writes a job dir under `/tmp/aitown-compact-<timestamp>/` containing
+the pre-compact export, a raw `db.sqlite3` backup, and a `report.md` with
+before/after sizes — keep these until you've confirmed the town looks right.
+
+A host crontab entry runs this daily (threshold-gated, so it's a no-op most
+days — see `crontab -l` for the exact line, installed 2026-07-29). There is
+brief real downtime for AI Town while a compaction actually runs (stop →
+reset → restart → reimport), typically well under a minute once the backend
+is healthy again, though function redeploy/reindexing can add several
+minutes on a large table set.
+
 ## Cast cards (source of truth)
 
 The full character set — the 8 NPCs plus **Juniper Feld** (human) and **Orion** (external join) — lives as authored cards in `cards/town_cards.yaml`. This is the single source of truth for identities.

--- a/services/orion-ai-town/patches/orion-engine-recovery.patch
+++ b/services/orion-ai-town/patches/orion-engine-recovery.patch
@@ -1,34 +1,52 @@
 diff --git a/convex/testing.ts b/convex/testing.ts
-index 106f186..e64590e 100644
+index 106f186..34fdb65 100644
 --- a/convex/testing.ts
 +++ b/convex/testing.ts
-@@ -59,6 +59,78 @@ export const kick = internalMutation({
+@@ -4,6 +4,7 @@ import {
+   DatabaseReader,
+   internalAction,
+   internalMutation,
++  internalQuery,
+   mutation,
+   query,
+ } from './_generated/server';
+@@ -59,6 +60,96 @@ export const kick = internalMutation({
    },
  });
  
 +// Read-only diagnostic: dump the default world's conversations and the tail of
 +// the engine input queue so we can see exactly which unactioned input poisons
 +// the step (produces a `lastMessage` with no numeric `timestamp`).
++//
++// Bounded to `limit` (default 200). Also fixed 2026-07-29: this originally
++// used `.withIndex(eq engineId only).filter(gt number)`, which cannot prune
++// the index range -- it linearly scans the engine's *entire* input history
++// (not just the pending tail) applying the `number > processed` test in JS,
++// so it timed out ("too many system operations") regardless of `.take()`
++// once that history got large. Chaining `.gt('number', processed)` into the
++// same `withIndex` call (matching `engine/abstractGame.ts`'s own `loadInputs`)
++// makes this a true bounded range scan from `processed` onward.
 +export const debugEngineState = internalMutation({
-+  handler: async (ctx) => {
++  args: { limit: v.optional(v.number()) },
++  handler: async (ctx, args) => {
++    const limit = args.limit ?? 200;
 +    const { worldStatus, engine } = await getDefaultWorld(ctx.db);
 +    const world = await ctx.db.get(worldStatus.worldId);
 +    const processed = engine.processedInputNumber ?? -1;
 +    const pending = await ctx.db
 +      .query('inputs')
-+      .withIndex('byInputNumber', (q) => q.eq('engineId', engine._id))
-+      .filter((q) => q.gt(q.field('number'), processed))
-+      .collect();
++      .withIndex('byInputNumber', (q) => q.eq('engineId', engine._id).gt('number', processed))
++      .take(limit);
 +    const byName: Record<string, number> = {};
 +    for (const i of pending) byName[i.name] = (byName[i.name] ?? 0) + 1;
 +    console.log(
-+      `debugEngineState: processedInputNumber=${processed} pending=${pending.length} byName=${JSON.stringify(byName)}`,
++      `debugEngineState: processedInputNumber=${processed} sampledPending=${pending.length} (limit=${limit}) byName=${JSON.stringify(byName)}`,
 +    );
 +    console.log(
 +      `conversations=${JSON.stringify((world?.conversations ?? []).map((c: any) => ({ id: c.id, numMessages: c.numMessages, lastMessage: c.lastMessage })))}`,
 +    );
 +    console.log(`firstPending=${JSON.stringify(pending.slice(0, 5).map((i) => ({ n: i.number, name: i.name, args: i.args })))}`);
-+    return { processed, pending: pending.length, byName };
++    return { processed, sampledPending: pending.length, limitReached: pending.length === limit, byName };
 +  },
 +});
 +
@@ -41,8 +59,17 @@ index 106f186..e64590e 100644
 +// town freezes. Delete those unactioned inputs (nothing past
 +// `processedInputNumber` then remains to replay) and scrub any malformed `lastMessage` from
 +// the stored world so the step loop can resume. New (post-fix) inputs are clean.
++//
++// Batched via `limit` (default 500) and, as of 2026-07-29, fixed to use a
++// real index range (see `debugEngineState` above for why the old
++// `.filter()` form scanned the whole input history and timed out no matter
++// what `limit` was). Call repeatedly (checking `limitReached`) until the
++// backlog drains. The lastMessage scrub is a single-document patch and
++// stays unbounded/one-shot -- it isn't what blows the budget.
 +export const recoverFrozenEngine = internalMutation({
-+  handler: async (ctx) => {
++  args: { limit: v.optional(v.number()) },
++  handler: async (ctx, args) => {
++    const limit = args.limit ?? 500;
 +    const { worldStatus, engine } = await getDefaultWorld(ctx.db);
 +    const world = await ctx.db.get(worldStatus.worldId);
 +    if (!world) {
@@ -60,24 +87,103 @@ index 106f186..e64590e 100644
 +    });
 +    await ctx.db.patch(world._id, { conversations } as any);
 +
-+    // 2. Delete all unactioned inputs (the stale pre-fix backlog) so nothing bad
-+    //    replays. They are stale because the town has been frozen.
++    // 2. Delete up to `limit` unactioned inputs (the stale pre-fix backlog) so
++    //    nothing bad replays. They are stale because the town has been frozen.
 +    const processed = engine.processedInputNumber ?? -1;
 +    const pending = await ctx.db
 +      .query('inputs')
-+      .withIndex('byInputNumber', (q) => q.eq('engineId', engine._id))
-+      .filter((q) => q.gt(q.field('number'), processed))
-+      .collect();
++      .withIndex('byInputNumber', (q) => q.eq('engineId', engine._id).gt('number', processed))
++      .take(limit);
 +    for (const i of pending) {
 +      await ctx.db.delete(i._id);
 +    }
 +    console.log(
-+      `recoverFrozenEngine: scrubbed ${scrubbed} lastMessage(s), deleted ${pending.length} unactioned inputs (processedInputNumber=${processed})`,
++      `recoverFrozenEngine: scrubbed ${scrubbed} lastMessage(s), deleted ${pending.length} unactioned inputs (limit=${limit}, processedInputNumber=${processed})`,
 +    );
-+    return { scrubbed, deletedInputs: pending.length };
++    return { scrubbed, deletedInputs: pending.length, limitReached: pending.length === limit };
 +  },
 +});
 +
  export const stopAllowed = query({
    handler: async () => {
      return !process.env.STOP_NOT_ALLOWED;
+@@ -200,3 +291,79 @@ export const testConvo = internalAction({
+     return await a.readAll();
+   },
+ });
++
++// Cheap, read-only sizing helper for retention-cleanup planning (added 2026-07-29).
++// Uses the auto `by_creation_time` index with a bounded `.take()` in narrow time
++// windows near the start and end of the table's lifetime, rather than a full
++// `.collect()`, to avoid the same system-operation-budget blowup found and
++// fixed above in debugEngineState/recoverFrozenEngine. This gives a rough
++// rows/day rate and an extrapolated total -- not an exact count -- which is
++// enough to scope a retention cleanup without straining the live backend.
++export const tableGrowthSample = internalQuery({
++  args: { table: v.string(), windowMs: v.optional(v.number()), sampleCap: v.optional(v.number()) },
++  handler: async (ctx, args) => {
++    const windowMs = args.windowMs ?? 60 * 60 * 1000; // 1 hour
++    const cap = args.sampleCap ?? 5000;
++    const table = args.table as any;
++    const oldest = await ctx.db.query(table).withIndex('by_creation_time').order('asc').take(1);
++    const newest = await ctx.db.query(table).withIndex('by_creation_time').order('desc').take(1);
++    if (oldest.length === 0 || newest.length === 0) {
++      return { table, empty: true };
++    }
++    const t0 = (oldest[0] as any)._creationTime;
++    const t1 = (newest[0] as any)._creationTime;
++    const recentWindowCount = (
++      await ctx.db
++        .query(table)
++        .withIndex('by_creation_time', (q) => q.gte('_creationTime', t1 - windowMs))
++        .take(cap)
++    ).length;
++    const lifetimeMs = t1 - t0;
++    const ratePerMs = recentWindowCount / windowMs;
++    const estimatedTotal = Math.round(ratePerMs * lifetimeMs);
++    return {
++      table,
++      oldestCreationTime: t0,
++      newestCreationTime: t1,
++      lifetimeDays: Math.round((lifetimeMs / (24 * 60 * 60 * 1000)) * 10) / 10,
++      recentWindowCount,
++      windowMs,
++      recentWindowSampleCapped: recentWindowCount === cap,
++      estimatedTotal,
++    };
++  },
++});
++
++// Read-only sizing probe for the singular `world` document (added 2026-07-29,
++// investigating a 22GB self-hosted SQLite file whose logical row counts across
++// inputs/messages/memories/etc. only add up to ~100-200MB -- checking whether
++// the single per-world doc itself, which embeds players/agents/conversations
++// inline, carries an unbounded field like a movement/position history array.
++export const worldDocSizeProbe = internalQuery({
++  handler: async (ctx) => {
++    const { worldStatus } = await getDefaultWorld(ctx.db);
++    const world = await ctx.db.get(worldStatus.worldId);
++    if (!world) return { found: false };
++    const json = JSON.stringify(world);
++    const perPlayerLens = (world.players as any[]).map((p) => ({
++      id: p.id,
++      keys: Object.keys(p),
++      approxBytes: JSON.stringify(p).length,
++    }));
++    const perAgentLens = (world.agents as any[]).map((a) => ({
++      id: a.id,
++      keys: Object.keys(a),
++      approxBytes: JSON.stringify(a).length,
++    }));
++    return {
++      found: true,
++      totalApproxBytes: json.length,
++      topLevelKeys: Object.keys(world),
++      numPlayers: (world.players as any[]).length,
++      numAgents: (world.agents as any[]).length,
++      numConversations: (world.conversations as any[]).length,
++      perPlayerLens,
++      perAgentLens,
++    };
++  },
++});

--- a/services/orion-ai-town/scripts/compact_convex_data.sh
+++ b/services/orion-ai-town/scripts/compact_convex_data.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Reclaim disk/RAM bloat on the self-hosted Convex backend by exporting live
+# data, resetting the on-disk SQLite file, and reimporting.
+#
+# Why this exists (found live 2026-07-29): self-hosted Convex retains a full
+# revision history for every document -- it never overwrites in place. The
+# `world`/`engines` rows get rewritten on every single engine tick, so a
+# continuously-running town accumulates history forever with no built-in
+# compaction. `VACUUM` cannot reclaim this (confirmed live: a 23.56GB file
+# only shrank to 22.24GB after a 14-minute VACUUM) because none of those
+# revisions are logically deleted from Convex's point of view -- they're
+# still "live" as far as SQLite is concerned. The only way to actually shed
+# accumulated history is to export current logical state and reimport it
+# into a fresh (empty) database, which starts a new history from that point
+# while preserving the live game world exactly as it was.
+#
+# Resetting the SQLite file wipes *everything* stored in it, not just app
+# data: the deployed Convex function code/modules and all `npx convex env`
+# variables live in the same file. Confirmed live 2026-07-29 -- after the
+# first real run of this script, the town had intact data but zero deployed
+# functions (every query/mutation call failed with "Could not find function")
+# and an empty env list (LLM_API_URL/LLM_MODEL/LLM_EMBEDDING_MODEL gone, so
+# NPC chat completion would have failed silently). Both are now captured
+# before the reset and restored after, and the world is explicitly
+# heartbeated back to "running" at the end so this doesn't depend on someone
+# happening to reload the frontend tab afterward.
+#
+# Usage:
+#   compact_convex_data.sh --check            # report current size, exit 0
+#   compact_convex_data.sh                    # compact only if over threshold
+#   compact_convex_data.sh --force             # compact regardless of size
+#
+# Env overrides:
+#   AITOWN_COMPACT_THRESHOLD_BYTES  (default 5368709120 = 5GiB)
+#   AITOWN_COMPACT_HEALTH_TIMEOUT_SEC (default 180)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPSTREAM="${ROOT}/upstream"
+COMPOSE=(docker compose)
+THRESHOLD_BYTES="${AITOWN_COMPACT_THRESHOLD_BYTES:-5368709120}"
+HEALTH_TIMEOUT_SEC="${AITOWN_COMPACT_HEALTH_TIMEOUT_SEC:-180}"
+JOB_DIR="/tmp/aitown-compact-$(date -u +%Y%m%d-%H%M%S)"
+
+CHECK_ONLY=0
+FORCE=0
+for arg in "$@"; do
+  case "${arg}" in
+    --check) CHECK_ONLY=1 ;;
+    --force) FORCE=1 ;;
+    *) echo "unknown arg: ${arg}" >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -d "${UPSTREAM}/convex" ]]; then
+  echo "missing ${UPSTREAM}/convex; clone upstream first (see README.md)" >&2
+  exit 1
+fi
+
+cd "${ROOT}"
+
+current_size() {
+  "${COMPOSE[@]}" exec -T backend stat -c%s /convex/data/db.sqlite3 2>/dev/null | tr -d '\r'
+}
+
+log() { echo "[$(date -u +%H:%M:%S)] $*"; }
+
+SIZE_BEFORE="$(current_size || echo 0)"
+if [[ -z "${SIZE_BEFORE}" || "${SIZE_BEFORE}" == "0" ]]; then
+  echo "could not read current db.sqlite3 size (backend down or path changed)" >&2
+  exit 1
+fi
+
+log "current db.sqlite3 size: ${SIZE_BEFORE} bytes"
+
+if [[ "${CHECK_ONLY}" == "1" ]]; then
+  exit 0
+fi
+
+# Resolve the actual data volume from the running container's mounts rather
+# than assuming Compose's default "<project>_<volume>" naming -- a
+# COMPOSE_PROJECT_NAME override would otherwise make the backup/rename steps
+# below silently target a nonexistent (docker-auto-created, empty) volume
+# while the real data volume goes untouched.
+VOLUME_NAME="$(docker inspect "$("${COMPOSE[@]}" ps -q backend)" \
+  --format '{{range .Mounts}}{{if eq .Destination "/convex/data"}}{{.Name}}{{end}}{{end}}')"
+if [[ -z "${VOLUME_NAME}" ]]; then
+  echo "could not resolve the /convex/data volume from the running backend container -- aborting" >&2
+  exit 1
+fi
+
+if [[ "${FORCE}" != "1" && "${SIZE_BEFORE}" -lt "${THRESHOLD_BYTES}" ]]; then
+  log "below threshold (${THRESHOLD_BYTES} bytes); skipping. Pass --force to override."
+  exit 0
+fi
+
+mkdir -p "${JOB_DIR}"
+PROGRESS="${JOB_DIR}/progress.log"
+exec > >(tee -a "${PROGRESS}") 2>&1
+
+log "job dir: ${JOB_DIR}"
+log "step 1/7: exporting live data (no downtime)"
+(cd "${UPSTREAM}" && npx convex export --path "${JOB_DIR}/export.zip")
+EXPORT_SIZE="$(stat -c%s "${JOB_DIR}/export.zip" 2>/dev/null || echo 0)"
+if [[ "${EXPORT_SIZE}" -lt 1024 ]]; then
+  echo "export.zip suspiciously small (${EXPORT_SIZE} bytes) -- aborting before touching anything" >&2
+  exit 1
+fi
+log "export ok: ${JOB_DIR}/export.zip (${EXPORT_SIZE} bytes)"
+
+log "step 1b/7: capturing deployed env vars (also wiped by the reset)"
+(cd "${UPSTREAM}" && npx convex env list) > "${JOB_DIR}/env.backup" || true
+log "env backup: ${JOB_DIR}/env.backup ($(wc -l < "${JOB_DIR}/env.backup" 2>/dev/null || echo 0) vars)"
+
+log "step 2/7: stopping backend"
+"${COMPOSE[@]}" stop backend
+
+log "step 3/7: snapshotting current db.sqlite3 out of the volume (belt-and-suspenders alongside the export)"
+BACKEND_CID="$("${COMPOSE[@]}" ps -a -q backend 2>/dev/null || true)"
+if [[ -n "${BACKEND_CID}" ]] && docker cp "${BACKEND_CID}:/convex/data/db.sqlite3" "${JOB_DIR}/db.sqlite3.pre-compact.bak" 2>/dev/null; then
+  :
+else
+  docker run --rm -v "${VOLUME_NAME}:/data" -v "${JOB_DIR}:/backup" alpine \
+    cp /data/db.sqlite3 "/backup/db.sqlite3.pre-compact.bak"
+fi
+log "backup: ${JOB_DIR}/db.sqlite3.pre-compact.bak"
+
+log "step 4/7: renaming (not deleting) db.sqlite3 inside the volume so a fresh one gets created on start"
+RENAME_TS="$(date +%s)"
+if ! docker run --rm -v "${VOLUME_NAME}:/data" alpine \
+     sh -c "test -f /data/db.sqlite3 && mv /data/db.sqlite3 /data/db.sqlite3.pre-compact-${RENAME_TS}"; then
+  echo "rename failed (or db.sqlite3 was already missing) -- aborting before starting the backend" >&2
+  echo "RECOVERY: the export at ${JOB_DIR}/export.zip and backup at ${JOB_DIR}/db.sqlite3.pre-compact.bak are intact; investigate the volume '${VOLUME_NAME}' manually before restarting backend" >&2
+  exit 1
+fi
+log "renamed to db.sqlite3.pre-compact-${RENAME_TS} inside the volume"
+
+log "step 5/7: starting backend fresh and waiting for health"
+"${COMPOSE[@]}" start backend
+deadline=$((SECONDS + HEALTH_TIMEOUT_SEC))
+until curl -fsS -m 3 http://127.0.0.1:"${PORT:-3210}"/version >/dev/null 2>&1; do
+  if (( SECONDS > deadline )); then
+    echo "backend did not become healthy within ${HEALTH_TIMEOUT_SEC}s" >&2
+    echo "RECOVERY: restore ${JOB_DIR}/db.sqlite3.pre-compact.bak or the in-volume db.sqlite3.pre-compact-${RENAME_TS} and restart" >&2
+    exit 1
+  fi
+  sleep 3
+done
+log "backend healthy"
+
+log "step 5b/7: redeploying Convex functions (fresh DB has no code until this runs)"
+(cd "${UPSTREAM}" && npx convex dev --once)
+
+log "step 5c/7: restoring deployed env vars"
+if [[ -s "${JOB_DIR}/env.backup" ]]; then
+  (cd "${UPSTREAM}" && npx convex env set --from-file "${JOB_DIR}/env.backup")
+else
+  log "no env vars to restore (env.backup empty)"
+fi
+
+log "step 6/7: reimporting exported data (--replace-all)"
+(cd "${UPSTREAM}" && npx convex import --replace-all -y "${JOB_DIR}/export.zip")
+
+log "step 7/7: heartbeating the default world back to running (don't depend on a frontend reload)"
+DEFAULT_WORLD_ID="$(cd "${UPSTREAM}" && npx convex run world:defaultWorldStatus 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("worldId",""))' 2>/dev/null || true)"
+if [[ -n "${DEFAULT_WORLD_ID}" ]]; then
+  (cd "${UPSTREAM}" && npx convex run world:heartbeatWorld "{\"worldId\": \"${DEFAULT_WORLD_ID}\"}") || log "heartbeat failed -- reload the frontend tab manually to resume the world"
+else
+  log "could not resolve default worldId -- reload the frontend tab manually to resume the world"
+fi
+
+SIZE_AFTER="$(current_size || echo 0)"
+log "done. size before=${SIZE_BEFORE} after=${SIZE_AFTER} (job dir: ${JOB_DIR})"
+
+cat > "${JOB_DIR}/report.md" <<EOF
+# AI Town Convex compaction report
+
+- Started: job dir ${JOB_DIR}
+- Size before: ${SIZE_BEFORE} bytes
+- Size after: ${SIZE_AFTER} bytes
+- Export: ${JOB_DIR}/export.zip (${EXPORT_SIZE} bytes)
+- Pre-compact backup: ${JOB_DIR}/db.sqlite3.pre-compact.bak
+- In-volume renamed original: db.sqlite3.pre-compact-${RENAME_TS} (safe to delete once verified)
+
+Verify the town looks correct (players/agents/conversations) before deleting backups.
+EOF
+log "report written: ${JOB_DIR}/report.md"

--- a/services/orion-ai-town/tests/test_compact_convex_data_script.py
+++ b/services/orion-ai-town/tests/test_compact_convex_data_script.py
@@ -1,0 +1,82 @@
+"""Gate tests for the Convex data-compaction script (structural, no Docker).
+
+These check the script's shape (flags, safety steps present) without running
+it -- actually exercising it requires a live Docker/Convex deployment, which
+is exactly what services/orion-ai-town/README.md's own "Smoke" section
+covers manually. See scripts/compact_convex_data.sh's header comment for why
+this exists: self-hosted Convex retains unbounded document-revision history
+with no built-in compaction (confirmed live 2026-07-29: 23.5GB file, VACUUM
+recovered only ~5%, a full export/reset/reimport cycle took it to 240MB).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_SCRIPT = _SERVICE / "scripts" / "compact_convex_data.sh"
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT.exists()
+    mode = _SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR
+
+
+def test_script_supports_check_and_force_flags():
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "--check" in text
+    assert "--force" in text
+    assert "CHECK_ONLY" in text
+    assert "FORCE" in text
+
+
+def test_script_is_threshold_gated_not_blind():
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "AITOWN_COMPACT_THRESHOLD_BYTES" in text
+    assert "below threshold" in text
+
+
+def test_script_exports_before_touching_anything():
+    text = _SCRIPT.read_text(encoding="utf-8")
+    export_idx = text.index("npx convex export")
+    stop_idx = text.index('"${COMPOSE[@]}" stop backend')
+    assert export_idx < stop_idx, "export must happen before the backend is stopped"
+
+
+def test_script_backs_up_before_removing_the_db_file():
+    text = _SCRIPT.read_text(encoding="utf-8")
+    backup_idx = text.index("db.sqlite3.pre-compact.bak")
+    rename_idx = text.index("mv /data/db.sqlite3 /data/db.sqlite3.pre-compact-")
+    assert backup_idx < rename_idx, "must snapshot before renaming/removing the live file"
+
+
+def test_script_restores_env_vars_and_redeploys_functions_after_reset():
+    # Regression: a live run found the reset wipes deployed function code and
+    # `npx convex env` vars along with the data, since they live in the same
+    # SQLite file. Both must be captured before and restored after.
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "npx convex env list" in text
+    assert "npx convex env set --from-file" in text
+    assert "npx convex dev --once" in text
+
+
+def test_script_heartbeats_world_back_to_running():
+    # Regression: without this, the world stays "inactive" after a reset
+    # until someone happens to reload the frontend tab.
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "world:heartbeatWorld" in text
+
+
+def test_script_has_bash_syntax_ok():
+    import subprocess
+
+    result = subprocess.run(
+        ["bash", "-n", str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr

--- a/services/orion-ai-town/tests/test_engine_recovery_patch.py
+++ b/services/orion-ai-town/tests/test_engine_recovery_patch.py
@@ -1,0 +1,52 @@
+"""Gate tests for the engine-recovery patch's index-range fix and sizing probes.
+
+Regression coverage for a bug found live 2026-07-29: `debugEngineState` and
+`recoverFrozenEngine` used `.withIndex(eq engineId only).filter(gt number)`,
+which can't prune the index range and forces a full scan of the engine's
+entire input history (300k+ rows) instead of just the pending tail. Both
+timed out ("too many system operations") regardless of `.take()` limit until
+fixed to chain the range into `withIndex` directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_PATCH = _SERVICE / "patches" / "orion-engine-recovery.patch"
+_APPLY = _SERVICE / "scripts" / "apply_upstream_patches.sh"
+
+
+def test_engine_recovery_patch_registered_in_apply_script():
+    text = _APPLY.read_text(encoding="utf-8")
+    assert "orion-engine-recovery.patch" in text
+
+
+def test_debug_and_recover_use_indexed_range_not_post_filter():
+    patch = _PATCH.read_text(encoding="utf-8")
+    # The fixed form chains .gt('number', processed) into the same withIndex
+    # call so Convex can prune the scan range.
+    assert patch.count("q.eq('engineId', engine._id).gt('number', processed)") == 2
+    # The old, broken form (index eq-only + a post-hoc .filter for the range)
+    # must not reappear.
+    assert ".filter((q) => q.gt(q.field('number'), processed))" not in patch
+
+
+def test_debug_and_recover_are_bounded_by_limit():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "args: { limit: v.optional(v.number()) }" in patch
+    assert ".take(limit)" in patch
+    # The old unbounded form collected the whole (filtered) pending set;
+    # the fixed form never collects the inputs index at all.
+    assert "byInputNumber', (q) => q.eq('engineId', engine._id))\n      .filter" not in patch
+
+
+def test_table_growth_sample_probe_present():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "tableGrowthSample" in patch
+    assert "by_creation_time" in patch
+
+
+def test_world_doc_size_probe_present():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "worldDocSizeProbe" in patch


### PR DESCRIPTION
## Summary
- Fixed a real bug in the engine-recovery diagnostic/recovery mutations (`debugEngineState`, `recoverFrozenEngine`): they used `.withIndex(eq engineId only).filter(gt number)`, which can't prune the index range and forces a full scan of the engine's entire input history instead of just the pending tail. Confirmed live this timed out ("too many system operations") regardless of `.take()` limit once history passed ~300k rows. Fixed to chain the range directly into `withIndex`, matching the engine's own `loadInputs` pattern in `convex/engine/abstractGame.ts`.
- Found and fixed the actual root cause of AI Town lag/timeouts: self-hosted Convex retains full document-revision history forever (no built-in compaction), so the continuously-ticking town accumulated 23.5GB of mostly-history bloat over ~3 weeks even though logical/current data was only ~240MB. `VACUUM` only recovered ~5%.
- Added `scripts/compact_convex_data.sh`: exports live data → stops backend → snapshots+renames (not deletes) the old `db.sqlite3` → starts fresh → redeploys Convex functions → restores `npx convex env` vars → reimports (`--replace-all`) → heartbeats the world back to `running`. Threshold-gated (default 5GiB), so it's a no-op most days.
- Wired a daily host crontab entry to run it automatically.
- Added two new read-only diagnostic queries (`tableGrowthSample`, `worldDocSizeProbe`) used during the investigation, kept for future use.

## Outcome moved
Live-verified on the running `orion-ai-town` deployment: `db.sqlite3` 23.56GB → 22.24GB (VACUUM, ~5% only) → 240MB (export/reset/reimport). Backend CPU 123% → 0%, RSS 52GB → ~1.5GB idle, OCC error rate ~20-30/min → 0/min. All 216,460 documents round-tripped intact across every table.

## Current architecture
`services/orion-ai-town` wraps a16z's self-hosted `ai-town` (Convex backend + frontend + dashboard, `upstream/` gitignored clone pinned via SHA, patched via tracked `.patch` files applied by `scripts/apply_upstream_patches.sh`). No prior maintenance/compaction tooling existed; the backend had been running continuously since ~2026-07-06/07 with no restarts.

## Architecture touched
- `patches/orion-engine-recovery.patch` (diff against `upstream/convex/testing.ts`) — query fix + two new sizing-probe queries.
- New `scripts/compact_convex_data.sh` — data compaction runbook.
- `.env_example`, `README.md` — documented new optional env keys and the new Maintenance section.
- Host crontab (not part of this diff) — daily invocation, threshold-gated.

## Files changed
- `services/orion-ai-town/patches/orion-engine-recovery.patch`: index-range fix for `debugEngineState`/`recoverFrozenEngine`; added `tableGrowthSample` and `worldDocSizeProbe`.
- `services/orion-ai-town/scripts/compact_convex_data.sh`: new compaction script.
- `services/orion-ai-town/tests/test_engine_recovery_patch.py`, `test_compact_convex_data_script.py`: new structural gate tests.
- `services/orion-ai-town/README.md`: new "Maintenance: Convex data compaction" section.
- `services/orion-ai-town/.env_example`: documented (commented, optional) `AITOWN_COMPACT_THRESHOLD_BYTES`/`AITOWN_COMPACT_HEALTH_TIMEOUT_SEC`.

## Schema / bus / API changes
None. `tableGrowthSample`/`worldDocSizeProbe` are internal-only Convex diagnostic queries, not part of any bus/schema contract.

## Env/config changes
- Added keys (optional, commented in `.env_example`): `AITOWN_COMPACT_THRESHOLD_BYTES` (default 5GiB), `AITOWN_COMPACT_HEALTH_TIMEOUT_SEC` (default 180s).
- `.env_example` updated: yes.
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes (no changes needed — new keys are commented/optional).
- skipped keys requiring operator action: none.

## Tests run
```
/mnt/scripts/Orion-Sapienform/venv/bin/pytest services/orion-ai-town/tests/ -v
29 passed, 1 pre-existing/environment-dependent failure (test_juniper_blurb_present_in_world_ts
requires the gitignored upstream/ clone, which doesn't exist in a fresh worktree — unrelated to
this change, same failure occurs on main in a fresh worktree).
```

## Evals run
No eval harness exists for this service. This is infra/ops tooling, not a cognition-loop change; live verification (documented above) served as the functional check.

## Docker/build/smoke checks
Full live run performed against the running deployment during this session:
- `npx convex export` (no downtime)
- `docker compose stop backend` / `docker cp` backup / in-volume rename
- `docker compose start backend`, health check
- `npx convex dev --once` (function redeploy) + `npx convex env set --from-file` (env restore)
- `npx convex import --replace-all` (216,460 documents restored)
- `npx convex run world:heartbeatWorld` (world back to `running`)
- Verified `worldStatus`, `playerDescriptions`, engine tick (`processedInputNumber` advancing), and `docker stats` resource usage post-recovery.
- Patch chain re-verified: all 6 patches (including the regenerated `orion-engine-recovery.patch`) apply cleanly in sequence against a fresh clone of the pinned upstream SHA.

## Review findings fixed
- Finding: `compact_convex_data.sh`'s rename-old-db step silently swallowed failure (`|| true`), so a failed rename would silently proceed as if compaction happened.
  - Fix: rename failure now aborts the script loudly with explicit recovery instructions.
  - Evidence: `scripts/compact_convex_data.sh` step 4/7.
- Finding: hardcoded `VOLUME_NAME` assumed Compose's default project-name-prefix convention; a `COMPOSE_PROJECT_NAME` override would silently target a nonexistent volume.
  - Fix: volume name now resolved dynamically from the running backend container's actual mount via `docker inspect`.
  - Evidence: `scripts/compact_convex_data.sh`, volume resolution block.
- Finding: new optional env keys weren't documented in `.env_example`.
  - Fix: added as commented/optional entries.
  - Evidence: `services/orion-ai-town/.env_example`.

## Restart required
```
No restart required — the live deployment was already recovered and verified during this session
(backend healthy, functions deployed, env restored, world running). Merging this branch only
updates the tracked patch/script/docs to match what's already live; no further action needed
unless upstream/ is re-cloned from scratch, in which case scripts/apply_upstream_patches.sh
picks up the fixed patch automatically.
```

## Risks / concerns
- Severity: low
- Concern: the pre-compaction `npx convex env` values (LLM_API_URL/LLM_MODEL/LLM_EMBEDDING_MODEL) were not captured before the *first* live compaction run (that capture step was added only after discovering the gap), so they were restored via `scripts/wire_llm_gateway.sh`'s own defaults, which set `LLM_MODEL=quick` — the README's documented default is `LLM_MODEL=chat`. I could not confirm which was actually in use beforehand.
- Mitigation: worth an operator check of `npx convex env list` against README expectations; low blast radius (both are valid gateway routes, this only affects which llamacpp lane NPC chat completion uses).

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/aitown-convex-compaction