### PR TITLE
fix(substrate): protect reducer-owned metadata in materializer's merge path

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-30-bus-synaptic-materializer-clobber-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-bus-synaptic-materializer-clobber-pr.md
@@ -1,0 +1,126 @@
+# Bus synaptic materializer metadata-clobber fix
+
+## Summary
+
+- Second, independent cause of the `node:substrate.bus_synaptic` false "Bus Anomaly Detected" alerts, found via live re-verification after PR #1498's write-skip-on-zero fix landed and the value still snapped back to a stale `1.0` within seconds.
+- Traced via FalkorDB `CLIENT LIST`/`MONITOR` to `orion-cortex-exec-background`'s concept-induction pipeline, which re-materializes this node's identity every few seconds through `SubstrateGraphMaterializer.apply_record()`'s merge branch — far more often than the owning reducer's 30s tick.
+- `reconcile.py`'s `merge_node()` always keeps `existing.metadata` for any key `incoming` doesn't provide (including `prediction_error`), and the merge branch's `upsert_node()` call had no `skip_metadata_keys` protection, so that read-time snapshot got durably re-persisted every pass — a self-reinforcing stale fixed point that kept beating the real reducer's fresher writes.
+- Fix: pass `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS` on the merge branch's `upsert_node()` call, reusing the exact protection mechanism already proven for `SubstrateDynamicsEngine.tick()`'s identical bug class.
+- Code review before merge caught a real regression this change surfaced (two test-double store wrappers didn't accept the new kwarg, breaking the Concept Atlas ingest route) — fixed in the same patch, confirmed against the existing test suite.
+- Live end-to-end verified: rebuilt both affected services, watched the node track real values (0.73 → 0.076 → 0.046) across a 64s window with zero snap-back.
+- Three related, same-bug-class gaps found in other services during review — documented, not fixed here (see "Known related risk").
+
+## Outcome moved
+
+The false "Bus Anomaly Detected" alert this session set out to fix is now genuinely resolved end to end — not just the first of two compounding causes. `node:substrate.bus_synaptic` reflects real, live reducer output continuously instead of a value any concept-induction pass could durably re-freeze.
+
+## Current architecture
+
+`orion-cortex-exec-background` runs concept induction, which materializes extracted concepts into the durable substrate graph via `SubstrateGraphMaterializer.apply_record()`. When an incoming concept's identity resolves to an already-existing node (the "merge" branch), `reconcile.py`'s `merge_node()` builds a merged node by preferring `existing.metadata` over `incoming.metadata` for any key already present, then `apply_record()` durably upserts that merged node. This path has no awareness of which metadata fields are "owned" by a different subsystem (a reducer like `_bus_synaptic_tick()`) versus genuinely part of the concept's own state — it treats every concept node identically.
+
+## Architecture touched
+
+`orion/substrate/materializer.py` (core fix). `services/orion-hub/scripts/concept_atlas_routes.py` and its test file (regression fix surfaced by the core fix, same PR). No contract/schema/bus changes.
+
+## Files changed
+
+- `orion/substrate/materializer.py`: `apply_record()`'s merge branch now passes `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS` to `upsert_node()`. The create branch is deliberately unchanged (no existing state to protect).
+- `orion/substrate/tests/test_materializer_reducer_owned_metadata_protection.py` (new): asserts the create-branch call has `skip_metadata_keys=None` and the merge-branch call has `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`, via a spy on `store.upsert_node`. Confirmed red-before-green (fails against pre-fix code via `git stash`).
+- `services/orion-hub/scripts/concept_atlas_routes.py`: `_CountingSubstrateStore.upsert_node()` now accepts and forwards `skip_metadata_keys` — it previously didn't, and defining its own `upsert_node` meant `__getattr__` never bailed out to the wrapped store, so the materializer's new call raised `TypeError` on this wrapper.
+- `services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py`: `_FailAfterNUpsertsStore` test double gets the identical fix for hygiene (not currently exercised by the merge branch, but same latent gap).
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. No `.env_example` changes; nothing to sync.
+
+## Tests run
+
+```
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/substrate/tests/test_materializer_reducer_owned_metadata_protection.py tests/test_cognitive_substrate_phase3_materialization.py orion/substrate/tests/test_reconcile.py -q
+15 passed in 1.07s
+
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/substrate/tests -q --ignore=orion/substrate/relational/tests
+490 passed, 16 warnings in ~9s   (489 on main + 1 new test; zero regressions)
+
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py -q
+31 passed, 17 warnings in 6.50s   (4 of these failed with TypeError before the regression fix in this same patch)
+```
+
+Red-before-green check on the new materializer test:
+```
+$ git stash push -- orion/substrate/materializer.py && pytest orion/substrate/tests/test_materializer_reducer_owned_metadata_protection.py -q
+1 failed, 1 passed   (the skip_metadata_keys assertion correctly fails against pre-fix code)
+$ git stash pop
+```
+
+## Evals run
+
+No dedicated eval harness for this narrow path; not applicable.
+
+## Docker/build/smoke checks
+
+```
+$ bash scripts/safe_docker_build.sh orion-cortex-exec up -d --build
+... all 4 cortex-exec containers (cortex-exec, -chat, -spark, -background) rebuilt and restarted ...
+
+$ bash scripts/safe_docker_build.sh orion-hub up -d --build
+... rebuilt and restarted (picks up the concept_atlas_routes.py regression fix) ...
+```
+
+Live-verified post-deploy, directly against FalkorDB:
+```
+$ redis-cli GRAPH.QUERY orion_substrate "MATCH (n) WHERE n.node_id = 'node:substrate.bus_synaptic' SET n.prediction_error = 0.73 RETURN n.prediction_error"
+20:12:49 prediction_error=0.73
+20:12:57 prediction_error=0.07615
+20:13:05 prediction_error=0.07615
+20:13:13 prediction_error=0.07615
+20:13:21 prediction_error=0.045842
+20:13:29 prediction_error=0.045842
+20:13:37 prediction_error=0.045842
+20:13:46 prediction_error=0.045842
+```
+Real, varying, non-saturated values tracked continuously across a 64s window (spanning both the materializer's fast re-touch cycle and the reducer's 30s tick) — zero snap-back to the stale `1.0`, confirming both this fix and PR #1498 together close the incident.
+
+## Review findings fixed
+
+- Finding: `services/orion-hub/scripts/concept_atlas_routes.py`'s `_CountingSubstrateStore.upsert_node()` and `services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py`'s `_FailAfterNUpsertsStore.upsert_node()` didn't accept `skip_metadata_keys`, so the materializer's newly-added kwarg on the merge branch raised `TypeError` on every re-ingest of an already-existing concept/entity via the Concept Atlas topic-foundry route — degrading the whole ingest call to `available: false` (caught by the route's broad `except Exception`). Confirmed reproducible: 4 previously-passing tests failed before this fix.
+  - Fix: both wrapper classes now accept and forward `skip_metadata_keys`.
+  - Evidence: `pytest services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py -q` — 31/31 passing after the fix, 4 failing before it (same session, same commit history).
+- Finding (confirmed, correctly out of scope for this PR): `orion/spark/concept_induction/falkor_materialization.py`'s `materialize_concept_profile_to_falkor()` calls `store.upsert_node()` directly with no `skip_metadata_keys` at all — and unlike this bug, it **nulls** (not just freezes) `prediction_error`/`contributing_turn_ids` on any node it touches, since `falkor_codec.py` always emits those params (default `None`) and `set_assignments()` never filters `None` out of the Cypher `SET` clause. Live default backend (`CONCEPT_PROFILE_GRAPH_BACKEND=falkor`), not opt-in.
+  - Fix: not attempted here — separate service (`orion-spark-concept-induction`), separate call path, needs its own review given the null-vs-freeze distinction changes the blast radius.
+  - Evidence: `orion/spark/concept_induction/falkor_materialization.py`, `orion/substrate/falkor_codec.py:205` (`_safe_float(row.get("prediction_error"), default=None)`), `orion/graph/falkor_client.py::set_assignments()`.
+- Finding (confirmed, correctly out of scope): two lower-frequency, same-shape gaps — `services/orion-hub/scripts/api_routes.py`'s concept decay scheduler (~line 372) and `services/orion-recall/app/collectors/concept_region.py`'s reinforcement path (~line 248) — both read-modify-write a node's full metadata without `skip_metadata_keys` protection, event/scheduler-triggered rather than a tight loop so lower collision probability, but not zero.
+  - Fix: not attempted here.
+  - Evidence: file/line references above.
+- Finding (confirmed, pre-existing, not introduced by this diff): `apply_record()`'s existing-node lookup has an asymmetry — when `identity_key` is non-`None` but has no identity-index entry yet, there's no fallback to a direct `get_node_by_id(node.node_id)` check, so a raw `node.node_id` collision with an already-existing node stored under a different identity would take the "created" branch (full wholesale overwrite, no merge, no protection at all) instead of merging. Unlikely to fire for `bus_synaptic` specifically in steady state.
+  - Fix: not attempted here.
+  - Evidence: `orion/substrate/materializer.py:50-56`.
+
+## Restart required
+
+```
+bash scripts/safe_docker_build.sh orion-cortex-exec up -d --build
+bash scripts/safe_docker_build.sh orion-hub up -d --build
+```
+
+Already run during this session's live verification; both are reflected in the currently-running containers. No further restart needed unless this branch is rebuilt from a fresh checkout.
+
+## Risks / concerns
+
+- Severity: High (live, currently unaddressed, separate from this PR)
+- Concern: `orion/spark/concept_induction/falkor_materialization.py` nulls (not freezes) reducer-owned metadata on the live default backend.
+- Mitigation: Documented above with exact file/line evidence; recommend a fast follow-up PR, not bundled here to keep this patch's blast radius scoped and reviewable.
+- Severity: Medium
+- Concern: Two more same-shape unprotected read-modify-write paths (`api_routes.py` decay scheduler, `concept_region.py` reinforcement).
+- Mitigation: Documented above; recommend a tracking issue.
+- Severity: Low
+- Concern: `apply_record()`'s create/merge branch selection has a narrow identity-collision edge case predating this PR.
+- Mitigation: Documented above; not urgent given low collision probability in steady state.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/bus-synaptic-materializer-clobber

--- a/orion/substrate/materializer.py
+++ b/orion/substrate/materializer.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1, SubstrateGraphRecordV1
 
+from .falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
 from .reconcile import EdgeMergeDecision, NodeMergeDecision, SubstrateIdentityResolver, merge_edge, merge_node, tier_rank_decision
 from .graphdb_store import build_substrate_store_from_env
 from .store import SubstrateGraphStore
@@ -61,7 +62,27 @@ class SubstrateGraphMaterializer:
             else:
                 tc, to = tier_rank_decision(existing_node, node)
                 canonical_node = merge_node(existing_node, node, source_graph_id=record.graph_id)
-                self._store.upsert_node(identity_key=identity_key, node=canonical_node)
+                # skip_metadata_keys: merge_node()'s metadata merge keeps whatever
+                # `existing.metadata` held for reducer-owned keys (prediction_error,
+                # contributing_turn_ids) -- but that's a snapshot read at the START
+                # of this call, not a live value, and this materializer has no
+                # business re-persisting it regardless. Confirmed live 2026-07-30:
+                # this exact path (invoked by orion-cortex-exec-background's
+                # concept-induction pipeline, any time a materialized concept
+                # happens to resolve to the same identity as a reducer-owned node
+                # like node:substrate.bus_synaptic) re-touches such nodes every
+                # few seconds -- far more often than the owning reducer's own
+                # tick cadence -- so it kept winning the race and durably
+                # re-locking whatever prediction_error value it last read back
+                # into itself, a self-reinforcing stale fixed point. Same
+                # protection SubstrateDynamicsEngine.tick() already uses for the
+                # same reason -- see falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's
+                # docstring for the original incident this pattern was built for.
+                self._store.upsert_node(
+                    identity_key=identity_key,
+                    node=canonical_node,
+                    skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS,
+                )
                 nodes_merged += 1
                 node_decisions.append(NodeMergeDecision(canonical_node_id=canonical_node.node_id, merged=True, reason="identity_match" if identity_key else "node_id_match", tier_conflict=tc, tier_outcome=to))
 

--- a/orion/substrate/tests/test_materializer_reducer_owned_metadata_protection.py
+++ b/orion/substrate/tests/test_materializer_reducer_owned_metadata_protection.py
@@ -1,0 +1,55 @@
+"""Regression guard (2026-07-30): SubstrateGraphMaterializer's merge-branch
+upsert_node call must protect reducer-owned metadata keys (prediction_error,
+contributing_turn_ids) the same way SubstrateDynamicsEngine.tick() already
+does -- see falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring for the
+original incident this pattern was built for.
+
+Confirmed live: orion-cortex-exec-background's concept-induction pipeline
+re-materializes node:substrate.bus_synaptic (and any other reducer-owned
+node whose anchor_scope/subject_ref/label happens to collide with an
+induced concept's identity) every few seconds via this exact merge path --
+far more often than the owning reducer's own tick cadence -- durably
+re-locking a stale prediction_error read back into itself on every pass.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+from orion.core.schemas.concept_induction import ConceptEvidenceRef, ConceptItem, ConceptProfile
+from orion.substrate import InMemorySubstrateGraphStore, SubstrateGraphMaterializer, map_concept_profile_to_substrate
+from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
+
+
+def _concept_profile(*, concept_id: str, label: str) -> ConceptProfile:
+    now = datetime.now(timezone.utc)
+    evidence = ConceptEvidenceRef(message_id=uuid4(), timestamp=now, channel="orion:test")
+    return ConceptProfile(
+        profile_id=f"profile-{concept_id}",
+        subject="orion",
+        window_start=now - timedelta(hours=1),
+        window_end=now,
+        concepts=[ConceptItem(concept_id=concept_id, label=label, confidence=0.8, salience=0.6, evidence=[evidence])],
+        metadata={"subject_ref": "project:orion"},
+    )
+
+
+def test_apply_record_protects_reducer_owned_keys_on_merge_but_not_on_create() -> None:
+    store = InMemorySubstrateGraphStore()
+    materializer = SubstrateGraphMaterializer(store=store)
+
+    record = map_concept_profile_to_substrate(profile=_concept_profile(concept_id="c-guard", label="Coherence"))
+
+    with patch.object(store, "upsert_node", wraps=store.upsert_node) as spy:
+        materializer.apply_record(record)  # first pass: create branch
+        create_call = spy.call_args
+        materializer.apply_record(record)  # second pass: merge branch (same identity)
+        merge_call = spy.call_args
+
+    # Create branch: no existing node to protect, must not pass skip_metadata_keys.
+    assert create_call.kwargs.get("skip_metadata_keys") is None
+    # Merge branch: must protect reducer-owned metadata from this materializer's
+    # own write, regardless of what it read into canonical_node.metadata.
+    assert merge_call.kwargs.get("skip_metadata_keys") == EXTERNALLY_OWNED_METADATA_KEYS

--- a/services/orion-hub/scripts/concept_atlas_routes.py
+++ b/services/orion-hub/scripts/concept_atlas_routes.py
@@ -376,8 +376,14 @@ class _CountingSubstrateStore:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def upsert_node(self, *, identity_key: str | None, node: Any) -> None:
-        self._inner.upsert_node(identity_key=identity_key, node=node)
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: Any,
+        skip_metadata_keys: Any = None,
+    ) -> None:
+        self._inner.upsert_node(identity_key=identity_key, node=node, skip_metadata_keys=skip_metadata_keys)
         kind = getattr(node, "node_kind", None)
         if kind == "concept":
             self.concepts_written += 1

--- a/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
+++ b/services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py
@@ -496,10 +496,16 @@ class _FailAfterNUpsertsStore:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
-    def upsert_node(self, *, identity_key: str | None, node: Any) -> None:
+    def upsert_node(
+        self,
+        *,
+        identity_key: str | None,
+        node: Any,
+        skip_metadata_keys: Any = None,
+    ) -> None:
         if self._upserts >= self._fail_after:
             raise RuntimeError("simulated upsert_node failure after partial write")
-        self._inner.upsert_node(identity_key=identity_key, node=node)
+        self._inner.upsert_node(identity_key=identity_key, node=node, skip_metadata_keys=skip_metadata_keys)
         self._upserts += 1
 
     def upsert_edge(self, *, identity_key: str, edge: Any) -> None:


### PR DESCRIPTION
## Summary

Second, independent cause of PR #1498's target bug — the `node:substrate.bus_synaptic` false "Bus Anomaly Detected" alerts persisted even after that fix landed. Traced live to `orion-cortex-exec-background`'s concept-induction pipeline re-materializing this node's identity every few seconds via `SubstrateGraphMaterializer.apply_record()`'s merge branch, with no protection for reducer-owned metadata — a self-reinforcing stale fixed point that kept beating the real reducer's fresher writes.

Fix: reuse the exact `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS` protection already proven for `SubstrateDynamicsEngine.tick()`'s identical bug class, applied to the materializer's merge-branch `upsert_node()` call.

## Regression caught by review, fixed in the same patch

Two test-double store wrappers (`_CountingSubstrateStore` in `concept_atlas_routes.py`, `_FailAfterNUpsertsStore` in its test file) didn't accept the new `skip_metadata_keys` kwarg, breaking the Concept Atlas topic-foundry ingest route (4 previously-passing tests failed with `TypeError`). Fixed by forwarding the parameter in both wrappers.

## Known related risk (not fixed here)

`orion/spark/concept_induction/falkor_materialization.py` has the same unprotected-write bug, but worse: it **nulls** (not just freezes) reducer-owned fields, on the live default backend. Two more lower-frequency same-shape gaps also found (`api_routes.py` decay scheduler, `concept_region.py` reinforcement). Full write-up: `docs/superpowers/pr-reports/2026-07-30-bus-synaptic-materializer-clobber-pr.md`

## Live verification

After rebuilding `orion-substrate-runtime`, `orion-cortex-exec` (all 4 containers), and `orion-hub`, watched `node:substrate.bus_synaptic` track real values (0.73 → 0.076 → 0.046) across a 64s window with zero snap-back — confirming this PR + #1498 together close the incident end to end.

## Test plan

- [x] `pytest orion/substrate/tests -q` — 490 passed (489 on main + 1 new), zero regressions
- [x] `pytest services/orion-hub/tests/test_concept_atlas_ingest_topic_foundry.py -q` — 31/31 pass (4 failed before the regression fix, same patch)
- [x] Red-before-green confirmed on the new test via `git stash`
- [x] Rebuilt + restarted all affected services, live-verified against FalkorDB directly
- [x] Code review pass, all findings addressed or explicitly documented as out-of-scope follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)