### PR TITLE
fix(cortex-exec): inject identity context for non-brain-mode verbs too

### DIFF
--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -1014,6 +1014,23 @@ class PlanRunner:
                 )
             else:
                 await prepare_brain_reply_context(ctx)
+        elif not _is_runtime_skill_verb(plan.verb_name) and bool(
+            str((plan.metadata or {}).get("personality_file") or "").strip()
+        ):
+            # The brain-mode branch above is the only place identity gets injected today, so any
+            # verb whose plan declares personality_file (e.g. chat_quick.yaml) silently renders
+            # empty orion_identity_summary/juniper_relationship_summary/response_policy_summary
+            # whenever it's dispatched with mode != "brain" -- e.g. AI Town's embodiment worker
+            # dispatches chat_quick with mode="quick" for every one of Orion's speech turns.
+            # _inject_identity_context (called via prepare_chat_quick_reply_context) is idempotent
+            # and GraphDB-free, so it's safe to call here regardless of mode.
+            logger.info(
+                "router_identity_inject_non_brain_mode corr=%s verb=%s mode=%s",
+                correlation_id,
+                plan.verb_name,
+                mode,
+            )
+            prepare_chat_quick_reply_context(ctx)
         existing_scope = str(ctx.get("_run_scope_corr_id") or "")
         if existing_scope and existing_scope != correlation_id:
             logger.warning(

--- a/services/orion-cortex-exec/tests/test_router_identity_injection_non_brain_mode.py
+++ b/services/orion-cortex-exec/tests/test_router_identity_injection_non_brain_mode.py
@@ -1,0 +1,129 @@
+"""Regression: verbs that declare personality_file must get identity injected even when
+dispatched with mode != "brain" (e.g. AI Town's embodiment worker dispatches chat_quick with
+mode="quick" via EMBODIMENT_SPEECH_LANE=quick, per services/orion-embodiment/app/worker.py).
+
+Before this fix, app/router.py only called prepare_chat_quick_reply_context /
+prepare_brain_reply_context inside an `if mode == "brain"` gate, so chat_quick.yaml's declared
+personality_file (orion/cognition/personality/orion_identity.yaml) never got loaded for any
+non-brain-mode dispatch, and orion_identity_summary / juniper_relationship_summary /
+response_policy_summary rendered empty in chat_quick.j2 for every AI Town speech turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from app import router
+from app.router import PlanRunner
+from orion.core.bus.bus_schemas import ServiceRef
+from orion.schemas.cortex.schemas import (
+    ExecutionPlan,
+    ExecutionStep,
+    PlanExecutionArgs,
+    PlanExecutionRequest,
+    StepExecutionResult,
+)
+
+_IDENTITY_KEYS = ("orion_identity_summary", "juniper_relationship_summary", "response_policy_summary")
+
+
+def _chat_quick_plan(*, mode: str) -> PlanExecutionRequest:
+    plan = ExecutionPlan(
+        verb_name="chat_quick",
+        label="chat_quick",
+        description="",
+        category="x",
+        priority="normal",
+        interruptible=True,
+        can_interrupt_others=False,
+        timeout_ms=1000,
+        max_recursion_depth=0,
+        metadata={
+            "recall_profile": "chat.general.v1",
+            "personality_file": "orion/cognition/personality/orion_identity.yaml",
+        },
+        steps=[
+            ExecutionStep(
+                verb_name="chat_quick",
+                step_name="llm_chat_quick",
+                description="",
+                order=1,
+                services=["LLMGatewayService"],
+                requires_memory=True,
+            )
+        ],
+    )
+    return PlanExecutionRequest(
+        plan=plan,
+        args=PlanExecutionArgs(
+            request_id=f"rq-{mode}",
+            extra={"mode": mode, "recall": {"enabled": False}},
+        ),
+        context={"mode": mode, "raw_user_text": "hi"},
+    )
+
+
+def _fake_llm_step() -> StepExecutionResult:
+    return StepExecutionResult(
+        status="success",
+        verb_name="chat_quick",
+        step_name="llm_chat_quick",
+        order=1,
+        result={"LLMGatewayService": {"content": "ok"}},
+        latency_ms=1,
+        node="n",
+        logs=[],
+        error=None,
+    )
+
+
+def _run(*, mode: str, monkeypatch, prepare_brain_reply_context_mock: AsyncMock | None = None) -> dict:
+    monkeypatch.setattr(router, "call_step_services", AsyncMock(return_value=_fake_llm_step()))
+    if prepare_brain_reply_context_mock is not None:
+        monkeypatch.setattr(router, "prepare_brain_reply_context", prepare_brain_reply_context_mock)
+
+    req = _chat_quick_plan(mode=mode)
+    plan_metadata = req.plan.metadata if isinstance(req.plan.metadata, dict) else {}
+    # Mirror the real ctx-building callers (app/main.py's exec handler and
+    # app/verb_adapters.py's LegacyPlanVerb), both of which copy plan.metadata into
+    # ctx["plan_metadata"]/ctx["personality_file"] before calling router.run_plan --
+    # _inject_identity_context reads personality_file off ctx, not off plan.metadata directly.
+    ctx: dict = {"mode": mode, "raw_user_text": "hi", "plan_metadata": plan_metadata}
+    if "personality_file" in plan_metadata:
+        ctx["personality_file"] = plan_metadata.get("personality_file")
+
+    runner = PlanRunner()
+    result = asyncio.run(
+        runner.run_plan(
+            bus=object(),
+            source=ServiceRef(name="x", version="0", node="n"),
+            req=req,
+            correlation_id=f"corr-{mode}",
+            ctx=ctx,
+        )
+    )
+    assert result.status == "success"
+    return ctx
+
+
+def test_chat_quick_quick_mode_gets_identity_injected(monkeypatch) -> None:
+    """AI Town's mode="quick" chat_quick dispatch must now receive real identity context."""
+    ctx = _run(mode="quick", monkeypatch=monkeypatch)
+
+    for key in _IDENTITY_KEYS:
+        assert ctx.get(key), f"{key} should be populated for mode=quick chat_quick"
+    assert ctx.get("identity_kernel_source") == "configured_yaml"
+
+
+def test_chat_quick_brain_mode_unchanged(monkeypatch) -> None:
+    """Existing mode="brain" chat_quick behavior (prepare_chat_quick_reply_context) is untouched."""
+    prepare_brain_reply_context_mock = AsyncMock(return_value=None)
+    ctx = _run(mode="brain", monkeypatch=monkeypatch, prepare_brain_reply_context_mock=prepare_brain_reply_context_mock)
+
+    # brain-mode chat_quick (without chat_quick_full_stance) still goes through
+    # prepare_chat_quick_reply_context directly, never prepare_brain_reply_context.
+    prepare_brain_reply_context_mock.assert_not_called()
+    for key in _IDENTITY_KEYS:
+        assert ctx.get(key), f"{key} should still be populated for mode=brain chat_quick"
+    assert ctx.get("identity_kernel_source") == "configured_yaml"


### PR DESCRIPTION
## Summary
- `chat_quick.yaml` declares `personality_file: orion/cognition/personality/orion_identity.yaml` and its prompt expects `orion_identity_summary`/`juniper_relationship_summary`/`response_policy_summary`, but `router.py` only injected these when `mode == "brain"`. AI Town's embodiment worker dispatches `chat_quick` with `mode="quick"`, so every one of Orion's AI Town speech turns rendered those variables empty — a real, confirmed contributor to Orion's town dialogue feeling transactional/ungrounded (design doc: #1460).
- Added a narrow `elif`: any verb whose plan declares a non-empty `personality_file` gets identity injected regardless of `mode`. Existing brain-mode behavior (`chat_quick`/`chat_kids_story`, including `chat_quick_full_stance`) is untouched.

## Outcome moved
AI Town's `chat_quick` calls will now receive real identity grounding instead of empty template variables.

## Current architecture
`app/router.py` gated `_inject_identity_context` (via `prepare_chat_quick_reply_context`/`prepare_brain_reply_context`) behind `mode == "brain"` only. `ctx["personality_file"]`/`ctx["plan_metadata"]` are populated unconditionally in `app/main.py:522-538` regardless of mode, so the downstream resolution was already mode-agnostic — only the *trigger* to call it was mode-gated.

## Architecture touched
`services/orion-cortex-exec/app/router.py` only.

## Files changed
- `services/orion-cortex-exec/app/router.py`: added the non-brain-mode `elif` branch.
- `services/orion-cortex-exec/tests/test_router_identity_injection_non_brain_mode.py`: new — regression coverage for both `mode="quick"` (the bug) and `mode="brain"` (unchanged behavior).

## Schema / bus / API changes
None.

## Env/config changes
None.

## Tests run
```
services/orion-cortex-exec: pytest tests/test_router_identity_injection_non_brain_mode.py -v
2 passed

pytest tests/ -q --continue-on-collection-errors
514 passed, 93 failed, 12 errors (same 12 pre-existing collection errors as
unmodified main: "Verb already registered: legacy.plan" -- confirmed by
running the identical command against main, which shows 91 failed/514
passed/12 errors -- same errors, 2 fewer failures)
```

Diffed the two failure sets directly. This branch introduces 3 new failures beyond main's 91 (`test_chat_stance_brief.py::test_build_chat_stance_inputs_maps_social_reflective_and_dream`, `test_harness_finalize_max_tokens.py`'s two tests) and loses 1 (`test_attention_frame.py::test_high_value_open_loop_selects_single_ask`, present on main, absent here — likely the same class of flakiness in the other direction).

