### PR TITLE
fix(actions): give world_pulse_digest its own daily email cap slot

### DIFF
--- a/orion/journaler/dispatch_registry.py
+++ b/orion/journaler/dispatch_registry.py
@@ -55,6 +55,15 @@ class JournalDispatchPolicy:
     # needs its own uncapped or independently-capped email is a one-line registry
     # edit here, not new branching logic in the dispatch function.
     subject_to_daily_cap: bool = True
+    # 2026-07-30: which cap pool this trigger_kind's one-per-day slot is drawn from.
+    # "shared" (default) competes with every other shared-scope trigger_kind for one
+    # slot/day -- whichever fires first each day wins, and the rest get
+    # daily_cap_reached silently. A non-"shared" value gets its own independent
+    # slot/day, isolated from the shared pool. world_pulse_digest was confirmed live
+    # to be losing the shared race most/all days (Juniper reported daily-digest
+    # emails silently stopping ~a week prior); giving it its own scope guarantees it
+    # one email/day regardless of what else fires that day.
+    daily_cap_scope: str = "shared"
 
 
 JOURNAL_DISPATCH_REGISTRY: dict[str, JournalDispatchPolicy] = {
@@ -75,6 +84,7 @@ JOURNAL_DISPATCH_REGISTRY: dict[str, JournalDispatchPolicy] = {
         email_enabled=True,
         in_app_enabled=False,
         recall_profile_setting="actions_journal_world_pulse_recall_profile",
+        daily_cap_scope="world_pulse_digest",
     ),
     "notify_summary": JournalDispatchPolicy(
         "notify_summary",

--- a/services/orion-actions/app/main.py
+++ b/services/orion-actions/app/main.py
@@ -675,15 +675,20 @@ def _resolve_now_utc(now_utc: datetime | None) -> datetime:
     return now.astimezone(timezone.utc)
 
 
-def _journal_email_daily_cap_key(*, now_utc: datetime | None = None) -> str:
-    """One key per local calendar day, shared across every `trigger_kind` --
-    caps freeform journal emails (daily_summary, metacog_digest, world_pulse_digest,
-    notify_summary, autonomy_episode, collapse_response, manual) at one send/day
-    regardless of which trigger fires first. Journal entries still persist either
-    way; only the email step is gated."""
+def _journal_email_daily_cap_key(*, scope: str = "shared", now_utc: datetime | None = None) -> str:
+    """One key per local calendar day, per cap `scope` (see
+    `JournalDispatchPolicy.daily_cap_scope`). The default "shared" scope is shared
+    across every trigger_kind still using it (daily_summary, metacog_digest,
+    notify_summary, autonomy_episode, collapse_response, manual) -- one send/day
+    across all of them, regardless of which fires first. A non-"shared" scope (e.g.
+    world_pulse_digest) gets its own independent slot/day, isolated from the shared
+    pool. Journal entries always persist regardless of scope; only the email step is
+    gated."""
     now = _resolve_now_utc(now_utc)
     local_date = now.astimezone(ZoneInfo(settings.actions_daily_timezone)).date().isoformat()
-    return f"actions:journal:notify:daily_email_cap:{local_date}:{settings.node_name}"
+    if scope == "shared":
+        return f"actions:journal:notify:daily_email_cap:{local_date}:{settings.node_name}"
+    return f"actions:journal:notify:daily_email_cap:{scope}:{local_date}:{settings.node_name}"
 
 
 def _seconds_until_next_local_midnight(*, now_utc: datetime | None = None) -> float:
@@ -876,7 +881,7 @@ def _dispatch_journal_notifications(
                 return ok
 
             if policy.subject_to_daily_cap:
-                daily_cap_key = _journal_email_daily_cap_key(now_utc=now_utc)
+                daily_cap_key = _journal_email_daily_cap_key(scope=policy.daily_cap_scope, now_utc=now_utc)
                 if not deduper.try_acquire(daily_cap_key):
                     email_ok = True  # not required -> don't block dedupe completion
                     logger.info(

--- a/services/orion-actions/tests/test_journal_actions.py
+++ b/services/orion-actions/tests/test_journal_actions.py
@@ -209,6 +209,52 @@ def test_second_freeform_journal_of_the_day_is_not_emailed_even_with_a_different
     assert len(notify.send_calls) == 1  # still just the first email
 
 
+def _world_pulse_digest_entry(entry_id: str = "entry-world-pulse-1") -> JournalEntryWriteV1:
+    return JournalEntryWriteV1(
+        entry_id=entry_id,
+        author="orion",
+        mode="daily",
+        title="World Pulse Digest",
+        body="Today's news and current-events digest.",
+        source_kind="world_pulse",
+        source_ref="2026-07-30",
+        correlation_id="corr-world-pulse-1",
+        trigger_kind="world_pulse_digest",
+    )
+
+
+def test_world_pulse_digest_has_its_own_daily_cap_slot_independent_of_the_shared_pool() -> None:
+    """world_pulse_digest was confirmed live (2026-07-30) to be losing the shared
+    daily-cap race most/all days -- Juniper reported the daily digest email silently
+    stopping ~a week prior, with no error anywhere, because some other shared-scope
+    trigger_kind (daily_summary/metacog_digest/notify_summary/...) kept claiming the
+    single shared slot first each day. daily_cap_scope="world_pulse_digest" in
+    orion/journaler/dispatch_registry.py isolates it into its own slot: exhausting
+    the shared pool first must not block world_pulse_digest's email."""
+    notify = _FakeNotify()
+    deduper = ActionDedupe(ttl_seconds=3600)
+    same_moment = datetime(2026, 7, 30, 15, 0, tzinfo=timezone.utc)
+
+    shared_first = _dispatch_journal_notifications(
+        _daily_summary_entry(entry_id="entry-daily-1"), correlation_id="corr-1", notify=notify, deduper=deduper, now_utc=same_moment
+    )
+    assert shared_first["email_ok"] is True
+    assert len(notify.send_calls) == 1
+
+    world_pulse = _dispatch_journal_notifications(
+        _world_pulse_digest_entry(), correlation_id="corr-2", notify=notify, deduper=deduper, now_utc=same_moment
+    )
+    assert world_pulse["email_ok"] is True
+    assert len(notify.send_calls) == 2  # world-pulse's own scope -> sent despite the shared pool already being spent
+
+    # A second world_pulse_digest the same day still respects its own cap.
+    world_pulse_again = _dispatch_journal_notifications(
+        _world_pulse_digest_entry(entry_id="entry-world-pulse-2"), correlation_id="corr-3", notify=notify, deduper=deduper, now_utc=same_moment
+    )
+    assert world_pulse_again["email_ok"] is True  # not required -> True, but nothing actually sent
+    assert len(notify.send_calls) == 2  # still 2 -- world-pulse's own slot for the day is now spent too
+
+
 def test_daily_email_cap_resets_on_the_next_local_calendar_day() -> None:
     """The cap is per-day, not permanent -- a journal email on day 2 must still
     send even though day 1 already used its slot."""


### PR DESCRIPTION
## Summary

Juniper reported the daily world-pulse digest email (news categories) silently stopping ~a week ago, after receiving it reliably for months. Root-caused live: since 2026-07-14's shared daily-email cap, `world_pulse_digest` has been competing with `daily_summary`/`metacog_digest`/`notify_summary`/`autonomy_episode`/`collapse_response`/`manual` for a **single shared** one-email-per-day slot across all of them.

## Root cause

- The daily trigger itself never stopped firing (`scheduler_cursors.json` shows `daily_pulse_v1` fired every day through 2026-07-29).
- But `_dispatch_journal_notifications`'s daily cap (`services/orion-actions/app/main.py`) gates the *email* step on one shared dedupe key per calendar day, regardless of `trigger_kind`.
- Confirmed live 2026-07-30: triggering 4 real world-pulse runs in a row sent exactly 1 email total (the first); the other 3 hit `journal_notify_email_skipped reason=daily_cap_reached` -- silently, no error anywhere a human would see.

## Fix

- `JournalDispatchPolicy.daily_cap_scope` (new field, default `"shared"` -- preserves today's behavior for every other trigger_kind).
- `world_pulse_digest` now sets `daily_cap_scope="world_pulse_digest"`, giving it its own calendar-day cap key isolated from the shared pool.
- `_journal_email_daily_cap_key()` takes a `scope` param; `"shared"` keeps the exact same key format as before (zero behavior change for anything still on it).

## Live verification (better than staged)

Right after deploying this fix, real production traffic reproduced the exact failure scenario and showed it now resolved:

```
05:53:29 journal_notify_email_sent ... trigger_kind=metacog_digest   <- claims the shared pool first
05:53:39 journal_notify_email_sent ... trigger_kind=world_pulse_digest  <- still sends, own scope
```

Before this fix, that second line would have read `journal_notify_email_skipped reason=daily_cap_reached` -- exactly the failure mode Juniper described.

## Tests run

```
PYTHONPATH=... pytest services/orion-actions/tests/test_journal_actions.py -q
# 14 passed (13 pre-existing + 1 new: world_pulse_digest sends even after the shared
# pool is spent, and still respects its own single-slot-per-day cap)

pytest tests/test_check_journal_dispatch_registry.py -q
# 8 passed
python scripts/check_journal_dispatch_registry.py
# OK -- all 8 trigger_kind(s) in _TRIGGER_TO_MODE have a JOURNAL_DISPATCH_REGISTRY row.

pytest services/orion-actions/tests/test_async_notify_producers.py -q
# 11 passed
```

## Docker/build/smoke checks

```
scripts/safe_docker_build.sh orion-actions build --no-cache
scripts/safe_docker_build.sh orion-actions up -d --force-recreate
```
Rebuilt and restarted live on this host; see live verification above.

## Restart required

Already done live on this host. If deployed elsewhere:
```bash
scripts/safe_docker_build.sh orion-actions build --no-cache
scripts/safe_docker_build.sh orion-actions up -d --force-recreate
```

## Risks / concerns

- Severity: low -- `daily_cap_scope` defaults to `"shared"`, so every other trigger_kind's behavior is byte-identical to before. Only `world_pulse_digest` changes.
- Severity: informational -- this doesn't audit whether any *other* trigger_kind is also silently losing the shared race; only world_pulse_digest was reported and confirmed. Worth revisiting if another digest type is found to have gone quiet.
