### PR TITLE
fix(aitown): repoint atlas storage to /mnt/telemetry, retire stale athena backup target

### DIFF
--- a/scripts/backup/README.md
+++ b/scripts/backup/README.md
@@ -274,3 +274,11 @@ PYTHONPATH=. ./venv/bin/python -m pytest tests/test_orion_backup_databases.py -q
   but isn't wired into this tool.
 - **bus-mirror**: not a backup target -- it's a disabled debug tap, not a
   database (see `services/orion-bus-mirror/README.md`).
+- **convex (orion-ai-town)**: removed 2026-07-29 when ai-town moved from
+  athena to atlas -- this tool's targets all assume the container lives on
+  the same host the nightly timer runs on (athena), which no longer holds
+  for ai-town. Needs a dedicated atlas-side backup mechanism (this tool
+  running there too, or a standalone script) as a follow-up; in the
+  meantime `services/orion-ai-town/scripts/compact_convex_data.sh` still
+  captures a pre-compaction `db.sqlite3` snapshot on every compaction run,
+  which is partial coverage, not a substitute.

--- a/scripts/backup/orion_backup_databases.py
+++ b/scripts/backup/orion_backup_databases.py
@@ -234,15 +234,14 @@ def default_targets() -> list[Target]:
                 log=log,
             ),
         ),
-        Target(
-            "convex",
-            lambda dest, log: capture_stopped_container_tree(
-                dest,
-                container="orion-ai-town-backend-1",
-                host_path=Path("/mnt/docker/volumes/orion-ai-town_convex-data/_data"),
-                log=log,
-            ),
-        ),
+        # "convex" (orion-ai-town-backend-1) removed 2026-07-29: ai-town moved
+        # to atlas (docs/superpowers/specs/2026-07-29-aitown-atlas-migration-runbook.md).
+        # This tool assumes every target's container lives on the same host
+        # it runs on (systemd timer on athena) -- with the backend gone from
+        # athena, the old hardcoded container name/volume path would just
+        # fail every night rather than silently backing up stale data, but
+        # either way convex backup coverage needs a follow-up on atlas, not
+        # a same-host fix here. See "Known gaps" in scripts/backup/README.md.
     ]
 
 

