### PR TITLE
fix(backup): give pg_dumpall its own timeout, not the shared 300s default

### DIFF
--- a/scripts/backup/orion_backup_databases.py
+++ b/scripts/backup/orion_backup_databases.py
@@ -38,6 +38,13 @@ from scripts.backup.orion_backup_mnt_scripts import (
 DEFAULT_STORAGE_WARM = Path("/mnt/storage-warm")
 DEFAULT_KEEP_SUCCESSFUL = 14
 DEFAULT_SUBPROCESS_TIMEOUT_SEC = 300
+# pg_dumpall duration grows with the live database's size (17GB and climbing as of
+# 2026-07-30; the last 5 nightly runs took 166s/168s/233s/266s/312s+, finally
+# exceeding DEFAULT_SUBPROCESS_TIMEOUT_SEC and failing the whole backup run on
+# 2026-07-30). A logical dump has no natural upper bound the way a fixed-size
+# snapshot does, so this gets its own generous timeout instead of sharing the
+# 300s default used for fast operations elsewhere in this script.
+POSTGRES_DUMP_TIMEOUT_SEC = 1800
 
 
 @dataclass(frozen=True)
@@ -117,7 +124,7 @@ def capture_postgres(dest_dir: Path, *, container: str, pg_user: str, log: list[
     cmd = ["docker", "exec", container, "pg_dumpall", "-U", pg_user]
     log.append("$ " + " ".join(cmd) + f" > {dest_file}")
     with dest_file.open("wb") as fh:
-        proc = subprocess.run(cmd, stdout=fh, stderr=subprocess.PIPE, timeout=DEFAULT_SUBPROCESS_TIMEOUT_SEC)
+        proc = subprocess.run(cmd, stdout=fh, stderr=subprocess.PIPE, timeout=POSTGRES_DUMP_TIMEOUT_SEC)
     if proc.returncode != 0:
         dest_file.unlink(missing_ok=True)
         raise RuntimeError(f"pg_dumpall failed ({proc.returncode}): {proc.stderr.decode(errors='replace')[:500]}")

--- a/tests/test_orion_backup_databases.py
+++ b/tests/test_orion_backup_databases.py
@@ -9,7 +9,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from scripts.backup.orion_backup_databases import (
+    DEFAULT_SUBPROCESS_TIMEOUT_SEC,
+    POSTGRES_DUMP_TIMEOUT_SEC,
     Target,
+    capture_postgres,
     capture_stopped_container_tree,
     run_backup,
     run_target_backup,
@@ -25,6 +28,28 @@ def _ok_capture(dest: Path, log: list[str]) -> None:
 
 def _failing_capture(dest: Path, log: list[str]) -> None:
     raise RuntimeError("boom")
+
+
+def test_postgres_dump_timeout_exceeds_shared_default() -> None:
+    # A live nightly dump against a 17GB+ database has already exceeded
+    # DEFAULT_SUBPROCESS_TIMEOUT_SEC (300s) and failed the whole backup run
+    # (2026-07-30). This pins capture_postgres's own timeout well above the
+    # shared default so that regression can't silently come back.
+    assert POSTGRES_DUMP_TIMEOUT_SEC > DEFAULT_SUBPROCESS_TIMEOUT_SEC
+
+
+def test_capture_postgres_uses_dedicated_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_kwargs: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured_kwargs.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    dest = tmp_path / "postgres_snapshot"
+    capture_postgres(dest, container="orion-athena-sql-db", pg_user="postgres", log=[])
+
+    assert captured_kwargs["timeout"] == POSTGRES_DUMP_TIMEOUT_SEC
 
 
 def test_run_target_backup_success_updates_latest_and_prunes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`orion-backup-databases.service` failed for the first time last night (2026-07-30, run_id=2026-07-30T03-45-01Z-830098): `pg_dumpall` timed out after the shared 300s default. Not a fluke -- the last 5 nightly runs (Jul 25-29) show wall time climbing steadily (166s/168s/233s/266s/312s+) as the `conjourney` database has grown to 17GB. A logical dump has no natural size cap the way the other backup targets (FalkorDB snapshot, Chroma) do.

## Fix

`capture_postgres()` now uses its own `POSTGRES_DUMP_TIMEOUT_SEC=1800` instead of sharing `DEFAULT_SUBPROCESS_TIMEOUT_SEC=300` with every other subprocess call in the script (including fast ones like `docker stop`/`start`).

## Live verification

Ran `capture_postgres()` directly against the real 17GB production database (not a fixture, not `/mnt/storage-warm` -- this host's unprivileged user can't write there, matching the systemd service running as a separate privileged user): took 392.6s, produced a 35GB dump. Would have failed under the old 300s timeout exactly like last night's run; succeeds cleanly under the new one. Scratch output deleted immediately after.

## Tests run

```
.venv/bin/pytest tests/test_orion_backup_databases.py -q
# 19 passed (17 pre-existing + 2 new: pin POSTGRES_DUMP_TIMEOUT_SEC > DEFAULT_SUBPROCESS_TIMEOUT_SEC,
# and assert capture_postgres actually passes the dedicated timeout to subprocess.run)
```

## Restart required

None -- this only affects the next scheduled run of `orion-backup-databases.service` (systemd timer, fires nightly at 03:45 UTC). No container restart needed.

## Risks / concerns

- Severity: low -- 1800s is generous headroom for a dump currently taking ~6.5 minutes, but if the database keeps growing at its recent rate this will eventually need raising again. Worth a follow-up alert if backup duration approaches the new ceiling.