### PR TITLE
feat(hub): Attention Organ operator tab — live heartbeat ensemble, AST/HOT wire, and per-domain prediction error

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-30-hub-attention-organ-operator-tab-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-hub-attention-organ-operator-tab-pr.md
@@ -354,4 +354,4 @@ change that needs its own metric-quality-gate pass and its own proposal.
 
 ## PR link
 
-<to be filled after push>
+https://github.com/junebug-junie/Orion-Sapienform/pull/1504

--- a/docs/superpowers/pr-reports/2026-07-30-hub-attention-organ-operator-tab-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-hub-attention-organ-operator-tab-pr.md
@@ -1,0 +1,357 @@
+# Hub Attention Organ operator tab — PR report
+
+Branch: `feat/hub-attention-organ-tab`
+Date: 2026-07-30
+Status: **DONE_WITH_CONCERNS** (see Risks / concerns — the concerns are live findings this tab
+surfaced about *existing* signals, not defects in the tab itself)
+
+## Summary
+
+- New top-level Hub tab, **Attention Organ**, visualizing in near-realtime the three live pieces of
+  `docs/superpowers/specs/2026-07-28-precision-weighted-attention-organ-and-heartbeat-discrimination-design.md`,
+  which had no human-visible surface anywhere: the heartbeat ensemble, the AST/HOT row that consumes
+  it, and each Active-Inference domain's raw prediction error.
+- Two panels are the design doc's own **acceptance checks computed live** rather than by eyeballing
+  container logs: verdict-band distribution over a window (Acceptance Check 1) and `predicted_shift`
+  domain dominance (Acceptance Check 3).
+- New read-only Hub API (`/api/attention-organ/snapshot` + `/history`) that fans out to three
+  independent backends and degrades each one separately.
+- Additive `orion-heartbeat` inspectability so the tab reports **values a real producer produced**
+  rather than mirroring another service's constants: per-trajectory `ratios` on `/h1`, and `config`
+  (live tuning + verdict band edges), `last_reheat`, `organ_site_map`, `absorb_queue_maxsize` on
+  `/health`.
+- Read-only throughout: no writes, no bus publish, no new channel, no new schema.
+
+## Outcome moved
+
+The design spec's central question — *does the attention organ actually discriminate, and is its
+signal reaching AST/HOT* — was previously answerable only by `docker logs` plus manual Postgres and
+FalkorDB queries. It is now a tab. Concretely, within minutes of the tab existing it surfaced two
+live problems that were not previously visible (see Risks / concerns).
+
+## Current architecture (before this patch)
+
+- `orion-heartbeat` ran an 8-trajectory quimb MPS dissipation ensemble, exposing `/h1` (mean ratio,
+  std, verdict, tick_count, seeds) and `/health` (event counters). Registered in
+  `orion/bus/channels.yaml` as a read-only research consumer that "publishes nothing back."
+- `orion-substrate-runtime`'s `_attention_self_model_tick()` fetched that `/h1` and threaded it into
+  `AttentionSelfModelV1` as `heartbeat_mean_ratio`/`heartbeat_verdict`/`heartbeat_basis`, persisting
+  to `substrate_attention_self_model` on a ~30s tick (PR #1459 + the 2026-07-29 heartbeat-into-AST/HOT
+  patch).
+- Per-domain `prediction_error` lived as a flat property on `node:substrate.<domain>` in the
+  `orion_substrate` FalkorDB graph, read back by `_brain_frame_prediction_error_by_domain()`.
+- None of these three had any UI. `AttentionSelfModelV1` still has no bus channel and no downstream
+  consumer — this patch does not change that.
+
+## Architecture touched
+
+- **services/orion-hub** — new read-only route module + new tab panel + tab-router registration.
+- **services/orion-heartbeat** — additive fields on the existing debug HTTP surface only. No change
+  to the substrate, the ensemble mathematics, the dissipation loop's behavior, or what it consumes.
+- No contract surfaces touched: `orion/bus/channels.yaml`, `orion/schemas/registry.py`, and
+  `orion/schemas/` are all unchanged.
+
+## Files changed
+
+- `services/orion-hub/scripts/attention_organ_routes.py` (new): the read-only API. Pure helpers
+  (`parse_predicted_shift_domain`, `summarize_history`, `build_domain_rows`, `reconcile_confidence`)
+  are separated from I/O so the aggregation logic is testable against fixed rows.
+- `services/orion-hub/static/js/attention-organ.js` (new): rendering + poll lifecycle. Vanilla,
+  inline SVG, no external deps, `textContent` only.
+- `services/orion-hub/tests/test_attention_organ_page.py` (new): 34 tests.
+- `services/orion-hub/scripts/api_routes.py`: register the router.
+- `services/orion-hub/templates/index.html`: nav anchor, panel section with nine mount points,
+  script tag.
+- `services/orion-hub/static/js/app.js`: the six registration points `setActiveTab` needs, plus the
+  `activate()`/`deactivate()` poll lifecycle.
+- `services/orion-hub/app/settings.py`, `.env_example`, `docker-compose.yml`: three new keys.
+- `services/orion-heartbeat/app/substrate/ensemble.py`: `EnsembleH1ResultV1.ratios`.
+- `services/orion-heartbeat/app/substrate/reconstruction.py`: populate `ratios`; new
+  `verdict_thresholds()`.
+- `services/orion-heartbeat/app/service.py`: record `last_reheat`; expose `config`,
+  `organ_site_map`, `absorb_queue_maxsize` on `/health`.
+- `services/orion-heartbeat/tests/{test_reconstruction_h1,test_http_endpoints}.py`: 4 new tests.
+
+## Schema / bus / API changes
+
+- **Added** (HTTP debug surfaces only, no bus/schema registry impact):
+  - `orion-heartbeat` `GET /h1` → `h1.ratios: list[float]`, index-aligned with `seeds`.
+  - `orion-heartbeat` `GET /health` → `config` (n_trajectories, gamma, base_decay_prob,
+    decay_spread_sensitivity, reheat_strength, reheat_prob_scale, decay_reheat_interval_sec,
+    h1_interval_sec, high_ratio, low_ratio), `last_reheat`, `organ_site_map`,
+    `absorb_queue_maxsize`.
+  - Hub `GET /api/attention-organ/snapshot`, `GET /api/attention-organ/history?minutes=`.
+- **Removed / renamed**: none.
+- **Behavior changed**: none. Every heartbeat addition is a new key on an existing response;
+  existing keys are untouched.
+- **Compatibility**: the Hub frontend treats every new heartbeat field as optional and renders an
+  explicit "not reported by this build" note when absent, so a Hub running against an older
+  heartbeat degrades honestly rather than breaking.
+
+## Env/config changes
+
+- Added keys (services/orion-hub): `FALKORDB_SUBSTRATE_GRAPH` (default `orion_substrate` — same env
+  key and default `build_falkor_substrate_store_from_env()` already uses, deliberately not a second
+  name for the same graph), `HUB_HEARTBEAT_BASE_URL` (default `http://localhost:7251`),
+  `HUB_ATTENTION_ORGAN_TIMEOUT_SEC` (default `3.0`).
+- Removed keys: none. Renamed keys: none.
+- `.env_example` updated: yes. `docker-compose.yml` inline `${VAR:-default}` fallbacks also set to
+  the real working values, because a worktree with no Hub `.env` falls through to those, not to
+  `.env_example` — the exact gap that silently killed the AST/HOT tick for an hour on 2026-07-29.
+- local `.env` synced: yes. `scripts/sync_local_env_from_example.py` skips this service in a fresh
+  worktree ("no .env"), so the live `/mnt/scripts/Orion-Sapienform/services/orion-hub/.env` was
+  updated directly. `FALKORDB_SUBSTRATE_GRAPH` was already present there (a pre-existing
+  `.env`/`.env_example` drift this patch also closes); the two `HUB_*` keys were appended.
+- Skipped keys requiring operator action: none.
+
+**`HUB_HEARTBEAT_BASE_URL` is the published port, not the compose DNS name, on purpose.** Verified
+live: Hub runs on the host network in this deployment, and `orion-athena-heartbeat` does not resolve
+from inside the Hub container while `http://localhost:7251` does.
+
+## Tests run
+
+```text
+services/orion-heartbeat$ ORION_BUS_ENABLED=false pytest tests -q
+57 passed, 14 warnings in 18.62s
+
+services/orion-hub$ pytest tests/test_attention_organ_page.py -q
+34 passed, 15 warnings in 5.33s
+
+services/orion-hub$ pytest tests -q            # full suite
+35 failed, 1068 passed, 5 skipped in 171.01s
+```
+
+The 35 hub failures are **pre-existing and not caused by this patch**, established by running the
+same suite on a scratch worktree at `origin/main`:
+
+```text
+origin/main baseline:  34 failures
+this branch:           35 failures
+symmetric difference:  1 test, and it is a swap WITHIN the same file
+  only on branch:   test_substrate_mutation_manual_route_routing.py::test_routing_apply_succeeds_for_auto_promote_and_can_rollback
+  only on baseline: test_substrate_mutation_manual_route_routing.py::test_routing_dry_run_produces_trial_and_decision_without_side_effects
+```
+
+That file is flaky on both, confirmed by running it in isolation 3× on each:
+
+```text
+this branch:  7 passed / 1 failed / 7 passed
+origin/main:  1 failed / 1 failed / 1 failed
+```
+
+Two of the pre-existing failures assert on `app.js` strings, so they were checked directly rather
+than assumed: `openResponseFeedbackModal('up', meta, text)` and
+`const substrateTabButton = document.getElementById("substratePageLink");` are absent from
+`origin/main`'s `app.js` as well (`grep -cF` → 0 on both). This patch only ever inserted into
+`app.js`; every edit was an exact-match replacement asserted `count == 1` and replaced with a
+superset.
+
+## Evals run
+
+```text
+No eval harness exists for services/orion-hub or services/orion-heartbeat.
+```
+
+Neither service has an `evals/` directory. Not created here: the meaningful eval for this surface
+would be "does the organ discriminate," which is the *subject* of the design spec's own acceptance
+checks and belongs to `orion-heartbeat`'s calibration harness
+(`scripts/analysis/measure_heartbeat_ensemble_calibration.py`), not to a read-only viewer of it.
+Flagged as a follow-up rather than silently claimed.
+
+## Docker/build/smoke checks
+
+```text
+$ scripts/safe_docker_build.sh orion-heartbeat up -d --build
+Image orion-heartbeat-heartbeat Built
+Container orion-athena-heartbeat Recreated / Started
+
+$ curl -fsS http://localhost:7251/h1
+{"ok":true,"h1":{"mean_ratio":0.9041836228299582,"std_ratio":0.03225184412851619,
+ "verdict":"redundant","tick_count":90,"seeds":[42,...,49],
+ "ratios":[0.94515,0.91386,0.88107,0.90808,0.93307,0.83436,0.92000,0.89787],...}}
+
+$ curl -fsS http://localhost:7251/health
+... "last_reheat":{"raw_mean_abs_gap_zscore":29.27,"zscore_saturation":3.0,
+     "signal":1.0,"reheat_prob":0.02,"at":"2026-07-30T20:11:50Z"},
+    "config":{...,"high_ratio":0.6,"low_ratio":0.2}, "organ_site_map":{...}
+```
+
+Hub endpoints exercised through the real `api_routes.router` against live Postgres + FalkorDB +
+heartbeat (Hub itself not redeployed — see Restart required):
+
+```text
+GET /api/attention-organ/snapshot        -> 200 in 167ms
+  heartbeat.ok      True
+  reconciliation    verdict=within_drift  delta=0.0022  row_age=0.3s
+  link              self_model_mean_ratio 0.7711 == live_mean_ratio 0.7711,
+                    basis tick_count 6184 == live tick_count 6184
+GET /api/attention-organ/history?minutes=60 -> 200
+  sample_count 119, verdict_counts {'redundant': 116}, null_verdict 3,
+  domain_counts {'execution': 68, 'bus_synaptic': 40, 'biometrics': 9}
+GET /api/attention-organ/history?minutes=7  -> normalized to 60
+```
+
+**Metric quality gate** (CLAUDE.md §0A) for the one derived number this tab computes,
+`reconciliation.recomputed`:
+
+1. *Provenance*: `1 - mean(prediction_error over ACTIVE_INFERENCE_DOMAINS)`, the literal formula in
+   `_unconditional_prediction_error_confidence()`. Inputs are the flat `prediction_error` property
+   on `node:substrate.<domain>` — the same values `_brain_frame_prediction_error_by_domain()` feeds
+   the reducer.
+2. *Independence*: it is not independent, and is not claimed to be — it is deliberately a
+   **redundant recomputation** of a value the reducer already stored, whose entire purpose is to
+   diff the two.
+3. *Theory anchor*: none needed; it is an identity check, not a new measurement.
+4. *Live-data sanity*: verified by hand against real data — five live domain values
+   (execution 1.0, bus_synaptic 1.0, biometrics 0.102157, chat 0.013468, route 0.00025) give
+   `1 - mean = 0.5768`, exactly the persisted `prediction_error_confidence` of the row written at
+   the same time.
+5. *Existing mechanism*: none — no existing surface compared these two.
+6. *Reversibility*: trivially removable; nothing consumes it.
+
+## Review findings fixed
+
+Code review ran in a subagent per CLAUDE.md §12. All three must-fix and all seven should-fix
+findings were fixed.
+
+- **M1 — poll timer never stops when leaving via the "Self" tab.**
+  `self_observability.js` hides every `section[data-panel]` directly and `preventDefault()`s its own
+  click, and `app.js` has zero references to it — so `setActiveTab`, the only caller of
+  `deactivate()`, never runs on that path. The timer would have kept firing forever into a hidden
+  panel: 2 HTTP calls + a Postgres query + a FalkorDB query every 2–5s.
+  - Fix: the interval body checks real DOM visibility and self-deactivates, so the contract holds
+    against any panel that hides it, not just the current router.
+  - Evidence: `test_attention_organ_js_guards_polling_on_real_visibility` inspects the
+    `startTimer`→`activate` region for both the visibility check and the `deactivate()` call.
+
+- **M2 — fabricated `tick lag` when the organ is offline.**
+  Global `isFinite(null)` is `true`, so an unreachable heartbeat (`live_tick_count: null`) rendered
+  a confident negative lag in ordinary gray, next to two rows honestly showing `—` for the same
+  null. Reviewer reproduced it: `lag rendered: -1614`.
+  - Fix: `Number.isFinite`. The `lag > 5000` amber threshold was also removed — `tick_count` counts
+    absorbed events at a rate set entirely by live organ traffic, so no fixed threshold means
+    anything (and 5000 was larger than the metric had ever been). Staleness is now keyed on row age,
+    which is a real duration.
+  - Evidence: `test_attention_organ_js_uses_strict_number_isfinite_for_nullable_readings`.
+
+- **M3 — blocking I/O on the event loop at a 2s cadence.**
+  Both handlers were `async def` with blocking `requests.get` ×2, blocking SQLAlchemy, and blocking
+  redis — up to ~6s of a frozen Hub (chat, websockets, every route) per poll. The pattern exists in
+  older read-only route modules, but those are user-initiated one-shots, not an always-open tab.
+  - Fix: dropped `async`; FastAPI runs sync handlers in its threadpool.
+  - Evidence: `test_attention_organ_routes_are_sync_handlers` asserts via `inspect.iscoroutinefunction`.
+
+- **S1 — history failure masked, stale history rendered as current.** The "History unavailable"
+  status was immediately overwritten by "Updated <now>", while `lastHistory` kept rendering an old
+  window under its own `window_minutes`/`sample_count` labels.
+  - Fix: `state.historyError`, `"history"` pushed into the status line's degraded list, and a
+    banner on both history-backed panels stating how old the data actually is.
+
+- **S2 — hardcoded `"0.2"` band edge**, the exact mirrored constant `verdict_thresholds()` was added
+  to eliminate. Fix: with no live `config`, the sentence omits the number entirely.
+
+- **S3 — `last_reheat` staleness invisible.** `service.py` only overwrites it after a *successful*
+  tick, so a persistently failing FalkorDB query serves the last good block forever. Fix: aged
+  against the loop's own `decay_reheat_interval_sec` and flagged amber past 5×.
+
+- **S4 — new Redis client + connection pool per request**, never closed (the class has no
+  `close()`). Not an unbounded leak, but ~30 TCP connect/teardowns per minute for a 7-row query.
+  Fix: module-level cache, matching `_engine()` directly above it.
+
+- **S5 — unlabeled `MATCH (n)`** on the substrate concept graph, with no index on `node_id`
+  (confirmed: `CALL db.indexes()` is empty), scanned every poll. Fix: `MATCH (n:SubstrateNode)`.
+  `STARTS WITH` kept over an `IN $ids` form so an unknown future domain node is still discovered.
+
+- **S6 — `heartbeat.ok` true when there is no H1 at all.** `/h1` answers HTTP 200 with
+  `{"ok": false, "reason": "no_h1_computed_yet"}` before the first ensemble tick; the transport-level
+  flag reported healthy while the panel showed a red "no H1" block. Fix: `and live_h1 is not None`.
+  Evidence: `test_snapshot_is_not_ok_when_heartbeat_is_reachable_but_has_no_h1_yet`.
+
+- **S7 — no PR report.** This file.
+
+- **T2/T3 — tests were string-matching, not behavior.** Added 9 tests that execute the handlers with
+  stubbed backends, covering snapshot's independent-degradation contract (all three failure
+  branches), the `/history` SQL, and the `truncated` flag. Added `malformed_row_count` so a window
+  where every row failed to parse cannot look identical to a window with no activity.
+
+- **N1/N2/N4/N5/N6 fixed** (time-proportional x-axis so an outage draws as a gap rather than an
+  unbroken line; lag threshold removed; trace relabeled "ensemble ticks" since it deduplicates on
+  `tick_count`; a comment that asserted the opposite of the real load order corrected;
+  `absorb_queue_maxsize` given the consumer it was shipped without). **N7 fixed** by dropping two
+  unrendered fields from the history series payload. N3 left as-is — it degrades honestly.
+
+### Found by live verification after the review, not by the review
+
+The reviewer confirmed `reconcile_confidence`'s `abs(delta) <= 0.05` tolerance matched the reducer
+exactly on the data it was tested against. A later live poll returned `delta = -0.0908` →
+`reconciles: False`, and the cause was not a defect in either signal: the row is written on
+substrate-runtime's ~30s tick while the graph read happens now, and `execution`/`bus_synaptic`
+genuinely swing across their whole range between ticks. A flat tolerance therefore reported
+"divergent" **as a function of when the operator happened to poll** — a check firing on its own
+sampling schedule, which is precisely the kind of instrument this tab exists to expose.
+
+Replaced with a stated model rather than a tuned constant: one of five domains traversing its full
+range can move the mean by at most `1/5 = 0.2`, so a delta within that is `within_drift`; beyond it
+would need two or more domains to have moved fully, which points at a source mismatch. Past a 60s
+row age the comparison carries no information either way and the verdict is withheld (`unknown`)
+rather than manufactured. `basis` states which rule fired. Covered by
+`test_reconcile_confidence_does_not_cry_divergence_on_ordinary_sampling_skew` and
+`test_reconcile_confidence_withholds_a_verdict_on_a_stale_row`.
+
+## Restart required
+
+`orion-heartbeat` is already rebuilt and running with this branch's code (see Docker checks). Note
+its ensemble restarts from a fresh random state on every deploy — v0 has no crash-safe persistence
+by design, so `tick_count` reset from ~35,700 to 0.
+
+Hub still needs a redeploy to pick up the new route module and settings. `templates/` and `static/`
+are volume-mounted **relative to the checkout the deploy runs from**, so this must be run from the
+main checkout after merge, not from the worktree — deploying Hub from a worktree would repoint those
+mounts at a directory that disappears when the worktree is pruned:
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+git pull --ff-only
+scripts/safe_docker_build.sh orion-hub up -d --build
+curl -fsS http://localhost:8081/api/attention-organ/snapshot | head -c 400
+```
+
+(That wrapper refuses to run from the shared checkout by design. Deploying Hub is the documented
+exception that needs `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1`, set consciously for this one command.)
+
+## Risks / concerns
+
+Both concerns are **live findings about existing signals that this tab made visible**. Neither is a
+defect in this patch, and neither is fixed here — fixing either is a heartbeat/substrate calibration
+change that needs its own metric-quality-gate pass and its own proposal.
+
+- **Severity: should-fix. The `bus_synaptic` reheat driver is fully saturated, so it is not gating
+  anything.** `last_reheat.raw_mean_abs_gap_zscore` reads **~29.3** against a
+  `BUS_SYNAPTIC_ZSCORE_SATURATION` of **3.0**, making `signal = min(1, z/3.0)` a constant **1.0**
+  and `reheat_prob` a constant `0.02` regardless of how bus activity moves. Verified stable across
+  three direct FalkorDB samples (29.30 / 29.31 / 29.27 over 436 edges, max |gap_zscore| 7087.8).
+  The design spec's own calibration states this raw value "sits around 1.0-1.1 during normal
+  operation" — it is ~30× that. The whole point of the reheat term is to be a *dynamic* driver;
+  clipped at its ceiling it is a constant. The tab flags this explicitly with a red "saturated"
+  badge and an explanation.
+  *Mitigation*: none applied. Recommend re-deriving the saturation constant against real
+  `orion_bus_synapse` data before the reheat term is trusted as dynamic — and checking whether the
+  underlying `gap_zscore` distribution itself is healthy, given a max of 7087.
+
+- **Severity: note. Acceptance Check 1 is still not met live, and the tab says so.** 24h of persisted
+  rows carry exactly one distinct `heartbeat_verdict` (`redundant`). This is already documented in
+  the spec as a structural gap deferred by explicit decision (2026-07-29), not a new finding — but
+  the tab now states it as a live verdict rather than leaving it to a doc.
+
+- **Severity: note. Two Active-Inference domains sit pinned at exactly 1.0.** `execution` and
+  `bus_synaptic` both read a saturated `prediction_error = 1.0` on most ticks, dragging
+  `prediction_error_confidence` into a bimodal 0.5768 ↔ ~0.96 pattern. `chat` and `transport` nodes
+  are ~6 days stale, and `chat` is nonetheless still averaged into the aggregate by the upstream
+  reducer. All are flagged in the tab (red at-ceiling badges, staleness ages) rather than rendered as
+  ordinary values. Directly relevant to the spec's still-open Missing Question 3.
+
+- **Severity: note. No eval harness** for either touched service (see Evals run).
+
+## PR link
+
+<to be filled after push>

--- a/services/orion-heartbeat/app/service.py
+++ b/services/orion-heartbeat/app/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import asdict
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from orion.core.bus.bus_service_chassis import BaseChassis, ChassisConfig
@@ -11,7 +12,7 @@ from orion.core.bus.codec import OrionCodec
 from .settings import settings
 from .substrate.bus_synaptic import BUS_SYNAPTIC_ZSCORE_SATURATION, query_real_bus_synaptic_raw_mean_abs_z
 from .substrate.ensemble import EnsembleConfig, EnsembleH1ResultV1, EnsembleSubstrate
-from .substrate.reconstruction import compute_h1_ensemble
+from .substrate.reconstruction import compute_h1_ensemble, verdict_thresholds
 from .substrate.routing import (
     ORGAN_SITE_MAP,
     SiteAssignment,
@@ -109,6 +110,15 @@ class HeartbeatService(BaseChassis):
         self.events_skipped_atom_type = 0
         self.events_skipped_no_atom = 0
         self.events_skipped_malformed = 0
+        # Last real dissipation-tick inputs, recorded by _decay_reheat_loop
+        # (2026-07-30). These are the ACTUAL values that loop fed into
+        # decay_reheat_tick(), not a re-derivation -- a read-only surface
+        # that recomputed `reheat_prob` from its own copy of
+        # reheat_prob_scale/BUS_SYNAPTIC_ZSCORE_SATURATION would be showing
+        # a plausible number rather than the one the substrate actually used,
+        # and would drift silently the moment either constant is retuned.
+        # None until the first dissipation tick completes.
+        self.last_reheat: dict[str, Any] | None = None
 
     def latest_h1_dict(self) -> dict[str, Any] | None:
         if self.latest_h1 is None:
@@ -141,7 +151,25 @@ class HeartbeatService(BaseChassis):
             "events_skipped_malformed": self.events_skipped_malformed,
             **ensemble_stats,
             "absorb_queue_size": self._absorb_queue.qsize(),
+            "absorb_queue_maxsize": settings.absorb_queue_maxsize,
             "allowlisted_organs": sorted(ORGAN_SITE_MAP.keys()),
+            "organ_site_map": dict(ORGAN_SITE_MAP),
+            "last_reheat": self.last_reheat,
+            # The live tuning actually in force, so a read-only surface can
+            # explain the mechanism (decay rate, spread sensitivity, reheat
+            # scale, band edges) from the running service rather than from a
+            # mirrored copy of .env_example that may not match this container.
+            "config": {
+                "n_trajectories": settings.n_trajectories,
+                "gamma": settings.decay_gamma,
+                "base_decay_prob": settings.base_decay_prob,
+                "decay_spread_sensitivity": settings.decay_spread_sensitivity,
+                "reheat_strength": settings.reheat_strength,
+                "reheat_prob_scale": settings.reheat_prob_scale,
+                "decay_reheat_interval_sec": settings.decay_reheat_interval_sec,
+                "h1_interval_sec": settings.h1_interval_sec,
+                **verdict_thresholds(),
+            },
         }
 
     def _handle_atom_payload(self, atom: dict[str, Any]) -> None:
@@ -307,6 +335,16 @@ class HeartbeatService(BaseChassis):
                 reheat_prob = settings.reheat_prob_scale * real_signal
                 async with self._ensemble_lock:
                     await asyncio.to_thread(self.ensemble.decay_reheat_tick, reheat_prob)
+                # Recorded AFTER the tick actually applied -- a failed query
+                # or a failed decay_reheat_tick() must not leave a stale
+                # entry claiming the substrate was reheated when it wasn't.
+                self.last_reheat = {
+                    "raw_mean_abs_gap_zscore": raw_z,
+                    "zscore_saturation": BUS_SYNAPTIC_ZSCORE_SATURATION,
+                    "signal": real_signal,
+                    "reheat_prob": reheat_prob,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
             except Exception as exc:  # noqa: BLE001 - must not kill the dissipation loop
                 logger.warning("heartbeat_decay_reheat_failed err=%s", exc)
 

--- a/services/orion-heartbeat/app/substrate/ensemble.py
+++ b/services/orion-heartbeat/app/substrate/ensemble.py
@@ -78,6 +78,14 @@ class EnsembleH1ResultV1:
     verdict: str
     tick_count: int
     seeds: list[int] = field(default_factory=list)
+    # Per-trajectory ratios, index-aligned with `seeds`. 2026-07-30: added so
+    # a reader can see the actual N samples the mean/std summarize, not just
+    # the two summary statistics -- an ensemble whose trajectories have all
+    # collapsed to the same value and one whose spread genuinely averages out
+    # are indistinguishable from mean+std alone at small N. Computed anyway
+    # by compute_h1_ensemble (it already calls ensemble.ratios()), so this
+    # carries zero extra compute; it was simply being discarded.
+    ratios: list[float] = field(default_factory=list)
     generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/services/orion-heartbeat/app/substrate/reconstruction.py
+++ b/services/orion-heartbeat/app/substrate/reconstruction.py
@@ -156,4 +156,18 @@ def compute_h1_ensemble(ensemble: EnsembleSubstrate) -> EnsembleH1ResultV1:
         verdict=verdict,
         tick_count=ensemble.tick_count(),
         seeds=list(ensemble.seeds),
+        ratios=[float(r) for r in ratios],
     )
+
+
+def verdict_thresholds() -> dict[str, float]:
+    """The live _HIGH_RATIO/_LOW_RATIO band edges, for read-only surfaces that
+    need to draw or explain the bands rather than re-declare them.
+
+    Exists so a consumer (services/orion-hub's attention-organ operator tab)
+    renders the SAME thresholds this module actually classifies with, instead
+    of mirroring two float constants that would then silently drift apart the
+    next time these are retuned -- design doc "Recommended next patch" step 4
+    explicitly anticipates retuning them against live data.
+    """
+    return {"high_ratio": _HIGH_RATIO, "low_ratio": _LOW_RATIO}

--- a/services/orion-heartbeat/tests/test_http_endpoints.py
+++ b/services/orion-heartbeat/tests/test_http_endpoints.py
@@ -31,3 +31,42 @@ def test_h1_endpoint_before_first_computation() -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body == {"ok": False, "reason": "no_h1_computed_yet"}
+
+
+def test_health_endpoint_exposes_live_tuning_and_band_edges() -> None:
+    """A read-only consumer must be able to explain the mechanism from the
+    RUNNING service, not from a mirrored copy of .env_example that may not
+    match this container -- the same config-drift failure that silently
+    reverted two live flags on 2026-07-29."""
+    from app.substrate.reconstruction import verdict_thresholds
+
+    with TestClient(app) as client:
+        body = client.get("/health").json()
+
+    config = body["config"]
+    for key in (
+        "n_trajectories",
+        "gamma",
+        "base_decay_prob",
+        "decay_spread_sensitivity",
+        "reheat_strength",
+        "reheat_prob_scale",
+        "decay_reheat_interval_sec",
+        "h1_interval_sec",
+    ):
+        assert key in config, key
+    assert config["high_ratio"] == verdict_thresholds()["high_ratio"]
+    assert config["low_ratio"] == verdict_thresholds()["low_ratio"]
+    assert body["absorb_queue_maxsize"] >= 1
+    assert set(body["organ_site_map"]) == set(body["allowlisted_organs"])
+
+
+def test_health_last_reheat_is_absent_until_a_real_dissipation_tick() -> None:
+    """`last_reheat` reports what the dissipation loop ACTUALLY fed the
+    substrate. Before any tick has run there is nothing real to report, and a
+    fabricated zero would read as "the organ was reheated by a calm bus"
+    rather than "the organ has not been reheated yet"."""
+    with TestClient(app) as client:
+        body = client.get("/health").json()
+
+    assert body["last_reheat"] is None

--- a/services/orion-heartbeat/tests/test_reconstruction_h1.py
+++ b/services/orion-heartbeat/tests/test_reconstruction_h1.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import statistics
 
 import pytest
 
@@ -60,3 +61,45 @@ def test_boundary_subprofile_length() -> None:
     result = compute_h1(sub)
     # boundary block has 5 sites -> 4 internal cuts
     assert len(result.boundary_subprofile) == 4
+
+
+def test_compute_h1_ensemble_reports_every_trajectory_ratio() -> None:
+    """2026-07-30: the per-trajectory ratios behind mean/std are reported, not
+    discarded. At small N, mean+std alone cannot distinguish "all trajectories
+    agree" from "two clusters that average out" -- which is the entire reason
+    this substrate runs an ensemble rather than one trajectory, so the samples
+    have to be inspectable, not just their summary."""
+    from app.substrate.ensemble import EnsembleConfig, EnsembleSubstrate
+    from app.substrate.reconstruction import compute_h1_ensemble
+
+    ensemble = EnsembleSubstrate(config=EnsembleConfig(n_trajectories=4), base_seed=100)
+    result = compute_h1_ensemble(ensemble)
+
+    assert len(result.ratios) == 4
+    assert len(result.ratios) == len(result.seeds)
+    assert all(0.0 <= r <= 1.0 for r in result.ratios)
+    # The reported mean/std must actually summarize the reported samples --
+    # not be computed from a second, independently-recomputed sample set.
+    assert result.mean_ratio == pytest.approx(sum(result.ratios) / len(result.ratios))
+    assert result.std_ratio == pytest.approx(statistics.pstdev(result.ratios))
+
+
+def test_verdict_thresholds_helper_matches_live_classification() -> None:
+    """The helper a read-only surface draws its bands from must be the same
+    numbers compute_h1_ensemble actually classifies with -- the point of
+    exposing them is precisely so they cannot drift apart when retuned
+    (design doc "Recommended next patch" step 4 anticipates retuning)."""
+    from app.substrate.ensemble import EnsembleConfig, EnsembleSubstrate
+    from app.substrate.reconstruction import compute_h1_ensemble, verdict_thresholds
+
+    bands = verdict_thresholds()
+    assert bands["low_ratio"] < bands["high_ratio"]
+
+    ensemble = EnsembleSubstrate(config=EnsembleConfig(n_trajectories=3), base_seed=200)
+    result = compute_h1_ensemble(ensemble)
+    if result.mean_ratio >= bands["high_ratio"]:
+        assert result.verdict == "redundant"
+    elif result.mean_ratio <= bands["low_ratio"]:
+        assert result.verdict == "concentrated"
+    else:
+        assert result.verdict == "mixed"

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -251,6 +251,21 @@ FALKORDB_URI=redis://127.0.0.1:6380
 # Read-only from Hub's side -- these routes never write to this graph.
 FALKORDB_BUS_GRAPH=orion_bus_synapse
 
+# --- Attention organ operator tab (attention_organ_routes.py, read-only) ---
+# Substrate concept graph, read to surface each Active-Inference domain's live
+# node:substrate.<domain> prediction_error. Same env key and default as
+# orion/substrate/falkor_store.py::build_falkor_substrate_store_from_env() --
+# deliberately not a second name for the same graph.
+FALKORDB_SUBSTRATE_GRAPH=orion_substrate
+# orion-heartbeat's debug HTTP surface (/h1 + /health). Hub runs on the host
+# network in this deployment, so this must be the container's PUBLISHED port,
+# not the compose service DNS name: verified live 2026-07-30 that
+# `orion-athena-heartbeat` does not resolve from inside the Hub container
+# while `http://localhost:7251` does. Leave empty to disable the heartbeat
+# half of the tab (the AST/HOT and per-domain panels still work).
+HUB_HEARTBEAT_BASE_URL=http://localhost:7251
+HUB_ATTENTION_ORGAN_TIMEOUT_SEC=3.0
+
 # --- Memory crystallization projections ---
 CRYSTALLIZER_VECTOR_COLLECTION=orion_memory_crystallizations
 # Minimum dynamics.activation for recall injection (hub active-packet route + recall collector).

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -372,6 +372,27 @@ class Settings(BaseSettings):
     # Same shared FalkorDB instance as FALKORDB_URI above; matches
     # services/orion-bus-mirror's own FALKORDB_BUS_GRAPH setting name/default.
     FALKORDB_BUS_GRAPH: str = Field(default="orion_bus_synapse", alias="FALKORDB_BUS_GRAPH")
