### PR TITLE
fix(aitown): throttle NPC conversation cadence to shed load on orion-llm-gateway

### DIFF
--- a/services/orion-ai-town/README.md
+++ b/services/orion-ai-town/README.md
@@ -262,6 +262,15 @@ Fixes NPC-human chats where agents talk over the human, narrate scene prose inst
 
 Orion's external embodiment worker already walks on `walkingOver` via `approach_player` intents in `services/orion-embodiment/app/worker.py`.
 
+### NPC cooldown tuning (`patches/orion-npc-cooldown-tuning.patch`)
+
+Load-shedding, not a gameplay change. Every NPC conversation message is an `agentGenerateMessage` call routed through `orion-llm-gateway`; when that gateway's host is under load, throttling how often those calls happen is the direct lever. Raised from `convex/constants.ts` upstream defaults (2026-07-29):
+
+- `CONVERSATION_COOLDOWN`: `15000` → `45000` (agents wait 3x longer after ending a conversation before starting another)
+- `MESSAGE_COOLDOWN`: `2000` → `8000` (4x longer between messages within an active conversation — the main per-conversation LLM-call-rate lever)
+
+Revert both to their upstream defaults if the gateway's host load profile changes and the throttling is no longer needed.
+
 ## MCP integration
 
 Gameplay MCP lives in `mcp/orion_aitown_mcp/`. Hub fcc-claude includes it when `HUB_AITOWN_ENABLED=true` and MCP is enabled.

--- a/services/orion-ai-town/patches/orion-npc-cooldown-tuning.patch
+++ b/services/orion-ai-town/patches/orion-npc-cooldown-tuning.patch
@@ -1,0 +1,35 @@
+diff --git a/convex/constants.ts b/convex/constants.ts
+index 98c8d79..067b0ec 100644
+--- a/convex/constants.ts
++++ b/convex/constants.ts
+@@ -22,8 +22,14 @@ export const COLLISION_THRESHOLD = 0.75;
+ // How many human players can be in a world at once.
+ export const MAX_HUMAN_PLAYERS = 8;
+ 
+-// Don't talk to anyone for 15s after having a conversation.
+-export const CONVERSATION_COOLDOWN = 15000;
++// Don't talk to anyone for 45s after having a conversation. Raised from the
++// upstream default of 15s (2026-07-29, Orion mesh) specifically to reduce how
++// often new conversations start townwide -- each new conversation eventually
++// drives agentGenerateMessage (LLM) calls through orion-llm-gateway, and that
++// gateway's host was found under real, variable load. This is a load-shedding
++// knob, not a gameplay-feel change; revert to 15000 if that host's load
++// profile changes.
++export const CONVERSATION_COOLDOWN = 45000;
+ 
+ // Don't do another activity for 10s after doing one.
+ export const ACTIVITY_COOLDOWN = 10_000;
+@@ -58,8 +64,11 @@ export const INPUT_DELAY = 1000;
+ // This is over-fetched by 10x so we can prioritize memories by more than relevance.
+ export const NUM_MEMORIES_TO_SEARCH = 3;
+ 
+-// Wait for at least two seconds before sending another message.
+-export const MESSAGE_COOLDOWN = 2000;
++// Wait for at least 8s before sending another message (raised from 2s,
++// 2026-07-29, Orion mesh). Each message is an agentGenerateMessage LLM call
++// through orion-llm-gateway; this is the main per-conversation load lever --
++// see the CONVERSATION_COOLDOWN comment above for the same rationale.
++export const MESSAGE_COOLDOWN = 8000;
+ 
+ // Don't run a turn of the agent more than once a second.
+ export const AGENT_WAKEUP_THRESHOLD = 1000;

--- a/services/orion-ai-town/scripts/apply_upstream_patches.sh
+++ b/services/orion-ai-town/scripts/apply_upstream_patches.sh
@@ -10,6 +10,7 @@ PATCHES=(
   "orion-engine-recovery.patch"
   "orion-conversation-proximity.patch"
   "orion-town-chat-turns.patch"
+  "orion-npc-cooldown-tuning.patch"
 )
 
 if [[ ! -d "${UPSTREAM}/.git" ]]; then