--- a/services/orion-ai-town/README.md
+++ b/services/orion-ai-town/README.md
@@ -4,6 +4,14 @@ Mesh deployment wrapper for [a16z-infra/ai-town](https://github.com/a16z-infra/a
 
 **Upstream pin:** `AITOWN_UPSTREAM_REF=7b242334bfbfef02f7718bded120d431e8f307df` — the a16z SHA the tracked `patches/` were generated against. The patches carry exact context and will not apply to a moved `main`; re-pin (and regenerate patches) intentionally when bumping upstream.
 
+**Live deployment:** runs on `atlas` (`100.121.214.30`, tailscale) as of 2026-07-29 — relocated from `athena` due to host-wide CPU contention there (`orion-heartbeat`'s tensor-network substrate). See `docs/superpowers/specs/2026-07-29-aitown-atlas-migration-runbook.md` for the full migration path. The Convex data directory is a host bind mount under `${TELEMETRY_ROOT:-/mnt/telemetry}/orion-atlas/ai-town/convex-data` (not a Docker-managed named volume) — matches this repo's other `/mnt/telemetry`-backed services. Create the directory before first `docker compose up` (the `convex-backend` container runs as root, so root will otherwise auto-create it on `up`, but pre-creating it under the node's own user avoids depending on that):
+
+```bash
+mkdir -p ${TELEMETRY_ROOT:-/mnt/telemetry}/orion-atlas/ai-town/convex-data
+```
+
+The daily compaction cron (`scripts/compact_convex_data.sh`, see "Maintenance" below) must run on whichever host actually holds these containers — move the crontab entry along with the deployment, don't leave it running against a stopped remote host.
+
 ## Services
 
 | Service | Port (default) | Role |

--- a/services/orion-ai-town/docker-compose.yml
+++ b/services/orion-ai-town/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "${SITE_PROXY_PORT:-3211}:3211"
       - "${OLLAMA_PORT:-11434}:11434"
     volumes:
-      - convex-data:/convex/data
+      - ${TELEMETRY_ROOT:-/mnt/telemetry}/orion-atlas/ai-town/convex-data:/convex/data
     environment:
       - INSTANCE_NAME=${INSTANCE_NAME:-orion-aitown}
       - INSTANCE_SECRET=${INSTANCE_SECRET:-}
@@ -52,9 +52,6 @@ services:
         condition: service_healthy
     networks:
       - ai-town-network
-
-volumes:
-  convex-data:
 
 networks:
   ai-town-network:

--- a/services/orion-ai-town/scripts/compact_convex_data.sh
+++ b/services/orion-ai-town/scripts/compact_convex_data.sh
@@ -77,15 +77,18 @@ if [[ "${CHECK_ONLY}" == "1" ]]; then
   exit 0
 fi
 
-# Resolve the actual data volume from the running container's mounts rather
+# Resolve the actual data mount from the running container's mounts rather
 # than assuming Compose's default "<project>_<volume>" naming -- a
 # COMPOSE_PROJECT_NAME override would otherwise make the backup/rename steps
 # below silently target a nonexistent (docker-auto-created, empty) volume
-# while the real data volume goes untouched.
+# while the real data volume goes untouched. Falls back to the mount's
+# .Source (host path) when it's a bind mount rather than a named volume --
+# `docker run -v <arg>:/data` accepts either a volume name or a host path
+# interchangeably, so the rest of the script is unaffected either way.
 VOLUME_NAME="$(docker inspect "$("${COMPOSE[@]}" ps -q backend)" \
-  --format '{{range .Mounts}}{{if eq .Destination "/convex/data"}}{{.Name}}{{end}}{{end}}')"
+  --format '{{range .Mounts}}{{if eq .Destination "/convex/data"}}{{if .Name}}{{.Name}}{{else}}{{.Source}}{{end}}{{end}}{{end}}')"
 if [[ -z "${VOLUME_NAME}" ]]; then
-  echo "could not resolve the /convex/data volume from the running backend container -- aborting" >&2
+  echo "could not resolve the /convex/data mount from the running backend container -- aborting" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Executes Phases 1-3 of `docs/superpowers/specs/2026-07-29-aitown-atlas-migration-runbook.md` (PR #1465): `services/orion-ai-town` is now live and healthy on `atlas`, with athena's real world data (204,628 documents, Orion's player `p:24` intact) migrated in via Convex export/import.
- Convex data storage moved from a Docker-managed named volume to a host bind mount under `/mnt/telemetry/orion-atlas/ai-town/convex-data`, matching this repo's other `/mnt/telemetry`-backed services.
- Fixed `compact_convex_data.sh`'s volume-resolution logic, which would have silently broken against a bind mount (`.Name` is empty for bind mounts; falls back to `.Source` now).
- Removed the nightly `orion_backup_databases.py` "convex" target, which hardcoded `orion-ai-town-backend-1`'s old athena volume path/container name and runs on an **already-installed, currently-active** systemd timer on athena (`orion-backup-databases.timer`, next run in ~20h at time of writing) — would have failed every night once athena's container is gone.
- `orion-hub`'s local `.env` (on atlas) now has `HUB_AITOWN_ENABLED=true` / `HUB_AITOWN_UI_URL=http://127.0.0.1:5173` (was silently falling back to `false` — the key was entirely absent from this node's `.env` despite being documented in `.env_example`). Confirmed hub's `docker-compose.yml` already defaults to `network_mode: host` (not `app-net`), which is required now that ai-town is co-located on the same node.

## Outcome moved

`orion-ai-town` fully operational on atlas: `backend`/`dashboard`/`frontend` containers healthy, real migrated world data verified (not empty/fresh), LLM gateway wired to athena's `orion-llm-gateway` over tailscale (confirmed reachable from inside the backend container), storage on `/mnt/telemetry` instead of a Docker-managed volume.

## Current architecture

Before this change, `orion-ai-town` ran only on athena, using a Docker-managed named volume (`orion-ai-town_convex-data`, physically at `/mnt/docker/volumes/.../_data`), and was the sole "convex" target in athena's nightly `orion_backup_databases.py` run.

## Architecture touched

- `services/orion-ai-town/docker-compose.yml`
- `services/orion-ai-town/scripts/compact_convex_data.sh`
- `services/orion-ai-town/README.md`
- `scripts/backup/orion_backup_databases.py`
- `scripts/backup/README.md`

## Files changed

- `services/orion-ai-town/docker-compose.yml`: bind-mount `/mnt/telemetry/orion-atlas/ai-town/convex-data` instead of the named `convex-data` volume; removed the now-unused top-level `volumes:` block.
- `services/orion-ai-town/scripts/compact_convex_data.sh`: mount resolution falls back to `.Source` (host path) when `.Name` (volume name) is empty.
- `services/orion-ai-town/README.md`: notes the live deployment now runs on atlas, the bind-mount storage convention, a `mkdir -p` bootstrap step, and that the compaction cron must move with the deployment.
- `scripts/backup/orion_backup_databases.py`: removed the stale "convex" target (see Summary).
- `scripts/backup/README.md`: documented the removed convex backup target as a known gap needing an atlas-side follow-up.

## Schema / bus / API changes

None.

## Env/config changes

- Added keys: none new to `.env_example` (`TELEMETRY_ROOT` is an existing root-level global var, already defined).
- `.env_example` updated: no changes needed.
- local `.env` synced: `services/orion-hub/.env` (both the shared checkout and this worktree) got `HUB_AITOWN_ENABLED=true` / `HUB_AITOWN_UI_URL=http://127.0.0.1:5173` added manually (targeted addition, not a full `--all-keys` sync -- this node's hub `.env` is ~90 keys behind `.env_example` in general, out of scope for this PR). `services/orion-ai-town/.env` created locally on atlas (gitignored, not part of this diff) with a **fresh** `INSTANCE_SECRET` (intentionally not athena's -- distinct bootstrap + data import, not a volume clone).
- Skipped keys requiring operator action: none.

## Tests run

```text
/tmp/aitown-test-venv/bin/python -m pytest services/orion-ai-town/tests -q
29 passed

PYTHONPATH=. /tmp/aitown-test-venv/bin/python -m pytest tests/test_orion_backup_databases.py -q
17 passed
```
(No local venv/pytest existed on atlas prior to this session; used a throwaway venv for verification.)

## Evals run

No eval harness exists for this service (infra/ops tooling). Live verification against the real migrated deployment substitutes (see below).

## Docker/build/smoke checks

```text
bash scripts/safe_docker_build.sh orion-ai-town config      # valid, bind mount resolves correctly
bash scripts/safe_docker_build.sh orion-ai-town up -d --build
  -> backend, dashboard, frontend all healthy/running

curl -fsS http://127.0.0.1:3210/version                     # responds
curl -fsS http://127.0.0.1:5173/ai-town                      # 200

du -sh /mnt/telemetry/orion-atlas/ai-town/convex-data        # 341M, confirmed on the bind mount

# Live data migration (Convex CLI via throwaway node:20 containers --
# host has no Node.js/npm installed, and convex 1.41.0's CLI needs Node 20+
# regardless -- Node 18, which the frontend Docker build itself uses, hits
# `SyntaxError: Invalid flags supplied to RegExp constructor 'v'`):
npx convex export --path .../export.zip                     # from athena's live backend, read-only
npx convex import --replace-all -y .../export.zip            # into atlas's fresh backend
  -> 204,628 documents added, every table non-zero
npx convex data playerDescriptions / testing:debugEngineState
  -> Orion's player p:24 present and actively receiving pending engine inputs
  (moveTo/finishDoSomething), not an empty/fresh world

npx convex env set LLM_API_URL http://100.92.216.81:8210 (athena's orion-llm-gateway)
docker exec orion-ai-town-backend-1 curl http://100.92.216.81:8210/health
  -> {"status":"ok","service":"llm-gateway", ...,"routes":["agent","chat","metacog","quick"]}
```

## Review findings fixed

- Finding: removing the named `convex-data` volume left `orion_backup_databases.py`'s "convex" target pointing at a now-dead path/container, on an already-active nightly systemd timer on athena.
  - Fix: removed the target from `default_targets()`, documented as a known gap requiring an atlas-side follow-up.
  - Evidence: `scripts/backup/orion_backup_databases.py`, `scripts/backup/README.md`.
- Finding: README referenced the migration runbook doc before confirming it existed on this branch.
  - Fix: rebased onto `origin/main` after PR #1465 (the runbook doc) merged mid-session; reference now resolves.
  - Evidence: `git log -1 --format=%H` post-rebase; `git show origin/main:docs/.../2026-07-29-aitown-atlas-migration-runbook.md` succeeds.
- Finding: no bootstrap note for the new bind-mount directory, inconsistent with other `/mnt/telemetry`-backed services' READMEs.
  - Fix: added `mkdir -p` note plus a compaction-cron relocation reminder.
  - Evidence: `services/orion-ai-town/README.md`.
- Finding (self-caught during review, not by the reviewer): compact_convex_data.sh's Go-template mount resolution would return empty for a bind mount, aborting the script.
  - Fix: falls back to `.Source` when `.Name` is empty.
  - Evidence: `services/orion-ai-town/scripts/compact_convex_data.sh`.

## Restart required

No restart required for this PR's tracked-file changes alone -- the live atlas deployment was already brought up and verified during this session using these exact files.

**Operator follow-up before/as part of retiring athena's copy** (not part of this diff, since these touch athena-side config/cron this session didn't have standing to change unilaterally):

1. Move the compaction cron off athena's crontab (`0 13 * * * cd .../orion-ai-town && bash scripts/compact_convex_data.sh ...`) onto atlas, pointed at wherever the canonical atlas checkout ends up living once this PR is pulled there.
2. Repoint `~/.fcc/.env` (`AITOWN_CONVEX_URL=http://100.121.214.30:3210`, `AITOWN_ADMIN_KEY=<atlas admin key>`, `AITOWN_WORLD_ID=m174spk0rd4namch9qvt53fs4x8a4f62`) so `orion-embodiment` keeps perceiving/acting as `p:24` in the migrated world.
3. Correct `services/orion-harness-governor/.env`'s `HARNESS_AITOWN_CONVEX_URL` (not live today, but should point at atlas going forward).
4. If athena's own `orion-hub` currently points `HUB_AITOWN_UI_URL` at its own `127.0.0.1:5173`, repoint it to `http://100.121.214.30:5173` before/when athena's containers stop.
5. `docker compose stop` (not `down -v`) athena's `orion-ai-town` containers -- keep the volume as a rollback path per the runbook, don't delete yet.

## Risks / concerns

- Severity: low -- Convex nightly backup coverage for ai-town is currently a documented gap (no automated backup on either host until an atlas-side mechanism is built). `compact_convex_data.sh`'s own pre-compaction snapshot is partial mitigation.
- Severity: low -- this node (atlas) had no Node.js/npm or Python venv/pytest installed; all CLI-dependent steps in this session used throwaway containers/venvs rather than host-installed tooling, so nothing was installed system-wide, but a future maintainer running `compact_convex_data.sh` by hand on atlas will hit the same Node-18-vs-20 issue this session did (documented inline in the PR description above, not yet reflected in the script itself since it currently has no direct `npx` invocation of its own beyond what already works via the Dockerfile's pinned Node 18 for the frontend *build* specifically, which is unaffected).

## PR link

(populated by gh pr create output)