### PR TITLE
feat(structural-mass): graph_delta + snapshot_history -- graphify structural deltas

### DIFF
--- a/orion/structural_mass/graph_delta.py
+++ b/orion/structural_mass/graph_delta.py
@@ -1,0 +1,103 @@
+"""Graphify structural-graph deltas -- the ``graph_delta`` piece of the
+codebase-mass domain (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
+design.md, Phase 1). Diffs two ``GraphSnapshotStats``
+(``orion/structural_mass/snapshot_history.py``) into node/edge/community count
+deltas (design spec idea #2) and god-node Jaccard churn (idea #3).
+
+**Hop-distance drift (idea #6) is deliberately not implemented in this patch.**
+Unlike the other two ideas, which are pure functions over already-computed
+snapshot summaries, hop-distance drift requires live shortest-path traversal
+calls (``graphify path``) over a fixed sample of node pairs -- a materially
+different cost/complexity class, and not yet validated as non-degenerate on
+real data the way the two ideas here now are (see
+``scripts/analysis/measure_graph_structural_delta.py``). Building it alongside
+these two before either is proven would be exactly the kind of premature
+scope-stacking this repo's "thin seams, not ornamental layers" rule exists to
+prevent -- a real follow-up, not dropped, just sequenced after this slice
+measures clean.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from orion.structural_mass.snapshot_history import GraphSnapshotStats
+
+
+@dataclass(frozen=True)
+class GraphStructuralDelta:
+    node_count_delta: int
+    edge_count_delta: int
+    community_count_delta: int
+    # 0.0 (completely different god-node sets) to 1.0 (identical sets) --
+    # Jaccard similarity of prev/curr god-node label sets. 1.0 (not 0.0) when
+    # both snapshots have zero *real* god nodes -- "nothing changed" is the
+    # correct read for two empty sets, not "totally different." None (not a
+    # fabricated 1.0 or 0.0) when either snapshot's god_nodes could not be
+    # determined at all (GraphSnapshotStats.god_nodes is None) -- see
+    # parse_graph_report_god_nodes()'s docstring for why collapsing "unknown"
+    # into "unchanged" is exactly the failure this repo has been burned by
+    # twice before (CLAUDE.md's metric-quality-gate step 4).
+    god_node_jaccard_similarity: float | None
+    god_nodes_entered: tuple[str, ...] | None = field(default_factory=tuple)
+    god_nodes_exited: tuple[str, ...] | None = field(default_factory=tuple)
+
+
+def graph_structural_delta(
+    prev: GraphSnapshotStats,
+    curr: GraphSnapshotStats,
+) -> GraphStructuralDelta:
+    """Pure diff of two graph snapshots -- no I/O, no state, mirrors
+    ``git_churn_delta``'s and ``pr_lifecycle_delta``'s shape (a caller-owned
+    pair of "before"/"after" states in, a plain delta out).
+
+    God-node churn is Jaccard similarity of the two label *sets* (order-
+    independent) rather than a positional diff -- a god node re-ranking from
+    #3 to #7 without leaving the top-10 list entirely is real churn by rank
+    but not by *set membership*, and this program's SSP §7 "reuse the live
+    pipeline" framing treats the top-10 list itself (not its internal order)
+    as the meaningful graphify-computed artifact to track. ``god_nodes_
+    entered``/``god_nodes_exited`` name exactly which labels moved, for a
+    future concept-classification consumer that wants to say *which* god node
+    changed, not just that churn happened.
+
+    **``god_node_jaccard_similarity`` (and ``entered``/``exited``) are
+    ``None``, not a fabricated value, whenever either side's ``god_nodes`` is
+    ``None``** (unparseable/missing GRAPH_REPORT.md section) -- live-confirmed
+    during code review 2026-07-30: during this repo's own real
+    graph-shrink-then-revert incident (CLAUDE.md's documented 2026-07-14
+    destructive-update bug), the god-node top-10 list happened to survive
+    intact even while node/edge counts dropped ~95%, so jaccard alone would
+    have read "1.0, nothing changed" through the entire incident regardless
+    of this fix -- ``node_count_delta``/``edge_count_delta`` are what actually
+    catch that case. This ``None`` handling protects a *different* failure
+    mode: two snapshots whose god-node data genuinely could not be read at
+    all must not silently report "calm" either.
+    """
+    node_count_delta = curr.node_count - prev.node_count
+    edge_count_delta = curr.edge_count - prev.edge_count
+    community_count_delta = curr.community_count - prev.community_count
+
+    if prev.god_nodes is None or curr.god_nodes is None:
+        return GraphStructuralDelta(
+            node_count_delta=node_count_delta,
+            edge_count_delta=edge_count_delta,
+            community_count_delta=community_count_delta,
+            god_node_jaccard_similarity=None,
+            god_nodes_entered=None,
+            god_nodes_exited=None,
+        )
+
+    prev_set = set(prev.god_nodes)
+    curr_set = set(curr.god_nodes)
+    union = prev_set | curr_set
+    jaccard = 1.0 if not union else len(prev_set & curr_set) / len(union)
+
+    return GraphStructuralDelta(
+        node_count_delta=node_count_delta,
+        edge_count_delta=edge_count_delta,
+        community_count_delta=community_count_delta,
+        god_node_jaccard_similarity=jaccard,
+        god_nodes_entered=tuple(curr_set - prev_set),
+        god_nodes_exited=tuple(prev_set - curr_set),
+    )

--- a/orion/structural_mass/snapshot_history.py
+++ b/orion/structural_mass/snapshot_history.py
@@ -1,0 +1,167 @@
+"""Graphify structural-snapshot extraction and an append-only history log --
+the ``snapshot_history`` piece of the codebase-mass domain
+(docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md, Phase 1).
+
+graphify itself retains no time series (each ``graphify update`` overwrites
+``graphify-out/graph.json`` in place) -- this module is new state that fills
+that gap, either going forward (``scripts/safe_graphify_update.sh`` appending
+after each successful, non-reverted update -- not wired in this patch, see the
+design spec's Phase 1 bullet) or backward (reconstructed from git history via
+``git show <sha>:graphify-out/graph.json``, see
+``scripts/analysis/measure_graph_structural_delta.py``).
+
+**God nodes are read from ``GRAPH_REPORT.md``'s own "God Nodes" section, not
+recomputed from raw edges here.** graphify already computes this (its own
+degree-ranking logic, already tested, already the thing a human reads) --
+duplicating that computation in this module would risk drifting from
+graphify's real definition (weighting, tie-breaking, top-N cutoff) and
+violates this program's "reuse the live pipeline, don't parallel it" rule
+(SSP §7) one layer down from where it's usually invoked.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Consumes the *whole* header line (e.g. the "(most connected - your core
+# abstractions)" suffix), not just the "## God Nodes" prefix -- otherwise the
+# leftover suffix text would count as non-empty "section content" and make
+# a legitimately empty god-nodes list misfire the format-changed/None check
+# below (confirmed live while fixing that check).
+_GOD_NODES_HEADER_RE = re.compile(r"^## God Nodes[^\n]*\n?", re.MULTILINE)
+_GOD_NODES_LINE_RE = re.compile(r"^\d+\.\s+`([^`]+)`")
+
+
+@dataclass(frozen=True)
+class GraphSnapshotStats:
+    node_count: int
+    edge_count: int
+    community_count: int
+    # None means "could not determine god nodes for this snapshot" (missing
+    # or unparseable GRAPH_REPORT.md section) -- distinct from `()`, a real
+    # "zero god nodes." See parse_graph_report_god_nodes()'s docstring for why
+    # this distinction matters (a silently-collapsed None->() would make
+    # graph_structural_delta() misreport a parse failure as "nothing
+    # changed").
+    god_nodes: tuple[str, ...] | None = field(default_factory=tuple)
+    # Provenance -- which commit this snapshot reflects (git SHA) and whether
+    # it was reconstructed from history vs. captured live going forward.
+    commit_sha: str | None = None
+    backfilled: bool = False
+
+    def to_json_dict(self) -> dict:
+        return {
+            "node_count": self.node_count,
+            "edge_count": self.edge_count,
+            "community_count": self.community_count,
+            "god_nodes": None if self.god_nodes is None else list(self.god_nodes),
+            "commit_sha": self.commit_sha,
+            "backfilled": self.backfilled,
+        }
+
+    @classmethod
+    def from_json_dict(cls, data: dict) -> "GraphSnapshotStats":
+        raw_god_nodes = data.get("god_nodes")
+        return cls(
+            node_count=int(data["node_count"]),
+            edge_count=int(data["edge_count"]),
+            community_count=int(data["community_count"]),
+            god_nodes=None if raw_god_nodes is None else tuple(raw_god_nodes),
+            commit_sha=data.get("commit_sha"),
+            backfilled=bool(data.get("backfilled", False)),
+        )
+
+
+def parse_graph_report_god_nodes(report_text: str) -> tuple[str, ...] | None:
+    """Extracts the ordered god-node label list from GRAPH_REPORT.md's
+    ``## God Nodes`` section (``N. \\`Label\\` - D edges``), stopping at the
+    next ``##`` heading.
+
+    **Returns ``None``, not ``()``, whenever god-node data cannot actually be
+    determined -- distinct from a real, empty result.** Two failure shapes
+    both matter here, confirmed live by code review 2026-07-30: no
+    ``## God Nodes`` header at all (report predates this section, or the
+    report is missing/truncated), *or* the header is present with real
+    section content but zero lines match the expected ``N. \\`Label\\```
+    pattern (graphify's own report format changed). Both would otherwise
+    silently collapse to the same ``()`` as "genuinely zero god nodes exist" --
+    live-reproduced during review: two consecutive parse failures would make
+    ``graph_structural_delta()`` report ``god_node_jaccard_similarity=1.0``
+    ("nothing changed"), the exact "looks calm, isn't" failure shape
+    CLAUDE.md's metric-quality-gate step 4 already names twice by incident
+    (the permanent-0.27 bus_synaptic floor, and node:substrate.route's
+    decay-to-zero). A header present with a genuinely *empty* body (real "no
+    god nodes yet," e.g. a brand-new/tiny graph) is not conflated with a
+    parse failure -- that case still returns ``()``.
+    """
+    header_match = _GOD_NODES_HEADER_RE.search(report_text)
+    if header_match is None:
+        return None
+    section_start = header_match.end()
+    next_header = report_text.find("\n## ", section_start)
+    section = report_text[section_start : next_header if next_header != -1 else len(report_text)]
+    labels: list[str] = []
+    for line in section.splitlines():
+        match = _GOD_NODES_LINE_RE.match(line.strip())
+        if match:
+            labels.append(match.group(1))
+    if not labels and section.strip():
+        # Header present, non-empty body, nothing matched -- the expected
+        # format likely changed. Not the same state as a genuinely empty body.
+        return None
+    return tuple(labels)
+
+
+def graph_snapshot_stats_from_text(
+    graph_json_text: str,
+    graph_report_text: str,
+    *,
+    commit_sha: str | None = None,
+    backfilled: bool = False,
+) -> GraphSnapshotStats:
+    """Pure function: compute node/edge/community counts from a ``graph.json``
+    payload's text, and the god-node list from a ``GRAPH_REPORT.md`` payload's
+    text -- both taken as raw text (not file paths) so this works identically
+    whether the caller read a live file or a ``git show`` blob."""
+    graph = json.loads(graph_json_text)
+    nodes = graph.get("nodes") or []
+    links = graph.get("links") or []
+    communities = {node.get("community") for node in nodes if isinstance(node, dict) and "community" in node}
+    return GraphSnapshotStats(
+        node_count=len(nodes),
+        edge_count=len(links),
+        community_count=len(communities),
+        god_nodes=parse_graph_report_god_nodes(graph_report_text),
+        commit_sha=commit_sha,
+        backfilled=backfilled,
+    )
+
+
+def append_snapshot(path: str | Path, snapshot: GraphSnapshotStats) -> None:
+    """Append one snapshot as a JSONL line. Append-only by design -- this is a
+    history log, not a mutable table; a wrong entry gets corrected by
+    appending a corrected one, not by editing history in place."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(snapshot.to_json_dict()) + "\n")
+
+
+def read_snapshots(path: str | Path) -> list[GraphSnapshotStats]:
+    """Reads the full JSONL history log in append order (oldest first). Missing
+    file returns an empty list -- "no history captured yet" is a real, valid
+    state for a brand-new log, not an error."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    snapshots: list[GraphSnapshotStats] = []
+    with p.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            snapshots.append(GraphSnapshotStats.from_json_dict(json.loads(line)))
+    return snapshots