Root-caused, not just noticed: all 3 pass individually and pass paired with only the new test file. Replacing the new test's bodies with bare `pass` (keeping only its imports) reproduces the exact same 3 failures — proving it's a pure *import-order* side effect of `app.router`/`PlanRunner` occupying a new collection-order slot, not anything the test's logic executes. 11 *other* existing test files already import the same modules, so this isn't a new import path, just a new position for it. `tests/conftest.py` has zero registry-reset/autouse fixtures — this is a genuine, pre-existing test-suite isolation gap (same disease as the 12 already-broken collection errors), not a defect in this fix's logic.

## Evals run
No eval harness exists for this service's router logic specifically.

## Docker/build/smoke checks
Not performed live against the running `orion-cortex-exec` container this session — the fix was verified via the test suite only. `orion-cortex-exec`'s containers were left untouched/running throughout (confirmed via `docker ps` before starting this work).

## Review findings fixed
Dispatched a review subagent. No material findings — confirmed: if/elif mutual exclusivity is correct (including `_is_runtime_skill_verb` interaction), the personality_file truthiness check correctly handles `None`/missing/empty-string, logging matches surrounding style, and the new test's manual `ctx` construction is byte-for-byte the same pattern as both real callers (`app/main.py`, `app/verb_adapters.py`). Reviewer independently confirmed the import-order-pollution root cause via `grep` (11 other files already import the same modules) and concurred with shipping as DONE_WITH_CONCERNS.

## Restart required
```bash
bash scripts/safe_docker_build.sh orion-cortex-exec up -d --build
```
Not run this session (containers left untouched); needed for the live fix to take effect.

## Risks / concerns
- Severity: low
- Concern: full-suite test run shows 3 failures beyond main's pre-existing 91, but root-caused to a pre-existing test-isolation gap (no registry-reset fixture exists at all in `tests/conftest.py`) that any new `app.router`-importing test file would expose, not a defect in this fix's actual logic. Fixing the suite's global-state isolation is out of scope for this bugfix and deserves its own dedicated pass if it becomes a bigger nuisance.
- Mitigation: the fix's own dedicated tests pass reliably in every isolation configuration tried; the underlying logic was manually traced end-to-end and confirmed correct by an independent reviewer.

## PR link
(populated by gh pr create output)