### PR TITLE
fix(proposals): remove 5 dead dimension_ids from 9 templates, no live signal since 2026-07-22

### DIFF
--- a/config/proposals/proposal_policy.v1.yaml
+++ b/config/proposals/proposal_policy.v1.yaml
@@ -10,15 +10,22 @@ thresholds:
   suppress_below: 0.05
   policy_required_above_risk: 0.20
 
+# 2026-07-30: uncertainty/field_intensity/agency_readiness/coherence weights
+# removed. None of those 4 dimension_ids are ever produced by
+# orion/field/pressure.py::field_pressures() (see that module's own
+# docstring -- composite, hand-tuned SelfStateV1 dimensions with no
+# principled non-hand-tuned replacement, not rebuilt in the 2026-07-22 burn).
+# No template below references them anymore either (see the same-day removal
+# of contract_pressure/field_intensity/agency_readiness/uncertainty from each
+# template's own `dimensions` map) -- keeping dead weights here was a live
+# trap: dimension_confidence() returns 0.0 PERMANENTLY for any dimension_id
+# outside orion/proposals/scoring.py::PRESSURE_DIMENSIONS, so these weights
+# multiplied a value that could only ever be 0.0.
 dimension_weights:
   execution_pressure: 0.30
   resource_pressure: 0.25
   reasoning_pressure: 0.15
   reliability_pressure: 0.35
-  uncertainty: 0.25
-  field_intensity: 0.20
-  agency_readiness: -0.15
-  coherence: -0.20
 
 proposal_templates:
   inspect_execution_pressure:
@@ -42,8 +49,12 @@ proposal_templates:
     base_priority: 0.35
     base_risk: 0.05
     reversibility: 1.0
+    # field_intensity removed 2026-07-30: never produced by field_pressures()
+    # (see dimension_weights' own comment above) -- was a dead entry that
+    # contributed 0.0 to match_score (harmless there, template_match_score()
+    # uses max()) but PERMANENTLY halved proposal_confidence() via its
+    # sum()/len() average with resource_pressure's real confidence.
     dimensions:
-      field_intensity: 0.50
       resource_pressure: 0.40
 
   watch_reliability:
@@ -67,8 +78,9 @@ proposal_templates:
     base_priority: 0.20
     base_risk: 0.30
     reversibility: 0.8
+    # agency_readiness removed 2026-07-30: never produced by field_pressures()
+    # -- see dimension_weights' own comment above.
     dimensions:
-      agency_readiness: 0.50
       execution_pressure: 0.40
 
   inspect_transport_status:
@@ -80,8 +92,10 @@ proposal_templates:
     base_priority: 0.42
     base_risk: 0.05
     reversibility: 1.0
+    # contract_pressure removed 2026-07-30: never produced by field_pressures()
+    # -- "already always 0.0 before the [2026-07-22 SelfStateV1] burn" per
+    # that module's own docstring; was never real, not a regression.
     dimensions:
-      contract_pressure: 0.55
       reliability_pressure: 0.40
 
   inspect_bus_channel_catalog:
@@ -93,8 +107,23 @@ proposal_templates:
     base_priority: 0.38
     base_risk: 0.05
     reversibility: 1.0
-    dimensions:
-      contract_pressure: 0.60
+    # contract_pressure removed 2026-07-30: never produced by field_pressures()
+    # -- was this template's ONLY dimension, so match_score/confidence were
+    # both permanently 0.0 and proposal_urgency() was ALSO permanently 0.0
+    # (contract_pressure's "_pressure" suffix let it pass proposal_urgency()'s
+    # own dimension filter while contributing nothing, which suppressed that
+    # function's real all-4-core-dimensions fallback that an empty dimensions
+    # dict now correctly triggers). No real transport/bus-health dimension
+    # exists in field_pressures() yet to replace it with -- CHANNEL_DIMENSION_MAP
+    # (orion/field/pressure.py) doesn't route any transport-domain channel to
+    # any category. Building that is real, separate follow-up work (a new
+    # CHANNEL_DIMENSION_MAP category + PRESSURE_DIMENSIONS extension +
+    # live variance verification, same discipline already applied to the
+    # existing 4 dimensions), not done here. This template now honestly
+    # scores 0.0 match/confidence and derives its urgency and priority from
+    # the real all-4-core-pressures fallback plus base_priority, not from a
+    # fabricated transport-specific signal.
+    dimensions: {}
 
   summarize_transport_contract_drift:
     kind: summarize
