### PR TITLE
fix(biometrics): surface real gpu_pressure into field lattice

### DIFF
--- a/orion/substrate/biometrics_loop/grammar_extract.py
+++ b/orion/substrate/biometrics_loop/grammar_extract.py
@@ -114,9 +114,8 @@ def extract_node_state_from_events(
                 pressure_hints["strain"] = float(atom.salience)
         elif atom.semantic_role == "node_availability":
             availability_summary = atom.summary
-        elif atom.semantic_role == "capability_surface" and atom.salience is not None:
-            if profile.capabilities.get("local_llm_heavy"):
-                pressure_hints["gpu"] = float(atom.salience)
+        elif atom.semantic_role == "gpu_pressure_signal" and atom.salience is not None:
+            pressure_hints["gpu"] = float(atom.salience)
         elif atom.semantic_role == "memory_pressure_signal" and atom.salience is not None:
             pressure_hints["memory_pressure"] = float(atom.salience)
         elif atom.semantic_role == "thermal_pressure_signal" and atom.salience is not None:

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -138,17 +138,32 @@ block turns into lattice `Perturbation`s:
 | Atom `semantic_role` | `pressure_hints` key | Lattice channel (`NODE_CHANNELS`) |
 | :--- | :--- | :--- |
 | `body_state` (composite `strain`) | `strain` | `cpu_pressure` |
-| `capability_surface` (gated on `local_llm_heavy`) | `gpu` | `gpu_pressure` |
+| `gpu_pressure_signal` | `gpu` | `gpu_pressure` |
 | `memory_pressure_signal` | `memory_pressure` | `memory_pressure` |
 | `thermal_pressure_signal` | `thermal_pressure` | `thermal_pressure` |
 | `disk_pressure_signal` | `disk_pressure` | `disk_pressure` |
 
-`memory_pressure_signal`/`thermal_pressure_signal`/`disk_pressure_signal` carry
-the individually-computed `mem`/`thermal`/`disk` values from
-`orion/telemetry/biometrics_pipeline.py`'s `pressures` dict (2026-07-16 fix --
-these were previously only folded into the `strain` composite and never
-reached the field lattice, so the corresponding channels stayed pinned at
-`0.0`). This is additive: `strain`/`gpu` are unchanged.
+`gpu_pressure_signal`/`memory_pressure_signal`/`thermal_pressure_signal`/
+`disk_pressure_signal` carry the individually-computed `gpu_util`/`mem`/
+`thermal`/`disk` values from `orion/telemetry/biometrics_pipeline.py`'s
+`pressures` dict. `memory_pressure_signal`/`thermal_pressure_signal`/
+`disk_pressure_signal` were wired in by the 2026-07-16 fix -- these were
+previously only folded into the `strain` composite and never reached the
+field lattice, so the corresponding channels stayed pinned at `0.0`.
+`gpu_pressure_signal` was wired in by a 2026-07-28 fix for the same class of
+bug: `pressure_hints["gpu"]` previously came from `capability_surface`'s
+`salience`, which is an **unconditional hardcoded literal (`0.8`)** in this
+file, not a telemetry sample -- it had no relationship to real GPU load and
+was gated on `local_llm_heavy` besides. `node:atlas`'s `gpu_pressure` field
+channel read a flat `0.8` for ~42,400 consecutive real ticks (24h) as a
+result. `gpu_pressure_signal` is emitted unconditionally for every node
+(same as the memory/thermal/disk siblings, no capability gate) carrying the
+real `gpu_util` value, which is `0.0` for nodes with no GPU samples --
+`pressure_hints["gpu"]` is now populated for every node's tick, not just
+`local_llm_heavy` ones. `capability_surface`'s own `salience` is unchanged
+and still used for its own confidence/summary display; it is simply no
+longer read as the source of the gpu pressure hint. This is additive to
+`strain`: unaffected.
 
 All five of these `Perturbation`s (`strain`/`gpu`/`memory_pressure`/
 `thermal_pressure`/`disk_pressure`) use `mode="replace"`, not the library