+    # Graph name for the substrate concept graph, read by the attention-organ
+    # operator tab to surface each Active-Inference domain's live
+    # `node:substrate.<domain>` prediction_error. Same env key and default
+    # orion/substrate/falkor_store.py::build_falkor_substrate_store_from_env()
+    # already uses -- deliberately not a new name for the same graph.
+    FALKORDB_SUBSTRATE_GRAPH: str = Field(
+        default="orion_substrate", alias="FALKORDB_SUBSTRATE_GRAPH"
+    )
+
+    # --- Attention organ operator tab (read-only) ---
+    # orion-heartbeat's debug HTTP surface. Hub runs on the host network in
+    # this deployment, so the container's published port is the reachable
+    # address, NOT the compose service DNS name (verified live 2026-07-30:
+    # `orion-athena-heartbeat` does not resolve from inside the Hub
+    # container; `http://localhost:7251` does).
+    HUB_HEARTBEAT_BASE_URL: str = Field(
+        default="http://localhost:7251", alias="HUB_HEARTBEAT_BASE_URL"
+    )
+    HUB_ATTENTION_ORGAN_TIMEOUT_SEC: float = Field(
+        default=3.0, alias="HUB_ATTENTION_ORGAN_TIMEOUT_SEC"
+    )
 
     # --- Memory crystallization projections (Chroma via vector bus) ---
     CRYSTALLIZER_VECTOR_COLLECTION: str = Field(

--- a/services/orion-hub/docker-compose.yml
+++ b/services/orion-hub/docker-compose.yml
@@ -156,6 +156,14 @@ services:
       - GRAPHITI_URL=${GRAPHITI_URL:-}
       - FALKORDB_URI=${FALKORDB_URI:-}
       - FALKORDB_BUS_GRAPH=${FALKORDB_BUS_GRAPH:-orion_bus_synapse}
+      # Attention organ operator tab (read-only). Inline defaults are the real
+      # working values, not placeholders: a worktree with no Hub .env falls
+      # through to these, not to .env_example (this repo's new_worktree.sh does
+      # not provision one) -- the exact gap that silently killed the AST/HOT
+      # tick for an hour on 2026-07-29.
+      - FALKORDB_SUBSTRATE_GRAPH=${FALKORDB_SUBSTRATE_GRAPH:-orion_substrate}
+      - HUB_HEARTBEAT_BASE_URL=${HUB_HEARTBEAT_BASE_URL:-http://localhost:7251}
+      - HUB_ATTENTION_ORGAN_TIMEOUT_SEC=${HUB_ATTENTION_ORGAN_TIMEOUT_SEC:-3.0}
       - CRYSTALLIZER_VECTOR_COLLECTION=${CRYSTALLIZER_VECTOR_COLLECTION:-orion_memory_crystallizations}
       - CRYSTALLIZER_EMBED_HOST_URL=${CRYSTALLIZER_EMBED_HOST_URL:-}
       - CRYSTALLIZER_EMBED_MODE=${CRYSTALLIZER_EMBED_MODE:-http}

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -171,6 +171,7 @@ from .substrate_lattice_routes import router as substrate_lattice_router
 from .self_brain_routes import router as self_brain_router
 from .field_channel_glossary_routes import router as field_channel_glossary_router
 from .bus_synaptic_graph_routes import router as bus_synaptic_graph_router
+from .attention_organ_routes import router as attention_organ_router
 from .chat_turn_trace_routes import router as chat_turn_trace_router
 router.include_router(grammar_atlas_router)
 router.include_router(chat_turn_trace_router)
@@ -188,6 +189,7 @@ router.include_router(substrate_lattice_router)
 router.include_router(self_brain_router)
 router.include_router(field_channel_glossary_router)
 router.include_router(bus_synaptic_graph_router)
+router.include_router(attention_organ_router)
 
 
 def _hub_uses_host_network_mode() -> bool:

--- a/services/orion-hub/scripts/attention_organ_routes.py
+++ b/services/orion-hub/scripts/attention_organ_routes.py
@@ -79,6 +79,7 @@ DEFAULT_HISTORY_MINUTES: int = 60
 HISTORY_ROW_CAP: int = 4000
 
 _engine_instance: Any = None
+_graph_client_instance: Any = None
 
 
 def _engine():
@@ -92,13 +93,23 @@ def _engine():
 
 
 def _substrate_graph_client() -> RedisGraphQueryClient:
+    """Module-level cached, matching _engine() above. RedisGraphQueryClient
+    builds its own redis.Redis + ConnectionPool and exposes no close(), so a
+    per-request client meant a fresh TCP connect/teardown on every poll --
+    ~30/minute at the tab's fastest cadence, for a query returning 7 rows.
+    Not a leak (refcounting drops the sockets), but pointless churn against a
+    surface designed to be polled continuously.
+    """
+    global _graph_client_instance
     uri = (settings.FALKORDB_URI or "").strip()
     if not uri:
         raise HTTPException(status_code=503, detail="falkordb_uri_not_configured")
-    graph_name = (
-        getattr(settings, "FALKORDB_SUBSTRATE_GRAPH", "") or "orion_substrate"
-    )
-    return RedisGraphQueryClient(uri=uri, graph_name=graph_name)
+    if _graph_client_instance is None:
+        graph_name = (
+            getattr(settings, "FALKORDB_SUBSTRATE_GRAPH", "") or "orion_substrate"
+        )
+        _graph_client_instance = RedisGraphQueryClient(uri=uri, graph_name=graph_name)
+    return _graph_client_instance
 
 
 # --------------------------------------------------------------------------
@@ -152,6 +163,7 @@ def summarize_history(rows: list[dict[str, Any]]) -> dict[str, Any]:
     domain_counts: dict[str, int] = {}
     null_verdict = 0
     null_domain = 0
+    malformed = 0
 
     for row in rows:
         payload = row.get("self_model_json")
@@ -159,8 +171,10 @@ def summarize_history(rows: list[dict[str, Any]]) -> dict[str, Any]:
             try:
                 payload = json.loads(payload)
             except (TypeError, ValueError):
+                malformed += 1
                 continue
         if not isinstance(payload, dict):
+            malformed += 1
             continue
 
         verdict = payload.get("heartbeat_verdict")
@@ -186,8 +200,6 @@ def summarize_history(rows: list[dict[str, Any]]) -> dict[str, Any]:
                 "heartbeat_mean_ratio": payload.get("heartbeat_mean_ratio"),
                 "heartbeat_verdict": verdict if isinstance(verdict, str) else None,
                 "prediction_error_confidence": payload.get("prediction_error_confidence"),
-                "confidence": payload.get("confidence"),
-                "attention_reason": payload.get("attention_reason"),
                 "predicted_shift_domain": domain,
             }
         )
@@ -200,6 +212,10 @@ def summarize_history(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "null_verdict_count": null_verdict,
         "domain_counts": domain_counts,
         "null_domain_count": null_domain,
+        # Same argument as the null_* counters above, applied to rows that
+        # could not be read at all: a window where every row failed to parse
+        # must not look identical to a window with no activity.
+        "malformed_row_count": malformed,
     }
 
 
