### PR TITLE
fix(embodiment): use the shared correlation_id on the social-turn envelope

### DIFF
--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -485,7 +485,7 @@ class EmbodimentWorker:
             )
             social_env = BaseEnvelope(
                 kind=SOCIAL_TURN_KIND, source=self._service_ref(),
-                correlation_id=uuid4(), payload=social_turn.model_dump(mode="json"),
+                correlation_id=correlation_id, payload=social_turn.model_dump(mode="json"),
             )
             await publish_with_reconnect(
                 self._bus, SOCIAL_TURN_CHANNEL, social_env, log_label="embodiment_social_turn"

--- a/services/orion-embodiment/tests/test_worker_conversation_memory.py
+++ b/services/orion-embodiment/tests/test_worker_conversation_memory.py
@@ -86,7 +86,14 @@ def test_speak_once_publishes_to_both_channels_with_shared_correlation_id():
     assert social_turn.response == "Hi Juniper!"
     # Both publishes for one exchange share a correlation_id, so a later
     # journal entry can cross-reference the exact chat-log/social-turn rows.
+    # Checked at BOTH the envelope level (what orion-sql-writer actually
+    # persists as each row's correlation_id column -- confirmed live: a prior
+    # version of this code set the social envelope's correlation_id to a
+    # fresh uuid4() instead of the shared one, and the payload-level check
+    # alone did not catch it) and the payload level.
+    assert str(chat_env.correlation_id) == str(social_env.correlation_id)
     assert str(chat_turn.correlation_id) == str(social_turn.correlation_id)
+    assert str(chat_env.correlation_id) == str(chat_turn.correlation_id)
 
     for turn in (chat_turn, social_turn):
         assert turn.client_meta["external_room"] == {"platform": "aitown", "room_id": "conv1"}


### PR DESCRIPTION
## Summary

- One-line bug in `_publish_conversation_memory` (`services/orion-embodiment/app/worker.py`), introduced in #1478: the social-turn `BaseEnvelope` was built with `correlation_id=uuid4()` instead of the shared `correlation_id` variable also used for the chat-history-turn envelope.
- Confirmed live on athena's Postgres immediately after #1478 deployed: `chat_history_log` and `social_room_turns` rows for the same Orion<->NPC exchange (matching prompt/response text) had different `correlation_id` values.
- This breaks the cross-reference `JournalTriggerV1.spawned_correlation_id` is meant to provide (it points at the shared value, which matched `chat_history_log` but not `social_room_turns`).

## Outcome moved

Both tables now persist the same correlation_id per exchange, restoring the intended cross-reference.

## Files changed

- `services/orion-embodiment/app/worker.py`: `correlation_id=uuid4()` -> `correlation_id=correlation_id` on the social-turn envelope
- `services/orion-embodiment/tests/test_worker_conversation_memory.py`: strengthened the shared-correlation-id assertion to check the envelope-level `correlation_id` (what `orion-sql-writer` actually persists) on both envelopes, not just the payload-level field -- the prior test only checked the payload field, which was already correct, so it never caught this

## Tests run

```text
PYTHONPATH=<repo-root> pytest services/orion-embodiment/tests -q
70 passed
```

## Review findings fixed

Self-caught via live production data inspection (queried `chat_history_log`/`social_room_turns` directly on athena's Postgres after deploy to verify #1478 was working) rather than a separate review pass -- flagging here since it's a real correctness bug in already-merged, already-deployed code.

## Restart required

```bash
# On athena, once merged:
git pull --ff-only
docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: any `chat_history_log`/`social_room_turns` rows already written by the buggy code (a handful of exchanges during the ~12 minutes between #1478's deploy and this fix) have mismatched correlation_ids permanently -- the content itself is correct and undamaged, only the cross-reference linkage for those specific rows is broken.
- Mitigation: none needed -- low-value, small blast radius, not worth a backfill.

## PR link

(added by gh pr create output below)