@@ -105,8 +134,9 @@ proposal_templates:
     base_priority: 0.36
     base_risk: 0.05
     reversibility: 1.0
-    dimensions:
-      contract_pressure: 0.65
+    # contract_pressure removed 2026-07-30 -- see inspect_bus_channel_catalog's
+    # comment above for the full account (same disease, same template shape).
+    dimensions: {}
 
   watch_transport_backpressure:
     kind: observe
@@ -117,8 +147,9 @@ proposal_templates:
     base_priority: 0.32
     base_risk: 0.02
     reversibility: 1.0
-    dimensions:
-      contract_pressure: 0.50
+    # contract_pressure removed 2026-07-30 -- see inspect_bus_channel_catalog's
+    # comment above for the full account (same disease, same template shape).
+    dimensions: {}
 
   defer_due_to_low_readiness:
     kind: defer
@@ -129,8 +160,9 @@ proposal_templates:
     base_priority: 0.25
     base_risk: 0.0
     reversibility: 1.0
+    # uncertainty removed 2026-07-30: never produced by field_pressures()
+    # -- see dimension_weights' own comment above.
     dimensions:
-      uncertainty: 0.50
       reliability_pressure: 0.50
 
   inspect_node_resource_pressure:
@@ -154,8 +186,15 @@ proposal_templates:
     base_priority: 0.33
     base_risk: 0.05
     reversibility: 1.0
-    dimensions:
-      field_intensity: 0.45
+    # field_intensity removed 2026-07-30: never produced by field_pressures()
+    # -- was this template's ONLY dimension (match_score/confidence
+    # permanently 0.0 either way it's expressed). Unlike the contract_pressure
+    # templates above, field_intensity never passed proposal_urgency()'s
+    # "_pressure"-suffix filter, so that function's real all-4-core-
+    # dimensions fallback was ALREADY triggering before this change --
+    # urgency is unaffected, this edit only makes the empty match/confidence
+    # honest in the schema instead of implying a scored (but fake) dimension.
+    dimensions: {}
 
   # P5: attention-bound proposal target. target_id/target_kind below are the
   # fallback literal, used only if target_binding fails to resolve (empty
@@ -178,5 +217,9 @@ proposal_templates:
     base_priority: 0.34   # shipped live per explicit user go-ahead ("turn on whatever you need"), not dark-shipped at 0.0 -- read-only inspect proposal under the existing policy gate, same risk class as every other already-live inspect template
     base_risk: 0.05
     reversibility: 1.0
-    dimensions:
-      field_intensity: 0.30
+    # field_intensity removed 2026-07-30 -- see inspect_field_topology_catalog's
+    # comment above for the full account (same disease, same template shape).
+    # This template's real live relevance signal is the attention binding
+    # itself (target_binding above), not a pressure dimension -- it was never
+    # this template's actual reason to exist.
+    dimensions: {}