--- a/services/orion-ai-town/tests/test_npc_cooldown_tuning_patch.py
+++ b/services/orion-ai-town/tests/test_npc_cooldown_tuning_patch.py
@@ -1,0 +1,51 @@
+"""Gate tests for the NPC cooldown tuning patch (load-shedding on orion-llm-gateway)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_PATCH = _SERVICE / "patches" / "orion-npc-cooldown-tuning.patch"
+_APPLY = _SERVICE / "scripts" / "apply_upstream_patches.sh"
+
+
+def test_cooldown_patch_registered_in_apply_script():
+    text = _APPLY.read_text(encoding="utf-8")
+    assert "orion-npc-cooldown-tuning.patch" in text
+
+
+def test_cooldown_patch_registered_after_patches_that_also_touch_constants():
+    text = _APPLY.read_text(encoding="utf-8")
+    # This patch's diff hunks are generated against constants.ts *after* the
+    # other patches that also touch it -- it must stay last in the array or
+    # it will fail to apply / apply against the wrong base.
+    order = [
+        line.strip().strip('",')
+        for line in text.splitlines()
+        if line.strip().startswith('"orion-')
+    ]
+    assert order[-1] == "orion-npc-cooldown-tuning.patch"
+    for other in (
+        "orion-town-chat-turns.patch",
+        "orion-human-juniper.patch",
+        "orion-hub-embed.patch",
+    ):
+        assert order.index(other) < order.index("orion-npc-cooldown-tuning.patch")
+
+
+def test_cooldown_patch_raises_conversation_cooldown():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "-export const CONVERSATION_COOLDOWN = 15000;" in patch
+    assert "+export const CONVERSATION_COOLDOWN = 45000;" in patch
+
+
+def test_cooldown_patch_raises_message_cooldown():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "-export const MESSAGE_COOLDOWN = 2000;" in patch
+    assert "+export const MESSAGE_COOLDOWN = 8000;" in patch
+
+
+def test_cooldown_patch_only_touches_constants_file():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert patch.count("diff --git") == 1
+    assert "convex/constants.ts" in patch


### PR DESCRIPTION
## Summary

- Following up on PR #1467 (ai-town migration to atlas): Convex/engine latency on atlas is healthy, but NPC dialogue still feels slow because `agentGenerateMessage` calls route through `orion-llm-gateway`, still hosted on athena, which was found under real, variable load (load average 36-42 during this session, one test completion spiking to 4.35s wall-clock vs ~1.2s of actual model compute).
- Added a new patch, `orion-npc-cooldown-tuning.patch`, raising two upstream `ai-town` constants in `convex/constants.ts`:
  - `CONVERSATION_COOLDOWN`: `15000` → `45000` ms
  - `MESSAGE_COOLDOWN`: `2000` → `8000` ms
- This is a load-shedding tuning change, not a gameplay redesign — throttles how often NPC conversations start and how fast messages fire within one, directly reducing the rate of LLM calls against the contended gateway.
- Deployed live to the running atlas backend during this session (`npx convex dev --once`); confirmed the world stayed `"running"` after redeploy.

## Outcome moved

Reduces the rate of `agentGenerateMessage` LLM calls per unit time townwide, without changing conversation logic/behavior otherwise. Root-caused via live investigation: atlas host and disk are not bottlenecks (load avg ~1.75/96 cores, `/mnt/telemetry` at ~5% util); Convex engine itself is healthy (ticking normally, OCC rate down to ~14/min from ~20-30/min pre-migration); the remaining user-visible slowness traces to athena's LLM gateway host being under load.

## Current architecture

`services/orion-ai-town` applies a fixed, ordered chain of patches (`scripts/apply_upstream_patches.sh`) on top of a pinned upstream `ai-town` SHA. Four existing patches already touch `convex/constants.ts` (`orion-conversation-proximity`, `orion-town-chat-turns`, `orion-human-juniper`; `orion-hub-embed` only imports from it) but none read or touch `CONVERSATION_COOLDOWN`/`MESSAGE_COOLDOWN`'s specific values.

## Architecture touched

- `services/orion-ai-town/patches/orion-npc-cooldown-tuning.patch` (new)
- `services/orion-ai-town/scripts/apply_upstream_patches.sh`
- `services/orion-ai-town/tests/test_npc_cooldown_tuning_patch.py` (new)
- `services/orion-ai-town/README.md`

## Files changed

- `services/orion-ai-town/patches/orion-npc-cooldown-tuning.patch`: new -- raises `CONVERSATION_COOLDOWN`/`MESSAGE_COOLDOWN` in `convex/constants.ts`, generated against the fully-patched (post 6-patch) baseline.
- `services/orion-ai-town/scripts/apply_upstream_patches.sh`: appends the new patch to the end of `PATCHES` -- required, since it was generated against the state after the other constants.ts-touching patches.
- `services/orion-ai-town/tests/test_npc_cooldown_tuning_patch.py`: new -- structural tests (registration, ordering, exact before/after values, single-file-diff guard), matching the existing patch-test convention.
- `services/orion-ai-town/README.md`: new subsection documenting the patch and its rationale.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
/tmp/aitown-test-venv/bin/python -m pytest services/orion-ai-town/tests -q
34 passed
```

## Evals run

No eval harness exists for this service; live verification substitutes (see Docker/build/smoke checks).

## Docker/build/smoke checks

```text
# Fresh clone + full patch chain re-verified from scratch:
rm -rf upstream && git clone .../ai-town.git upstream
git -C upstream checkout 7b242334bfbfef02f7718bded120d431e8f307df
bash scripts/apply_upstream_patches.sh
  -> all 7 patches applied cleanly, in order

grep CONVERSATION_COOLDOWN\|MESSAGE_COOLDOWN upstream/convex/constants.ts
  -> CONVERSATION_COOLDOWN = 45000; MESSAGE_COOLDOWN = 8000;

# Deployed live to the running atlas backend (same deployment from PR #1467):
npx convex dev --once
  -> Convex functions ready
npx convex data worldStatus
  -> status: "running" (unaffected by the redeploy)
```

## Review findings fixed

None -- code-reviewer subagent found no correctness issues (verified patch ordering is safe/necessary given the other constants.ts-touching patches, verified no non-obvious interaction with `AWKWARD_CONVERSATION_TIMEOUT`/`MAX_CONVERSATION_DURATION`/`PLAYER_CONVERSATION_COOLDOWN`, verified patch contains exactly one clean diff hunk).

## Restart required

No restart required -- already deployed live to the running atlas `orion-ai-town-backend-1` container during this session (Convex functions redeploy takes effect immediately, no container restart needed).

## Risks / concerns

- Severity: low -- these are the same values for every NPC/conversation; if the felt pacing is now too slow, they're a one-line revert per constant (documented as such in both the patch's own comments and the README section).
- Severity: low -- doesn't address the actual root cause (athena's LLM gateway host load) directly, only reduces call volume against it. If athena's load doesn't subside, dialogue may still feel measurably slower than a fully unloaded baseline, just less frequently triggered.

## PR link

(populated by gh pr create output)