### PR TITLE
feat(structural-mass): git_churn_delta + skeleton codebase_prediction_error

### DIFF
--- a/orion/structural_mass/__init__.py
+++ b/orion/structural_mass/__init__.py
@@ -1,0 +1,9 @@
+"""Codebase-mass domain: sixth Predictive Processing/Active Inference domain (see
+``orion/substrate/prediction_error.py::codebase_prediction_error``).
+
+Phase 1 slice only (docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md):
+``git_delta.py``'s pure git-diff summary. ``graph_delta.py`` (graphify structural
+deltas) and ``pr_lifecycle.py`` (GitHub PR lifecycle counts) are not implemented yet
+-- this package will grow those alongside the ``orion-cocreation-signals`` service
+that schedules them, not before.
+"""

--- a/orion/structural_mass/git_delta.py
+++ b/orion/structural_mass/git_delta.py
@@ -1,0 +1,141 @@
+"""Pure git-diff summary between two commits -- the ``git_churn_delta`` piece of
+the codebase-mass domain (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
+design.md, Phase 1). Shells out to ``git``, holds no state of its own: the caller
+(the not-yet-built ``orion-cocreation-signals`` producer) owns persisting
+``head_sha`` as the next call's ``prev_sha``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GitChurnDelta:
+    prev_sha: str
+    head_sha: str
+    commit_count: int
+    files_added: int
+    files_deleted: int
+    files_modified: int
+    lines_added: int
+    lines_removed: int
+
+    @property
+    def files_changed(self) -> int:
+        return self.files_added + self.files_deleted + self.files_modified
+
+    @property
+    def lines_changed(self) -> int:
+        return self.lines_added + self.lines_removed
+
+
+def _run_git(args: list[str], repo_path: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # subprocess.CalledProcessError's own __str__ drops stderr (just "returned
+        # non-zero exit status N") -- surface git's real message (e.g. "fatal:
+        # Invalid revision range") in the exception text itself, since a caller
+        # that logs str(exc) (the common case) would otherwise lose it.
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def git_churn_delta(prev_sha: str, head_sha: str, repo_path: str | Path = ".") -> GitChurnDelta:
+    """Commit count, file add/delete/modify counts, and net line churn between
+    ``prev_sha`` and ``head_sha`` (``git diff prev_sha head_sha``, i.e. the total
+    working-tree difference, not a squash of individual per-commit diffs -- matches
+    how every other domain in this module diffs two snapshots, not a sum of
+    intermediate states).
+
+    ``prev_sha == head_sha`` returns an explicit all-zero delta rather than
+    shelling out -- a real no-op tick (nothing changed since the last check), not
+    a degenerate/uncomputed value. Per this repo's "no empty-shell cognition"
+    rule, a real, deliberately-computed zero is not the same failure as a value
+    that was never actually measured.
+
+    Trigger shape is caller-driven and tick-interval-based, not git-hook-driven
+    (see the design spec's "self-healing by construction" note): a commit made on
+    another node, via Cursor, or without this repo's ``post-commit`` hook firing
+    doesn't lose anything -- the next successful check just diffs a larger range.
+    """
+    repo = Path(repo_path)
+    if prev_sha == head_sha:
+        return GitChurnDelta(
+            prev_sha=prev_sha,
+            head_sha=head_sha,
+            commit_count=0,
+            files_added=0,
+            files_deleted=0,
+            files_modified=0,
+            lines_added=0,
+            lines_removed=0,
+        )
+
+    commit_count = int(
+        _run_git(["rev-list", "--count", f"{prev_sha}..{head_sha}"], repo).strip()
+    )
+
+    # --find-renames: plain `git diff` does NOT detect renames/copies by default
+    # (confirmed live, git 2.43.0 -- a pure rename with no flags reports as an
+    # unrelated A+D pair, not a single R line). Without this flag, every rename
+    # would double-count as one added file and one deleted file instead of one
+    # modified file -- exactly the "net new/removed file" miscount this bucketing
+    # exists to avoid. `--find-copies` is deliberately not added: copy detection
+    # is more expensive (it has to scan unchanged blobs too, not just the diff)
+    # and this domain has no real need to distinguish "copied" from "added" for a
+    # mass-sensing signal, unlike a rename, which is not new mass.
+    files_added = files_deleted = files_modified = 0
+    for line in _run_git(
+        ["diff", "--find-renames", "--name-status", prev_sha, head_sha], repo
+    ).splitlines():
+        if not line.strip():
+            continue
+        status = line.split("\t", 1)[0]
+        if status.startswith("A"):
+            files_added += 1
+        elif status.startswith("D"):
+            files_deleted += 1
+        else:
+            # M (modified), R (renamed, now detected via --find-renames above),
+            # T (type-changed) all count as "modified" for mass-sensing purposes
+            # -- a rename isn't a net new or removed file, and the spec names
+            # only three buckets (added/deleted/modified).
+            files_modified += 1
+
+    lines_added = lines_removed = 0
+    for line in _run_git(
+        ["diff", "--find-renames", "--numstat", prev_sha, head_sha], repo
+    ).splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        added, removed = parts[0], parts[1]
+        # Binary files report "-" for both columns -- not line-countable, skip.
+        if added != "-":
+            lines_added += int(added)
+        if removed != "-":
+            lines_removed += int(removed)
+
+    return GitChurnDelta(
+        prev_sha=prev_sha,
+        head_sha=head_sha,
+        commit_count=commit_count,
+        files_added=files_added,
+        files_deleted=files_deleted,
+        files_modified=files_modified,
+        lines_added=lines_added,
+        lines_removed=lines_removed,
+    )

--- a/orion/structural_mass/tests/test_git_delta.py
+++ b/orion/structural_mass/tests/test_git_delta.py
@@ -1,0 +1,160 @@
+"""Unit tests for ``orion/structural_mass/git_delta.py::git_churn_delta`` -- built
+against a real, throwaway git repo (not this repo's own history) so results are
+deterministic and independent of whatever commits happen to exist locally."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from orion.structural_mass.git_delta import git_churn_delta
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def test_git_churn_delta_zero_when_prev_equals_head(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "a.txt").write_text("hello\n")
+    sha = _commit(repo, "initial")
+
+    delta = git_churn_delta(sha, sha, repo_path=repo)
+
+    assert delta.commit_count == 0
+    assert delta.files_added == 0
+    assert delta.files_deleted == 0
+    assert delta.files_modified == 0
+    assert delta.lines_added == 0
+    assert delta.lines_removed == 0
+    assert delta.files_changed == 0
+    assert delta.lines_changed == 0
+
+
+def test_git_churn_delta_counts_added_deleted_modified_files(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "keep.txt").write_text("line1\nline2\n")
+    (repo / "remove.txt").write_text("gone\n")
+    prev_sha = _commit(repo, "initial")
+
+    (repo / "keep.txt").write_text("line1\nline2-changed\nline3\n")
+    (repo / "remove.txt").unlink()
+    (repo / "new.txt").write_text("brand new\n")
+    head_sha = _commit(repo, "second")
+
+    delta = git_churn_delta(prev_sha, head_sha, repo_path=repo)
+
+    assert delta.commit_count == 1
+    assert delta.files_added == 1  # new.txt
+    assert delta.files_deleted == 1  # remove.txt
+    assert delta.files_modified == 1  # keep.txt
+    assert delta.files_changed == 3
+    # keep.txt: -1 line2 +1 line2-changed +1 line3 => 2 added, 1 removed
+    # remove.txt: -1 line
+    # new.txt: +1 line
+    assert delta.lines_added == 3
+    assert delta.lines_removed == 2
+    assert delta.lines_changed == 5
+
+
+def test_git_churn_delta_counts_multiple_commits(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "a.txt").write_text("v1\n")
+    prev_sha = _commit(repo, "c1")
+
+    (repo / "a.txt").write_text("v2\n")
+    _commit(repo, "c2")
+    (repo / "b.txt").write_text("new\n")
+    head_sha = _commit(repo, "c3")
+
+    delta = git_churn_delta(prev_sha, head_sha, repo_path=repo)
+
+    assert delta.commit_count == 2
+    assert delta.files_added == 1
+    assert delta.files_modified == 1
+
+
+def test_git_churn_delta_counts_pure_rename_as_modified_not_add_plus_delete(
+    tmp_path: Path,
+) -> None:
+    """`git diff --find-renames --name-status` emits a single `R100\told\tnew`
+    line for a rename with unchanged content (two path columns, not one) --
+    must count as one "modified" file, not one added + one deleted. Without
+    `--find-renames` this repo's own git 2.43.0 build reports a plain rename as
+    an unrelated A+D pair by default -- confirmed live -- which is exactly the
+    miscount `git_churn_delta` passes `--find-renames` to avoid."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "old.txt").write_text("line1\nline2\nline3\n")
+    prev_sha = _commit(repo, "initial")
+
+    _git(repo, "mv", "old.txt", "new.txt")
+    head_sha = _commit(repo, "rename")
+
+    delta = git_churn_delta(prev_sha, head_sha, repo_path=repo)
+
+    assert delta.files_added == 0
+    assert delta.files_deleted == 0
+    assert delta.files_modified == 1
+    assert delta.files_changed == 1
+    assert delta.lines_added == 0
+    assert delta.lines_removed == 0
+
+
+def test_git_churn_delta_skips_binary_files_in_line_counts(tmp_path: Path) -> None:
+    """`git diff --numstat` reports `-\t-\tpath` for binary files -- must not
+    raise trying to `int("-")`, and must not contribute to line counts, while
+    still counting the file itself in the name-status buckets."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "placeholder.txt").write_text("unrelated\n")
+    prev_sha = _commit(repo, "initial")
+
+    (repo / "image.bin").write_bytes(b"\x00\x01\x02\xff\xfe")
+    head_sha = _commit(repo, "add binary")
+
+    delta = git_churn_delta(prev_sha, head_sha, repo_path=repo)
+
+    assert delta.files_added == 1
+    assert delta.lines_added == 0
+    assert delta.lines_removed == 0
+
+
+def test_git_churn_delta_skips_no_op_ticks_between_calls(tmp_path: Path) -> None:
+    """Mirrors the design spec's tick-driven, self-healing-by-construction shape:
+    a caller comparing the same last-seen SHA across two no-op checks should get
+    an explicit zero delta both times, not an error or a stale value."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "a.txt").write_text("v1\n")
+    sha = _commit(repo, "c1")
+
+    first = git_churn_delta(sha, sha, repo_path=repo)
+    second = git_churn_delta(sha, sha, repo_path=repo)
+
+    assert first == second
+    assert first.lines_changed == 0

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from typing import Any
 
 from orion.bus.ewma import compute_ewma_update
@@ -9,6 +10,7 @@ from orion.schemas.chat_projection import ChatSessionProjectionV1
 from orion.schemas.execution_projection import ExecutionTrajectoryProjectionV1
 from orion.schemas.route_projection import RouteArbitrationProjectionV1
 from orion.schemas.transport_projection import TransportBusProjectionV1
+from orion.structural_mass.git_delta import GitChurnDelta
 from orion.substrate.chat_loop.grammar_extract import compute_chat_pressure_hints
 
 _THRESHOLD = 0.30
@@ -60,6 +62,125 @@ _EXECUTION_PREDICTION_ERROR_ZSCORE_SATURATION = 3.0
 # saturation) -- not re-tuned per this domain's future drift, so revisit if
 # execution's real delta scale ever shifts by orders of magnitude.
 _EXECUTION_PREDICTION_ERROR_MIN_VARIANCE = 1e-10
+
+
+# 2026-07-30: codebase_prediction_error's EWMA baseline calibration (Phase 1 skeleton,
+# docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md -- no bus wiring, no
+# NODE_CHANNELS registration yet, see that spec's "Recommended next patch"). alpha=0.2
+# reuses execution_prediction_error's own alpha rather than inventing a new number for
+# a domain that, like execution, updates per real observation (a real git-churn tick,
+# not a fixed wall-clock cadence). min_variance calibrated against this repo's own real,
+# if shallow-clone-limited, commit history via
+# scripts/analysis/measure_codebase_prediction_error.py -- see that constant's own
+# comment for the live numbers.
+_CODEBASE_PREDICTION_ERROR_EWMA_ALPHA = 0.2
+_CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION = 3.0
+
+# 2026-07-30: live-confirmed via scripts/analysis/measure_codebase_prediction_error.py
+# against this repo's own real (shallow-clone-limited to 49 ticks/50 commits locally --
+# a real limitation, not a full backfill; see the design spec's "Backfill" section for
+# why a deeper replay needs scripts/analysis/backfill_structural_mass.py, not this
+# script) recent commit history, one tick per real commit: raw per-tick line-churn
+# magnitude (lines_changed) ranged 0-15,285 (mean 2,611, stdev 4,314; only 2/48 ticks
+# were true zero-churn no-ops), and the EWMA's own accumulated variance warmed up into
+# the 1.5M-60M range within a handful of ticks -- squared-magnitude units on a
+# thousands-scale raw signal are naturally large, several orders of magnitude *above*
+# the shared orion/bus/ewma.py default (1e-6), the mirror-image relationship to
+# execution_prediction_error's real variance (which sat far *below* that default).
+# Because the EWMA's own accumulated variance dominates this floor immediately once
+# any real deviation has been folded in, this constant's only actual effect across the
+# whole replayed window was guarding the single first real z-score computation (the
+# second observed tick, where prev_variance is still exactly 0.0 from the cold-start
+# branch) against amplifying a small real deviation into a false-large z purely from
+# dividing by a near-zero floor -- every later tick's z-score was already governed by
+# the domain's own real accumulated variance regardless of this constant's exact value.
+# Set low relative to this domain's observed real variance scale (not tuned to match
+# it -- there is nothing here for it to match, it is intentionally never the binding
+# term past the first tick) while staying safely nonzero; revisit only if a much
+# larger/deeper replay (post-backfill) shows a materially different cold-start regime.
+_CODEBASE_PREDICTION_ERROR_MIN_VARIANCE = 1.0
+
+
+@dataclass(frozen=True)
+class CodebaseMassBaseline:
+    """EWMA baseline state for ``codebase_prediction_error``, threaded explicitly by
+    the caller rather than read off a persisted projection -- unlike the other five
+    domains in this module, no ``structural_mass`` projection schema or bus channel
+    exists yet (Phase 1 skeleton only; see this module's codebase_prediction_error
+    docstring)."""
+
+    ewma: float = 0.0
+    variance: float = 0.0
+    n: int = 0
+
+
+@dataclass(frozen=True)
+class CodebasePredictionErrorResult:
+    score: float
+    baseline: CodebaseMassBaseline
+
+
+def codebase_prediction_error(
+    delta: GitChurnDelta,
+    baseline: CodebaseMassBaseline,
+) -> CodebasePredictionErrorResult:
+    """0-1 surprise score: how much did this tick's git churn deviate from this
+    domain's own recent normal.
+
+    **Phase 1 skeleton** (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
+    design.md) -- not wired into any tick, no ``NODE_CHANNELS`` registration, no bus
+    channel. Exists so the replay script
+    (``scripts/analysis/measure_codebase_prediction_error.py``) has a real function to
+    call before any of that is built, per this program's "measure before minting"
+    discipline (SSP §7) -- same order every other domain in this module has followed.
+
+    Unlike the other five domains, there is no ``prev``/``curr`` projection pair to
+    diff here -- ``GitChurnDelta`` (``orion/structural_mass/git_delta.py``) is
+    already a diff (of two git SHAs), so this function's job is scoring *that*
+    delta's magnitude against this domain's own EWMA baseline, the same shape
+    ``execution_prediction_error`` uses once it already has its raw per-tick delta
+    in hand. Raw magnitude is ``delta.lines_changed`` (net lines added + removed) --
+    the single continuous scale that best reflects "how much of the codebase moved,"
+    with commit/file counts available on ``delta`` itself for callers that want them
+    as separate descriptive fields (e.g. a future concept-classification consumer)
+    without folding them into this one scalar and reintroducing an arbitrary
+    cross-scale weighting (commits vs. files vs. lines) this function deliberately
+    avoids, the same reasoning ``route_prediction_error``'s docstring gives for not
+    hand-encoding categorical fields into one number.
+
+    No baseline state is read from or written to any persisted store -- the caller
+    owns threading ``baseline`` from one call to the next (mirrors
+    ``compute_ewma_update``'s own explicit-state-in, explicit-state-out shape,
+    rather than the other domains' "mutate the projection in place" pattern, since
+    there is no projection object to mutate here yet).
+
+    Returns ``score=0.0`` on the very first observation (``baseline.n == 0``) --
+    ``compute_ewma_update`` returns no z-score until a real baseline exists, and
+    reporting a nonzero value here would misrepresent "no baseline yet" as
+    "measured, not anomalous" (this repo's "no empty-shell cognition" rule). A
+    below-baseline tick (this commit churned *less* than usual) is clamped to 0.0,
+    not reported as negative surprise -- "surprising" here means "more churn than
+    usual," matching ``execution_prediction_error``'s same clamp for the same
+    reason.
+    """
+    raw_magnitude = float(delta.lines_changed)
+    update = compute_ewma_update(
+        prev_ewma=baseline.ewma,
+        prev_variance=baseline.variance,
+        prev_count=baseline.n,
+        value=raw_magnitude,
+        alpha=_CODEBASE_PREDICTION_ERROR_EWMA_ALPHA,
+        min_variance=_CODEBASE_PREDICTION_ERROR_MIN_VARIANCE,
+    )
+    new_baseline = CodebaseMassBaseline(
+        ewma=update.ewma, variance=update.variance, n=baseline.n + 1
+    )
+    if update.zscore is None:
+        return CodebasePredictionErrorResult(score=0.0, baseline=new_baseline)
+    score = min(
+        1.0, max(0.0, update.zscore) / _CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION
+    )
+    return CodebasePredictionErrorResult(score=score, baseline=new_baseline)
 
 
 def _mean(values: list[float]) -> float:

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -23,10 +23,13 @@ from orion.schemas.route_projection import (
     RouteArbitrationProjectionV1,
     RouteArbitrationRunStateV1,
 )
+from orion.structural_mass.git_delta import GitChurnDelta
 from orion.substrate.prediction_error import (
+    CodebaseMassBaseline,
     biometrics_prediction_error,
     bus_synaptic_prediction_error,
     chat_prediction_error,
+    codebase_prediction_error,
     execution_prediction_error,
     route_prediction_error,
 )
@@ -655,3 +658,116 @@ class TestBusSynapticPredictionError:
         """Expected value updated 2026-07-26 for the calm-floor subtraction:
         mean([0.0, 3.0]) = 1.5, same transform as the 1.5 case above."""
         assert bus_synaptic_prediction_error([0.0, 3.0]) == pytest.approx(0.3188367996970756)
+
+
+class TestCodebasePredictionError:
+    """Phase 1 skeleton (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
+    design.md) -- not wired into any tick yet. Unlike the other five instruments,
+    the input is already a diff (``GitChurnDelta``, itself a diff of two git SHAs),
+    so there is no prev/curr projection pair here; state (the EWMA baseline) is
+    threaded explicitly via ``CodebaseMassBaseline`` rather than mutated on a
+    persisted projection object, since no such schema exists yet."""
+
+    def _delta(
+        self,
+        *,
+        lines_added: int = 0,
+        lines_removed: int = 0,
+        commit_count: int = 1,
+        files_added: int = 0,
+        files_deleted: int = 0,
+        files_modified: int = 0,
+    ) -> GitChurnDelta:
+        return GitChurnDelta(
+            prev_sha="a" * 40,
+            head_sha="b" * 40,
+            commit_count=commit_count,
+            files_added=files_added,
+            files_deleted=files_deleted,
+            files_modified=files_modified,
+            lines_added=lines_added,
+            lines_removed=lines_removed,
+        )
+
+    def test_no_commit_since_last_tick_is_explicit_no_op(self) -> None:
+        """A zero-magnitude delta (git_churn_delta's own prev_sha == head_sha
+        shape) must read 0.0, and -- like every other domain's cold-start
+        behavior -- must still seed the baseline rather than silently no-op the
+        state too."""
+        delta = self._delta(commit_count=0, lines_added=0, lines_removed=0)
+        baseline = CodebaseMassBaseline()
+        result = codebase_prediction_error(delta, baseline)
+        assert result.score == 0.0
+        assert result.baseline.n == 1
+        assert result.baseline.ewma == 0.0
+
+    def test_first_tick_is_cold_start_but_seeds_baseline(self) -> None:
+        """No established baseline yet (baseline.n == 0) -- must return 0.0 (no
+        z-score to compute against -- 'no empty-shell cognition'), but the
+        returned baseline must carry this tick's real raw magnitude forward so
+        the very next tick has something real to compare against."""
+        delta = self._delta(lines_added=400, lines_removed=200)
+        baseline = CodebaseMassBaseline()
+        result = codebase_prediction_error(delta, baseline)
+        assert result.score == 0.0
+        assert result.baseline.ewma == pytest.approx(600.0)
+        assert result.baseline.variance == 0.0
+        assert result.baseline.n == 1
+
+    def test_one_normal_commit_scores_against_established_baseline(self) -> None:
+        """Once a baseline is established, a tick close to that baseline's own
+        recent normal should read a low/near-zero score, not a spike -- this is
+        the 'genuine rest state' the metric-quality-gate step 4 requires (a
+        normal-sized commit must not look anomalous by construction)."""
+        baseline = CodebaseMassBaseline(ewma=500.0, variance=10_000.0, n=5)
+        delta = self._delta(lines_added=300, lines_removed=220)  # magnitude 520
+        result = codebase_prediction_error(delta, baseline)
+        # zscore = (520 - 500) / sqrt(10_000) = 0.2 -> well below saturation
+        assert result.score == pytest.approx(0.2 / 3.0)
+        assert result.baseline.n == 6
+
+    def test_saturates_exactly_at_zscore_saturation_boundary(self) -> None:
+        """No off-by-one at the saturation ceiling: a zscore of exactly 3.0 (this
+        module's _CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION) must score exactly
+        1.0, not something just short of or past it."""
+        baseline = CodebaseMassBaseline(ewma=500.0, variance=100.0, n=10)
+        delta = self._delta(lines_added=530, lines_removed=0)  # magnitude 530
+        # zscore = (530 - 500) / sqrt(100) = 3.0 exactly
+        result = codebase_prediction_error(delta, baseline)
+        assert result.score == pytest.approx(1.0)
+
+    def test_large_catch_up_diff_spanning_missed_ticks_scores_high(self) -> None:
+        """A big diff accumulated across several missed ticks (a commit made on
+        another node, via Cursor, or without the post-commit hook firing --
+        the design spec's 'self-healing by construction' shape) should read as
+        a real spike relative to the domain's own established baseline, not be
+        silently absorbed."""
+        baseline = CodebaseMassBaseline(ewma=500.0, variance=10_000.0, n=20)
+        delta = self._delta(
+            lines_added=9000, lines_removed=6000, commit_count=14, files_modified=40
+        )  # magnitude 15,000
+        result = codebase_prediction_error(delta, baseline)
+        # zscore = (15_000 - 500) / sqrt(10_000) = 145.0 -> far past saturation
+        assert result.score == pytest.approx(1.0)
+
+    def test_below_baseline_tick_clamps_to_zero_not_negative(self) -> None:
+        """A quieter-than-usual tick (negative z-score) must clamp to 0.0, not
+        go negative -- 'surprising' means 'more churn than usual,' matching
+        execution_prediction_error's identical clamp for the same reason."""
+        baseline = CodebaseMassBaseline(ewma=5000.0, variance=1_000_000.0, n=10)
+        delta = self._delta(lines_added=10, lines_removed=5)  # magnitude 15
+        result = codebase_prediction_error(delta, baseline)
+        assert result.score == 0.0
+
+    def test_baseline_state_flows_independently_of_module_globals(self) -> None:
+        """Two independent baseline threads (e.g. two different replay windows)
+        must not interfere with each other -- state is entirely caller-owned,
+        no hidden module-level mutation."""
+        delta = self._delta(lines_added=100, lines_removed=0)
+        baseline_a = CodebaseMassBaseline()
+        baseline_b = CodebaseMassBaseline(ewma=9999.0, variance=1.0, n=50)
+        result_a = codebase_prediction_error(delta, baseline_a)
+        result_b = codebase_prediction_error(delta, baseline_b)
+        assert result_a.baseline.n == 1
+        assert result_b.baseline.n == 51
+        assert result_a.baseline.ewma != result_b.baseline.ewma

--- a/scripts/analysis/measure_codebase_prediction_error.py
+++ b/scripts/analysis/measure_codebase_prediction_error.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Read-only replay of ``codebase_prediction_error()`` against this repo's own real
+commit history -- SSP §7's "measure before minting" discipline, same order every
+other domain in ``orion/substrate/prediction_error.py`` has followed (see
+docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md, "Recommended next
+patch"). No bus wiring, no NODE_CHANNELS registration -- this script only proves the
+function is non-degenerate before either of those exist.
+
+Walks ``git log --reverse`` on the given branch/range, computes one
+``git_churn_delta`` per consecutive commit pair (one tick per real commit), and
+reports whether the resulting scores are non-degenerate (real variance, not flat)
+and whether the domain can genuinely rest near a low/zero reading, per CLAUDE.md's
+metric-quality-gate step 4.
+
+Run:
+    python scripts/analysis/measure_codebase_prediction_error.py
+    python scripts/analysis/measure_codebase_prediction_error.py --max-commits 200
+    python scripts/analysis/measure_codebase_prediction_error.py --since-sha <sha> --until-sha <sha>
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from orion.structural_mass.git_delta import git_churn_delta  # noqa: E402
+from orion.substrate.prediction_error import (  # noqa: E402
+    CodebaseMassBaseline,
+    codebase_prediction_error,
+)
+
+
+def _commit_shas(repo_path: Path, since_sha: str | None, until_sha: str, max_commits: int) -> list[str]:
+    args = ["log", "--reverse", "--format=%H"]
+    if since_sha:
+        args.append(f"{since_sha}..{until_sha}")
+    else:
+        args.append(until_sha)
+    result = subprocess.run(
+        ["git", *args], cwd=repo_path, capture_output=True, text=True, check=True
+    )
+    shas = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if max_commits and len(shas) > max_commits:
+        shas = shas[-max_commits:]
+    return shas
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-path", default=str(_REPO_ROOT))
+    parser.add_argument("--since-sha", default=None, help="Exclusive lower bound; default walks full local history.")
+    parser.add_argument("--until-sha", default="HEAD")
+    parser.add_argument("--max-commits", type=int, default=500, help="Cap on ticks replayed (0 = no cap).")
+    args = parser.parse_args()
+
+    repo_path = Path(args.repo_path)
+    shas = _commit_shas(repo_path, args.since_sha, args.until_sha, args.max_commits)
+    if len(shas) < 2:
+        print(f"Not enough commits to replay (found {len(shas)}) -- widen the range.")
+        return 1
+
+    baseline = CodebaseMassBaseline()
+    raw_magnitudes: list[float] = []
+    scores: list[float] = []
+    variances_after_warmup: list[float] = []
+
+    print(f"Replaying {len(shas) - 1} tick(s) across {len(shas)} commits "
+          f"({shas[0][:10]}..{shas[-1][:10]})\n")
+    print(f"{'sha':<12} {'commits':>7} {'+files':>6} {'-files':>6} {'~files':>6} "
+          f"{'lines':>8} {'zscore/score':>14}")
+
+    for prev_sha, head_sha in zip(shas, shas[1:]):
+        delta = git_churn_delta(prev_sha, head_sha, repo_path=repo_path)
+        result = codebase_prediction_error(delta, baseline)
+        raw_magnitudes.append(float(delta.lines_changed))
+        scores.append(result.score)
+        if baseline.n >= 5:  # "warmed up" -- ignore cold-start variance=0.0 entries
+            variances_after_warmup.append(result.baseline.variance)
+        baseline = result.baseline
+        print(
+            f"{head_sha[:10]:<12} {delta.commit_count:>7} {delta.files_added:>6} "
+            f"{delta.files_deleted:>6} {delta.files_modified:>6} "
+            f"{delta.lines_changed:>8} {result.score:>14.4f}"
+        )
+
+    print("\n--- Distributional sanity (CLAUDE.md metric-quality-gate step 4) ---")
+    print(f"raw magnitude (lines_changed): min={min(raw_magnitudes):.0f} "
+          f"max={max(raw_magnitudes):.0f} mean={statistics.fmean(raw_magnitudes):.1f} "
+          f"stdev={statistics.pstdev(raw_magnitudes):.1f}")
+    print(f"score: min={min(scores):.4f} max={max(scores):.4f} "
+          f"mean={statistics.fmean(scores):.4f}")
+    n_zero_magnitude = sum(1 for m in raw_magnitudes if m == 0.0)
+    print(f"zero-churn ticks (real no-op commits): {n_zero_magnitude}/{len(raw_magnitudes)}")
+    if variances_after_warmup:
+        print(f"warmed-up EWMA variance (n>=5): min={min(variances_after_warmup):.2f} "
+              f"max={max(variances_after_warmup):.2f} "
+              f"mean={statistics.fmean(variances_after_warmup):.2f}")
+
+    if len(set(scores)) == 1:
+        print("\nFLAG: every score identical -- degenerate, do not trust this domain yet.")
+        return 1
+    if min(scores) > 0.05 and len(scores) > 5:
+        print("\nFLAG: never reads near-zero across the replayed window -- check for a "
+              "structurally-incapable-of-calm bug (see bus_synaptic_prediction_error's "
+              "2026-07-26 floor-bias history).")
+        return 1
+
+    print("\nOK: scores are non-degenerate and include near-zero readings.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 1's first implementation slice of the "codebase mass" signal — a sixth Predictive Processing/Active Inference domain sensing git churn (design: `docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md`). Per that spec's "Recommended next patch": measure first, register once MET — this patch deliberately has **no bus wiring, no `NODE_CHANNELS` registration, no service scaffolding**.

- `orion/structural_mass/git_delta.py`: `git_churn_delta(prev_sha, head_sha)` — pure function shelling out to `git diff --find-renames`, returning commit count, file add/delete/modify counts, and net line churn between two SHAs.
- `orion/substrate/prediction_error.py`: `codebase_prediction_error()` scores a `GitChurnDelta`'s magnitude as an EWMA z-score against an explicitly-threaded `CodebaseMassBaseline` (no persisted projection schema exists for this domain yet, unlike the module's other five domains, which mutate fields on a projection object).
- `scripts/analysis/measure_codebase_prediction_error.py`: read-only replay script, run against this repo's own real (shallow-clone-limited to 49 local commits) history to calibrate `_CODEBASE_PREDICTION_ERROR_MIN_VARIANCE`.

## Outcome moved

Two of Phase 1's three acceptance checks are now real, not aspirational:
- Replay script produces non-degenerate values on real git history, with genuine near-zero readings (not a decay artifact).
- `codebase_prediction_error()` unit tests cover no-op tick, one normal commit, and a large catch-up diff spanning missed ticks.

## Current architecture

Before this patch, Orion had no interoceptive sense of its own codebase's size/shape — every existing `prediction_error` domain (execution, transport, biometrics, chat, route, bus_synaptic) senses runtime state, not the substrate itself.

## Architecture touched

`orion/substrate/prediction_error.py` only — no service, bus, or schema contract changes.

## Files changed

- `orion/structural_mass/__init__.py`: new module, scoped explicitly to Phase 1 (git delta only — `graph_delta.py`/`pr_lifecycle.py` not implemented yet).
- `orion/structural_mass/git_delta.py`: `GitChurnDelta` dataclass + `git_churn_delta()`.
- `orion/structural_mass/tests/test_git_delta.py`: builds real throwaway git repos via subprocess to test add/delete/modify/rename/binary-file parsing and the no-op short-circuit.
- `orion/substrate/prediction_error.py`: `CodebaseMassBaseline`, `CodebasePredictionErrorResult`, `codebase_prediction_error()`, and the calibrated EWMA constants.
- `orion/substrate/tests/test_prediction_error.py`: `TestCodebasePredictionError` (7 tests: no-op, cold-start seeding, normal-commit scoring, saturation boundary, large catch-up diff, below-baseline clamp, independent baseline threading).
- `scripts/analysis/measure_codebase_prediction_error.py`: replay script — walks real commit history, computes one tick per commit, reports distributional sanity stats.

## Schema / bus / API changes

None. No `orion/bus/channels.yaml` or `orion/schemas/registry.py` changes — this domain has no bus channel yet by design.

## Env/config changes

None.

## Tests run

```
cd orion/structural_mass/tests + orion/substrate/tests/test_prediction_error.py
57 passed, 1 warning in 2.61s

Full orion/substrate/tests/ regression suite:
488 passed, 16 warnings in 10.20s
```

## Evals run

The replay script (`scripts/analysis/measure_codebase_prediction_error.py`) is this domain's "eval" per SSP §7's measure-before-minting discipline — no other eval harness exists for this not-yet-registered domain.

```
$ python3 scripts/analysis/measure_codebase_prediction_error.py --max-commits 49
Replaying 48 tick(s) across 49 commits
raw magnitude (lines_changed): min=0 max=15285 mean=2610.8 stdev=4313.5
score: min=0.0000 max=1.0000 mean=0.1243
zero-churn ticks (real no-op commits): 2/48
warmed-up EWMA variance (n>=5): min=1513282.87 max=59553878.61 mean=20530925.95
OK: scores are non-degenerate and include near-zero readings.
```

Note: this repo's local clone is shallow (49 commits) — this is a real-data sanity check, not the full drives-arc backfill described in the design spec's "Backfill" section (that's `scripts/analysis/backfill_structural_mass.py`, a separate, not-yet-built follow-up).

## Docker/build/smoke checks

Not applicable — no service, no runtime, no compose changes.

## Review findings fixed

- Finding: Rename/copy/type-change parsing was entirely untested, and on this repo's real git 2.43.0 build, plain `git diff --name-status` (no flags) doesn't detect renames at all by default — a rename reports as an unrelated add+delete pair, which the code's original comment incorrectly implied was already handled.
  - Fix: Added `--find-renames` to both `git diff` invocations in `git_churn_delta`, so a real rename is correctly bucketed as "modified," not double-counted as add+delete. Added a test confirming this against a real throwaway repo.
  - Evidence: `orion/structural_mass/git_delta.py` (`--find-renames` flag + updated comment); `orion/structural_mass/tests/test_git_delta.py::test_git_churn_delta_counts_pure_rename_as_modified_not_add_plus_delete`.
- Finding: `subprocess.CalledProcessError`'s default `__str__()` drops `stderr` (just "returned non-zero exit status 128"), so a caller that logs `str(exc)` (the common case) would lose git's real error message.
  - Fix: `_run_git()` now raises `RuntimeError` with git's actual stderr text embedded in the message.
  - Evidence: `orion/structural_mass/git_delta.py::_run_git`.
- Finding: A misleading comment claimed `C` (copy) status lines were handled, when `git diff --name-status` never emits `C` without an explicit `-C` flag (not added, since copy detection is more expensive and not needed for this domain).
  - Fix: Corrected the comment to say this bucket is defensive/unreachable for `C`, not "handled."
  - Evidence: `orion/structural_mass/git_delta.py` inline comment.
- Finding: No test covered the exact z-score saturation boundary (`zscore == 3.0` → `score == 1.0`), only "far past saturation."
  - Fix: Added `test_saturates_exactly_at_zscore_saturation_boundary`.
  - Evidence: `orion/substrate/tests/test_prediction_error.py::TestCodebasePredictionError::test_saturates_exactly_at_zscore_saturation_boundary`.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: Low
- Concern: `_CODEBASE_PREDICTION_ERROR_MIN_VARIANCE` and `_CODEBASE_PREDICTION_ERROR_EWMA_ALPHA` are calibrated against a shallow, 49-commit local window, not the full drives-arc backfill the design spec names as the ideal first seed event.
- Mitigation: The constant's docstring says this explicitly and names the follow-up (`scripts/analysis/backfill_structural_mass.py`) that should re-run this calibration against deeper history before this domain is ever registered into a live `NODE_CHANNELS`/bus channel.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1496
