### PR TITLE
fix(substrate): write bus_synaptic node on every tick, not just error > 0.0

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-30-bus-synaptic-stale-write-skip-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-bus-synaptic-stale-write-skip-pr.md
@@ -1,0 +1,95 @@
+# Bus synaptic prediction_error stale-write-skip fix
+
+## Summary
+
+- `_bus_synaptic_tick()` (`services/orion-substrate-runtime/app/worker.py`) only wrote `node:substrate.bus_synaptic`'s durable node when the freshly-computed error was `> 0.0`, so a calm tick simply skipped the write instead of refreshing the node to reflect true current state.
+- Live-verified: the node was frozen at `prediction_error=1.0` for hours while the real tick logged fresh, varying, non-saturated values (0.000-0.144) every 30s the whole time.
+- `orion-equilibrium-service`'s `_bus_synaptic_poll_loop` polls this node's raw value with zero staleness check, so the frozen value produced recurring false "Bus Anomaly Detected" alerts.
+- Fix: split the gate so the receipt write (audit trail) stays gated on `error > 0.0`, but the node write (polled current-state) now runs unconditionally every tick.
+- Added a README entry documenting the incident and fix, per this service's established convention.
+- **Found but not fixed in this patch:** a second, independent bug in `orion/substrate/reconcile.py`'s `merge_node()` (used by `orion-cortex-exec-background`'s concept-induction materializer) re-locks this same node's `prediction_error` on a much faster cadence than this fix's 30s tick, so the false alerts will likely persist until that's also fixed. See "Known related risk" below.
+
+## Outcome moved
+
+`node:substrate.bus_synaptic`'s durable node can now read a genuine calm (`prediction_error=0.0`) state on any tick where the real signal is calm, instead of only ever ratcheting up to the last nonzero value and staying there forever. This directly targets the metric-quality-gate failure mode CLAUDE.md names explicitly (a metric that can vary but structurally can't return to calm).
+
+## Current architecture
+
+`orion-substrate-runtime`'s `_bus_synaptic_tick()` runs every `SUBSTRATE_BUS_SYNAPTIC_TICK_INTERVAL_SEC` (default 30s), reads live `gap_zscore`/`latency_zscore` edges from the `orion_bus_synapse` FalkorDB graph (written by `orion-bus-mirror`), computes `bus_synaptic_prediction_error()`, and — previously only when that error was `> 0.0` — wrote a receipt and durably upserted `node:substrate.bus_synaptic` in the `orion_substrate` FalkorDB graph. `orion-equilibrium-service`'s `_bus_synaptic_poll_loop` separately polls that same node's raw `prediction_error` property on its own interval and fires a `transport` metacog trigger (`MetacogTriggerV1`, `reason="transport:bus_synaptic:error=..."`) when it's at or above `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_ERROR_THRESHOLD` (default `1.0`).
+
+## Architecture touched
+
+`services/orion-substrate-runtime` only. No contract/schema/bus changes — this is a pure bugfix to an existing write path's gating condition.
+
+## Files changed
+
+- `services/orion-substrate-runtime/app/worker.py`: `_bus_synaptic_tick()` — moved the `_write_prediction_error_node(...)` call out of the `if error > 0.0:` block so it runs on every tick; the `save_receipt(...)` call stays gated.
+- `services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py`: renamed/rewrote `test_bus_synaptic_tick_no_edges_writes_nothing` → `test_bus_synaptic_tick_no_edges_still_writes_calm_node`, asserting the node write now happens (with `error=0.0`) while the receipt still doesn't.
+- `services/orion-substrate-runtime/README.md`: added a dated entry describing the incident, the fix, the deliberately-out-of-scope sibling risk (4 other `_*_tick` methods share the same gate shape), and the separate `reconcile.py`/materializer root cause found during live verification.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. No `.env_example` changes; nothing to sync.
+
+## Tests run
+
+```
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py -q
+9 passed, 3 warnings in 2.75s
+
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-substrate-runtime/tests -q --ignore=services/orion-substrate-runtime/tests/test_grammar_consumer_integration.py
+16 failed, 192 passed, 15 warnings in 7.38s
+```
+
+The 16 failures are pre-existing and unrelated (cursor-reset auth, quarantine truth, reducer-health cross-test pollution, etc.) — confirmed by running the identical command against `main` and diffing: byte-for-byte the same 16 test names, same 192/16 split. This patch introduces zero new failures. `test_grammar_consumer_integration.py` fails to *collect* on `main` too (`ModuleNotFoundError: app.models`), unrelated to this change.
+
+## Evals run
+
+No dedicated eval harness exists for this narrow tick; not applicable.
+
+## Docker/build/smoke checks
+
+```
+$ bash scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
+... build succeeded, container recreated and started ...
+```
+
+Live-verified post-deploy:
+- `docker logs orion-athena-substrate-runtime` shows `substrate_prediction_error_node_written node_id=node:substrate.bus_synaptic error=0.000 reducer_key=bus_synaptic` on calm ticks (previously no log line / no write at all on those ticks).
+- Confirmed via direct FalkorDB `GRAPH.QUERY` against `orion_substrate` that the write path itself is correct and reaches durable storage when nothing else is racing it.
+- **Also confirmed the write is currently still getting raced and overwritten** by the separate `reconcile.py`/materializer bug described above — traced via `redis-cli CLIENT LIST`/`MONITOR` on the FalkorDB container to a persistent connection from `orion-athena-cortex-exec-background`, re-touching this exact node every few seconds with a stale, self-reinforced `prediction_error=1.0`. This fix is real and correct in isolation (verified the write call itself lands when nothing else interferes, and the receipt/write split behaves exactly as intended per the passing tests), but the live symptom (false "Bus Anomaly Detected" alerts) will likely persist until the second bug is separately fixed.
+
+## Review findings fixed
+
+- Finding: No dated README entry for this incident/fix, despite this file's established convention of one per prior bus_synaptic change.
+  - Fix: Added the entry (see Files changed).
+  - Evidence: `services/orion-substrate-runtime/README.md` diff.
+- Finding (confirmed, correctly left as-is): 4 sibling `_*_tick` methods (biometrics, execution, chat, route) share the identical `if error > 0.0:` gate around both their receipt and node write, so they carry the same latent staleness risk.
+  - Fix: Not fixed in this patch — deliberately scoped to `bus_synaptic` only, per the task. Documented as a follow-up in the README and this report.
+  - Evidence: `worker.py` lines ~735 (biometrics), ~2142 (execution), ~2202 (chat), ~2255 (route), all unchanged.
+- No other material findings from the review pass (correctness, test coverage, and downstream consumer behavior all verified sound).
+
+## Restart required
+
+```
+bash scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
+```
+
+Already run once during this session's live verification; the running container reflects this fix. No further restart needed unless this branch is rebuilt from a fresh checkout.
+
+## Risks / concerns
+
+- Severity: Medium
+- Concern: This fix alone does not resolve the live "Bus Anomaly Detected" false-alarm symptom, because a separate, independently-discovered bug in `orion/substrate/reconcile.py`'s `merge_node()` (invoked by `orion-cortex-exec-background`'s concept-induction materializer path) re-locks `node:substrate.bus_synaptic`'s `prediction_error` on a faster cadence than this tick's 30s interval, via an unconditional `merged_metadata = {**incoming.metadata, **existing.metadata}` (existing always wins, including reducer-owned keys) followed by an `upsert_node()` call with no `skip_metadata_keys` protection.
+- Mitigation: Documented in this report and the README with exact file/line evidence and live-verification method (FalkorDB `CLIENT LIST`/`MONITOR` tracing). Needs its own fix and its own review, since `merge_node()` is shared by any concept merge in the repo, not just this one node — deliberately not attempted in this patch without sign-off given the wider blast radius.
+- Severity: Low
+- Concern: 4 sibling domains (biometrics, execution, chat, route) share the exact same write-skip-on-zero gate shape fixed here for bus_synaptic.
+- Mitigation: Documented as a known follow-up; not fixed here to keep this patch scoped and reviewable.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/bus-synaptic-stale-write-skip

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -529,6 +529,34 @@ saturation ceiling, which both the old and new formulas only reach at raw `mean(
 identical fire condition before and after this fix, confirmed by reading
 `services/orion-equilibrium-service/app/settings.py` and its `.env_example` (both `1.0`).
 
+**Fixed 2026-07-30: `_bus_synaptic_tick()` skipped the node write entirely on a calm (error == 0.0)
+tick, letting `node:substrate.bus_synaptic` go stale indefinitely once any nonzero error was ever
+written.** Confirmed live: the node was frozen at `prediction_error=1.0` for hours while this tick
+kept logging real, varying, non-saturated values (0.000-0.144) every 30s the whole time --
+`orion-equilibrium-service`'s `_bus_synaptic_poll_loop` (`transport_metacog_gate.py`) polls this
+node's raw current value with no staleness check of its own, so the frozen value produced recurring
+false "Bus Anomaly Detected" alerts, functionally the same downstream symptom as the
+`SubstrateDynamicsEngine.tick()` clobber bug fixed 2026-07-29 (`falkor_codec.py`'s
+`EXTERNALLY_OWNED_METADATA_KEYS`) but via a different, still-live mechanism that fix didn't touch.
+Split the gate in `_bus_synaptic_tick()`: the receipt write (an audit trail of notable events) stays
+gated on `error > 0.0`; the node write (the polled current-state value) now runs unconditionally
+every tick, including a calm tick writing `prediction_error=0.0` -- the node can finally read a
+genuine calm state again instead of only ever ratcheting up. The other four `_*_tick` methods in
+this file (biometrics, execution, chat, route) share the identical `if error > 0.0:` gate around
+both their receipt and node write and were deliberately left unfixed here -- same latent risk,
+scoped out of this patch, worth a follow-up. Separately, and not fixed by this patch: live tracing
+during this same incident found `orion/substrate/reconcile.py`'s `merge_node()` (used by
+`SubstrateGraphMaterializer`, driven by `orion-cortex-exec-background`'s concept-induction
+pipeline) unconditionally prefers `existing.metadata` over `incoming.metadata` for every key,
+including reducer-owned ones like `prediction_error`, then re-persists that through `upsert_node()`
+with no `skip_metadata_keys` protection -- confirmed live via `CLIENT LIST`/`MONITOR` on FalkorDB
+that this path re-touches `node:substrate.bus_synaptic` every few seconds, far more often than this
+tick's 30s cadence, so it wins the race and durably re-locks whatever `prediction_error` value it
+last read back into itself (a self-reinforcing fixed point). This is the real reason the false
+alerts persisted even after this fix landed, and needs its own fix in `reconcile.py`/
+`materializer.py` -- out of scope here since `merge_node()` is shared by any concept merge, not
+just this node.
+
 **RETIRED, 2026-07-26: `transport_prediction_error()`'s live write removed entirely.** Following
 Juniper's explicit go-ahead after proposal mode
 (`docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-successor-design.md`),

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -867,12 +867,25 @@ class BiometricsSubstrateWorker:
                         now=now,
                     )
                 )
-                self._write_prediction_error_node(
-                    node_id="node:substrate.bus_synaptic",
-                    error=error,
-                    now=now,
-                    reducer_key="bus_synaptic",
-                )
+            # Write the node on every tick, not just when error > 0.0 (confirmed
+            # live 2026-07-30: gating this the same way as the receipt above left
+            # `node:substrate.bus_synaptic` frozen at a stale prediction_error=1.0
+            # for hours while this tick kept logging real, varying, non-saturated
+            # values every 30s the whole time -- orion-equilibrium-service polls
+            # this node's raw current value with no staleness check of its own
+            # (transport_metacog_gate.py), so a value that can only ever go up
+            # and never refresh back down to a genuine calm reading produces
+            # permanent false "Bus Anomaly Detected" alerts once any real spike
+            # ever occurs. The receipt above stays gated -- it's an audit trail
+            # of notable prediction-error events, not a polled "current state"
+            # read, so skipping a receipt for a calm (error == 0.0) tick is
+            # correct and not the bug.
+            self._write_prediction_error_node(
+                node_id="node:substrate.bus_synaptic",
+                error=error,
+                now=now,
+                reducer_key="bus_synaptic",
+            )
             logger.info(
                 "substrate_bus_synaptic_tick_completed edge_count=%d error=%.3f",
                 len(zscores),

--- a/services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py
+++ b/services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py
@@ -114,12 +114,24 @@ def test_bus_synaptic_edge_queries_filter_stale_edges() -> None:
         assert "$stale_cutoff_epoch" in cypher
 
 
-def test_bus_synaptic_tick_no_edges_writes_nothing(monkeypatch):
+def test_bus_synaptic_tick_no_edges_still_writes_calm_node(monkeypatch):
+    """Regression guard (2026-07-30): the node write must happen every tick,
+    including a calm error=0.0 tick -- gating it the same way as the receipt
+    below left `node:substrate.bus_synaptic` frozen at a stale nonzero value
+    for hours (confirmed live) while orion-equilibrium-service polled that
+    frozen value with no staleness check of its own, producing permanent
+    false "Bus Anomaly Detected" alerts. The receipt stays gated on
+    error > 0.0 -- it's an audit trail of notable events, not a polled
+    current-state read, so no receipt on a calm tick is correct."""
     worker = _make_worker(monkeypatch, enabled=True)
     worker._bus_synaptic_client = _client_returning([], [])
     with patch.object(worker, "_write_prediction_error_node") as write_node:
         worker._bus_synaptic_tick()
-    write_node.assert_not_called()
+    write_node.assert_called_once()
+    _, kwargs = write_node.call_args
+    assert kwargs["node_id"] == "node:substrate.bus_synaptic"
+    assert kwargs["error"] == 0.0
+    assert kwargs["reducer_key"] == "bus_synaptic"
     worker._store.save_receipt.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- `_bus_synaptic_tick()` only wrote `node:substrate.bus_synaptic`'s durable node when error was `> 0.0`, so a calm tick skipped the write instead of refreshing the node to reflect true current state.
- Live-verified: the node was frozen at `prediction_error=1.0` for hours while the real tick logged fresh, varying values every 30s the whole time.
- `orion-equilibrium-service` polls this node's raw value with no staleness check, producing recurring false "Bus Anomaly Detected" alerts.
- Fix: split the gate so the receipt write stays gated on `error > 0.0`, but the node write now runs unconditionally every tick.

## Known related risk (not fixed here)

A second, independent bug in `orion/substrate/reconcile.py`'s `merge_node()` (used by `orion-cortex-exec-background`'s concept-induction materializer) re-locks this same node's `prediction_error` on a faster cadence than this fix's 30s tick — confirmed live via FalkorDB `CLIENT LIST`/`MONITOR` tracing. The false alerts will likely persist until that's separately fixed; `merge_node()` is shared repo-wide so it needs its own review. Also: 4 sibling `_*_tick` methods (biometrics, execution, chat, route) share the identical write-skip-on-zero gate shape, deliberately left unfixed to keep this patch scoped.

Full write-up: `docs/superpowers/pr-reports/2026-07-30-bus-synaptic-stale-write-skip-pr.md`

## Test plan

- [x] `pytest services/orion-substrate-runtime/tests/test_worker_bus_synaptic_tick.py -q` — 9/9 pass
- [x] `pytest services/orion-substrate-runtime/tests -q` (minus one pre-existing collection error) — 192 passed, 16 pre-existing failures identical to `main`, zero new failures
- [x] Rebuilt + restarted `orion-substrate-runtime`, live-verified the write path lands when nothing else races it
- [x] Code review pass, findings addressed (README entry added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)