### PR TITLE
chore(mesh): exclude orion-ai-town from athena's bring-up-all

### DIFF
--- a/mesh-utilities/common/exclude_services.txt
+++ b/mesh-utilities/common/exclude_services.txt
@@ -21,3 +21,9 @@ orion-bus-tap
 # anyone running from a fresh worktree/clone. Committed for real 2026-07-24.
 orion-rdf-writer
 orion-rdf-store
+# orion-ai-town relocated athena -> atlas 2026-07-29 (host-wide CPU contention
+# from orion-heartbeat's tensor-network substrate; see
+# docs/superpowers/specs/2026-07-29-aitown-atlas-migration-runbook.md and
+# PR #1467). Excluded so athena's bring-up-all doesn't try to start a stale
+# local copy pointing at the old, now-stopped athena volume/containers.
+orion-ai-town


### PR DESCRIPTION
## Summary
`orion-ai-town` moved from athena to atlas 2026-07-29 (PR #1467, runbook in #1465) due to host-wide CPU contention on athena. Its containers there are stopped (kept as rollback, not deleted). Added it to `mesh-utilities/common/exclude_services.txt` so athena's `up_all_services.sh`/`up_all_services_batched.sh` don't try to auto-start the stale local copy.

## Tests run
No test coverage exists for this plain config file. Verified `up_all_services.sh` parses the updated list correctly (`bash -n` syntax check + manual list dump).

## Restart required
None — this only affects future bring-up-all runs, doesn't touch anything currently running.