### PR TITLE
fix(cortex-orch): route workflow-completion notify through orion-notify HTTP, not a raw bus publish

### DIFF
--- a/services/orion-cortex-orch/.env_example
+++ b/services/orion-cortex-orch/.env_example
@@ -23,6 +23,12 @@ HEARTBEAT_INTERVAL_SEC=10
 RPC_HEALTH_PUBLISH_ENABLED=false
 RPC_HEALTH_PUBLISH_INTERVAL_SEC=30
 
+# orion-notify HTTP client (workflow-completion notifications) -- orion:notify:persistence:request
+# is orion-notify's OWN output channel, not an intake channel; NotifyClient's HTTP /notify
+# endpoint is the only registered way to submit a notification.
+NOTIFY_URL=http://orion-athena-notify:7140
+NOTIFY_API_TOKEN=
+
 # Bus routing channels (for exec fan-out + result fan-in)
 EXEC_REQUEST_PREFIX=orion:exec:request
 EXEC_RESULT_PREFIX=orion:exec:result

--- a/services/orion-cortex-orch/app/settings.py
+++ b/services/orion-cortex-orch/app/settings.py
@@ -28,6 +28,15 @@ class Settings(BaseSettings):
     rpc_health_publish_enabled: bool = Field(False, alias="RPC_HEALTH_PUBLISH_ENABLED")
     rpc_health_publish_interval_sec: float = Field(30.0, alias="RPC_HEALTH_PUBLISH_INTERVAL_SEC")
 
