### PR TITLE
feat(orion-actions): bootstrap daily github_compactor_pass schedule

### DIFF
--- a/services/orion-actions/app/main.py
+++ b/services/orion-actions/app/main.py
@@ -1073,6 +1073,12 @@ async def lifespan(app: FastAPI):
         ensure_chat_history_compactor_daily_schedule(workflow_schedule_store)
     except Exception:
         logger.exception("chat_history_compactor_schedule_bootstrap_failed")
+    try:
+        from .workflow_schedule_bootstrap import ensure_github_compactor_daily_schedule
+
+        ensure_github_compactor_daily_schedule(workflow_schedule_store)
+    except Exception:
+        logger.exception("github_compactor_schedule_bootstrap_failed")
     scheduler_cursor_store = SchedulerCursorStore(
         resolve_scheduler_cursor_store_path(
             settings.actions_scheduler_cursor_store_path or None,

--- a/services/orion-actions/app/workflow_schedule_bootstrap.py
+++ b/services/orion-actions/app/workflow_schedule_bootstrap.py
@@ -15,22 +15,25 @@ from .workflow_schedule_store import WorkflowScheduleStore
 logger = logging.getLogger("orion.actions.workflow_schedule_bootstrap")
 
 CHAT_HISTORY_COMPACTOR_WORKFLOW_ID = "chat_history_compactor_pass"
-_BOOTSTRAP_REQUEST_ID = "bootstrap:chat_history_compactor_pass:daily:06:00:America/Denver"
+_CHAT_HISTORY_COMPACTOR_BOOTSTRAP_REQUEST_ID = "bootstrap:chat_history_compactor_pass:daily:06:00:America/Denver"
+
+GITHUB_COMPACTOR_WORKFLOW_ID = "github_compactor_pass"
+_GITHUB_COMPACTOR_BOOTSTRAP_REQUEST_ID = "bootstrap:github_compactor_pass:daily:06:10:America/Denver"
 
 
-def _blocks_bootstrap_seed(schedule) -> bool:
+def _blocks_bootstrap_seed(schedule, *, workflow_id: str, bootstrap_request_id: str) -> bool:
     """True when an existing record means bootstrap must not (re-)seed.
 
     Two cases block seeding:
     - Any record ever created by this bootstrap (matched by request_id), in ANY
       state — so an operator cancel or time edit sticks across restarts instead
-      of being resurrected or duplicated at 06:00.
+      of being resurrected or duplicated at the bootstrap slot.
     - Any live recurring schedule for the workflow (operator-created), so a
       manual replacement schedule is not doubled up by bootstrap.
     """
-    if getattr(schedule, "request_id", None) == _BOOTSTRAP_REQUEST_ID:
+    if getattr(schedule, "request_id", None) == bootstrap_request_id:
         return True
-    if schedule.workflow_id != CHAT_HISTORY_COMPACTOR_WORKFLOW_ID:
+    if schedule.workflow_id != workflow_id:
         return False
     if schedule.state in {"cancelled", "completed"}:
         return False
@@ -38,43 +41,57 @@ def _blocks_bootstrap_seed(schedule) -> bool:
     return spec is not None and spec.kind == "recurring"
 
 
-def ensure_chat_history_compactor_daily_schedule(
+def _ensure_daily_schedule(
     store: WorkflowScheduleStore,
+    *,
+    workflow_id: str,
+    workflow_display_name: str,
+    bootstrap_request_id: str,
+    hour_local: int,
+    minute_local: int,
+    label: str,
+    policy_summary: str,
+    log_prefix: str,
 ) -> object | None:
-    """Idempotently seed daily 06:00 America/Denver chat history compactor schedule.
+    """Idempotently seed a daily America/Denver schedule for a workflow.
 
     Returns the created record, or None if a matching schedule already exists.
     """
-    existing = [s for s in store.list_schedules(include_inactive=True) if _blocks_bootstrap_seed(s)]
+    existing = [
+        s
+        for s in store.list_schedules(include_inactive=True)
+        if _blocks_bootstrap_seed(s, workflow_id=workflow_id, bootstrap_request_id=bootstrap_request_id)
+    ]
     if existing:
         logger.info(
-            "chat_history_compactor_schedule_bootstrap_skip existing_schedule_id=%s",
+            "%s_schedule_bootstrap_skip existing_schedule_id=%s",
+            log_prefix,
             existing[0].schedule_id,
         )
         return None
 
     policy = WorkflowExecutionPolicyV1(
-        workflow_id=CHAT_HISTORY_COMPACTOR_WORKFLOW_ID,
+        workflow_id=workflow_id,
         invocation_mode="scheduled",
         schedule=WorkflowScheduleSpecV1(
             kind="recurring",
             timezone="America/Denver",
             cadence="daily",
-            hour_local=6,
-            minute_local=0,
-            label="Chat history compactor (daily Denver)",
+            hour_local=hour_local,
+            minute_local=minute_local,
+            label=label,
         ),
         notify_on="completion",
         recipient_group="juniper_primary",
         requested_from_chat=False,
-        policy_summary="Bootstrap: daily chat_history_log digest into indexed memory card",
+        policy_summary=policy_summary,
     )
     request = WorkflowDispatchRequestV1(
-        request_id=_BOOTSTRAP_REQUEST_ID,
-        workflow_id=CHAT_HISTORY_COMPACTOR_WORKFLOW_ID,
+        request_id=bootstrap_request_id,
+        workflow_id=workflow_id,
         workflow_request={
-            "workflow_id": CHAT_HISTORY_COMPACTOR_WORKFLOW_ID,
-            "workflow_display_name": "Chat History Compactor",
+            "workflow_id": workflow_id,
+            "workflow_display_name": workflow_display_name,
             "window_mode": "day",
             "execution_policy": policy.model_dump(mode="json"),
         },
@@ -86,8 +103,47 @@ def ensure_chat_history_compactor_daily_schedule(
     )
     record = store.upsert_from_dispatch(request)
     logger.info(
-        "chat_history_compactor_schedule_bootstrap_created schedule_id=%s next_run_at=%s",
+        "%s_schedule_bootstrap_created schedule_id=%s next_run_at=%s",
+        log_prefix,
         getattr(record, "schedule_id", None),
         getattr(record, "next_run_at", None),
     )
     return record
+
+
+def ensure_chat_history_compactor_daily_schedule(
+    store: WorkflowScheduleStore,
+) -> object | None:
+    """Idempotently seed daily 06:00 America/Denver chat history compactor schedule."""
+    return _ensure_daily_schedule(
+        store,
+        workflow_id=CHAT_HISTORY_COMPACTOR_WORKFLOW_ID,
+        workflow_display_name="Chat History Compactor",
+        bootstrap_request_id=_CHAT_HISTORY_COMPACTOR_BOOTSTRAP_REQUEST_ID,
+        hour_local=6,
+        minute_local=0,
+        label="Chat history compactor (daily Denver)",
+        policy_summary="Bootstrap: daily chat_history_log digest into indexed memory card",
+        log_prefix="chat_history_compactor",
+    )
+
+
+def ensure_github_compactor_daily_schedule(
+    store: WorkflowScheduleStore,
+) -> object | None:
+    """Idempotently seed daily 06:10 America/Denver GitHub compactor schedule.
+
+    Runs 10 minutes after the chat history compactor's 06:00 slot so the two
+    daily digests don't contend for the same cortex-orch dispatch window.
+    """
+    return _ensure_daily_schedule(
+        store,
+        workflow_id=GITHUB_COMPACTOR_WORKFLOW_ID,
+        workflow_display_name="GitHub Compactor",
+        bootstrap_request_id=_GITHUB_COMPACTOR_BOOTSTRAP_REQUEST_ID,
+        hour_local=6,
+        minute_local=10,
+        label="GitHub compactor (daily Denver, +10m after chat)",
+        policy_summary="Bootstrap: daily merged-PR digest into indexed memory card",
+        log_prefix="github_compactor",
+    )

--- a/services/orion-actions/tests/test_github_compactor_schedule_bootstrap.py
+++ b/services/orion-actions/tests/test_github_compactor_schedule_bootstrap.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orion.schemas.workflow_execution import (
+    WorkflowScheduleManageRequestV1,
+    WorkflowScheduleUpdatePatchV1,
+)
+
+from app.workflow_schedule_bootstrap import (
+    ensure_chat_history_compactor_daily_schedule,
+    ensure_github_compactor_daily_schedule,
+)
+from app.workflow_schedule_store import WorkflowScheduleStore
+
+
+def test_github_compactor_schedule_bootstrap_creates_once(tmp_path: Path) -> None:
+    store = WorkflowScheduleStore(str(tmp_path / "schedules.json"))
+    first = ensure_github_compactor_daily_schedule(store)
+    assert first is not None
+    assert first.workflow_id == "github_compactor_pass"
+    assert first.execution_policy.schedule is not None
+    assert first.execution_policy.schedule.kind == "recurring"
+    assert first.execution_policy.schedule.cadence == "daily"
+    assert first.execution_policy.schedule.hour_local == 6
+    assert first.execution_policy.schedule.minute_local == 10
+    assert first.execution_policy.schedule.timezone == "America/Denver"
+    assert first.workflow_request.get("window_mode") == "day"
+
+    second = ensure_github_compactor_daily_schedule(store)
+    assert second is None
+    active = [s for s in store.list_schedules() if s.workflow_id == "github_compactor_pass"]
+    assert len(active) == 1
+
+
+def test_github_bootstrap_does_not_resurrect_cancelled_schedule(tmp_path: Path) -> None:
+    store = WorkflowScheduleStore(str(tmp_path / "schedules.json"))
+    record = ensure_github_compactor_daily_schedule(store)
+    assert record is not None
+
+    resp = store.apply_management(
+        WorkflowScheduleManageRequestV1(
+            operation="cancel",
+            request_id="test-cancel",
+            schedule_id=record.schedule_id,
+        )
+    )
+    assert resp.ok is True
+
+    # Simulated restart: bootstrap must respect the operator's cancel.
+    assert ensure_github_compactor_daily_schedule(store) is None
+    active = [s for s in store.list_schedules() if s.workflow_id == "github_compactor_pass"]
+    assert active == []
+
+
+def test_github_bootstrap_does_not_duplicate_operator_edited_schedule(tmp_path: Path) -> None:
+    store = WorkflowScheduleStore(str(tmp_path / "schedules.json"))
+    record = ensure_github_compactor_daily_schedule(store)
+    assert record is not None
+
+    resp = store.apply_management(
+        WorkflowScheduleManageRequestV1(
+            operation="update",
+            request_id="test-update",
+            schedule_id=record.schedule_id,
+            patch=WorkflowScheduleUpdatePatchV1(hour_local=7),
+        )
+    )
+    assert resp.ok is True
+
+    # Simulated restart: the edited schedule counts as existing; no 06:10 twin.
+    assert ensure_github_compactor_daily_schedule(store) is None
+    active = [s for s in store.list_schedules() if s.workflow_id == "github_compactor_pass"]
+    assert len(active) == 1
+    assert active[0].execution_policy.schedule.hour_local == 7
+
+
+def test_chat_and_github_compactor_bootstraps_coexist_independently(tmp_path: Path) -> None:
+    store = WorkflowScheduleStore(str(tmp_path / "schedules.json"))
+    chat = ensure_chat_history_compactor_daily_schedule(store)
+    github = ensure_github_compactor_daily_schedule(store)
+    assert chat is not None
+    assert github is not None
+    assert chat.schedule_id != github.schedule_id
+
+    # Re-running both bootstraps is a no-op for each independently.
+    assert ensure_chat_history_compactor_daily_schedule(store) is None
+    assert ensure_github_compactor_daily_schedule(store) is None
+    assert len(store.list_schedules()) == 2


### PR DESCRIPTION
## Summary
- `chat_history_compactor_pass` had a startup bootstrap seeding a durable daily 06:00 America/Denver schedule; `github_compactor_pass` never got one, despite its own design doc (`docs/superpowers/specs/2026-07-08-github-compactor-design.md`) saying it should be scheduled the same way. That's why it never showed up in the Hub schedule panel.
- Factored the bootstrap logic into a shared `_ensure_daily_schedule()` helper in `services/orion-actions/app/workflow_schedule_bootstrap.py`, keeping the existing chat compactor bootstrap byte-identical in behavior (same request_id, hour/minute/label/policy_summary).
- Added `ensure_github_compactor_daily_schedule()`, seeding `github_compactor_pass` daily at **06:10 America/Denver** — 10 minutes after the chat compactor, so the two daily digests don't contend for the same cortex-orch dispatch window.
- Wired the new bootstrap into `main.py` startup, in its own try/except so a failure in one bootstrap can't block the other.

## Outcome moved
Hub's "Workflow Schedules" panel will show both durable compactor schedules instead of just one.

## Files changed
- `services/orion-actions/app/workflow_schedule_bootstrap.py`: shared `_ensure_daily_schedule()` helper + new `ensure_github_compactor_daily_schedule()`
- `services/orion-actions/app/main.py`: calls the new bootstrap at startup, alongside the existing chat one
- `services/orion-actions/tests/test_github_compactor_schedule_bootstrap.py`: idempotency, cancel-respecting, edit-respecting, and chat/github-coexistence tests

## Schema / bus / API changes
None. Uses the existing `WorkflowDispatchRequestV1` / `WorkflowScheduleStore` contract, same as the chat compactor.

## Env/config changes
None.

## Tests run
```
/mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest services/orion-actions/tests -q
106 passed, 70 warnings
```

## Review findings fixed
Reviewed via subagent (orion-repo-agent). No material findings — refactor preserves the chat schedule's exact identity/timing, per-workflow scoping in `_blocks_bootstrap_seed` is correct, `github_compactor_pass`'s dispatch-time request shape defaults safely (`DEFAULT_LOOKBACK_DAYS`), and the two bootstrap calls can't collide (different request_ids, sequential at startup, store is RLock-guarded).

## Docker/build/smoke checks
Pending live deploy (next step in this session).

## Restart required
```bash
scripts/safe_docker_build.sh orion-actions up -d --build
```

## Risks / concerns
- Severity: low
- Concern: `github_compactor_pass` hasn't had a real scheduled dispatch fire yet (next run is today at 06:10 America/Denver) — first live run is unverified.
- Mitigation: Hub schedule panel shows `next_run_at`/analytics per-schedule; will be visible after first fire.