### PR TITLE
feat(metacog): add recent-trend-signals evidence cue (Tier 1)

### DIFF
--- a/docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md
+++ b/docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md
@@ -309,4 +309,4 @@ never a new output field or a new instruction to the draft LLM. The arbitration-
 the section above is unrelated and still unresolved; this patch does not compete for Layer 5
 attention's budget or touch `orion/proposals/`.
 
-Implemented: PR #TBD (filled in once opened).
+Implemented: [PR #1477](https://github.com/junebug-junie/Orion-Sapienform/pull/1477).

--- a/docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md
+++ b/docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md
@@ -271,3 +271,42 @@ This doc's Missing Questions 1-2 and the trend-reducer build itself are not canc
 re-sequenced: they remain the right next step for metacog specifically, but only after (or in
 parallel with, if scoped as a fully separate consumer of attention output) the arbitration-layer
 question above gets its own resolution.
+
+## 2026-07-29/30 update — Tier 1 shipped: MetacogContextService evidence cue
+
+Juniper's explicit direction, out-of-band from this doc (not itself recorded anywhere before this
+section): implement the cheapest real consumer named in Missing Question 3 directly — "do it tier
+1" — without waiting on the arbitration-layer fix above. This section exists so that authorization
+is traced to a real place instead of being implicit, per this doc's own metric-quality-gate
+discipline (root CLAUDE.md §0A: "record the findings from this gate in the same design doc").
+
+**What shipped.** `MetacogContextService` (`services/orion-cortex-exec/app/executor.py`) now reads
+two already-computed, already-persisted signal sources' *latest* value and renders them into a new,
+additive `RECENT TREND SIGNALS` prompt block in
+`orion/cognition/prompts/log_orion_metacognition_draft.j2` — exactly Missing Question 3's
+cheapest-option answer ("a new evidence-cue block back into `MetacogContextService`"), not a new
+reducer:
+
+1. **`substrate_field_state`'s `prediction_error`** for `node:substrate.execution` and
+   `node:substrate.biometrics` — live-verified this session: 24h variance execution
+   0.0002–1.0 (mean 0.346, stddev 0.270), biometrics 0–0.7471 (mean 0.052, stddev 0.059), genuine
+   calm-to-spike shape confirmed against real Postgres history, not merely "code compiles."
+2. **`orion_biometrics_induction`'s per-channel `{level, trend, spike_rate, volatility}`** — real
+   windowed stats already computed by `orion-biometrics`/`orion-field-digester`/`orion-sql-writer`;
+   live-verified this session across `athena`/`atlas`/`circe` (e.g. `athena.cpu.trend` 24h range
+   0.429–0.590, stddev 0.017 — real directional movement, not a flat 0.5 placeholder).
+
+New code: `orion/substrate/metacog_trend_signals.py` (pure read functions, generalizing
+`orion/substrate/bus_synaptic_surprise.py::latest_bus_synaptic_prediction_error`'s single-row
+`substrate_field_state` read to multiple node ids, plus a new `DISTINCT ON (node)` reader for
+`orion_biometrics_induction`) and `services/orion-cortex-exec/app/metacog_trend_reader.py`
+(bounded, fail-open async wiring, mirroring `drive_state_postgres.py`'s existing convention).
+
+**Scope discipline maintained.** No new reducer, poll loop, or persistence — both sources were
+already computed/persisted upstream; this patch only reads the latest row. `MetacogDraftService`,
+`MetacogPublishService`, and `MetacogDraftTextPatchV1` are structurally untouched — new input only,
+never a new output field or a new instruction to the draft LLM. The arbitration-layer question in
+the section above is unrelated and still unresolved; this patch does not compete for Layer 5
+attention's budget or touch `orion/proposals/`.
+
+Implemented: PR #TBD (filled in once opened).

--- a/orion/cognition/prompts/log_orion_metacognition_draft.j2
+++ b/orion/cognition/prompts/log_orion_metacognition_draft.j2
@@ -39,6 +39,11 @@ TURN EFFECT (JSON; evidence cues only; do NOT paste into output):
 RECENT TURN-EFFECT ALERTS (evidence cues only):
 {{ recent_turn_effect_alerts_json }}
 
+RECENT TREND SIGNALS (JSON; latest substrate prediction-error + biometrics
+induction trend readings, real windowed stats already computed upstream --
+evidence cues only; do NOT paste into output):
+{{ recent_trend_signals_json }}
+
 RECOMMENDED ACTIONS POLICY (evidence cues only; do NOT copy verbatim into output):
 {{ turn_effect_policy_json }}
 

--- a/orion/substrate/metacog_trend_signals.py
+++ b/orion/substrate/metacog_trend_signals.py
@@ -1,0 +1,247 @@
+"""Latest-value readers for metacog's evidence-cue "recent trend signals" block.
+
+Tier 1 patch from `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-
+reducer-design.md`'s "2026-07-29/30 update" section -- the design doc's own
+Missing Question 3 answer: the cheapest real consumer for "how does trend data
+reach metacog" is a new, additive evidence-cue block in `MetacogContextService`
+(`services/orion-cortex-exec/app/executor.py`), reading two already-computed,
+already-persisted signal sources' *latest* value. This module does not compute
+a window/trend itself -- both sources below are windowed/reduced upstream by
+their own producers (`orion-substrate-runtime` and `orion-biometrics`/
+`orion-field-digester`/`orion-sql-writer` respectively). Building a new reducer,
+poll loop, or persistence layer here would violate that doc's explicit scope
+boundary.
+
+Two Tier-1 signal sources, both independently verified real and non-degenerate
+against live Postgres data on 2026-07-28/29 (see the design doc's own
+"2026-07-28 update" section and the PR description for this patch):
+
+1. `substrate_field_state`'s `prediction_error` node vectors for
+   `node:substrate.execution` and `node:substrate.biometrics` -- real-time
+   "surprise" scores, 0-1 range, ~2s write cadence. `prediction_error` was
+   removed from every domain's decay set 2026-07-26
+   (`services/orion-field-digester/app/digestion/decay.py::NODE_DECAY_CHANNELS`)
+   so it is an undecayed raw snapshot for every domain, not just
+   `node:substrate.bus_synaptic` -- the same `STALENESS_HORIZON_SEC` guard
+   `orion.substrate.bus_synaptic_surprise.latest_bus_synaptic_prediction_error`
+   already applies is reused here rather than re-derived.
+
+2. `orion_biometrics_induction`'s per-channel windowed stats
+   (`metrics.<channel>.{level, trend, spike_rate, volatility}`), one row per
+   node per ~30-45s tick -- already-computed windowed statistics (the writer's
+   own `window_sec` column), not something this module computes fresh.
+
+Confirmed live 2026-07-30: a single `substrate_field_state` row's `field_json`
+carries every live domain's node_vectors as of that tick (one row, not one row
+per domain) -- so both prediction_error values are read in a single
+round trip, not two.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from orion.substrate.bus_synaptic_surprise import STALENESS_HORIZON_SEC
+
+# Fixed per this patch's Tier-1 scope (design doc's own two named candidates) --
+# not operator-configurable, unlike the biometrics_induction node list below,
+# because these two node ids are load-bearing to which signal this cue claims
+# to be (a different node id would silently change what "recent_trend_signals"
+# means without changing its name).
+PREDICTION_ERROR_NODE_IDS: tuple[str, ...] = (
+    "node:substrate.execution",
+    "node:substrate.biometrics",
+)
+
+
+def latest_node_prediction_errors(
+    engine: Engine, node_ids: Sequence[str] = PREDICTION_ERROR_NODE_IDS
+) -> dict[str, float | None]:
+    """Latest real `prediction_error` value per requested `substrate_field_state`
+    node id, read off the single most recent row.
+
+    Same undecayed-raw-snapshot staleness contract as
+    `latest_bus_synaptic_prediction_error`: a row older than
+    `STALENESS_HORIZON_SEC` returns `None` for every requested node (all-or-
+    nothing on row age, not per-node -- there is only one row to be stale),
+    so "no real signal available" stays distinguishable from "genuinely calm".
+
+    Returns a dict with every requested node id as a key; values are `None`
+    when the node is absent from that row, the row itself is missing, too
+    stale, or unparseable.
+    """
+    result: dict[str, float | None] = {node_id: None for node_id in node_ids}
+    if not node_ids:
+        return result
+
+    select_parts: list[str] = []
+    params: dict[str, Any] = {}
+    for i, node_id in enumerate(node_ids):
+        key = f"node_{i}"
+        select_parts.append(
+            f"field_json -> 'node_vectors' -> :{key} ->> 'prediction_error' AS {key}"
+        )
+        params[key] = node_id
+
+    query = text(
+        f"""
+        SELECT generated_at, {', '.join(select_parts)}
+        FROM substrate_field_state
+        ORDER BY generated_at DESC
+        LIMIT 1
+        """
+    )
+    with engine.connect() as conn:
+        row = conn.execute(query, params).mappings().first()
+    if not row:
+        return result
+
+    generated_at = row.get("generated_at")
+    if generated_at is not None:
+        if generated_at.tzinfo is None:
+            generated_at = generated_at.replace(tzinfo=timezone.utc)
+        age_seconds = (datetime.now(timezone.utc) - generated_at).total_seconds()
+        if age_seconds > STALENESS_HORIZON_SEC:
+            return result
+
+    for i, node_id in enumerate(node_ids):
+        raw = row.get(f"node_{i}")
+        if raw is None:
+            continue
+        try:
+            result[node_id] = float(raw)
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def latest_biometrics_induction_by_node(
+    engine: Engine,
+    nodes: Sequence[str],
+    *,
+    max_age_sec: float = 180.0,
+) -> dict[str, dict[str, Any]]:
+    """Latest `orion_biometrics_induction` row per requested node.
+
+    Real windowed level/trend/spike_rate/volatility per hardware channel,
+    already computed by `orion-biometrics` and persisted by `orion-sql-writer`
+    off the `channel_biometrics_induction` bus payload (the same payload
+    `orion-state-service`'s in-memory `_biometrics_induction_by_node` cache
+    ingests -- see that service's `store.py::ingest_biometrics_induction`).
+    That in-memory cache is not reused here: `MetacogContextService`'s existing
+    `state.get_latest` RPC requests `scope="global"`, which resolves via
+    `orion-state-service`'s own `_pick_latest` to exactly one node (the
+    configured `primary_node`, or whichever node's induction happens to be
+    newest) -- not the per-node comparison this cue wants across the known
+    field-topology hardware nodes. Reading the durable table directly is a
+    fresh, small query, not a duplicate of that existing RPC path.
+
+    `timestamp` on `orion_biometrics_induction` is a text column (see
+    `services/orion-sql-writer/app/models/biometrics_induction.py`), not a
+    native timestamp column -- confirmed live 2026-07-30 that a raw
+    `timestamp > ...` comparison errors ("operator does not exist: character
+    varying > timestamp with time zone"); every comparison here casts to
+    `timestamptz` explicitly instead.
+
+    Returns only nodes with a real row within `max_age_sec`; a missing or
+    stale node is simply absent from the returned dict, not a zero-filled
+    placeholder (same "honest absence over degenerate zero" contract as
+    `latest_node_prediction_errors`).
+    """
+    if not nodes:
+        return {}
+
+    query = text(
+        """
+        SELECT DISTINCT ON (node) node, metrics, timestamp::timestamptz AS ts
+        FROM orion_biometrics_induction
+        WHERE node = ANY(:nodes)
+        ORDER BY node, timestamp::timestamptz DESC
+        """
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(query, {"nodes": list(nodes)}).mappings().all()
+
+    now = datetime.now(timezone.utc)
+    out: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        ts = row.get("ts")
+        if ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if (now - ts).total_seconds() > max_age_sec:
+            continue
+        metrics = row.get("metrics")
+        node = row.get("node")
+        if isinstance(metrics, dict) and node:
+            out[str(node)] = metrics
+    return out
+
+
+def most_notable_trend_channel(
+    metrics: Mapping[str, Any],
+) -> tuple[str, dict[str, float]] | None:
+    """Pick the single channel whose `trend` deviates furthest from 0.5 (no
+    directional change) out of one node's `orion_biometrics_induction.metrics`
+    dict.
+
+    Pure, no I/O. Exists so the evidence cue stays compact (one channel per
+    node, not all ~14) while still always returning *something* -- including
+    on a genuinely calm tick, where the "most notable" channel just reports a
+    near-0.5 trend, honestly representing calm rather than being filtered out
+    by a fixed threshold that could hide "nothing is moving" as easily as it
+    hides noise.
+    """
+    best: tuple[str, dict[str, float]] | None = None
+    best_dev = -1.0
+    for channel, raw in metrics.items():
+        if not isinstance(raw, Mapping):
+            continue
+        trend = raw.get("trend")
+        if not isinstance(trend, (int, float)) or isinstance(trend, bool):
+            continue
+        dev = abs(float(trend) - 0.5)
+        if dev > best_dev:
+            best_dev = dev
+            best = (str(channel), dict(raw))
+    return best
+
+
+def build_recent_trend_signals_cue(
+    *,
+    prediction_errors: Mapping[str, float | None],
+    induction_by_node: Mapping[str, Mapping[str, Any]],
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Assemble the compact, structured evidence cue rendered into
+    `ctx["recent_trend_signals"]` -- a real evidence cue, not a raw telemetry
+    dump: prediction_error is already a single scalar per node, and induction
+    is reduced to each node's single most-notable channel via
+    `most_notable_trend_channel` rather than all ~14 channels.
+    """
+    cue: dict[str, Any] = {
+        "prediction_error": {
+            node_id: value for node_id, value in prediction_errors.items()
+        },
+        "biometrics_induction": {},
+    }
+    for node, metrics in induction_by_node.items():
+        notable = most_notable_trend_channel(metrics)
+        if notable is None:
+            continue
+        channel, values = notable
+        cue["biometrics_induction"][node] = {
+            "channel": channel,
+            "trend": values.get("trend"),
+            "level": values.get("level"),
+            "spike_rate": values.get("spike_rate"),
+            "volatility": values.get("volatility"),
+        }
+    if generated_at is not None:
+        cue["as_of"] = generated_at.isoformat()
+    return cue

--- a/orion/substrate/metacog_trend_signals.py
+++ b/orion/substrate/metacog_trend_signals.py
@@ -1,20 +1,25 @@
 """Latest-value readers for metacog's evidence-cue "recent trend signals" block.
 
-Tier 1 patch from `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-
-reducer-design.md`'s "2026-07-29/30 update" section -- the design doc's own
-Missing Question 3 answer: the cheapest real consumer for "how does trend data
-reach metacog" is a new, additive evidence-cue block in `MetacogContextService`
+Tier 1 patch, per `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-
+reducer-design.md`. That doc's own "Missing questions" §3 names the cheapest
+real consumer for "how does trend data reach metacog": a new, additive
+evidence-cue block in `MetacogContextService`
 (`services/orion-cortex-exec/app/executor.py`), reading two already-computed,
-already-persisted signal sources' *latest* value. This module does not compute
-a window/trend itself -- both sources below are windowed/reduced upstream by
-their own producers (`orion-substrate-runtime` and `orion-biometrics`/
-`orion-field-digester`/`orion-sql-writer` respectively). Building a new reducer,
-poll loop, or persistence layer here would violate that doc's explicit scope
-boundary.
+already-persisted signal sources' *latest* value -- not a new reducer. This
+module does not compute a window/trend itself -- both sources below are
+windowed/reduced upstream by their own producers (`orion-substrate-runtime`
+and `orion-biometrics`/`orion-field-digester`/`orion-sql-writer`
+respectively). Building a new reducer, poll loop, or persistence layer here
+would violate that doc's explicit scope boundary. Juniper's direct
+authorization to implement this exact Tier-1 slice ("do it tier 1") and this
+patch's own scope are recorded in the doc's "2026-07-29/30 update" section,
+added alongside this patch.
 
 Two Tier-1 signal sources, both independently verified real and non-degenerate
-against live Postgres data on 2026-07-28/29 (see the design doc's own
-"2026-07-28 update" section and the PR description for this patch):
+against live Postgres data on 2026-07-28/29/30 (see the design doc's "2026-07-28
+update" section for the arbitration-layer measurement discipline this reuses,
+the "2026-07-29/30 update" section for this patch's own numbers, and the PR
+description for this patch):
 
 1. `substrate_field_state`'s `prediction_error` node vectors for
    `node:substrate.execution` and `node:substrate.biometrics` -- real-time

--- a/orion/substrate/tests/test_metacog_trend_signals.py
+++ b/orion/substrate/tests/test_metacog_trend_signals.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from orion.substrate.metacog_trend_signals import (
+    build_recent_trend_signals_cue,
+    latest_biometrics_induction_by_node,
+    latest_node_prediction_errors,
+    most_notable_trend_channel,
+)
+
+NODE_IDS = ("node:substrate.execution", "node:substrate.biometrics")
+
+
+def _engine_with_first_row(row: dict | None) -> MagicMock:
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = row
+    return engine
+
+
+def _engine_with_all_rows(rows: list[dict]) -> MagicMock:
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.all.return_value = rows
+    return engine
+
+
+# --- latest_node_prediction_errors ---
+
+
+def test_prediction_errors_returns_real_values() -> None:
+    engine = _engine_with_first_row(
+        {
+            "generated_at": datetime.now(timezone.utc),
+            "node_0": "0.297",
+            "node_1": "0.155",
+        }
+    )
+    result = latest_node_prediction_errors(engine, NODE_IDS)
+    assert result == {
+        "node:substrate.execution": 0.297,
+        "node:substrate.biometrics": 0.155,
+    }
+
+
+def test_prediction_errors_none_when_no_row() -> None:
+    engine = _engine_with_first_row(None)
+    result = latest_node_prediction_errors(engine, NODE_IDS)
+    assert result == {nid: None for nid in NODE_IDS}
+
+
+def test_prediction_errors_none_per_node_when_node_absent() -> None:
+    engine = _engine_with_first_row(
+        {"generated_at": datetime.now(timezone.utc), "node_0": None, "node_1": "0.4"}
+    )
+    result = latest_node_prediction_errors(engine, NODE_IDS)
+    assert result["node:substrate.execution"] is None
+    assert result["node:substrate.biometrics"] == 0.4
+
+
+def test_prediction_errors_all_none_when_stale() -> None:
+    stale = datetime.now(timezone.utc) - timedelta(hours=2)
+    engine = _engine_with_first_row(
+        {"generated_at": stale, "node_0": "0.297", "node_1": "0.155"}
+    )
+    result = latest_node_prediction_errors(engine, NODE_IDS)
+    assert result == {nid: None for nid in NODE_IDS}
+
+
+def test_prediction_errors_empty_node_ids_returns_empty_dict() -> None:
+    engine = MagicMock()
+    assert latest_node_prediction_errors(engine, ()) == {}
+    engine.connect.assert_not_called()
+
+
+# --- latest_biometrics_induction_by_node ---
+
+
+def test_induction_by_node_returns_metrics_within_max_age() -> None:
+    now = datetime.now(timezone.utc)
+    engine = _engine_with_all_rows(
+        [
+            {"node": "athena", "metrics": {"cpu": {"trend": 0.55}}, "ts": now},
+            {
+                "node": "atlas",
+                "metrics": {"gpu_util": {"trend": 0.51}},
+                "ts": now - timedelta(seconds=30),
+            },
+        ]
+    )
+    result = latest_biometrics_induction_by_node(engine, ("athena", "atlas", "circe"))
+    assert result["athena"] == {"cpu": {"trend": 0.55}}
+    assert result["atlas"] == {"gpu_util": {"trend": 0.51}}
+    assert "circe" not in result
+
+
+def test_induction_by_node_drops_stale_rows() -> None:
+    now = datetime.now(timezone.utc)
+    engine = _engine_with_all_rows(
+        [
+            {
+                "node": "circe",
+                "metrics": {"cpu": {"trend": 0.5}},
+                "ts": now - timedelta(seconds=600),
+            }
+        ]
+    )
+    result = latest_biometrics_induction_by_node(engine, ("circe",), max_age_sec=180.0)
+    assert result == {}
+
+
+def test_induction_by_node_empty_nodes_returns_empty_dict() -> None:
+    engine = MagicMock()
+    assert latest_biometrics_induction_by_node(engine, ()) == {}
+    engine.connect.assert_not_called()
+
+
+# --- most_notable_trend_channel ---
+
+
+def test_most_notable_trend_channel_picks_max_deviation() -> None:
+    metrics = {
+        "cpu": {"trend": 0.505, "level": 0.3, "spike_rate": 0.0, "volatility": 0.06},
+        "gpu_util": {"trend": 0.7, "level": 0.1, "spike_rate": 0.1, "volatility": 0.2},
+        "mem": {"trend": 0.5, "level": 0.05},
+    }
+    channel, values = most_notable_trend_channel(metrics)
+    assert channel == "gpu_util"
+    assert values["trend"] == 0.7
+
+
+def test_most_notable_trend_channel_none_when_no_valid_trend() -> None:
+    assert most_notable_trend_channel({"cpu": {"level": 0.1}}) is None
+    assert most_notable_trend_channel({}) is None
+
+
+# --- build_recent_trend_signals_cue ---
+
+
+def test_build_recent_trend_signals_cue_shape() -> None:
+    cue = build_recent_trend_signals_cue(
+        prediction_errors={
+            "node:substrate.execution": 0.297,
+            "node:substrate.biometrics": 0.155,
+        },
+        induction_by_node={
+            "athena": {"cpu": {"trend": 0.505, "level": 0.31, "spike_rate": 0.0, "volatility": 0.06}},
+        },
+    )
+    assert cue["prediction_error"]["node:substrate.execution"] == 0.297
+    assert cue["biometrics_induction"]["athena"]["channel"] == "cpu"
+    assert cue["biometrics_induction"]["athena"]["trend"] == 0.505
+
+
+def test_build_recent_trend_signals_cue_skips_nodes_with_no_notable_channel() -> None:
+    cue = build_recent_trend_signals_cue(
+        prediction_errors={},
+        induction_by_node={"athena": {"cpu": {"level": 0.1}}},
+    )
+    assert cue["biometrics_induction"] == {}

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -244,6 +244,20 @@ SUBSTRATE_FELT_STATE_MAX_AGE_SEC=120
 # which a self:{dimension_id} node folds a hazard into stance social hazards.
 SELF_STATE_STANCE_PRESSURE_THRESHOLD=0.8
 
+# --- Metacog "recent trend signals" evidence cue (Tier 1 patch, docs/superpowers/
+# specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md) ---
+# Additive-only: MetacogContextService reads the *latest* substrate_field_state
+# prediction_error (node:substrate.execution / node:substrate.biometrics) and
+# the latest per-node orion_biometrics_induction trend row, and renders both
+# into a new RECENT TREND SIGNALS prompt block. No new reducer/poll loop; both
+# sources are already computed upstream. Fail-open + bounded; DB URL reuses
+# SUBSTRATE_FELT_STATE_DATABASE_URL / ENDOGENOUS_RUNTIME_SQL_DATABASE_URL above
+# rather than a third DSN key for the same conjourney instance.
+ENABLE_METACOG_TREND_CUE=true
+METACOG_TREND_CUE_NODES=athena,atlas,circe
+METACOG_TREND_CUE_FETCH_TIMEOUT_SEC=0.8
+METACOG_TREND_CUE_INDUCTION_MAX_AGE_SEC=180
+
 # Legacy GraphDB substrate (explicit SUBSTRATE_STORE_BACKEND=graphdb only):
 # SUBSTRATE_STORE_BACKEND=graphdb
 # SUBSTRATE_GRAPHDB_ENDPOINT=http://orion-athena-graphdb:7200/repositories/collapse

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -188,6 +188,7 @@ _METACOG_DRAFT_CTX_LEN_KEYS: tuple[str, ...] = (
     "metacog_biometrics_cue",
     "metacog_substrate_cue",
     "trigger_upstream_json",
+    "recent_trend_signals_json",
 )
 
 def _filter_world_context_capsule(
@@ -3652,6 +3653,24 @@ async def call_step_services(
                 ctx["substrate_eventfulness_reasons"] = list(ev.reasons)
                 if "biometrics_json" not in ctx:
                     ctx["biometrics_json"] = json.dumps(ctx.get("biometrics") or {}, indent=2)
+
+                # Recent trend signals (Tier 1 patch, docs/superpowers/specs/
+                # 2026-07-28-metacog-turn-scoped-trend-reducer-design.md's
+                # "2026-07-29/30 update"). Reads the *latest* value from two
+                # already-computed, already-persisted signal sources -- no
+                # window/trend computation happens here, no new reducer/poll
+                # loop, additive-only evidence cue. Bounded + fail-open: never
+                # raises, never blocks this step past its own short timeout.
+                from app.metacog_trend_reader import fetch_recent_trend_signals
+
+                recent_trend_signals = await fetch_recent_trend_signals(correlation_id)
+                ctx["recent_trend_signals"] = recent_trend_signals or {}
+                ctx["recent_trend_signals_json"] = (
+                    json.dumps(recent_trend_signals, indent=2, default=str)
+                    if recent_trend_signals
+                    else "{}"
+                )
+
                 merged_result[service] = {"ok": True, "summary_len": len(summary_text)}
                 logs.append("ok <- MetacogContextService")
                 continue

--- a/services/orion-cortex-exec/app/metacog_trend_reader.py
+++ b/services/orion-cortex-exec/app/metacog_trend_reader.py
@@ -1,0 +1,173 @@
+"""Bounded fail-open fetch of MetacogContextService's "recent trend signals"
+evidence cue.
+
+Tier 1 patch, per `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-
+reducer-design.md`'s "2026-07-29/30 update". Wires
+`orion.substrate.metacog_trend_signals`'s pure read functions into this
+service's own engine-caching / DSN-resolution / bounded-timeout conventions --
+mirrors `drive_state_postgres.py`'s shape (module-level cached engine,
+`asyncio.wait_for(asyncio.to_thread(...))`, fail-open, never raises to the
+caller). Differs from that module in one way: the statement-timeout guard is
+set as a per-connection `-c statement_timeout=...` GUC via `connect_args`
+rather than a per-transaction `SET LOCAL`, because the two reader functions
+below each own a short-lived `engine.connect()` rather than sharing one
+transaction (see `_get_engine()`'s docstring comment).
+
+Read-only. Never mutates `ctx` itself -- `executor.py`'s MetacogContextService
+step is the only writer of `ctx["recent_trend_signals"]`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import create_engine
+
+from orion.substrate.metacog_trend_signals import (
+    PREDICTION_ERROR_NODE_IDS,
+    build_recent_trend_signals_cue,
+    latest_biometrics_induction_by_node,
+    latest_node_prediction_errors,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Per-connection statement_timeout (ms), independent of the outer asyncio
+# timeout below -- same belt-and-suspenders pattern as
+# drive_state_postgres.py's _DRIVE_STATE_QUERY_STATEMENT_TIMEOUT_MS. Set above
+# that module's 300ms: 2026-07-30 EXPLAIN ANALYZE against real
+# orion_biometrics_induction history (46k rows, no index on node/timestamp yet
+# -- see this patch's PR report for the disclosed follow-up) measured ~60-150ms
+# for the induction query alone; this cap leaves real headroom rather than
+# racing that number.
+_METACOG_TREND_QUERY_STATEMENT_TIMEOUT_MS = 800
+
+_ENGINE = None
+_ENGINE_URL: str | None = None
+
+
+def _flag_enabled() -> bool:
+    return os.getenv("ENABLE_METACOG_TREND_CUE", "true").strip().lower() in _TRUTHY
+
+
+def _dsn() -> str:
+    # Same conjourney instance every other cortex-exec Postgres reader in this
+    # service targets. Reuses the felt-state / endogenous-runtime DSN fallback
+    # chain rather than adding a third DB-URL env key for the same database.
+    return (
+        os.getenv("SUBSTRATE_FELT_STATE_DATABASE_URL", "").strip()
+        or os.getenv("ENDOGENOUS_RUNTIME_SQL_DATABASE_URL", "").strip()
+    )
+
+
+def _timeout_sec() -> float:
+    raw = os.getenv("METACOG_TREND_CUE_FETCH_TIMEOUT_SEC", "0.8").strip()
+    try:
+        return max(0.01, float(raw))
+    except ValueError:
+        return 0.8
+
+
+def _induction_nodes() -> tuple[str, ...]:
+    raw = os.getenv("METACOG_TREND_CUE_NODES", "athena,atlas,circe")
+    nodes = tuple(n.strip() for n in raw.split(",") if n.strip())
+    return nodes or ("athena", "atlas", "circe")
+
+
+def _induction_max_age_sec() -> float:
+    raw = os.getenv("METACOG_TREND_CUE_INDUCTION_MAX_AGE_SEC", "180").strip()
+    try:
+        return max(1.0, float(raw))
+    except ValueError:
+        return 180.0
+
+
+def _get_engine():
+    global _ENGINE, _ENGINE_URL
+    url = _dsn()
+    if not url:
+        return None
+    if _ENGINE is None or _ENGINE_URL != url:
+        # statement_timeout set as a per-connection GUC via connect_args
+        # (applies to every statement on every connection this engine hands
+        # out), not a per-transaction `SET LOCAL` -- the two reader functions
+        # below each open their own short-lived `engine.connect()` (matching
+        # `latest_bus_synaptic_prediction_error(engine)`'s own signature/
+        # testing convention in orion/substrate/bus_synaptic_surprise.py
+        # rather than threading a shared Connection through both), so there
+        # is no single transaction to attach a `SET LOCAL` to.
+        _ENGINE = create_engine(
+            url,
+            pool_pre_ping=True,
+            connect_args={
+                "options": f"-c statement_timeout={_METACOG_TREND_QUERY_STATEMENT_TIMEOUT_MS}"
+            },
+        )
+        _ENGINE_URL = url
+    return _ENGINE
+
+
+def _fetch_sync() -> dict[str, Any] | None:
+    engine = _get_engine()
+    if engine is None:
+        raise RuntimeError("metacog_trend_cue_dsn_unset")
+    prediction_errors = latest_node_prediction_errors(engine, PREDICTION_ERROR_NODE_IDS)
+    induction_by_node = latest_biometrics_induction_by_node(
+        engine, _induction_nodes(), max_age_sec=_induction_max_age_sec()
+    )
+    return build_recent_trend_signals_cue(
+        prediction_errors=prediction_errors,
+        induction_by_node=induction_by_node,
+        generated_at=datetime.now(timezone.utc),
+    )
+
+
+async def fetch_recent_trend_signals(correlation_id: str) -> dict[str, Any] | None:
+    """Bounded fail-open fetch. Returns `None` on any disabled/unset/timeout/
+    error condition -- caller renders that as an empty cue, never a crash."""
+    if not _flag_enabled():
+        return None
+    if not _dsn():
+        logger.debug(
+            "metacog_trend_cue_dsn_unset correlation_id=%s", correlation_id
+        )
+        return None
+
+    timeout_sec = _timeout_sec()
+    t0 = time.perf_counter()
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(_fetch_sync), timeout=timeout_sec
+        )
+    except asyncio.TimeoutError:
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        logger.warning(
+            "metacog_trend_cue_fetch_timeout correlation_id=%s elapsed_ms=%s timeout_sec=%s",
+            correlation_id,
+            elapsed_ms,
+            timeout_sec,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 -- fail-open by contract
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        logger.warning(
+            "metacog_trend_cue_fetch_failed correlation_id=%s elapsed_ms=%s exc_type=%s err=%s",
+            correlation_id,
+            elapsed_ms,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
+def reset_metacog_trend_reader_engine_for_tests() -> None:
+    global _ENGINE, _ENGINE_URL
+    _ENGINE = None
+    _ENGINE_URL = None

--- a/services/orion-cortex-exec/tests/test_metacog_trend_cue_prompt_render.py
+++ b/services/orion-cortex-exec/tests/test_metacog_trend_cue_prompt_render.py
@@ -1,0 +1,101 @@
+"""Tier 1 patch: renders the real log_orion_metacognition_draft.j2 template
+with a ctx containing `recent_trend_signals_json` and asserts the new RECENT
+TREND SIGNALS section shows up with the real value -- a render-shape test,
+not just an assertion that the ctx key was set.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+EXEC_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_PATH = ROOT / "orion" / "cognition" / "prompts" / "log_orion_metacognition_draft.j2"
+
+
+def _load_executor_module():
+    app_dir = EXEC_ROOT / "app"
+    executor_path = app_dir / "executor.py"
+    package_name = "orion_cortex_exec_trend_cue_render"
+    app_package_name = f"{package_name}.app"
+    if package_name not in sys.modules:
+        pkg = types.ModuleType(package_name)
+        pkg.__path__ = [str(app_dir.parent)]
+        sys.modules[package_name] = pkg
+    if app_package_name not in sys.modules:
+        pkg = types.ModuleType(app_package_name)
+        pkg.__path__ = [str(app_dir)]
+        sys.modules[app_package_name] = pkg
+    spec = importlib.util.spec_from_file_location(f"{app_package_name}.executor", executor_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _base_ctx() -> dict:
+    return {
+        "trigger": {
+            "trigger_kind": "baseline",
+            "reason": "scheduled_check",
+            "pressure": 0.2,
+            "zen_state": "calm",
+        },
+    }
+
+
+def test_recent_trend_signals_section_renders_real_data():
+    executor = _load_executor_module()
+    cue = {
+        "prediction_error": {
+            "node:substrate.execution": 0.297,
+            "node:substrate.biometrics": 0.155,
+        },
+        "biometrics_induction": {
+            "athena": {
+                "channel": "cpu",
+                "trend": 0.505,
+                "level": 0.31,
+                "spike_rate": 0.0,
+                "volatility": 0.063,
+            },
+        },
+        "as_of": "2026-07-30T02:28:44+00:00",
+    }
+    ctx = _base_ctx()
+    ctx["recent_trend_signals_json"] = json.dumps(cue, indent=2)
+
+    prompt = executor._render_prompt(TEMPLATE_PATH.read_text(encoding="utf-8"), ctx)
+
+    assert "RECENT TREND SIGNALS" in prompt
+    assert '"node:substrate.execution": 0.297' in prompt
+    assert '"channel": "cpu"' in prompt
+    assert '"trend": 0.505' in prompt
+
+
+def test_recent_trend_signals_section_renders_empty_object_when_absent():
+    executor = _load_executor_module()
+    ctx = _base_ctx()
+    ctx["recent_trend_signals_json"] = "{}"
+
+    prompt = executor._render_prompt(TEMPLATE_PATH.read_text(encoding="utf-8"), ctx)
+
+    assert "RECENT TREND SIGNALS" in prompt
+    assert "{}" in prompt
+
+
+def test_template_does_not_crash_when_key_missing():
+    """Matches the sibling recent_turn_effect_alerts_json block's own convention
+    of having no defensive default in _render_prompt's `defaults` dict --
+    Jinja's default Undefined renders as an empty string rather than raising."""
+    executor = _load_executor_module()
+    ctx = _base_ctx()
+
+    prompt = executor._render_prompt(TEMPLATE_PATH.read_text(encoding="utf-8"), ctx)
+
+    assert "RECENT TREND SIGNALS" in prompt

--- a/services/orion-cortex-exec/tests/test_metacog_trend_reader.py
+++ b/services/orion-cortex-exec/tests/test_metacog_trend_reader.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app import metacog_trend_reader as mtr
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine(monkeypatch: pytest.MonkeyPatch):
+    mtr.reset_metacog_trend_reader_engine_for_tests()
+    monkeypatch.setenv(
+        "SUBSTRATE_FELT_STATE_DATABASE_URL",
+        "postgresql://postgres:postgres@localhost:5432/conjourney",
+    )
+    monkeypatch.setenv("ENABLE_METACOG_TREND_CUE", "true")
+    monkeypatch.setenv("METACOG_TREND_CUE_FETCH_TIMEOUT_SEC", "0.8")
+    yield
+    mtr.reset_metacog_trend_reader_engine_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_fetch_sync() -> dict[str, Any]:
+        return {
+            "prediction_error": {
+                "node:substrate.execution": 0.297,
+                "node:substrate.biometrics": 0.155,
+            },
+            "biometrics_induction": {
+                "athena": {"channel": "cpu", "trend": 0.505},
+            },
+        }
+
+    monkeypatch.setattr(mtr, "_fetch_sync", _fake_fetch_sync)
+    cue = await mtr.fetch_recent_trend_signals("corr-1")
+    assert cue is not None
+    assert cue["prediction_error"]["node:substrate.execution"] == 0.297
+    assert cue["biometrics_induction"]["athena"]["channel"] == "cpu"
+
+
+@pytest.mark.asyncio
+async def test_fetch_disabled_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLE_METACOG_TREND_CUE", "false")
+    cue = await mtr.fetch_recent_trend_signals("corr-2")
+    assert cue is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_dsn_unset_fail_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SUBSTRATE_FELT_STATE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("ENDOGENOUS_RUNTIME_SQL_DATABASE_URL", raising=False)
+    cue = await mtr.fetch_recent_trend_signals("corr-3")
+    assert cue is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeout_fail_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("METACOG_TREND_CUE_FETCH_TIMEOUT_SEC", "0.05")
+
+    def _slow() -> dict[str, Any]:
+        import time
+
+        time.sleep(0.3)
+        return {"prediction_error": {}, "biometrics_induction": {}}
+
+    monkeypatch.setattr(mtr, "_fetch_sync", _slow)
+    cue = await mtr.fetch_recent_trend_signals("corr-4")
+    assert cue is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_exception_fail_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> dict[str, Any]:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(mtr, "_fetch_sync", _boom)
+    cue = await mtr.fetch_recent_trend_signals("corr-5")
+    assert cue is None
+
+
+def test_induction_nodes_defaults() -> None:
+    assert mtr._induction_nodes() == ("athena", "atlas", "circe")
+
+
+def test_induction_nodes_parses_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("METACOG_TREND_CUE_NODES", "athena, atlas")
+    assert mtr._induction_nodes() == ("athena", "atlas")
+
+
+def test_dsn_falls_back_to_endogenous_runtime_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SUBSTRATE_FELT_STATE_DATABASE_URL", raising=False)
+    monkeypatch.setenv(
+        "ENDOGENOUS_RUNTIME_SQL_DATABASE_URL",
+        "postgresql://postgres:postgres@localhost:5432/conjourney",
+    )
+    assert mtr._dsn() == "postgresql://postgres:postgres@localhost:5432/conjourney"


### PR DESCRIPTION
## Summary

- `MetacogContextService` (`services/orion-cortex-exec/app/executor.py`) now reads the *latest* `substrate_field_state` `prediction_error` for `node:substrate.execution`/`node:substrate.biometrics`, and the latest per-node `orion_biometrics_induction` trend row (athena/atlas/circe), into a new additive `RECENT TREND SIGNALS` evidence-cue block.
- New pure read functions: `orion/substrate/metacog_trend_signals.py` (generalizes `bus_synaptic_surprise.py`'s single-row `substrate_field_state` read to multiple node ids; adds a `DISTINCT ON (node)` reader for `orion_biometrics_induction`).
- New bounded, fail-open async wiring: `services/orion-cortex-exec/app/metacog_trend_reader.py`, mirroring the existing `drive_state_postgres.py` convention (cached engine, `asyncio.wait_for(asyncio.to_thread(...))`, never raises).
- New prompt section in `orion/cognition/prompts/log_orion_metacognition_draft.j2` ("RECENT TREND SIGNALS"), same style as the existing "RECENT TURN-EFFECT ALERTS" block. Purely additive input -- `MetacogDraftService`/`MetacogPublishService`/`MetacogDraftTextPatchV1` are untouched.
- New env keys in `services/orion-cortex-exec/.env_example`: `ENABLE_METACOG_TREND_CUE`, `METACOG_TREND_CUE_NODES`, `METACOG_TREND_CUE_FETCH_TIMEOUT_SEC`, `METACOG_TREND_CUE_INDUCTION_MAX_AGE_SEC`.
- Implements the "Recommended next patch" (Missing Question 3's cheapest option) from `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md`; added a "2026-07-29/30 update" section to that doc recording the authorization and scope.

## Outcome moved

Metacog's per-turn LLM draft previously had zero temporal/trend context beyond its own single-tick snapshot (per the design doc's arsonist summary). It now sees the latest real surprise/prediction-error scores for two substrate domains and the latest real per-node hardware trend stats -- both already computed upstream, read fresh, not fabricated -- as evidence cues it may (not must) draw on.

## Current architecture

`MetacogContextService` already did real single-RPC context-gathering (spark/state snapshot, turn_effect, recent alerts, biometrics cue, substrate felt-state cue) but had no path to trend/windowed data at all -- `orion_metacog` history was never read back, and neither `substrate_field_state`'s prediction_error nor `orion_biometrics_induction`'s trend stats reached the draft prompt.

## Architecture touched

- `services/orion-cortex-exec/app/executor.py`: `MetacogContextService` step gains one new async call + two new `ctx` keys (`recent_trend_signals`, `recent_trend_signals_json`); `recent_trend_signals_json` added to `_METACOG_DRAFT_CTX_LEN_KEYS` for prompt-size diagnostics parity.
- New files: `orion/substrate/metacog_trend_signals.py`, `services/orion-cortex-exec/app/metacog_trend_reader.py`.
- `orion/cognition/prompts/log_orion_metacognition_draft.j2`: new prompt section.
- `services/orion-cortex-exec/.env_example`: 4 new keys.
- `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md`: implementation note.

## Files changed

- `orion/substrate/metacog_trend_signals.py`: new -- `latest_node_prediction_errors`, `latest_biometrics_induction_by_node`, `most_notable_trend_channel`, `build_recent_trend_signals_cue`.
- `services/orion-cortex-exec/app/metacog_trend_reader.py`: new -- bounded/fail-open async wrapper (DSN resolution, cached engine, timeout).
- `services/orion-cortex-exec/app/executor.py`: wires the new reader into `MetacogContextService`.
- `orion/cognition/prompts/log_orion_metacognition_draft.j2`: renders the new evidence cue.
- `services/orion-cortex-exec/.env_example`: new env keys + comment block.
- `orion/substrate/tests/test_metacog_trend_signals.py`, `services/orion-cortex-exec/tests/test_metacog_trend_reader.py`, `services/orion-cortex-exec/tests/test_metacog_trend_cue_prompt_render.py`: new tests.
- `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md`: "2026-07-29/30 update" implementation note.

## Schema / bus / API changes

- Added: none (no new bus channel, no new schema/registry entry -- this reads two pre-existing Postgres tables directly, following the exact precedent `orion/substrate/bus_synaptic_surprise.py` already established for `substrate_field_state`).
- Removed: none.
- Renamed: none.
- Behavior changed: `MetacogContextService`'s ctx now carries `recent_trend_signals`/`recent_trend_signals_json`; the draft prompt has one new evidence-cue section. `MetacogDraftTextPatchV1`'s output shape is unchanged.
- Compatibility notes: fully additive and fail-open; disabling `ENABLE_METACOG_TREND_CUE` (or leaving DSN unset) reverts to the exact prior prompt shape (`recent_trend_signals_json` renders as `"{}"`).

## Env/config changes

- Added keys: `ENABLE_METACOG_TREND_CUE=true`, `METACOG_TREND_CUE_NODES=athena,atlas,circe`, `METACOG_TREND_CUE_FETCH_TIMEOUT_SEC=0.8`, `METACOG_TREND_CUE_INDUCTION_MAX_AGE_SEC=180`.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: yes (`services/orion-cortex-exec/.env_example`).
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: ran; this worktree has no local `.env` files for any service (fresh worktree, gitignored), so the script reported "skip ... no .env" for every service including orion-cortex-exec. Nothing to sync in this environment; flagging for the operator's own machine.
- skipped keys requiring operator action: none.
- No new DB URL env var: reuses `SUBSTRATE_FELT_STATE_DATABASE_URL` / `ENDOGENOUS_RUNTIME_SQL_DATABASE_URL` (same conjourney instance every other cortex-exec Postgres reader already targets).

## Tests run

```text
/mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest orion/substrate/tests/test_metacog_trend_signals.py services/orion-cortex-exec/tests/test_metacog_trend_reader.py services/orion-cortex-exec/tests/test_metacog_trend_cue_prompt_render.py -q
-> 23 passed

/mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest orion/substrate/tests/test_bus_synaptic_surprise.py services/orion-cortex-exec/tests/test_drive_state_postgres.py -q
-> 15 passed (regression check on the sibling patterns this reuses)

/mnt/scripts/Orion-Sapienform/venv/bin/python3 -m pytest services/orion-cortex-exec/tests/test_metacog_draft_trigger_kind_type_mapping.py services/orion-cortex-exec/tests/test_metacog_publish_lane.py services/orion-cortex-exec/tests/test_metacog_route_profile.py services/orion-cortex-exec/tests/test_metacog_trigger_lineage.py services/orion-cortex-exec/tests/test_metacog_two_pass_draft.py services/orion-cortex-exec/tests/test_metacog_trend_reader.py services/orion-cortex-exec/tests/test_metacog_trend_cue_prompt_render.py -q
-> 45 passed (no regression in the metacog test surface this patch touches)
```

Also live-verified end-to-end against the real running Postgres (not mocked): `fetch_recent_trend_signals()` and the real Jinja render both produce real, non-degenerate values off the live `substrate_field_state`/`orion_biometrics_induction` tables (see the final chat response for the actual JSON and rendered prompt block).

Note: `services/orion-cortex-exec/tests/ -k metacog` (whole-directory run) hits 12 pre-existing collection errors (`ValueError: Verb already registered: legacy.plan`) from unrelated test files importing `app.main` more than once in the same session -- a pre-existing cross-test-pollution issue in this suite, not introduced by this patch. Ran the specific metacog-named files directly instead (all pass, shown above).

## Evals run

No eval harness exists for `orion-cortex-exec`'s prompt-context assembly specifically. This patch's own live-data sanity check (CLAUDE.md's metric-quality-gate step 4) was already run against real Postgres history for both signal sources earlier this session (numbers recorded in the design doc's "2026-07-28 update" and "2026-07-29/30 update" sections) rather than re-derived here.

## Docker/build/smoke checks

Docker not run for this patch: purely additive prompt-context code behind a Postgres read, no new bus channel/dependency/port/health-check/compose wiring. Verified `services/orion-cortex-exec/docker-compose.yml` uses a blanket `env_file: - .env` directive, so the 4 new env keys need no explicit compose wiring (confirmed by reading the compose file, not assumed).

## Review findings fixed

- Finding: `orion/substrate/metacog_trend_signals.py` and `services/orion-cortex-exec/app/metacog_trend_reader.py`'s docstrings cited a "2026-07-29/30 update" section of the design doc that did not exist yet (the doc, as of the review, ended at the "2026-07-28 update" section) -- a real citation/provenance bug, flagged should-fix given this repo's documented history of confabulated-provenance incidents.
  - Fix: added the actual "2026-07-29/30 update" section to `docs/superpowers/specs/2026-07-28-metacog-turn-scoped-trend-reducer-design.md`, recording Juniper's out-of-band "do it tier 1" authorization and this patch's real scope/numbers; corrected `metacog_trend_signals.py`'s docstring to cite the doc's actual "Missing questions" §3 for the design rationale instead.
  - Evidence: see commit "docs(metacog): fix fabricated design-doc citation + record Tier 1 authorization"; re-ran the 23 new/changed tests after the fix, all still pass.
- Finding (nit, not blocking): `latest_biometrics_induction_by_node`'s `timestamp::timestamptz` cast (needed because `orion_biometrics_induction.timestamp` is a text column, not native timestamptz) would throw if any row in the whole table has a malformed timestamp, not just the queried nodes' latest row -- caught by the fail-open wrapper, so the whole cue silently disappears rather than only affecting one node, but never crashes the caller.
  - Fix: not changed (correctly contained by the existing fail-open contract); documented as a known, non-blocking edge case.
  - Evidence: reviewed `orion/substrate/metacog_trend_signals.py`'s `latest_biometrics_induction_by_node` and `services/orion-cortex-exec/app/metacog_trend_reader.py`'s `fetch_recent_trend_signals` exception handling.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml \
  up -d --build orion-cortex-exec
```

## Risks / concerns

- Severity: low
- Concern: `orion_biometrics_induction` has no index on `(node, timestamp)`; the new `DISTINCT ON (node) ... ORDER BY node, timestamp::timestamptz DESC` query currently does a full sequential scan + sort (~60-150ms measured live against ~46k real rows at time of writing) rather than an index scan. Bounded by a per-connection `statement_timeout` (800ms default) and an outer `asyncio.wait_for` (same default), so it fails open rather than hanging, but will get slower as the table grows (~8k rows/day across 3 nodes).
- Mitigation: disclosed rather than silently accepted; a follow-up could add `Index("idx_orion_biometrics_induction_node_ts", "node", "timestamp")` to `services/orion-sql-writer/app/models/biometrics_induction.py` (that service's own established convention -- see `evidence_unit.py`/`grammar_trace.py` for precedent) if this cue's latency or table growth becomes a real problem. Deliberately not done in this patch since it touches a different service's schema and the current cost (well under the fetch timeout) doesn't yet warrant it.

## PR link

(filled in by gh pr create output)
