### PR TITLE
fix(aitown): never let AI Town's NPC dialogue land on circe

### DIFF
--- a/services/orion-ai-town/README.md
+++ b/services/orion-ai-town/README.md
@@ -92,11 +92,22 @@ Defaults:
 | Convex env | Value | Meaning |
 |------------|-------|---------|
 | `LLM_API_URL` | `http://<mesh-ip>:8210` | Gateway base (no `/v1` suffix) |
-| `LLM_MODEL` | `chat` | Route key in `LLM_GATEWAY_ROUTE_TABLE_JSON` |
+| `LLM_MODEL` | `quick` | Route key in `LLM_GATEWAY_ROUTE_TABLE_JSON` |
 | `LLM_EMBEDDING_MODEL` | `orion-vector-host` | Label only; gateway proxies to vector-host |
 | `EMBEDDING_DIMENSION` | `1024` | Must match `VECTOR_HOST_EMBEDDING_MODEL` (bge-large-en-v1.5) |
 
 Override: `AITOWN_LLM_GATEWAY_URL`, `AITOWN_LLM_CHAT_ROUTE`, `AITOWN_EMBEDDING_DIMENSION`.
+
+> **`LLM_MODEL` must never resolve to a circe-hosted worker.** Circe is
+> reserved for Juniper's direct deep/FCC turns (see
+> `services/orion-llm-gateway/README.md`'s mesh-LLM-wiring note); AI Town's
+> NPC dialogue competing for it is exactly what caused a silent, town-wide
+> 10+ hour dialogue outage on 2026-07-30 (this world's already-provisioned
+> `LLM_MODEL` had been left on `chat` -> circe since before the `quick`
+> default above even existed, and nothing checked the live value against
+> policy). `wire_llm_gateway.sh` now hard-fails if it would leave AI Town on
+> circe; run `python3 services/orion-ai-town/scripts/check_llm_route_not_circe.py`
+> any time to check the live state directly.
 
 **Requires:** `LLM_GATEWAY_OPENAI_PASSTHROUGH_ENABLED=true` and `ORION_VECTOR_HOST_URL` on orion-llm-gateway.
 

