### PR TITLE
fix(aitown): eliminate OCC contention on sendInput's hot path

### DIFF
--- a/services/orion-ai-town/README.md
+++ b/services/orion-ai-town/README.md
@@ -271,6 +271,22 @@ Load-shedding, not a gameplay change. Every NPC conversation message is an `agen
 
 Revert both to their upstream defaults if the gateway's host load profile changes and the throttling is no longer needed.
 
+### Input-counter contention fix (`patches/orion-input-counter-contention.patch`)
+
+Not a throttle -- a real contention fix. Investigation (2026-07-29/30) found the cooldown tuning above didn't touch the actual cause of laggy player movement: every `sendInput` call (movement, NPC actions, embodiment) allocated its `inputs.number` by reading the last input for the engine and incrementing, and separately read `worldStatus` to resolve `worldId` -> `engineId`. Both reads created wide Convex OCC conflict surfaces:
+
+- The read-last-then-increment pattern made every `sendInput` call conflict with every other concurrent `sendInput` call, and with `saveWorld` patching `returnValue` onto recently-inserted input rows in the same index range.
+- The `worldStatus` read collided with `heartbeatWorld`, which patches `lastViewed` on that same document on nearly every call.
+
+Neither is a storage-engine issue (an earlier Postgres-backend experiment for this same symptom found no improvement, consistent with the conflicts being enforced by Convex's own OCC layer, not SQLite locking).
+
+Fix: two new narrow tables that nothing else reads or writes:
+
+- `inputCounters` (one row per engine) -- `engineInsertInput` allocates `number` from this instead of scanning `inputs`.
+- `worldEngineMap` (one row per world) -- `insertInput` resolves `engineId` from this instead of reading `worldStatus`.
+
+Both are lazily backfilled on first use per engine/world (falls back to the legacy read once, then seeds the new table), so this needed no separate migration step against the live world's existing data.
+
 ## MCP integration
 
 Gameplay MCP lives in `mcp/orion_aitown_mcp/`. Hub fcc-claude includes it when `HUB_AITOWN_ENABLED=true` and MCP is enabled.

--- a/services/orion-ai-town/patches/orion-input-counter-contention.patch
+++ b/services/orion-ai-town/patches/orion-input-counter-contention.patch
@@ -1,0 +1,147 @@
+diff --git a/convex/aiTown/insertInput.ts b/convex/aiTown/insertInput.ts
+index 3b4fa76..e0b8f3f 100644
+--- a/convex/aiTown/insertInput.ts
++++ b/convex/aiTown/insertInput.ts
+@@ -3,12 +3,22 @@ import { Id } from '../_generated/dataModel';
+ import { engineInsertInput } from '../engine/abstractGame';
+ import { InputNames, InputArgs } from './inputs';
+ 
+-export async function insertInput<Name extends InputNames>(
+-  ctx: MutationCtx,
+-  worldId: Id<'worlds'>,
+-  name: Name,
+-  args: InputArgs<Name>,
+-): Promise<Id<'inputs'>> {
++// worldId -> engineId is static once a world is created, but `worldStatus`
++// also carries `lastViewed`/`status`, which heartbeatWorld patches on nearly
++// every call. Reading worldStatus here to resolve engineId meant every
++// sendInput call raced heartbeatWorld's writes under OCC. `worldEngineMap`
++// holds only the immutable mapping so this read never conflicts with a
++// heartbeat write. Lazily backfilled from worldStatus on first use per world
++// so this works against worlds created before this table existed, with no
++// separate migration step required.
++async function resolveEngineId(ctx: MutationCtx, worldId: Id<'worlds'>): Promise<Id<'engines'>> {
++  const mapping = await ctx.db
++    .query('worldEngineMap')
++    .withIndex('worldId', (q) => q.eq('worldId', worldId))
++    .unique();
++  if (mapping) {
++    return mapping.engineId;
++  }
+   const worldStatus = await ctx.db
+     .query('worldStatus')
+     .withIndex('worldId', (q) => q.eq('worldId', worldId))
+@@ -16,5 +26,16 @@ export async function insertInput<Name extends InputNames>(
+   if (!worldStatus) {
+     throw new Error(`World for engine ${worldId} not found`);
+   }
+-  return await engineInsertInput(ctx, worldStatus.engineId, name, args);
++  await ctx.db.insert('worldEngineMap', { worldId, engineId: worldStatus.engineId });
++  return worldStatus.engineId;
++}
++
++export async function insertInput<Name extends InputNames>(
++  ctx: MutationCtx,
++  worldId: Id<'worlds'>,
++  name: Name,
++  args: InputArgs<Name>,
++): Promise<Id<'inputs'>> {
++  const engineId = await resolveEngineId(ctx, worldId);
++  return await engineInsertInput(ctx, engineId, name, args);
+ }
+diff --git a/convex/aiTown/schema.ts b/convex/aiTown/schema.ts
+index 55f2b61..a9e3fd5 100644
+--- a/convex/aiTown/schema.ts
++++ b/convex/aiTown/schema.ts
+@@ -24,6 +24,16 @@ export const aiTownTables = {
+     status: v.union(v.literal('running'), v.literal('stoppedByDeveloper'), v.literal('inactive')),
+   }).index('worldId', ['worldId']),
+ 
++  // worldId -> engineId only, kept separate from worldStatus because
++  // heartbeatWorld patches worldStatus.lastViewed on nearly every call and
++  // insertInput needs to read the engineId mapping on every single input --
++  // sharing a document meant those two collided under OCC. See
++  // resolveEngineId in insertInput.ts.
++  worldEngineMap: defineTable({
++    worldId: v.id('worlds'),
++    engineId: v.id('engines'),
++  }).index('worldId', ['worldId']),
++
+   // This table contains the map data for a given world. Since it's a bit larger than the player
+   // state and infrequently changes, we store it in a separate table.
+   maps: defineTable({
+diff --git a/convex/engine/abstractGame.ts b/convex/engine/abstractGame.ts
+index 0ff3662..2e964f6 100644
+--- a/convex/engine/abstractGame.ts
++++ b/convex/engine/abstractGame.ts
+@@ -130,6 +130,35 @@ export async function loadEngine(
+   return engine;
+ }
+ 
++// Allocating `number` via "read the last input, then +1" made every
++// sendInput call's read conflict with (a) every other concurrent sendInput
++// doing the same read and (b) saveWorld patching returnValue onto recently
++// inserted input rows in that same index range -- both under Convex OCC.
++// `inputCounters` is a narrow, single-purpose row per engine that nothing
++// else reads or writes, so allocating from it doesn't collide with saveWorld
++// at all, and only serializes against other concurrent sendInput calls (an
++// unavoidable, but now much cheaper, conflict). Lazily seeded from the
++// legacy scan on first use per engine so this needs no separate migration
++// step against engines that already have inputs.
++async function nextInputNumber(ctx: MutationCtx, engineId: Id<'engines'>): Promise<number> {
++  const counter = await ctx.db
++    .query('inputCounters')
++    .withIndex('engineId', (q) => q.eq('engineId', engineId))
++    .unique();
++  if (counter) {
++    await ctx.db.patch(counter._id, { nextNumber: counter.nextNumber + 1 });
++    return counter.nextNumber;
++  }
++  const prevInput = await ctx.db
++    .query('inputs')
++    .withIndex('byInputNumber', (q) => q.eq('engineId', engineId))
++    .order('desc')
++    .first();
++  const number = prevInput ? prevInput.number + 1 : 0;
++  await ctx.db.insert('inputCounters', { engineId, nextNumber: number + 1 });
++  return number;
++}
++
+ export async function engineInsertInput(
+   ctx: MutationCtx,
+   engineId: Id<'engines'>,
+@@ -137,12 +166,7 @@ export async function engineInsertInput(
+   args: any,
+ ): Promise<Id<'inputs'>> {
+   const now = Date.now();
+-  const prevInput = await ctx.db
+-    .query('inputs')
+-    .withIndex('byInputNumber', (q) => q.eq('engineId', engineId))
+-    .order('desc')
+-    .first();
+-  const number = prevInput ? prevInput.number + 1 : 0;
++  const number = await nextInputNumber(ctx, engineId);
+   const inputId = await ctx.db.insert('inputs', {
+     engineId,
+     number,
+diff --git a/convex/engine/schema.ts b/convex/engine/schema.ts
+index 87c4083..66b8eb3 100644
+--- a/convex/engine/schema.ts
++++ b/convex/engine/schema.ts
+@@ -50,7 +50,16 @@ export const engine = v.object({
+ });
+ export type Engine = Infer<typeof engine>;
+ 
++// A narrow, single-purpose counter row per engine so sendInput can allocate
++// `inputs.number` without reading the `inputs` table itself -- see
++// `nextInputNumber` in abstractGame.ts for why that matters.
++export const inputCounter = v.object({
++  engineId: v.id('engines'),
++  nextNumber: v.number(),
++});
++
+ export const engineTables = {
+   inputs: defineTable(input).index('byInputNumber', ['engineId', 'number']),
+   engines: defineTable(engine),
++  inputCounters: defineTable(inputCounter).index('engineId', ['engineId']),
+ };

--- a/services/orion-ai-town/scripts/apply_upstream_patches.sh
+++ b/services/orion-ai-town/scripts/apply_upstream_patches.sh
@@ -11,6 +11,7 @@ PATCHES=(
   "orion-conversation-proximity.patch"
   "orion-town-chat-turns.patch"
   "orion-npc-cooldown-tuning.patch"
+  "orion-input-counter-contention.patch"
 )
 
 if [[ ! -d "${UPSTREAM}/.git" ]]; then

--- a/services/orion-ai-town/tests/test_input_counter_contention_patch.py
+++ b/services/orion-ai-town/tests/test_input_counter_contention_patch.py
@@ -1,0 +1,65 @@
+"""Gate tests for the input-counter contention fix (reduces OCC retries on sendInput)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_PATCH = _SERVICE / "patches" / "orion-input-counter-contention.patch"
+_APPLY = _SERVICE / "scripts" / "apply_upstream_patches.sh"
+
+
+def test_patch_registered_in_apply_script():
+    text = _APPLY.read_text(encoding="utf-8")
+    assert "orion-input-counter-contention.patch" in text
+
+
+def test_patch_registered_last():
+    text = _APPLY.read_text(encoding="utf-8")
+    order = [
+        line.strip().strip('",')
+        for line in text.splitlines()
+        if line.strip().startswith('"orion-')
+    ]
+    assert order[-1] == "orion-input-counter-contention.patch"
+
+
+def test_patch_touches_exactly_the_expected_files():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert patch.count("diff --git") == 4
+    for path in (
+        "convex/aiTown/insertInput.ts",
+        "convex/aiTown/schema.ts",
+        "convex/engine/abstractGame.ts",
+        "convex/engine/schema.ts",
+    ):
+        assert path in patch
+
+
+def test_patch_adds_input_counters_table():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "inputCounters: defineTable(inputCounter).index('engineId', ['engineId'])" in patch
+
+
+def test_patch_adds_world_engine_map_table():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "worldEngineMap: defineTable({" in patch
+
+
+def test_patch_removes_read_before_increment_from_engine_insert_input():
+    patch = _PATCH.read_text(encoding="utf-8")
+    # The old read-last-input-then-increment pattern must be removed from
+    # engineInsertInput's hot path -- it's what made every sendInput call
+    # conflict with every other concurrent sendInput and with saveWorld.
+    assert "-  const prevInput = await ctx.db" in patch
+    assert "-  const number = prevInput ? prevInput.number + 1 : 0;" in patch
+    assert "+  const number = await nextInputNumber(ctx, engineId);" in patch
+
+
+def test_patch_lazily_seeds_counters_and_mapping_no_separate_migration():
+    patch = _PATCH.read_text(encoding="utf-8")
+    # Both new tables must be populated lazily on first use per
+    # engine/world -- there is no separate migration script, so engines and
+    # worlds that predate this patch must self-heal on the first call.
+    assert "await ctx.db.insert('inputCounters'" in patch
+    assert "await ctx.db.insert('worldEngineMap'" in patch

--- a/services/orion-ai-town/tests/test_npc_cooldown_tuning_patch.py
+++ b/services/orion-ai-town/tests/test_npc_cooldown_tuning_patch.py
@@ -17,14 +17,15 @@ def test_cooldown_patch_registered_in_apply_script():
 def test_cooldown_patch_registered_after_patches_that_also_touch_constants():
     text = _APPLY.read_text(encoding="utf-8")
     # This patch's diff hunks are generated against constants.ts *after* the
-    # other patches that also touch it -- it must stay last in the array or
-    # it will fail to apply / apply against the wrong base.
+    # other patches that also touch it -- it must come after all of them (not
+    # necessarily last overall; later patches touching unrelated files, like
+    # orion-input-counter-contention.patch, are free to follow it) or it will
+    # fail to apply / apply against the wrong base.
     order = [
         line.strip().strip('",')
         for line in text.splitlines()
         if line.strip().startswith('"orion-')
     ]
-    assert order[-1] == "orion-npc-cooldown-tuning.patch"
     for other in (
         "orion-town-chat-turns.patch",
         "orion-human-juniper.patch",


### PR DESCRIPTION
## Summary

- Every `sendInput` call (player moves, NPC actions, embodiment perception) read `worldStatus` to resolve `engineId` and read-then-incremented the last input number to assign one -- both reads collided under Convex OCC with `heartbeatWorld` and `saveWorld` respectively, causing multi-second mutation stalls felt as laggy movement/interact-button delay.
- Confirmed this is not a storage-engine or CPU-parallelism problem: a prior live experiment swapping the self-hosted backend to Postgres for this same symptom found no improvement, consistent with the conflicts being enforced by Convex's own OCC layer, not SQLite/storage-level locking. No thread-pool knob exists in `convex-local-backend` either (checked `--help`, container env, binary strings).
- Adds two narrow, single-purpose tables that nothing else reads or writes: `worldEngineMap` (worldId -> engineId, replaces the `worldStatus` read) and `inputCounters` (one row per engine, replaces the read-last-input-then-increment scan).
- Both are lazily backfilled on first use per engine/world (fall back to the legacy read once, then seed the new table) -- no separate migration step needed against the live world's existing engines/worlds/inputs.
- Already deployed to the live backend (`npx convex dev --once`); pre-deploy snapshot taken first as a safety net.

## Outcome moved

Measured on the live world, same methodology before/after (10-min baseline vs 6-min post-deploy window, comparable log tabulation):

| | before | after |
|---|---|---|
| OCC errors | 169 (16.9/min) | 27 (4.5/min) |
| `sendInput` retries caused by `saveWorld`/`heartbeatWorld` | 84 | 1 |
| worst mutation latency | 5072ms | 154ms |
| backend CPU | 97-127% (single core pegged) | 40% |
| mutations processed | ~9.2/min | ~27/min |

Remaining OCC (26/27 in the post-deploy window) is the expected, much cheaper residual: concurrent actors still serialize on one small counter row per engine instead of the whole `inputs` index, so it's a fast single-document conflict rather than a full-table collision with the game loop.

## Current architecture

`sendInput` (`aiTown/main.ts`) -> `insertInput` (`aiTown/insertInput.ts`) -> `engineInsertInput` (`engine/abstractGame.ts`). `insertInput` read `worldStatus` by `worldId` to get `engineId`; `worldStatus` also holds `lastViewed`/`status`, patched by `heartbeatWorld` on nearly every call. `engineInsertInput` allocated `inputs.number` via `.query('inputs').withIndex('byInputNumber', eq(engineId)).order('desc').first()` then `+1` -- an open-ended index-range read that collided with any concurrent insert into that range, including `saveWorld` patching `returnValue` onto already-inserted rows. The simulation itself never used `number` for ordering (it batches by the `received` wall-clock timestamp already stored on every input row) -- `number` is pure bookkeeping for `loadInputs`'s resumable cursor.

## Architecture touched

`services/orion-ai-town`'s vendored ai-town Convex functions, via a new patch file (`patches/orion-input-counter-contention.patch`) applied by `scripts/apply_upstream_patches.sh`. Schema-additive only (two new tables), no changes to existing table shapes or the public `sendInput`/`insertInput` API.

## Files changed

- `services/orion-ai-town/patches/orion-input-counter-contention.patch`: the actual diff -- `convex/aiTown/insertInput.ts` (new `resolveEngineId` using `worldEngineMap` with lazy fallback), `convex/aiTown/schema.ts` (new `worldEngineMap` table), `convex/engine/abstractGame.ts` (new `nextInputNumber` using `inputCounters` with lazy fallback), `convex/engine/schema.ts` (new `inputCounters` table)
- `services/orion-ai-town/scripts/apply_upstream_patches.sh`: registers the new patch, appended last (touches none of the same files as the other 7, so ordering relative to them doesn't matter)
- `services/orion-ai-town/tests/test_input_counter_contention_patch.py`: new gate tests -- registration, exact file set touched, both new tables present, read-before-increment pattern removed, lazy seeding present
- `services/orion-ai-town/tests/test_npc_cooldown_tuning_patch.py`: loosened one assertion to check relative ordering against other `constants.ts`-touching patches instead of asserting absolute-last, since this new patch (which doesn't touch `constants.ts`) is now appended after it
- `services/orion-ai-town/README.md`: new subsection documenting the patch and rationale

## Schema / bus / API changes

- Added: `worldEngineMap` table (`convex/aiTown/schema.ts`), `inputCounters` table (`convex/engine/schema.ts`)
- Removed: none
- Renamed: none
- Behavior changed: `sendInput`'s internal allocation of `engineId`/`inputs.number` no longer reads `worldStatus`/scans `inputs`; externally-visible behavior (mutation args, return values, `inputs.number` semantics/values) is unchanged
- Compatibility notes: both new tables are lazily backfilled per engine/world on first use after deploy -- no separate migration script, safe against the live world's pre-existing data

## Env/config changes

None.

## Tests run

```text
pytest services/orion-ai-town/tests/ -q --ignore=services/orion-ai-town/tests/test_generate_descriptions.py
33 passed (in the venv used for local iteration; test_generate_descriptions.py excluded only for an unrelated missing `yaml` dependency in that scratch venv, not a change from this patch)
```

Also validated the full 8-patch sequence applies cleanly from a fresh upstream clone (not just the existing worktree state), and round-tripped the new patch (`git apply --reverse --check` / `--check` / re-apply) to confirm it's well-formed.

## Evals run

No dedicated eval harness exists for `orion-ai-town`; the before/after live-metric comparison above (OCC rate, latency, CPU, throughput) served as the functional eval for this change, since the actual claim being tested (contention reduction) can only be observed against the live backend.

## Docker/build/smoke checks

Deployed directly to the live self-hosted Convex backend via `npx convex dev --once` (from a `node:20` container against `upstream/`, pointed at `CONVEX_SELF_HOSTED_URL`/`ADMIN_KEY`) -- schema push succeeded with both new table indexes added, no errors. Confirmed post-deploy: no new error classes in backend logs beyond the expected residual OCC, mutations continuing to succeed (200s), backend process healthy.

## Review findings fixed

- Finding: none blocking. Code review (orion-repo-agent) traced the OCC/schema reasoning against actual upstream source, confirmed `worldId->engineId` immutability elsewhere in the codebase (safe to cache in `worldEngineMap`), confirmed the lazy-backfill race self-heals via the same OCC retry mechanism the old code already relied on, confirmed zero file overlap with the other 7 vendored patches, and ran the full test suite clean.
  - Fix: n/a
  - Evidence: reviewer's traced grep/diff output against `upstream/convex/world.ts`, `init.ts`, `aiTown/main.ts`; noted as informational-only that no TS/Convex functional test harness exists in this repo to mechanically execute the OCC-race claim (same pre-existing gap as every other vendored patch, not introduced by this change).

## Restart required

None beyond the deploy already performed -- `npx convex dev --once` push takes effect immediately, no container restart needed. For any future re-deploy from a clean checkout:

```bash
cd services/orion-ai-town && bash scripts/apply_upstream_patches.sh
docker run --rm -v "$(pwd)/upstream:/app" -w /app node:20 bash -lc "npm ci"
docker run --rm -v "$(pwd)/upstream:/app" -w /app \
  -e CONVEX_SELF_HOSTED_URL="http://100.121.214.30:3210" \
  -e CONVEX_SELF_HOSTED_ADMIN_KEY="<admin key>" \
  node:20 bash -lc "npx convex dev --once"
```

## Risks / concerns

- Severity: low
- Concern: this touches the persisted schema and hot write path of a live, currently-populated world. The lazy-backfill logic was reviewed and traced but not exercised under an actual concurrent-load test harness (none exists for this service in TypeScript/Convex).
- Mitigation: a full pre-deploy snapshot export was taken (`pre-inputcounter-export.zip`, live world state) before deploying; the change is schema-additive only (no existing fields/tables removed or retyped); post-deploy live metrics confirm the fix is working as intended with no new error classes.

## PR link

(added by gh pr create output below)