### PR TITLE
fix(substrate): widen materializer's existing-node fallback to catch raw node_id collisions

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-30-materializer-identity-fallback-gap-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-materializer-identity-fallback-gap-pr.md
@@ -1,0 +1,84 @@
+# Materializer node_id-collision fallback gap fix
+
+## Summary
+
+- Found during code review of PR #1501 (bus_synaptic materializer clobber fix): `SubstrateGraphMaterializer.apply_record()`'s existing-node lookup only fell back to a direct `get_node_by_id(node.node_id)` check when `identity_key` was `None` outright.
+- When `identity_key` resolved to something (the common case) but the identity-index lookup found nothing, `apply_record()` took the "created" branch: a full wholesale overwrite via `node.model_copy()`, no `merge_node()` call, no `skip_metadata_keys` protection at all — worse than a metadata-only clobber, since it replaces the entire node.
+- Fix: widen the fallback to fire whenever the identity lookup comes up empty, regardless of whether `identity_key` was `None` or just unresolved.
+- Verified correct and beneficial standing alone (converts a full-node replace into a same-call metadata-preserving merge via `reconcile.merge_node()`'s existing-wins precedence), and verified to combine cleanly with PR #1501 via `git merge-tree` (no conflicts, complementary line ranges).
+
+## Outcome moved
+
+Closes a narrow but real gap: any node_id collision where the existing node's registered identity_key doesn't match what `SubstrateIdentityResolver.canonical_node_key()` independently computes for a colliding incoming node — exactly the shape of every reducer-owned node (`_write_prediction_error_node` registers `f"substrate_prediction_error|{node_id}"`, never reproducible by the resolver) — no longer risks a full wholesale node replacement.
+
+## Current architecture
+
+`apply_record()` resolves each incoming node's canonical identity via `SubstrateIdentityResolver.canonical_node_key()`, looks that up in the store's identity index, and only fell back to a raw `node_id` check when the resolver itself returned `None`. The durable Falkor write (`MERGE (n:SubstrateNode:{label} {node_id: $node_id})`) is keyed purely on raw `node_id` regardless of any of this Python-level identity bookkeeping — so a collision at that layer was always inevitable once two records shared a `node_id`; this patch only changes which merge *strategy* gets applied to a collision the store was always going to make anyway.
+
+## Architecture touched
+
+`orion/substrate/materializer.py` only (shared library, used by `orion-cortex-exec-background`'s concept-induction pipeline and other materializer callers). No contract/schema/bus changes.
+
+## Files changed
+
+- `orion/substrate/materializer.py`: widened the existing-node fallback; the merge-decision `reason` field now correctly reports `"node_id_match"` (not `"identity_match"`) when the raw-id fallback is what found the match.
+- `orion/substrate/tests/test_materializer_node_id_collision_fallback.py` (new): two tests — one confirms a node_id collision with an unregistered/mismatched identity_key takes the merge branch (not created) and preserves reducer-owned metadata; the other confirms genuinely new node_ids still take the created branch normally.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/substrate/tests/test_materializer_node_id_collision_fallback.py -q
+2 passed
+
+$ /mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest orion/substrate/tests --ignore=orion/substrate/relational/tests -q
+491 passed (489 baseline + 2 new), zero regressions.
+```
+
+Red-before-green confirmed via `git show HEAD:<path>` (not `git stash` — a real cross-worktree stash leak happened during this exact investigation; see the "Incident" note below and `feedback_git_stash_shared_across_worktrees` memory, updated this session).
+
+## Evals run
+
+Not applicable.
+
+## Docker/build/smoke checks
+
+Not run for this specific patch — it's a narrow, low-frequency edge-case fallback (a node_id collision with a mismatched identity_key), not a demonstrated live symptom the way the sibling bus_synaptic fixes were. Covered by unit tests; live verification wasn't pursued given the low blast radius and that `orion-cortex-exec-background` was already rebuilt/redeployed once this session for the sibling materializer-clobber fix (PR #1501), which this patch is designed to combine cleanly with.
+
+## Review findings fixed
+
+- Finding: three places (commit message, module docstring, `_reducer_owned_node()` helper docstring) claimed `_write_prediction_error_node` calls `store.upsert_node(identity_key=None, ...)`. Confirmed false via reading `services/orion-substrate-runtime/app/worker.py:1044-1047` — it registers a real, non-`None` identity_key (`f"substrate_prediction_error|{node_id}"`), present since 2026-07-01 (`git log -p -S`), not a recent drift.
+  - Fix: corrected all three docstrings/comments and the test's own seed call to register that real identity_key convention instead of `None`. Re-verified the test still passes — it never depended on the false claim; `SubstrateIdentityResolver.canonical_node_key()` never reproduces the reducer's identity_key format regardless of whether the registered value was `None` or that real string, so the raw-node_id fallback under test is exercised correctly either way, now for the accurate reason. Follow-up commit `f45d6a4c3`.
+  - Evidence: `git log -p -S "identity_key=f\"substrate_prediction_error"` on `worker.py`; `pytest orion/substrate/tests/test_materializer_node_id_collision_fallback.py -q` — 2/2 passing after the correction.
+- Finding: does this PR stand alone safely without #1501's `skip_metadata_keys`, and do the two combine cleanly?
+  - Verified (not a defect, confirmation only): `reconcile.merge_node()`'s `existing.model_copy(update={...})` construction and `{**incoming.metadata, **existing.metadata}` precedence mean even standing alone, this PR converts a full-node clobber into a same-call metadata-preserving merge. `git merge-tree` against PR #1501's branch produced no conflict — the two PRs touch adjacent, non-overlapping lines within the same merge branch (this PR: the `existing_node` lookup + `reason` field; #1501: the `upsert_node()` call's `skip_metadata_keys` kwarg).
+  - Evidence: `git merge-tree <common-ancestor> <this-branch> <1501-branch>`; direct reading of `reconcile.py:244-328`, `falkor_store.py:511-590`.
+- No correctness regressions found in the widened fallback itself, the `reason` field's accuracy, or any downstream consumer (`relational/layer.py`, `frontier_landing.py`, `concept_atlas_routes.py`'s `_CountingSubstrateStore` — none branch on `reason` or rely on `created`/`merged` counts in a way this changes).
+
+## Restart required
+
+No restart required for this branch alone (not yet deployed independently — see Docker/build/smoke checks above). Once merged, will take effect on the next `orion-cortex-exec-background` rebuild:
+
+```bash
+bash scripts/safe_docker_build.sh orion-cortex-exec up -d --build
+```
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: This patch alone (without #1501) still routes newly-caught collision cases into an *unprotected* merge branch `upsert_node()` call (no `skip_metadata_keys` yet in this branch's own history) — a strict improvement over the prior full-overwrite behavior, but not the full protection until #1501 also lands.
+- Mitigation: Verified the two PRs merge cleanly in either order; recommend merging both together or #1501 first.
+- Severity: Low
+- Concern: Not live-verified against a running service the way the sibling bus_synaptic fixes were.
+- Mitigation: Narrow, low-frequency edge case; covered by targeted unit tests; low blast radius.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/materializer-identity-fallback-gap

--- a/orion/substrate/materializer.py
+++ b/orion/substrate/materializer.py
@@ -48,10 +48,28 @@ class SubstrateGraphMaterializer:
 
         for node in record.nodes:
             identity_key = self._identity_resolver.canonical_node_key(node)
-            existing_id = self._store.get_node_id_by_identity(identity_key) if identity_key else self._store.get_node_by_id(node.node_id)
+            existing_id = self._store.get_node_id_by_identity(identity_key) if identity_key else None
             existing_node = self._store.get_node_by_id(existing_id) if isinstance(existing_id, str) else None
-            if existing_node is None and identity_key is None:
-                existing_node = self._store.get_node_by_id(node.node_id)
+            matched_by_raw_node_id = False
+            if existing_node is None:
+                # Safety-net fallback, regardless of whether identity_key
+                # resolved above: Cypher's MERGE always matches on raw
+                # node_id in the durable graph, independent of this
+                # process's identity-index lookup -- so a node_id collision
+                # with an existing node indexed under a different identity
+                # (or no identity at all yet) must still be caught here.
+                # Without this, apply_record() would take the "created"
+                # branch below and do a full wholesale overwrite (no merge,
+                # no skip_metadata_keys protection) on a node that already
+                # durably exists -- worse than a metadata-only clobber.
+                # Previously this fallback only fired when identity_key was
+                # None; widened 2026-07-30 after finding the gap during
+                # review of the sibling merge-branch clobber fix (see
+                # falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring).
+                fallback_node = self._store.get_node_by_id(node.node_id)
+                if fallback_node is not None:
+                    existing_node = fallback_node
+                    matched_by_raw_node_id = True
 
             if existing_node is None:
                 canonical_node = node.model_copy(update={"metadata": {**node.metadata, "materialized_from_graph_id": record.graph_id}})
@@ -63,7 +81,8 @@ class SubstrateGraphMaterializer:
                 canonical_node = merge_node(existing_node, node, source_graph_id=record.graph_id)
                 self._store.upsert_node(identity_key=identity_key, node=canonical_node)
                 nodes_merged += 1
-                node_decisions.append(NodeMergeDecision(canonical_node_id=canonical_node.node_id, merged=True, reason="identity_match" if identity_key else "node_id_match", tier_conflict=tc, tier_outcome=to))
+                reason = "identity_match" if (identity_key and not matched_by_raw_node_id) else "node_id_match"
+                node_decisions.append(NodeMergeDecision(canonical_node_id=canonical_node.node_id, merged=True, reason=reason, tier_conflict=tc, tier_outcome=to))
 
             canonical_id_by_input_id[node.node_id] = canonical_node.node_id
 

--- a/orion/substrate/tests/test_materializer_node_id_collision_fallback.py
+++ b/orion/substrate/tests/test_materializer_node_id_collision_fallback.py
@@ -1,17 +1,22 @@
 """Regression guard (2026-07-30): SubstrateGraphMaterializer.apply_record()'s
 existing-node lookup must catch a raw node_id collision even when the
 incoming node's own identity_key fails to resolve (no identity-index entry
-yet for that key) -- not just when identity_key is None outright.
+found for that key) -- not just when identity_key is None outright.
 
 Found during review of the sibling merge-branch metadata-clobber fix (see
 falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring for the original
 incident). Before this fix, a node_id collision with an existing node
-indexed under a different identity (or no identity at all, e.g. a reducer's
-own direct write via _write_prediction_error_node, which never registers a
-canonical identity_key) took the "created" branch: a full wholesale
-overwrite via node.model_copy(...), no merge_node() call, and no
+indexed under a *different* identity_key took the "created" branch: a full
+wholesale overwrite via node.model_copy(...), no merge_node() call, and no
 skip_metadata_keys protection at all -- strictly worse than a metadata-only
-clobber.
+clobber. This applies even though a reducer's own direct write (e.g.
+_write_prediction_error_node) DOES register a real, non-None identity_key
+(services/orion-substrate-runtime/app/worker.py:
+f"substrate_prediction_error|{node_id}") -- that string is never what
+SubstrateIdentityResolver.canonical_node_key() independently computes for
+an incoming concept-induction node sharing the same raw node_id, so the
+identity-index lookup still misses and the raw-node_id fallback is what
+has to catch it.
 """
 
 from __future__ import annotations
@@ -29,9 +34,13 @@ from orion.substrate import InMemorySubstrateGraphStore, SubstrateGraphMateriali
 
 def _reducer_owned_node(*, node_id: str, prediction_error: float) -> ConceptNodeV1:
     """Shaped like a real reducer's own direct write (_write_prediction_error_node):
-    fixed label/anchor_scope/subject_ref, never registered under a canonical
-    identity_key (upsert_node(identity_key=None, ...) is exactly how a reducer
-    like this calls it)."""
+    fixed label/anchor_scope/subject_ref. Registered under the reducer's own
+    identity_key convention (f"substrate_prediction_error|{node_id}"), not the
+    canonical identity_key SubstrateIdentityResolver.canonical_node_key()
+    would independently compute from anchor_scope/subject_ref/label -- these
+    two identity schemes never agree, which is exactly why a colliding
+    incoming node's identity-index lookup misses even though a real,
+    non-None identity_key is registered for the existing node."""
     return ConceptNodeV1(
         node_id=node_id,
         anchor_scope="orion",
@@ -52,8 +61,11 @@ def _reducer_owned_node(*, node_id: str, prediction_error: float) -> ConceptNode
 def _colliding_incoming_record_node(*, node_id: str) -> ConceptNodeV1:
     """A differently-shaped incoming node that happens to share node_id with
     the reducer-owned node above -- its own canonical identity_key (derived
-    from anchor_scope/subject_ref/label) won't match anything indexed,
-    because the reducer's write above never registered one."""
+    by SubstrateIdentityResolver.canonical_node_key() from this node's own
+    anchor_scope/subject_ref/label) won't match anything indexed, because it
+    is a structurally different string from the reducer's own
+    "substrate_prediction_error|..." identity_key convention -- the two
+    schemes are independent, not because nothing was registered."""
     from orion.core.schemas.cognitive_substrate import SubstrateGraphRecordV1
 
     node = ConceptNodeV1(
@@ -76,9 +88,14 @@ def _colliding_incoming_record_node(*, node_id: str) -> ConceptNodeV1:
 
 def test_node_id_collision_with_unregistered_identity_takes_merge_not_created_branch() -> None:
     store = InMemorySubstrateGraphStore()
-    # Simulate a reducer's real direct write -- identity_key=None, exactly
-    # how _write_prediction_error_node calls store.upsert_node().
-    store.upsert_node(identity_key=None, node=_reducer_owned_node(node_id="node:substrate.bus_synaptic", prediction_error=0.73))
+    # Simulate a reducer's real direct write, including its real identity_key
+    # convention -- this is a genuine, non-None identity_key (matching
+    # _write_prediction_error_node's actual call), just one the resolver
+    # below never independently reproduces.
+    store.upsert_node(
+        identity_key="substrate_prediction_error|node:substrate.bus_synaptic",
+        node=_reducer_owned_node(node_id="node:substrate.bus_synaptic", prediction_error=0.73),
+    )
 
     materializer = SubstrateGraphMaterializer(store=store)
     record = _colliding_incoming_record_node(node_id="node:substrate.bus_synaptic")

--- a/orion/substrate/tests/test_materializer_node_id_collision_fallback.py
+++ b/orion/substrate/tests/test_materializer_node_id_collision_fallback.py
@@ -1,0 +1,112 @@
+"""Regression guard (2026-07-30): SubstrateGraphMaterializer.apply_record()'s
+existing-node lookup must catch a raw node_id collision even when the
+incoming node's own identity_key fails to resolve (no identity-index entry
+yet for that key) -- not just when identity_key is None outright.
+
+Found during review of the sibling merge-branch metadata-clobber fix (see
+falkor_codec.EXTERNALLY_OWNED_METADATA_KEYS's docstring for the original
+incident). Before this fix, a node_id collision with an existing node
+indexed under a different identity (or no identity at all, e.g. a reducer's
+own direct write via _write_prediction_error_node, which never registers a
+canonical identity_key) took the "created" branch: a full wholesale
+overwrite via node.model_copy(...), no merge_node() call, and no
+skip_metadata_keys protection at all -- strictly worse than a metadata-only
+clobber.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate import InMemorySubstrateGraphStore, SubstrateGraphMaterializer
+
+
+def _reducer_owned_node(*, node_id: str, prediction_error: float) -> ConceptNodeV1:
+    """Shaped like a real reducer's own direct write (_write_prediction_error_node):
+    fixed label/anchor_scope/subject_ref, never registered under a canonical
+    identity_key (upsert_node(identity_key=None, ...) is exactly how a reducer
+    like this calls it)."""
+    return ConceptNodeV1(
+        node_id=node_id,
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label=f"substrate:{node_id}",
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="substrate_prediction_error",
+            source_channel="substrate.runtime",
+            producer="substrate_runtime_worker",
+        ),
+        signals=SubstrateSignalBundleV1(confidence=1.0, salience=1.0),
+        metadata={"prediction_error": prediction_error},
+    )
+
+
+def _colliding_incoming_record_node(*, node_id: str) -> ConceptNodeV1:
+    """A differently-shaped incoming node that happens to share node_id with
+    the reducer-owned node above -- its own canonical identity_key (derived
+    from anchor_scope/subject_ref/label) won't match anything indexed,
+    because the reducer's write above never registered one."""
+    from orion.core.schemas.cognitive_substrate import SubstrateGraphRecordV1
+
+    node = ConceptNodeV1(
+        node_id=node_id,
+        anchor_scope="orion",
+        subject_ref="project:orion",
+        label="some induced concept label",
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="concept_induction",
+            source_channel="orion:chat:history:log",
+            producer="concept_induction",
+        ),
+        signals=SubstrateSignalBundleV1(confidence=0.8, salience=0.6),
+        metadata={},
+    )
+    return SubstrateGraphRecordV1(graph_id="test-graph", anchor_scope="orion", nodes=[node], edges=[])
+
+
+def test_node_id_collision_with_unregistered_identity_takes_merge_not_created_branch() -> None:
+    store = InMemorySubstrateGraphStore()
+    # Simulate a reducer's real direct write -- identity_key=None, exactly
+    # how _write_prediction_error_node calls store.upsert_node().
+    store.upsert_node(identity_key=None, node=_reducer_owned_node(node_id="node:substrate.bus_synaptic", prediction_error=0.73))
+
+    materializer = SubstrateGraphMaterializer(store=store)
+    record = _colliding_incoming_record_node(node_id="node:substrate.bus_synaptic")
+    result = materializer.apply_record(record)
+
+    # Must merge into the existing node, not silently create/overwrite it.
+    assert result.nodes_created == 0
+    assert result.nodes_merged == 1
+    assert result.node_decisions[0].merged is True
+    assert result.node_decisions[0].reason == "node_id_match"
+
+    # merge_node() preserves the existing reducer-owned metadata (existing
+    # wins for keys incoming doesn't provide) -- confirms this went through
+    # the real merge path, not a wholesale replace that would have dropped it.
+    merged = store.get_node_by_id("node:substrate.bus_synaptic")
+    assert merged is not None
+    assert merged.metadata.get("prediction_error") == 0.73
+
+
+def test_no_collision_still_creates_normally() -> None:
+    """Sanity check: the widened fallback must not turn every fresh node
+    into a false merge -- a genuinely new node_id still takes the created
+    branch."""
+    store = InMemorySubstrateGraphStore()
+    materializer = SubstrateGraphMaterializer(store=store)
+    record = _colliding_incoming_record_node(node_id="sub-concept-brand-new")
+    result = materializer.apply_record(record)
+
+    assert result.nodes_created == 1
+    assert result.nodes_merged == 0
+    assert result.node_decisions[0].reason == "created"


### PR DESCRIPTION
## Summary

Found during review of PR #1501. `SubstrateGraphMaterializer.apply_record()`'s existing-node lookup only fell back to a raw `get_node_by_id(node.node_id)` check when `identity_key` was `None` outright. When `identity_key` resolved to something but the identity-index lookup found nothing, `apply_record()` took the "created" branch: a full wholesale overwrite, no merge, no `skip_metadata_keys` protection — worse than a metadata-only clobber.

Fix: widen the fallback to fire whenever the identity lookup comes up empty, regardless of whether `identity_key` was `None` or just unresolved.

## Verified standalone safety + compatibility with #1501

- Standing alone (without #1501's `skip_metadata_keys`): still a strict improvement — `reconcile.merge_node()`'s existing-wins metadata precedence means this converts a full-node clobber into a same-call metadata-preserving merge.
- Combines cleanly with #1501: confirmed via `git merge-tree` — no conflicts, the two PRs touch adjacent non-overlapping lines in the same function.

## Review findings fixed

Code review caught a factual inaccuracy in the original commit message and test docstrings (claimed `_write_prediction_error_node` registers `identity_key=None` — it actually registers a real, non-`None` key that just never matches the resolver's independently-computed identity). Corrected in follow-up commit `f45d6a4c3`; the fix itself and test logic were unaffected, just the documentation accuracy.

## Test plan

- [x] `pytest orion/substrate/tests --ignore=orion/substrate/relational/tests -q` — 491 passed (489 baseline + 2 new), zero regressions
- [x] Red-before-green confirmed
- [x] Code review pass — no correctness regressions found; one documentation-accuracy finding, fixed
- [x] `git merge-tree` verified clean combination with sibling PR #1501

Full write-up: `docs/superpowers/pr-reports/2026-07-30-materializer-identity-fallback-gap-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)