### PR TITLE
fix(attention): confidence_score must check all 5 real prior-frame buckets, not 2

### DIFF
--- a/docs/superpowers/specs/2026-07-30-candidate-b-hosts-capabilities-live-wiring.md
+++ b/docs/superpowers/specs/2026-07-30-candidate-b-hosts-capabilities-live-wiring.md
@@ -180,6 +180,22 @@ The `pressure_proxy` values above are no longer directionally blind (compare
 not distinguish a calm host from an overloaded one whenever a higher-is-better channel
 sat near its healthy default).
 
+### 2026-07-30 second fix (verification review on the fix above)
+
+A follow-up review of the Finding 2 fix itself found it was still incomplete: it checked
+`target_id` presence in only `previous_frame.node_targets`/`.capability_targets` -- the
+two "active" buckets -- while `prior_salience_for_target()` (what `novelty_scorer()`
+actually uses to compute the novelty diff) searches five buckets, including
+`suppressed_targets`. `build_attention_frame()` puts any target scored below
+`suppress_below` into `suppressed_targets` only, never into `node_targets`/
+`capability_targets` -- a real prior observation, just not an "active" one. The
+two-bucket check would under-report `confidence_score=0.0` for a target that was real
+but suppressed last tick, even though a real prior value was used to compute its novelty
+this tick. Fixed by extracting `target_had_real_prior_entry()` in `scoring.py`, using the
+same five-bucket search `prior_salience_for_target()` already used, so confidence and
+novelty always agree on the same real fact. New regression test:
+`test_select_host_targets_suppressed_prior_entry_still_counts_as_real`.
+
 ## Non-goals
 
 - Not the full three-scorer Candidate B (magnitude/dwell excluded, both disclosed above).

--- a/orion/attention/field_attention/scoring.py
+++ b/orion/attention/field_attention/scoring.py
@@ -1,18 +1,30 @@
 from __future__ import annotations
 
-from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 
 
 def clamp01(x: float) -> float:
     return max(0.0, min(1.0, float(x)))
 
 
-def prior_salience_for_target(
+def _find_prior_target(
     target_id: str,
     previous_frame: FieldAttentionFrameV1 | None,
-) -> float:
+) -> FieldAttentionTargetV1 | None:
+    """Real search order for "did this target_id have a real entry in the
+    previous frame" -- all five buckets a target can land in, not just the
+    two "active" ones (`node_targets`/`capability_targets`). A target
+    scored below `policy.thresholds.suppress_below` or between
+    `suppress_below`/`min_salience` last tick lands in `suppressed_targets`
+    only (see `build_attention_frame()`), not in `node_targets`/
+    `capability_targets` -- a real prior observation, just not an "active"
+    one. Any caller asking "does a real prior value exist for this target"
+    (confidence claims, not just novelty diffing) must use the same search
+    this function does, or it will under-report confidence for a target
+    that was real but suppressed last tick (code review, 2026-07-30).
+    """
     if previous_frame is None:
