### PR TITLE
fix(hub): protect reducer-owned metadata in concept decay scheduler

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-30-concept-decay-scheduler-metadata-protection-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-concept-decay-scheduler-metadata-protection-pr.md
@@ -1,0 +1,82 @@
+# Concept decay scheduler metadata-clobber protection
+
+## Summary
+
+- Fourth fix in a same-day incident chain (PR #1498, #1501, #1503) around `node:substrate.bus_synaptic`'s `prediction_error` getting durably frozen/nulled by unprotected writes.
+- `decay_concept_activations()` (`services/orion-hub/scripts/api_routes.py`) reads a concept node's full metadata via `snapshot()`, recomputes only `signals.activation`, and re-persists the whole node — re-writing whatever stale copy of reducer-owned fields (`prediction_error`, `contributing_turn_ids`) happened to be in that read.
+- Lower frequency than the materializer/concept-induction paths (scheduler-triggered, not a tight loop), so lower collision probability, but the same bug class.
+- Fix: `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`, same reused protection as the earlier PRs.
+
+## Outcome moved
+
+Closes another live instance of the same-day incident's root bug class in the Hub's periodic concept-activation decay pass.
+
+## Current architecture
+
+`decay_concept_activations()` runs on a schedule (Hub's own scheduler) over `SUBSTRATE_SEMANTIC_STORE`'s concept nodes, decaying `signals.activation.activation` toward each node's configured floor based on elapsed time since `observed_at`, then re-persisting each node via `upsert_node()`.
+
+## Architecture touched
+
+`services/orion-hub` only. No contract/schema/bus changes.
+
+## Files changed
+
+- `services/orion-hub/scripts/api_routes.py`: `decay_concept_activations()`'s `upsert_node()` call now passes `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`.
+- `services/orion-hub/tests/test_substrate_concept_decay_scheduler.py`: new test `test_decay_concept_activations_protects_reducer_owned_metadata` spies on the store's `upsert_node` and asserts the kwarg is passed correctly.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-hub/tests/test_substrate_concept_decay_scheduler.py -q
+9 passed (8 baseline + 1 new), zero regressions.
+```
+
+Red-before-green confirmed via `git show HEAD:<path>` (not `git stash` — see sibling PRs' reports for why).
+
+## Evals run
+
+Not applicable.
+
+## Docker/build/smoke checks
+
+```
+$ bash scripts/safe_docker_build.sh orion-hub up -d --build
+... rebuilt and restarted ...
+```
+
+Live-verified: clean startup, serving requests normally post-restart.
+
+## Review findings fixed
+
+Code review pass (subagent) found **no blocking issues**. Notes from that pass:
+
+- Traced every concrete backend `build_substrate_store_from_env()` can return (`InMemorySubstrateGraphStore`, `FalkorSubstrateStore` — the live backend — `RoutedSubstrateGraphStore`, `GraphDBSubstrateStore`/`SparqlSubstrateStore`): all already declare and correctly handle `skip_metadata_keys` in their shared abstract interface, so this call could not have broken any real backend the way a mismatched test-double wrapper did on the sibling materializer PR.
+- Confirmed this is the only `SUBSTRATE_SEMANTIC_STORE.upsert_node()` call site in `api_routes.py` — no other collision risk in this file.
+- Flagged (informationally, not a defect in this diff): `services/orion-hub/scripts/concept_atlas_routes.py`'s `_CountingSubstrateStore.upsert_node()` still lacks `skip_metadata_keys` as of this branch's tip — already found and fixed on the sibling `fix/bus-synaptic-materializer-clobber` branch (commit `79acfd871`), unrelated to this diff's own call path.
+- Minor, non-blocking observation: the new test verifies wiring (the kwarg is passed) via a spy, matching the rigor level of the sibling materializer PR's own test, but doesn't independently re-verify the *value* survives an actual race the way `orion/substrate/tests/test_dynamics.py`'s more elaborate race-simulation test does for the original `SubstrateDynamicsEngine.tick()` fix. Not fixed here — the underlying store-level merge behavior is already covered by that existing test suite; this PR's test only needed to prove correct wiring at this new call site.
+
+## Restart required
+
+```
+bash scripts/safe_docker_build.sh orion-hub up -d --build
+```
+
+Already run during this session's live verification. No further restart needed unless this branch is rebuilt from a fresh checkout.
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: None material identified by review.
+- Mitigation: N/A.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/concept-decay-scheduler-metadata-protection

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -127,6 +127,7 @@ from orion.core.schemas.substrate_mutation import (
 )
 from orion.core.activation_decay import decay_activation
 from orion.substrate import build_substrate_policy_store_from_env, build_substrate_store_from_env
+from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
 from orion.substrate.consolidation import GraphConsolidationEvaluator
 from orion.substrate.policy_comparison import SubstratePolicyComparisonService
 from orion.substrate.review_queue import GraphReviewQueue
@@ -369,8 +370,20 @@ def decay_concept_activations(elapsed_seconds: Optional[float] = None) -> dict[s
             updated_signals = node.signals.model_copy(update={"activation": updated_signal})
             updated_node = node.model_copy(update={"signals": updated_signals})
 
+            # skip_metadata_keys: updated_node's metadata is node.metadata,
+            # read moments earlier by SUBSTRATE_SEMANTIC_STORE.snapshot()
+            # above -- only signals.activation is actually recomputed here,
+            # but re-persisting the whole node re-writes reducer-owned
+            # metadata fields (prediction_error, contributing_turn_ids) from
+            # that stale read too. Same protection already proven for
+            # SubstrateDynamicsEngine.tick() and (2026-07-30)
+            # SubstrateGraphMaterializer.apply_record()'s merge branch and
+            # concept_induction's materialize_concept_profile_to_falkor() --
+            # see falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring.
             SUBSTRATE_SEMANTIC_STORE.upsert_node(
-                identity_key=identity_by_node_id.get(node.node_id), node=updated_node
+                identity_key=identity_by_node_id.get(node.node_id),
+                node=updated_node,
+                skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS,
             )
             summary["decayed"] += 1
         except Exception as exc:

--- a/services/orion-hub/tests/test_substrate_concept_decay_scheduler.py
+++ b/services/orion-hub/tests/test_substrate_concept_decay_scheduler.py
@@ -229,6 +229,38 @@ def test_decay_concept_activations_skips_malformed_activation_without_crashing(m
     assert updated_good.signals.activation.activation < 0.6
 
 
+def test_decay_concept_activations_protects_reducer_owned_metadata(monkeypatch) -> None:
+    """Regression guard (2026-07-30): the decay scheduler reads a node's full
+    metadata via snapshot(), mutates only signals.activation, and re-persists
+    the whole node -- without skip_metadata_keys, that re-persists whatever
+    (possibly stale, relative to a concurrent reducer write) copy of
+    reducer-owned fields like prediction_error happened to be in this read.
+    Same protection already proven for SubstrateDynamicsEngine.tick() and
+    (2026-07-30) SubstrateGraphMaterializer.apply_record()'s merge branch --
+    see falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring."""
+    from unittest.mock import patch
+
+    from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
+
+    fresh_store = InMemorySubstrateGraphStore()
+    node = _make_concept_node(
+        node_id="concept-reducer-owned",
+        activation=0.9,
+        decay_half_life_seconds=3600,
+        decay_floor=0.0,
+        observed_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    node = node.model_copy(update={"metadata": {"prediction_error": 0.42}})
+    fresh_store.upsert_node(identity_key=node.node_id, node=node)
+    monkeypatch.setattr(api_routes, "SUBSTRATE_SEMANTIC_STORE", fresh_store)
+
+    with patch.object(fresh_store, "upsert_node", wraps=fresh_store.upsert_node) as spy:
+        api_routes.decay_concept_activations()
+
+    spy.assert_called_once()
+    assert spy.call_args.kwargs.get("skip_metadata_keys") == EXTERNALLY_OWNED_METADATA_KEYS
+
+
 def test_decay_concept_activations_snapshot_failure_never_raises(monkeypatch) -> None:
     class _BoomStore:
         def snapshot(self):


### PR DESCRIPTION
## Summary

Fourth fix in a same-day incident chain (#1498, #1501, #1503). `decay_concept_activations()` reads a concept node's full metadata, recomputes only `signals.activation`, and re-persists the whole node with no `skip_metadata_keys` protection — same bug class, lower frequency (scheduler-triggered, not a tight loop).

Fix: `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`, reusing the same protection as the earlier PRs.

## Live verification

Rebuilt + restarted `orion-hub`, confirmed clean startup and normal request serving.

## Test plan

- [x] `pytest services/orion-hub/tests/test_substrate_concept_decay_scheduler.py -q` — 9/9 passing, zero regressions
- [x] Red-before-green confirmed
- [x] Code review pass — no blocking issues. Traced every real backend `build_substrate_store_from_env()` can return; all already support `skip_metadata_keys`, so no test-double regression risk like #1501 hit.
- [x] Rebuilt + restarted the service, live-verified

Full write-up: `docs/superpowers/pr-reports/2026-07-30-concept-decay-scheduler-metadata-protection-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)