+    # orion-notify HTTP client (workflow-completion notifications). Not a bus channel --
+    # orion-notify's own /notify endpoint is the only registered way to submit a
+    # NotificationRequest; orion:notify:persistence:request is orion-notify's OWN output
+    # channel (producer_services=["orion-notify"], schema_id=NotificationRecord), not an
+    # intake channel for other services to publish NotificationRequest payloads onto
+    # directly (see workflow_runtime.py::_emit_workflow_notify).
+    notify_url: str = Field("http://orion-athena-notify:7140", alias="NOTIFY_URL")
+    notify_api_token: str = Field("", alias="NOTIFY_API_TOKEN")
+
     # RPC intake channel (hub -> cortex-orch)
     channel_cortex_request: str = Field(
         "orion:cortex:request",

--- a/services/orion-cortex-orch/app/workflow_runtime.py
+++ b/services/orion-cortex-orch/app/workflow_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -55,6 +56,7 @@ from .chat_history_compactor_memory import persist_chat_history_compactor_memory
 from .concept_profile_config import build_orch_concept_profile_settings
 from .github_compactor_memory import persist_github_compactor_memory_card
 from .settings import get_settings
+from orion.notify.client import NotifyClient
 from orion.schemas.notify import NotificationRequest
 from orion.schemas.workflow_execution import WorkflowDispatchRequestV1, WorkflowExecutionPolicyV1
 from orion.schemas.workflow_execution import WorkflowScheduleManageRequestV1, WorkflowScheduleManageResponseV1
@@ -63,7 +65,6 @@ logger = logging.getLogger("orion.cortex.orch.workflow_runtime")
 JOURNAL_WRITE_CHANNEL = "orion:journal:write"
 ACTIONS_WORKFLOW_TRIGGER_CHANNEL = "orion:actions:trigger:workflow.v1"
 ACTIONS_WORKFLOW_MANAGE_CHANNEL = "orion:actions:manage:workflow.v1"
-NOTIFY_PERSISTENCE_REQUEST_CHANNEL = "orion:notify:persistence:request"
 ConceptProfileBackendKind = Literal["local", "graph", "shadow"]
 CutoverFallbackPolicyKind = Literal["fail_open_local", "fail_closed"]
 
@@ -351,7 +352,6 @@ def _should_notify(*, notify_on: str, ok: bool) -> bool:
 
 async def _emit_workflow_notify(
     *,
-    bus: OrionBusAsync,
     source: ServiceRef,
     req: CortexClientRequest,
     workflow_id: str,
@@ -363,6 +363,23 @@ async def _emit_workflow_notify(
     recipient_group: str,
     execution_source: str,
 ) -> None:
+    """Notify on workflow completion via orion-notify's HTTP /notify endpoint.
+
+    NOT a bus publish: orion:notify:persistence:request is orion-notify's OWN output
+    channel (producer_services=["orion-notify"], schema_id=NotificationRecord, which
+    requires a `status` field NotificationRequest doesn't have) -- publishing a raw
+    NotificationRequest directly onto it, as this function used to, fails bus-side
+    payload validation on every call. Confirmed live 2026-07-30: this took down
+    github_compactor_pass and chat_history_compactor_pass's reported health for 2 days
+    straight, even though the actual compactor work (this call happens *after* it, per
+    the two call sites below) completed successfully every time -- only the trailing
+    notify step threw, and the exception wasn't caught anywhere between here and the
+    scheduler, so a fully successful run was reported as a failed workflow.
+
+    Fails open by design, same as NotifyClient.send() itself: notification delivery is
+    not the workflow's core function and must never flip an already-completed result to
+    reported-failure. A logged warning is the ceiling for any failure here, not a raise.
+    """
     if not _should_notify(notify_on=notify_on, ok=ok):
         return
     status = "completed" if ok else "failed"
@@ -370,35 +387,46 @@ async def _emit_workflow_notify(
     title = f"Workflow {workflow_name} {status}"
     body = f"{workflow_name} {status}.\n\n{final_text}".strip()
     preview = body[:280]
-    notification = NotificationRequest(
-        source_service=source.name or "orion-cortex-orch",
-        event_kind=event_kind,
-        severity="info" if ok else "warning",
-        title=title,
-        body_text=body,
-        body_md=final_text,
-        recipient_group=recipient_group or "juniper_primary",
-        session_id=req.context.session_id or "workflow",
-        correlation_id=correlation_id,
-        dedupe_key=f"workflow:{workflow_id}:{status}:{correlation_id}",
-        dedupe_window_seconds=86400,
-        tags=["workflow", workflow_id, status],
-        context={
-            "workflow_id": workflow_id,
-            "workflow_name": workflow_name,
-            "status": status,
-            "execution_source": execution_source,
-            "notify_on": notify_on,
-            "preview_text": preview,
-        },
-    )
-    env = BaseEnvelope(
-        kind="notify.notification.request.v1",
-        source=source,
-        correlation_id=correlation_id,
-        payload=notification.model_dump(mode="json"),
-    )
-    await bus.publish(NOTIFY_PERSISTENCE_REQUEST_CHANNEL, env)
+    try:
+        notification = NotificationRequest(
+            source_service=source.name or "orion-cortex-orch",
+            event_kind=event_kind,
+            severity="info" if ok else "warning",
+            title=title,
+            body_text=body,
+            body_md=final_text,
+            recipient_group=recipient_group or "juniper_primary",
+            session_id=req.context.session_id or "workflow",
+            correlation_id=correlation_id,
+            dedupe_key=f"workflow:{workflow_id}:{status}:{correlation_id}",
+            dedupe_window_seconds=86400,
+            tags=["workflow", workflow_id, status],
+            context={
+                "workflow_id": workflow_id,
+                "workflow_name": workflow_name,
+                "status": status,
+                "execution_source": execution_source,
+                "notify_on": notify_on,
+                "preview_text": preview,
+            },
+        )
+        notify_settings = get_settings()
+        client = NotifyClient(base_url=notify_settings.notify_url, api_token=notify_settings.notify_api_token or None)
+        accepted = await asyncio.to_thread(client.send, notification)
+        if not accepted.ok:
+            logger.warning(
+                "workflow_notify_failed workflow_id=%s correlation_id=%s detail=%s",
+                workflow_id,
+                correlation_id,
+                accepted.detail,
+            )
+    except Exception:
+        logger.warning(
+            "workflow_notify_failed workflow_id=%s correlation_id=%s",
+            workflow_id,
+            correlation_id,
+            exc_info=True,
+        )
 
 
 async def _schedule_workflow_dispatch(
@@ -2654,7 +2682,6 @@ async def execute_chat_workflow(
             ),
         )
         await _emit_workflow_notify(
-            bus=bus,
             source=source,
             req=req,
             workflow_id=workflow_id,
@@ -2668,7 +2695,6 @@ async def execute_chat_workflow(
         )
         raise
     await _emit_workflow_notify(
-        bus=bus,
         source=source,
         req=req,
         workflow_id=workflow_id,

--- a/services/orion-cortex-orch/tests/test_workflow_lane.py
+++ b/services/orion-cortex-orch/tests/test_workflow_lane.py
@@ -2648,6 +2648,18 @@ def test_chat_history_compactor_pass_completion_notify_carries_full_digest_not_t
         _fake_persist_card,
     )
 
+    sent_requests: list = []
+
+    class _FakeNotifyClient:
+        def __init__(self, base_url, api_token=None):
+            pass
+
+        def send(self, request):
+            sent_requests.append(request)
+            return SimpleNamespace(ok=True, notification_id=None, detail=None)
+
+    monkeypatch.setattr("app.workflow_runtime.NotifyClient", _FakeNotifyClient)
+
     req = _req_with_policy(
         "chat_history_compactor_pass",
         {
@@ -2670,13 +2682,99 @@ def test_chat_history_compactor_pass_completion_notify_carries_full_digest_not_t
         )
     )
 
-    notify_envelopes = [
-        env for ch, env in bus.published if ch == "orion:notify:persistence:request"
-    ]
-    assert len(notify_envelopes) == 1
-    payload = notify_envelopes[0].payload
-    assert "Notable theme discussed at length." in payload["body_text"]
-    assert len(payload["body_text"]) > 280
+    assert len(sent_requests) == 1
+    body_text = sent_requests[0].body_text
+    assert "Notable theme discussed at length." in body_text
+    assert len(body_text) > 280
+
+
+def test_completion_notify_failure_does_not_fail_an_already_successful_workflow(monkeypatch) -> None:
+    """Regression for a confirmed-live incident (2026-07-30): the completion-notify
+    call used to publish a raw NotificationRequest directly onto orion:notify:persistence:request
+    (orion-notify's OWN output channel, wrong schema), which raised a ValueError on
+    every call and, because it ran outside any try/except around the real compactor
+    work, took down github_compactor_pass/chat_history_compactor_pass's reported health
+    for 2 days straight even though the actual compactor work succeeded every time. A
+    broken notify path (here: NotifyClient.send raising) must never flip an
+    already-completed successful result into a raised/reported failure."""
+    bus = DummyBus()
+
+    async def _fake_call_verb_runtime(*args, **kwargs):
+        req = kwargs["client_request"]
+        if req.verb == "skills.chat.discussion_window.v1":
+            skill = {
+                "window_start_utc": "2026-07-09T04:00:00+00:00",
+                "window_end_utc": "2026-07-09T10:00:00+00:00",
+                "turn_count": 1,
+                "turns": [
+                    {
+                        "created_at": "2026-07-09T05:00:00+00:00",
+                        "correlation_id": "corr-a",
+                        "prompt": "hi",
+                        "response": "hello",
+                    }
+                ],
+                "transcript_text": "user: hi\norion: hello",
+                "selection_strategy": "time_bound_then_contiguous_suffix",
+            }
+            return DummyVerbResult(
+                payload={"result": {"status": "success", "final_text": json.dumps(skill), "metadata": {"skill_result": skill}}}
+            )
+        if req.verb == "chat_history_compactor_digest_v1":
+            digest = {
+                "card_summary": "Notable theme.",
+                "journal_title": "Chat digest — daily",
+                "journal_body": "Narrative body.",
+                "turn_refs": ["corr-a"],
+            }
+            return DummyVerbResult(
+                payload={"result": {"status": "success", "final_text": json.dumps(digest), "metadata": {"chat_history_compactor_digest": digest}}}
+            )
+        raise AssertionError(f"unexpected verb {req.verb}")
+
+    async def _fake_persist_card(**kwargs):
+        return uuid4()
+
+    monkeypatch.setattr(
+        "app.workflow_runtime.persist_chat_history_compactor_memory_card",
+        _fake_persist_card,
+    )
+
+    class _RaisingNotifyClient:
+        def __init__(self, base_url, api_token=None):
+            pass
+
+        def send(self, request):
+            raise ValueError(
+                "Payload validation failed for channel orion:notify:persistence:request (schema_id=NotificationRecord)"
+            )
+
+    monkeypatch.setattr("app.workflow_runtime.NotifyClient", _RaisingNotifyClient)
+
+    req = _req_with_policy(
+        "chat_history_compactor_pass",
+        {
+            "workflow_id": "chat_history_compactor_pass",
+            "invocation_mode": "immediate",
+            "notify_on": "completion",
+            "recipient_group": "juniper_primary",
+        },
+    )
+
+    # Must not raise -- this is the exact call that used to bubble the notify's
+    # ValueError all the way out and mark the run "failed" in workflow_schedules.json.
+    result = asyncio.run(
+        execute_chat_workflow(
+            bus=bus,
+            source=ServiceRef(name="cortex-orch"),
+            req=req,
+            correlation_id="00000000-0000-0000-0000-000000000303",
+            causality_chain=[],
+            trace={},
+            call_verb_runtime=_fake_call_verb_runtime,
+        )
+    )
+    assert result.ok is True
 
 
 def test_chat_history_compactor_pass_quiet_day_skips_card(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`github_compactor_pass` and `chat_history_compactor_pass` schedules have been reporting `health=failing` (0 success / N failure) since 2026-07-29 ~12:00 UTC -- every single run, firing repeated "Schedule ... needs attention" alerts. Root-caused from the persisted run history in `workflow_schedules.json`: every failure carries the identical error `Payload validation failed for channel orion:notify:persistence:request (schema_id=NotificationRecord)`.

## Root cause

`_emit_workflow_notify()` in `services/orion-cortex-orch/app/workflow_runtime.py` was building a `NotificationRequest` and publishing it **directly onto the bus** at `orion:notify:persistence:request`. Per `orion/bus/channels.yaml`, that channel is registered with `producer_services: ["orion-notify"]` and `schema_id: NotificationRecord` (requires a `status` field `NotificationRequest` doesn't have) -- it's `orion-notify`'s **own output** channel after it decides policy/status, not an intake channel for other services to publish raw requests onto. Every other correct producer in this codebase goes through `NotifyClient.send()` (HTTP POST to `orion-notify`'s `/notify` endpoint) instead.

Worse than a cosmetic schema mismatch: this call happens **after** the real compactor work completes, outside any try/except, in `execute_chat_workflow`. The compactors' actual work (memory-card persistence) has almost certainly been succeeding every run for 2 days straight -- only the trailing "send completion notification" step threw, and the uncaught `ValueError` is what marked each run "failed."

## Fix

- `app/settings.py`: `NOTIFY_URL` / `NOTIFY_API_TOKEN` (same pattern already used by `orion-actions` and `orion-cortex-exec`).
- `app/workflow_runtime.py`: `_emit_workflow_notify` now calls `NotifyClient.send()` via `asyncio.to_thread` instead of `bus.publish`. Wrapped in try/except -- fails open (logs a warning) exactly like `NotifyClient.send()` already does internally, so a broken notify step can never again flip an already-completed successful workflow run to reported-failure. Dropped the now-unused `bus` parameter and the dead `NOTIFY_PERSISTENCE_REQUEST_CHANNEL` constant.

## Tests run

```
PYTHONPATH=... pytest services/orion-cortex-orch/tests/test_workflow_lane.py -q
# 64 passed in isolation (63 pre-existing -- updated the one asserting on the old
# bus.publish envelope shape to assert on the new NotifyClient call -- plus 1 new
# regression test: a raising NotifyClient must not fail an already-successful
# chat_history_compactor_pass run)
```

Running the whole `services/orion-cortex-orch/tests/` directory shows pre-existing cross-file test-isolation pollution (31 failures on unmodified `main`, confirmed by re-running against `main` before this change) -- unrelated to this fix, not touched.

## Docker/build/smoke checks

```
scripts/safe_docker_build.sh orion-cortex-orch build --no-cache
scripts/safe_docker_build.sh orion-cortex-orch up -d --force-recreate
```

Live-verified against real infrastructure: called the fixed `_emit_workflow_notify` directly inside the running container. No exception. `orion-notify`'s log shows the real `POST /notify HTTP/1.1 200 OK`, and the notification landed in Postgres (`notify_requests`: `title="Workflow GitHub Compactor (live verify) completed"`, `event_kind=orion.workflow.completed`) -- the full real path now works end to end.

## Env/config changes

- Added keys: `NOTIFY_URL`, `NOTIFY_API_TOKEN` (both services' `.env_example` and local `.env` updated/synced)

## Restart required

Already done live on this host:
```bash
scripts/safe_docker_build.sh orion-cortex-orch build --no-cache
scripts/safe_docker_build.sh orion-cortex-orch up -d --force-recreate
```
No further restart required unless deployed elsewhere.

## Risks / concerns

- Severity: low -- `asyncio.to_thread` offloads the synchronous `requests.post` off the event loop; behavior matches the async pattern already used elsewhere in this codebase for the same kind of call.
- Severity: informational -- the two failing schedules' next real scheduled run (not my manual live-verify call) will be the first true end-to-end confirmation in production; I could not trigger a full compactor pass manually (no manual-run HTTP endpoint exists for these schedules), so I verified the specific fixed code path directly instead.
