### PR TITLE
fix(proposals): precision-weighted priority + real root cause of 8/12-template dispatch blackout

### DIFF
--- a/orion/proposals/scoring.py
+++ b/orion/proposals/scoring.py
@@ -200,6 +200,27 @@ def template_match_score(
     return clamp01(match), contributions
 
 
+def _pressure_dimension_ids(template: ProposalTemplateV1) -> list[str]:
+    """The dimension set proposal_urgency() and proposal_confidence() both
+    read: template.dimensions filtered to real pressure dimensions, falling
+    back to all of PRESSURE_DIMENSIONS if the template scores on none (e.g.
+    an honestly-empty `dimensions: {}` post-2026-07-30 dead-dimension fix).
+
+    Shared by both functions so they can never again drift out of sync the
+    way they did before that fix: proposal_urgency()'s own filter used to
+    let a dead dimension ending in "_pressure" (contract_pressure) pass
+    through and suppress this exact fallback, while proposal_confidence()
+    had no fallback at all and returned a bare 0.0 for the same template.
+    One shared dimension-set means one fallback behavior for both signals.
+    """
+    dims = [
+        dim_id
+        for dim_id in template.dimensions
+        if dim_id in PRESSURE_DIMENSIONS or dim_id.endswith("_pressure")
+    ]
+    return dims if dims else list(PRESSURE_DIMENSIONS)
+
+
 def proposal_urgency(
     *,
     field_pressures: dict[str, float],
@@ -207,11 +228,8 @@ def proposal_urgency(
 ) -> float:
     scores = [
         dimension_score(field_pressures, dim_id)
-        for dim_id in template.dimensions
-        if dim_id in PRESSURE_DIMENSIONS or dim_id.endswith("_pressure")
+        for dim_id in _pressure_dimension_ids(template)
     ]
-    if not scores:
-        scores = [dimension_score(field_pressures, d) for d in PRESSURE_DIMENSIONS]
     # No SelfStateV1.overall_intensity fallback survives the burn -- honest
     # 0.0 ("no pressure data this tick") rather than a fabricated rollup.
     return clamp01(max(scores) if scores else 0.0)
@@ -225,13 +243,34 @@ def proposal_confidence(
 ) -> float:
     confs = [
         dimension_confidence(field, field_pressures, dim_id)
-        for dim_id in template.dimensions
+        for dim_id in _pressure_dimension_ids(template)
     ]
     if not confs:
         return 0.0
     return clamp01(sum(confs) / len(confs))
 
 
+# 2026-07-30 (docs/superpowers/specs/2026-07-30-proposal-priority-theory-
+# anchor-design.md): replaces the original hand-picked
+# `base_priority + 0.4*match_score + 0.2*urgency + 0.1*confidence` blend --
+# three constants with no theory anchor or citation, unlike every other
+# scoring function in this module. Precision-weighting (Feldman & Friston
+# 2010 -- same anchor already shipped for dimension_confidence() above and
+# for Candidate A's attention salience, orion/attention/field_attention/
+# candidate_precision_weighted.py) says a signal should be gated by how much
+# it can be trusted, not added to it as an independent term: confidence acts
+# as a multiplicative precision weight on whichever real pressure signal is
+# stronger (match_score, the template-weighted relevance read, or urgency,
+# the raw unweighted severity read -- max() because either alone is a
+# sufficient reason to raise priority, same max()-not-sum() shape
+# template_match_score() and proposal_urgency() already use internally).
+#
+# This is NOT yet verified to fix the 98%-single-template dispatch capture
+# documented in that design doc (open question 2 there: real pressure
+# elevation vs. a scoring-floor artifact) -- it removes the arbitrary
+# constants, it does not by itself guarantee dispatch diversity. That is a
+# separate, deliberately deferred follow-up (direction (b), diversity-aware
+# dispatch), pending real post-deploy dispatch data under this formula.
 def proposal_priority(
     *,
     base_priority: float,
@@ -239,9 +278,7 @@ def proposal_priority(
     urgency: float,
     confidence: float,
 ) -> float:
-    return clamp01(
-        base_priority + 0.4 * match_score + 0.2 * urgency + 0.1 * confidence
-    )
+    return clamp01(base_priority + confidence * max(match_score, urgency))
 
 
 def proposal_risk(

--- a/tests/test_proposal_scoring.py
+++ b/tests/test_proposal_scoring.py
@@ -96,6 +96,103 @@ def test_scores_clamped() -> None:
     ) == 1.0
 
 
+# 2026-07-30 precision-weighted priority (docs/superpowers/specs/2026-07-30-
+# proposal-priority-theory-anchor-design.md): replaces the hand-picked
+# 0.4/0.2/0.1 additive blend with confidence * max(match_score, urgency).
+
+
+def test_priority_zero_confidence_never_exceeds_base_priority() -> None:
+    """Precision-weighting means an untrusted signal, however strong, must
+    not raise priority above the template's own base_priority -- confidence
+    is a gate, not an independent additive term."""
+    assert proposal_priority(
+        base_priority=0.3, match_score=1.0, urgency=1.0, confidence=0.0
+    ) == 0.3
+
+
+def test_priority_scales_with_confidence_at_fixed_signal() -> None:
+    low = proposal_priority(base_priority=0.2, match_score=0.8, urgency=0.0, confidence=0.2)
+    high = proposal_priority(base_priority=0.2, match_score=0.8, urgency=0.0, confidence=0.9)
+    assert low < high
+
+
+def test_priority_uses_stronger_of_match_or_urgency() -> None:
+    """Either a strong template-weighted match or a strong raw urgency
+    reading is independently sufficient to raise priority -- max(), not
+    sum(), matching the shape template_match_score() and proposal_urgency()
+    already use internally for combining multiple dimension contributions."""
+    via_match = proposal_priority(base_priority=0.1, match_score=0.9, urgency=0.1, confidence=1.0)
+    via_urgency = proposal_priority(base_priority=0.1, match_score=0.1, urgency=0.9, confidence=1.0)
+    assert via_match == via_urgency == 1.0
+
+
+def test_priority_empty_dimension_template_still_gets_real_confidence() -> None:
+    """Regression guard: an honestly-empty `dimensions: {}` template (post
+    PR #1493's dead-dimension fix) must not collapse proposal_priority() to
+    base_priority forever just because confidence is gating the signal now.
+    _pressure_dimension_ids()'s shared fallback to PRESSURE_DIMENSIONS means
+    proposal_confidence() reads the same 4 core dimensions proposal_urgency()
+    already falls back to -- a real, non-zero confidence, not the bare 0.0
+    the old ungated proposal_confidence() returned for these templates
+    (harmless under the old additive formula's independent 0.1 term, would
+    have silently zeroed the entire signal under a naive
+    confidence * max(...) formula that didn't fix this fallback first)."""
+    template = POLICY.proposal_templates["inspect_bus_channel_catalog"]
+    assert template.dimensions == {}
+    field = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_test",
+        dimension_precision_ewma_n={"execution_pressure": DIMENSION_PRECISION_EWMA_MIN_SAMPLES},
+        dimension_precision_zscore={"execution_pressure": 0.0},
+    )
+    pressures = {"execution_pressure": 0.9}
+    urgency = proposal_urgency(field_pressures=pressures, template=template)
+    confidence = proposal_confidence(field=field, field_pressures=pressures, template=template)
+    match, _ = template_match_score(field_pressures=pressures, template=template)
+    assert confidence > 0.0
+    priority = proposal_priority(
+        base_priority=template.base_priority,
+        match_score=match,
+        urgency=urgency,
+        confidence=confidence,
+    )
+    assert priority > template.base_priority
+
+
+def test_empty_dimension_template_confidence_can_clear_the_real_policy_review_gate() -> None:
+    """The actual mechanism behind 8/12 templates never dispatching (found
+    live via scripts/analysis/measure_proposal_feedback_correlation.py,
+    2026-07-30: several templates show dispatch_status='blocked' in 100% of
+    ~196k real rows) is NOT proposal_priority() losing a ranking race -- it's
+    orion/policy/evaluator.py::evaluate_proposal_candidate() forcing
+    decision='requires_operator_review' whenever
+    `candidate.confidence_score < require_review_below_confidence` (0.50,
+    config/policy/substrate_policy.v1.yaml), and
+    execution_dispatch_policy.v1.yaml hard-blocking that decision. Before
+    this session's `_pressure_dimension_ids()` fallback,
+    `proposal_confidence()` returned a hardcoded 0.0 for any template with no
+    PRESSURE_DIMENSIONS-matching `dimensions` (every honestly-empty template
+    from PR #1493, and every dead-dimension template before it) -- always
+    below 0.5, so these templates were mechanically forced into
+    requires_operator_review and blocked on every single tick, entirely
+    independent of priority_score. This test proves the fallback fix clears
+    that real threshold under a plausible calm/matching field reading, not
+    just that confidence is "greater than 0" (test_priority_empty_dimension_
+    template_still_gets_real_confidence above only checked the latter)."""
+    REAL_POLICY_REQUIRE_REVIEW_BELOW_CONFIDENCE = 0.50  # config/policy/substrate_policy.v1.yaml
+    template = POLICY.proposal_templates["inspect_bus_channel_catalog"]
+    assert template.dimensions == {}
+    field = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_test",
+        dimension_precision_ewma_n={d: DIMENSION_PRECISION_EWMA_MIN_SAMPLES for d in PRESSURE_DIMENSIONS},
+        dimension_precision_zscore={d: 0.0 for d in PRESSURE_DIMENSIONS},
+    )
+    pressures = {d: 0.3 for d in PRESSURE_DIMENSIONS}
+    confidence = proposal_confidence(field=field, field_pressures=pressures, template=template)
+    assert confidence > REAL_POLICY_REQUIRE_REVIEW_BELOW_CONFIDENCE
+
+
 # 2026-07-28 precision-weighted confidence fix (docs/superpowers/specs/2026-
 # 07-28-precision-weighted-proposal-scoring-design.md). dimension_confidence()
 # used to be a binary presence flag with no state; it now reads a per-


### PR DESCRIPTION
## Summary

- Replaced `proposal_priority()`'s hand-picked `base_priority + 0.4*match_score + 0.2*urgency + 0.1*confidence` blend with `base_priority + confidence * max(match_score, urgency)` — precision-weighting (Feldman & Friston), the same theory anchor already shipped for `dimension_confidence()` in this file and Candidate A's attention salience. No more uncited constants.
- Fixed a regression the formula change would otherwise have caused: `proposal_confidence()` returned a hardcoded `0.0` for any template with no `PRESSURE_DIMENSIONS`-matching entry in `dimensions` (every template PR #1493 emptied to `dimensions: {}`). Harmless under the old additive formula (confidence was only a small independent term); would have zeroed the *entire* signal under the new multiplicative one. Fixed by sharing `proposal_urgency()`'s existing fallback-to-`PRESSURE_DIMENSIONS` logic via a new `_pressure_dimension_ids()` helper, used by both functions now.
- **Found the real root cause of why 8/12 live templates have never dispatched** — it isn't priority ranking. `orion/policy/evaluator.py::evaluate_proposal_candidate()` force-sets `decision="requires_operator_review"` whenever `confidence_score < 0.50` (`config/policy/substrate_policy.v1.yaml`), and `execution_dispatch_policy.v1.yaml` hard-blocks that decision. Real production data (196,296 rows, pulled live via `scripts/analysis/measure_proposal_feedback_correlation.py` — a real calibration probe from an earlier session I'd missed until this investigation) shows `inspect_attended_target`, `inspect_bus_channel_catalog`, `inspect_field_topology_catalog`, `summarize_transport_contract_drift`, `watch_transport_backpressure` at `dispatch_status="blocked"` in **100%** of all real rows ever recorded. Their `confidence_score` has been permanently `0.0` this whole time (both before and after PR #1493), tripping the gate on every tick — nothing to do with `proposal_priority()` or the single-dispatch-slot competition. This patch's `_pressure_dimension_ids()` fallback is what actually gives these templates a real chance to clear 0.50 for the first time.

## Outcome moved

`proposal_confidence()` is no longer permanently zero for any template scoring on real, live pressure dimensions via the fallback — this is a real behavior change to a live policy gate, not just a formula cleanup. Whether it actually unblocks those 5 templates in production depends on real field EWMA state at dispatch time (untested here — no live deploy in this pass); the mechanism that was permanently preventing it either way is now gone.

## Current architecture

`orion/proposals/scoring.py::proposal_priority()` was the only scoring function in the module with no theory anchor (unlike `dimension_confidence()`, precision-weighted and EWMA-calibrated since PR #1442/#1493-era work). `proposal_confidence()` had no dimension-set fallback, unlike `proposal_urgency()`, which already fell back to `PRESSURE_DIMENSIONS` when a template's own `dimensions` had nothing pressure-shaped.

## Architecture touched

`orion/proposals/scoring.py` only. No schema, bus, or config changes — `orion/policy/evaluator.py` and `execution_dispatch_policy.v1.yaml` were read to understand the mechanism but not modified in this patch.

## Files changed

- `orion/proposals/scoring.py`: new `_pressure_dimension_ids()` helper shared by `proposal_urgency()`/`proposal_confidence()`; `proposal_priority()` reformulated to `base_priority + confidence * max(match_score, urgency)`.
- `tests/test_proposal_scoring.py`: 5 new tests — `test_priority_zero_confidence_never_exceeds_base_priority`, `test_priority_scales_with_confidence_at_fixed_signal`, `test_priority_uses_stronger_of_match_or_urgency`, `test_priority_empty_dimension_template_still_gets_real_confidence`, `test_empty_dimension_template_confidence_can_clear_the_real_policy_review_gate` (proves the real 0.50 policy threshold is clearable, not just "confidence > 0").

## Schema / bus / API changes

None. Pure scoring-function behavior change within `orion/proposals/`.

## Env/config changes

None.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-proposal-priority-precision-weighted
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest tests/test_proposal_scoring.py tests/test_proposal_policy_loader.py tests/test_proposal_frame_builder.py tests/test_proposal_frame_schemas.py tests/test_proposal_runtime_store.py tests/test_proposal_runtime_worker.py tests/test_proposal_transport_readonly_candidates.py tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_policy_loader.py tests/test_measure_proposal_feedback_correlation.py tests/test_policy_evaluator.py tests/test_policy_decision_builder.py tests/test_policy_loader.py tests/test_policy_transport_gates.py -q
# 112 passed
```

## Evals run

`scripts/analysis/measure_proposal_feedback_correlation.py --window-hours 200` (read-only, real Postgres data, pre-existing script) — used as the diagnostic that found the real root cause, not modified by this patch. Verdict from that run: only 4/12 templates have ≥30 real `cortex_result` observations to estimate anything from; explicitly recommends against building a data-calibrated weight-fit yet. This patch does not attempt calibration — it removes uncited constants via a principled theory anchor and fixes the confidence-fallback bug found along the way.

## Docker/build/smoke checks

Not run — no live deploy in this pass. Whether the 5 previously-blocked templates actually start dispatching depends on real field EWMA state (`dimension_precision_ewma_n`/`_zscore`) at dispatch time in production, which this patch doesn't simulate beyond the unit tests' synthetic FieldStateV1 fixtures.

## Review findings fixed

- Finding: none material. Reviewing subagent (orion-repo-agent) independently verified the formula, the shared-helper refactor, traced the single production caller (`orion/proposals/builder.py`), hand-checked the new tests' arithmetic against the real 0.50 threshold, and ran the relevant test files itself (64 passed). One non-blocking note: `proposal_confidence()` now applies `proposal_urgency()`'s pressure-dimension filter too, not just the fallback — zero live effect today since every configured template's `dimensions` is either a single canonical pressure dimension or empty, would only matter for a hypothetical future template mixing a canonical and non-`_pressure`-suffixed dimension.
  - Fix: none needed (flagged as non-blocking, not required for a template that doesn't exist yet).
  - Evidence: reviewed diff, traced `orion/proposals/builder.py:89-90` as the sole call site, ran full relevant test suite.

## Restart required

```bash
# orion-proposal-runtime reads orion/proposals/scoring.py directly; restart to pick up the new formula:
docker compose --env-file .env --env-file services/orion-proposal-runtime/.env -f services/orion-proposal-runtime/docker-compose.yml restart
```

## Risks / concerns

- Severity: medium
- Concern: unverified against live traffic. The 5 previously-permanently-blocked templates may or may not actually start dispatching depending on real field EWMA state — this patch removes the mechanism that made it *impossible*, it doesn't guarantee it now happens. Recommend watching `action_outcomes`/`substrate_feedback_frames` dispatch_status distribution for those 5 template keys over the following 24-48h post-deploy.
- Severity: low
- Concern: `proposal_priority()`'s new formula is itself unverified against the 98%-single-template dispatch capture problem documented in `docs/superpowers/specs/2026-07-30-proposal-priority-theory-anchor-design.md` (PR #1495) — that finding turns out to be secondary to the confidence-gate bug fixed here, but hasn't been re-measured after this fix ships.
- Mitigation: both concerns point to the same next action — re-run `scripts/analysis/measure_proposal_feedback_correlation.py` after this deploys and a real observation window has passed.