--- a/services/orion-biometrics/app/grammar_emit.py
+++ b/services/orion-biometrics/app/grammar_emit.py
@@ -196,6 +196,19 @@ def build_biometrics_node_grammar_events(
         # composite "strain" salience on `body_state` above -- no downstream
         # consumer could ever see them individually. Additive: `strain` and
         # `capability_surface`'s "gpu" hint are untouched.
+        "gpu_pressure_signal": GrammarAtomV1(
+            atom_id=atom_id("gpu_pressure_signal"),
+            trace_id=trace_id,
+            atom_type="signal",
+            semantic_role="gpu_pressure_signal",
+            layer="organ_signal",
+            dimensions=["physiology", "telemetry", "node", "resource"],
+            summary=f"{node_id} GPU pressure observed",
+            confidence=0.9,
+            salience=float((summary.pressures or {}).get("gpu_util", 0.0)),
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.pressure.gpu:{node_id}:{ts}",
+        ),
         "memory_pressure_signal": GrammarAtomV1(
             atom_id=atom_id("memory_pressure_signal"),
             trace_id=trace_id,
@@ -291,6 +304,7 @@ def build_biometrics_node_grammar_events(
         ("body_state", "capability_surface", "influenced"),
         ("node_availability", "capability_surface", "influenced"),
         ("node_context", "capability_surface", "supports"),
+        ("telemetry_sample", "gpu_pressure_signal", "derived_from"),
         ("telemetry_sample", "memory_pressure_signal", "derived_from"),
         ("telemetry_sample", "thermal_pressure_signal", "derived_from"),
         ("telemetry_sample", "disk_pressure_signal", "derived_from"),
@@ -303,6 +317,7 @@ def build_biometrics_node_grammar_events(
         ("power_pressure_signal", "capability_surface", "influenced"),
         ("disk_capacity_pressure_signal", "capability_surface", "influenced"),
         ("fan_pressure_signal", "capability_surface", "influenced"),
+        ("gpu_pressure_signal", "capability_surface", "influenced"),
     ]
 
     events: list[GrammarEventV1] = [root_event]

--- a/services/orion-biometrics/tests/test_biometrics_grammar_emit.py
+++ b/services/orion-biometrics/tests/test_biometrics_grammar_emit.py
@@ -181,6 +181,50 @@ def test_memory_thermal_disk_pressure_signals_default_to_zero_when_absent(
     assert atoms_by_role["disk_pressure_signal"].salience == 0.0
 
 
+def test_gpu_pressure_signal_carries_real_gpu_util_not_hardcoded_capability_salience(
+    catalog: NodeCatalog,
+) -> None:
+    # Regression for the bug where node:atlas's gpu_pressure field channel read a
+    # flat 0.8 for ~42,400 consecutive real ticks: `capability_surface`'s salience
+    # is an unconditional hardcoded 0.8 (see grammar_emit.py's capability_surface
+    # atom), not a telemetry sample. The dedicated gpu_pressure_signal atom must
+    # carry the real computed `gpu_util` value from
+    # orion/telemetry/biometrics_pipeline.py's `pressures` dict instead.
+    sample, summary, induction = _fixtures("atlas", pressures={"gpu_util": 0.27})
+    profile = catalog.resolve("atlas")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    atoms_by_role = {
+        e.atom.semantic_role: e.atom for e in events if e.atom is not None
+    }
+    assert atoms_by_role["gpu_pressure_signal"].salience == pytest.approx(0.27)
+    # capability_surface stays fixed at its own hardcoded value -- unaffected.
+    assert atoms_by_role["capability_surface"].salience == pytest.approx(0.8)
+
+
+def test_gpu_pressure_signal_defaults_to_zero_when_absent(
+    catalog: NodeCatalog,
+) -> None:
+    sample, summary, induction = _fixtures("atlas")
+    profile = catalog.resolve("atlas")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    atoms_by_role = {
+        e.atom.semantic_role: e.atom for e in events if e.atom is not None
+    }
+    assert atoms_by_role["gpu_pressure_signal"].salience == 0.0
+
+
 def test_circe_node_availability_reflects_expected_offline(catalog: NodeCatalog) -> None:
     sample, summary, induction = _fixtures("circe")
     profile = catalog.resolve("circe")

--- a/tests/test_biometrics_grammar_extract.py
+++ b/tests/test_biometrics_grammar_extract.py
@@ -160,6 +160,45 @@ def test_extract_ignores_memory_thermal_disk_signals_with_no_salience(
     assert "memory_pressure" not in state.pressure_hints
 
 
+def test_extract_sets_gpu_pressure_hint_from_dedicated_signal_atom(
+    catalog: NodeCatalog,
+) -> None:
+    # Regression: pressure_hints["gpu"] must come from the dedicated
+    # gpu_pressure_signal atom's real computed salience, not from
+    # capability_surface's hardcoded 0.8 constant.
+    trace_id = "biometrics.node:atlas:2026-05-24T12:00:00Z"
+    events = [
+        _atom_event(
+            trace_id=trace_id,
+            event_id="gev_gpu",
+            role="gpu_pressure_signal",
+            observed_at=FIXED_TS,
+            salience=0.27,
+        ),
+    ]
+    state = extract_node_state_from_events(events, catalog, stale_after_sec=180, now=FIXED_TS)
+    assert state.pressure_hints.get("gpu") == pytest.approx(0.27)
+
+
+def test_extract_capability_surface_no_longer_sources_gpu_pressure_hint(
+    catalog: NodeCatalog,
+) -> None:
+    # capability_surface's salience is a hardcoded constant (0.8), not telemetry --
+    # it must never populate pressure_hints["gpu"] even for a local_llm_heavy node.
+    trace_id = "biometrics.node:atlas:2026-05-24T12:00:00Z"
+    events = [
+        _atom_event(
+            trace_id=trace_id,
+            event_id="gev_cap",
+            role="capability_surface",
+            observed_at=FIXED_TS,
+            salience=0.8,
+        ),
+    ]
+    state = extract_node_state_from_events(events, catalog, stale_after_sec=180, now=FIXED_TS)
+    assert "gpu" not in state.pressure_hints
+
+
 def test_extract_availability_online_when_fresh(catalog: NodeCatalog) -> None:
     trace_id = "biometrics.node:atlas:2026-05-24T12:00:00Z"
     events = [


### PR DESCRIPTION
## Summary

- `node:atlas`'s `gpu_pressure` field channel read a flat `0.8` for ~42,400 consecutive real ticks (24h, confirmed via live Postgres query: zero trailing float precision vs `cpu_pressure`'s 17 digits of real computed noise).
- Root cause: `orion/substrate/biometrics_loop/grammar_extract.py` sourced `pressure_hints["gpu"]` from the `capability_surface` grammar atom's `salience`, an unconditional **hardcoded literal `0.8`** (`services/orion-biometrics/app/grammar_emit.py`'s `capability_surface` atom) -- a static capability descriptor, not a telemetry sample.
- The real computed value already existed as `gpu_util` in `orion/telemetry/biometrics_pipeline.py`'s `pressures` dict but was never wired through.
- Fix mirrors the exact pattern from commit `610599b0f` (2026-07-16, "surface memory/thermal/disk pressure into field lattice"), which fixed the same disease for three sibling channels but explicitly left `gpu` untouched because its failure mode (a plausible-looking nonzero `0.8`) didn't look broken the way a flat `0.0` does.
- Added a dedicated `gpu_pressure_signal` grammar atom (producer) and a matching consumer branch, additive alongside the existing `body_state`/`capability_surface` atoms. `capability_surface` itself is untouched -- still emitted, still used for its own confidence/summary display, just no longer double-duty as the gpu-hint source.

## Outcome moved

`node:atlas`'s (and every other node's) `gpu_pressure` field-lattice channel now carries real computed GPU utilization instead of a hardcoded constant. Live-verified: pre-fix baseline confirmed flat `0.8` across the most recent 10 ticks in `substrate_field_state` as of this session (see Docker/build/smoke checks below for exact query and numbers).

## Current architecture

- Producer: `services/orion-biometrics/app/grammar_emit.py::build_biometrics_node_grammar_events` emits grammar atoms per node tick onto the `orion:grammar:event` trace.
- Consumer: `orion/substrate/biometrics_loop/grammar_extract.py::extract_node_state_from_events` reads atom `salience` values into a `pressure_hints` dict, keyed by hint name (`strain`, `gpu`, `memory_pressure`, etc).
- `services/orion-field-digester/app/ingest/state_deltas.py`'s `node_biometrics` block turns `pressure_hints["gpu"]` into a `gpu_pressure` lattice `Perturbation` (`mode="replace"`) on `node:atlas`/`node:circe` (the two `GPU_NODES`).
- Before this patch, `pressure_hints["gpu"]` came from `capability_surface`'s hardcoded `salience=0.8`, gated on `profile.capabilities.get("local_llm_heavy")`.

## Architecture touched

- `services/orion-biometrics` (producer, grammar atom emission)
- `orion/substrate/biometrics_loop` (consumer, grammar atom -> `pressure_hints` extraction)
- No bus channel, schema registry, or env key changes. No changes to `config/field/orion_field_topology.v1.yaml`, `config/field/biometrics_lattice.yaml`, `services/orion-field-digester/app/ingest/state_deltas.py`, or `orion/field/pressure.py` -- all deliberately out of scope and already correct.

## Files changed

- `services/orion-biometrics/app/grammar_emit.py`: new `gpu_pressure_signal` `GrammarAtomV1` (mirrors `memory_pressure_signal`/`thermal_pressure_signal`/`disk_pressure_signal`), `salience=float(summary.pressures.get("gpu_util", 0.0))`; added `edge_specs` entries (`telemetry_sample -> gpu_pressure_signal -> capability_surface`).
- `orion/substrate/biometrics_loop/grammar_extract.py`: replaced the `capability_surface`/`local_llm_heavy`-gated branch that wrote `pressure_hints["gpu"]` with a new `gpu_pressure_signal` branch, mirroring the memory/thermal/disk siblings exactly.
- `services/orion-biometrics/README.md`: corrected the `pressure_hints` table (`capability_surface (gated on local_llm_heavy)` -> `gpu_pressure_signal`) and prose to document the real fix and the new unconditional (non-gated) emission.
- `services/orion-biometrics/tests/test_biometrics_grammar_emit.py`: two new tests -- real `gpu_util` flows into `gpu_pressure_signal.salience` (not `capability_surface`'s fixed 0.8), and defaults to `0.0` when absent.
- `tests/test_biometrics_grammar_extract.py`: two new tests -- `pressure_hints["gpu"]` is sourced from `gpu_pressure_signal`, and `capability_surface` no longer populates it even when it carries its old hardcoded salience.

## Schema / bus / API changes

- Added: new grammar `semantic_role` string `"gpu_pressure_signal"` (plain `str` field on `GrammarAtomV1`, no enum/registry entry required).
- Removed: none.
- Renamed: none.
- Behavior changed: `pressure_hints["gpu"]` is now populated for **every** node's tick (matching the memory/thermal/disk siblings), not just nodes where `local_llm_heavy` capability is set. Value is `0.0` for nodes with no real GPU samples (verified: `_gpu_pressures()` in `orion/telemetry/biometrics_pipeline.py` returns `0.0` naturally for an empty `gpu.gpus` list, no extra node-kind gating needed -- `state_deltas.py`'s `GPU_NODES` scoping already restricts which nodes actually get the lattice channel).
- Compatibility notes: additive-only in the grammar/atom sense; `capability_surface` atom is unchanged. Downstream `pressure_organ.py` and `state_deltas.py` treat any populated hint key generically (same as the 2026-07-16 precedent), so this is a real repo-wide behavior expansion consistent with that precedent, not a new pattern.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: n/a (no env changes).
- local `.env` synced: n/a (no env changes).
- skipped keys requiring operator action: none.

## Tests run

```text
# venv bootstrapped locally (pytest/pydantic/pydantic_settings/requests not preinstalled in this sandbox)
PYTHONPATH=<worktree>:<worktree>/services/orion-biometrics python -m pytest \
  tests/test_biometrics_grammar_extract.py \
  tests/test_biometrics_pipeline.py \
  tests/test_biometrics_pipeline_ilo_pressures.py \
  tests/test_biometrics_pressure_organ.py \
  tests/test_node_biometrics_reducer.py \
  services/orion-biometrics/tests -q

63 passed, 4 failed (all 4 failures pre-existing and unrelated: circe's
expected_online was flipped true->false in config/biometrics/node_catalog.yaml
on 2026-07-18 but 4 stale tests still assert the old "expected offline"
behavior -- confirmed by running the identical suite against the
pre-patch tree via `git stash`, same failures reproduce verbatim with none
of this patch's code applied).
```

All 4 new tests (2 producer, 2 consumer) pass and would have failed
pre-fix (they assert the atom/hint carries the real computed value, not
the old hardcoded `0.8`).

## Evals run

No dedicated eval harness exists for `services/orion-biometrics` or
`orion/substrate/biometrics_loop` beyond the unit test suites run above.

## Docker/build/smoke checks

Live containers (`orion-athena-biometrics`, `orion-athena-substrate-runtime`,
`orion-athena-field-digester`) are running in this environment. Pre-fix
baseline confirmed directly against Postgres before this patch was deployed:

```text
select generated_at,
       (field_json->'node_vectors'->'node:atlas'->'gpu_pressure')::text as gpu_pressure,
       (field_json->'node_vectors'->'node:atlas'->'cpu_pressure')::text as cpu_pressure
from substrate_field_state order by generated_at desc limit 10;

 generated_at                  | gpu_pressure | cpu_pressure
 2026-07-29 05:19:32.465379+00 | 0.8          | 0.07022119037406602
 2026-07-29 05:19:30.439853+00 | 0.8          | 0.07022119037406602
 ... (flat 0.8 across all 10 rows, cpu_pressure carries real float noise)
```

Could not rebuild/restart the live containers from this isolated worktree:
`scripts/safe_docker_build.sh orion-biometrics config` fails with "couldn't
find env file" -- this worktree has no `services/*/.env` (gitignored,
per-worktree, and not something this session should fabricate/copy from
elsewhere without explicit instruction). No env keys changed by this patch,
so no `.env_example` sync was needed either way. Post-restart live
verification (confirming `gpu_pressure` now carries real float variance the
way `cpu_pressure` does) needs to be done by an operator/session with the
real env files after restart -- see Restart required below for the exact
commands.

## Review findings fixed

- Finding: `services/orion-biometrics/README.md`'s `pressure_hints` table and prose still documented the old `capability_surface (gated on local_llm_heavy)` -> `gpu` sourcing, and its "additive: strain/gpu are unchanged" claim was now false.
  - Fix: Updated the table row to `gpu_pressure_signal`, and rewrote the prose to document the real fix, the bug's live-observed magnitude (42,400 flat ticks), and the new unconditional (non-`local_llm_heavy`-gated) emission behavior.
  - Evidence: `services/orion-biometrics/README.md` lines ~138-166 in the diff.
- Finding: reviewer flagged that removing the `local_llm_heavy` gate is a real behavior expansion (every node now gets a `gpu` pressure hint, not just capability-flagged ones) that wasn't called out anywhere in the diff.
  - Fix: Documented explicitly in this PR's "Schema / bus / API changes" section and in the README rewrite above, rather than left implicit.
  - Evidence: PR body sections above; `services/orion-biometrics/README.md` diff.
- Finding (non-blocking, follow-up not attempted): no test covers the downstream consumer-behavior change itself (a non-`local_llm_heavy` node now producing `node_pressure_detected`/`reinforced` via `pressure_organ.py`, or `state_deltas.py` now writing a `gpu_pressure` Perturbation for such a node).
  - Fix: Not attempted in this patch -- matches how the 2026-07-16 memory/thermal/disk precedent was tested (atom/hint-level only), and the actual gating scope (`GPU_NODES = {"atlas", "circe"}` in `state_deltas.py`) already restricts which nodes can receive a `gpu_pressure` lattice channel regardless of this hint's presence.
  - Evidence: reviewer's finding #3; `services/orion-field-digester/app/ingest/state_deltas.py:8`.
- Reviewer also confirmed: no key-name bug (`gpu_util` matches exactly between producer and pipeline), no dangling atom/edge references, and `capability_surface`'s own `salience=0.8` remains genuinely used elsewhere (its own confidence/summary display) -- not dead weight.

## Restart required

```bash
# From a checkout/worktree with real services/orion-biometrics/.env and
# services/orion-substrate-runtime/.env present:
scripts/safe_docker_build.sh orion-biometrics up -d --build
scripts/safe_docker_build.sh orion-substrate-runtime up -d --build

# Verify post-restart (real float variance expected instead of flat 0.8):
psql -h localhost -p 55432 -U postgres -d conjourney -c "
  select generated_at,
         (field_json->'node_vectors'->'node:atlas'->'gpu_pressure')::text as gpu_pressure,
         (field_json->'node_vectors'->'node:atlas'->'cpu_pressure')::text as cpu_pressure
  from substrate_field_state order by generated_at desc limit 10;"
```

## Risks / concerns

- Severity: low
- Concern: `pressure_hints["gpu"]` is now populated unconditionally (every node, not just `local_llm_heavy` ones). Downstream `pressure_organ.py` Rule C/D and `state_deltas.py`'s `if "gpu" in hints:` will now fire real GPU-load-driven pressure events/perturbations for nodes that never produced them before.
- Mitigation: This is the same unconditional pattern already shipped for memory/thermal/disk on 2026-07-16 with no reported issues, and `state_deltas.py`'s `GPU_NODES = {"atlas", "circe"}` scoping already restricts which nodes can actually receive a `gpu_pressure` lattice channel. Flagged explicitly here rather than left implicit, per review finding.
- Severity: low
- Concern: `orion/mood_arc/`'s windowed sequence autoencoder trains on `field_channel_corpus.v1`'s ~29 raw channels including `gpu_pressure`, very plausibly on a near-constant `0.8` given how long this bug has existed. Its learned weight for this input dimension may be miscalibrated once real variance starts flowing.
  - Follow-up (not attempted here): retrain and verify once enough real post-fix `gpu_pressure` history has accumulated.
- Severity: low
- Concern: `config/attention/field_attention_policy.v1.yaml`'s `node_channel_weights: gpu_pressure: 0.60` was very plausibly chosen trusting the channel's glossary meaning without knowing the underlying value was fake.
  - Follow-up (not attempted here): revisit the weight once real signal has accumulated post-fix -- do not guess at a new weight without real post-fix data.