-        return 0.0
+        return None
     for bucket in (
         previous_frame.dominant_targets,
         previous_frame.node_targets,
@@ -22,8 +34,33 @@ def prior_salience_for_target(
     ):
         for t in bucket:
             if t.target_id == target_id:
-                return t.salience_score
-    return 0.0
+                return t
+    return None
+
+
+def prior_salience_for_target(
+    target_id: str,
+    previous_frame: FieldAttentionFrameV1 | None,
+) -> float:
+    found = _find_prior_target(target_id, previous_frame)
+    return found.salience_score if found is not None else 0.0
+
+
+def target_had_real_prior_entry(
+    target_id: str,
+    previous_frame: FieldAttentionFrameV1 | None,
+) -> bool:
+    """Whether `target_id` had a real entry in ANY of the previous frame's
+    five target buckets (dominant/node/capability/system/suppressed) --
+    the same search `prior_salience_for_target()` uses. A caller reporting
+    `confidence_score` for a novelty claim must ask this, not just whether
+    `previous_frame is not None` or whether the target is in one particular
+    "active" bucket -- both under-report confidence for a target that
+    really was observed but landed in a bucket the caller didn't check
+    (code review, 2026-07-30: `_novelty_targets()` originally checked only
+    `node_targets`/`capability_targets`, missing `suppressed_targets`).
+    """
+    return _find_prior_target(target_id, previous_frame) is not None
 
 
 def novelty_for_target(

--- a/orion/attention/field_attention/selectors.py
+++ b/orion/attention/field_attention/selectors.py
@@ -9,7 +9,7 @@ from orion.attention.field_attention.candidate_precision_weighted import (
 )
 from orion.attention.field_attention.candidate_society_of_mind import novelty_scorer
 from orion.attention.field_attention.policy import FieldAttentionPolicyV1
-from orion.attention.field_attention.scoring import clamp01
+from orion.attention.field_attention.scoring import clamp01, target_had_real_prior_entry
 from orion.field.pressure import (
     RECENT_PERTURBATION_EWMA_MIN_SAMPLES,
     RECENT_PERTURBATION_ZSCORE_SATURATION,
@@ -162,6 +162,20 @@ def _novelty_targets(
     observation backing that confidence, identical to the no-frame-at-all
     case.
 
+    2026-07-30 second fix (code review verification pass, same day): the
+    first version of this fix checked presence in only `previous_frame.
+    node_targets`/`.capability_targets` -- the two "active" buckets -- but
+    `prior_salience_for_target()` (what `novelty_scorer()` actually uses to
+    compute the novelty diff above) searches five buckets, including
+    `suppressed_targets`. A target scored below `suppress_below` last tick
+    lands ONLY in `suppressed_targets` (`build_attention_frame()`), a real
+    prior observation, not an absent one -- the two-bucket check
+    under-reported confidence=0.0 for such a target even though a real
+    prior value was actually used to compute its novelty. Now uses
+    `target_had_real_prior_entry()` (`scoring.py`), the same five-bucket
+    search `prior_salience_for_target()` uses, so confidence and novelty
+    are always answered from the same real fact.
+
     **One-time transition artifact, disclosed (2026-07-30):** `novelty_for_
     target()` diffs this tick's `_current_pressure_proxy()` value against
     whatever `salience_score` the *previous persisted frame* recorded for
@@ -185,16 +199,10 @@ def _novelty_targets(
     current_salience = {tid: _current_pressure_proxy(vectors[tid]) for tid in target_ids}
     novelty_scores = novelty_scorer(target_ids, current_salience, previous_frame)
 
-    if previous_frame is None:
-        prior_target_ids: frozenset[str] = frozenset()
-    else:
-        prior_list = previous_frame.node_targets if target_kind == "node" else previous_frame.capability_targets
-        prior_target_ids = frozenset(t.target_id for t in prior_list)
-
     targets: list[FieldAttentionTargetV1] = []
     for target_id in target_ids:
         novelty = novelty_scores.get(target_id, 0.0)
-        confidence = 1.0 if target_id in prior_target_ids else 0.0
+        confidence = 1.0 if target_had_real_prior_entry(target_id, previous_frame) else 0.0
         targets.append(
             FieldAttentionTargetV1(
                 target_id=target_id,

--- a/tests/test_attention_field_selectors.py
+++ b/tests/test_attention_field_selectors.py
@@ -408,6 +408,58 @@ def test_select_host_targets_new_target_absent_from_existing_prior_frame_has_zer
     assert by_id["node:circe"].confidence_score == 0.0  # no real prior entry, despite a real prior_frame existing
 
 
+def test_select_host_targets_suppressed_prior_entry_still_counts_as_real() -> None:
+    # Code-review verification-pass regression test (2026-07-30): a target
+    # scored below suppress_below last tick lands ONLY in
+    # previous_frame.suppressed_targets, never in .node_targets -- a real
+    # prior observation, not an absent one. novelty_for_target() (via
+    # prior_salience_for_target()) searches suppressed_targets too and uses
+    # that real prior value to compute novelty -- confidence_score must
+    # agree that a real prior existed, not just check the two "active"
+    # buckets.
+    suppressed_prior = FieldAttentionTargetV1(
+        target_id="node:circe",
+        target_kind="node",
+        salience_score=0.02,  # below suppress_below -- landed in suppressed_targets only
+        pressure_score=0.02,
+        novelty_score=0.0,
+        urgency_score=0.0,
+        confidence_score=1.0,
+        dominant_channels={},
+        reasons=["prior tick"],
+        evidence_refs=[],
+        suggested_observation_mode="ignore",
+    )
+    prev_frame = FieldAttentionFrameV1(
+        frame_id="f3",
+        generated_at=BASE,
+        source_field_tick_id="tick_host_prev3",
+        source_field_generated_at=BASE,
+        attention_policy_id=POLICY.policy_id,
+        overall_salience=0.0,
+        dominant_targets=[],
+        node_targets=[],  # NOT here
+        capability_targets=[],
+        system_targets=[],
+        suppressed_targets=[suppressed_prior],  # only here
+        recent_perturbations=[],
+        warnings=[],
+    )
+
+    field_now = FieldStateV1(
+        generated_at=BASE,
+        tick_id="tick_host_now3",
+        node_vectors={"node:circe": {"cpu_pressure": 0.9}},
+    )
+    targets = select_host_targets(field_now, POLICY, prev_frame)
+    assert len(targets) == 1
+    # Real novelty is computed against the real suppressed-bucket prior value.
+    assert targets[0].novelty_score > 0.5
+    # Confidence must agree a real prior existed, even though it lived in
+    # suppressed_targets, not node_targets.
+    assert targets[0].confidence_score == 1.0
+
+
 def test_select_host_targets_multi_target_real_hosts() -> None:
     # Code-review regression test (2026-07-30, Finding 4): production always
     # faces multiple real hosts simultaneously (athena/atlas/circe/


### PR DESCRIPTION
## Summary

- Follow-up to PR #1484 (merged), which wired Candidate B (Global-Workspace/Society-of-Mind novelty scoring) live for physical hosts and capabilities in Orion's Layer 5 attention pipeline, and fixed two review findings (directionally-blind pressure proxy, and `confidence_score` conflating "any previous frame exists" with "this target had a real entry in it").
- A verification-pass review on that second fix (run after #1484 had already merged) found the `confidence_score` fix was still incomplete: it checked `target_id` presence in only `previous_frame.node_targets`/`.capability_targets` — the two "active" buckets — while `prior_salience_for_target()` (what `novelty_scorer()` actually uses to compute the novelty diff) searches five buckets, including `suppressed_targets`.
- `build_attention_frame()` puts any target scored below `suppress_below` into `suppressed_targets` only, never into `node_targets`/`capability_targets` — a real prior observation, just not an "active" one. The two-bucket check under-reported `confidence_score=0.0` for a target that was real but suppressed last tick, even though its real prior value was used to compute this tick's novelty.
- Fixed by extracting `target_had_real_prior_entry()` in `orion/attention/field_attention/scoring.py`, reusing the exact same five-bucket search `prior_salience_for_target()` already used, so confidence and novelty always answer from the same real fact.

## Outcome moved

`confidence_score` for host/capability attention targets no longer under-reports for targets that were real but suppressed on the previous tick — confidence and novelty are now guaranteed to agree on the same real prior-frame fact instead of drifting via two different bucket-search implementations.

## Current architecture

Before this patch: `_novelty_targets()` in `orion/attention/field_attention/selectors.py` checked `target_id in {t.target_id for t in previous_frame.node_targets or .capability_targets}` to set `confidence_score`. `prior_salience_for_target()` in `scoring.py` (used by `novelty_for_target()`, the actual novelty computation) searched all five of `FieldAttentionFrameV1`'s target buckets (`dominant_targets`, `node_targets`, `capability_targets`, `system_targets`, `suppressed_targets`). These two functions disagreed about what counts as "a real prior entry."

## Architecture touched

- `orion/attention/field_attention/scoring.py`: extracted `_find_prior_target()` (shared internal search across all 5 buckets), `prior_salience_for_target()` now built on top of it, added `target_had_real_prior_entry()`.
- `orion/attention/field_attention/selectors.py`: `_novelty_targets()` now calls `target_had_real_prior_entry()` instead of its own narrower 2-bucket check.

## Files changed

- `orion/attention/field_attention/scoring.py`: shared 5-bucket prior-target search, new `target_had_real_prior_entry()` helper.
- `orion/attention/field_attention/selectors.py`: `_novelty_targets()` uses the shared helper.
- `tests/test_attention_field_selectors.py`: new regression test `test_select_host_targets_suppressed_prior_entry_still_counts_as_real`, builds a real `previous_frame` with the target ONLY in `suppressed_targets` and asserts `confidence_score == 1.0`.
- `docs/superpowers/specs/2026-07-30-candidate-b-hosts-capabilities-live-wiring.md`: documented this second fix.

## Schema / bus / API changes

- Added: none (internal function only, `target_had_real_prior_entry()` is not part of any schema).
- Removed: none.
- Renamed: none.
- Behavior changed: `confidence_score` for host/capability attention targets now correctly reads `1.0` for targets that were real-but-suppressed on the previous tick (previously read `0.0`, a false "no real prior context" claim).
- Compatibility notes: no schema change, no bus/API contract change, no restart-order dependency beyond the standard `orion-attention-runtime` restart.

## Env/config changes

None.

## Tests run

```text
cd /mnt/scripts/Orion-Sapienform-kill-hand-weighted-attention
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest tests/test_attention_field_selectors.py tests/test_attention_frame_builder.py tests/test_attention_transport_visibility.py tests/test_attention_policy_loader.py tests/test_measure_candidate_a_vs_b_head_to_head.py services/orion-attention-runtime/tests -q
69 passed, 14 warnings in 3.81s
```

## Evals run

No dedicated eval harness for this service; the head-to-head comparison script (`scripts/analysis/measure_candidate_a_vs_b_head_to_head.py`, shipped in #1484) already covers the Candidate A/B quality-comparison angle. Not re-run here since this patch only touches confidence-score bucket coverage, not either candidate's scoring math.

## Docker/build/smoke checks

Not run — this is a pure-function fix (no new I/O, no schema, no env). Deferred to the standard `orion-attention-runtime` restart.

## Review findings fixed

- Finding: `confidence_score` under-reports for targets that were real but suppressed on the previous tick, since it only checked 2 of the 5 real target buckets `prior_salience_for_target()` searches.
  - Fix: extracted `target_had_real_prior_entry()` reusing the same 5-bucket search, replaced the ad hoc 2-bucket check in `_novelty_targets()`.
  - Evidence: new regression test `test_select_host_targets_suppressed_prior_entry_still_counts_as_real`, passing; full affected-suite re-run at 69/69.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-attention-runtime/.env \
  -f services/orion-attention-runtime/docker-compose.yml \
  up -d --build orion-attention-runtime
```

## Risks / concerns

- Severity: low
- Concern: none identified — pure function, additive helper, no schema/contract change, full test suite green.
- Mitigation: n/a

## PR link

(filled in by `gh pr create` output)