--- a/orion/proposals/templates.py
+++ b/orion/proposals/templates.py
@@ -48,7 +48,7 @@ _TEMPLATE_COPY: dict[str, tuple[str, str, list[str]]] = {
     ),
     "summarize_loaded_state": (
         "Summarize loaded operating condition",
-        "Self-state is loaded with elevated field/resource/execution pressure; summarize for downstream review.",
+        "Resource pressure is loaded; summarize for downstream review.",
         ["loaded_operating_condition", "downstream_review"],
     ),
     "watch_reliability": (
@@ -58,19 +58,25 @@ _TEMPLATE_COPY: dict[str, tuple[str, str, list[str]]] = {
     ),
     "request_policy_review_for_action": (
         "Prepare policy review for possible action",
-        "Agency readiness and execution pressure are sufficient to consider a policy-gated action proposal.",
+        "Execution pressure is sufficient to consider a policy-gated action proposal.",
         ["policy_gate_required", "not_approval", "not_execution"],
     ),
     "defer_due_to_low_readiness": (
         "Defer action until readiness improves",
-        "Uncertainty or reliability pressure suggests deferring possible action until policy can evaluate later.",
+        "Reliability pressure suggests deferring possible action until policy can evaluate later.",
         ["defer_stability", "low_readiness"],
     ),
     "inspect_transport_status": (
         "Inspect transport capability status",
-        "Transport contract or reliability pressure is elevated; inspect capability:transport evidence.",
+        "Reliability pressure is elevated; inspect capability:transport evidence.",
         ["transport_inspect", "read_only"],
     ),
+    # 2026-07-30: these 3 transport templates no longer score against any real
+    # dimension (contract_pressure was never produced by field_pressures() --
+    # see config/proposals/proposal_policy.v1.yaml's own comment on each).
+    # Descriptions no longer claim a "pressure signal" reasoning that doesn't
+    # exist; they surface on base_priority + the real all-4-core-dimensions
+    # urgency fallback alone, same read-only bounded action either way.
     "inspect_bus_channel_catalog": (
         "Inspect bus channel catalog alignment",
         "Configured observer streams may be uncataloged; inspect orion/bus/channels.yaml read-only.",
@@ -78,12 +84,12 @@ _TEMPLATE_COPY: dict[str, tuple[str, str, list[str]]] = {
     ),
     "summarize_transport_contract_drift": (
         "Summarize transport contract drift",
-        "Catalog drift pressure on capability:transport warrants a bounded summary for review.",
+        "Periodic bounded summary of capability:transport for review.",
         ["transport_contract_drift", "read_only"],
     ),
     "watch_transport_backpressure": (
         "Watch transport backpressure",
-        "Transport pressure signals warrant observation without bus mutation.",
+        "Periodic observation of transport signals without bus mutation.",
         ["transport_backpressure_watch", "read_only"],
     ),
 }
@@ -117,7 +123,11 @@ def template_title_description(
         template_key,
         (
             f"Proposal for {target_id}",
-            f"Template {template_key} matched current self-state dimensions.",
+            # 2026-07-30: was "...matched current self-state dimensions" --
+            # stale since the 2026-07-22 SelfStateV1 burn (builder.py now
+            # scores directly off FieldStateV1's field_pressures(), not
+            # self-state).
+            f"Template {template_key} matched current field pressure dimensions.",
             [f"template:{template_key}"],
         ),
     )

--- a/tests/test_proposal_policy_loader.py
+++ b/tests/test_proposal_policy_loader.py
@@ -47,7 +47,10 @@ def test_inspect_field_topology_catalog_template_targets_field() -> None:
     assert tmpl.kind == "inspect"
     assert tmpl.target_kind == "field"
     assert tmpl.target_id == "config/field/orion_field_topology.v1.yaml"
-    assert "field_intensity" in tmpl.dimensions
+    # 2026-07-30: field_intensity removed -- never produced by
+    # field_pressures(), was this template's only (dead) dimension. Honestly
+    # empty now rather than implying a scored-but-fake dimension.
+    assert tmpl.dimensions == {}
 
 
 def test_inspect_attended_target_template_has_attention_binding() -> None:
@@ -58,7 +61,9 @@ def test_inspect_attended_target_template_has_attention_binding() -> None:
     assert tmpl.target_id == "capability:orchestration"
     assert tmpl.target_binding == "attention.dominant_targets[0]"
     assert tmpl.required_policy_gate == "read_only"
-    assert "field_intensity" in tmpl.dimensions
+    # 2026-07-30: field_intensity removed -- see
+    # test_inspect_field_topology_catalog_template_targets_field's comment.
+    assert tmpl.dimensions == {}
 
 
 def test_other_templates_have_no_target_binding() -> None:

--- a/tests/test_proposal_scoring.py
+++ b/tests/test_proposal_scoring.py
@@ -15,6 +15,7 @@ from orion.proposals.scoring import (
     proposal_confidence,
     proposal_priority,
     proposal_risk,
+    proposal_urgency,
     template_match_score,
 )
 from orion.schemas.field_state import FieldStateV1
@@ -48,10 +49,11 @@ def test_high_execution_pressure_raises_inspect_match() -> None:
 
 
 def test_high_resource_pressure_raises_summarize_match() -> None:
-    """field_intensity (the other dimension summarize_loaded_state scores on)
-    is a composite SelfStateV1 dimension with no post-burn replacement -- it
-    always reads 0.0 now (orion/field/pressure.py's module docstring). Only
-    resource_pressure can move this template's match score post-burn."""
+    """summarize_loaded_state used to also score on field_intensity, a
+    composite SelfStateV1 dimension with no post-burn replacement (always
+    0.0). Removed from the template's own `dimensions` 2026-07-30 (config/
+    proposals/proposal_policy.v1.yaml) -- resource_pressure is now its only,
+    real scoring dimension."""
     high = _pressures(pressure=0.9)
     low = _pressures(pressure=0.1)
     tmpl = POLICY.proposal_templates["summarize_loaded_state"]
@@ -67,9 +69,13 @@ def test_read_only_proposals_low_risk() -> None:
 
 
 def test_policy_review_higher_risk() -> None:
-    """agency_readiness (request_policy_review_for_action's other scoring
-    dimension) is composite and gone post-burn -- reliability_pressure alone
-    now drives the risk-bump comparison between these two template kinds."""
+    """request_policy_review_for_action used to also score on
+    agency_readiness, composite and gone post-burn. Removed from the
+    template's own `dimensions` 2026-07-30 -- execution_pressure is now its
+    only, real scoring dimension. `proposal_risk()` doesn't read
+    `dimensions` at all (only `reliability_pressure` directly and
+    `template.kind`/`required_policy_gate`), so this test's own risk-bump
+    comparison was never affected by that dimension either way."""
     pressures = _pressures(execution_pressure=1.0, reliability_pressure=0.8)
     review = POLICY.proposal_templates["request_policy_review_for_action"]
     inspect = POLICY.proposal_templates["inspect_execution_pressure"]
@@ -194,6 +200,49 @@ def test_proposal_confidence_zero_for_cold_start_field() -> None:
     field = FieldStateV1(generated_at=NOW, tick_id="tick_fresh")
     pressures = {"execution_pressure": 0.6}
     assert proposal_confidence(field=field, field_pressures=pressures, template=template) == 0.0
+
+
+def test_proposal_confidence_no_longer_capped_by_a_dead_dimension() -> None:
+    """Regression test (2026-07-30): summarize_loaded_state used to also
+    score on field_intensity, a composite dimension field_pressures() never
+    produces -- dimension_confidence() returns 0.0 PERMANENTLY for a
+    dimension absent from field_pressures this tick, and
+    proposal_confidence() averages across a template's dimensions, so this
+    template's real confidence was silently halved forever (capped at 0.5
+    even with a perfect real resource_pressure reading). field_intensity was
+    removed from the template's own `dimensions`
+    (config/proposals/proposal_policy.v1.yaml) -- confidence should now
+    equal resource_pressure's own real confidence directly, not half of it."""
+    template = POLICY.proposal_templates["summarize_loaded_state"]
+    assert template.dimensions == {"resource_pressure": 0.40}
+    field = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_test",
+        dimension_precision_ewma_n={"resource_pressure": DIMENSION_PRECISION_EWMA_MIN_SAMPLES},
+        dimension_precision_zscore={"resource_pressure": 0.0},
+    )
+    pressures = {"resource_pressure": 0.6}
+    assert proposal_confidence(field=field, field_pressures=pressures, template=template) == 1.0
+
+
+def test_proposal_urgency_wakes_up_once_the_dead_only_dimension_is_removed() -> None:
+    """Regression test (2026-07-30): inspect_bus_channel_catalog used to
+    score ONLY on contract_pressure, a dimension field_pressures() never
+    produces. proposal_urgency()'s own dimension filter
+    (`dim_id in PRESSURE_DIMENSIONS or dim_id.endswith("_pressure")`) let
+    "contract_pressure" pass through on the suffix check alone, contributing
+    a permanent dimension_score() of 0.0 -- a non-empty `scores` list, so
+    proposal_urgency()'s real all-4-core-dimensions fallback (`if not
+    scores`) never triggered, and urgency was permanently 0.0 regardless of
+    real field pressure. Now that the template's `dimensions` is honestly
+    empty, the fallback correctly triggers and urgency reflects the real
+    field."""
+    template = POLICY.proposal_templates["inspect_bus_channel_catalog"]
+    assert template.dimensions == {}
+    quiet = proposal_urgency(field_pressures={"execution_pressure": 0.05}, template=template)
+    loud = proposal_urgency(field_pressures={"execution_pressure": 0.95}, template=template)
+    assert quiet < loud
+    assert loud > 0.5
 
 
 # Real historical max per dimension, scripts/analysis/measure_proposal_


