### PR TITLE
fix(orion-embodiment): raise aitown_client HTTP timeout, was killing all actuation

### DIFF
--- a/orion/embodiment/aitown_client.py
+++ b/orion/embodiment/aitown_client.py
@@ -30,6 +30,26 @@ def _world_id() -> str:
     return str(os.environ.get("AITOWN_WORLD_ID") or "").strip()
 
 
+def _http_timeout_sec() -> float:
+    # Confirmed live 2026-07-29: under normal multi-NPC OCC contention this
+    # self-hosted Convex backend's mutations routinely take 15-25s (a plain
+    # `sendInput` moveTo measured at 21.6s). The old hardcoded 15s timeout
+    # made every one of Orion's actuations (movement, speech injection) fail
+    # client-side even though the mutation was still landing server-side a
+    # few seconds later -- `processedInputNumber` kept advancing while
+    # Orion's own `pathfinding`/conversation state never updated. 30s default
+    # gives real headroom over the observed worst case; override per-caller
+    # via env if the backend's contention profile changes.
+    try:
+        value = float(os.environ.get("AITOWN_HTTP_TIMEOUT_SEC") or 30.0)
+    except ValueError:
+        return 30.0
+    # A non-positive value (e.g. "0") is a string, so `or 30.0` above doesn't
+    # catch it -- treat it the same as unset/invalid rather than handing
+    # urlopen an instant/negative timeout.
+    return value if value > 0 else 30.0
+
+
 def convex_request(endpoint: str, *, path: str, args: Optional[Dict[str, Any]] = None) -> Any:
     base = _base_url()
     key = _admin_key()
