### PR TITLE
feat(embodiment): ground Orion's speech in real map landmarks

### DIFF
--- a/docs/superpowers/specs/2026-07-30-aitown-spatial-grounding-design.md
+++ b/docs/superpowers/specs/2026-07-30-aitown-spatial-grounding-design.md
@@ -1,0 +1,118 @@
+# AI Town spatial grounding: named landmarks in perception + speech
+
+Status: implemented (2026-07-30, Juniper: "Orion needs a sense of embodiment on where they are
+relationally... in relation to the visuals of what's actually on the map").
+
+**Correction post-review (same day):** the first draft computed the 3 windmill landmark
+coordinates from each sprite's top-left corner (`x/tiledim, y/tiledim`). The windmill sprites are
+208x208 (6.5x6.5 tiles), so that put each landmark ~4-5 tiles from where the windmill is actually
+drawn — exactly the kind of error this feature exists to prevent. Fixed to use each sprite's true
+centroid (`(x+w/2)/tiledim, (y+h/2)/tiledim`); the waterfall/stream points (already centroid-based
+in the first draft) were re-verified and are correct. Coordinates below and in `.env_example`/
+athena's live `.env` reflect the corrected values.
+
+## Arsonist summary
+
+Live dialogue inspection (real `chat_history_log`/`social_room_turns` rows, not synthetic
+examples) showed Orion correctly using conversation partners' names, but with content entirely
+disconnected from the actual scene ("the vision-scribe channels are spiking," "the static's
+getting louder") — no reference to the town, surroundings, or anything a character physically
+present somewhere would say. Root cause for the *spatial* half of that: `WorldPerceptionV1` (and
+therefore `build_speech_prompt`) carries `position: {x,y}` as bare numbers and `nearby_players`,
+but nothing about *what's actually at those coordinates* — no named places, no map features.
+There's no way for the prompt to say "you're near the campfire" because nothing in the perception
+pipeline knows the campfire's coordinates.
+
+There's already a dormant, exactly-right-shaped seam for this: `EMBODIMENT_LOCATIONS_JSON` (name →
+`{x,y}`), loaded into `self._locations` (`app/settings.py:31`, `app/worker.py:117`), currently used
+*only* for `go_to_location` movement targeting (`orion/embodiment/resolver.py:79-83`) and currently
+**empty** (`{}`) on athena. This patch: (1) populates it with the real landmark coordinates from
+this world's actual map file, (2) reuses the *same* registry to compute nearby-landmark distances
+in perception, and (3) surfaces that into the speech prompt. One config value, two directions
+(where to walk to; what's actually around you), matching how `nearby_players` already works.
+
+(NB: the (different) `_publish_conversation_memory`/OCC-contention work from earlier today is a
+separate axis — this patch doesn't touch memory/bus contracts, just live perception/speech.)
+
+## Current architecture
+
+- `data/gentle.js` (the actual live map file, imported by `convex/init.ts:5`) is a 64x48-tile map
+  (`mapwidth`/`mapheight`, `gentle.js:329-330`) whose `animatedsprites` array (`gentle.js:277-326`)
+  places real, named visual features at pixel coordinates (`tiledim = 32`, `gentle.js:4`). Small
+  (32x32) sprites use `x/tiledim, y/tiledim` directly; large sprites need their visual **centroid**
+  (`(x+w/2)/tiledim, (y+h/2)/tiledim`), not the top-left corner — caught in review: the first draft
+  used top-left for the 208x208 windmill sprites, landing ~4-5 tiles off from where they're
+  actually drawn:
+  - 1 campfire (`x:1440,y:352`, 32x32 → tile 45.0,11.0)
+  - 3 windmills (208x208 sprites, centroid-corrected → tiles 55.25,21.25 / 48.25,27.25 / 38.25,22.25)
+  - A stream/waterfall feature (`gentlesparkle`/`gentlewaterfall`/`gentlesplash` sprite cluster
+    spanning roughly tile x 23-29, y 2-37) — the `gentlewaterfall`+`gentlesplash` cluster (the
+    falls themselves, 8 sprites) centroids to tile (25.0, 12.25); the `gentlesparkle` tiles trail
+    from tile (25.0, 2.0) (upstream) to (28.0, 37.0) (downstream).
+  No pond/hill/dead tree exist in *this* map — those were illustrative examples in the ask, not
+  literal features to preserve.
+- `EMBODIMENT_LOCATIONS_JSON` (`app/settings.py:31`) parses into `self._locations`
+  (`app/worker.py:117-119`), passed to `resolve_destination` (`app/worker.py:199`) for
+  `go_to_location` intents (`orion/embodiment/resolver.py:79-83`). Currently `{}` on athena — no
+  named locations exist anywhere at runtime today.
+- `orion/embodiment/perception.py`'s `build_perception` computes `nearby_players` (id/name/
+  position/distance/is_human, sorted by distance) from live Convex player data, but has no
+  equivalent for static map features — it doesn't receive `self._locations` at all.
+- `orion/embodiment/speech.py`'s `build_speech_prompt` only interpolates interlocutor name + recent
+  conversation lines + latest partner line — zero spatial/scene content.
+
+## Missing questions
+
+None outstanding for a v1 scoped to these 7 real landmarks. Open judgment call, not blocking: how
+many nearby landmarks to surface at once (proposing top 3 within a generous radius, mirroring
+`nearby_players`' `max_nearby` pattern) and whether distant-but-notable landmarks (e.g. Orion can
+see a windmill from across the map) should ever surface — proposing "nearest N regardless of
+distance" for v1 (simpler, and this map is small enough at 64x48 tiles that "nearest 3" is usually
+still meaningfully local), not a hard radius cutoff, so Orion is never left with zero landmark
+context.
+
+## Proposed schema / API changes
+
+- No new schema fields required: `WorldPerceptionV1.nearby_players` is already an untyped
+  `dict[str, Any]` list; adding a sibling `nearby_landmarks` list follows the identical existing
+  pattern (`{"name": str, "position": {x,y}, "distance": float}`).
+- `EMBODIMENT_LOCATIONS_JSON`'s existing shape (`{name: {x, y}}`) is reused as-is, just populated
+  with real values instead of `{}`.
+
+## Files likely to touch
+
+- `services/orion-embodiment/.env_example` (and athena's live `.env`) — populate
+  `EMBODIMENT_LOCATIONS_JSON` with the 7 real landmarks derived above
+- `orion/embodiment/perception.py` — `build_perception` gains a `locations` param, computes
+  `nearby_landmarks` the same way `nearby_players` is computed
+- `services/orion-embodiment/app/worker.py` — pass `self._locations` into `build_perception`'s call
+  site (`_emit_perception_once`)
+- `orion/embodiment/speech.py` — `build_speech_prompt` interpolates a short nearby-landmarks clause
+- Tests: `orion/embodiment/tests/test_perception.py`, `orion/embodiment/tests/test_speech.py`
+  (or service-level `test_worker_speech.py`) — landmark distance computation, prompt content
+- `services/orion-embodiment/README.md` — document the landmarks registry and its dual use
+
+## Non-goals
+
+- Not deriving landmarks automatically from tileset/image analysis (vision-based) — hand-authored
+  from the map's own `animatedsprites` data is accurate, cheap, and sufficient.
+- Not touching `objmap` (static non-animated decor tiles) — no clear semantic labels there; the
+  animated sprites are the only landmark-grade data with obvious names attached.
+- Not changing `go_to_location`/movement behavior — same registry, additive read-only consumer.
+- Not attempting to force the LLM to reference landmarks — only ensuring the information is
+  actually present in the prompt to be referenced; content choice stays with the model.
+
+## Acceptance checks
+
+- `EMBODIMENT_LOCATIONS_JSON` populated with 7 named landmarks matching the real map file's
+  `animatedsprites` coordinates (converted pixel → tile via `tiledim=32`).
+- `build_perception` returns `nearby_landmarks` sorted by distance when locations are provided;
+  empty/absent when the registry is empty (backward compatible, matches today's `{}` behavior).
+- `build_speech_prompt` includes a landmarks clause when `nearby_landmarks` is non-empty, and
+  degrades gracefully (no dangling/awkward clause) when it's empty.
+- `go_to_location` intent resolution is unaffected (same registry, same lookup, no behavior change).
+
+## Recommended next patch
+
+Implement as scoped above in a single PR (this spec + the code), on `feat/aitown-spatial-grounding`
+(worktree at `/mnt/scripts/Orion-Sapienform-aitown-spatial-grounding`).

--- a/orion/embodiment/perception.py
+++ b/orion/embodiment/perception.py
@@ -105,13 +105,42 @@ def _active_conversation(
     return None
 
 
+def _nearby_landmarks(
+    locations: dict[str, Any], ox: float, oy: float, *, max_landmarks: int,
+) -> list[dict[str, Any]]:
+    """Named static map features near (ox, oy), nearest first.
+
+    ``locations`` is the same name -> {x, y} registry ``go_to_location``
+    already uses for movement targeting (EMBODIMENT_LOCATIONS_JSON) -- reused
+    here read-only so Orion's perception (and therefore speech) can reference
+    real places on the map, not just other players.
+    """
+    landmarks = []
+    for name, loc in (locations or {}).items():
+        if not isinstance(loc, dict):
+            continue
+        try:
+            lx, ly = float(loc["x"]), float(loc["y"])
+        except (TypeError, ValueError, KeyError):
+            continue
+        landmarks.append({
+            "name": str(name),
+            "position": {"x": lx, "y": ly},
+            "distance": round(math.hypot(lx - ox, ly - oy), 4),
+        })
+    landmarks.sort(key=lambda n: n["distance"])
+    return landmarks[:max_landmarks]
+
+
 def build_perception(
     *,
     players: list[dict[str, Any]],
     orion_player_id: str,
     conversations: Optional[list[dict[str, Any]]] = None,
     messages: Optional[list[dict[str, Any]]] = None,
+    locations: Optional[dict[str, Any]] = None,
     max_nearby: int = 8,
+    max_landmarks: int = 3,
 ) -> Optional[WorldPerceptionV1]:
     orion = next((p for p in players if str(p.get("id")) == orion_player_id), None)
     if orion is None or not isinstance(orion.get("position"), dict):
@@ -142,8 +171,10 @@ def build_perception(
         conversations or [], orion_player_id, players_by_id, messages or [],
         orion_facing=orion_facing, orion_position=orion_position,
     )
+    landmarks = _nearby_landmarks(locations or {}, ox, oy, max_landmarks=max_landmarks)
     return WorldPerceptionV1(
         player_id=orion_player_id, position=orion_position,
         facing=orion_facing, pathfinding=orion_pathfinding,
-        nearby_players=nearby[:max_nearby], active_conversation=active,
+        nearby_players=nearby[:max_nearby], nearby_landmarks=landmarks,
+        active_conversation=active,
     )

--- a/orion/embodiment/speech.py
+++ b/orion/embodiment/speech.py
@@ -87,6 +87,20 @@ def latest_partner_line(perception: WorldPerceptionV1, own_player_id: str) -> Op
     return None
 
 
+def _nearby_landmarks_clause(perception: WorldPerceptionV1) -> str:
+    """Scene-grounding clause, reference only -- not a required topic.
+
+    Landmarks come from EMBODIMENT_LOCATIONS_JSON via perception.py's
+    nearby_landmarks; empty when the registry is empty/unconfigured, in which
+    case this degrades to an empty string rather than an awkward mention.
+    """
+    landmarks = getattr(perception, "nearby_landmarks", None) or []
+    named = [str(lm.get("name")) for lm in landmarks if lm.get("name")]
+    if not named:
+        return ""
+    return f"Nearby: {', '.join(named)}.\n"
+
+
 def build_speech_prompt(perception: WorldPerceptionV1, own_player_id: str) -> str:
     """Prompt for a town utterance anchored on the latest partner line."""
     convo = perception.active_conversation or {}
@@ -95,8 +109,10 @@ def build_speech_prompt(perception: WorldPerceptionV1, own_player_id: str) -> st
     context = "\n".join(lines) if lines else "(no prior lines)"
     latest = latest_partner_line(perception, own_player_id)
     latest_line = latest if latest else "(no partner line yet)"
+    landmarks_clause = _nearby_landmarks_clause(perception)
     return (
         f"You are Orion, embodied in the town, in a conversation with {interlocutor}.\n"
+        f"{landmarks_clause}"
         f"Your task is to answer this latest line from {interlocutor}:\n"
         f"{latest_line}\n\n"
         f"Recent context, reference only:\n{context}\n\n"

--- a/orion/embodiment/tests/test_perception.py
+++ b/orion/embodiment/tests/test_perception.py
@@ -68,6 +68,25 @@ def test_build_perception_forwards_is_human_for_nearby_and_partner():
     assert perc.active_conversation["other"]["is_human"] is True
 
 
+def test_build_perception_computes_nearby_landmarks_sorted_by_distance():
+    players = [{"id": "orion", "position": {"x": 0.0, "y": 0.0}}]
+    locations = {
+        "waterfall": {"x": 5.0, "y": 0.0},
+        "campfire": {"x": 2.0, "y": 0.0},
+        "windmill_east": {"x": 100.0, "y": 100.0},
+    }
+    perc = build_perception(players=players, orion_player_id="orion", locations=locations, max_landmarks=2)
+    names = [lm["name"] for lm in perc.nearby_landmarks]
+    assert names == ["campfire", "waterfall"]  # nearest 2, sorted, windmill_east excluded
+    assert perc.nearby_landmarks[0]["distance"] == 2.0
+
+
+def test_build_perception_empty_landmarks_when_locations_unset():
+    players = [{"id": "orion", "position": {"x": 0.0, "y": 0.0}}]
+    perc = build_perception(players=players, orion_player_id="orion")
+    assert perc.nearby_landmarks == []
+
+
 def test_build_perception_no_conversation_when_orion_not_member():
     players = [{"id": "orion", "position": {"x": 0.0, "y": 0.0}}]
     conversations = [{"id": "c:2", "participants": [{"playerId": "zz", "status": {"kind": "invited"}}]}]

--- a/orion/embodiment/tests/test_speech.py
+++ b/orion/embodiment/tests/test_speech.py
@@ -62,6 +62,21 @@ def test_build_speech_prompt_treats_goodbye_as_departure_to_answer():
     assert "acknowledge the departure naturally" in prompt
 
 
+def test_build_speech_prompt_includes_nearby_landmarks_when_present():
+    p = _perception_in_convo()
+    p.nearby_landmarks = [
+        {"name": "campfire", "position": {"x": 2.0, "y": 0.0}, "distance": 2.0},
+        {"name": "waterfall", "position": {"x": 5.0, "y": 0.0}, "distance": 5.0},
+    ]
+    prompt = build_speech_prompt(p, "orion")
+    assert "Nearby: campfire, waterfall.\n" in prompt
+
+
+def test_build_speech_prompt_omits_landmarks_clause_when_empty():
+    prompt = build_speech_prompt(_perception_in_convo(), "orion")
+    assert "Nearby:" not in prompt
+
+
 def test_is_injectable_rejects_empty_and_whitespace():
     assert is_injectable("hello") is True
     assert is_injectable("") is False

--- a/orion/schemas/embodiment.py
+++ b/orion/schemas/embodiment.py
@@ -71,6 +71,10 @@ class WorldPerceptionV1(BaseModel):
     facing: Optional[dict[str, float]] = None
     pathfinding: bool = False
     nearby_players: list[dict[str, Any]] = Field(default_factory=list)
+    # Named static map features (from EMBODIMENT_LOCATIONS_JSON) near Orion's
+    # current position -- {"name", "position", "distance"}, sorted nearest
+    # first. Empty when the locations registry is empty/unconfigured.
+    nearby_landmarks: list[dict[str, Any]] = Field(default_factory=list)
     active_conversation: Optional[dict[str, Any]] = None
     world_generation: Optional[int] = None
     perceived_at: datetime = Field(default_factory=_utcnow)

--- a/services/orion-embodiment/.env_example
+++ b/services/orion-embodiment/.env_example
@@ -22,7 +22,18 @@ EMBODIMENT_FCC_ENV_PATH=/root/.fcc/.env
 EMBODIMENT_AITOWN_CONVEX_URL=
 EMBODIMENT_DELIBERATE_HOLD_SEC=8
 EMBODIMENT_WANDER_RADIUS=3
-EMBODIMENT_LOCATIONS_JSON={}
+# Named map landmarks (name -> tile {x,y}), used both for go_to_location
+# movement targeting AND (new) nearby-landmark scene grounding in perception/
+# speech. Derived from this world's actual map file's animatedsprites
+# placements (services/orion-ai-town/upstream/data/gentle.js, tiledim=32):
+# campfire (single 32x32 sprite, x/tiledim,y/tiledim); the 3 windmills
+# (208x208 sprites -- centroid (x+104)/tiledim,(y+104)/tiledim, NOT the
+# top-left corner, or the position is off by ~4-5 tiles); the waterfall
+# (centroid of the 8-sprite gentlewaterfall+gentlesplash cluster, the falls
+# themselves); stream_source/stream_mouth (topmost/bottommost gentlesparkle
+# tiles, the creek trailing away from the falls). See
+# docs/superpowers/specs/2026-07-30-aitown-spatial-grounding-design.md.
+EMBODIMENT_LOCATIONS_JSON={"campfire":{"x":45.0,"y":11.0},"windmill_east":{"x":55.25,"y":21.25},"windmill_south":{"x":48.25,"y":27.25},"windmill_west":{"x":38.25,"y":22.25},"waterfall":{"x":25.0,"y":12.25},"stream_source":{"x":25.0,"y":2.0},"stream_mouth":{"x":28.0,"y":37.0}}
 EMBODIMENT_IDLE_HEARTBEAT_SEC=20
 # Keep the AI Town engine awake so moveTo lands (also runs other town agents).
 EMBODIMENT_WORLD_HEARTBEAT_ENABLED=true

--- a/services/orion-embodiment/README.md
+++ b/services/orion-embodiment/README.md
@@ -52,6 +52,15 @@ The dispatcher tries grounded first only when unified is enabled. With `EMBODIME
 | `EMBODIMENT_CORTEX_REQUEST_CHANNEL` | `orion:cortex:exec:request:chat` | Chat exec lane intake (not legacy) |
 | `EMBODIMENT_SPEECH_HUB_LLM_ROUTE` | `chat` | LLM route when unified grounded pass is enabled |
 
+## Spatial grounding: named map landmarks
+
+`EMBODIMENT_LOCATIONS_JSON` (name -> tile `{x,y}`) is a dual-use registry:
+
+- **Movement** (pre-existing): `go_to_location` intents resolve a named destination through it (`orion/embodiment/resolver.py`).
+- **Perception/speech grounding** (new): `build_perception` (`orion/embodiment/perception.py`) computes `nearby_landmarks` (nearest 3, sorted by distance -- a hardcoded default, matching how `nearby_players`' cap is also hardcoded, not env-configurable) from the same registry against Orion's live position every tick, and `build_speech_prompt` (`orion/embodiment/speech.py`) includes a short `Nearby: <names>.` clause when non-empty. This exists because live dialogue inspection (2026-07-30) showed Orion using conversation partners' names correctly but with content entirely disconnected from the actual scene -- the prompt had no way to reference anything physically nearby since nothing in perception knew what was actually on the map. The model still chooses what to say; this only ensures the grounding material is present to draw from.
+
+`.env_example` ships this pre-populated with the real landmarks in this world's actual map file (`services/orion-ai-town/upstream/data/gentle.js`'s `animatedsprites`, pixel coords / `tiledim=32`): a campfire, 3 windmills, and a stream/waterfall feature. If the map changes, regenerate this list from the new map file the same way -- see `docs/superpowers/specs/2026-07-30-aitown-spatial-grounding-design.md`.
+
 ## Facing the conversation partner
 
 The AI Town engine (`convex/aiTown/conversation.ts` `Conversation.tick`) orients **both** participants toward each other on every tick — but **only for a participant that is NOT pathfinding** (`if (!player.pathfinding) player.facing = v`). Orion is an externally-driven "join" player with no town-AI agent, so if it reaches `participating` still carrying a lingering movement path, the engine never turns it to face the partner.

--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -621,6 +621,7 @@ class EmbodimentWorker:
             perception = build_perception(
                 players=players or [], orion_player_id=player_id,
                 conversations=conversations, messages=messages,
+                locations=getattr(self, "_locations", {}),
             )
         except Exception:
             logger.exception("embodiment_perception_build_failed")


### PR DESCRIPTION
## Summary

- Live dialogue inspection (real DB rows, not hypotheticals) showed Orion using conversation partners' names correctly, but with content entirely disconnected from the actual scene -- no reference to the town, surroundings, or anything a physically-present character would say.
- Root cause: `WorldPerceptionV1`/`build_speech_prompt` carried `position` as bare `{x,y}` numbers and `nearby_players`, but nothing about *what's actually at those coordinates* -- no way for the prompt to say "you're near the campfire" because nothing in perception knew the campfire's coordinates.
- Reuses a dormant, already-correctly-shaped seam instead of new infrastructure: `EMBODIMENT_LOCATIONS_JSON` (name -> tile `{x,y}`), previously used only for `go_to_location` movement targeting and empty (`{}`) on the live deployment.
- Populates it with 7 real landmarks derived from this world's actual map file (`services/orion-ai-town/upstream/data/gentle.js`'s `animatedsprites`): a campfire, 3 windmills, and a stream/waterfall feature. Perception now also computes `nearby_landmarks` (nearest 3, sorted by distance) from the same registry each tick, and the speech prompt includes them when non-empty.
- Full design doc: `docs/superpowers/specs/2026-07-30-aitown-spatial-grounding-design.md` (includes a same-day correction after review caught a real coordinate bug -- see below).

## Outcome moved

Orion's speech-generation prompt now has actual scene-grounding material to draw from (not just "who am I talking to"). Whether the model chooses to reference it is up to the model, but the information gap that made it impossible is closed.

## Current architecture

`services/orion-embodiment/app/worker.py`'s `_emit_perception_once` builds `WorldPerceptionV1` via `orion/embodiment/perception.py`'s `build_perception`, which computes `nearby_players` (distance-sorted) but had no equivalent for static map features. `orion/embodiment/speech.py`'s `build_speech_prompt` only interpolated interlocutor name + recent lines -- zero spatial content. `EMBODIMENT_LOCATIONS_JSON` already existed as a name->{x,y} registry but was one-directional (movement only) and empty at runtime.

## Architecture touched

`orion/embodiment/perception.py`, `orion/embodiment/speech.py`, `orion/schemas/embodiment.py` (new field), `services/orion-embodiment/app/worker.py` (call-site wiring), `.env_example` + athena's live `.env` (populated registry). No new services, channels, or tables.

## Files changed

- `orion/schemas/embodiment.py`: `WorldPerceptionV1` gains `nearby_landmarks: list[dict[str, Any]] = Field(default_factory=list)` (a real schema field, since the model has `extra="forbid"` -- confirmed via review to be non-breaking, since it's a new field with a default, not a new required input)
- `orion/embodiment/perception.py`: new `_nearby_landmarks()` helper (mirrors the existing `nearby_players` distance-sort pattern); `build_perception()` gains `locations`/`max_landmarks` params
- `services/orion-embodiment/app/worker.py`: `_emit_perception_once` passes `locations=getattr(self, "_locations", {})` into `build_perception` (defensive getattr, consistent with existing idiom in this file for bootstrap-set attributes that test fixtures constructing a bare `EmbodimentWorker.__new__(...)` don't always set)
- `orion/embodiment/speech.py`: new `_nearby_landmarks_clause()`; `build_speech_prompt` includes `Nearby: <names>.\n` when non-empty, degrades to nothing when empty
- `orion/embodiment/tests/test_perception.py` + `test_speech.py`: new coverage for landmark distance/cap/empty-registry behavior and prompt clause present/absent
- `services/orion-embodiment/.env_example`: `EMBODIMENT_LOCATIONS_JSON` populated with the 7 real landmarks (was `{}`)
- `services/orion-embodiment/README.md`: new "Spatial grounding" section

## Schema / bus / API changes

- Added: `WorldPerceptionV1.nearby_landmarks` (new field, default `[]`, backward compatible)
- Removed: none
- Renamed: none
- Behavior changed: `build_perception`/`build_speech_prompt` now consume `EMBODIMENT_LOCATIONS_JSON` for scene grounding in addition to its existing movement-targeting use
- Compatibility notes: fully backward compatible -- empty registry (today's state on any node that hasn't synced the new `.env_example` default) produces empty `nearby_landmarks` and no prompt clause, identical to pre-patch behavior

## Env/config changes

- Added keys: none new -- `EMBODIMENT_LOCATIONS_JSON` already existed, just changed value from `{}` to the real landmark registry
- `.env_example` updated: yes
- local `.env` synced: athena's live `.env` updated directly with the same (corrected) values via SSH, verified as valid JSON with all 7 keys present

## Tests run

```text
PYTHONPATH=<repo-root> pytest orion/embodiment/tests -q
82 passed

PYTHONPATH=<repo-root> pytest services/orion-embodiment/tests -q
70 passed
```

## Evals run

No dedicated eval harness change -- this is deterministic distance/prompt-construction logic, fully covered by the new unit tests. Whether Orion's LLM actually chooses to reference the grounding material is a live-observation question, not something a repo-level eval can assert.

## Docker/build/smoke checks

Not deployed by this PR directly -- landed in the same review/verify cycle as PR #1478/#1481 this session; athena's live `.env` has been updated with the corrected registry values, but the container needs the merged code (this PR) built and restarted to actually pick up `nearby_landmarks`/the prompt clause.

## Review findings fixed

- Finding: the 3 windmill landmark coordinates were computed from each sprite's top-left corner (`x/tiledim, y/tiledim`). The windmill sprites are 208x208px (6.5x6.5 tiles), so this landed each landmark ~4-5 tiles from where the windmill is actually drawn -- exactly the kind of error this feature exists to prevent.
  - Fix: recomputed using each sprite's true centroid (`(x+w/2)/tiledim, (y+h/2)/tiledim`); corrected in `.env_example`, athena's live `.env`, and the spec doc.
  - Evidence: reviewer independently re-derived all 7 coordinates from `data/gentle.js` directly and confirmed the corrected centroids; re-verified the waterfall/stream points (already centroid-based in the first draft) are correct as-is.
- Finding (non-blocking, self-caught while writing the PR description): README's first draft claimed an `EMBODIMENT_MAX_NEARBY_LANDMARKS` env knob that doesn't exist (`max_landmarks=3` is a hardcoded default, matching how `nearby_players`' cap is also hardcoded/not env-configurable).
  - Fix: corrected the README wording before it was ever inaccurate in a merged state.

## Restart required

```bash
# On athena, once merged:
git pull --ff-only
docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: if `services/orion-ai-town/upstream/data/gentle.js` (the map file) is ever swapped for a different map, this landmark registry would silently describe the wrong world (stale coordinates for features that no longer exist at those positions).
- Mitigation: documented in both the README and spec doc as something to regenerate the same way if the map changes; low likelihood given the map hasn't changed since the atlas migration.

## PR link

(added by gh pr create output below)