### PR TITLE
fix(recall): protect reducer-owned metadata in concept-region reinforcement

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-30-concept-region-reinforcement-metadata-protection-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-concept-region-reinforcement-metadata-protection-pr.md
@@ -1,0 +1,84 @@
+# Concept-region reinforcement metadata-clobber protection
+
+## Summary
+
+- Fifth fix in a same-day incident chain (PR #1498, #1501, #1503, #1505) around `node:substrate.bus_synaptic`'s `prediction_error` getting durably frozen/nulled by unprotected writes.
+- `reinforce_matched_concepts()` (`services/orion-recall/app/collectors/concept_region.py`) reads a concept node's full metadata via `get_node_by_id()`, boosts only `signals.activation.activation`, and re-persists the whole node — re-writing whatever stale copy of reducer-owned fields happened to be in that read.
+- Lower frequency than the materializer/concept-induction paths (query-triggered per matched turn, not a tight loop), same bug class.
+- Fix: `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`, same reused protection as the earlier PRs.
+
+## Outcome moved
+
+Closes another live instance of the same-day incident's root bug class, in orion-recall's concept-region reinforcement path.
+
+## Current architecture
+
+`reinforce_matched_concepts()` is called from `fetch_concept_region_fragment_and_reinforce()`, itself called from `orion-recall`'s worker for turns that mention a seeded concept label — boosting the matched concept node's activation toward 1.0 (a recall-relevance signal) and re-persisting via `store.upsert_node()`. Production resolves `store` to a real `FalkorSubstrateStore` (`SUBSTRATE_STORE_BACKEND=falkor` is this service's configured default).
+
+## Architecture touched
+
+`services/orion-recall` only. No contract/schema/bus changes.
+
+## Files changed
+
+- `services/orion-recall/app/collectors/concept_region.py`: `reinforce_matched_concepts()`'s `store.upsert_node()` call now passes `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`.
+- `services/orion-recall/tests/test_concept_region_collector.py`: new test `test_reinforcement_protects_reducer_owned_metadata` spies on the store's `upsert_node` and asserts the kwarg is passed correctly.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-recall/tests/test_concept_region_collector.py -q
+28 passed (27 baseline + 1 new), zero regressions.
+
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-recall/tests -q
+243 passed, 3 pre-existing failures — confirmed identical on main, zero regressions.
+```
+
+Red-before-green confirmed via `git show HEAD:<path>` (not `git stash`).
+
+## Evals run
+
+Not applicable.
+
+## Docker/build/smoke checks
+
+```
+$ bash scripts/safe_docker_build.sh orion-recall up -d --build
+... rebuilt and restarted ...
+```
+
+Live-verified: clean startup (bus connected, RPC listener ready). One pre-existing, unrelated log line at startup (`RDF endpoint check failed ... orion-athena-fuseki ... NameResolutionError`) — expected, Fuseki was fully decommissioned in an earlier, unrelated change; not caused by this patch.
+
+## Review findings fixed
+
+Code review pass (subagent) found **no blocking issues** in this diff's own files. Notes from that pass:
+
+- Traced the real production call chain (`worker.py` → `fetch_concept_region_fragment_and_reinforce` → `get_substrate_store()` → `build_substrate_store_from_env()`) and confirmed `.env`/`.env_example`/`docker-compose.yml` all set `SUBSTRATE_STORE_BACKEND=falkor`, so production genuinely uses `FalkorSubstrateStore`, which already correctly supports `skip_metadata_keys`. Also checked every other concrete backend for completeness — all support it, no test-double regression risk like PR #1501 hit for a different service.
+- Confirmed no other write call site in `orion-recall` touches substrate nodes — this was the only unprotected `upsert_node()` call in the service.
+- **Flagged an inaccuracy in this diff's own code comment**: the comment lists `concept_induction`'s `materialize_concept_profile_to_falkor()` as already having this same protection "proven" — that's correct as of when this PR's branch was created, but the reviewing agent's worktree happened to predate PR #1503 (which fixes exactly that function) landing/being reviewed, so it read as unfixed from that vantage point. No code change needed here since PR #1503 already covers it; noting for the record so a future reader isn't confused by the apparent mismatch between the comment and an isolated worktree's view of `git log --all`.
+
+## Restart required
+
+```
+bash scripts/safe_docker_build.sh orion-recall up -d --build
+```
+
+Already run during this session's live verification. No further restart needed unless this branch is rebuilt from a fresh checkout.
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: None material identified by review.
+- Mitigation: N/A.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/concept-region-reinforcement-metadata-protection

--- a/services/orion-recall/app/collectors/concept_region.py
+++ b/services/orion-recall/app/collectors/concept_region.py
@@ -38,6 +38,7 @@ import logging
 from typing import Any, Iterable
 
 from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
+from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
 from orion.substrate.store import SubstrateGraphStore
 
 logger = logging.getLogger(__name__)
@@ -245,7 +246,22 @@ def reinforce_matched_concepts(
             updated_signal = activation_signal.model_copy(update={"activation": boosted})
             updated_signals = node.signals.model_copy(update={"activation": updated_signal})
             updated_node = node.model_copy(update={"signals": updated_signals})
-            store.upsert_node(identity_key=identity_key, node=updated_node)
+            # skip_metadata_keys: updated_node's metadata is node.metadata,
+            # read moments earlier by get_node_by_id() above -- only
+            # signals.activation is actually recomputed here, but
+            # re-persisting the whole node re-writes reducer-owned metadata
+            # fields (prediction_error, contributing_turn_ids) from that
+            # stale read too. Same protection already proven for
+            # SubstrateDynamicsEngine.tick() and (2026-07-30)
+            # SubstrateGraphMaterializer.apply_record()'s merge branch,
+            # concept_induction's materialize_concept_profile_to_falkor(),
+            # and orion-hub's concept decay scheduler -- see
+            # falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring.
+            store.upsert_node(
+                identity_key=identity_key,
+                node=updated_node,
+                skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS,
+            )
             reinforced += 1
         except Exception as exc:  # noqa: BLE001 - one node's failure must not block the rest
             logger.debug("concept_region reinforcement: node %s failed: %s", node_id, exc)

--- a/services/orion-recall/tests/test_concept_region_collector.py
+++ b/services/orion-recall/tests/test_concept_region_collector.py
@@ -291,6 +291,33 @@ def test_reinforcement_skips_unknown_node_ids():
     assert reinforced == 0
 
 
+def test_reinforcement_protects_reducer_owned_metadata():
+    """Regression guard (2026-07-30): reinforce_matched_concepts reads a
+    node's full metadata via get_node_by_id(), mutates only
+    signals.activation, and re-persists the whole node -- without
+    skip_metadata_keys, that re-persists whatever (possibly stale, relative
+    to a concurrent reducer write) copy of reducer-owned fields like
+    prediction_error happened to be in this read. Same protection already
+    proven for SubstrateDynamicsEngine.tick() and (2026-07-30)
+    SubstrateGraphMaterializer.apply_record()'s merge branch -- see
+    falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring."""
+    from unittest.mock import patch
+
+    from orion.substrate.falkor_codec import EXTERNALLY_OWNED_METADATA_KEYS
+
+    store = _seeded_store()
+    node = store.get_node_by_id("sub-concept-seed-juniper")
+    identity_key = store.get_identity_key_by_node_id("sub-concept-seed-juniper")
+    node = node.model_copy(update={"metadata": {"prediction_error": 0.42}})
+    store.upsert_node(identity_key=identity_key, node=node)
+
+    with patch.object(store, "upsert_node", wraps=store.upsert_node) as spy:
+        reinforce_matched_concepts(["sub-concept-seed-juniper"], store=store)
+
+    spy.assert_called_once()
+    assert spy.call_args.kwargs.get("skip_metadata_keys") == EXTERNALLY_OWNED_METADATA_KEYS
+
+
 def test_reinforcement_empty_ids_is_a_noop():
     store = _seeded_store()
 


### PR DESCRIPTION
## Summary

Fifth fix in a same-day incident chain (#1498, #1501, #1503, #1505). `reinforce_matched_concepts()` reads a concept node's full metadata, boosts only `signals.activation`, and re-persists the whole node with no `skip_metadata_keys` protection — same bug class.

Fix: `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`, reusing the same protection as the earlier PRs.

## Live verification

Rebuilt + restarted `orion-recall`, confirmed clean startup and bus connectivity.

## Test plan

- [x] `pytest services/orion-recall/tests -q` — 243 passed, 3 pre-existing unrelated failures (confirmed identical on `main`), zero regressions
- [x] Red-before-green confirmed
- [x] Code review pass — no blocking issues. Traced the real production call chain to confirm `FalkorSubstrateStore` (the live backend) already supports `skip_metadata_keys`.
- [x] Rebuilt + restarted the service, live-verified

Full write-up: `docs/superpowers/pr-reports/2026-07-30-concept-region-reinforcement-metadata-protection-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)