### PR DESCRIPTION
## Summary

- First patch from a design-mode scoping session on redesigning `orion/proposals/`'s scoring: removes 5 dimension_ids (`field_intensity`, `contract_pressure`, `agency_readiness`, `uncertainty`, `coherence`) that `orion/field/pressure.py::field_pressures()` has never produced since the 2026-07-22 SelfStateV1 burn, but that 9 of 12 live templates in `config/proposals/proposal_policy.v1.yaml` still referenced.
- This wasn't just inert config drift — it broke 3 different real scoring functions in different ways (see below).
- Deliberately scoped to removing dead/fake inputs only. `proposal_priority()`'s own hand-picked `0.4/0.2/0.1` blend and `proposal_risk()`'s hand-picked bumps are untouched — that's separate, larger, still-open work.

## Outcome moved

- **3 templates un-froze**: `inspect_bus_channel_catalog`, `summarize_transport_contract_drift`, `watch_transport_backpressure` had `contract_pressure` as their *only* dimension. Because that string ends in `"_pressure"`, it passed `proposal_urgency()`'s dimension filter while permanently scoring `0.0` — suppressing that function's real all-4-core-dimensions fallback. Combined with match/confidence also permanently `0.0`, these 3 templates' `proposal_priority()` was a frozen constant (`base_priority` alone), no real live signal at all, despite looking like scored proposals. Now they derive real urgency from the field.
- **4 templates' confidence un-capped**: `summarize_loaded_state`, `request_policy_review_for_action`, `inspect_transport_status`, `defer_due_to_low_readiness` had one dead + one real dimension. `proposal_confidence()` averages (`sum()/len()`) across a template's dimensions, and a dead dimension's confidence is *always* exactly `0.0` — permanently capping these 4 templates' real confidence at 0.5 no matter how confident the real dimension's own precision-weighted reading was. Now confidence reflects the real dimension directly (up to 1.0).
- **2 templates got an honest schema**: `inspect_field_topology_catalog`, `inspect_attended_target` had only `field_intensity` — match/confidence were already permanently 0.0 and urgency's fallback was already triggering (that string doesn't end in `_pressure`), so this is a schema-honesty fix (`dimensions: {}` instead of implying a scored-but-fake dimension) rather than a live-behavior change for these two.