--- a/orion/structural_mass/tests/test_graph_delta.py
+++ b/orion/structural_mass/tests/test_graph_delta.py
@@ -1,0 +1,138 @@
+"""Unit tests for ``orion/structural_mass/graph_delta.py``."""
+
+from __future__ import annotations
+
+import pytest
+
+from orion.structural_mass.graph_delta import graph_structural_delta
+from orion.structural_mass.snapshot_history import GraphSnapshotStats
+
+
+def _snap(
+    *,
+    node_count: int = 0,
+    edge_count: int = 0,
+    community_count: int = 0,
+    god_nodes: tuple[str, ...] | None = (),
+) -> GraphSnapshotStats:
+    return GraphSnapshotStats(
+        node_count=node_count,
+        edge_count=edge_count,
+        community_count=community_count,
+        god_nodes=god_nodes,
+    )
+
+
+def test_zero_delta_when_identical_snapshots() -> None:
+    snap = _snap(node_count=100, edge_count=200, community_count=10, god_nodes=("A", "B"))
+    delta = graph_structural_delta(snap, snap)
+    assert delta.node_count_delta == 0
+    assert delta.edge_count_delta == 0
+    assert delta.community_count_delta == 0
+    assert delta.god_node_jaccard_similarity == pytest.approx(1.0)
+    assert delta.god_nodes_entered == ()
+    assert delta.god_nodes_exited == ()
+
+
+def test_counts_positive_deltas() -> None:
+    prev = _snap(node_count=100, edge_count=200, community_count=10)
+    curr = _snap(node_count=150, edge_count=260, community_count=12)
+    delta = graph_structural_delta(prev, curr)
+    assert delta.node_count_delta == 50
+    assert delta.edge_count_delta == 60
+    assert delta.community_count_delta == 2
+
+
+def test_counts_negative_deltas() -> None:
+    """A shrinking graph (a deletion arc, e.g. PR #879->#1486's drives-system
+    removal) is real signal, not clamped to zero."""
+    prev = _snap(node_count=100, edge_count=200, community_count=10)
+    curr = _snap(node_count=60, edge_count=90, community_count=7)
+    delta = graph_structural_delta(prev, curr)
+    assert delta.node_count_delta == -40
+    assert delta.edge_count_delta == -110
+    assert delta.community_count_delta == -3
+
+
+def test_god_node_jaccard_identical_sets_is_one() -> None:
+    prev = _snap(god_nodes=("A", "B", "C"))
+    curr = _snap(god_nodes=("C", "B", "A"))  # same set, different order
+    delta = graph_structural_delta(prev, curr)
+    assert delta.god_node_jaccard_similarity == pytest.approx(1.0)
+    assert delta.god_nodes_entered == ()
+    assert delta.god_nodes_exited == ()
+
+
+def test_god_node_jaccard_completely_disjoint_sets_is_zero() -> None:
+    prev = _snap(god_nodes=("A", "B"))
+    curr = _snap(god_nodes=("C", "D"))
+    delta = graph_structural_delta(prev, curr)
+    assert delta.god_node_jaccard_similarity == pytest.approx(0.0)
+    assert set(delta.god_nodes_entered) == {"C", "D"}
+    assert set(delta.god_nodes_exited) == {"A", "B"}
+
+
+def test_god_node_jaccard_partial_overlap() -> None:
+    prev = _snap(god_nodes=("A", "B", "C", "D"))
+    curr = _snap(god_nodes=("C", "D", "E", "F"))
+    delta = graph_structural_delta(prev, curr)
+    # intersection {C, D} = 2, union {A,B,C,D,E,F} = 6 -> 2/6
+    assert delta.god_node_jaccard_similarity == pytest.approx(2 / 6)
+    assert set(delta.god_nodes_entered) == {"E", "F"}
+    assert set(delta.god_nodes_exited) == {"A", "B"}
+
+
+def test_god_node_jaccard_both_empty_is_one_not_zero() -> None:
+    """Two snapshots with zero god nodes each represent 'nothing changed,' not
+    'totally different' -- an empty-set/empty-set comparison must not
+    misreport maximal churn via a 0/0 division artifact."""
+    prev = _snap(god_nodes=())
+    curr = _snap(god_nodes=())
+    delta = graph_structural_delta(prev, curr)
+    assert delta.god_node_jaccard_similarity == pytest.approx(1.0)
+
+
+def test_god_node_jaccard_one_empty_one_populated_is_zero() -> None:
+    prev = _snap(god_nodes=())
+    curr = _snap(god_nodes=("A",))
+    delta = graph_structural_delta(prev, curr)
+    assert delta.god_node_jaccard_similarity == pytest.approx(0.0)
+    assert delta.god_nodes_entered == ("A",)
+
+
+def test_god_nodes_none_on_either_side_yields_none_not_fabricated_value() -> None:
+    """Regression guard for the 2026-07-30 code-review finding: when a
+    snapshot's god_nodes could not be determined (None -- unparseable
+    GRAPH_REPORT.md), the delta must say "unknown" (None), not silently
+    report 1.0 ("nothing changed") or 0.0 ("totally different") -- either
+    fabricated value would misrepresent a parse failure as a real reading.
+    Count deltas (which don't depend on god-node parsing) must still compute
+    normally."""
+    prev = _snap(node_count=100, edge_count=200, god_nodes=None)
+    curr = _snap(node_count=110, edge_count=210, god_nodes=("A", "B"))
+    delta = graph_structural_delta(prev, curr)
+    assert delta.god_node_jaccard_similarity is None
+    assert delta.god_nodes_entered is None
+    assert delta.god_nodes_exited is None
+    assert delta.node_count_delta == 10
+    assert delta.edge_count_delta == 10
+
+
+def test_god_nodes_none_on_curr_side_also_yields_none() -> None:
+    prev = _snap(god_nodes=("A", "B"))
+    curr = _snap(god_nodes=None)
+    delta = graph_structural_delta(prev, curr)
+    assert delta.god_node_jaccard_similarity is None
+
+
+def test_god_nodes_both_none_yields_none_not_calm() -> None:
+    """Two consecutive parse failures must not average out to 'calm' -- this
+    is exactly the scenario that would have masked the real 2026-07-14
+    destructive-graph-update incident had the god-node section itself been
+    unparseable during that window (it wasn't, in the real replay -- but the
+    code must not depend on that being true by luck)."""
+    prev = _snap(node_count=100, god_nodes=None)
+    curr = _snap(node_count=5, god_nodes=None)  # a real ~95% node-count crash
+    delta = graph_structural_delta(prev, curr)
+    assert delta.god_node_jaccard_similarity is None
+    assert delta.node_count_delta == -95  # still correctly caught by the count delta