@@ -46,7 +66,7 @@ def convex_request(endpoint: str, *, path: str, args: Optional[Dict[str, Any]] =
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with urllib.request.urlopen(req, timeout=_http_timeout_sec()) as resp:
             body = resp.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")[:500]

--- a/orion/embodiment/tests/test_aitown_client.py
+++ b/orion/embodiment/tests/test_aitown_client.py
@@ -98,3 +98,55 @@ def test_send_input_requires_world_id(monkeypatch):
         assert False, "expected AitownClientError"
     except aitown_client.AitownClientError:
         pass
+
+
+def test_http_timeout_defaults_to_30s(monkeypatch):
+    monkeypatch.delenv("AITOWN_HTTP_TIMEOUT_SEC", raising=False)
+    assert aitown_client._http_timeout_sec() == 30.0
+
+
+def test_http_timeout_overridable_via_env(monkeypatch):
+    monkeypatch.setenv("AITOWN_HTTP_TIMEOUT_SEC", "45")
+    assert aitown_client._http_timeout_sec() == 45.0
+
+
+def test_http_timeout_falls_back_on_bad_value(monkeypatch):
+    monkeypatch.setenv("AITOWN_HTTP_TIMEOUT_SEC", "not-a-number")
+    assert aitown_client._http_timeout_sec() == 30.0
+
+
+def test_http_timeout_rejects_zero(monkeypatch):
+    # "0" is a non-empty string, so `... or 30.0` doesn't catch it -- must be
+    # rejected explicitly or callers get an instant-timeout client.
+    monkeypatch.setenv("AITOWN_HTTP_TIMEOUT_SEC", "0")
+    assert aitown_client._http_timeout_sec() == 30.0
+
+
+def test_http_timeout_rejects_negative(monkeypatch):
+    monkeypatch.setenv("AITOWN_HTTP_TIMEOUT_SEC", "-5")
+    assert aitown_client._http_timeout_sec() == 30.0
+
+
+def test_convex_request_uses_configured_timeout(monkeypatch):
+    monkeypatch.setenv("AITOWN_CONVEX_URL", "http://example.invalid")
+    monkeypatch.setenv("AITOWN_ADMIN_KEY", "k")
+    monkeypatch.setenv("AITOWN_HTTP_TIMEOUT_SEC", "45")
+    captured = {}
+
+    class _Resp:
+        def read(self):
+            return b'{"status": "success", "value": {}}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None):
+        captured["timeout"] = timeout
+        return _Resp()
+
+    monkeypatch.setattr(aitown_client.urllib.request, "urlopen", fake_urlopen)
+    aitown_client.convex_query("world:worldState", {})
+    assert captured["timeout"] == 45.0


### PR DESCRIPTION
## Summary
- `orion/embodiment/aitown_client.py`'s `convex_request()` had a hardcoded 15s `urlopen` timeout. The self-hosted AI Town Convex backend routinely takes 15-25s per mutation under this town's current multi-NPC OCC contention (measured live: a plain `moveTo` `sendInput` took 18.5s and 21.6s on separate direct CLI runs). Every one of Orion's actuations — movement, speech injection, conversation-accept — was timing out client-side even though the mutation was still landing server-side a few seconds later.
- Raised the default to 30s via a new `_http_timeout_sec()` helper, overridable per-deployment via `AITOWN_HTTP_TIMEOUT_SEC`.
- Fixed a review finding: guards against `AITOWN_HTTP_TIMEOUT_SEC=0` (or negative) silently producing an instant-timeout client — a plain `x or 30.0` doesn't catch a non-empty `"0"` string.

## Outcome moved
Live-verified after rebuild+redeploy of `orion-embodiment`: Orion's position actually changed (43,17 → 40,16 — it had never moved since world creation, ~3 weeks) and it held a real multi-turn conversation with a town NPC (Juno Park) — both previously always failed with `TimeoutError: timed out`.

This was one of three compounding causes behind a broader "AI Town is broken" report investigated in this session:
1. Embodiment's perception was completely blind (`~/.fcc/.env` was missing `AITOWN_CONVEX_URL`/`AITOWN_ADMIN_KEY`/`AITOWN_WORLD_ID` — predates this session, fixed operationally, not part of this diff).
2. An accidental duplicate "Orion" player from a debugging mis-step, cleaned up operationally.
3. This timeout bug — the one actually fixed here, since it's the one that's a real code defect rather than live-environment state.

## Current architecture
`services/orion-embodiment`'s worker (`app/worker.py`) drives Orion's AI Town body via `orion/embodiment/aitown_client.py`, a synchronous urllib-based HTTP client (mirrors the existing MCP client, wrapped in `asyncio.to_thread` by async callers). No other timeout in the actuation call chain — confirmed via review that `worker.py`'s only `asyncio.wait_for` calls are unrelated (pubsub polling, stop-event wait), so nothing shorter than this client-level timeout could preempt it.

## Architecture touched
`orion/embodiment/aitown_client.py` only — a shared lib, no schema/bus/API surface.

## Files changed
- `orion/embodiment/aitown_client.py`: hardcoded 15s timeout → configurable, defaults 30s, guards `0`/negative.
- `orion/embodiment/tests/test_aitown_client.py`: 6 new tests (default, env override, bad-value fallback, zero/negative rejection, and that `convex_request` actually passes the configured timeout through to `urlopen`).

## Schema / bus / API changes
None.

## Env/config changes
- Added key: `AITOWN_HTTP_TIMEOUT_SEC` (optional, default 30.0, no `.env_example` entry needed — this is a shared lib env var read at call time, not a per-service compose-injected variable, matching how `AITOWN_CONVEX_URL`/`AITOWN_ADMIN_KEY`/`AITOWN_WORLD_ID` already work in this same file).
- `.env_example` updated: n/a (see above).
- local `.env` synced: n/a, no `.env_example` change.

## Tests run
```
/mnt/scripts/Orion-Sapienform/venv/bin/pytest orion/embodiment/tests/test_aitown_client.py -q
17 passed

/mnt/scripts/Orion-Sapienform/venv/bin/pytest orion/embodiment/tests/ -q
75 passed
```

## Evals run
No eval harness for this module; live verification (documented above) served as the functional check for a live-ops fix.

## Docker/build/smoke checks
```
bash scripts/safe_docker_build.sh orion-embodiment up -d --build
docker compose ps   # healthy
docker compose logs embodiment   # perceiving normally, nearby=8, no errors
```
Rebuilt and redeployed twice during this session (once for the initial fix, once more after the review-driven zero/negative guard was added).

## Review findings fixed
- Finding: `AITOWN_HTTP_TIMEOUT_SEC=0` (or a negative value) would silently produce an instant-timeout `urlopen` call instead of falling back to the 30s default, because `os.environ.get(...) or 30.0` only catches unset/empty-string, not a non-empty `"0"` string.
  - Fix: explicit `value if value > 0 else 30.0` check after the float conversion.
  - Evidence: `orion/embodiment/aitown_client.py:_http_timeout_sec()`, plus new tests `test_http_timeout_rejects_zero`/`test_http_timeout_rejects_negative`.
- Reviewed and confirmed clean: no outer `asyncio.wait_for` in `worker.py` could preempt this timeout; the `urllib.request.urlopen` mock patch target matches the file's actual `import urllib.request` style; no other hardcoded timeouts in this file.

## Restart required
```
No restart required -- already rebuilt and redeployed live during this session:
bash scripts/safe_docker_build.sh orion-embodiment up -d --build
```

## Risks / concerns
- Severity: low
- Concern: 30s is a generous but not unlimited ceiling. The underlying backend mutation latency (15-25s, occasionally more under heavier concurrent load) is itself a separate, deeper issue in `services/orion-ai-town`'s self-hosted Convex OCC contention profile, not something this client-side timeout bump actually fixes -- it just gives real mutations enough time to land instead of being abandoned client-side. If contention gets meaningfully worse, this ceiling may need raising again (already env-overridable) or the underlying contention needs separate investigation.
- Mitigation: `AITOWN_HTTP_TIMEOUT_SEC` is env-overridable without a code change if needed.

## PR link
https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/aitown-embodiment-http-timeout