## Current architecture

`build_proposal_frame()` → per template, `template_match_score()`/`proposal_urgency()`/`proposal_confidence()` read `template.dimensions: dict[str, float]` against `field_pressures(field)`'s real output, then `proposal_priority()` blends them. `field_pressures()` only ever emits 7 real keys (`execution/resource/reasoning/reliability/continuity/introspection/social_pressure`) — confirmed by reading `CHANNEL_DIMENSION_MAP` directly, not assumed from comments.

## Architecture touched

- `config/proposals/proposal_policy.v1.yaml`: removed 5 dead dimension_ids from 9 templates' `dimensions` maps and from top-level `dimension_weights`.
- `orion/proposals/templates.py`: updated `_TEMPLATE_COPY` description strings that claimed reasoning based on now-removed dimensions; fixed one unrelated stale "self-state dimensions" fallback string in `template_title_description()`.

## Files changed

- `config/proposals/proposal_policy.v1.yaml`: dead dimension_id removal, inline comments explaining each removal.
- `orion/proposals/templates.py`: description copy fixes.
- `tests/test_proposal_policy_loader.py`: 2 stale assertions updated to `dimensions == {}`.
- `tests/test_proposal_scoring.py`: 2 stale docstrings updated, 2 new regression tests added.

## Schema / bus / API changes