--- a/services/orion-ai-town/scripts/check_llm_route_not_circe.py
+++ b/services/orion-ai-town/scripts/check_llm_route_not_circe.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fail loudly if AI Town's live LLM route resolves to a circe-hosted worker.
+
+Circe is reserved for Juniper's direct deep/FCC conversations (see the
+2026-07-10 "Route AI Town and default LLM consumers to quick" fix and
+services/orion-llm-gateway/README.md) -- AI Town's own NPC dialogue must
+never compete for it.
+
+Why this exists: that 2026-07-10 fix only changed `wire_llm_gateway.sh`'s
+*default*. This world's live Convex `LLM_MODEL` env var was set to "chat"
+(-> circe) before that fix ever landed and was never updated afterward --
+Convex env vars are a persisted, out-of-band store that doesn't re-derive
+from the repo's defaults. Confirmed live 2026-07-30: that stale value
+survived undetected for weeks (through at least one `compact_convex_data.sh`
+export/restore cycle, which faithfully preserves whatever was already set)
+until circe went offline and every NPC conversation in the town silently
+stalled for 10+ hours. Nothing had ever checked the *live* value against
+policy -- only the script default had been fixed, not the deployed state.
+
+This script checks the live state directly: it reads AI Town's actual
+deployed `LLM_MODEL`/`LLM_API_URL` from Convex, resolves that model through
+the gateway's own `/v1/models` (the gateway's live, authoritative view of
+which worker actually serves each route), and refuses to pass if that
+worker is circe-hosted.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from orion.autonomy.fcc_env import expand_env_path, load_fcc_env as _load_fcc_env_file  # noqa: E402
+
+DEFAULT_FCC_ENV_PATH = os.path.expanduser("~/.fcc/.env")
+
+
+def load_fcc_env(path: str) -> None:
+    """Populate os.environ from the fcc env file, AITOWN_* keys always winning.
+
+    Reuses orion.autonomy.fcc_env (a generic top-level lib, not an
+    embodiment-internal one) for parsing/quote-stripping rather than
+    hand-rolling it -- and matches services/orion-embodiment/app/worker.py's
+    `_load_fcc_env` precedence exactly: AITOWN_* keys must track ~/.fcc/.env
+    updates unconditionally (a stale process env must lose), everything else
+    only fills in what's unset. A check script whose whole job is catching
+    silent drift must not itself be fooled by a stale AITOWN_CONVEX_URL/
+    AITOWN_ADMIN_KEY left in someone's shell.
+    """
+    for key, value in _load_fcc_env_file(expand_env_path(path)).items():
+        if key.startswith("AITOWN_"):
+            os.environ[key] = value
+        else:
+            os.environ.setdefault(key, value)
+
+
+def convex_query(base_url: str, admin_key: str, path: str, *, timeout_sec: float = 10.0):
+    """Minimal self-hosted Convex admin query call (POST /api/query).
+
+    Deliberately not shared with orion/embodiment/aitown_client.py: that
+    module belongs to orion-embodiment, and this script has no other reason
+    to depend on that service. The call shape (admin-key auth header, JSON
+    body) is derived directly from Convex's own CLI
+    (node_modules/convex/dist/cli.bundle.cjs) -- see wire_llm_gateway.sh's
+    `npx convex env set`/`env list`, which do the same thing through the CLI.
+    """
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/query",
+        data=json.dumps({"path": path, "args": {}, "format": "json"}).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Authorization": f"Convex {admin_key}"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout_sec) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    if body.get("status") == "error":
+        raise RuntimeError(str(body.get("errorMessage") or body))
+    return body.get("value")
+
+
+def fetch_gateway_models(gateway_url: str, *, timeout_sec: float = 10.0) -> list:
+    url = f"{gateway_url.rstrip('/')}/v1/models"
+    with urllib.request.urlopen(url, timeout=timeout_sec) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    return body.get("data", [])
+
+
+def resolve_served_by(models: list, model_id: str) -> Optional[str]:
+    for entry in models:
+        if entry.get("id") == model_id:
+            served_by = entry.get("served_by")
+            return str(served_by) if served_by is not None else None
+    return None
+
+
+def check_not_circe(served_by: Optional[str], *, model_id: str, allow_circe: bool) -> Optional[str]:
+    """Return an error message if the check fails, else None."""
+    if served_by is None:
+        return (
+            f"AI Town's configured model {model_id!r} was not found in the gateway's "
+            "/v1/models list -- cannot confirm it's safe. Refusing to pass."
+        )
+    if served_by.lower().startswith("circe") and not allow_circe:
+        return (
+            f"AI Town's LLM_MODEL={model_id!r} resolves to served_by={served_by!r} -- "
+            "CIRCE. AI Town must never use circe (reserved for Juniper's direct deep/FCC "
+            "turns; see services/orion-llm-gateway/README.md). Fix: re-run "
+            "services/orion-ai-town/scripts/wire_llm_gateway.sh (defaults to the 'quick' "
+            "lane) against this world. If this is a deliberate, conscious exception, set "
+            "AITOWN_ALLOW_CIRCE=1."
+        )
+    return None
+
+
+def main() -> int:
+    load_fcc_env(os.environ.get("AITOWN_FCC_ENV_PATH", DEFAULT_FCC_ENV_PATH))
+    allow_circe = os.environ.get("AITOWN_ALLOW_CIRCE", "").strip() == "1"
+
+    convex_url = os.environ.get("AITOWN_CONVEX_URL", "").strip()
+    admin_key = os.environ.get("AITOWN_ADMIN_KEY", "").strip()
+    if not convex_url or not admin_key:
+        print(
+            "check_llm_route_not_circe: AITOWN_CONVEX_URL/AITOWN_ADMIN_KEY not set "
+            f"(checked env and {DEFAULT_FCC_ENV_PATH}) -- cannot reach Convex.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        rows = convex_query(convex_url, admin_key, "_system/cli/queryEnvironmentVariables")
+    except Exception as exc:  # noqa: BLE001 -- fail loudly with a clean message, not a traceback
+        print(f"check_llm_route_not_circe: could not query Convex at {convex_url}: {exc}", file=sys.stderr)
+        return 1
+
+    by_name = {row["name"]: row["value"] for row in rows}
+    llm_model = by_name.get("LLM_MODEL")
+    gateway_url = by_name.get("LLM_API_URL")
+    if not llm_model or not gateway_url:
+        print(
+            "check_llm_route_not_circe: AI Town's Convex deployment has no "
+            "LLM_MODEL/LLM_API_URL set -- run wire_llm_gateway.sh first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        models = fetch_gateway_models(gateway_url)
+    except Exception as exc:  # noqa: BLE001 -- fail loudly with a clean message, not a traceback
+        print(f"check_llm_route_not_circe: could not reach gateway at {gateway_url}: {exc}", file=sys.stderr)
+        return 1
+    served_by = resolve_served_by(models, llm_model)
+    error = check_not_circe(served_by, model_id=llm_model, allow_circe=allow_circe)
+    if error:
+        print(f"check_llm_route_not_circe FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(f"check_llm_route_not_circe: OK -- LLM_MODEL={llm_model!r} served_by={served_by!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-ai-town/scripts/compact_convex_data.sh
+++ b/services/orion-ai-town/scripts/compact_convex_data.sh
@@ -161,6 +161,23 @@ else
   log "no env vars to restore (env.backup empty)"
 fi
 
+# This restore is a straight replay of whatever was backed up in step 1b --
+# including a stale LLM_MODEL if one was already silently pointed at circe
+# before this script ever ran (confirmed live 2026-07-30: exactly this
+# happened, undetected, for weeks). Don't abort the compaction over it --
+# data reimport (step 6) still needs to happen regardless -- but self-heal
+# it here rather than silently perpetuating the same drift on every future
+# compaction. See check_llm_route_not_circe.py's docstring for the incident.
+if ! python3 "${ROOT}/scripts/check_llm_route_not_circe.py"; then
+  log "WARNING: restored LLM_MODEL resolves to circe -- correcting to the safe default"
+  (cd "${UPSTREAM}" && npx convex env set LLM_MODEL "${AITOWN_LLM_CHAT_ROUTE:-quick}")
+  if python3 "${ROOT}/scripts/check_llm_route_not_circe.py"; then
+    log "corrected: LLM_MODEL is no longer on circe"
+  else
+    log "WARNING: could not auto-correct LLM_MODEL off circe -- investigate manually before relying on NPC dialogue"
+  fi
+fi
+
 log "step 6/7: reimporting exported data (--replace-all)"
 (cd "${UPSTREAM}" && npx convex import --replace-all -y "${JOB_DIR}/export.zip")
 

--- a/services/orion-ai-town/scripts/wire_llm_gateway.sh
+++ b/services/orion-ai-town/scripts/wire_llm_gateway.sh
@@ -39,4 +39,11 @@ npx convex env set LLM_EMBEDDING_MODEL "${EMBED_MODEL}"
 echo "Redeploying Convex functions (embedding dimension ${EMBED_DIM})..."
 npx convex dev --once
 
+# Circe is reserved for Juniper's direct deep/FCC turns -- AI Town must never
+# land on it. Verify what was JUST written, not just what we intended to
+# write: confirmed live 2026-07-30 that this exact drift (a stale LLM_MODEL
+# left pointed at circe) can silently persist for weeks with nothing
+# checking the live value. See check_llm_route_not_circe.py's docstring.
+python3 "${ROOT}/scripts/check_llm_route_not_circe.py"
+
 echo "Done. Chat → gateway ${CHAT_ROUTE} lane (llamacpp). Embeddings → gateway → orion-vector-host (${EMBED_DIM} dims)."

--- a/services/orion-ai-town/tests/test_check_llm_route_not_circe.py
+++ b/services/orion-ai-town/tests/test_check_llm_route_not_circe.py
@@ -1,0 +1,78 @@
+"""Gate tests for check_llm_route_not_circe.py's resolution/assertion logic.
+
+See scripts/check_llm_route_not_circe.py's module docstring for why this
+exists: AI Town's live Convex LLM_MODEL silently drifted onto a
+circe-hosted worker for weeks with nothing checking the *live* value
+against policy. These tests cover the pure resolve/assert logic directly
+(no live Convex/gateway needed); the script's __main__ wiring is smoke-
+tested manually per services/orion-ai-town/README.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import stat
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _SERVICE / "scripts" / "check_llm_route_not_circe.py"
+
+_spec = importlib.util.spec_from_file_location("check_llm_route_not_circe", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+resolve_served_by = _mod.resolve_served_by
+check_not_circe = _mod.check_not_circe
+
+_MODELS = [
+    {"id": "chat", "served_by": "circe-worker-1"},
+    {"id": "agent", "served_by": "circe-worker-1"},
+    {"id": "metacog", "served_by": "atlas-worker-2"},
+    {"id": "quick", "served_by": "atlas-worker-fast-1"},
+]
+
+
+def test_script_exists_and_is_executable():
+    assert _SCRIPT_PATH.exists()
+    assert _SCRIPT_PATH.stat().st_mode & stat.S_IXUSR
+
+
+def test_resolve_served_by_finds_matching_model():
+    assert resolve_served_by(_MODELS, "quick") == "atlas-worker-fast-1"
+    assert resolve_served_by(_MODELS, "chat") == "circe-worker-1"
+
+
+def test_resolve_served_by_returns_none_for_unknown_model():
+    assert resolve_served_by(_MODELS, "not-a-real-route") is None
+
+
+def test_check_not_circe_passes_for_atlas_worker():
+    assert check_not_circe("atlas-worker-fast-1", model_id="quick", allow_circe=False) is None
+
+
+def test_check_not_circe_fails_for_circe_worker():
+    error = check_not_circe("circe-worker-1", model_id="chat", allow_circe=False)
+    assert error is not None
+    assert "circe" in error.lower()
+    assert "chat" in error
+
+
+def test_check_not_circe_is_case_insensitive():
+    error = check_not_circe("Circe-Worker-1", model_id="chat", allow_circe=False)
+    assert error is not None
+
+
+def test_check_not_circe_allows_explicit_override():
+    assert check_not_circe("circe-worker-1", model_id="chat", allow_circe=True) is None
+
+
+def test_check_not_circe_fails_when_model_missing_from_gateway():
+    error = check_not_circe(None, model_id="ghost-route", allow_circe=False)
+    assert error is not None
+    assert "ghost-route" in error
+
+
+def test_check_not_circe_does_not_false_positive_on_similar_names():
+    # A hypothetical "circe-adjacent" or "not-circe" label should not match --
+    # the policy is specifically about circe-hosted workers.
+    assert check_not_circe("atlas-circe-relay", model_id="quick", allow_circe=False) is None

--- a/services/orion-llm-gateway/README.md
+++ b/services/orion-llm-gateway/README.md
@@ -170,26 +170,32 @@ LLM_GATEWAY_ROUTE_TABLE_JSON='{
 
 `quick` is the FAST lane route used by user-facing quick chat and chat_general pass-1.
 
-> **Known gap (2026-07-18): circe is not wired into `LLM_GATEWAY_ROUTE_TABLE_JSON`.**
-> Every route above (`chat`/`agent`/`metacog`/`quick`) is `served_by` an
-> `atlas-worker-*` label. `config/llm_profiles.yaml` has real circe-hosted
-> profiles defined (2xV100, PIX-linked, benched 2026-07-09), but nothing in
-> the live route table points at them -- this was never deliberate, just
-> deprioritized while getting circe fully online. Consequence: `node:circe`
-> never appears as an `execution_run` producer, so `orion-field-digester`'s
-> `reasoning_load`/`cortex_exec_step_load`/etc. channels for `node:circe` read
-> permanently `0.0` -- not a code bug (see
-> `services/orion-field-digester/README.md`'s `reasoning_load` glossary
-> entry), just zero real traffic ever routing there. When circe comes
-> online: (1) add a route entry above with `"served_by": "circe-worker-N"`
-> (the live worker process's current name needs renaming to match this
-> `{node}-worker[-lane][-N]` convention -- `services/orion-cortex-exec/app/executor.py`'s
-> `_normalize_served_by_to_node()` only recognizes labels split on the
-> literal `"-worker"` substring, and only resolves to a node in
-> `_KNOWN_FIELD_NODES` if the prefix is exactly `atlas`/`athena`/`circe`/
-> `prometheus`); (2) no code changes needed beyond that -- `circe` is already
-> in `_KNOWN_FIELD_NODES` and the field topology
-> (`config/field/orion_field_topology.v1.yaml`).
+> **Update (2026-07-30): circe IS wired into `chat`/`agent` now, and that's**
+> **reserved capacity -- AI Town must never land on it.** The note that used
+> to live here (dated 2026-07-18) described circe as not-yet-wired-in and
+> deprioritized; that's stale. Circe came online, `chat`/`agent` route to it
+> (`served_by: "circe-worker-N"`, correctly labeled since `0e3cae4d`), and it
+> now appears as a real `execution_run` producer as this note originally
+> anticipated. What that old note didn't anticipate: circe is meant to be
+> **reserved for Juniper's direct deep/FCC turns**, not shared with AI Town's
+> NPC dialogue (`2026-07-10`, `cfcb3126`, "Route AI Town and default LLM
+> consumers to quick" -- deliberately pointed AI Town at the `quick` lane
+> instead). That fix only changed a *script default*; it never touched the
+> already-provisioned AI Town world's persisted Convex `LLM_MODEL`, which
+> silently stayed on `chat` (-> circe) for weeks, undetected, until circe
+> went offline and the whole town's NPC dialogue silently stalled for 10+
+> hours (confirmed live 2026-07-30). Fixed by re-pointing that world's
+> `LLM_MODEL` at `quick` and adding
+> `services/orion-ai-town/scripts/check_llm_route_not_circe.py` -- a gate
+> that reads AI Town's *live* configured model, resolves it through this
+> gateway's own `/v1/models`, and refuses to pass if the resolved worker is
+> circe-hosted. It's wired into both `wire_llm_gateway.sh` (hard-fails a
+> fresh wire-up that points at circe) and `compact_convex_data.sh` (which
+> replays whatever `LLM_MODEL` was already set, so it self-corrects instead
+> of quietly re-preserving the same drift on every future compaction). If
+> AI Town's `served_by` for its configured route ever needs to change,
+> update `AITOWN_LLM_CHAT_ROUTE` deliberately -- don't just add a route
+> entry that happens to point at circe.
 
 ### Route table example (optional split agent mode)
 ```bash


### PR DESCRIPTION
## Summary

- AI Town's whole town silently stalled for 10+ hours: its live Convex `LLM_MODEL` was stuck on `chat` (-> `circe-worker-1`), which went offline. Every NPC's `agentGenerateMessage` retried against a dead backend forever with no visible error.
- Root cause is a regression, not a new bug: `cfcb3126` (2026-07-10) deliberately repointed AI Town at the `quick` lane specifically to keep circe reserved for Juniper's direct deep/FCC turns -- but that fix only changed `wire_llm_gateway.sh`'s *script default*. This world's already-provisioned Convex `LLM_MODEL` was never updated and silently stayed on `chat` for weeks, surviving at least one `compact_convex_data.sh` export/restore cycle (which faithfully replays whatever was already set).
- Live drift already corrected directly against the running deployment (`LLM_MODEL` -> `quick`), verified live: fresh `chat_history_log` rows show real NPC dialogue flowing again within minutes.
- This PR adds the durable fix so it can't silently recur: `check_llm_route_not_circe.py` reads AI Town's live Convex `LLM_MODEL`/`LLM_API_URL`, resolves the model through the gateway's own `/v1/models`, and fails loudly if the resolved worker is circe-hosted.
- Wired into `wire_llm_gateway.sh` (hard-fail -- a fresh wire-up can never silently leave AI Town on circe) and `compact_convex_data.sh` (warn + self-correct, since that script's job is data preservation and a mid-pipeline abort would be worse).
- Fixes two independently-stale docs that had been quietly relabeling the bug as intended state: `orion-ai-town/README.md`'s default table said `LLM_MODEL` is `chat` (should've said `quick` since the same 07-10 fix), and `orion-llm-gateway/README.md`'s 2026-07-18 note claimed circe "is not wired into" the route table at all (false -- it is, correctly labeled `circe-worker-1`, and does carry real traffic).

## Outcome moved

AI Town's NPC dialogue generation no longer depends on circe's availability. A future drift back onto circe now fails loudly at wire-up time instead of silently stalling every conversation in the town.

## Current architecture

- `services/orion-ai-town/upstream/convex/agent.ts`'s native per-tick NPC loop calls `agentGenerateMessage`, which resolves an LLM chat completion via `LLM_API_URL`/`LLM_MODEL` (Convex env vars, set once via `wire_llm_gateway.sh`, persisted independently of the repo).
- `services/orion-llm-gateway`'s `LLM_GATEWAY_ROUTE_TABLE_JSON` maps route keys (`chat`, `agent`, `metacog`, `quick`) to backing llama.cpp workers; `chat`/`agent` -> `circe-worker-1`, `quick`/`metacog` -> `atlas-worker-*`.
- Nothing previously checked AI Town's *live* configured route against the "never use circe" policy -- only a script default reflected the intended value.

## Architecture touched

- `services/orion-ai-town/scripts/check_llm_route_not_circe.py` (new): live gate, no schema/contract changes.
- `services/orion-ai-town/scripts/wire_llm_gateway.sh`, `compact_convex_data.sh`: call the new gate after setting/restoring env.
- Docs only otherwise.

## Files changed

- `services/orion-ai-town/scripts/check_llm_route_not_circe.py`: new gate script (reads live Convex env + gateway `/v1/models`, refuses to pass if AI Town resolves to a circe-hosted worker; `AITOWN_ALLOW_CIRCE=1` escape hatch for a deliberate exception).
- `services/orion-ai-town/tests/test_check_llm_route_not_circe.py`: 9 tests covering the pure resolve/assert logic (no live network needed).
- `services/orion-ai-town/scripts/wire_llm_gateway.sh`: hard-fails if the just-applied config would leave AI Town on circe.
- `services/orion-ai-town/scripts/compact_convex_data.sh`: after restoring env vars from backup, checks and self-corrects if they'd leave AI Town on circe (warns either way, never aborts the compaction).
- `services/orion-ai-town/README.md`: fixed a stale `LLM_MODEL=chat` default in the wiring table (should've said `quick` since 07-10); added a policy note pointing at the new gate.
- `services/orion-llm-gateway/README.md`: replaced a stale 2026-07-18 "circe is not wired in" note (false as of now) with an accurate one describing the incident and the fix.

## Schema / bus / API changes

None.

## Env/config changes

- Added keys: none new. Live-corrected an existing Convex env var (`LLM_MODEL: chat -> quick`) directly against the running deployment via its admin API (not a repo file change -- Convex env vars are a separate, persisted, out-of-band store; see the new script's docstring).
- `.env_example` updated: n/a -- no repo-tracked env files needed changes; the drift was entirely in the live Convex deployment's own env store.
- local `.env` synced: n/a.
- skipped keys requiring operator action: none.

## Tests run

```
/tmp/aitownvenv/bin/python -m pytest services/orion-ai-town/tests/ -q
# 49 passed, 1 pre-existing unrelated failure (test_generate_descriptions.py::
# test_juniper_blurb_present_in_world_ts -- needs services/orion-ai-town/upstream/,
# a separately-cloned, gitignored dir not present in a fresh worktree; not
# caused by this change)
```

## Evals run

No dedicated eval harness for this service; the live smoke-test below is the equivalent verification for this kind of infra-config check.

## Docker/build/smoke checks

```
# Live, against the real running deployment on athena:
python3 services/orion-ai-town/scripts/check_llm_route_not_circe.py
# check_llm_route_not_circe: OK -- LLM_MODEL='quick' served_by='atlas-worker-fast-1'

# Negative case (simulated circe-routed config) confirmed to fail correctly.

# Post-fix dialogue confirmed flowing again via fresh chat_history_log rows
# (real NPC exchanges, seconds apart, immediately after the live LLM_MODEL fix).
```

## Review findings fixed

- Finding: `load_fcc_env()` hand-rolled quote-stripping and used a `key not in os.environ` guard that's the wrong precedence for `AITOWN_*` keys -- diverges from `orion/autonomy/fcc_env.py` (the shared canonical loader) in two ways that would have broken this exact script: unstripped quotes around `AITOWN_ADMIN_KEY` (the README documents the quoted convention) would silently corrupt the auth header, and stale-process-env-wins is the opposite of the existing regression-tested policy for these keys.
  - Fix: reused `orion.autonomy.fcc_env.load_fcc_env`/`expand_env_path` directly and replicated `services/orion-embodiment/app/worker.py`'s exact precedence (`AITOWN_*` always overwrites, everything else `setdefault`s).
  - Evidence: re-ran the live smoke test on athena with the corrected script -- `check_llm_route_not_circe: OK -- LLM_MODEL='quick' served_by='atlas-worker-fast-1'`.
- Finding (minor): `convex_query`/`fetch_gateway_models` had no error handling -- a network failure would surface as an uncaught traceback instead of a clean stderr message.
  - Fix: wrapped both calls in `main()` with a clean error message on failure (still exits non-zero either way).
  - Evidence: code review, verified in final read-through.

## Restart required

```
No restart required.
```

Nothing in this PR needs a container restart -- the live Convex `LLM_MODEL` correction was already applied directly against the running deployment, independent of this PR landing.

## Risks / concerns

- Severity: low
- Concern: `check_llm_route_not_circe.py` depends on Convex's internal `_system/cli/queryEnvironmentVariables` function (undocumented but stable within this self-hosted Convex version; derived directly from Convex's own CLI bundle since the CLI itself can't run reliably here due to a Node 18/unicode-regex incompatibility in this deployment's frontend container).
- Mitigation: documented in the script's own comment; if this ever breaks across a Convex version bump, the failure mode is a clean, loud script error, not a silent pass.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/aitown-no-circe