@@ -290,21 +306,47 @@ def build_domain_rows(
     return out
 
 
+# How much the 5-domain mean can move if exactly ONE active domain traverses
+# its full [0, 1] range between the row's write and this module's graph read:
+# 1.0 / len(ACTIVE_INFERENCE_DOMAINS). Confirmed live 2026-07-30 that this is
+# not hypothetical -- `execution` and `bus_synaptic` both swing between ~0 and
+# a pinned 1.0 across consecutive ~30s ticks, so a delta of ~0.2 on a row a few
+# seconds old is ordinary sampling skew, not evidence of anything.
+_SINGLE_DOMAIN_SWING = 1.0 / max(1, len(ACTIVE_INFERENCE_DOMAINS))
+
+# Past this row age, the two readings are simply too far apart in time for the
+# comparison to carry information either way, and asserting a verdict would be
+# manufacturing one.
+_RECONCILE_MAX_ROW_AGE_SEC = 60.0
+
+
 def reconcile_confidence(
-    domain_rows: list[dict[str, Any]], prediction_error_confidence: float | None
+    domain_rows: list[dict[str, Any]],
+    prediction_error_confidence: float | None,
+    *,
+    row_age_sec: float | None = None,
 ) -> dict[str, Any]:
     """Check the persisted aggregate against the live per-domain values.
 
     `_unconditional_prediction_error_confidence()` is
     `1 - mean(prediction_error over ACTIVE_INFERENCE_DOMAINS)`. Recomputing
     that from the domain nodes and diffing it against what the row actually
-    stored is a live provenance check, not decoration: a large gap means the
-    two are no longer reading the same thing (the domain nodes moved after
-    the row was written, an instrument is being clobbered, or the reducer's
-    domain set drifted from this module's). Tolerance is deliberately loose
-    (0.05) because the row and the graph read happen at different instants
-    on a continuously-moving signal -- this flags structural divergence, not
-    sampling skew.
+    stored is a live provenance check: a gap too large to be explained by the
+    domains simply having moved means the two are no longer reading the same
+    thing (an instrument is being clobbered, or the reducer's domain set has
+    drifted from this module's).
+
+    **The verdict is deliberately not a fixed-tolerance boolean.** The first
+    version of this used `abs(delta) <= 0.05`, and live data immediately
+    showed why that is a bad instrument: the row is written on
+    substrate-runtime's ~30s tick while the graph read happens now, and two of
+    the five domains genuinely swing across their whole range between ticks --
+    so a flat tolerance reports "divergent" purely as a function of when the
+    operator happened to poll. A check that fires on its own sampling schedule
+    is noise, and shipping it would be the exact failure mode this tab exists
+    to expose. The verdict is therefore stated against a model of how far the
+    aggregate could legitimately have moved, and withheld entirely once the
+    row is too old to compare against at all.
     """
     values = [
         r["prediction_error"]
@@ -317,17 +359,48 @@ def reconcile_confidence(
             "persisted": prediction_error_confidence,
             "delta": None,
             "domains_used": len(values),
-            "reconciles": None,
+            "row_age_sec": row_age_sec,
+            "verdict": "unknown",
+            "basis": "no active-domain values or no persisted aggregate to compare",
         }
+
     recomputed = 1.0 - (sum(values) / len(values))
     delta = recomputed - float(prediction_error_confidence)
-    return {
+    out = {
         "recomputed": round(recomputed, 4),
         "persisted": float(prediction_error_confidence),
         "delta": round(delta, 4),
         "domains_used": len(values),
-        "reconciles": abs(delta) <= 0.05,
+        "row_age_sec": row_age_sec,
     }
+
+    # Compared at the persisted value's OWN precision, not raw float equality:
+    # the reducer rounds prediction_error_confidence to 4dp before storing it,
+    # so an exact float match is unreachable by construction and "exact" would
+    # be dead code.
+    if round(delta, 4) == 0.0:
+        out["verdict"] = "exact"
+        out["basis"] = "row was written from the same domain values read here"
+    elif row_age_sec is not None and row_age_sec > _RECONCILE_MAX_ROW_AGE_SEC:
+        out["verdict"] = "unknown"
+        out["basis"] = (
+            f"row is {row_age_sec:.0f}s old -- too far from this graph read for the "
+            "comparison to mean anything either way"
+        )
+    elif abs(delta) <= _SINGLE_DOMAIN_SWING:
+        out["verdict"] = "within_drift"
+        out["basis"] = (
+            f"delta is within {_SINGLE_DOMAIN_SWING:.2f}, the most one of "
+            f"{len(ACTIVE_INFERENCE_DOMAINS)} domains moving across its full range "
+            "can shift the mean between the row's write and this read"
+        )
+    else:
+        out["verdict"] = "divergent"
+        out["basis"] = (
+            f"delta exceeds {_SINGLE_DOMAIN_SWING:.2f} -- more than one domain would "
+            "have had to move fully, which points at a source mismatch rather than timing"
+        )
+    return out
 
 
 def normalize_history_minutes(minutes: int | None) -> int:
@@ -388,9 +461,15 @@ def _load_latest_self_model() -> tuple[dict[str, Any] | None, datetime | None]:
 
 def _load_domain_rows() -> list[dict[str, Any]]:
     client = _substrate_graph_client()
+    # Labelled (:SubstrateNode) rather than a bare MATCH (n): there is no
+    # index on node_id (checked live -- CALL db.indexes() is empty), and this
+    # is the substrate CONCEPT graph, designed to accumulate, scanned on every
+    # poll. Free today at 10 nodes; not free later. STARTS WITH is kept over
+    # an `IN $ids` form on purpose so a domain node this module does not yet
+    # know about is still discovered (see build_domain_rows' tail).
     return client.graph_query(
         """
-        MATCH (n)
+        MATCH (n:SubstrateNode)
         WHERE n.node_id STARTS WITH $prefix
         RETURN n.node_id AS node_id,
                n.prediction_error AS prediction_error,
@@ -402,10 +481,19 @@ def _load_domain_rows() -> list[dict[str, Any]]:
 
 
 @router.get("/snapshot")
-async def snapshot() -> dict[str, Any]:
+def snapshot() -> dict[str, Any]:
     """One poll = one request. Each of the three sources degrades
     independently: any one being down leaves its own block flagged and the
     others intact.
+
+    Deliberately `def`, not `async def`: this handler does blocking I/O (two
+    `requests.get` calls, a Postgres read, a FalkorDB read) and the tab
+    auto-polls it as fast as every 2s. Declared async, that would block Hub's
+    single event loop -- chat, websockets, every other route -- for the full
+    duration of every poll. FastAPI runs a sync handler in its threadpool
+    instead. Some older read-only routes here are `async def` with the same
+    blocking bodies; those are user-initiated one-shots, which is why the
+    pattern survived. It is not safe at this cadence.
     """
     now = datetime.now(timezone.utc)
 
@@ -455,7 +543,12 @@ async def snapshot() -> dict[str, Any]:
     return {
         "generated_at": now.isoformat(),
         "heartbeat": {
-            "ok": bool(h1.get("ok") and health.get("ok")),
+            # Both endpoints reachable AND an actual H1 reading present.
+            # `h1.get("ok")` is only transport-level: /h1 answers 200 with
+            # {"ok": false, "reason": "no_h1_computed_yet"} before the first
+            # ensemble tick, which is precisely a degraded state the status
+            # line must report, not a healthy one.
+            "ok": bool(h1.get("ok") and health.get("ok") and live_h1 is not None),
             "h1": live_h1,
             "h1_error": None if h1.get("ok") else h1.get("error"),
             "h1_reason": (h1.get("payload") or {}).get("reason") if h1.get("ok") else None,
@@ -476,7 +569,9 @@ async def snapshot() -> dict[str, Any]:
             "active_domains": sorted(ACTIVE_INFERENCE_DOMAINS),
             "rows": domain_rows,
             "reconciliation": reconcile_confidence(
-                domain_rows, (self_model or {}).get("prediction_error_confidence")
+                domain_rows,
+                (self_model or {}).get("prediction_error_confidence"),
+                row_age_sec=link["self_model_age_sec"],
             ),
         },
         "link": link,
@@ -484,7 +579,8 @@ async def snapshot() -> dict[str, Any]:
 
 
 @router.get("/history")
-async def history(minutes: int = Query(DEFAULT_HISTORY_MINUTES)) -> dict[str, Any]:
+def history(minutes: int = Query(DEFAULT_HISTORY_MINUTES)) -> dict[str, Any]:
+    """Sync for the same reason as snapshot() -- blocking SQLAlchemy read."""
     window_minutes = normalize_history_minutes(minutes)
     with _engine().connect() as conn:
         # DESC + reverse (not ASC + LIMIT) so a window wide enough to hit the

--- a/services/orion-hub/scripts/attention_organ_routes.py
+++ b/services/orion-hub/scripts/attention_organ_routes.py
@@ -1,0 +1,516 @@
+"""Read-only Hub API for the Attention Organ operator tab.
+
+Surfaces, in one place, the three live pieces of the precision-weighted
+attention arc described in
+``docs/superpowers/specs/2026-07-28-precision-weighted-attention-organ-and-
+heartbeat-discrimination-design.md``:
+
+1. **The organ** -- ``orion-heartbeat``'s N-trajectory tensor-network
+   dissipation ensemble (``/h1`` + ``/health``): ensemble mean ratio, the
+   per-trajectory ratios behind it, cross-trajectory spread, the verdict
+   band edges it classifies with, intake/backpressure counters, and the real
+   ``bus_synaptic``-driven reheat inputs the dissipation loop last used.
+2. **The consumer** -- AST/HOT's ``AttentionSelfModelV1``, read from the
+   durable ``substrate_attention_self_model`` table that
+   ``orion-substrate-runtime``'s ``_attention_self_model_tick()`` writes,
+   including the three ``heartbeat_*`` fields that carry (1) into it.
+3. **The problem the arc is about** -- each Active-Inference domain's live
+   ``prediction_error``, read straight off its ``node:substrate.<domain>``
+   node in the substrate graph. This is the same value
+   ``_brain_frame_prediction_error_by_domain()`` feeds the reducer, so the
+   per-domain bars and the row's own ``prediction_error_confidence``
+   reconcile exactly (verified live 2026-07-30: five domain values whose
+   mean is exactly ``1 - prediction_error_confidence``).
+
+Everything here is a read. No writes, no bus publishes, no new channel or
+schema. Nothing this module returns is consumed by any cognition path -- it
+exists so an operator can *see* whether the organ discriminates and whether
+its signal is reaching AST/HOT, which is precisely what the design doc's
+Acceptance Checks 1 and 3 ask for and which had no human-visible surface.
+
+**Deliberately not computed here**: nothing is re-derived from a mirrored
+copy of a constant that lives in another service. The verdict band edges
+(``high_ratio``/``low_ratio``) and the reheat inputs
+(``raw_mean_abs_gap_zscore`` -> ``signal`` -> ``reheat_prob``) are read from
+``orion-heartbeat``'s own ``/health`` payload, which reports the values that
+service actually used. A number this tab shows is a number some real
+producer actually produced.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import create_engine, text
+
+from orion.graph.falkor_client import RedisGraphQueryClient
+from orion.substrate.attention_self_model import ACTIVE_INFERENCE_DOMAINS
+
+from app.settings import settings
+
+router = APIRouter(prefix="/api/attention-organ", tags=["attention-organ"])
+
+# `node:substrate.<domain>` is the fixed identity
+# `_write_prediction_error_node()` upserts per domain
+# (services/orion-substrate-runtime/app/worker.py). Domains outside
+# ACTIVE_INFERENCE_DOMAINS are still fetched and returned, flagged
+# `active=False`, precisely so a retired instrument that is still ticking is
+# visible rather than hidden -- CLAUDE.md's "a narrow, known-bad instrument
+# merely excluded from one consumer is not retired, it is hiding".
+KNOWN_PREDICTION_ERROR_DOMAINS: tuple[str, ...] = (
+    "biometrics",
+    "bus_synaptic",
+    "chat",
+    "execution",
+    "route",
+    "transport",
+    "harness_closure",
+)
+
+_NODE_ID_PREFIX = "node:substrate."
+
+ALLOWED_HISTORY_MINUTES: frozenset[int] = frozenset({15, 60, 360, 1440})
+DEFAULT_HISTORY_MINUTES: int = 60
+HISTORY_ROW_CAP: int = 4000
+
+_engine_instance: Any = None
+
+
+def _engine():
+    global _engine_instance
+    if _engine_instance is None:
+        uri = os.getenv("POSTGRES_URI", "").strip()
+        if not uri:
+            raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+        _engine_instance = create_engine(uri, pool_pre_ping=True)
+    return _engine_instance
+
+
+def _substrate_graph_client() -> RedisGraphQueryClient:
+    uri = (settings.FALKORDB_URI or "").strip()
+    if not uri:
+        raise HTTPException(status_code=503, detail="falkordb_uri_not_configured")
+    graph_name = (
+        getattr(settings, "FALKORDB_SUBSTRATE_GRAPH", "") or "orion_substrate"
+    )
+    return RedisGraphQueryClient(uri=uri, graph_name=graph_name)
+
+
+# --------------------------------------------------------------------------
+# Pure helpers (no I/O) -- separated so the parsing/aggregation logic is
+# testable against fixed rows, matching this repo's established route-module
+# convention (see bus_synaptic_graph_routes.propagate_from_organ).
+# --------------------------------------------------------------------------
+
+
+def parse_predicted_shift_domain(predicted_shift: str | None) -> str | None:
+    """Recover which domain won a tick's `predicted_shift`.
+
+    `reduce_attention_self_model()` renders this field as a prose sentence
+    (`"<domain> prediction-error rising (trend=...)"`) -- the winning domain
+    is not persisted as its own column, so a rolling domain-dominance tally
+    has to read it back off the front of that string. Kept narrow and
+    anchored on the literal ` prediction-error ` marker the reducer emits
+    rather than a loose split, so an unrelated future `predicted_shift`
+    phrasing returns None (honestly "unknown") instead of silently
+    contributing a garbage domain name to the tally.
+    """
+    if not predicted_shift or not isinstance(predicted_shift, str):
+        return None
+    marker = " prediction-error "
+    idx = predicted_shift.find(marker)
+    if idx <= 0:
+        return None
+    candidate = predicted_shift[:idx].strip()
+    if not candidate or " " in candidate:
+        return None
+    return candidate
+
+
+def summarize_history(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Roll a window of persisted AttentionSelfModelV1 payloads into the two
+    distributions the design doc's acceptance checks are stated in terms of.
+
+    - `verdict_counts`: how often each heartbeat verdict band fired. Acceptance
+      Check 1 is literally "the verdict takes more than one value" -- this is
+      that check, computed live rather than by eyeballing container logs.
+    - `domain_counts`: how often each domain won `predicted_shift`. Acceptance
+      Check 3 asks for this distribution to be materially less dominated by
+      1-2 domains after any precision-weighting fix; showing it live is the
+      before-picture that check compares against.
+
+    `null_*` counters are kept explicitly rather than dropped so "this window
+    had no heartbeat data" is visibly different from "the band never fired".
+    """
+    series: list[dict[str, Any]] = []
+    verdict_counts: dict[str, int] = {}
+    domain_counts: dict[str, int] = {}
+    null_verdict = 0
+    null_domain = 0
+
+    for row in rows:
+        payload = row.get("self_model_json")
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except (TypeError, ValueError):
+                continue
+        if not isinstance(payload, dict):
+            continue
+
+        verdict = payload.get("heartbeat_verdict")
+        if isinstance(verdict, str) and verdict:
+            verdict_counts[verdict] = verdict_counts.get(verdict, 0) + 1
+        else:
+            null_verdict += 1
+
+        domain = parse_predicted_shift_domain(payload.get("predicted_shift"))
+        if domain:
+            domain_counts[domain] = domain_counts.get(domain, 0) + 1
+        else:
+            null_domain += 1
+
+        generated_at = row.get("generated_at")
+        series.append(
+            {
+                "generated_at": (
+                    generated_at.isoformat()
+                    if isinstance(generated_at, datetime)
+                    else str(generated_at)
+                ),
+                "heartbeat_mean_ratio": payload.get("heartbeat_mean_ratio"),
+                "heartbeat_verdict": verdict if isinstance(verdict, str) else None,
+                "prediction_error_confidence": payload.get("prediction_error_confidence"),
+                "confidence": payload.get("confidence"),
+                "attention_reason": payload.get("attention_reason"),
+                "predicted_shift_domain": domain,
+            }
+        )
+
+    return {
+        "sample_count": len(series),
+        "series": series,
+        "verdict_counts": verdict_counts,
+        "verdict_distinct_values": len(verdict_counts),
+        "null_verdict_count": null_verdict,
+        "domain_counts": domain_counts,
+        "null_domain_count": null_domain,
+    }
+
+
+def build_domain_rows(
+    graph_rows: list[dict[str, Any]], *, now: datetime | None = None
+) -> list[dict[str, Any]]:
+    """Shape raw `node:substrate.<domain>` graph rows into per-domain entries.
+
+    `active` marks membership in `ACTIVE_INFERENCE_DOMAINS` -- the set
+    `_unconditional_prediction_error_confidence()` actually averages over.
+    Inactive domains are still returned (see KNOWN_PREDICTION_ERROR_DOMAINS'
+    comment) so an excluded-but-still-ticking instrument stays visible.
+
+    `at_ceiling`/`at_floor` are flagged rather than silently rendered as
+    ordinary values: CLAUDE.md's metric quality gate step 4 treats both a
+    pinned 1.0 and a decayed-to-0.0 reading as suspect-until-checked, and
+    both failure modes have real incident history on these exact nodes
+    (bus_synaptic frozen at 1.0, PR #1449; route decayed toward 0.0 by a
+    generic staleness loop, 2026-07-26).
+    """
+    now = now or datetime.now(timezone.utc)
+    by_domain: dict[str, dict[str, Any]] = {}
+
+    for row in graph_rows:
+        node_id = str(row.get("node_id") or "")
+        if not node_id.startswith(_NODE_ID_PREFIX):
+            continue
+        domain = node_id[len(_NODE_ID_PREFIX) :]
+        raw_value = row.get("prediction_error")
+        try:
+            value = float(raw_value) if raw_value is not None else None
+        except (TypeError, ValueError):
+            value = None
+
+        observed_at = row.get("observed_at")
+        observed_age_sec: float | None = None
+        if isinstance(observed_at, str) and observed_at:
+            try:
+                parsed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                observed_age_sec = round((now - parsed).total_seconds(), 1)
+            except ValueError:
+                observed_age_sec = None
+
+        try:
+            activation = float(row["activation"]) if row.get("activation") is not None else None
+        except (TypeError, ValueError):
+            activation = None
+
+        by_domain[domain] = {
+            "domain": domain,
+            "node_id": node_id,
+            "prediction_error": value,
+            "active": domain in ACTIVE_INFERENCE_DOMAINS,
+            "activation": activation,
+            "observed_at": observed_at if isinstance(observed_at, str) else None,
+            "observed_age_sec": observed_age_sec,
+            "at_ceiling": value is not None and value >= 1.0,
+            "at_floor": value is not None and value <= 0.0,
+            "present": True,
+        }
+
+    out: list[dict[str, Any]] = []
+    for domain in KNOWN_PREDICTION_ERROR_DOMAINS:
+        if domain in by_domain:
+            out.append(by_domain.pop(domain))
+        else:
+            # A known domain with no node at all is a different, louder
+            # failure than a node reading 0.0 -- never collapse them.
+            out.append(
+                {
+                    "domain": domain,
+                    "node_id": f"{_NODE_ID_PREFIX}{domain}",
+                    "prediction_error": None,
+                    "active": domain in ACTIVE_INFERENCE_DOMAINS,
+                    "activation": None,
+                    "observed_at": None,
+                    "observed_age_sec": None,
+                    "at_ceiling": False,
+                    "at_floor": False,
+                    "present": False,
+                }
+            )
+    # Any domain node that exists but isn't in the known list (a new producer
+    # landed and this module wasn't updated) is appended rather than dropped.
+    out.extend(by_domain.values())
+    return out
+
+
+def reconcile_confidence(
+    domain_rows: list[dict[str, Any]], prediction_error_confidence: float | None
+) -> dict[str, Any]:
+    """Check the persisted aggregate against the live per-domain values.
+
+    `_unconditional_prediction_error_confidence()` is
+    `1 - mean(prediction_error over ACTIVE_INFERENCE_DOMAINS)`. Recomputing
+    that from the domain nodes and diffing it against what the row actually
+    stored is a live provenance check, not decoration: a large gap means the
+    two are no longer reading the same thing (the domain nodes moved after
+    the row was written, an instrument is being clobbered, or the reducer's
+    domain set drifted from this module's). Tolerance is deliberately loose
+    (0.05) because the row and the graph read happen at different instants
+    on a continuously-moving signal -- this flags structural divergence, not
+    sampling skew.
+    """
+    values = [
+        r["prediction_error"]
+        for r in domain_rows
+        if r.get("active") and r.get("prediction_error") is not None
+    ]
+    if not values or prediction_error_confidence is None:
+        return {
+            "recomputed": None,
+            "persisted": prediction_error_confidence,
+            "delta": None,
+            "domains_used": len(values),
+            "reconciles": None,
+        }
+    recomputed = 1.0 - (sum(values) / len(values))
+    delta = recomputed - float(prediction_error_confidence)
+    return {
+        "recomputed": round(recomputed, 4),
+        "persisted": float(prediction_error_confidence),
+        "delta": round(delta, 4),
+        "domains_used": len(values),
+        "reconciles": abs(delta) <= 0.05,
+    }
+
+
+def normalize_history_minutes(minutes: int | None) -> int:
+    if minutes in ALLOWED_HISTORY_MINUTES:
+        return int(minutes)
+    return DEFAULT_HISTORY_MINUTES
+
+
+# --------------------------------------------------------------------------
+# I/O
+# --------------------------------------------------------------------------
+
+
+def _heartbeat_get(path: str) -> dict[str, Any]:
+    """One heartbeat debug-endpoint read. Never raises -- an unreachable
+    heartbeat must render as an honest "organ offline" panel, not a 500 that
+    also blanks the AST/HOT and per-domain panels next to it, which are
+    served by entirely different backends and are still perfectly valid.
+    """
+    base = (settings.HUB_HEARTBEAT_BASE_URL or "").strip().rstrip("/")
+    if not base:
+        return {"ok": False, "error": "heartbeat_base_url_not_configured"}
+    try:
+        resp = requests.get(
+            f"{base}{path}",
+            timeout=float(settings.HUB_ATTENTION_ORGAN_TIMEOUT_SEC),
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        return {"ok": True, "payload": payload}
+    except Exception as exc:  # noqa: BLE001 - reported to the operator, not raised
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _load_latest_self_model() -> tuple[dict[str, Any] | None, datetime | None]:
+    with _engine().connect() as conn:
+        row = (
+            conn.execute(
+                text(
+                    """
+                    SELECT generated_at, self_model_json
+                    FROM substrate_attention_self_model
+                    ORDER BY generated_at DESC
+                    LIMIT 1
+                    """
+                )
+            )
+            .mappings()
+            .first()
+        )
+    if not row:
+        return None, None
+    payload = row["self_model_json"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return (payload if isinstance(payload, dict) else None), row["generated_at"]
+
+
+def _load_domain_rows() -> list[dict[str, Any]]:
+    client = _substrate_graph_client()
+    return client.graph_query(
+        """
+        MATCH (n)
+        WHERE n.node_id STARTS WITH $prefix
+        RETURN n.node_id AS node_id,
+               n.prediction_error AS prediction_error,
+               n.observed_at AS observed_at,
+               n.activation AS activation
+        """,
+        {"prefix": _NODE_ID_PREFIX},
+    )
+
+
+@router.get("/snapshot")
+async def snapshot() -> dict[str, Any]:
+    """One poll = one request. Each of the three sources degrades
+    independently: any one being down leaves its own block flagged and the
+    others intact.
+    """
+    now = datetime.now(timezone.utc)
+
+    h1 = _heartbeat_get("/h1")
+    health = _heartbeat_get("/health")
+
+    self_model: dict[str, Any] | None = None
+    self_model_generated_at: datetime | None = None
+    self_model_error: str | None = None
+    try:
+        self_model, self_model_generated_at = _load_latest_self_model()
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        self_model_error = f"{type(exc).__name__}: {exc}"
+
+    domain_rows: list[dict[str, Any]] = []
+    domains_error: str | None = None
+    try:
+        domain_rows = build_domain_rows(_load_domain_rows(), now=now)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        domains_error = f"{type(exc).__name__}: {exc}"
+
+    live_h1 = (h1.get("payload") or {}).get("h1") if h1.get("ok") else None
+
+    # Is the heartbeat -> AST/HOT wire actually live right now? The row's own
+    # heartbeat_basis string names the tick_count it was built from, so a
+    # frozen wire shows up as a growing gap between that and the organ's
+    # current tick_count -- a real staleness check, not just "the field is
+    # non-null".
+    link: dict[str, Any] = {
+        "self_model_has_heartbeat": bool(self_model and self_model.get("heartbeat_verdict")),
+        "self_model_mean_ratio": (self_model or {}).get("heartbeat_mean_ratio"),
+        "live_mean_ratio": (live_h1 or {}).get("mean_ratio"),
+        "self_model_basis": (self_model or {}).get("heartbeat_basis") or "",
+        "live_tick_count": (live_h1 or {}).get("tick_count"),
+    }
+    if self_model_generated_at is not None:
+        link["self_model_age_sec"] = round(
+            (now - self_model_generated_at).total_seconds(), 1
+        )
+    else:
+        link["self_model_age_sec"] = None
+
+    return {
+        "generated_at": now.isoformat(),
+        "heartbeat": {
+            "ok": bool(h1.get("ok") and health.get("ok")),
+            "h1": live_h1,
+            "h1_error": None if h1.get("ok") else h1.get("error"),
+            "h1_reason": (h1.get("payload") or {}).get("reason") if h1.get("ok") else None,
+            "health": health.get("payload") if health.get("ok") else None,
+            "health_error": None if health.get("ok") else health.get("error"),
+        },
+        "self_model": {
+            "ok": self_model is not None,
+            "error": self_model_error,
+            "generated_at": (
+                self_model_generated_at.isoformat() if self_model_generated_at else None
+            ),
+            "model": self_model,
+        },
+        "domains": {
+            "ok": domains_error is None,
+            "error": domains_error,
+            "active_domains": sorted(ACTIVE_INFERENCE_DOMAINS),
+            "rows": domain_rows,
+            "reconciliation": reconcile_confidence(
+                domain_rows, (self_model or {}).get("prediction_error_confidence")
+            ),
+        },
+        "link": link,
+    }
+
+
+@router.get("/history")
+async def history(minutes: int = Query(DEFAULT_HISTORY_MINUTES)) -> dict[str, Any]:
+    window_minutes = normalize_history_minutes(minutes)
+    with _engine().connect() as conn:
+        # DESC + reverse (not ASC + LIMIT) so a window wide enough to hit the
+        # cap keeps the NEWEST rows, not the oldest -- same reasoning as
+        # field_channel_glossary_routes.health().
+        result = (
+            conn.execute(
+                text(
+                    """
+                    SELECT generated_at, self_model_json
+                    FROM substrate_attention_self_model
+                    WHERE generated_at >= NOW() - (:minutes * INTERVAL '1 minute')
+                    ORDER BY generated_at DESC
+                    LIMIT :row_cap
+                    """
+                ),
+                {"minutes": window_minutes, "row_cap": HISTORY_ROW_CAP},
+            )
+            .mappings()
+            .all()
+        )
+    rows = [dict(r) for r in reversed(result)]
+    summary = summarize_history(rows)
+    return {
+        "window_minutes": window_minutes,
+        "row_cap": HISTORY_ROW_CAP,
+        "truncated": len(rows) >= HISTORY_ROW_CAP,
+        **summary,
+    }

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -647,6 +647,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const collapseMirrorPanel = document.getElementById("collapse-mirror");
   const aiTownTabButton = document.getElementById("aiTownTabButton");
   const aiTownPanel = document.getElementById("ai-town");
+  const attentionOrganTabButton = document.getElementById("attentionOrganTabButton");
+  const attentionOrganPanel = document.getElementById("attention-organ");
   const pressureAnalyticsFrame = document.getElementById("pressureAnalyticsFrame");
   const pressureAnalyticsRefresh = document.getElementById("pressureAnalyticsRefresh");
   const substrateLatticeTabButton = document.getElementById("substrateLatticeTabButton");
@@ -945,6 +947,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (tabKey === "ai-town" && !aiTownPanel) {
       effectiveTab = "hub";
     }
+    if (tabKey === "attention-organ" && !attentionOrganPanel) {
+      effectiveTab = "hub";
+    }
     const isHub = effectiveTab === "hub";
     const isTopicStudio = effectiveTab === "topic-studio";
     const isServiceLogs = effectiveTab === "service-logs";
@@ -961,6 +966,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const isSignals = effectiveTab === "signals";
     const isCollapseMirror = effectiveTab === "collapse-mirror";
     const isAiTown = effectiveTab === "ai-town";
+    const isAttentionOrgan = effectiveTab === "attention-organ";
     hubTabPanel.classList.toggle("hidden", !isHub);
     topicStudioPanel.classList.toggle("hidden", !isTopicStudio);
     serviceLogsPanel.classList.toggle("hidden", !isServiceLogs);
@@ -1067,6 +1073,19 @@ document.addEventListener("DOMContentLoaded", () => {
         window.OrionAitownPanel.deactivate();
       }
     }
+    if (attentionOrganPanel) {
+      attentionOrganPanel.classList.toggle("hidden", !isAttentionOrgan);
+      // Polling runs only while the tab is visible; rendered DOM is left in
+      // place on deactivate so returning to the tab shows the last frame
+      // immediately rather than an empty panel.
+      if (isAttentionOrgan) {
+        if (window.OrionAttentionOrgan && typeof window.OrionAttentionOrgan.activate === "function") {
+          window.OrionAttentionOrgan.activate();
+        }
+      } else if (window.OrionAttentionOrgan && typeof window.OrionAttentionOrgan.deactivate === "function") {
+        window.OrionAttentionOrgan.deactivate();
+      }
+    }
     styleTabButton(hubTabButton, isHub);
     styleTabButton(topicStudioTabButton, isTopicStudio);
     styleTabButton(serviceLogsTabButton, isServiceLogs);
@@ -1106,6 +1125,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (aiTownTabButton) {
       styleTabButton(aiTownTabButton, isAiTown);
+    }
+    if (attentionOrganTabButton) {
+      styleTabButton(attentionOrganTabButton, isAttentionOrgan);
     }
   }
 
@@ -1691,6 +1713,8 @@ document.addEventListener("DOMContentLoaded", () => {
       setActiveTab("collapse-mirror");
     } else if (h === "#ai-town" && aiTownPanel && aiTownTabButton) {
       setActiveTab("ai-town");
+    } else if (h === "#attention-organ" && attentionOrganPanel && attentionOrganTabButton) {
+      setActiveTab("attention-organ");
     } else {
       if (
         h === "#pressure"
@@ -1703,6 +1727,7 @@ document.addEventListener("DOMContentLoaded", () => {
         || h === "#concept-atlas"
         || h === "#collapse-mirror"
         || h === "#ai-town"
+        || h === "#attention-organ"
       ) {
         history.replaceState(null, "", "#hub");
       }
@@ -11490,6 +11515,13 @@ document.addEventListener("DOMContentLoaded", () => {
         event.preventDefault();
         setActiveTab("ai-town");
         history.replaceState(null, "", "#ai-town");
+      });
+    }
+    if (attentionOrganTabButton && attentionOrganPanel) {
+      attentionOrganTabButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        setActiveTab("attention-organ");
+        history.replaceState(null, "", "#attention-organ");
       });
     }
     applyHashToTab();

--- a/services/orion-hub/static/js/attention-organ.js
+++ b/services/orion-hub/static/js/attention-organ.js
@@ -43,6 +43,7 @@
     inFlight: false,
     lastSnapshotAt: 0,
     lastHistoryAt: 0,
+    historyError: null,
     intervalMs: 5000,
     windowMinutes: 60,
     live: true,
@@ -99,6 +100,11 @@
     if (seconds === null || seconds === undefined) return "—";
     var s = Number(seconds);
     if (!isFinite(s)) return "—";
+    // A slightly negative age is sub-second clock skew between the producing
+    // container and Hub (seen live: -0.4s), not information — render it as
+    // "now". A LARGE negative is a genuinely wrong clock somewhere and stays
+    // visible as a negative rather than being quietly clamped away.
+    if (s < 0) return s > -2 ? "0.0s" : s.toFixed(1) + "s";
     if (s < 90) return s.toFixed(1) + "s";
     if (s < 5400) return (s / 60).toFixed(1) + "m";
     if (s < 172800) return (s / 3600).toFixed(1) + "h";
@@ -408,6 +414,54 @@
 
   // ---------------------------------------------------------------- panels
 
+  // Normalize a series' generated_at timestamps into 0..1 x positions.
+  // Returns index-proportional spacing if the timestamps are missing or all
+  // identical, so a degenerate window still renders rather than collapsing.
+  function timePositions(points) {
+    var times = points.map(function (point) {
+      var parsed = Date.parse(point.generated_at);
+      return Number.isFinite(parsed) ? parsed : NaN;
+    });
+    var usable = times.filter(function (t) {
+      return Number.isFinite(t);
+    });
+    if (usable.length !== times.length || times.length < 2) {
+      return points.map(function (_point, index) {
+        return points.length > 1 ? index / (points.length - 1) : 0;
+      });
+    }
+    var min = Math.min.apply(null, usable);
+    var max = Math.max.apply(null, usable);
+    var span = max - min;
+    if (span <= 0) {
+      return points.map(function (_point, index) {
+        return points.length > 1 ? index / (points.length - 1) : 0;
+      });
+    }
+    return times.map(function (t) {
+      return (t - min) / span;
+    });
+  }
+
+  // Both history-backed panels render `lastHistory`, which is deliberately
+  // retained across a failed refresh so a transient error does not blank them.
+  // That retention is only honest if the panel says how old it is.
+  function historyAgeBanner(host) {
+    if (!state.historyError) return;
+    var ageSec = state.lastHistoryAt ? (Date.now() - state.lastHistoryAt) / 1000 : null;
+    host.appendChild(
+      el(
+        "div",
+        "mb-2 rounded-lg border border-amber-800 bg-amber-950/30 px-2 py-1 text-[10px] text-amber-200",
+        "History refresh failing (" +
+          state.historyError +
+          ") — showing data from " +
+          (ageSec === null ? "an earlier fetch" : age(ageSec) + " ago") +
+          ", not now."
+      )
+    );
+  }
+
   function renderEnsemble(host, snapshot) {
     var hb = snapshot.heartbeat || {};
     if (!hb.h1) {
@@ -461,7 +515,7 @@
       el(
         "div",
         "text-[10px] uppercase tracking-wide text-gray-500 mb-1",
-        "Live /h1 trace (" + state.liveTrace.length + " polls, ±spread band)"
+        "Live /h1 trace (" + state.liveTrace.length + " ensemble ticks, ±spread band)"
       )
     );
     var traceCount = state.liveTrace.length;
@@ -491,6 +545,7 @@
       note(host, "History not loaded yet.");
       return;
     }
+    historyAgeBanner(host);
 
     var histWrap = el("div", "mb-3");
     histWrap.appendChild(
@@ -510,10 +565,14 @@
     });
     renderSeries(
       histWrap,
-      series.map(function (point, index) {
+      // Positioned by real elapsed time, not row index: a window containing a
+      // substrate-runtime outage must draw as a gap, not as an unbroken
+      // evenly-spaced line that hides the outage entirely. Falls back to index
+      // spacing only if the timestamps are unusable.
+      timePositions(series).map(function (x, index) {
         return {
-          x: series.length > 1 ? index / (series.length - 1) : 0,
-          value: Number(point.heartbeat_mean_ratio),
+          x: x,
+          value: Number(series[index].heartbeat_mean_ratio),
           spread: NaN,
         };
       }),
@@ -572,9 +631,9 @@
       el(
         "div",
         "",
-        "The spec records the concentrated band (<=" +
-          (config ? config.low_ratio : "0.2") +
-          ") as a structural gap, not a waiting game: 4 of 5 organs stay continuously active regardless of chat, " +
+        "The spec records the concentrated band" +
+          (config ? " (<=" + config.low_ratio + ")" : "") +
+          " as a structural gap, not a waiting game: 4 of 5 organs stay continuously active regardless of chat, " +
           "so real operation may never produce the simultaneous silence it needs. Deferred by explicit decision (2026-07-29)."
       )
     );
@@ -665,17 +724,27 @@
     }
 
     var rec = domains.reconciliation || {};
-    var recTone =
-      rec.reconciles === null || rec.reconciles === undefined
-        ? "border-gray-700 bg-gray-900/60 text-gray-400"
-        : rec.reconciles
-        ? "border-emerald-800 bg-emerald-950/30 text-emerald-200"
-        : "border-red-800 bg-red-950/30 text-red-200";
-    var recBox = el("div", "mt-3 rounded-lg border p-2 text-[10px] leading-relaxed font-mono " + recTone);
+    var recTone;
+    if (rec.verdict === "exact" || rec.verdict === "within_drift") {
+      recTone = "border-emerald-800 bg-emerald-950/30 text-emerald-200";
+    } else if (rec.verdict === "divergent") {
+      recTone = "border-red-800 bg-red-950/30 text-red-200";
+    } else {
+      recTone = "border-gray-700 bg-gray-900/60 text-gray-400";
+    }
+    var recBox = el("div", "mt-3 rounded-lg border p-2 text-[10px] leading-relaxed " + recTone);
+    var recHead = el("div", "flex items-center justify-between gap-2 mb-1");
+    recHead.appendChild(
+      el("span", "font-semibold uppercase tracking-wide", rec.verdict || "unknown")
+    );
+    recHead.appendChild(
+      el("span", "font-mono opacity-70", "row " + age(rec.row_age_sec) + " old")
+    );
+    recBox.appendChild(recHead);
     recBox.appendChild(
       el(
         "div",
-        "",
+        "font-mono",
         "1 - mean(active domains) = " +
           num(rec.recomputed, 4) +
           "   vs persisted prediction_error_confidence = " +
@@ -687,6 +756,9 @@
           ")"
       )
     );
+    if (rec.basis) {
+      recBox.appendChild(el("div", "opacity-80 mt-1", rec.basis));
+    }
     host.appendChild(recBox);
     note(
       host,
@@ -702,6 +774,7 @@
       note(host, "History not loaded yet.");
       return;
     }
+    historyAgeBanner(host);
     host.appendChild(
       el(
         "div",
@@ -720,6 +793,14 @@
       note(
         host,
         history.null_domain_count + " row(s) had no predicted_shift at all (no trend resolved that tick)."
+      );
+    }
+    if (history.malformed_row_count) {
+      note(
+        host,
+        history.malformed_row_count +
+          " row(s) in this window could not be parsed at all — the tallies above describe the rest, not the window.",
+        "text-amber-400/80"
       );
     }
     note(
@@ -819,7 +900,15 @@
     );
 
     var rows = el("div", "mt-2");
-    rows.appendChild(kvRow("row age", age(link.self_model_age_sec)));
+    rows.appendChild(
+      kvRow(
+        "row age",
+        age(link.self_model_age_sec),
+        Number.isFinite(link.self_model_age_sec) && Number(link.self_model_age_sec) > 120
+          ? "text-amber-300"
+          : "text-gray-200"
+      )
+    );
     rows.appendChild(kvRow("row's mean_ratio", num(link.self_model_mean_ratio, 4)));
     rows.appendChild(kvRow("organ's mean_ratio now", num(link.live_mean_ratio, 4)));
     rows.appendChild(kvRow("organ tick_count now", int(link.live_tick_count)));
@@ -832,15 +921,16 @@
     var match = /tick_count=(\d+)/.exec(link.self_model_basis || "");
     if (match) basisTick = Number(match[1]);
     rows.appendChild(kvRow("row's basis tick", basisTick === null ? "—" : int(basisTick)));
-    if (basisTick !== null && isFinite(link.live_tick_count)) {
+    // Number.isFinite, NOT the global isFinite: the global coerces, so
+    // isFinite(null) is true and an offline organ (live_tick_count === null)
+    // would render a confident negative lag — a number no producer produced,
+    // shown precisely when the organ is down.
+    if (basisTick !== null && Number.isFinite(link.live_tick_count)) {
       var lag = Number(link.live_tick_count) - basisTick;
-      rows.appendChild(
-        kvRow(
-          "tick lag",
-          int(lag) + " ticks",
-          lag > 5000 ? "text-amber-300" : "text-gray-200"
-        )
-      );
+      // Reported without a health verdict attached: tick_count counts absorbed
+      // events, whose rate depends entirely on live organ traffic, so no fixed
+      // lag threshold means anything. Row age below is the real staleness read.
+      rows.appendChild(kvRow("tick lag", int(lag) + " ticks"));
     }
     host.appendChild(rows);
 
@@ -871,7 +961,14 @@
     grid.appendChild(statTile("Events seen", int(health.events_seen)));
     grid.appendChild(statTile("Queued", int(health.events_queued)));
     grid.appendChild(statTile("Absorbed", int(health.events_absorbed)));
-    grid.appendChild(statTile("Queue depth", int(health.absorb_queue_size), queueTone));
+    grid.appendChild(
+      statTile(
+        "Queue depth",
+        int(health.absorb_queue_size) +
+          (health.absorb_queue_maxsize ? " / " + int(health.absorb_queue_maxsize) : ""),
+        queueTone
+      )
+    );
     grid.appendChild(
       statTile(
         "Dropped (queue full)",
@@ -968,7 +1065,29 @@
         "  × scale  → reheat_prob " +
         num(reheat.reheat_prob, 5);
       chain.appendChild(flow);
-      chain.appendChild(el("div", "text-[10px] text-gray-500 mt-1", reheat.at || ""));
+      // service.py only overwrites last_reheat after a SUCCESSFUL tick, so a
+      // persistently failing FalkorDB query serves the last good block
+      // forever. Age it against the loop's own configured interval rather
+      // than rendering the timestamp as inert gray text.
+      var reheatAgeSec = null;
+      if (reheat.at) {
+        var parsedAt = Date.parse(reheat.at);
+        if (Number.isFinite(parsedAt)) reheatAgeSec = (Date.now() - parsedAt) / 1000;
+      }
+      var interval = config && Number(config.decay_reheat_interval_sec);
+      var reheatStale =
+        reheatAgeSec !== null && Number.isFinite(interval) && interval > 0
+          ? reheatAgeSec > interval * 5
+          : false;
+      chain.appendChild(
+        el(
+          "div",
+          "text-[10px] mt-1 " + (reheatStale ? "text-amber-300" : "text-gray-500"),
+          (reheat.at || "") +
+            (reheatAgeSec === null ? "" : "  ·  " + age(reheatAgeSec) + " ago") +
+            (reheatStale ? "  ·  STALE — dissipation loop may be failing" : "")
+        )
+      );
       host.appendChild(chain);
       if (saturated) {
         note(
@@ -1075,9 +1194,14 @@
         try {
           lastHistory = await fetchJson(HISTORY_URL + "?minutes=" + state.windowMinutes);
           state.lastHistoryAt = Date.now();
+          state.historyError = null;
         } catch (err) {
-          // A history failure must not blank the live panels next to it.
-          setStatus("History unavailable: " + (err.message || err), "text-amber-400");
+          // A history failure must not blank the live panels next to it — but
+          // the previous payload then keeps rendering with its own
+          // window/sample labels, so the failure has to survive into the
+          // status line and into both consuming panels as a real age, or a
+          // stale window reads as the current one.
+          state.historyError = String(err.message || err);
         }
       }
 
@@ -1094,6 +1218,7 @@
       if (!(snapshot.heartbeat || {}).ok) problems.push("heartbeat");
       if (!(snapshot.self_model || {}).ok) problems.push("self-model");
       if (!(snapshot.domains || {}).ok) problems.push("domains");
+      if (state.historyError) problems.push("history");
       if (problems.length) {
         setStatus(
           "Updated " +
@@ -1131,6 +1256,17 @@
     stopTimer();
     if (!state.active || !state.live) return;
     state.timer = setInterval(function () {
+      // Visibility, not just the router's activate/deactivate calls, is what
+      // actually gates polling. self_observability.js hides every
+      // section[data-panel] directly and preventDefault()s its own click, so
+      // app.js's setActiveTab -- the only caller of deactivate() -- never runs
+      // on that path, and the timer would otherwise keep firing forever into a
+      // hidden panel. Checking the DOM makes the contract hold against any
+      // future panel that does the same thing.
+      if (!els.panel || els.panel.classList.contains("hidden")) {
+        deactivate();
+        return;
+      }
       poll();
     }, state.intervalMs);
   }
@@ -1186,9 +1322,11 @@
     state.windowMinutes = Number(els.windowSelect && els.windowSelect.value) || 60;
     state.live = !els.liveToggle || !!els.liveToggle.checked;
     wireControls();
-    // If the tab was deep-linked, app.js's hash routing has already unhidden
-    // the panel by the time this runs — start immediately rather than waiting
-    // for a click that will never come.
+    // Defensive only. Both scripts are `defer` and this one is listed before
+    // app.js, so in practice app.js's DOMContentLoaded handler (which is what
+    // calls setActiveTab) has not run yet and the panel is still hidden here —
+    // setActiveTab does the real activation a moment later. This branch exists
+    // so a future load-order change cannot leave a visible panel unpolled.
     if (!els.panel.classList.contains("hidden")) {
       activate();
     }

--- a/services/orion-hub/static/js/attention-organ.js
+++ b/services/orion-hub/static/js/attention-organ.js
@@ -1,0 +1,1210 @@
+// Attention Organ operator tab.
+//
+// Near-realtime view of the precision-weighted attention arc described in
+// docs/superpowers/specs/2026-07-28-precision-weighted-attention-organ-and-
+// heartbeat-discrimination-design.md:
+//
+//   orion-heartbeat's N-trajectory dissipation ensemble  (the organ)
+//     -> AttentionSelfModelV1's heartbeat_* fields       (the wire)
+//       -> AST/HOT's own per-domain prediction error     (the problem)
+//
+// Backed entirely by /api/attention-organ/snapshot + /history. This file owns
+// rendering and the poll lifecycle only; every number it draws comes from a
+// real producer via that API — nothing here computes a cognition signal, and
+// nothing is written back.
+//
+// Panel show/hide is app.js's setActiveTab; this module exposes
+// activate()/deactivate() so polling runs ONLY while the tab is visible
+// (following aitown-panel.js's lifecycle contract). Rendered state is left
+// in the DOM on deactivate, so switching away and back shows the last frame
+// immediately instead of an empty panel, and the rest of the Hub — chat,
+// websocket, every other tab's state — is untouched throughout.
+(function () {
+  "use strict";
+
+  var SNAPSHOT_URL = "/api/attention-organ/snapshot";
+  var HISTORY_URL = "/api/attention-organ/history";
+  var SVG_NS = "http://www.w3.org/2000/svg";
+
+  // History is far cheaper to serve stale than the live snapshot and moves on
+  // a ~30s tick anyway (substrate-runtime's attention self-model cadence), so
+  // it refreshes on its own slower multiple rather than on every poll.
+  var HISTORY_REFRESH_MS = 30000;
+
+  // orion-heartbeat's own live incident threshold: absorb_queue_size reaching
+  // ~30 under normal traffic was enough to starve the dissipation loop's
+  // socket I/O (see services/orion-heartbeat/app/service.py's
+  // _absorb_worker_loop docstring). Flagged, not silently rendered.
+  var ABSORB_QUEUE_WARN = 30;
+
+  var state = {
+    active: false,
+    timer: null,
+    inFlight: false,
+    lastSnapshotAt: 0,
+    lastHistoryAt: 0,
+    intervalMs: 5000,
+    windowMinutes: 60,
+    live: true,
+    // Rolling client-side trace of the live /h1 reading, at poll resolution.
+    // Distinct from the /history series (which is the persisted AST/HOT row's
+    // COPY of the ratio, at substrate-runtime's ~30s tick) — this one shows
+    // the organ's own faster movement between those writes. Bounded so a tab
+    // left open for hours cannot grow without limit.
+    liveTrace: [],
+    liveTraceMax: 240,
+  };
+
+  var els = {};
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function bindElements() {
+    els.panel = $("attention-organ");
+    els.status = $("attentionOrganStatus");
+    els.ensemble = $("attentionOrganEnsemble");
+    els.discrimination = $("attentionOrganDiscrimination");
+    els.domains = $("attentionOrganDomains");
+    els.dominance = $("attentionOrganDominance");
+    els.selfModel = $("attentionOrganSelfModel");
+    els.link = $("attentionOrganLink");
+    els.intake = $("attentionOrganIntake");
+    els.dissipation = $("attentionOrganDissipation");
+    els.windowSelect = $("attentionOrganWindow");
+    els.intervalSelect = $("attentionOrganInterval");
+    els.liveToggle = $("attentionOrganLive");
+    els.refreshBtn = $("attentionOrganRefreshBtn");
+    return !!els.panel;
+  }
+
+  // ---------------------------------------------------------------- helpers
+
+  function num(value, digits) {
+    if (value === null || value === undefined || value === "") return "—";
+    var parsed = Number(value);
+    if (!isFinite(parsed)) return "—";
+    return parsed.toFixed(digits === undefined ? 4 : digits);
+  }
+
+  function int(value) {
+    if (value === null || value === undefined || value === "") return "—";
+    var parsed = Number(value);
+    if (!isFinite(parsed)) return "—";
+    return parsed.toLocaleString();
+  }
+
+  function age(seconds) {
+    if (seconds === null || seconds === undefined) return "—";
+    var s = Number(seconds);
+    if (!isFinite(s)) return "—";
+    if (s < 90) return s.toFixed(1) + "s";
+    if (s < 5400) return (s / 60).toFixed(1) + "m";
+    if (s < 172800) return (s / 3600).toFixed(1) + "h";
+    return (s / 86400).toFixed(1) + "d";
+  }
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = String(text);
+    return node;
+  }
+
+  function card(host, title, subtitle) {
+    host.textContent = "";
+    var head = el("div", "flex items-baseline justify-between gap-2 mb-3");
+    head.appendChild(el("h3", "text-sm font-semibold text-gray-100", title));
+    if (subtitle) {
+      head.appendChild(el("span", "text-[10px] uppercase tracking-wide text-gray-500", subtitle));
+    }
+    host.appendChild(head);
+    return host;
+  }
+
+  function statTile(label, value, tone) {
+    var wrap = el("div", "rounded-lg border border-gray-800 bg-black/30 px-2 py-1.5");
+    wrap.appendChild(el("div", "text-[10px] uppercase tracking-wide text-gray-500", label));
+    wrap.appendChild(el("div", "text-sm font-mono " + (tone || "text-gray-100"), value));
+    return wrap;
+  }
+
+  function kvRow(label, value, tone) {
+    var row = el("div", "flex items-start justify-between gap-3 py-1 border-b border-gray-800/60 last:border-b-0");
+    row.appendChild(el("div", "text-[11px] text-gray-400 shrink-0", label));
+    row.appendChild(el("div", "text-[11px] font-mono text-right break-all " + (tone || "text-gray-200"), value));
+    return row;
+  }
+
+  function badge(text, tone) {
+    return el("span", "inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold border " + tone, text);
+  }
+
+  function verdictTone(verdict) {
+    if (verdict === "redundant") return "border-amber-700 bg-amber-950/50 text-amber-200";
+    if (verdict === "concentrated") return "border-emerald-700 bg-emerald-950/50 text-emerald-200";
+    if (verdict === "mixed") return "border-sky-700 bg-sky-950/50 text-sky-200";
+    return "border-gray-700 bg-gray-900 text-gray-400";
+  }
+
+  function note(host, text, tone) {
+    host.appendChild(
+      el("p", "text-[10px] leading-relaxed mt-2 " + (tone || "text-gray-500"), text)
+    );
+  }
+
+  function errorBlock(host, title, message) {
+    card(host, title, "unavailable");
+    host.appendChild(
+      el(
+        "div",
+        "text-[11px] font-mono text-red-300 bg-red-950/30 border border-red-900/60 rounded-lg p-2 break-all",
+        message || "no data"
+      )
+    );
+  }
+
+  function svg(viewBox, className, heightClass) {
+    var node = document.createElementNS(SVG_NS, "svg");
+    node.setAttribute("viewBox", viewBox);
+    node.setAttribute("preserveAspectRatio", "none");
+    node.setAttribute("class", "w-full " + (heightClass || "h-24") + " " + (className || ""));
+    return node;
+  }
+
+  function svgEl(tag, attrs) {
+    var node = document.createElementNS(SVG_NS, tag);
+    Object.keys(attrs || {}).forEach(function (key) {
+      node.setAttribute(key, attrs[key]);
+    });
+    return node;
+  }
+
+  // ------------------------------------------------------------- renderers
+
+  // Horizontal 0..1 band gauge with the live verdict thresholds drawn where
+  // orion-heartbeat actually classifies them (read from /health's config, not
+  // hardcoded here — see attention_organ_routes.py's "deliberately not
+  // computed here" note).
+  function renderBandGauge(host, meanRatio, stdRatio, thresholds) {
+    var low = thresholds && isFinite(thresholds.low_ratio) ? thresholds.low_ratio : null;
+    var high = thresholds && isFinite(thresholds.high_ratio) ? thresholds.high_ratio : null;
+    var chart = svg("0 0 100 22", "", "h-14");
+
+    function band(x0, x1, fill) {
+      chart.appendChild(
+        svgEl("rect", { x: x0 * 100, y: 2, width: Math.max(0, (x1 - x0) * 100), height: 8, fill: fill })
+      );
+    }
+    if (low !== null && high !== null) {
+      band(0, low, "rgba(16,185,129,0.30)");
+      band(low, high, "rgba(56,189,248,0.30)");
+      band(high, 1, "rgba(245,158,11,0.30)");
+    } else {
+      band(0, 1, "rgba(75,85,99,0.35)");
+    }
+
+    if (meanRatio !== null && meanRatio !== undefined && isFinite(meanRatio)) {
+      var cx = Math.max(0, Math.min(1, Number(meanRatio))) * 100;
+      if (stdRatio !== null && stdRatio !== undefined && isFinite(stdRatio)) {
+        var lo = Math.max(0, Math.min(1, Number(meanRatio) - Number(stdRatio))) * 100;
+        var hi = Math.max(0, Math.min(1, Number(meanRatio) + Number(stdRatio))) * 100;
+        chart.appendChild(
+          svgEl("rect", {
+            x: lo,
+            y: 4.5,
+            width: Math.max(0.4, hi - lo),
+            height: 3,
+            fill: "rgba(255,255,255,0.45)",
+          })
+        );
+      }
+      chart.appendChild(
+        svgEl("rect", { x: Math.max(0, cx - 0.5), y: 0.5, width: 1, height: 11, fill: "#f8fafc" })
+      );
+    }
+
+    [
+      [0, "0"],
+      [low, low === null ? null : String(low)],
+      [high, high === null ? null : String(high)],
+      [1, "1"],
+    ].forEach(function (pair) {
+      if (pair[0] === null || pair[1] === null) return;
+      var tick = svgEl("text", {
+        x: Math.max(2, Math.min(96, pair[0] * 100)),
+        y: 19,
+        fill: "#6b7280",
+        "font-size": "5",
+        "text-anchor": "middle",
+      });
+      tick.textContent = pair[1];
+      chart.appendChild(tick);
+    });
+    host.appendChild(chart);
+
+    var legend = el("div", "flex items-center justify-between text-[9px] text-gray-500 -mt-1");
+    legend.appendChild(el("span", "", "concentrated"));
+    legend.appendChild(el("span", "", "mixed"));
+    legend.appendChild(el("span", "", "redundant"));
+    host.appendChild(legend);
+  }
+
+  // The N individual trajectories behind the mean. At small N the mean+std
+  // alone cannot distinguish "all trajectories agree" from "two clusters that
+  // average out" — this is the whole point of running an ensemble rather than
+  // one trajectory, so it gets drawn rather than summarized away.
+  function renderTrajectories(host, ratios, seeds, meanRatio) {
+    if (!Array.isArray(ratios) || !ratios.length) {
+      note(
+        host,
+        "Per-trajectory ratios not reported by this orion-heartbeat build (/h1 returns mean + std only). " +
+          "Rebuild the heartbeat service to populate them.",
+        "text-amber-400/80"
+      );
+      return;
+    }
+    var chart = svg("0 0 100 16", "", "h-10");
+    chart.appendChild(svgEl("line", { x1: 0, y1: 8, x2: 100, y2: 8, stroke: "#374151", "stroke-width": 0.4 }));
+    if (meanRatio !== null && meanRatio !== undefined && isFinite(meanRatio)) {
+      var mx = Math.max(0, Math.min(1, Number(meanRatio))) * 100;
+      chart.appendChild(
+        svgEl("line", { x1: mx, y1: 1, x2: mx, y2: 15, stroke: "#f8fafc", "stroke-width": 0.6 })
+      );
+    }
+    ratios.forEach(function (ratio) {
+      if (!isFinite(ratio)) return;
+      chart.appendChild(
+        svgEl("circle", {
+          cx: Math.max(0, Math.min(1, Number(ratio))) * 100,
+          cy: 8,
+          r: 1.6,
+          fill: "rgba(129,140,248,0.85)",
+        })
+      );
+    });
+    host.appendChild(chart);
+
+    var caption = "n=" + ratios.length;
+    if (Array.isArray(seeds) && seeds.length === ratios.length) {
+      caption += " · seeds " + seeds.join(", ");
+    }
+    host.appendChild(el("div", "text-[9px] text-gray-500 font-mono", caption));
+  }
+
+  // Time series with an optional ±spread band. `points` entries are
+  // {x, value, spread}; x is already normalized 0..1 by the caller.
+  function renderSeries(host, points, opts) {
+    opts = opts || {};
+    if (!points.length) {
+      note(host, opts.emptyText || "No samples in this window yet.");
+      return;
+    }
+    var chart = svg("0 0 100 40", "", opts.heightClass || "h-28");
+    var lo = opts.min === undefined ? 0 : opts.min;
+    var hi = opts.max === undefined ? 1 : opts.max;
+    var span = hi - lo || 1;
+
+    function y(value) {
+      return 38 - ((Math.max(lo, Math.min(hi, value)) - lo) / span) * 36;
+    }
+
+    (opts.guides || []).forEach(function (guide) {
+      if (guide.value === null || guide.value === undefined || !isFinite(guide.value)) return;
+      chart.appendChild(
+        svgEl("line", {
+          x1: 0,
+          y1: y(guide.value),
+          x2: 100,
+          y2: y(guide.value),
+          stroke: guide.color || "#4b5563",
+          "stroke-width": 0.4,
+          "stroke-dasharray": "2 2",
+        })
+      );
+    });
+
+    var withSpread = points.filter(function (p) {
+      return isFinite(p.spread) && isFinite(p.value);
+    });
+    if (withSpread.length > 1) {
+      var upper = withSpread.map(function (p) {
+        return p.x * 100 + "," + y(p.value + p.spread);
+      });
+      var lower = withSpread
+        .slice()
+        .reverse()
+        .map(function (p) {
+          return p.x * 100 + "," + y(p.value - p.spread);
+        });
+      chart.appendChild(
+        svgEl("polygon", {
+          points: upper.concat(lower).join(" "),
+          fill: "rgba(129,140,248,0.18)",
+        })
+      );
+    }
+
+    var line = points
+      .filter(function (p) {
+        return isFinite(p.value);
+      })
+      .map(function (p) {
+        return p.x * 100 + "," + y(p.value);
+      });
+    if (line.length > 1) {
+      chart.appendChild(
+        svgEl("polyline", {
+          points: line.join(" "),
+          fill: "none",
+          stroke: opts.color || "#818cf8",
+          "stroke-width": 0.8,
+          "vector-effect": "non-scaling-stroke",
+        })
+      );
+    } else if (line.length === 1) {
+      var only = line[0].split(",");
+      chart.appendChild(
+        svgEl("circle", { cx: only[0], cy: only[1], r: 1, fill: opts.color || "#818cf8" })
+      );
+    }
+    host.appendChild(chart);
+  }
+
+  function renderTallyBars(host, counts, opts) {
+    opts = opts || {};
+    var keys = Object.keys(counts || {});
+    if (!keys.length) {
+      note(host, opts.emptyText || "No samples in this window.");
+      return;
+    }
+    var total = keys.reduce(function (acc, key) {
+      return acc + counts[key];
+    }, 0);
+    keys
+      .sort(function (a, b) {
+        return counts[b] - counts[a];
+      })
+      .forEach(function (key) {
+        var pct = total ? (counts[key] / total) * 100 : 0;
+        var row = el("div", "mb-1.5");
+        var head = el("div", "flex items-baseline justify-between gap-2");
+        head.appendChild(
+          el("span", "text-[11px] " + (opts.labelTone ? opts.labelTone(key) : "text-gray-300"), key)
+        );
+        head.appendChild(
+          el("span", "text-[10px] font-mono text-gray-500", counts[key] + " · " + pct.toFixed(1) + "%")
+        );
+        row.appendChild(head);
+        var track = el("div", "h-1.5 rounded-full bg-gray-800 overflow-hidden mt-0.5");
+        var fill = el("div", "h-full " + (opts.barTone ? opts.barTone(key) : "bg-indigo-500"));
+        fill.style.width = Math.max(1, pct) + "%";
+        track.appendChild(fill);
+        row.appendChild(track);
+        host.appendChild(row);
+      });
+  }
+
+  // ---------------------------------------------------------------- panels
+
+  function renderEnsemble(host, snapshot) {
+    var hb = snapshot.heartbeat || {};
+    if (!hb.h1) {
+      errorBlock(
+        host,
+        "Ensemble H1",
+        hb.h1_error || hb.h1_reason || "orion-heartbeat has not computed an H1 tick yet."
+      );
+      return;
+    }
+    var h1 = hb.h1;
+    var config = (hb.health && hb.health.config) || null;
+    card(host, "Ensemble H1", "orion-heartbeat /h1");
+
+    var headline = el("div", "flex items-end justify-between gap-3 mb-2");
+    var left = el("div");
+    left.appendChild(el("div", "text-3xl font-mono text-white leading-none", num(h1.mean_ratio, 4)));
+    left.appendChild(el("div", "text-[10px] uppercase tracking-wide text-gray-500 mt-1", "ensemble mean ratio"));
+    headline.appendChild(left);
+    var right = el("div", "text-right");
+    right.appendChild(badge(h1.verdict || "unknown", verdictTone(h1.verdict)));
+    right.appendChild(el("div", "text-[10px] text-gray-500 mt-1 font-mono", "±" + num(h1.std_ratio, 4) + " spread"));
+    headline.appendChild(right);
+    host.appendChild(headline);
+
+    renderBandGauge(host, h1.mean_ratio, h1.std_ratio, config);
+    renderTrajectories(host, h1.ratios, h1.seeds, h1.mean_ratio);
+
+    var grid = el("div", "grid grid-cols-2 gap-2 mt-3");
+    grid.appendChild(statTile("Absorbed ticks", int(h1.tick_count)));
+    grid.appendChild(statTile("Trajectories", int(h1.seeds ? h1.seeds.length : (config ? config.n_trajectories : null))));
+    grid.appendChild(statTile("Max bond", int(hb.health ? hb.health.max_bond : null)));
+    grid.appendChild(statTile("Norm", num(hb.health ? hb.health.norm : null, 4)));
+    host.appendChild(grid);
+
+    note(
+      host,
+      "Spread is agreement between independently-seeded trajectories absorbing the same real event stream — " +
+        "wide spread means the self-model's state is genuinely undetermined, not noisy measurement."
+    );
+  }
+
+  function renderDiscrimination(host, snapshot, history) {
+    card(host, "Discrimination over window", "acceptance check 1");
+
+    var hb = snapshot.heartbeat || {};
+    var config = (hb.health && hb.health.config) || null;
+
+    var liveWrap = el("div", "mb-3");
+    liveWrap.appendChild(
+      el(
+        "div",
+        "text-[10px] uppercase tracking-wide text-gray-500 mb-1",
+        "Live /h1 trace (" + state.liveTrace.length + " polls, ±spread band)"
+      )
+    );
+    var traceCount = state.liveTrace.length;
+    renderSeries(
+      liveWrap,
+      state.liveTrace.map(function (point, index) {
+        return {
+          x: traceCount > 1 ? index / (traceCount - 1) : 0,
+          value: point.mean,
+          spread: point.std,
+        };
+      }),
+      {
+        guides: config
+          ? [
+              { value: config.high_ratio, color: "#b45309" },
+              { value: config.low_ratio, color: "#047857" },
+            ]
+          : [],
+        emptyText: "Waiting for the first poll.",
+        heightClass: "h-24",
+      }
+    );
+    host.appendChild(liveWrap);
+
+    if (!history) {
+      note(host, "History not loaded yet.");
+      return;
+    }
+
+    var histWrap = el("div", "mb-3");
+    histWrap.appendChild(
+      el(
+        "div",
+        "text-[10px] uppercase tracking-wide text-gray-500 mb-1",
+        "Persisted AST/HOT copy — " +
+          history.window_minutes +
+          " min, " +
+          history.sample_count +
+          " rows" +
+          (history.truncated ? " (truncated at row cap)" : "")
+      )
+    );
+    var series = (history.series || []).filter(function (point) {
+      return point.heartbeat_mean_ratio !== null && point.heartbeat_mean_ratio !== undefined;
+    });
+    renderSeries(
+      histWrap,
+      series.map(function (point, index) {
+        return {
+          x: series.length > 1 ? index / (series.length - 1) : 0,
+          value: Number(point.heartbeat_mean_ratio),
+          spread: NaN,
+        };
+      }),
+      {
+        color: "#38bdf8",
+        guides: config
+          ? [
+              { value: config.high_ratio, color: "#b45309" },
+              { value: config.low_ratio, color: "#047857" },
+            ]
+          : [],
+        emptyText: "No heartbeat_mean_ratio values persisted in this window.",
+        heightClass: "h-24",
+      }
+    );
+    host.appendChild(histWrap);
+
+    var tally = el("div");
+    tally.appendChild(
+      el("div", "text-[10px] uppercase tracking-wide text-gray-500 mb-1", "Verdict bands fired")
+    );
+    renderTallyBars(tally, history.verdict_counts || {}, {
+      barTone: function (key) {
+        if (key === "redundant") return "bg-amber-500";
+        if (key === "concentrated") return "bg-emerald-500";
+        return "bg-sky-500";
+      },
+      emptyText: "No heartbeat verdict persisted in this window.",
+    });
+    if (history.null_verdict_count) {
+      note(
+        tally,
+        history.null_verdict_count +
+          " row(s) in this window carried no heartbeat verdict at all — the wire was down for those ticks, " +
+          "which is not the same as a band never firing."
+      );
+    }
+    host.appendChild(tally);
+
+    var distinct = history.verdict_distinct_values || 0;
+    var checkTone =
+      distinct > 1
+        ? "border-emerald-700 bg-emerald-950/40 text-emerald-200"
+        : "border-amber-700 bg-amber-950/40 text-amber-200";
+    var check = el("div", "mt-3 rounded-lg border p-2 text-[10px] leading-relaxed " + checkTone);
+    check.appendChild(
+      el(
+        "div",
+        "font-semibold mb-0.5",
+        distinct > 1
+          ? "Acceptance check 1 met in this window: verdict took " + distinct + " distinct values."
+          : "Acceptance check 1 NOT met in this window: verdict took a single value."
+      )
+    );
+    check.appendChild(
+      el(
+        "div",
+        "",
+        "The spec records the concentrated band (<=" +
+          (config ? config.low_ratio : "0.2") +
+          ") as a structural gap, not a waiting game: 4 of 5 organs stay continuously active regardless of chat, " +
+          "so real operation may never produce the simultaneous silence it needs. Deferred by explicit decision (2026-07-29)."
+      )
+    );
+    host.appendChild(check);
+  }
+
+  function renderDomains(host, snapshot) {
+    var domains = snapshot.domains || {};
+    if (!domains.ok) {
+      errorBlock(host, "Per-domain prediction error", domains.error);
+      return;
+    }
+    card(host, "Per-domain prediction error", "substrate graph, live");
+
+    var rows = domains.rows || [];
+    var active = rows.filter(function (row) {
+      return row.active;
+    });
+    var inactive = rows.filter(function (row) {
+      return !row.active;
+    });
+
+    function drawRow(row) {
+      var wrap = el("div", "mb-2");
+      var head = el("div", "flex items-baseline justify-between gap-2");
+      var labelWrap = el("div", "flex items-center gap-1.5 min-w-0");
+      labelWrap.appendChild(
+        el("span", "text-[11px] " + (row.active ? "text-gray-200" : "text-gray-500 line-through"), row.domain)
+      );
+      if (!row.present) {
+        labelWrap.appendChild(badge("no node", "border-red-800 bg-red-950/50 text-red-300"));
+      } else if (row.at_ceiling) {
+        labelWrap.appendChild(badge("at 1.0", "border-red-800 bg-red-950/50 text-red-300"));
+      } else if (row.at_floor) {
+        labelWrap.appendChild(badge("at 0.0", "border-red-800 bg-red-950/50 text-red-300"));
+      }
+      head.appendChild(labelWrap);
+      head.appendChild(
+        el(
+          "span",
+          "text-[10px] font-mono text-gray-500 shrink-0",
+          num(row.prediction_error, 4) + " · seen " + age(row.observed_age_sec)
+        )
+      );
+      wrap.appendChild(head);
+
+      var track = el("div", "h-2 rounded-full bg-gray-800 overflow-hidden mt-0.5");
+      var value = row.prediction_error;
+      if (value !== null && value !== undefined && isFinite(value)) {
+        var fill = el(
+          "div",
+          "h-full " +
+            (row.at_ceiling || row.at_floor
+              ? "bg-red-500"
+              : row.active
+              ? "bg-indigo-500"
+              : "bg-gray-600")
+        );
+        fill.style.width = Math.max(1, Math.max(0, Math.min(1, Number(value))) * 100) + "%";
+        track.appendChild(fill);
+      }
+      wrap.appendChild(track);
+      return wrap;
+    }
+
+    host.appendChild(
+      el(
+        "div",
+        "text-[10px] uppercase tracking-wide text-gray-500 mb-1",
+        "ACTIVE_INFERENCE_DOMAINS (" + active.length + ") — averaged into prediction_error_confidence"
+      )
+    );
+    active.forEach(function (row) {
+      host.appendChild(drawRow(row));
+    });
+
+    if (inactive.length) {
+      host.appendChild(
+        el(
+          "div",
+          "text-[10px] uppercase tracking-wide text-gray-500 mt-3 mb-1",
+          "Excluded from the aggregate (" + inactive.length + ") — still ticking, still readable elsewhere"
+        )
+      );
+      inactive.forEach(function (row) {
+        host.appendChild(drawRow(row));
+      });
+    }
+
+    var rec = domains.reconciliation || {};
+    var recTone =
+      rec.reconciles === null || rec.reconciles === undefined
+        ? "border-gray-700 bg-gray-900/60 text-gray-400"
+        : rec.reconciles
+        ? "border-emerald-800 bg-emerald-950/30 text-emerald-200"
+        : "border-red-800 bg-red-950/30 text-red-200";
+    var recBox = el("div", "mt-3 rounded-lg border p-2 text-[10px] leading-relaxed font-mono " + recTone);
+    recBox.appendChild(
+      el(
+        "div",
+        "",
+        "1 - mean(active domains) = " +
+          num(rec.recomputed, 4) +
+          "   vs persisted prediction_error_confidence = " +
+          num(rec.persisted, 4) +
+          "   (delta " +
+          num(rec.delta, 4) +
+          ", n=" +
+          (rec.domains_used === null || rec.domains_used === undefined ? "—" : rec.domains_used) +
+          ")"
+      )
+    );
+    host.appendChild(recBox);
+    note(
+      host,
+      "A domain pinned at exactly 1.0 or decayed to exactly 0.0 is flagged red because both have real incident " +
+        "history on these nodes (bus_synaptic frozen at 1.0, PR #1449; route decayed to ~0 by a generic staleness loop). " +
+        "A flag is a prompt to check provenance, not proof of a bug."
+    );
+  }
+
+  function renderDominance(host, history) {
+    card(host, "Domain dominance over window", "acceptance check 3");
+    if (!history) {
+      note(host, "History not loaded yet.");
+      return;
+    }
+    host.appendChild(
+      el(
+        "div",
+        "text-[10px] uppercase tracking-wide text-gray-500 mb-1",
+        "Which domain won predicted_shift — " +
+          history.window_minutes +
+          " min, " +
+          history.sample_count +
+          " rows"
+      )
+    );
+    renderTallyBars(host, history.domain_counts || {}, {
+      emptyText: "No predicted_shift domain resolved in this window.",
+    });
+    if (history.null_domain_count) {
+      note(
+        host,
+        history.null_domain_count + " row(s) had no predicted_shift at all (no trend resolved that tick)."
+      );
+    }
+    note(
+      host,
+      "The spec's 168h baseline was biometrics=69819, bus_synaptic=57360, execution=27, chat=1, route=1 — " +
+        "two of those five were later found to be broken instruments, not quiet domains (PR #1434, PR #1449). " +
+        "A flatter distribution here is the evidence a precision-weighting fix would have to produce."
+    );
+  }
+
+  function renderSelfModel(host, snapshot) {
+    var sm = snapshot.self_model || {};
+    if (!sm.ok || !sm.model) {
+      errorBlock(host, "AST/HOT self-model", sm.error || "No substrate_attention_self_model row found.");
+      return;
+    }
+    var model = sm.model;
+    card(host, "AST/HOT self-model", "AttentionSelfModelV1");
+
+    var grid = el("div", "grid grid-cols-1 md:grid-cols-2 gap-x-4");
+    var leftCol = el("div");
+    leftCol.appendChild(kvRow("attention_reason", model.attention_reason || "—"));
+    leftCol.appendChild(kvRow("confidence", num(model.confidence, 4)));
+    leftCol.appendChild(kvRow("confidence_basis", model.confidence_basis || "—", "text-gray-400"));
+    leftCol.appendChild(kvRow("prediction_error_confidence", num(model.prediction_error_confidence, 4)));
+    leftCol.appendChild(kvRow("predicted_shift", model.predicted_shift || "—"));
+    leftCol.appendChild(kvRow("predicted_shift_basis", model.predicted_shift_basis || "—", "text-gray-400"));
+    grid.appendChild(leftCol);
+
+    var rightCol = el("div");
+    rightCol.appendChild(kvRow("heartbeat_mean_ratio", num(model.heartbeat_mean_ratio, 4)));
+    rightCol.appendChild(
+      kvRow(
+        "heartbeat_verdict",
+        model.heartbeat_verdict || "—",
+        model.heartbeat_verdict ? "text-gray-200" : "text-amber-300"
+      )
+    );
+    rightCol.appendChild(kvRow("field_lane_present", String(model.field_lane_present)));
+    rightCol.appendChild(kvRow("field_overall_salience", num(model.field_overall_salience, 4)));
+    rightCol.appendChild(
+      kvRow(
+        "broadcast_lane",
+        (model.broadcast_lane_present ? "present" : "absent") +
+          (model.broadcast_lane_stale ? " · stale" : " · fresh") +
+          " · " +
+          age(model.broadcast_lane_age_sec),
+        model.broadcast_lane_stale ? "text-amber-300" : "text-gray-200"
+      )
+    );
+    rightCol.appendChild(
+      kvRow("voluntary_override", model.voluntary_override ? "set" : "none")
+    );
+    grid.appendChild(rightCol);
+    host.appendChild(grid);
+
+    var targets = model.field_salient_target_ids || [];
+    var targetsWrap = el("div", "mt-3");
+    targetsWrap.appendChild(
+      el("div", "text-[10px] uppercase tracking-wide text-gray-500 mb-1", "Salient target ids (" + targets.length + ")")
+    );
+    if (targets.length) {
+      var chips = el("div", "flex flex-wrap gap-1");
+      targets.forEach(function (id) {
+        chips.appendChild(badge(id, "border-gray-700 bg-gray-900 text-gray-300"));
+      });
+      targetsWrap.appendChild(chips);
+    } else {
+      targetsWrap.appendChild(el("div", "text-[11px] text-gray-500", "none"));
+    }
+    host.appendChild(targetsWrap);
+
+    if (model.reason_narrative) {
+      var narrative = el("div", "mt-3");
+      narrative.appendChild(
+        el("div", "text-[10px] uppercase tracking-wide text-gray-500 mb-1", "Reason narrative")
+      );
+      narrative.appendChild(
+        el("div", "text-[11px] text-gray-300 leading-relaxed", model.reason_narrative)
+      );
+      host.appendChild(narrative);
+    }
+  }
+
+  function renderLink(host, snapshot) {
+    card(host, "Organ → AST/HOT wire", "staleness");
+    var link = snapshot.link || {};
+
+    var wired = !!link.self_model_has_heartbeat;
+    host.appendChild(
+      badge(
+        wired ? "wire live" : "wire not carrying heartbeat",
+        wired
+          ? "border-emerald-700 bg-emerald-950/50 text-emerald-200"
+          : "border-red-800 bg-red-950/50 text-red-300"
+      )
+    );
+
+    var rows = el("div", "mt-2");
+    rows.appendChild(kvRow("row age", age(link.self_model_age_sec)));
+    rows.appendChild(kvRow("row's mean_ratio", num(link.self_model_mean_ratio, 4)));
+    rows.appendChild(kvRow("organ's mean_ratio now", num(link.live_mean_ratio, 4)));
+    rows.appendChild(kvRow("organ tick_count now", int(link.live_tick_count)));
+
+    // The row's own basis string names the tick it was built from, so the gap
+    // against the organ's current tick_count is a real staleness measure — a
+    // non-null heartbeat field alone would not tell you whether the value is
+    // seconds or hours old.
+    var basisTick = null;
+    var match = /tick_count=(\d+)/.exec(link.self_model_basis || "");
+    if (match) basisTick = Number(match[1]);
+    rows.appendChild(kvRow("row's basis tick", basisTick === null ? "—" : int(basisTick)));
+    if (basisTick !== null && isFinite(link.live_tick_count)) {
+      var lag = Number(link.live_tick_count) - basisTick;
+      rows.appendChild(
+        kvRow(
+          "tick lag",
+          int(lag) + " ticks",
+          lag > 5000 ? "text-amber-300" : "text-gray-200"
+        )
+      );
+    }
+    host.appendChild(rows);
+
+    if (link.self_model_basis) {
+      note(host, link.self_model_basis, "text-gray-500 font-mono");
+    }
+    note(
+      host,
+      "AttentionSelfModelV1 still has no bus channel and no downstream consumer — this wire ends here, at " +
+        "the persisted row and this panel. Nothing in Orion's decision path reads it yet."
+    );
+  }
+
+  function renderIntake(host, snapshot) {
+    var hb = snapshot.heartbeat || {};
+    if (!hb.health) {
+      errorBlock(host, "Intake & backpressure", hb.health_error);
+      return;
+    }
+    var health = hb.health;
+    card(host, "Intake & backpressure", "orion-heartbeat /health");
+
+    var queueSize = Number(health.absorb_queue_size);
+    var queueTone =
+      isFinite(queueSize) && queueSize >= ABSORB_QUEUE_WARN ? "text-amber-300" : "text-gray-100";
+
+    var grid = el("div", "grid grid-cols-2 md:grid-cols-4 gap-2");
+    grid.appendChild(statTile("Events seen", int(health.events_seen)));
+    grid.appendChild(statTile("Queued", int(health.events_queued)));
+    grid.appendChild(statTile("Absorbed", int(health.events_absorbed)));
+    grid.appendChild(statTile("Queue depth", int(health.absorb_queue_size), queueTone));
+    grid.appendChild(
+      statTile(
+        "Dropped (queue full)",
+        int(health.events_dropped_queue_full),
+        Number(health.events_dropped_queue_full) > 0 ? "text-red-300" : "text-gray-100"
+      )
+    );
+    grid.appendChild(statTile("Skipped: organ", int(health.events_skipped_organ)));
+    grid.appendChild(
+      statTile(
+        "Skipped: atom type",
+        int(health.events_skipped_atom_type),
+        Number(health.events_skipped_atom_type) > 0 ? "text-amber-300" : "text-gray-100"
+      )
+    );
+    grid.appendChild(
+      statTile(
+        "Skipped: malformed",
+        int(health.events_skipped_malformed),
+        Number(health.events_skipped_malformed) > 0 ? "text-amber-300" : "text-gray-100"
+      )
+    );
+    host.appendChild(grid);
+
+    var organs = health.allowlisted_organs || [];
+    if (organs.length) {
+      var organWrap = el("div", "mt-3");
+      organWrap.appendChild(
+        el(
+          "div",
+          "text-[10px] uppercase tracking-wide text-gray-500 mb-1",
+          "Routed organs (" + organs.length + " sites)"
+        )
+      );
+      var chips = el("div", "flex flex-wrap gap-1");
+      organs.forEach(function (organ) {
+        var site = health.organ_site_map ? health.organ_site_map[organ] : undefined;
+        chips.appendChild(
+          badge(
+            organ + (site === undefined ? "" : " → site " + site),
+            "border-gray-700 bg-gray-900 text-gray-300"
+          )
+        );
+      });
+      organWrap.appendChild(chips);
+      host.appendChild(organWrap);
+    }
+
+    if (isFinite(queueSize) && queueSize >= ABSORB_QUEUE_WARN) {
+      note(
+        host,
+        "Queue depth at or above " +
+          ABSORB_QUEUE_WARN +
+          " — the depth at which a live burst previously starved the dissipation loop's socket I/O and " +
+          "produced a spurious FalkorDB timeout. The substrate's freshness lags real events here, not its correctness.",
+        "text-amber-400/80"
+      );
+    }
+  }
+
+  function renderDissipation(host, snapshot) {
+    var hb = snapshot.heartbeat || {};
+    var health = hb.health;
+    if (!health) {
+      errorBlock(host, "Dissipation drive", hb.health_error);
+      return;
+    }
+    card(host, "Dissipation drive", "decay ⇄ reheat");
+
+    var reheat = health.last_reheat;
+    if (reheat) {
+      var saturated = Number(reheat.signal) >= 1.0;
+      var chain = el(
+        "div",
+        "rounded-lg border p-2 mb-3 " +
+          (saturated ? "border-red-900/60 bg-red-950/20" : "border-gray-800 bg-black/30")
+      );
+      var chainHead = el("div", "flex items-center justify-between gap-2 mb-1");
+      chainHead.appendChild(
+        el("div", "text-[10px] uppercase tracking-wide text-gray-500", "Last real reheat tick")
+      );
+      if (saturated) {
+        chainHead.appendChild(badge("saturated", "border-red-800 bg-red-950/50 text-red-300"));
+      }
+      chain.appendChild(chainHead);
+      var flow = el("div", "text-[11px] font-mono text-gray-200 break-all");
+      flow.textContent =
+        "raw mean|gap_z| " +
+        num(reheat.raw_mean_abs_gap_zscore, 4) +
+        "  ÷ " +
+        num(reheat.zscore_saturation, 1) +
+        "  → signal " +
+        num(reheat.signal, 4) +
+        "  × scale  → reheat_prob " +
+        num(reheat.reheat_prob, 5);
+      chain.appendChild(flow);
+      chain.appendChild(el("div", "text-[10px] text-gray-500 mt-1", reheat.at || ""));
+      host.appendChild(chain);
+      if (saturated) {
+        note(
+          host,
+          "Reheat signal is clipped at its ceiling: raw mean|gap_z| is above the saturation constant, so " +
+            "min(1, z/sat) returns 1.0 no matter how bus activity moves. Reheat is running at constant maximum, " +
+            "which means this input is not currently gating anything — the design spec's calibration assumed a " +
+            "raw value near 1.0–1.1. Worth re-checking the saturation constant against real data before trusting " +
+            "reheat as a dynamic driver.",
+          "text-red-300/90"
+        );
+      }
+    } else {
+      note(
+        host,
+        "No dissipation tick recorded yet by this orion-heartbeat build. Rebuild the heartbeat service to " +
+          "surface the live reheat inputs.",
+        "text-amber-400/80"
+      );
+    }
+
+    var config = health.config;
+    if (config) {
+      var cfg = el("div");
+      cfg.appendChild(
+        el("div", "text-[10px] uppercase tracking-wide text-gray-500 mb-1", "Live tuning in force")
+      );
+      [
+        ["n_trajectories", int(config.n_trajectories)],
+        ["gamma (relaxation)", num(config.gamma, 3)],
+        ["base_decay_prob", num(config.base_decay_prob, 3)],
+        ["decay_spread_sensitivity", num(config.decay_spread_sensitivity, 2)],
+        ["reheat_strength", num(config.reheat_strength, 3)],
+        ["reheat_prob_scale", num(config.reheat_prob_scale, 3)],
+        ["decay/reheat interval", num(config.decay_reheat_interval_sec, 1) + "s"],
+        ["h1 interval", num(config.h1_interval_sec, 1) + "s"],
+        ["verdict bands", "≤" + num(config.low_ratio, 2) + " / ≥" + num(config.high_ratio, 2)],
+      ].forEach(function (pair) {
+        cfg.appendChild(kvRow(pair[0], pair[1]));
+      });
+      host.appendChild(cfg);
+    } else {
+      note(host, "Live tuning not reported by this orion-heartbeat build.", "text-amber-400/80");
+    }
+
+    note(
+      host,
+      "Decay is gated by trajectory spread (disagreement suppresses relaxation); reheat is driven by real " +
+        "inter-service bus timing jitter. Without both, the substrate thermalizes and can never read anything but 'redundant'."
+    );
+  }
+
+  // ------------------------------------------------------------ poll cycle
+
+  function setStatus(text, tone) {
+    if (!els.status) return;
+    els.status.textContent = text;
+    els.status.className = "text-xs min-h-[1.25rem] " + (tone || "text-gray-400");
+  }
+
+  function pushLiveTrace(h1) {
+    if (!h1 || h1.mean_ratio === null || h1.mean_ratio === undefined) return;
+    var last = state.liveTrace[state.liveTrace.length - 1];
+    // The organ recomputes H1 on its own ~30s timer, so consecutive polls
+    // usually return the SAME tick. Deduplicating on tick_count keeps the
+    // trace a record of real ensemble ticks rather than a flat line whose
+    // apparent resolution is just the poll rate.
+    if (last && last.tick === h1.tick_count) return;
+    state.liveTrace.push({
+      tick: h1.tick_count,
+      mean: Number(h1.mean_ratio),
+      std: Number(h1.std_ratio),
+      at: h1.generated_at,
+    });
+    if (state.liveTrace.length > state.liveTraceMax) {
+      state.liveTrace.splice(0, state.liveTrace.length - state.liveTraceMax);
+    }
+  }
+
+  var lastHistory = null;
+
+  async function fetchJson(url) {
+    var resp = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!resp.ok) {
+      throw new Error("HTTP " + resp.status + " from " + url);
+    }
+    return resp.json();
+  }
+
+  async function poll(opts) {
+    opts = opts || {};
+    if (state.inFlight) return;
+    state.inFlight = true;
+    try {
+      var snapshot = await fetchJson(SNAPSHOT_URL);
+      pushLiveTrace(snapshot.heartbeat && snapshot.heartbeat.h1);
+      state.lastSnapshotAt = Date.now();
+
+      var needHistory =
+        opts.forceHistory ||
+        !lastHistory ||
+        Date.now() - state.lastHistoryAt >= HISTORY_REFRESH_MS;
+      if (needHistory) {
+        try {
+          lastHistory = await fetchJson(HISTORY_URL + "?minutes=" + state.windowMinutes);
+          state.lastHistoryAt = Date.now();
+        } catch (err) {
+          // A history failure must not blank the live panels next to it.
+          setStatus("History unavailable: " + (err.message || err), "text-amber-400");
+        }
+      }
+
+      renderEnsemble(els.ensemble, snapshot);
+      renderDiscrimination(els.discrimination, snapshot, lastHistory);
+      renderDomains(els.domains, snapshot);
+      renderDominance(els.dominance, lastHistory);
+      renderSelfModel(els.selfModel, snapshot);
+      renderLink(els.link, snapshot);
+      renderIntake(els.intake, snapshot);
+      renderDissipation(els.dissipation, snapshot);
+
+      var problems = [];
+      if (!(snapshot.heartbeat || {}).ok) problems.push("heartbeat");
+      if (!(snapshot.self_model || {}).ok) problems.push("self-model");
+      if (!(snapshot.domains || {}).ok) problems.push("domains");
+      if (problems.length) {
+        setStatus(
+          "Updated " +
+            new Date().toLocaleTimeString() +
+            " — degraded source(s): " +
+            problems.join(", "),
+          "text-amber-400"
+        );
+      } else {
+        setStatus(
+          "Updated " +
+            new Date().toLocaleTimeString() +
+            " · polling every " +
+            state.intervalMs / 1000 +
+            "s" +
+            (state.live ? "" : " (paused)"),
+          "text-gray-400"
+        );
+      }
+    } catch (err) {
+      setStatus("Failed to load: " + (err.message || err), "text-red-400");
+    } finally {
+      state.inFlight = false;
+    }
+  }
+
+  function stopTimer() {
+    if (state.timer !== null) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function startTimer() {
+    stopTimer();
+    if (!state.active || !state.live) return;
+    state.timer = setInterval(function () {
+      poll();
+    }, state.intervalMs);
+  }
+
+  function activate() {
+    if (!els.panel && !bindElements()) return;
+    state.active = true;
+    poll({ forceHistory: true });
+    startTimer();
+  }
+
+  function deactivate() {
+    state.active = false;
+    stopTimer();
+    // Rendered DOM is deliberately left in place — see this file's header.
+  }
+
+  function wireControls() {
+    if (els.windowSelect) {
+      els.windowSelect.addEventListener("change", function () {
+        state.windowMinutes = Number(els.windowSelect.value) || 60;
+        poll({ forceHistory: true });
+      });
+    }
+    if (els.intervalSelect) {
+      els.intervalSelect.addEventListener("change", function () {
+        state.intervalMs = Number(els.intervalSelect.value) || 5000;
+        startTimer();
+      });
+    }
+    if (els.liveToggle) {
+      els.liveToggle.addEventListener("change", function () {
+        state.live = !!els.liveToggle.checked;
+        if (state.live) {
+          poll();
+          startTimer();
+        } else {
+          stopTimer();
+          setStatus("Paused. Press Refresh for a single update.", "text-gray-400");
+        }
+      });
+    }
+    if (els.refreshBtn) {
+      els.refreshBtn.addEventListener("click", function () {
+        poll({ forceHistory: true });
+      });
+    }
+  }
+
+  function init() {
+    if (!bindElements()) return;
+    state.intervalMs = Number(els.intervalSelect && els.intervalSelect.value) || 5000;
+    state.windowMinutes = Number(els.windowSelect && els.windowSelect.value) || 60;
+    state.live = !els.liveToggle || !!els.liveToggle.checked;
+    wireControls();
+    // If the tab was deep-linked, app.js's hash routing has already unhidden
+    // the panel by the time this runs — start immediately rather than waiting
+    // for a click that will never come.
+    if (!els.panel.classList.contains("hidden")) {
+      activate();
+    }
+  }
+
+  window.OrionAttentionOrgan = {
+    activate: activate,
+    deactivate: deactivate,
+    refresh: function () {
+      poll({ forceHistory: true });
+    },
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -125,6 +125,13 @@
             class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
             role="button"
           >Collapse Mirror</a>
+          <a
+            id="attentionOrganTabButton"
+            href="#attention-organ"
+            data-hash-target="#attention-organ"
+            class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
+            role="button"
+          >Attention Organ</a>
           {{HUB_AITOWN_TAB_NAV}}
           <a
             id="selfObservabilityTabButton"
@@ -796,6 +803,67 @@
             <div class="text-[10px] uppercase tracking-wide text-gray-500">Selection / trace</div>
             <pre id="organSignalsDetail" class="flex-1 min-h-[12rem] text-[11px] leading-relaxed text-gray-200 bg-gray-950/50 border border-gray-800 rounded-lg p-2 overflow-auto whitespace-pre-wrap font-mono">Tap a node for JSON. If <code class="text-gray-500">otel_trace_id</code> is set, Hub trace chain loads here.</pre>
           </div>
+        </div>
+      </section>
+
+      <section id="attention-organ" data-panel="attention-organ" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="min-w-0">
+            <h2 class="text-xl font-bold text-white">Attention Organ — precision-weighted gain &amp; heartbeat discrimination</h2>
+            <p class="text-xs text-gray-400 max-w-4xl">
+              Live view of <code class="text-gray-500">orion-heartbeat</code>'s N-trajectory tensor-network dissipation ensemble, the
+              <code class="text-gray-500">AttentionSelfModelV1</code> (AST/HOT) row that consumes it, and each Active-Inference domain's
+              raw <code class="text-gray-500">prediction_error</code>. Served by <code class="text-gray-500">/api/attention-organ/*</code>.
+              Design spec: <code class="text-gray-500">docs/superpowers/specs/2026-07-28-precision-weighted-attention-organ-and-heartbeat-discrimination-design.md</code>.
+              Read-only — this surface consumes signals, it does not produce or publish any.
+            </p>
+          </div>
+          <div class="flex items-center gap-2 text-xs shrink-0">
+            <label class="inline-flex items-center gap-1 text-gray-400">
+              Window
+              <select id="attentionOrganWindow" class="rounded border border-gray-600 bg-gray-800 text-gray-200 px-2 py-1">
+                <option value="15">15 min</option>
+                <option value="60" selected>1 hour</option>
+                <option value="360">6 hours</option>
+                <option value="1440">24 hours</option>
+              </select>
+            </label>
+            <label class="inline-flex items-center gap-1 text-gray-400">
+              Poll
+              <select id="attentionOrganInterval" class="rounded border border-gray-600 bg-gray-800 text-gray-200 px-2 py-1">
+                <option value="2000">2s</option>
+                <option value="5000" selected>5s</option>
+                <option value="15000">15s</option>
+                <option value="30000">30s</option>
+              </select>
+            </label>
+            <label class="inline-flex items-center gap-2 text-gray-400">
+              <input id="attentionOrganLive" type="checkbox" class="rounded border border-gray-600 bg-gray-800" checked />
+              Live
+            </label>
+            <button type="button" id="attentionOrganRefreshBtn" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 hover:bg-gray-700">Refresh</button>
+          </div>
+        </div>
+        <div id="attentionOrganStatus" class="text-xs text-gray-400 min-h-[1.25rem]">Open this tab to start polling.</div>
+
+        <div class="grid grid-cols-1 xl:grid-cols-3 gap-4">
+          <div id="attentionOrganEnsemble" class="xl:col-span-1 rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+          <div id="attentionOrganDiscrimination" class="xl:col-span-2 rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+        </div>
+
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-4">
+          <div id="attentionOrganDomains" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+          <div id="attentionOrganDominance" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+        </div>
+
+        <div class="grid grid-cols-1 xl:grid-cols-3 gap-4">
+          <div id="attentionOrganSelfModel" class="xl:col-span-2 rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+          <div id="attentionOrganLink" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+        </div>
+
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-4">
+          <div id="attentionOrganIntake" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+          <div id="attentionOrganDissipation" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
         </div>
       </section>
 
@@ -3365,6 +3433,7 @@
   <script src="/static/js/substrate-effect-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/collapse-mirror.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/aitown-panel.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
+  <script src="/static/js/attention-organ.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/self_observability.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/app.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
 </body>

--- a/services/orion-hub/tests/test_attention_organ_page.py
+++ b/services/orion-hub/tests/test_attention_organ_page.py
@@ -261,12 +261,12 @@ def test_reconcile_confidence_matches_the_reducers_own_formula() -> None:
         ],
         now=NOW,
     )
-    out = reconcile_confidence(domain_rows, 0.5768)
+    out = reconcile_confidence(domain_rows, 0.5768, row_age_sec=1.0)
 
     assert out["domains_used"] == 5
     assert out["recomputed"] == 0.5768
     assert out["delta"] == 0.0
-    assert out["reconciles"] is True
+    assert out["verdict"] == "exact"
 
 
 def test_reconcile_confidence_flags_structural_divergence() -> None:
@@ -280,15 +280,53 @@ def test_reconcile_confidence_flags_structural_divergence() -> None:
         ],
         now=NOW,
     )
-    out = reconcile_confidence(domain_rows, 0.96)
-    assert out["reconciles"] is False
+    out = reconcile_confidence(domain_rows, 0.96, row_age_sec=1.0)
+    assert out["verdict"] == "divergent"
     assert out["recomputed"] == 0.0
+    assert "more than one domain" in out["basis"]
 
 
 def test_reconcile_confidence_reports_unknown_rather_than_a_fake_zero() -> None:
-    assert reconcile_confidence([], 0.5)["reconciles"] is None
+    assert reconcile_confidence([], 0.5)["verdict"] == "unknown"
     rows = build_domain_rows([{"node_id": "node:substrate.execution", "prediction_error": 0.2}], now=NOW)
-    assert reconcile_confidence(rows, None)["reconciles"] is None
+    assert reconcile_confidence(rows, None)["verdict"] == "unknown"
+
+
+def test_reconcile_confidence_does_not_cry_divergence_on_ordinary_sampling_skew() -> None:
+    """The first version of this check used a flat 0.05 tolerance, and live
+    data immediately showed it reporting "divergent" purely as a function of
+    when the operator happened to poll: the row is written on a ~30s tick
+    while the graph read happens now, and two of the five domains genuinely
+    swing across their full range between ticks. A check that fires on its own
+    sampling schedule is noise."""
+    rows = build_domain_rows(
+        [
+            # One domain has fully flipped since the row was written; the other
+            # four are unchanged. Aggregate moves by 1/5 = 0.2 -- entirely
+            # explicable by timing, not by a source mismatch.
+            {"node_id": "node:substrate.execution", "prediction_error": 1.0},
+            {"node_id": "node:substrate.bus_synaptic", "prediction_error": 0.0},
+            {"node_id": "node:substrate.biometrics", "prediction_error": 0.0},
+            {"node_id": "node:substrate.chat", "prediction_error": 0.0},
+            {"node_id": "node:substrate.route", "prediction_error": 0.0},
+        ],
+        now=NOW,
+    )
+    out = reconcile_confidence(rows, 1.0, row_age_sec=14.0)
+    assert out["delta"] == -0.2
+    assert out["verdict"] == "within_drift"
+
+
+def test_reconcile_confidence_withholds_a_verdict_on_a_stale_row() -> None:
+    """Past a point the two readings are too far apart in time for the
+    comparison to carry information, and asserting either way would be
+    manufacturing a verdict."""
+    rows = build_domain_rows(
+        [{"node_id": "node:substrate.execution", "prediction_error": 1.0}], now=NOW
+    )
+    out = reconcile_confidence(rows, 0.1, row_age_sec=3600.0)
+    assert out["verdict"] == "unknown"
+    assert "too far from this graph read" in out["basis"]
 
 
 def test_normalize_history_minutes_rejects_unlisted_windows() -> None:
@@ -385,3 +423,269 @@ def test_attention_organ_js_bounds_its_rolling_client_side_trace() -> None:
     uncapped-accumulation shape already fixed twice in this repo's reducers."""
     assert "liveTraceMax" in ORGAN_JS
     assert "state.liveTrace.splice" in ORGAN_JS
+
+
+# --------------------------------------------------------------------------
+# Endpoint behavior (real handler execution, backends stubbed)
+#
+# Review finding T2: the wiring assertions above are string matches and would
+# pass on syntactically broken code. These execute the handlers so the
+# independent-degradation contract in snapshot()'s docstring, the /history SQL,
+# and the `truncated` flag are actually covered.
+# --------------------------------------------------------------------------
+
+import pytest  # noqa: E402
+
+from scripts import attention_organ_routes as routes  # noqa: E402
+
+
+class _FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, statement, params=None):
+        self.statement = str(statement)
+        self.params = params
+        rows = self._rows
+        if params and "row_cap" in params:
+            rows = rows[: params["row_cap"]]
+
+        class _Result:
+            def mappings(self_inner):
+                return self_inner
+
+            def first(self_inner):
+                return rows[0] if rows else None
+
+            def all(self_inner):
+                return rows
+
+        return _Result()
+
+
+@pytest.fixture
+def stub_backends(monkeypatch):
+    """Each of the three sources is independently stubbable so a single
+    source's failure can be asserted in isolation."""
+
+    calls = {}
+
+    def set_heartbeat(h1_payload, health_payload):
+        def fake_get(path):
+            calls.setdefault("heartbeat_paths", []).append(path)
+            return h1_payload if path == "/h1" else health_payload
+
+        monkeypatch.setattr(routes, "_heartbeat_get", fake_get)
+
+    def set_self_model(rows):
+        monkeypatch.setattr(routes, "_engine", lambda: _FakeEngine(rows))
+
+    class _FakeEngine:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def connect(self):
+            return _FakeConn(self._rows)
+
+    def set_domains(rows_or_exc):
+        def fake_load():
+            if isinstance(rows_or_exc, Exception):
+                raise rows_or_exc
+            return rows_or_exc
+
+        monkeypatch.setattr(routes, "_load_domain_rows", fake_load)
+
+    return {
+        "heartbeat": set_heartbeat,
+        "self_model": set_self_model,
+        "domains": set_domains,
+        "calls": calls,
+    }
+
+
+_GOOD_H1 = {
+    "ok": True,
+    "payload": {"ok": True, "h1": {"mean_ratio": 0.81, "std_ratio": 0.03, "tick_count": 99}},
+}
+_GOOD_HEALTH = {"ok": True, "payload": {"config": {"high_ratio": 0.6, "low_ratio": 0.2}}}
+_GOOD_ROW = {
+    "generated_at": datetime.now(timezone.utc),
+    "self_model_json": {
+        "prediction_error_confidence": 0.5768,
+        "heartbeat_verdict": "redundant",
+        "heartbeat_mean_ratio": 0.81,
+        "heartbeat_basis": "orion-heartbeat /h1 ensemble mean_ratio (tick_count=90)",
+    },
+}
+_GOOD_DOMAINS = [
+    {"node_id": "node:substrate.execution", "prediction_error": 1.0},
+    {"node_id": "node:substrate.bus_synaptic", "prediction_error": 1.0},
+    {"node_id": "node:substrate.biometrics", "prediction_error": 0.102157},
+    {"node_id": "node:substrate.chat", "prediction_error": 0.013468},
+    {"node_id": "node:substrate.route", "prediction_error": 0.00025},
+]
+
+
+def test_snapshot_happy_path_reports_all_three_sources_healthy(stub_backends) -> None:
+    stub_backends["heartbeat"](_GOOD_H1, _GOOD_HEALTH)
+    stub_backends["self_model"]([_GOOD_ROW])
+    stub_backends["domains"](_GOOD_DOMAINS)
+
+    out = routes.snapshot()
+
+    assert out["heartbeat"]["ok"] is True
+    assert out["self_model"]["ok"] is True
+    assert out["domains"]["ok"] is True
+    assert out["domains"]["reconciliation"]["verdict"] in ("exact", "within_drift")
+    assert out["link"]["self_model_has_heartbeat"] is True
+    assert out["link"]["live_tick_count"] == 99
+
+
+def test_snapshot_degrades_each_source_independently(stub_backends) -> None:
+    """snapshot()'s core contract: one backend being down must not blank the
+    other two, which are served by entirely different systems and are still
+    perfectly valid."""
+    stub_backends["heartbeat"]({"ok": False, "error": "ConnectionError: refused"}, {"ok": False, "error": "boom"})
+    stub_backends["self_model"]([_GOOD_ROW])
+    stub_backends["domains"](_GOOD_DOMAINS)
+
+    out = routes.snapshot()
+
+    assert out["heartbeat"]["ok"] is False
+    assert "ConnectionError" in out["heartbeat"]["h1_error"]
+    # The other two survive intact.
+    assert out["self_model"]["ok"] is True
+    assert out["domains"]["ok"] is True
+    assert out["domains"]["reconciliation"]["verdict"] in ("exact", "within_drift")
+    # And nothing is invented for the missing organ.
+    assert out["link"]["live_mean_ratio"] is None
+    assert out["link"]["live_tick_count"] is None
+
+
+def test_snapshot_reports_domain_query_failure_without_losing_the_rest(stub_backends) -> None:
+    stub_backends["heartbeat"](_GOOD_H1, _GOOD_HEALTH)
+    stub_backends["self_model"]([_GOOD_ROW])
+    stub_backends["domains"](RuntimeError("falkordb unreachable"))
+
+    out = routes.snapshot()
+
+    assert out["domains"]["ok"] is False
+    assert "falkordb unreachable" in out["domains"]["error"]
+    assert out["domains"]["rows"] == []
+    assert out["domains"]["reconciliation"]["verdict"] == "unknown"
+    assert out["heartbeat"]["ok"] is True
+    assert out["self_model"]["ok"] is True
+
+
+def test_snapshot_reports_missing_self_model_row_honestly(stub_backends) -> None:
+    stub_backends["heartbeat"](_GOOD_H1, _GOOD_HEALTH)
+    stub_backends["self_model"]([])
+    stub_backends["domains"](_GOOD_DOMAINS)
+
+    out = routes.snapshot()
+
+    assert out["self_model"]["ok"] is False
+    assert out["self_model"]["model"] is None
+    assert out["self_model"]["generated_at"] is None
+    assert out["link"]["self_model_has_heartbeat"] is False
+    assert out["link"]["self_model_age_sec"] is None
+
+
+def test_snapshot_is_not_ok_when_heartbeat_is_reachable_but_has_no_h1_yet(
+    stub_backends,
+) -> None:
+    """Review finding S6: /h1 answers HTTP 200 with {"ok": false} before the
+    first ensemble tick. Transport success is not a reading, and the status
+    line must not call that healthy while the panel shows a red 'no H1' block."""
+    stub_backends["heartbeat"](
+        {"ok": True, "payload": {"ok": False, "reason": "no_h1_computed_yet"}}, _GOOD_HEALTH
+    )
+    stub_backends["self_model"]([_GOOD_ROW])
+    stub_backends["domains"](_GOOD_DOMAINS)
+
+    out = routes.snapshot()
+
+    assert out["heartbeat"]["ok"] is False
+    assert out["heartbeat"]["h1"] is None
+    assert out["heartbeat"]["h1_reason"] == "no_h1_computed_yet"
+    # Not an error — the organ is up, it just has not produced a reading.
+    assert out["heartbeat"]["h1_error"] is None
+
+
+def test_history_executes_its_sql_and_reports_truncation(stub_backends) -> None:
+    rows = [
+        {
+            "generated_at": datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc) + timedelta(seconds=30 * i),
+            "self_model_json": {
+                "heartbeat_verdict": "redundant",
+                "heartbeat_mean_ratio": 0.8,
+                "predicted_shift": "execution prediction-error rising (trend=+0.1 over recent window)",
+            },
+        }
+        for i in range(routes.HISTORY_ROW_CAP + 10)
+    ]
+    stub_backends["self_model"](rows)
+
+    out = routes.history(minutes=360)
+
+    assert out["window_minutes"] == 360
+    assert out["sample_count"] == routes.HISTORY_ROW_CAP
+    assert out["truncated"] is True
+    assert out["verdict_counts"] == {"redundant": routes.HISTORY_ROW_CAP}
+
+
+def test_history_normalizes_an_unlisted_window_before_querying(stub_backends) -> None:
+    stub_backends["self_model"]([_GOOD_ROW])
+    out = routes.history(minutes=7)
+    assert out["window_minutes"] == routes.DEFAULT_HISTORY_MINUTES
+    assert out["truncated"] is False
+
+
+def test_summarize_history_counts_unreadable_rows_rather_than_dropping_them() -> None:
+    """Review finding T3: a window where every row failed to parse must not
+    look identical to a window with no activity."""
+    out = summarize_history(
+        [
+            {"generated_at": datetime.now(timezone.utc), "self_model_json": "not json"},
+            {"generated_at": datetime.now(timezone.utc), "self_model_json": None},
+            {"generated_at": datetime.now(timezone.utc), "self_model_json": {"heartbeat_verdict": "mixed"}},
+        ]
+    )
+    assert out["malformed_row_count"] == 2
+    assert out["sample_count"] == 1
+
+
+def test_attention_organ_js_guards_polling_on_real_visibility() -> None:
+    """Review finding M1: app.js's setActiveTab is not the only thing that can
+    hide this panel — self_observability.js hides every section[data-panel]
+    directly and preventDefault()s its click, so deactivate() never fires on
+    that path. The timer must check the DOM, not trust the router."""
+    assert 'els.panel.classList.contains("hidden")' in ORGAN_JS
+    guard_region = ORGAN_JS[ORGAN_JS.index("function startTimer") : ORGAN_JS.index("function activate")]
+    assert "contains(\"hidden\")" in guard_region
+    assert "deactivate();" in guard_region
+
+
+def test_attention_organ_js_uses_strict_number_isfinite_for_nullable_readings() -> None:
+    """Review finding M2: global isFinite(null) is true, so an offline organ
+    rendered a confident negative tick lag — a number no producer produced."""
+    assert "Number.isFinite(link.live_tick_count)" in ORGAN_JS
+    assert "isFinite(link.live_tick_count)" not in ORGAN_JS.replace(
+        "Number.isFinite(link.live_tick_count)", ""
+    )
+
+
+def test_attention_organ_routes_are_sync_handlers() -> None:
+    """Review finding M3: these do blocking I/O (requests, SQLAlchemy, redis)
+    and the tab auto-polls as fast as every 2s. Declared async, that blocks
+    Hub's event loop — chat, websockets, every route — on every poll."""
+    import inspect
+
+    assert not inspect.iscoroutinefunction(routes.snapshot)
+    assert not inspect.iscoroutinefunction(routes.history)

--- a/services/orion-hub/tests/test_attention_organ_page.py
+++ b/services/orion-hub/tests/test_attention_organ_page.py
@@ -1,0 +1,387 @@
+"""Attention Organ operator tab: pure-logic unit tests + wiring contract.
+
+The wiring half exists because this tab is the *fourth* panel added to
+index.html that has to be registered in five separate places in app.js
+(element binding, missing-panel fallback, visibility toggle, button styling,
+hash routing) plus a script tag plus a nav anchor. Missing any one of them
+produces a tab that looks fine until a specific interaction (deep link,
+switching away and back, a fresh reload) silently falls back to Hub -- a
+failure shape this file turns into a failing test instead of a manual click
+path.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+os.environ.setdefault("CHANNEL_VOICE_TRANSCRIPT", "orion:voice:transcript")
+os.environ.setdefault("CHANNEL_VOICE_LLM", "orion:voice:llm")
+os.environ.setdefault("CHANNEL_VOICE_TTS", "orion:voice:tts")
+os.environ.setdefault("CHANNEL_COLLAPSE_INTAKE", "orion:collapse:intake")
+os.environ.setdefault("CHANNEL_COLLAPSE_TRIAGE", "orion:collapse:triage")
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+from scripts import api_routes  # noqa: E402
+from scripts.attention_organ_routes import (  # noqa: E402
+    ALLOWED_HISTORY_MINUTES,
+    DEFAULT_HISTORY_MINUTES,
+    build_domain_rows,
+    normalize_history_minutes,
+    parse_predicted_shift_domain,
+    reconcile_confidence,
+    summarize_history,
+)
+
+INDEX_HTML = (HUB_ROOT / "templates" / "index.html").read_text(encoding="utf-8")
+APP_JS = (HUB_ROOT / "static" / "js" / "app.js").read_text(encoding="utf-8")
+ORGAN_JS = (HUB_ROOT / "static" / "js" / "attention-organ.js").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# parse_predicted_shift_domain
+# --------------------------------------------------------------------------
+
+
+def test_parse_predicted_shift_domain_reads_the_reducers_real_phrasing() -> None:
+    assert (
+        parse_predicted_shift_domain(
+            "bus_synaptic prediction-error falling (trend=-0.3628 over recent window)"
+        )
+        == "bus_synaptic"
+    )
+    assert (
+        parse_predicted_shift_domain(
+            "execution prediction-error rising (trend=+0.4856 over recent window)"
+        )
+        == "execution"
+    )
+
+
+def test_parse_predicted_shift_domain_returns_none_rather_than_guessing() -> None:
+    """A tally is only worth showing if a phrasing this parser does not
+    understand lands in `null_domain_count` instead of silently contributing
+    a garbage domain name -- an invented domain would be indistinguishable
+    from a real one in the dominance chart."""
+    assert parse_predicted_shift_domain(None) is None
+    assert parse_predicted_shift_domain("") is None
+    assert parse_predicted_shift_domain("nothing notable this tick") is None
+    assert parse_predicted_shift_domain("prediction-error rising") is None
+    # Multi-word prefix: not a domain identifier, so refuse rather than guess.
+    assert parse_predicted_shift_domain("some domain prediction-error rising") is None
+    assert parse_predicted_shift_domain(12345) is None  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# summarize_history
+# --------------------------------------------------------------------------
+
+
+def _row(minutes_ago: int, **payload):
+    base = {
+        "heartbeat_verdict": "redundant",
+        "heartbeat_mean_ratio": 0.81,
+        "prediction_error_confidence": 0.58,
+        "confidence": 0.9,
+        "attention_reason": "bottom_up_salience",
+        "predicted_shift": "execution prediction-error rising (trend=+0.1 over recent window)",
+    }
+    base.update(payload)
+    return {
+        "generated_at": datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+        + timedelta(minutes=minutes_ago),
+        "self_model_json": base,
+    }
+
+
+def test_summarize_history_tallies_verdict_and_domain_distributions() -> None:
+    rows = [
+        _row(0),
+        _row(1, predicted_shift="biometrics prediction-error falling (trend=-0.2 over recent window)"),
+        _row(2, heartbeat_verdict="mixed"),
+    ]
+    out = summarize_history(rows)
+
+    assert out["sample_count"] == 3
+    assert out["verdict_counts"] == {"redundant": 2, "mixed": 1}
+    assert out["verdict_distinct_values"] == 2
+    assert out["domain_counts"] == {"execution": 2, "biometrics": 1}
+    assert out["series"][0]["predicted_shift_domain"] == "execution"
+
+
+def test_summarize_history_keeps_absent_signal_distinct_from_a_band_never_firing() -> None:
+    """"No heartbeat data on this row" and "the concentrated band never fired"
+    are different claims about the organ, and collapsing them would make a
+    broken wire look like a working-but-quiet one."""
+    rows = [_row(0, heartbeat_verdict=None), _row(1, predicted_shift=None)]
+    out = summarize_history(rows)
+
+    assert out["null_verdict_count"] == 1
+    assert out["null_domain_count"] == 1
+    assert out["verdict_counts"] == {"redundant": 1}
+    assert out["series"][0]["heartbeat_verdict"] is None
+
+
+def test_summarize_history_survives_json_strings_and_junk_rows() -> None:
+    rows = [
+        {"generated_at": datetime.now(timezone.utc), "self_model_json": '{"heartbeat_verdict": "mixed"}'},
+        {"generated_at": datetime.now(timezone.utc), "self_model_json": "not json at all"},
+        {"generated_at": datetime.now(timezone.utc), "self_model_json": None},
+    ]
+    out = summarize_history(rows)
+    assert out["sample_count"] == 1
+    assert out["verdict_counts"] == {"mixed": 1}
+
+
+# --------------------------------------------------------------------------
+# build_domain_rows
+# --------------------------------------------------------------------------
+
+
+NOW = datetime(2026, 7, 30, 20, 0, tzinfo=timezone.utc)
+
+
+def test_build_domain_rows_marks_active_inference_membership() -> None:
+    rows = build_domain_rows(
+        [
+            {
+                "node_id": "node:substrate.execution",
+                "prediction_error": 0.4,
+                "observed_at": "2026-07-30T19:59:00+00:00",
+                "activation": 0.9,
+            },
+            {
+                "node_id": "node:substrate.transport",
+                "prediction_error": 0.5,
+                "observed_at": "2026-07-24T21:00:00+00:00",
+                "activation": 0.1,
+            },
+        ],
+        now=NOW,
+    )
+    by_domain = {r["domain"]: r for r in rows}
+
+    assert by_domain["execution"]["active"] is True
+    assert by_domain["execution"]["prediction_error"] == 0.4
+    assert by_domain["execution"]["observed_age_sec"] == 60.0
+    # transport is a confirmed-dead instrument excluded from the aggregate --
+    # still returned so it stays visible rather than hiding.
+    assert by_domain["transport"]["active"] is False
+    assert by_domain["transport"]["present"] is True
+
+
+def test_build_domain_rows_flags_ceiling_and_floor_pins() -> None:
+    """Both directions have real incident history on these exact nodes
+    (bus_synaptic frozen at 1.0, PR #1449; route decayed toward 0.0 by a
+    generic staleness loop) -- neither may render as an ordinary value."""
+    rows = build_domain_rows(
+        [
+            {"node_id": "node:substrate.bus_synaptic", "prediction_error": 1.0},
+            {"node_id": "node:substrate.route", "prediction_error": 0.0},
+            {"node_id": "node:substrate.biometrics", "prediction_error": 0.1},
+        ],
+        now=NOW,
+    )
+    by_domain = {r["domain"]: r for r in rows}
+
+    assert by_domain["bus_synaptic"]["at_ceiling"] is True
+    assert by_domain["bus_synaptic"]["at_floor"] is False
+    assert by_domain["route"]["at_floor"] is True
+    assert by_domain["biometrics"]["at_ceiling"] is False
+    assert by_domain["biometrics"]["at_floor"] is False
+
+
+def test_build_domain_rows_distinguishes_missing_node_from_zero_reading() -> None:
+    rows = build_domain_rows([{"node_id": "node:substrate.chat", "prediction_error": 0.0}], now=NOW)
+    by_domain = {r["domain"]: r for r in rows}
+
+    assert by_domain["chat"]["present"] is True
+    assert by_domain["chat"]["prediction_error"] == 0.0
+    # A known domain whose node does not exist at all is a louder failure than
+    # one reading zero, and must not be rendered as "0.0".
+    assert by_domain["execution"]["present"] is False
+    assert by_domain["execution"]["prediction_error"] is None
+    assert by_domain["execution"]["at_floor"] is False
+
+
+def test_build_domain_rows_keeps_unknown_domains_instead_of_dropping_them() -> None:
+    rows = build_domain_rows(
+        [{"node_id": "node:substrate.brand_new_domain", "prediction_error": 0.3}], now=NOW
+    )
+    assert any(r["domain"] == "brand_new_domain" for r in rows)
+
+
+def test_build_domain_rows_tolerates_unparsable_values_and_timestamps() -> None:
+    rows = build_domain_rows(
+        [
+            {
+                "node_id": "node:substrate.execution",
+                "prediction_error": "not-a-number",
+                "observed_at": "definitely not a timestamp",
+                "activation": "nope",
+            }
+        ],
+        now=NOW,
+    )
+    row = {r["domain"]: r for r in rows}["execution"]
+    assert row["prediction_error"] is None
+    assert row["observed_age_sec"] is None
+    assert row["activation"] is None
+
+
+# --------------------------------------------------------------------------
+# reconcile_confidence
+# --------------------------------------------------------------------------
+
+
+def test_reconcile_confidence_matches_the_reducers_own_formula() -> None:
+    """`1 - mean(prediction_error over ACTIVE_INFERENCE_DOMAINS)` is exactly
+    what `_unconditional_prediction_error_confidence()` computes; verified
+    live 2026-07-30 that the five live domain values reproduce the persisted
+    0.5768 exactly. If this ever stops reconciling, the panel is showing two
+    numbers that no longer describe the same thing."""
+    domain_rows = build_domain_rows(
+        [
+            {"node_id": "node:substrate.execution", "prediction_error": 1.0},
+            {"node_id": "node:substrate.bus_synaptic", "prediction_error": 1.0},
+            {"node_id": "node:substrate.biometrics", "prediction_error": 0.102157},
+            {"node_id": "node:substrate.chat", "prediction_error": 0.013468},
+            {"node_id": "node:substrate.route", "prediction_error": 0.00025},
+            # Excluded domains must not be averaged in, or the check would
+            # disagree with the reducer for a reason that isn't a real defect.
+            {"node_id": "node:substrate.transport", "prediction_error": 0.556078},
+            {"node_id": "node:substrate.harness_closure", "prediction_error": 0.65},
+        ],
+        now=NOW,
+    )
+    out = reconcile_confidence(domain_rows, 0.5768)
+
+    assert out["domains_used"] == 5
+    assert out["recomputed"] == 0.5768
+    assert out["delta"] == 0.0
+    assert out["reconciles"] is True
+
+
+def test_reconcile_confidence_flags_structural_divergence() -> None:
+    domain_rows = build_domain_rows(
+        [
+            {"node_id": "node:substrate.execution", "prediction_error": 1.0},
+            {"node_id": "node:substrate.bus_synaptic", "prediction_error": 1.0},
+            {"node_id": "node:substrate.biometrics", "prediction_error": 1.0},
+            {"node_id": "node:substrate.chat", "prediction_error": 1.0},
+            {"node_id": "node:substrate.route", "prediction_error": 1.0},
+        ],
+        now=NOW,
+    )
+    out = reconcile_confidence(domain_rows, 0.96)
+    assert out["reconciles"] is False
+    assert out["recomputed"] == 0.0
+
+
+def test_reconcile_confidence_reports_unknown_rather_than_a_fake_zero() -> None:
+    assert reconcile_confidence([], 0.5)["reconciles"] is None
+    rows = build_domain_rows([{"node_id": "node:substrate.execution", "prediction_error": 0.2}], now=NOW)
+    assert reconcile_confidence(rows, None)["reconciles"] is None
+
+
+def test_normalize_history_minutes_rejects_unlisted_windows() -> None:
+    for allowed in ALLOWED_HISTORY_MINUTES:
+        assert normalize_history_minutes(allowed) == allowed
+    assert normalize_history_minutes(None) == DEFAULT_HISTORY_MINUTES
+    assert normalize_history_minutes(0) == DEFAULT_HISTORY_MINUTES
+    assert normalize_history_minutes(999999) == DEFAULT_HISTORY_MINUTES
+
+
+# --------------------------------------------------------------------------
+# Wiring contract
+# --------------------------------------------------------------------------
+
+
+def test_routes_are_registered_on_the_hub_api_router() -> None:
+    route_paths = {route.path for route in api_routes.router.routes}
+    assert "/api/attention-organ/snapshot" in route_paths
+    assert "/api/attention-organ/history" in route_paths
+
+
+def test_template_declares_nav_button_panel_and_script_tag() -> None:
+    assert 'data-hash-target="#attention-organ"' in INDEX_HTML
+    assert 'id="attentionOrganTabButton"' in INDEX_HTML
+    assert 'id="attention-organ" data-panel="attention-organ"' in INDEX_HTML
+    assert "/static/js/attention-organ.js?v={{HUB_UI_ASSET_VERSION}}" in INDEX_HTML
+    for mount_id in (
+        "attentionOrganStatus",
+        "attentionOrganEnsemble",
+        "attentionOrganDiscrimination",
+        "attentionOrganDomains",
+        "attentionOrganDominance",
+        "attentionOrganSelfModel",
+        "attentionOrganLink",
+        "attentionOrganIntake",
+        "attentionOrganDissipation",
+    ):
+        assert f'id="{mount_id}"' in INDEX_HTML, mount_id
+
+
+def test_app_js_registers_the_panel_in_every_place_setactivetab_needs() -> None:
+    """All five registration points, not just the visible one -- see this
+    module's docstring for why each omission fails silently and differently."""
+    assert 'document.getElementById("attention-organ")' in APP_JS  # element binding
+    assert 'tabKey === "attention-organ" && !attentionOrganPanel' in APP_JS  # fallback
+    assert 'const isAttentionOrgan = effectiveTab === "attention-organ";' in APP_JS  # flag
+    assert 'attentionOrganPanel.classList.toggle("hidden", !isAttentionOrgan);' in APP_JS  # toggle
+    assert "styleTabButton(attentionOrganTabButton, isAttentionOrgan);" in APP_JS  # styling
+    assert 'h === "#attention-organ" && attentionOrganPanel' in APP_JS  # hash routing
+    assert 'history.replaceState(null, "", "#attention-organ");' in APP_JS  # click handler
+
+
+def test_app_js_drives_the_panels_poll_lifecycle_on_tab_switch() -> None:
+    """Polling must stop when the tab is hidden. Concept Atlas' own comment
+    records the opposite bug already happening once in this codebase (Organ
+    Signals defines deactivate() but app.js never calls it) -- this asserts
+    both halves are wired, not just activate()."""
+    assert "window.OrionAttentionOrgan.activate()" in APP_JS
+    assert "window.OrionAttentionOrgan.deactivate()" in APP_JS
+
+
+def test_attention_organ_js_is_standalone_and_reads_only_its_own_api() -> None:
+    assert "window.OrionAttentionOrgan" in ORGAN_JS
+    assert "activate:" in ORGAN_JS and "deactivate:" in ORGAN_JS
+    assert '"/api/attention-organ/snapshot"' in ORGAN_JS
+    assert '"/api/attention-organ/history"' in ORGAN_JS
+    # Must not depend on app.js's globals -- same standalone contract the
+    # Causal Geometry bundle test asserts.
+    assert "window.OrionHub" not in ORGAN_JS
+    # Read-only surface: no writes to any Orion endpoint from this tab.
+    assert '"POST"' not in ORGAN_JS and "method: 'POST'" not in ORGAN_JS
+
+
+def test_attention_organ_js_renders_structure_not_a_raw_json_dump() -> None:
+    """The point of this tab is a legible operator surface. A JSON.stringify
+    of the snapshot would technically 'visualize' it and would be worthless."""
+    assert "JSON.stringify" not in ORGAN_JS
+    assert "createElementNS" in ORGAN_JS  # real SVG charts
+    for renderer in (
+        "renderEnsemble",
+        "renderDiscrimination",
+        "renderDomains",
+        "renderDominance",
+        "renderSelfModel",
+        "renderLink",
+        "renderIntake",
+        "renderDissipation",
+    ):
+        assert f"function {renderer}(" in ORGAN_JS, renderer
+
+
+def test_attention_organ_js_bounds_its_rolling_client_side_trace() -> None:
+    """A tab left open all day must not grow an unbounded array -- the same
+    uncapped-accumulation shape already fixed twice in this repo's reducers."""
+    assert "liveTraceMax" in ORGAN_JS
+    assert "state.liveTrace.splice" in ORGAN_JS


### PR DESCRIPTION
# Hub Attention Organ operator tab — PR report

Branch: `feat/hub-attention-organ-tab`
Date: 2026-07-30
Status: **DONE_WITH_CONCERNS** (see Risks / concerns — the concerns are live findings this tab
surfaced about *existing* signals, not defects in the tab itself)

## Summary

- New top-level Hub tab, **Attention Organ**, visualizing in near-realtime the three live pieces of
  `docs/superpowers/specs/2026-07-28-precision-weighted-attention-organ-and-heartbeat-discrimination-design.md`,
  which had no human-visible surface anywhere: the heartbeat ensemble, the AST/HOT row that consumes
  it, and each Active-Inference domain's raw prediction error.
- Two panels are the design doc's own **acceptance checks computed live** rather than by eyeballing
  container logs: verdict-band distribution over a window (Acceptance Check 1) and `predicted_shift`
  domain dominance (Acceptance Check 3).
- New read-only Hub API (`/api/attention-organ/snapshot` + `/history`) that fans out to three
  independent backends and degrades each one separately.
- Additive `orion-heartbeat` inspectability so the tab reports **values a real producer produced**
  rather than mirroring another service's constants: per-trajectory `ratios` on `/h1`, and `config`
  (live tuning + verdict band edges), `last_reheat`, `organ_site_map`, `absorb_queue_maxsize` on
  `/health`.
- Read-only throughout: no writes, no bus publish, no new channel, no new schema.

## Outcome moved

The design spec's central question — *does the attention organ actually discriminate, and is its
signal reaching AST/HOT* — was previously answerable only by `docker logs` plus manual Postgres and
FalkorDB queries. It is now a tab. Concretely, within minutes of the tab existing it surfaced two
live problems that were not previously visible (see Risks / concerns).

## Current architecture (before this patch)

- `orion-heartbeat` ran an 8-trajectory quimb MPS dissipation ensemble, exposing `/h1` (mean ratio,
  std, verdict, tick_count, seeds) and `/health` (event counters). Registered in
  `orion/bus/channels.yaml` as a read-only research consumer that "publishes nothing back."
- `orion-substrate-runtime`'s `_attention_self_model_tick()` fetched that `/h1` and threaded it into
  `AttentionSelfModelV1` as `heartbeat_mean_ratio`/`heartbeat_verdict`/`heartbeat_basis`, persisting
  to `substrate_attention_self_model` on a ~30s tick (PR #1459 + the 2026-07-29 heartbeat-into-AST/HOT
  patch).
- Per-domain `prediction_error` lived as a flat property on `node:substrate.<domain>` in the
  `orion_substrate` FalkorDB graph, read back by `_brain_frame_prediction_error_by_domain()`.
- None of these three had any UI. `AttentionSelfModelV1` still has no bus channel and no downstream
  consumer — this patch does not change that.

## Architecture touched

- **services/orion-hub** — new read-only route module + new tab panel + tab-router registration.
- **services/orion-heartbeat** — additive fields on the existing debug HTTP surface only. No change
  to the substrate, the ensemble mathematics, the dissipation loop's behavior, or what it consumes.
- No contract surfaces touched: `orion/bus/channels.yaml`, `orion/schemas/registry.py`, and
  `orion/schemas/` are all unchanged.

## Files changed

- `services/orion-hub/scripts/attention_organ_routes.py` (new): the read-only API. Pure helpers
  (`parse_predicted_shift_domain`, `summarize_history`, `build_domain_rows`, `reconcile_confidence`)
  are separated from I/O so the aggregation logic is testable against fixed rows.
- `services/orion-hub/static/js/attention-organ.js` (new): rendering + poll lifecycle. Vanilla,
  inline SVG, no external deps, `textContent` only.
- `services/orion-hub/tests/test_attention_organ_page.py` (new): 34 tests.
- `services/orion-hub/scripts/api_routes.py`: register the router.
- `services/orion-hub/templates/index.html`: nav anchor, panel section with nine mount points,
  script tag.
- `services/orion-hub/static/js/app.js`: the six registration points `setActiveTab` needs, plus the
  `activate()`/`deactivate()` poll lifecycle.
- `services/orion-hub/app/settings.py`, `.env_example`, `docker-compose.yml`: three new keys.
- `services/orion-heartbeat/app/substrate/ensemble.py`: `EnsembleH1ResultV1.ratios`.
- `services/orion-heartbeat/app/substrate/reconstruction.py`: populate `ratios`; new
  `verdict_thresholds()`.
- `services/orion-heartbeat/app/service.py`: record `last_reheat`; expose `config`,
  `organ_site_map`, `absorb_queue_maxsize` on `/health`.
- `services/orion-heartbeat/tests/{test_reconstruction_h1,test_http_endpoints}.py`: 4 new tests.

## Schema / bus / API changes

- **Added** (HTTP debug surfaces only, no bus/schema registry impact):
  - `orion-heartbeat` `GET /h1` → `h1.ratios: list[float]`, index-aligned with `seeds`.
  - `orion-heartbeat` `GET /health` → `config` (n_trajectories, gamma, base_decay_prob,
    decay_spread_sensitivity, reheat_strength, reheat_prob_scale, decay_reheat_interval_sec,
    h1_interval_sec, high_ratio, low_ratio), `last_reheat`, `organ_site_map`,
    `absorb_queue_maxsize`.
  - Hub `GET /api/attention-organ/snapshot`, `GET /api/attention-organ/history?minutes=`.
- **Removed / renamed**: none.
- **Behavior changed**: none. Every heartbeat addition is a new key on an existing response;
  existing keys are untouched.
- **Compatibility**: the Hub frontend treats every new heartbeat field as optional and renders an
  explicit "not reported by this build" note when absent, so a Hub running against an older
  heartbeat degrades honestly rather than breaking.

## Env/config changes

- Added keys (services/orion-hub): `FALKORDB_SUBSTRATE_GRAPH` (default `orion_substrate` — same env
  key and default `build_falkor_substrate_store_from_env()` already uses, deliberately not a second
  name for the same graph), `HUB_HEARTBEAT_BASE_URL` (default `http://localhost:7251`),
  `HUB_ATTENTION_ORGAN_TIMEOUT_SEC` (default `3.0`).
- Removed keys: none. Renamed keys: none.
- `.env_example` updated: yes. `docker-compose.yml` inline `${VAR:-default}` fallbacks also set to
  the real working values, because a worktree with no Hub `.env` falls through to those, not to
  `.env_example` — the exact gap that silently killed the AST/HOT tick for an hour on 2026-07-29.
- local `.env` synced: yes. `scripts/sync_local_env_from_example.py` skips this service in a fresh
  worktree ("no .env"), so the live `/mnt/scripts/Orion-Sapienform/services/orion-hub/.env` was
  updated directly. `FALKORDB_SUBSTRATE_GRAPH` was already present there (a pre-existing
  `.env`/`.env_example` drift this patch also closes); the two `HUB_*` keys were appended.
- Skipped keys requiring operator action: none.

**`HUB_HEARTBEAT_BASE_URL` is the published port, not the compose DNS name, on purpose.** Verified
live: Hub runs on the host network in this deployment, and `orion-athena-heartbeat` does not resolve
from inside the Hub container while `http://localhost:7251` does.

## Tests run

```text
services/orion-heartbeat$ ORION_BUS_ENABLED=false pytest tests -q
57 passed, 14 warnings in 18.62s

services/orion-hub$ pytest tests/test_attention_organ_page.py -q
34 passed, 15 warnings in 5.33s

services/orion-hub$ pytest tests -q            # full suite
35 failed, 1068 passed, 5 skipped in 171.01s
```

The 35 hub failures are **pre-existing and not caused by this patch**, established by running the
same suite on a scratch worktree at `origin/main`:

```text
origin/main baseline:  34 failures
this branch:           35 failures
symmetric difference:  1 test, and it is a swap WITHIN the same file
  only on branch:   test_substrate_mutation_manual_route_routing.py::test_routing_apply_succeeds_for_auto_promote_and_can_rollback
  only on baseline: test_substrate_mutation_manual_route_routing.py::test_routing_dry_run_produces_trial_and_decision_without_side_effects
```

That file is flaky on both, confirmed by running it in isolation 3× on each:

```text
this branch:  7 passed / 1 failed / 7 passed
origin/main:  1 failed / 1 failed / 1 failed
```

Two of the pre-existing failures assert on `app.js` strings, so they were checked directly rather
than assumed: `openResponseFeedbackModal('up', meta, text)` and
`const substrateTabButton = document.getElementById("substratePageLink");` are absent from
`origin/main`'s `app.js` as well (`grep -cF` → 0 on both). This patch only ever inserted into
`app.js`; every edit was an exact-match replacement asserted `count == 1` and replaced with a
superset.

## Evals run

```text
No eval harness exists for services/orion-hub or services/orion-heartbeat.
```

Neither service has an `evals/` directory. Not created here: the meaningful eval for this surface
would be "does the organ discriminate," which is the *subject* of the design spec's own acceptance
checks and belongs to `orion-heartbeat`'s calibration harness
(`scripts/analysis/measure_heartbeat_ensemble_calibration.py`), not to a read-only viewer of it.
Flagged as a follow-up rather than silently claimed.

## Docker/build/smoke checks

```text
$ scripts/safe_docker_build.sh orion-heartbeat up -d --build
Image orion-heartbeat-heartbeat Built
Container orion-athena-heartbeat Recreated / Started

$ curl -fsS http://localhost:7251/h1
{"ok":true,"h1":{"mean_ratio":0.9041836228299582,"std_ratio":0.03225184412851619,
 "verdict":"redundant","tick_count":90,"seeds":[42,...,49],
 "ratios":[0.94515,0.91386,0.88107,0.90808,0.93307,0.83436,0.92000,0.89787],...}}

$ curl -fsS http://localhost:7251/health
... "last_reheat":{"raw_mean_abs_gap_zscore":29.27,"zscore_saturation":3.0,
     "signal":1.0,"reheat_prob":0.02,"at":"2026-07-30T20:11:50Z"},
    "config":{...,"high_ratio":0.6,"low_ratio":0.2}, "organ_site_map":{...}
```

Hub endpoints exercised through the real `api_routes.router` against live Postgres + FalkorDB +
heartbeat (Hub itself not redeployed — see Restart required):

```text
GET /api/attention-organ/snapshot        -> 200 in 167ms
  heartbeat.ok      True
  reconciliation    verdict=within_drift  delta=0.0022  row_age=0.3s
  link              self_model_mean_ratio 0.7711 == live_mean_ratio 0.7711,
                    basis tick_count 6184 == live tick_count 6184
GET /api/attention-organ/history?minutes=60 -> 200
  sample_count 119, verdict_counts {'redundant': 116}, null_verdict 3,
  domain_counts {'execution': 68, 'bus_synaptic': 40, 'biometrics': 9}
GET /api/attention-organ/history?minutes=7  -> normalized to 60
```

**Metric quality gate** (CLAUDE.md §0A) for the one derived number this tab computes,
`reconciliation.recomputed`:

1. *Provenance*: `1 - mean(prediction_error over ACTIVE_INFERENCE_DOMAINS)`, the literal formula in
   `_unconditional_prediction_error_confidence()`. Inputs are the flat `prediction_error` property
   on `node:substrate.<domain>` — the same values `_brain_frame_prediction_error_by_domain()` feeds
   the reducer.
2. *Independence*: it is not independent, and is not claimed to be — it is deliberately a
   **redundant recomputation** of a value the reducer already stored, whose entire purpose is to
   diff the two.
3. *Theory anchor*: none needed; it is an identity check, not a new measurement.
4. *Live-data sanity*: verified by hand against real data — five live domain values
   (execution 1.0, bus_synaptic 1.0, biometrics 0.102157, chat 0.013468, route 0.00025) give
   `1 - mean = 0.5768`, exactly the persisted `prediction_error_confidence` of the row written at
   the same time.
5. *Existing mechanism*: none — no existing surface compared these two.
6. *Reversibility*: trivially removable; nothing consumes it.

## Review findings fixed

Code review ran in a subagent per CLAUDE.md §12. All three must-fix and all seven should-fix
findings were fixed.

- **M1 — poll timer never stops when leaving via the "Self" tab.**
  `self_observability.js` hides every `section[data-panel]` directly and `preventDefault()`s its own
  click, and `app.js` has zero references to it — so `setActiveTab`, the only caller of
  `deactivate()`, never runs on that path. The timer would have kept firing forever into a hidden
  panel: 2 HTTP calls + a Postgres query + a FalkorDB query every 2–5s.
  - Fix: the interval body checks real DOM visibility and self-deactivates, so the contract holds
    against any panel that hides it, not just the current router.
  - Evidence: `test_attention_organ_js_guards_polling_on_real_visibility` inspects the
    `startTimer`→`activate` region for both the visibility check and the `deactivate()` call.

- **M2 — fabricated `tick lag` when the organ is offline.**
  Global `isFinite(null)` is `true`, so an unreachable heartbeat (`live_tick_count: null`) rendered
  a confident negative lag in ordinary gray, next to two rows honestly showing `—` for the same
  null. Reviewer reproduced it: `lag rendered: -1614`.
  - Fix: `Number.isFinite`. The `lag > 5000` amber threshold was also removed — `tick_count` counts
    absorbed events at a rate set entirely by live organ traffic, so no fixed threshold means
    anything (and 5000 was larger than the metric had ever been). Staleness is now keyed on row age,
    which is a real duration.
  - Evidence: `test_attention_organ_js_uses_strict_number_isfinite_for_nullable_readings`.

- **M3 — blocking I/O on the event loop at a 2s cadence.**
  Both handlers were `async def` with blocking `requests.get` ×2, blocking SQLAlchemy, and blocking
  redis — up to ~6s of a frozen Hub (chat, websockets, every route) per poll. The pattern exists in
  older read-only route modules, but those are user-initiated one-shots, not an always-open tab.
  - Fix: dropped `async`; FastAPI runs sync handlers in its threadpool.
  - Evidence: `test_attention_organ_routes_are_sync_handlers` asserts via `inspect.iscoroutinefunction`.

- **S1 — history failure masked, stale history rendered as current.** The "History unavailable"
  status was immediately overwritten by "Updated <now>", while `lastHistory` kept rendering an old
  window under its own `window_minutes`/`sample_count` labels.
  - Fix: `state.historyError`, `"history"` pushed into the status line's degraded list, and a
    banner on both history-backed panels stating how old the data actually is.

- **S2 — hardcoded `"0.2"` band edge**, the exact mirrored constant `verdict_thresholds()` was added
  to eliminate. Fix: with no live `config`, the sentence omits the number entirely.

- **S3 — `last_reheat` staleness invisible.** `service.py` only overwrites it after a *successful*
  tick, so a persistently failing FalkorDB query serves the last good block forever. Fix: aged
  against the loop's own `decay_reheat_interval_sec` and flagged amber past 5×.

- **S4 — new Redis client + connection pool per request**, never closed (the class has no
  `close()`). Not an unbounded leak, but ~30 TCP connect/teardowns per minute for a 7-row query.
  Fix: module-level cache, matching `_engine()` directly above it.

- **S5 — unlabeled `MATCH (n)`** on the substrate concept graph, with no index on `node_id`
  (confirmed: `CALL db.indexes()` is empty), scanned every poll. Fix: `MATCH (n:SubstrateNode)`.
  `STARTS WITH` kept over an `IN $ids` form so an unknown future domain node is still discovered.

- **S6 — `heartbeat.ok` true when there is no H1 at all.** `/h1` answers HTTP 200 with
  `{"ok": false, "reason": "no_h1_computed_yet"}` before the first ensemble tick; the transport-level
  flag reported healthy while the panel showed a red "no H1" block. Fix: `and live_h1 is not None`.
  Evidence: `test_snapshot_is_not_ok_when_heartbeat_is_reachable_but_has_no_h1_yet`.

- **S7 — no PR report.** This file.

- **T2/T3 — tests were string-matching, not behavior.** Added 9 tests that execute the handlers with
  stubbed backends, covering snapshot's independent-degradation contract (all three failure
  branches), the `/history` SQL, and the `truncated` flag. Added `malformed_row_count` so a window
  where every row failed to parse cannot look identical to a window with no activity.

- **N1/N2/N4/N5/N6 fixed** (time-proportional x-axis so an outage draws as a gap rather than an
  unbroken line; lag threshold removed; trace relabeled "ensemble ticks" since it deduplicates on
  `tick_count`; a comment that asserted the opposite of the real load order corrected;
  `absorb_queue_maxsize` given the consumer it was shipped without). **N7 fixed** by dropping two
  unrendered fields from the history series payload. N3 left as-is — it degrades honestly.

### Found by live verification after the review, not by the review

The reviewer confirmed `reconcile_confidence`'s `abs(delta) <= 0.05` tolerance matched the reducer
exactly on the data it was tested against. A later live poll returned `delta = -0.0908` →
`reconciles: False`, and the cause was not a defect in either signal: the row is written on
substrate-runtime's ~30s tick while the graph read happens now, and `execution`/`bus_synaptic`
genuinely swing across their whole range between ticks. A flat tolerance therefore reported
"divergent" **as a function of when the operator happened to poll** — a check firing on its own
sampling schedule, which is precisely the kind of instrument this tab exists to expose.

Replaced with a stated model rather than a tuned constant: one of five domains traversing its full
range can move the mean by at most `1/5 = 0.2`, so a delta within that is `within_drift`; beyond it
would need two or more domains to have moved fully, which points at a source mismatch. Past a 60s
row age the comparison carries no information either way and the verdict is withheld (`unknown`)
rather than manufactured. `basis` states which rule fired. Covered by
`test_reconcile_confidence_does_not_cry_divergence_on_ordinary_sampling_skew` and
`test_reconcile_confidence_withholds_a_verdict_on_a_stale_row`.

## Restart required

`orion-heartbeat` is already rebuilt and running with this branch's code (see Docker checks). Note
its ensemble restarts from a fresh random state on every deploy — v0 has no crash-safe persistence
by design, so `tick_count` reset from ~35,700 to 0.

Hub still needs a redeploy to pick up the new route module and settings. `templates/` and `static/`
are volume-mounted **relative to the checkout the deploy runs from**, so this must be run from the
main checkout after merge, not from the worktree — deploying Hub from a worktree would repoint those
mounts at a directory that disappears when the worktree is pruned:

```bash
cd /mnt/scripts/Orion-Sapienform
git pull --ff-only
scripts/safe_docker_build.sh orion-hub up -d --build
curl -fsS http://localhost:8081/api/attention-organ/snapshot | head -c 400
```

(That wrapper refuses to run from the shared checkout by design. Deploying Hub is the documented
exception that needs `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1`, set consciously for this one command.)

## Risks / concerns

Both concerns are **live findings about existing signals that this tab made visible**. Neither is a
defect in this patch, and neither is fixed here — fixing either is a heartbeat/substrate calibration
change that needs its own metric-quality-gate pass and its own proposal.

- **Severity: should-fix. The `bus_synaptic` reheat driver is fully saturated, so it is not gating
  anything.** `last_reheat.raw_mean_abs_gap_zscore` reads **~29.3** against a
  `BUS_SYNAPTIC_ZSCORE_SATURATION` of **3.0**, making `signal = min(1, z/3.0)` a constant **1.0**
  and `reheat_prob` a constant `0.02` regardless of how bus activity moves. Verified stable across
  three direct FalkorDB samples (29.30 / 29.31 / 29.27 over 436 edges, max |gap_zscore| 7087.8).
  The design spec's own calibration states this raw value "sits around 1.0-1.1 during normal
  operation" — it is ~30× that. The whole point of the reheat term is to be a *dynamic* driver;
  clipped at its ceiling it is a constant. The tab flags this explicitly with a red "saturated"
  badge and an explanation.
  *Mitigation*: none applied. Recommend re-deriving the saturation constant against real
  `orion_bus_synapse` data before the reheat term is trusted as dynamic — and checking whether the
  underlying `gap_zscore` distribution itself is healthy, given a max of 7087.

- **Severity: note. Acceptance Check 1 is still not met live, and the tab says so.** 24h of persisted
  rows carry exactly one distinct `heartbeat_verdict` (`redundant`). This is already documented in
  the spec as a structural gap deferred by explicit decision (2026-07-29), not a new finding — but
  the tab now states it as a live verdict rather than leaving it to a doc.

- **Severity: note. Two Active-Inference domains sit pinned at exactly 1.0.** `execution` and
  `bus_synaptic` both read a saturated `prediction_error = 1.0` on most ticks, dragging
  `prediction_error_confidence` into a bimodal 0.5768 ↔ ~0.96 pattern. `chat` and `transport` nodes
  are ~6 days stale, and `chat` is nonetheless still averaged into the aggregate by the upstream
  reducer. All are flagged in the tab (red at-ceiling badges, staleness ages) rather than rendered as
  ordinary values. Directly relevant to the spec's still-open Missing Question 3.

- **Severity: note. No eval harness** for either touched service (see Evals run).

## PR link

<to be filled after push>