- Added: none.
- Removed: 5 dimension_ids no longer appear anywhere in `config/proposals/proposal_policy.v1.yaml` (they were never real schema fields, just dict keys with no producer).
- Renamed: none.
- Behavior changed: `proposal_urgency()`/`proposal_confidence()`/`ProposalCandidateV1.motivating_dimensions` now reflect real data only for the 9 affected templates — see "Outcome moved" above for the concrete before/after per template.
- Compatibility notes: `motivating_dimensions` (rendered in 3 Jinja prompt templates: `substrate_inspect/observe/summarize.j2`) already has an explicit empty-case branch, confirmed by code review — the 5 now-empty-dict templates render the honest "no dimension data" branch instead of a fabricated `dead_dim: 0.0` line. `scripts/analysis/measure_proposal_dimension_variance.py::template_dominant_dimension()` already guards `if not template.dimensions: continue`, handles this gracefully.

## Env/config changes

None.

## Tests run

```text
cd /mnt/scripts/Orion-Sapienform-proposal-dead-dimension-templates
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest tests/test_proposal_frame_builder.py tests/test_proposal_frame_schemas.py tests/test_proposal_policy_loader.py tests/test_proposal_scoring.py tests/test_proposal_transport_readonly_candidates.py tests/test_proposal_runtime_store.py tests/test_proposal_runtime_worker.py tests/test_measure_proposal_feedback_correlation.py services/orion-proposal-runtime/tests -q
74 passed, 14 warnings
```

`orion/reverie/tests/test_proposal.py` has 8 pre-existing, unrelated failures (stale `self_state_id` kwarg signature mismatch) — confirmed present even with this diff fully reverted, not caused by or fixed in this patch.

## Evals run

No dedicated eval harness beyond `scripts/analysis/measure_proposal_dimension_variance.py`, which isn't a pass/fail eval — it was used during review to confirm `template_dominant_dimension()` already handles empty `dimensions` dicts gracefully.

## Docker/build/smoke checks

Not run — pure config + Python-string change, no schema/env/runtime-boot-path change. `orion-proposal-runtime` picks up the new yaml on its next tick after restart.

## Review findings fixed

No material findings from the review pass. The reviewing subagent independently re-derived the match/confidence/urgency mechanism claims from `scoring.py` directly (not trusting my description), verified the 2 new regression tests actually fail against the pre-fix code via a real patch-revert-and-rerun exercise, and cross-checked every dead-dimension removal against the yaml line-by-line. One informational note surfaced, not a defect: `contract_pressure` is a real, live concept elsewhere in the repo (`config/substrate-lattice/transport_lattice_policy.v1.yaml`) — an entirely separate substrate-lattice salience system with its own `dimension_weights`, unrelated to this proposals config. This fix only concerns `contract_pressure` as a (fake) `field_pressures()`-sourced `orion/proposals/` dimension_id.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-proposal-runtime/.env \
  -f services/orion-proposal-runtime/docker-compose.yml \
  up -d --build orion-proposal-runtime
```

## Risks / concerns

- Severity: low
- Concern: the 3 transport templates (`inspect_bus_channel_catalog`, `summarize_transport_contract_drift`, `watch_transport_backpressure`) now score `match_score=0.0`/`confidence=0.0` permanently (unchanged from before) and derive `priority` only from `base_priority` + the real all-4-core-dimensions urgency fallback — a generic signal, not transport-specific. Building a real transport/bus-health dimension (a new `CHANNEL_DIMENSION_MAP` category, `PRESSURE_DIMENSIONS` extension, and live variance verification, same discipline already applied to the existing 4 dimensions) is real, disclosed follow-up work, not done here.
- Mitigation: named explicitly in this PR and in the proposals scoping doc discussion that preceded it; not silently left implicit.

## PR link

(filled in by `gh pr create` output)