--- a/orion/structural_mass/tests/test_snapshot_history.py
+++ b/orion/structural_mass/tests/test_snapshot_history.py
@@ -1,0 +1,156 @@
+"""Unit tests for ``orion/structural_mass/snapshot_history.py``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orion.structural_mass.snapshot_history import (
+    GraphSnapshotStats,
+    append_snapshot,
+    graph_snapshot_stats_from_text,
+    parse_graph_report_god_nodes,
+    read_snapshots,
+)
+
+_REAL_GOD_NODES_SECTION = """\
+Some preamble text.
+
+## God Nodes (most connected - your core abstractions)
+1. `ServiceRef` - 1033 edges
+2. `BaseEnvelope` - 980 edges
+3. `OrionBusAsync` - 628 edges
+
+## Surprising Connections (you probably didn't know these)
+- `A` --relates_to--> `B`
+"""
+
+
+def test_parse_graph_report_god_nodes_extracts_ordered_labels() -> None:
+    labels = parse_graph_report_god_nodes(_REAL_GOD_NODES_SECTION)
+    assert labels == ("ServiceRef", "BaseEnvelope", "OrionBusAsync")
+
+
+def test_parse_graph_report_god_nodes_missing_section_is_none() -> None:
+    """No `## God Nodes` header at all -- distinct from a header present with
+    a genuinely empty body. Returns None (unknown), not () (known-empty)."""
+    assert parse_graph_report_god_nodes("# Report\n\nNo god nodes section here.\n") is None
+
+
+def test_parse_graph_report_god_nodes_format_change_is_none_not_empty() -> None:
+    """Regression guard for the 2026-07-30 code-review finding: if graphify's
+    report format ever changes (e.g. labels no longer backtick-wrapped, a
+    bullet list instead of a numbered one), the header is present with real
+    content but zero lines match the expected pattern -- must report None
+    (parse failure), not silently collapse to () ("genuinely zero god
+    nodes"), which would make graph_structural_delta() misreport a broken
+    parse as "nothing changed" (god_node_jaccard_similarity=1.0)."""
+    text = (
+        "## God Nodes (most connected - your core abstractions)\n"
+        "1. ServiceRef - 1033 edges\n"  # no backticks -- doesn't match the real format
+        "2. BaseEnvelope - 980 edges\n"
+    )
+    assert parse_graph_report_god_nodes(text) is None
+
+
+def test_parse_graph_report_god_nodes_empty_section_is_empty() -> None:
+    text = "## God Nodes (most connected - your core abstractions)\n\n## Next Section\nsomething\n"
+    assert parse_graph_report_god_nodes(text) == ()
+
+
+def test_parse_graph_report_god_nodes_stops_at_next_header() -> None:
+    """A god node label containing text that looks like a numbered list item
+    in a *later* section must not be picked up -- the section boundary is the
+    next `## ` heading, not end-of-file."""
+    text = (
+        "## God Nodes (most connected - your core abstractions)\n"
+        "1. `Real` - 10 edges\n"
+        "\n"
+        "## Other Section\n"
+        "1. `NotAGodNode` - irrelevant\n"
+    )
+    assert parse_graph_report_god_nodes(text) == ("Real",)
+
+
+def test_graph_snapshot_stats_from_text_computes_counts() -> None:
+    graph_json = json.dumps(
+        {
+            "nodes": [
+                {"id": "a", "community": 1},
+                {"id": "b", "community": 1},
+                {"id": "c", "community": 2},
+            ],
+            "links": [
+                {"source": "a", "target": "b"},
+                {"source": "b", "target": "c"},
+            ],
+        }
+    )
+    stats = graph_snapshot_stats_from_text(
+        graph_json, _REAL_GOD_NODES_SECTION, commit_sha="abc123", backfilled=True
+    )
+    assert stats.node_count == 3
+    assert stats.edge_count == 2
+    assert stats.community_count == 2
+    assert stats.god_nodes == ("ServiceRef", "BaseEnvelope", "OrionBusAsync")
+    assert stats.commit_sha == "abc123"
+    assert stats.backfilled is True
+
+
+def test_graph_snapshot_stats_from_text_handles_missing_community_field() -> None:
+    """A node with no `community` key at all (schema-legal, just incomplete)
+    must not raise or silently count as its own community bucket."""
+    graph_json = json.dumps(
+        {
+            "nodes": [{"id": "a"}, {"id": "b", "community": 5}],
+            "links": [],
+        }
+    )
+    stats = graph_snapshot_stats_from_text(graph_json, "")
+    assert stats.node_count == 2
+    assert stats.community_count == 1
+
+
+def test_snapshot_json_round_trip_preserves_none_god_nodes() -> None:
+    """None (unparseable) must survive a JSON round-trip as None, not silently
+    become () -- json.dumps(None) is `null`, and from_json_dict must read
+    that back as None, not coerce it to an empty tuple."""
+    original = GraphSnapshotStats(node_count=5, edge_count=3, community_count=1, god_nodes=None)
+    restored = GraphSnapshotStats.from_json_dict(original.to_json_dict())
+    assert restored.god_nodes is None
+    assert restored == original
+
+
+def test_snapshot_json_round_trip() -> None:
+    original = GraphSnapshotStats(
+        node_count=10,
+        edge_count=20,
+        community_count=3,
+        god_nodes=("X", "Y"),
+        commit_sha="deadbeef",
+        backfilled=True,
+    )
+    restored = GraphSnapshotStats.from_json_dict(original.to_json_dict())
+    assert restored == original
+
+
+def test_append_and_read_snapshots_round_trip(tmp_path: Path) -> None:
+    log_path = tmp_path / "history" / "graph_snapshots.jsonl"
+    s1 = GraphSnapshotStats(node_count=1, edge_count=0, community_count=1, god_nodes=())
+    s2 = GraphSnapshotStats(node_count=2, edge_count=1, community_count=1, god_nodes=("X",))
+
+    append_snapshot(log_path, s1)
+    append_snapshot(log_path, s2)
+
+    snapshots = read_snapshots(log_path)
+    assert snapshots == [s1, s2]
+
+
+def test_read_snapshots_missing_file_returns_empty_list(tmp_path: Path) -> None:
+    assert read_snapshots(tmp_path / "does_not_exist.jsonl") == []
+
+
+def test_append_snapshot_creates_parent_directories(tmp_path: Path) -> None:
+    log_path = tmp_path / "deeply" / "nested" / "path" / "snapshots.jsonl"
+    append_snapshot(log_path, GraphSnapshotStats(node_count=1, edge_count=0, community_count=1))
+    assert log_path.exists()

--- a/scripts/analysis/measure_graph_structural_delta.py
+++ b/scripts/analysis/measure_graph_structural_delta.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Read-only replay of ``graph_structural_delta()`` against this repo's real,
+sparse ``graphify-out/graph.json``/``GRAPH_REPORT.md`` git history -- SSP §7's
+"measure before minting" discipline (docs/superpowers/specs/2026-07-30-
+codebase-mass-signal-design.md, "Backfill" section).
+
+graphify retains no time series of its own (each ``graphify update`` overwrites
+the snapshot in place) -- but git itself retains every historical commit that
+touched these two files, so this script reconstructs each one via
+``git show <sha>:path`` and diffs successive reconstructions. Real data,
+irregularly spaced, none before graphify's first commit to this repo
+(2026-07-14, PR #1034) -- sparse but real, exactly as the design spec's
+Backfill section describes, not a dense synthetic series.
+
+Run:
+    python scripts/analysis/measure_graph_structural_delta.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from orion.structural_mass.graph_delta import graph_structural_delta  # noqa: E402
+from orion.structural_mass.snapshot_history import (  # noqa: E402
+    graph_snapshot_stats_from_text,
+)
+
+_GRAPH_JSON_PATH = "graphify-out/graph.json"
+_GRAPH_REPORT_PATH = "graphify-out/GRAPH_REPORT.md"
+
+
+def _git_show(sha: str, path: str, repo_path: Path) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{sha}:{path}"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "does not exist" in stderr or "exists on disk, but not" in stderr:
+            # Real, expected case: GRAPH_REPORT.md (or, in principle,
+            # graph.json) not present yet at an early commit -- not every
+            # commit that touches one necessarily touches the other.
+            return ""
+        # Any other failure (corrupted object, ambiguous ref, etc.) is not
+        # the same as "file not present yet" -- surface it loudly rather than
+        # silently treating it as an empty/missing file, which this replay's
+        # whole purpose (trustworthy live-data sanity checking) depends on
+        # not doing quietly.
+        print(f"WARNING: git show {sha}:{path} failed unexpectedly: {stderr}", file=sys.stderr)
+        return ""
+    return result.stdout
+
+
+def _commits_touching(path: str, repo_path: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "log", "--reverse", "--format=%H", "--follow", "--", path],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> int:
+    repo_path = _REPO_ROOT
+    commit_shas = _commits_touching(_GRAPH_JSON_PATH, repo_path)
+    if len(commit_shas) < 2:
+        print(f"Not enough historical commits touching {_GRAPH_JSON_PATH} to replay "
+              f"(found {len(commit_shas)}).")
+        return 1
+
+    print(f"Replaying {len(commit_shas) - 1} delta(s) across {len(commit_shas)} "
+          f"real historical commits touching {_GRAPH_JSON_PATH}\n")
+
+    snapshots = []
+    for sha in commit_shas:
+        graph_json_text = _git_show(sha, _GRAPH_JSON_PATH, repo_path)
+        graph_report_text = _git_show(sha, _GRAPH_REPORT_PATH, repo_path)
+        if not graph_json_text.strip():
+            print(f"{sha[:10]}: {_GRAPH_JSON_PATH} empty/missing at this commit -- skipping")
+            continue
+        snapshot = graph_snapshot_stats_from_text(
+            graph_json_text, graph_report_text, commit_sha=sha, backfilled=True
+        )
+        snapshots.append(snapshot)
+        god_nodes_repr = "N/A (unparseable)" if snapshot.god_nodes is None else str(len(snapshot.god_nodes))
+        print(f"{sha[:10]}: nodes={snapshot.node_count:>6} edges={snapshot.edge_count:>6} "
+              f"communities={snapshot.community_count:>5} god_nodes={god_nodes_repr}")
+
+    print(f"\n--- Deltas between {len(snapshots)} reconstructed snapshots ---")
+    node_deltas = []
+    jaccards = []
+    unparseable_god_node_pairs = 0
+    for prev, curr in zip(snapshots, snapshots[1:]):
+        delta = graph_structural_delta(prev, curr)
+        node_deltas.append(delta.node_count_delta)
+        if delta.god_node_jaccard_similarity is None:
+            unparseable_god_node_pairs += 1
+            jaccard_repr = "N/A (unparseable)"
+        else:
+            jaccards.append(delta.god_node_jaccard_similarity)
+            jaccard_repr = f"{delta.god_node_jaccard_similarity:.3f}"
+        print(
+            f"{prev.commit_sha[:10]} -> {curr.commit_sha[:10]}: "
+            f"nodes {delta.node_count_delta:+d}  edges {delta.edge_count_delta:+d}  "
+            f"communities {delta.community_count_delta:+d}  "
+            f"god_node_jaccard {jaccard_repr}  "
+            f"entered={delta.god_nodes_entered}  exited={delta.god_nodes_exited}"
+        )
+
+    print("\n--- Distributional sanity (CLAUDE.md metric-quality-gate step 4) ---")
+    if len(snapshots) < 2:
+        print("FLAG: fewer than 2 real reconstructed snapshots -- nothing to diff.")
+        return 1
+    if len(set(node_deltas)) == 1 and len(node_deltas) > 1:
+        print("FLAG: every node-count delta identical -- degenerate, do not trust yet.")
+        return 1
+    print(f"node_count_delta: min={min(node_deltas)} max={max(node_deltas)} "
+          f"(non-degenerate: {len(set(node_deltas)) > 1})")
+    if jaccards:
+        print(f"god_node_jaccard_similarity: min={min(jaccards):.3f} max={max(jaccards):.3f} "
+              f"({unparseable_god_node_pairs} pair(s) unparseable, excluded)")
+    else:
+        print(f"god_node_jaccard_similarity: no parseable pairs "
+              f"({unparseable_god_node_pairs} pair(s) unparseable)")
+    print("\nOK: real, sparse, non-degenerate deltas across genuine historical "
+          "graphify commits.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Third Phase-1 slice of the "codebase mass" signal (design: `docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md`), sibling to #1496 (`git_delta.py`) and #1500 (`pr_lifecycle.py`). Same scoping: **no bus wiring, no `NODE_CHANNELS` registration, no service scaffolding.**

- `orion/structural_mass/snapshot_history.py`: `GraphSnapshotStats` + `parse_graph_report_god_nodes()` (parses `GRAPH_REPORT.md`'s "God Nodes" section — reuses graphify's own already-computed ranking rather than recomputing degree here, per SSP §7's "reuse the live pipeline") + `graph_snapshot_stats_from_text()` (pure, text-in not file-path-in, so it works identically on a live file or a `git show` blob) + `append_snapshot()`/`read_snapshots()` (JSONL log I/O).
- `orion/structural_mass/graph_delta.py`: `graph_structural_delta()` — pure diff of two snapshots into node/edge/community count deltas + god-node Jaccard-similarity churn.
- `scripts/analysis/measure_graph_structural_delta.py`: replay script walking every real historical commit touching `graphify-out/graph.json`.

## Outcome moved

Live-verified against this repo's own real, sparse history (git retains 7 historical commits touching `graph.json` since 2026-07-14, PR #1034 — graphify itself keeps no time series). The replay **reproduces the exact "graphify update can silently shrink the graph by ~95%" incident root `CLAUDE.md`'s own graphify section already documents by name**: commit `6664655faf` ("sync knowledge graph with today's 5 merged PRs") shows a ~95% node-count crash (31,566 → 1,559 nodes), immediately reverted by the very next commit `d7c2db029a` ("revert destructive graph update that shipped on main"), restoring exactly 31,566. This is concrete, non-synthetic proof this delta measures something real, not noise.

## Scope decision: hop-distance drift deferred

The design spec names three ideas for this domain: node/edge/community count deltas (#2), god-node Jaccard churn (#3), and hop-distance drift (#6, mean shortest-path length via `graphify path`). This patch implements the first two only. Hop-distance drift needs live `graphify path` traversal calls over a sampled set of node pairs — a materially different cost/complexity class from the other two (which are pure functions over already-computed summary stats) — and isn't validated the way these two now are. Building it alongside these two before either is proven would be scope-stacking; it's a real, named follow-up, not dropped.

## Current architecture

Before this patch, graphify retained no history of its own graph's structure over time — each `graphify update` overwrites `graph.json` in place, with no diffing of successive states anywhere in the repo.

## Architecture touched

New pure-library files only — no service, bus, or schema contract changes.

## Files changed

- `orion/structural_mass/snapshot_history.py`: `GraphSnapshotStats`, `parse_graph_report_god_nodes()`, `graph_snapshot_stats_from_text()`, `append_snapshot()`, `read_snapshots()`.
- `orion/structural_mass/graph_delta.py`: `GraphStructuralDelta`, `graph_structural_delta()`.
- `orion/structural_mass/tests/test_snapshot_history.py`, `test_graph_delta.py`: 47 tests total across the module (both new files + the two sibling files already on `main`).
- `scripts/analysis/measure_graph_structural_delta.py`: replay script.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
orion/structural_mass/tests/: 47 passed in 1.67s
```

## Evals run

```
$ python3 scripts/analysis/measure_graph_structural_delta.py
Replaying 6 delta(s) across 7 real historical commits touching graphify-out/graph.json
...
node_count_delta: min=-30007 max=30007 (non-degenerate: True)
god_node_jaccard_similarity: min=0.667 max=1.000 (0 pair(s) unparseable, excluded)
OK: real, sparse, non-degenerate deltas across genuine historical graphify commits.
```

## Docker/build/smoke checks

Not applicable — no service, no runtime, no compose changes.

## Review findings fixed

- Finding (Moderate-High): `parse_graph_report_god_nodes` couldn't distinguish "genuinely zero god nodes" from "the report format changed and parsing silently broke" — both collapsed to `()`. Live-reproduced: two consecutive parse failures would make `graph_structural_delta()` report `god_node_jaccard_similarity=1.0` ("nothing changed"), the exact "looks calm, isn't" failure CLAUDE.md's metric-quality-gate step 4 already names twice by incident. Confirmed via the real replay that during the actual 95%-node-loss incident, the god-node top-10 list happened to survive intact, so jaccard alone (pre-fix) would have read "calm" through the whole incident — only the count deltas caught it.
  - Fix: `parse_graph_report_god_nodes()` now returns `None` (not `()`) when the header is missing entirely, or when the header is present with real content but nothing matches the expected format. `GraphSnapshotStats.god_nodes` is now `tuple[str, ...] | None`, threaded through JSON round-tripping correctly. `graph_structural_delta()` now returns `god_node_jaccard_similarity=None` (not a fabricated 1.0/0.0) whenever either side is `None` — count deltas still compute normally regardless.
  - Evidence: `orion/structural_mass/snapshot_history.py::parse_graph_report_god_nodes`; `orion/structural_mass/graph_delta.py::graph_structural_delta`; `orion/structural_mass/tests/test_snapshot_history.py::test_parse_graph_report_god_nodes_format_change_is_none_not_empty`; `orion/structural_mass/tests/test_graph_delta.py::test_god_nodes_both_none_yields_none_not_calm`.
- Finding (Low-Moderate): `measure_graph_structural_delta.py`'s `_git_show` treated any non-zero `git show` exit as "file not present yet," silently swallowing genuine git errors (corrupted object, ambiguous ref).
  - Fix: only treats `git show` failures whose stderr indicates a real missing-path case as "not present"; any other failure prints an explicit warning to stderr instead of silently returning an empty string.
  - Evidence: `scripts/analysis/measure_graph_structural_delta.py::_git_show`.
- A follow-on bug surfaced while fixing the above: the god-node section header regex (`^## God Nodes`) only matched the header prefix, not the full line — so the header's own descriptive suffix text ("(most connected - your core abstractions)") was being counted as leftover "section content," making the new None-detection misfire on a legitimately empty god-nodes list. Fixed by extending the regex to consume the full header line.
  - Evidence: `orion/structural_mass/snapshot_history.py`'s `_GOD_NODES_HEADER_RE`; caught by `orion/structural_mass/tests/test_snapshot_history.py::test_parse_graph_report_god_nodes_empty_section_is_empty` failing, then fixed and reverified against the real `GRAPH_REPORT.md` via the replay script (0 unparseable pairs across all 7 real historical snapshots).

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: Low
- Concern: God-node Jaccard churn alone would not have caught the real 95%-node-loss incident (the top-10 list happened to survive) — it's a real but narrow signal, not a substitute for the node/edge count deltas.
- Mitigation: This is inherent to what Jaccard-over-a-top-10-list measures, not a bug — documented explicitly in `graph_structural_delta()`'s docstring so a future consumer doesn't over-trust this one field in isolation.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1502
