### PR TITLE
fix(execution-dispatch): discard stale backlog instead of dispatching against day-old field state

### DIFF
--- a/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
+++ b/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
@@ -1,0 +1,206 @@
+# execution-dispatch backlog: staleness discard (shipped) + throughput redesign (spec)
+
+2026-07-30. Follow-up to the proposals `proposal_priority()` precision-weighting patch
+(PR #1497). Verifying that patch against real post-deploy data surfaced something much bigger:
+`orion-execution-dispatch-runtime` was 46,617 policy decisions behind, oldest from 2026-07-29
+07:24 — over 37 hours — and the gap was growing, not shrinking. This doc has two parts: what
+shipped today (staleness discard, a correctness fix), and a design-mode spec for the harder,
+deferred follow-up (real throughput).
+
+## Part 1: what was found, live, 2026-07-30
+
+**Chain of discovery.** After merging PR #1497 (precision-weighted `proposal_priority()` +
+the `proposal_confidence()` fallback fix that unblocks 5 previously-permanently-blocked
+templates), real post-deploy data was pulled directly from Postgres to verify it. A specific
+tick's persisted policy decision showed `confidence_score: 0.0` — but recomputing the *same*
+shipped code against the *same* persisted field state gave `0.81`. That looked like a live
+code/data inconsistency at first. It wasn't: the discrepancy resolved once the *age* of the
+underlying policy decision was checked — `substrate_policy_decision_frames.generated_at` was
+`2026-07-29 07:24:47`, a full day-plus old, while the `substrate_execution_dispatch_frames` row
+built from it had `generated_at` of *right now*. `orion-execution-dispatch-runtime` was working
+through a backlog, not processing live traffic.
+
+**Root cause, precisely.** `ExecutionDispatchRuntimeStore.load_latest_policy_frame_without_
+dispatch()` (`services/orion-execution-dispatch-runtime/app/store.py:42`) is strict FIFO,
+oldest-first: `ORDER BY p.generated_at ASC LIMIT 1`. `_tick()`
+(`services/orion-execution-dispatch-runtime/app/worker.py`) processes exactly one policy
+decision frame per poll cycle, and when that frame has a real candidate to send, does a
+**synchronous** cortex-exec RPC inline before the tick completes
+(`await client.dispatch(...)`, `worker.py:527`, timeout 120s but real observed latency
+~7-11s). Poll interval is 2s, but the real tick-to-tick cadence is bounded by that RPC, not the
+interval — measured live via `action_outcomes.observed_at` deltas: **7.6-11.2 seconds between
+consecutive real dispatches**, consistently.
+
+**The math doesn't close.** Measured live, 5-minute windows:
+- Production: `substrate_policy_decision_frames` — **16/min**
+- Consumption: `substrate_execution_dispatch_frames` — **6.8/min**
+
+Net backlog growth: ~9/minute, ~13,000/day — consistent with a 46,617-row backlog accumulating
+since 2026-07-29 07:24. Confirmed **not** caused by the same-day `proposal_priority()` patch:
+policy-decision-frame production is one frame per field tick regardless of how many candidates
+are approved vs. blocked within it, and consumption cost is one LLM call per tick regardless of
+how many candidates existed — unblocking 5 more templates changes *who wins* the per-tick
+dispatch slot, not the throughput math on either side.
+
+**Why this is a correctness bug, not just a performance one.** Strict oldest-first FIFO means
+real cortex actions were being dispatched describing 37-hour-old field pressure as current —
+a "no empty-shell cognition" violation in its own right (CLAUDE.md §0A), independent of the
+throughput question.
+
+## Part 1 (continued): what shipped
+
+**Staleness discard**, `services/orion-execution-dispatch-runtime/app/worker.py`:
+
+- `_tick()` now fast-drains any policy frame older than a randomized
+  `[EXECUTION_DISPATCH_STALENESS_MIN_SEC, EXECUTION_DISPATCH_STALENESS_MAX_SEC]` threshold
+  (default 120-300s, drawn fresh via `random.uniform` on every check — deliberately not one
+  fixed constant, so there is no single sharp, predictable cliff every candidate sits the same
+  distance from) before considering a real send. Capped at `MAX_STALE_DISCARDS_PER_TICK` (200)
+  discards per `_tick()` call so the very first tick after this ships (which found the entire
+  46,617-row backlog stale) doesn't feed the new discard-rate EWMA one absurd one-time outlier
+  sample, and doesn't hold the poll loop for however long tens of thousands of real DB writes
+  take in one go.
+- **Materialized, never silently dropped.** `orion/execution_dispatch/builder.py::
+  build_stale_discard_execution_dispatch_frame()` saves a real `ExecutionDispatchFrameV1`
+  (`dispatch_attempted=False`, `blocked_count=len(decisions)`) with a
+  `stale_backlog_discarded age_sec=... threshold_sec=... candidates=N` warning plus one
+  `stale_discard:{template_key}:{decision}` entry per discarded candidate — real, queryable
+  forensic detail in the same `substrate_execution_dispatch_frames.warnings` column every real
+  frame already uses. No new table.
+- **Backlog-pressure signal.** `ExecutionDispatchFrameV1.staleness_discard_count_ewma`
+  (`_var`/`_n` alongside it) — an EWMA over "how many consecutive stale frames did this tick
+  discard before finding one fresh enough, or running out," updated once per `_tick()` call that
+  finds any policy frame at all (same "once per real cycle regardless of whether a real event
+  landed" convention `DIMENSION_PRECISION_EWMA_ALPHA` already uses in field-digester), carried
+  forward on every saved frame the same way `daily_risk_baseline_*` already is. **Disclosed gap
+  found in review**: a tick where the queue is fully empty from the start has no frame left to
+  carry a `value=0.0` sample on, so that tick's update is skipped rather than persisted —
+  deliberately not patched with a synthetic no-op frame (would be inventing content to carry a
+  metric, not recording something real); this only under-samples the true-idle case, never the
+  backlog case this patch exists for. Near 0 in steady state; rising
+  means the backlog is growing again — this is the thing a future health surface (see Part 1's
+  own closing note below) should read, rather than requiring another 20-query manual psql
+  investigation like this one.
+  - **Disclosed, uncalibrated constants**: `STALENESS_DISCARD_EWMA_ALPHA=0.2`,
+    `STALENESS_DISCARD_EWMA_MIN_VARIANCE=1.0` (`app/worker.py`). This is the first time this
+    metric has ever existed — unlike `DIMENSION_PRECISION_MIN_VARIANCE` or
+    `DAILY_RISK_BASELINE_MIN_VARIANCE` elsewhere in this repo, both seeded from a real measured
+    population before shipping, there is no real history to calibrate against yet. Revisit once
+    real post-deploy discard-count data exists, per this repo's metric-quality-gate discipline —
+    do not treat "the EWMA update runs without error" as proof this floor is right.
+- **Operator override shim.** `EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC` (unset by default)
+  bypasses the randomized window entirely and uses one fixed value every tick instead — same
+  "explicit override, don't touch the derived machinery" shape as
+  `ORION_DISPATCH_RISK_CAP_ADVISORY_ONLY`. Exists because this service's consumption/production
+  balance is not assumed permanent: if Orion's own attention/dispatch cadence changes later
+  (faster real consumption, fewer but more deliberate proposals, etc.), a deliberate
+  deep-backlog catch-up may become desirable again without a code change.
+
+**Files changed**: `orion/schemas/execution_dispatch_frame.py` (3 new fields),
+`orion/execution_dispatch/builder.py` (`build_stale_discard_execution_dispatch_frame`,
+`_decision_template_key`), `services/orion-execution-dispatch-runtime/app/worker.py`
+(`_staleness_threshold_sec`, `_drain_stale_policy_frames`, rewritten `_tick`),
+`services/orion-execution-dispatch-runtime/app/store.py`
+(`load_latest_staleness_discard_baseline`), `services/orion-execution-dispatch-runtime/app/
+settings.py` (3 new env-backed settings), `.env`/`.env_example` (synced), tests (worker + builder).
+
+**What this patch deliberately does not do**: fix the throughput gap itself. Once the backlog is
+drained (which this patch does quickly — stale-skip is a cheap DB write, not a ~9s LLM call),
+steady-state behavior is real but rate-limited: with production still exceeding raw dispatch
+throughput, a rolling fraction of candidates will always go stale rather than dispatch, forever,
+under this patch alone. That is arguably fine (the system dispatches what it can, in real time,
+against current field state, and drops the rest instead of queuing it up as false-freshness
+debt) — but it is a real, disclosed trade-off, not a full fix. Part 2 below specs the throughput
+side.
+
+## Part 2: throughput redesign — design mode, not implemented
+
+### Arsonist summary
+
+Even with staleness discard live, this service can only ever really dispatch ~6.8 candidates/min
+because `_send_one()` is awaited sequentially inside a loop bounded by `max_dispatches_per_tick`
+(currently 1) and the whole tick blocks on that RPC. Raising `max_dispatches_per_tick` alone does
+nothing today, because the `for candidate in to_send: newly_dispatched.append(await self._send_
+one(...))` loop (`worker.py:410-411`) still awaits each one in series. Real concurrency requires
+touching shared per-process state that assumes single-threaded-per-tick access.
+
+### Current architecture
+
+- `worker.py::_tick()` → `_send_prepared_candidates()` selects up to `max_dispatches_per_tick`
+  candidates by cumulative risk budget, then sequentially `await`s `_send_one()` for each.
+- `_send_one()` does: idempotency check (`load_dispatch_result_by_dispatch_id`), the real RPC
+  (`client.dispatch(...)`), `save_dispatch_result()`, `_recent_dispatch_statuses.append(status)`
+  (mutates `self.theater_tripwire_active`-adjacent in-process `deque`, not thread-safe), and
+  `_emit_action_outcome()` (a bus publish).
+- Risk budget accounting (`cumulative_risk`, `remaining_risk_budget`) is computed once per tick
+  from `frame.candidates`, assuming nothing else spends from the same budget concurrently.
+- Theater tripwire (`_check_theater_tripwire`) reads/writes `self._recent_dispatch_statuses`
+  (a `deque(maxlen=10)`) and `self.theater_tripwire_active`, both plain instance attributes with
+  no lock — safe today only because everything is strictly sequential.
+- `max_dispatches_per_tick=1` (`config/execution_dispatch/execution_dispatch_policy.v1.yaml`) —
+  already the real cap; the sequential-await loop is currently a distinction without a
+  difference at that setting, but becomes the actual bottleneck the moment this value is raised.
+
+### Missing questions
+
+1. **Is raising throughput even the right goal**, or is staleness discard's "dispatch what's
+   current, drop what isn't" already the intended long-run shape? Real production (16/min) may
+   keep exceeding real consumption (6.8/min) even after concurrency work, if `orion-cortex-exec`
+   itself has a real LLM-inference ceiling — concurrency inside this service doesn't help if the
+   downstream cortex-exec route is itself the bottleneck. Needs tracing `orion-cortex-exec`'s
+   own real concurrent-request capacity before assuming this service's serial loop is the only
+   constraint.
+2. **What does real concurrent risk-budget accounting look like?** `cumulative_risk` is computed
+   assuming candidates are reserved in the order they're sent; genuine concurrency means multiple
+   in-flight sends could all pass the same-tick budget check before any of them completes. Needs
+   either a pre-reservation step (claim budget before dispatching, release/adjust on failure) or
+   accepting some real over-spend risk and tightening the ceiling to compensate.
+3. **Does the theater tripwire's `deque` need a lock, or does it need to become per-batch instead
+   of per-process** (e.g., check tripwire status once per tick before firing a batch, not
+   per-candidate-in-flight)? Real answer depends on how tightly the tripwire is meant to react —
+   current behavior re-checks after every send; a batched version changes that granularity.
+4. **Is per-tick concurrency (asyncio.gather within one `_tick()`) enough, or does the underlying
+   one-poll-thread-per-process model need to change** (multiple worker processes/replicas)?
+   Concurrency within a tick only closes the gap up to whatever `orion-cortex-exec` itself can
+   sustain concurrently; if that's the real ceiling, no amount of restructuring this service's
+   loop helps further.
+
+### Proposed schema / API changes
+
+None proposed yet — blocked on missing questions 1 and 4 (whether the bottleneck is even in this
+service). If concurrency within a tick is the right direction: `_send_prepared_candidates` would
+need to reserve risk budget synchronously before firing each RPC (not after, as today), and
+`_check_theater_tripwire`'s deque would need either a lock or to move to a per-batch check.
+Neither is scoped as a patch here.
+
+### Files likely to touch (once a direction is chosen — not started)
+
+- `services/orion-execution-dispatch-runtime/app/worker.py` (`_send_prepared_candidates`,
+  `_send_one`, `_check_theater_tripwire`)
+- `config/execution_dispatch/execution_dispatch_policy.v1.yaml` (`max_dispatches_per_tick`, if
+  raised)
+- `services/orion-cortex-exec/` (tracing real concurrent-capacity, possibly touched if it's the
+  actual ceiling)
+- `tests/test_execution_dispatch_runtime_worker.py`
+
+### Non-goals
+
+- Not touching staleness discard's own thresholds/constants here (Part 1 is shipped and
+  separate).
+- Not proposing a multi-process/replica model without first tracing whether `orion-cortex-exec`
+  itself is the real ceiling (missing question 1) — no point building concurrency this service
+  can't actually benefit from.
+- Not building a health-surface UI in this doc (see Part 1's closing note — a script, not a
+  dashboard, was the right-sized answer when this question came up for proposals scoring
+  earlier the same day).
+
+### Acceptance checks
+
+N/A — no patch proposed yet.
+
+### Recommended next patch
+
+Trace `orion-cortex-exec`'s real concurrent-request capacity first (missing question 1) — cheap,
+and determines whether any of the concurrency work below is worth doing at all. Only after that:
+scope a minimal concurrent-send patch (missing questions 2-3) if the trace shows real headroom
+downstream.

--- a/orion/execution_dispatch/builder.py
+++ b/orion/execution_dispatch/builder.py
@@ -296,3 +296,73 @@ def build_unevaluable_execution_dispatch_frame(
         blocked_count=0,
         warnings=[*policy_frame.warnings, reason],
     )
+
+
+def _decision_template_key(proposal_id: str) -> str:
+    # stable_proposal_id() (orion/proposals/builder.py) is always
+    # "proposal:{template_key}:{field_tick_id}:{attention_frame_id}" --
+    # template_key is a plain config dict key (never contains ":"), so
+    # index [1] is exact, same convention scripts/analysis/measure_proposal_
+    # feedback_correlation.py's extract_template_key() already relies on.
+    parts = proposal_id.split(":")
+    return parts[1] if len(parts) > 1 else proposal_id
+
+
+def build_stale_discard_execution_dispatch_frame(
+    *,
+    policy_frame: PolicyDecisionFrameV1,
+    policy_id: str,
+    age_sec: float,
+    staleness_threshold_sec: float,
+    now: datetime | None = None,
+) -> ExecutionDispatchFrameV1:
+    """A policy frame past its staleness window gets discarded rather than
+    dispatched -- real cortex-exec dispatches are a synchronous, ~7-11s RPC
+    (measured live 2026-07-30) each, so a single-threaded FIFO consumer
+    cannot keep pace with real production of new policy_decision_frames
+    (measured live: ~16/min produced vs. ~6.8/min consumed). Continuing to
+    process a growing backlog strictly oldest-first means eventually
+    dispatching real cortex actions that describe field pressure as "current"
+    when it is actually hours old -- a "no empty-shell cognition" violation
+    in its own right, not just a throughput problem. See docs/superpowers/
+    specs/2026-07-30-execution-dispatch-staleness-discard-design.md.
+
+    Materializes what was discarded rather than silently dropping it: one
+    `stale_discard:{template_key}:{decision}` warning entry per candidate
+    that was in the discarded policy frame, so real discard content stays
+    queryable in `substrate_execution_dispatch_frames.warnings` (no new
+    table -- this repo's existing "no keyword cathedral" bias against a new
+    schema/surface unless it earns its keep). The worker separately tracks
+    an EWMA of discard counts (`ExecutionDispatchFrameV1.staleness_discard_
+    count_ewma`) as the aggregate backlog-pressure signal; this per-frame
+    warning list is the per-decision forensic detail underneath it.
+
+    Same "record honestly, never silently drop" contract as
+    `build_unevaluable_execution_dispatch_frame` above, and the same stable
+    frame_id so a later real build (should this exact policy_frame somehow
+    still be the FIFO head, which it won't be once discarded) naturally
+    supersedes rather than duplicates.
+    """
+    summary = [
+        f"stale_discard:{_decision_template_key(d.proposal_id)}:{d.decision}"
+        for d in policy_frame.decisions
+    ]
+    reason = (
+        f"stale_backlog_discarded age_sec={age_sec:.1f} "
+        f"threshold_sec={staleness_threshold_sec:.1f} candidates={len(policy_frame.decisions)}"
+    )
+    return ExecutionDispatchFrameV1(
+        frame_id=stable_execution_dispatch_frame_id(
+            policy_frame_id=policy_frame.frame_id,
+            policy_id=policy_id,
+        ),
+        generated_at=now or datetime.now(timezone.utc),
+        source_policy_frame_id=policy_frame.frame_id,
+        source_proposal_frame_id=policy_frame.source_proposal_frame_id,
+        source_field_tick_id=policy_frame.source_field_tick_id,
+        execution_dispatch_policy_id=policy_id,
+        dispatch_attempted=False,
+        dispatch_count=0,
+        blocked_count=len(policy_frame.decisions),
+        warnings=[*policy_frame.warnings, reason, *summary],
+    )

--- a/orion/schemas/execution_dispatch_frame.py
+++ b/orion/schemas/execution_dispatch_frame.py
@@ -120,3 +120,25 @@ class ExecutionDispatchFrameV1(BaseModel):
     # store's json_serializer=json.dumps (store.py) can't serialize a bare
     # `date`.
     daily_risk_baseline_last_day: str | None = None
+
+    # 2026-07-30 (docs/superpowers/specs/2026-07-30-execution-dispatch-
+    # staleness-discard-design.md): backlog-pressure signal. EWMA over "how
+    # many consecutive stale (past their staleness window) policy frames did
+    # this tick's FIFO drain discard before finding one fresh enough to
+    # process, or running out." A real, direct measure of execution-dispatch
+    # backlog depth -- 0 in steady state (healthy: consumption keeps pace
+    # with production), rising when production of new policy_decision_frames
+    # outpaces this service's real per-tick dispatch throughput (bounded by
+    # a synchronous cortex-exec RPC per real send, ~7-11s measured live
+    # 2026-07-30). Independent of daily_risk_baseline_* above (that measures
+    # risk-budget demand; this measures queue-depth/consumption-lag) -- same
+    # carried-forward-on-every-frame convention, same EWMA mechanism
+    # (orion.bus.ewma.compute_ewma_update), new domain. NOT persisted on a
+    # tick where the policy-decision queue is fully empty from the start (no
+    # frame at all to carry a value=0.0 sample on) -- see
+    # STALENESS_DISCARD_EWMA_ALPHA's own comment in app/worker.py for why
+    # this is a disclosed, deliberate under-sample of the true-idle case
+    # rather than a synthetic no-op frame invented to close the gap.
+    staleness_discard_count_ewma: float = 0.0
+    staleness_discard_count_ewma_var: float = 0.0
+    staleness_discard_count_ewma_n: int = 0

--- a/services/orion-execution-dispatch-runtime/.env_example
+++ b/services/orion-execution-dispatch-runtime/.env_example
@@ -25,6 +25,28 @@ ORION_BUS_ENABLED=true
 # connection from the RPC dispatch client above.
 HEARTBEAT_INTERVAL_SEC=10
 EXECUTION_DISPATCH_RPC_TIMEOUT_SEC=120
+# 2026-07-30: a real dispatch is a synchronous cortex-exec RPC, ~7-11s
+# measured live -- this single-threaded FIFO consumer cannot keep pace with
+# real production of new policy_decision_frames (~16/min produced vs ~6.8/
+# min consumed, measured live 2026-07-30), so the oldest-undispatched-first
+# queue grows without bound (46,617 backlogged, oldest 37h old, at the time
+# this was found). A policy frame older than a randomized [min, max]
+# threshold gets discarded (materialized as a real "stale_discard" frame,
+# never silently dropped) instead of dispatched, so real cortex actions
+# never describe hours-old field state as current.
+EXECUTION_DISPATCH_STALENESS_MIN_SEC=120.0
+EXECUTION_DISPATCH_STALENESS_MAX_SEC=300.0
+# Explicit operator override: when set, bypasses the randomized window
+# entirely and uses this fixed value every tick instead -- same "explicit
+# override, don't touch the derived machinery" shape as
+# ORION_DISPATCH_RISK_CAP_ADVISORY_ONLY below. Commented out (default) means
+# "use the randomized window" -- unlike NOTIFY_API_TOKEN below, this is a
+# float|None setting: an uncommented-but-empty value fails float parsing
+# rather than degrading to None, so "unset" here means the line is absent,
+# not present-and-blank. Uncomment and set very high if a deliberate
+# deep-backlog catch-up ever becomes desirable again (e.g. Orion's own
+# attention/dispatch cadence changes later) instead of reverting this patch.
+# EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC=600.0
 # 2026-07-29: no longer the primary mechanism -- app/worker.py's
 # _derive_daily_risk_cap now computes a real, self-calibrating EWMA ceiling
 # over uncapped daily demand (see app/settings.py's own comment on this key

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -77,6 +77,48 @@ promotes the candidate to a real, evidenced `dispatched` status.
   the fallback used when the EWMA baseline has never been seeded and no historical closed day
   with real candidate data exists at all.
 
+**Staleness discard (2026-07-30)**: this service consumes `substrate_policy_decision_frames`
+strictly FIFO, oldest-undispatched-first (`ExecutionDispatchRuntimeStore.
+load_latest_policy_frame_without_dispatch()`). Because a real dispatch is a synchronous
+`cortex-exec` RPC (~7-11s measured live, one per real send, bounded by
+`EXECUTION_DISPATCH_RPC_TIMEOUT_SEC`), this single-threaded consumer cannot keep pace with real
+production of new policy decisions (~16/min produced vs ~6.8/min consumed, measured live
+2026-07-30) — the queue grows without bound if nothing intervenes. Found live 2026-07-30: 46,617
+policy frames backlogged, oldest 37h old, meaning real cortex actions were describing hours-old
+field pressure as current.
+
+Every `_tick()` now first fast-drains any policy frame older than a randomized
+`[EXECUTION_DISPATCH_STALENESS_MIN_SEC, EXECUTION_DISPATCH_STALENESS_MAX_SEC]` threshold (default
+120-300s) — no single fixed cutoff every candidate sits the same distance from — capped at
+`MAX_STALE_DISCARDS_PER_TICK` (200) discards per tick so one deep-backlog catch-up tick doesn't
+feed the discard-rate EWMA below one absurd outlier sample. Each discard is **materialized, never
+silently dropped**: `build_stale_discard_execution_dispatch_frame` saves a real
+`ExecutionDispatchFrameV1` (`dispatch_attempted=False`, `blocked_count=len(decisions)`) with a
+`stale_backlog_discarded age_sec=... threshold_sec=... candidates=N` warning plus one
+`stale_discard:{template_key}:{decision}` warning per discarded candidate — real, queryable
+forensic content in `substrate_execution_dispatch_frames.warnings`, same table every real frame
+lands in.
+
+**Backlog-pressure signal**: `ExecutionDispatchFrameV1.staleness_discard_count_ewma` (`_var`/`_n`
+alongside it, same carried-forward-on-every-frame convention as `daily_risk_baseline_*`) — an
+EWMA over how many consecutive stale frames each `_tick()` call discarded before finding one
+fresh enough to process, or running out. Near 0 in steady state (consumption keeping pace);
+rising means the backlog is growing again. Read via
+`ExecutionDispatchRuntimeStore.load_latest_staleness_discard_baseline()`, same read pattern as the
+daily risk baseline. `STALENESS_DISCARD_EWMA_ALPHA`/`_MIN_VARIANCE` (`app/worker.py`) are a
+disclosed, uncalibrated first-pass guess — no real history existed to size them against before
+this shipped; revisit once real post-deploy discard-count data exists.
+
+**Operator override**: `EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC` (unset by default) bypasses the
+randomized window entirely and uses one fixed value every tick instead — set very high if a
+deliberate deep-backlog catch-up ever becomes desirable again (e.g. Orion's own attention/dispatch
+cadence changes later) instead of reverting this patch. Same "explicit override, don't touch the
+derived machinery" shape as `ORION_DISPATCH_RISK_CAP_ADVISORY_ONLY` above.
+
+See `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md` for the
+full live-data investigation (real backlog depth, throughput math, root cause) and the deferred
+part-2 throughput redesign this was scoped alongside but does not itself implement.
+
 **Theater tripwire**: if more than half of the trailing 10 real results have `status="empty"`
 (a real send that produced no usable observation), the worker stops sending for the rest of
 its process lifetime — visible via `GET /latest`'s `theater_tripwire_active` field and one

--- a/services/orion-execution-dispatch-runtime/app/settings.py
+++ b/services/orion-execution-dispatch-runtime/app/settings.py
@@ -43,6 +43,40 @@ class Settings(BaseSettings):
     execution_dispatch_rpc_timeout_sec: float = Field(
         120.0, alias="EXECUTION_DISPATCH_RPC_TIMEOUT_SEC"
     )
+    # 2026-07-30 (docs/superpowers/specs/2026-07-30-execution-dispatch-
+    # staleness-discard-design.md): a real dispatch is a synchronous
+    # cortex-exec RPC, ~7-11s measured live -- this single-threaded FIFO
+    # consumer cannot keep pace with real production of new policy_decision_
+    # frames (~16/min produced vs ~6.8/min consumed, measured live
+    # 2026-07-30), so the oldest-undispatched-first queue grows without
+    # bound (46,617 backlogged, oldest 37h old, at the time this was found).
+    # A policy frame older than a randomized [min,max] threshold gets
+    # discarded (materialized as a real, queryable "stale_discard" frame --
+    # see build_stale_discard_execution_dispatch_frame -- never silently
+    # dropped) instead of dispatched, so real cortex actions never describe
+    # hours-old field state as current. Randomized, not a single fixed
+    # constant, so there is no one sharp, predictable cliff every candidate
+    # sits at the same distance from.
+    execution_dispatch_staleness_min_sec: float = Field(
+        120.0, alias="EXECUTION_DISPATCH_STALENESS_MIN_SEC"
+    )
+    execution_dispatch_staleness_max_sec: float = Field(
+        300.0, alias="EXECUTION_DISPATCH_STALENESS_MAX_SEC"
+    )
+    # Explicit operator override shim: when set, BYPASSES the randomized
+    # [min, max] window entirely and uses this fixed value for every tick
+    # instead. Same "explicit operator override, no touching the derived
+    # machinery itself" shape as orion_dispatch_risk_cap_advisory_only above.
+    # Exists because this service's own consumption/production balance is
+    # not assumed permanent -- if Orion's attention/dispatch cadence changes
+    # later (faster real consumption, fewer but more deliberate proposals,
+    # etc.), a deliberate deep-backlog catch-up may become desirable again
+    # without a code change: set this very high (or, in the -- currently
+    # unimplemented -- limit, disable discarding outright) rather than
+    # reverting this patch. None (default) means "use the randomized window."
+    execution_dispatch_staleness_override_sec: float | None = Field(
+        None, alias="EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC"
+    )
     # 2026-07-29: no longer the primary mechanism -- see
     # orion_dispatch_risk_cap_advisory_only's comment below and
     # app/worker.py::ExecutionDispatchRuntimeWorker._derive_daily_risk_cap

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -454,6 +454,39 @@ class ExecutionDispatchRuntimeStore:
             "daily_risk_baseline_last_day": row["last_day"],
         }
 
+    def load_latest_staleness_discard_baseline(self) -> dict | None:
+        """Latest persisted staleness-discard-count EWMA baseline state, same
+        carried-forward-on-every-frame read pattern as
+        load_latest_daily_risk_baseline() above -- see that method's own
+        docstring for why None only means "no dispatch frame rows exist at
+        all" and a pre-migration row degrades to cold-start defaults instead.
+        """
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT
+                            dispatch_frame_json ->> 'staleness_discard_count_ewma' AS ewma,
+                            dispatch_frame_json ->> 'staleness_discard_count_ewma_var' AS var,
+                            dispatch_frame_json ->> 'staleness_discard_count_ewma_n' AS n
+                        FROM substrate_execution_dispatch_frames
+                        ORDER BY created_at DESC
+                        LIMIT 1
+                        """
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        return {
+            "staleness_discard_count_ewma": float(row["ewma"]) if row["ewma"] is not None else 0.0,
+            "staleness_discard_count_ewma_var": float(row["var"]) if row["var"] is not None else 0.0,
+            "staleness_discard_count_ewma_n": int(row["n"]) if row["n"] is not None else 0,
+        }
+
     def most_recent_closed_day_with_data(
         self, before_day_start_utc: datetime
     ) -> tuple[str, float] | None:

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import random
 from collections import deque
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
@@ -14,6 +15,7 @@ from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.execution_dispatch.builder import (
     build_execution_dispatch_frame,
+    build_stale_discard_execution_dispatch_frame,
     build_unevaluable_execution_dispatch_frame,
 )
 from orion.execution_dispatch.cortex_client import ExecutionDispatchCortexClient
@@ -25,6 +27,7 @@ from orion.execution_dispatch.result_extraction import (
 from orion.notify.client import NotifyClient
 from orion.schemas.execution_dispatch_frame import ExecutionDispatchCandidateV1, ExecutionDispatchFrameV1
 from orion.schemas.notify import NotificationRequest
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
 
 from app.settings import get_settings
 from app.store import ExecutionDispatchRuntimeStore
@@ -91,6 +94,50 @@ DAILY_RISK_BASELINE_MIN_SAMPLES = 2
 # bus_synaptic_graph_routes.py's anomalies() route.
 DAILY_RISK_BASELINE_Z = 3.0
 
+# 2026-07-30 (docs/superpowers/specs/2026-07-30-execution-dispatch-
+# staleness-discard-design.md): per-tick cap on how many consecutive stale
+# policy frames a single _tick() call will fast-drain before yielding back
+# to the poll loop's sleep. Without this, the first tick after this patch
+# ships would discard the entire pre-existing backlog (46,617 rows measured
+# live 2026-07-30) in one pass -- not unsafe, but it would feed the
+# staleness-discard EWMA baseline one absurd one-time outlier sample instead
+# of several real, representative ones, and would hold the poll loop's
+# single worker thread for however long tens of thousands of real DB writes
+# take. 200 is a disclosed, uncalibrated starting batch size (no real data
+# exists yet to size this against) -- large enough to make real progress
+# against a deep backlog across a handful of ticks, small enough that a
+# single tick's real wall-clock cost stays bounded.
+MAX_STALE_DISCARDS_PER_TICK = 200
+
+# Same disclosure as MAX_STALE_DISCARDS_PER_TICK above: this is the first
+# time this metric has ever been measured, so unlike DIMENSION_PRECISION_
+# MIN_VARIANCE / DAILY_RISK_BASELINE_MIN_VARIANCE elsewhere in this repo
+# (both seeded from a real measured population before shipping), there is no
+# real historical variance to calibrate against yet. alpha=0.2 is faster
+# than field-digester's per-2s-tick DIMENSION_PRECISION_EWMA_ALPHA (0.02)
+# since this updates once per real _tick() call that finds ANY policy frame
+# to act on (irregular, can fire far more or less often than every 2s
+# depending on backlog depth) -- slower than DAILY_RISK_BASELINE_ALPHA (0.4,
+# at most one real sample a day) since this can update many times a minute.
+# NOTE (code review, 2026-07-30): a tick where the policy-decision queue is
+# fully empty from the start (no frame at all, not even a fresh one) skips
+# this update entirely rather than persisting a value=0.0 sample -- there is
+# no frame left to carry it on in that exact case. Deliberately not "fixed"
+# with a synthetic no-op frame just to carry a metric forward when nothing
+# real happened (same "no empty-shell cognition" bias against inventing
+# content for its own sake) -- this only under-samples the true-idle case,
+# never the backlog case this patch exists for, and under-sampling a rare
+# calm tick is the same safe-direction trade DAILY_RISK_BASELINE's own
+# multi-day-outage gap comment already accepts elsewhere in this file.
+# MIN_VARIANCE=1.0 treats "one
+# discard" as the natural unit of spread for a small-non-negative-integer
+# count metric. Both are a disclosed, reasonable starting guess, not a
+# calibrated value -- revisit once real post-deploy discard-count history
+# exists, per this repo's metric-quality-gate discipline (do not treat "the
+# EWMA update runs without error" as proof this floor is right).
+STALENESS_DISCARD_EWMA_ALPHA = 0.2
+STALENESS_DISCARD_EWMA_MIN_VARIANCE = 1.0
+
 # ActionOutcomeEmitV1.summary lands in chat-visible evidence via
 # chat_stance.py's _project_recent_dispatch_actions -- bounded here at the
 # producer so nothing downstream needs to re-truncate raw model output.
@@ -155,12 +202,117 @@ class ExecutionDispatchRuntimeWorker:
             except asyncio.CancelledError:
                 break
 
+    def _staleness_threshold_sec(self) -> float:
+        override = self._settings.execution_dispatch_staleness_override_sec
+        if override is not None:
+            return float(override)
+        return random.uniform(
+            self._settings.execution_dispatch_staleness_min_sec,
+            self._settings.execution_dispatch_staleness_max_sec,
+        )
+
+    def _drain_stale_policy_frames(
+        self, baseline: dict
+    ) -> tuple[PolicyDecisionFrameV1 | None, int, ExecutionDispatchFrameV1 | None]:
+        """FIFO-drains policy frames older than a randomized staleness
+        threshold, discarding (materializing, never silently dropping -- see
+        build_stale_discard_execution_dispatch_frame) each one instead of
+        dispatching a real cortex action against hours-old field state. Stops
+        at the first frame still within its threshold (returned as the real
+        candidate for this tick to process normally), an empty queue, or
+        MAX_STALE_DISCARDS_PER_TICK, whichever comes first.
+
+        Each discard frame saved here carries the CURRENT (not-yet-updated-
+        for-this-tick) baseline forward, same as every other saved frame --
+        the real update for this tick's own discard count is computed once,
+        after this method returns, and re-stamped onto whichever frame ends
+        up being the last one saved this tick (see _tick()).
+
+        Returns (fresh_policy_frame_or_none, discarded_count, last_discard_
+        frame_or_none).
+        """
+        discarded = 0
+        last_discard_frame: ExecutionDispatchFrameV1 | None = None
+        while discarded < MAX_STALE_DISCARDS_PER_TICK:
+            candidate_frame = self._store.load_latest_policy_frame_without_dispatch()
+            if candidate_frame is None:
+                return None, discarded, last_discard_frame
+            # Defensive normalize, same idiom as _derive_daily_risk_cap above:
+            # PolicyDecisionFrameV1.generated_at is typed as a plain datetime,
+            # not enforced tz-aware. A naive value here would raise on the
+            # subtraction below -- caught by _poll_loop's broad except, but
+            # this exact policy frame would then be the permanent FIFO head
+            # forever (it can never resolve), reproducing the same
+            # queue-blocking failure shape build_unevaluable_execution_
+            # dispatch_frame exists to prevent for a missing proposal.
+            frame_generated_at = candidate_frame.generated_at
+            if frame_generated_at.tzinfo is None:
+                frame_generated_at = frame_generated_at.replace(tzinfo=timezone.utc)
+            age_sec = (datetime.now(timezone.utc) - frame_generated_at).total_seconds()
+            threshold_sec = self._staleness_threshold_sec()
+            if age_sec <= threshold_sec:
+                return candidate_frame, discarded, last_discard_frame
+            discard_frame = build_stale_discard_execution_dispatch_frame(
+                policy_frame=candidate_frame,
+                policy_id=self._policy.policy_id,
+                age_sec=age_sec,
+                staleness_threshold_sec=threshold_sec,
+            ).model_copy(update=baseline)
+            self._store.save_dispatch_frame(discard_frame)
+            last_discard_frame = discard_frame
+            discarded += 1
+            logger.info(
+                "execution_dispatch_stale_discard policy_frame_id=%s age_sec=%.1f "
+                "threshold_sec=%.1f discarded_this_tick=%d",
+                candidate_frame.frame_id,
+                age_sec,
+                threshold_sec,
+                discarded,
+            )
+        return None, discarded, last_discard_frame
+
     def _tick(self) -> None:
         if not self._settings.enable_execution_dispatch_runtime:
             return
 
-        policy_frame = self._store.load_latest_policy_frame_without_dispatch()
+        baseline = self._store.load_latest_staleness_discard_baseline() or {
+            "staleness_discard_count_ewma": 0.0,
+            "staleness_discard_count_ewma_var": 0.0,
+            "staleness_discard_count_ewma_n": 0,
+        }
+        policy_frame, discarded_this_tick, last_discard_frame = self._drain_stale_policy_frames(
+            baseline
+        )
+
+        update = compute_ewma_update(
+            prev_ewma=baseline["staleness_discard_count_ewma"],
+            prev_variance=baseline["staleness_discard_count_ewma_var"],
+            prev_count=baseline["staleness_discard_count_ewma_n"],
+            value=float(discarded_this_tick),
+            alpha=STALENESS_DISCARD_EWMA_ALPHA,
+            min_variance=STALENESS_DISCARD_EWMA_MIN_VARIANCE,
+        )
+        updated_baseline = {
+            "staleness_discard_count_ewma": update.ewma,
+            "staleness_discard_count_ewma_var": update.variance,
+            "staleness_discard_count_ewma_n": baseline["staleness_discard_count_ewma_n"] + 1,
+        }
+
         if policy_frame is None:
+            # Either the queue is fully drained, or this tick hit
+            # MAX_STALE_DISCARDS_PER_TICK with real backlog still queued
+            # behind it -- the next tick's load_latest_policy_frame_without_
+            # dispatch() naturally resumes at the new FIFO head either way,
+            # since every discard above was really saved. Nothing fresh to
+            # build a real frame for this tick; if at least one discard
+            # happened, this tick's real (not-yet-final at save time)
+            # baseline update still needs a home -- re-stamp it onto that
+            # same last discard frame (save_dispatch_frame's ON CONFLICT
+            # upsert makes this idempotent, not a duplicate row).
+            if last_discard_frame is not None:
+                self._store.save_dispatch_frame(
+                    last_discard_frame.model_copy(update=updated_baseline)
+                )
             return
 
         proposal = self._store.load_proposal_frame(policy_frame.source_proposal_frame_id)
@@ -178,7 +330,7 @@ class ExecutionDispatchRuntimeWorker:
                 policy_frame=policy_frame,
                 policy_id=self._policy.policy_id,
                 reason=f"proposal_frame {policy_frame.source_proposal_frame_id} unavailable",
-            )
+            ).model_copy(update=updated_baseline)
             self._store.save_dispatch_frame(frame)
             logger.info(
                 "execution_dispatch_frame_saved_unevaluable frame_id=%s policy_frame_id=%s",
@@ -197,7 +349,7 @@ class ExecutionDispatchRuntimeWorker:
             field_tick_id=policy_frame.source_field_tick_id,
             policy=self._policy,
             override_dispatch_mode=self._settings.execution_dispatch_mode,
-        )
+        ).model_copy(update=updated_baseline)
 
         if (
             self._settings.execution_dispatch_mode == "dispatch_read_only"

--- a/tests/test_execution_dispatch_builder.py
+++ b/tests/test_execution_dispatch_builder.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from orion.execution_dispatch.builder import (
     build_execution_dispatch_frame,
+    build_stale_discard_execution_dispatch_frame,
     stable_execution_dispatch_frame_id,
 )
 from orion.execution_dispatch.policy import load_execution_dispatch_policy
@@ -229,3 +230,32 @@ def test_stable_frame_id() -> None:
         now=NOW,
     )
     assert frame.frame_id == expected
+
+
+def test_stale_discard_frame_records_honestly_and_never_dispatches() -> None:
+    proposal = _proposal_frame()
+    policy_frame = _policy_frame(proposal)
+
+    frame = build_stale_discard_execution_dispatch_frame(
+        policy_frame=policy_frame,
+        policy_id=POLICY.policy_id,
+        age_sec=21600.0,
+        staleness_threshold_sec=180.0,
+        now=NOW,
+    )
+
+    assert frame.frame_id == stable_execution_dispatch_frame_id(
+        policy_frame_id=policy_frame.frame_id, policy_id=POLICY.policy_id
+    )
+    assert frame.dispatch_attempted is False
+    assert frame.dispatch_count == 0
+    assert frame.blocked_count == len(policy_frame.decisions)
+    assert frame.candidates == []
+    assert frame.dispatched_candidates == []
+    assert any("stale_backlog_discarded age_sec=21600.0 threshold_sec=180.0" in w for w in frame.warnings)
+    # Materialized, not silently dropped: one real per-decision entry, real
+    # template key + real decision, for every candidate that was discarded.
+    assert "stale_discard:inspect:approved_read_only" in frame.warnings
+    assert "stale_discard:summarize:approved_read_only" in frame.warnings
+    assert "stale_discard:review:requires_operator_review" in frame.warnings
+    assert "stale_discard:blocked:rejected" in frame.warnings

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import sys
 from collections import deque
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,7 +20,7 @@ from orion.schemas.execution_dispatch_frame import (  # noqa: E402
     ExecutionDispatchCandidateV1,
     ExecutionDispatchFrameV1,
 )
-from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1  # noqa: E402
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1  # noqa: E402
 from orion.schemas.proposal_frame import ProposalFrameV1  # noqa: E402
 
 NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
@@ -51,11 +51,16 @@ def _policy_frame() -> PolicyDecisionFrameV1:
 
 def test_worker_skips_when_no_policy_pending(monkeypatch) -> None:
     monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    # 2026-07-30: staleness-discard override disabled (very large) -- this
+    # test is about "no pending policy frame at all," not about staleness
+    # behavior, same reasoning as the two tests below.
+    monkeypatch.setenv("EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC", "99999999999")
     import app.settings as settings_mod
 
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
     worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=None)
+    worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
 
     worker._tick()
@@ -69,12 +74,21 @@ def test_worker_records_unevaluable_frame_when_proposal_missing(monkeypatch) -> 
     # behind it. The worker must record an honest "could not evaluate" frame
     # so the FIFO queue advances.
     monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    # 2026-07-30: _policy_frame()'s generated_at is a fixed historical
+    # constant (NOW, 2026-05-24) -- real wall-clock age against that would
+    # always exceed even the widest real staleness window and get fast-
+    # discarded before this test's actual target behavior (proposal-missing
+    # handling) ever runs. This test is about that handling, not staleness,
+    # so disable the discard path here (dedicated staleness tests below
+    # exercise it directly with controlled ages).
+    monkeypatch.setenv("EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC", "99999999999")
     import app.settings as settings_mod
 
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
     policy_frame = _policy_frame()
     worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=policy_frame)
+    worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.load_proposal_frame = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
 
@@ -93,12 +107,16 @@ def test_worker_saves_dispatch_frame_for_pending_policy(monkeypatch) -> None:
     # field_tick_id straight off policy_frame -- no separate self-state load
     # that could fail and stall the FIFO queue.
     monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    # 2026-07-30: see test_worker_records_unevaluable_frame_when_proposal_
+    # missing's comment above -- same fixed-historical-generated_at issue.
+    monkeypatch.setenv("EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC", "99999999999")
     import app.settings as settings_mod
 
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
     policy_frame = _policy_frame()
     worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=policy_frame)
+    worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.load_proposal_frame = MagicMock(return_value=_proposal())
     worker._store.save_dispatch_frame = MagicMock()
 
@@ -109,6 +127,198 @@ def test_worker_saves_dispatch_frame_for_pending_policy(monkeypatch) -> None:
     assert isinstance(saved, ExecutionDispatchFrameV1)
     assert saved.source_policy_frame_id == policy_frame.frame_id
     assert saved.source_field_tick_id == policy_frame.source_field_tick_id
+
+
+def _policy_frame_at(generated_at: datetime, *, frame_id: str = "policy.frame:staleness-test") -> PolicyDecisionFrameV1:
+    return PolicyDecisionFrameV1(
+        frame_id=frame_id,
+        generated_at=generated_at,
+        source_proposal_frame_id=f"proposal.frame:{frame_id}",
+        source_field_tick_id="tick:staleness-test",
+        overall_risk=0.0,
+    )
+
+
+def _staleness_worker(monkeypatch, *, override_sec: float | None = None) -> ExecutionDispatchRuntimeWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    if override_sec is not None:
+        monkeypatch.setenv("EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC", str(override_sec))
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = ExecutionDispatchRuntimeWorker()
+    worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
+    worker._store.save_dispatch_frame = MagicMock()
+    worker._store.load_proposal_frame = MagicMock(return_value=_proposal())
+    return worker
+
+
+def test_staleness_threshold_respects_override(monkeypatch) -> None:
+    worker = _staleness_worker(monkeypatch, override_sec=42.0)
+    for _ in range(5):
+        assert worker._staleness_threshold_sec() == 42.0
+
+
+def test_staleness_threshold_falls_in_configured_range_without_override(monkeypatch) -> None:
+    worker = _staleness_worker(monkeypatch)
+    lo = worker._settings.execution_dispatch_staleness_min_sec
+    hi = worker._settings.execution_dispatch_staleness_max_sec
+    seen = {worker._staleness_threshold_sec() for _ in range(50)}
+    assert all(lo <= v <= hi for v in seen)
+    # 50 draws from a continuous uniform range landing on fewer than 2
+    # distinct values would indicate this isn't actually randomized.
+    assert len(seen) > 1
+
+
+def test_worker_discards_a_lone_stale_policy_frame_without_dispatching(monkeypatch) -> None:
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    stale_frame = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=6))
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
+        side_effect=[stale_frame, None]
+    )
+
+    worker._tick()
+
+    # Saved twice: once during the drain (carrying the pre-tick baseline
+    # forward, unknown final count yet) and once more to re-stamp this
+    # tick's now-final EWMA update onto that same frame_id (idempotent
+    # upsert, not a duplicate row -- see _tick()'s own comment). The content
+    # that matters is the LAST call, same as what the next tick's
+    # load_latest_staleness_discard_baseline() would actually read back.
+    assert worker._store.save_dispatch_frame.call_count == 2
+    saved = worker._store.save_dispatch_frame.call_args[0][0]
+    assert saved.source_policy_frame_id == stale_frame.frame_id
+    assert saved.dispatch_attempted is False
+    assert any("stale_backlog_discarded" in w for w in saved.warnings)
+    worker._store.load_proposal_frame.assert_not_called()
+
+
+def test_worker_materializes_per_candidate_discard_summary(monkeypatch) -> None:
+    """The discard is not a silent drop -- each candidate's template and
+    decision are preserved in the saved frame's warnings, real forensic
+    content, not just a bare 'stale' flag."""
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    stale_frame = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=6)).model_copy(
+        update={
+            "decisions": [
+                PolicyDecisionV1(
+                    decision_id="policy.decision:1",
+                    proposal_id="proposal:inspect_bus_channel_catalog:tick_x:attention.frame:tick_x:field_attention_policy.v1",
+                    decision="approved_read_only",
+                    policy_gate="read_only",
+                    risk_score=0.1,
+                    reversibility_score=1.0,
+                    confidence_score=0.8,
+                )
+            ]
+        }
+    )
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
+        side_effect=[stale_frame, None]
+    )
+
+    worker._tick()
+
+    saved = worker._store.save_dispatch_frame.call_args[0][0]
+    assert "stale_discard:inspect_bus_channel_catalog:approved_read_only" in saved.warnings
+
+
+def test_worker_drains_stale_frames_then_processes_a_fresh_one(monkeypatch) -> None:
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    stale_1 = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=6), frame_id="policy.frame:stale-1")
+    stale_2 = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=3), frame_id="policy.frame:stale-2")
+    fresh = _policy_frame_at(datetime.now(timezone.utc) - timedelta(seconds=1), frame_id="policy.frame:fresh")
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
+        side_effect=[stale_1, stale_2, fresh]
+    )
+
+    worker._tick()
+
+    assert worker._store.save_dispatch_frame.call_count == 3
+    worker._store.load_proposal_frame.assert_called_once_with(fresh.source_proposal_frame_id)
+    final_saved = worker._store.save_dispatch_frame.call_args_list[-1][0][0]
+    assert final_saved.source_policy_frame_id == fresh.frame_id
+    assert final_saved.dispatch_attempted is False or final_saved.candidates == []
+
+
+def test_max_stale_discards_per_tick_caps_the_drain(monkeypatch) -> None:
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    ancient = _policy_frame_at(datetime.now(timezone.utc) - timedelta(days=2))
+    # Same object every call -- an unbounded drain loop would spin forever;
+    # the cap must stop it after exactly MAX_STALE_DISCARDS_PER_TICK saves.
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=ancient)
+
+    worker._tick()
+
+    # +1: the final re-stamp save of the last discard frame with this tick's
+    # now-final EWMA count, same reasoning as test_worker_discards_a_lone_
+    # stale_policy_frame_without_dispatching above.
+    assert worker._store.save_dispatch_frame.call_count == worker_mod.MAX_STALE_DISCARDS_PER_TICK + 1
+    worker._store.load_proposal_frame.assert_not_called()
+
+
+def test_staleness_discard_ewma_advances_and_persists(monkeypatch) -> None:
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    worker._store.load_latest_staleness_discard_baseline = MagicMock(
+        return_value={
+            "staleness_discard_count_ewma": 3.0,
+            "staleness_discard_count_ewma_var": 1.0,
+            "staleness_discard_count_ewma_n": 5,
+        }
+    )
+    stale_frame = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=6))
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
+        side_effect=[stale_frame, None]
+    )
+
+    worker._tick()
+
+    saved = worker._store.save_dispatch_frame.call_args[0][0]
+    assert saved.staleness_discard_count_ewma_n == 6
+    # value=1.0 (one real discard this tick) pulls the ewma up from its
+    # prior 3.0 baseline toward 1.0 -- direction, not exact magnitude
+    # (compute_ewma_update's own math is tested elsewhere), is what this
+    # regression guards.
+    assert saved.staleness_discard_count_ewma < 3.0
+
+
+def test_worker_fresh_policy_frame_never_discarded(monkeypatch) -> None:
+    """A policy frame well within the staleness window is processed
+    normally, not discarded -- the staleness path must not fire on healthy,
+    real-time traffic."""
+    worker = _staleness_worker(monkeypatch, override_sec=300.0)
+    fresh = _policy_frame_at(datetime.now(timezone.utc))
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=fresh)
+
+    worker._tick()
+
+    worker._store.save_dispatch_frame.assert_called_once()
+    saved = worker._store.save_dispatch_frame.call_args[0][0]
+    assert not any("stale_backlog_discarded" in w for w in saved.warnings)
+    worker._store.load_proposal_frame.assert_called_once()
+
+
+def test_worker_handles_naive_generated_at_without_crashing(monkeypatch) -> None:
+    """Regression guard (code review, 2026-07-30): PolicyDecisionFrameV1.
+    generated_at is a plain datetime, not enforced tz-aware. A naive value
+    subtracted from datetime.now(timezone.utc) without normalizing first
+    raises TypeError -- caught by _poll_loop's broad except, but that exact
+    policy frame would then be the permanent FIFO head forever (never
+    resolves, never gets marked processed), the same queue-blocking failure
+    shape build_unevaluable_execution_dispatch_frame exists to prevent for a
+    missing proposal. _drain_stale_policy_frames must normalize before
+    subtracting."""
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    naive_stale = _policy_frame_at(datetime.now() - timedelta(hours=6))
+    assert naive_stale.generated_at.tzinfo is None
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
+        side_effect=[naive_stale, None]
+    )
+
+    worker._tick()  # must not raise
+
+    saved = worker._store.save_dispatch_frame.call_args[0][0]
+    assert any("stale_backlog_discarded" in w for w in saved.warnings)
 
 
 def _make_worker(monkeypatch) -> ExecutionDispatchRuntimeWorker:


### PR DESCRIPTION
## Summary

- Found live 2026-07-30 while verifying PR #1497's proposal-confidence fix: `orion-execution-dispatch-runtime` was 46,617 policy decisions behind, oldest from 2026-07-29 07:24 (37h), growing ~9/min.
- Root cause: strict FIFO oldest-first consumption, but each real dispatch is a synchronous ~7-11s cortex-exec RPC blocking the whole poll loop — real throughput ~6.8/min against ~16/min production of new policy decisions.
- `_tick()` now fast-drains any policy frame older than a randomized `[EXECUTION_DISPATCH_STALENESS_MIN_SEC, _MAX_SEC]` threshold (default 120-300s) before considering a real send, capped at 200 discards/tick. Each discard is materialized (real `stale_discard:{template_key}:{decision}` warnings), never silently dropped.
- New backlog-pressure signal: `staleness_discard_count_ewma`/`_var`/`_n`, same carried-forward convention as the existing `daily_risk_baseline_*` fields.
- Operator override shim (`EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC`) for a deliberate future deep-backlog catch-up without a code change.
- Fixed a naive-datetime crash risk found in review (would have permanently stalled the FIFO queue on a malformed row).
- Part 2 (real throughput — concurrent dispatch) specced in the design doc, deliberately not implemented — pending tracing whether `orion-cortex-exec` itself is the real ceiling.

## Outcome moved

Real cortex dispatch actions no longer describe hours/days-old field pressure as current. The backlog drains fast (stale-skip is a cheap DB write vs. a ~9s LLM call) instead of growing forever.

## Current architecture

`ExecutionDispatchRuntimeStore.load_latest_policy_frame_without_dispatch()` was strict FIFO oldest-first with no staleness awareness; `_tick()` processed exactly one policy frame per poll cycle with no concept of "too old to be worth a real send."

## Architecture touched

`services/orion-execution-dispatch-runtime/app/worker.py` (`_tick`, new `_staleness_threshold_sec`/`_drain_stale_policy_frames`), `app/store.py` (new `load_latest_staleness_discard_baseline`), `app/settings.py` (3 new env-backed settings), `orion/execution_dispatch/builder.py` (new `build_stale_discard_execution_dispatch_frame`), `orion/schemas/execution_dispatch_frame.py` (3 new EWMA fields, JSONB-backed, no migration needed).

## Files changed

- `orion/schemas/execution_dispatch_frame.py`: `staleness_discard_count_ewma`/`_var`/`_n` fields.
- `orion/execution_dispatch/builder.py`: `build_stale_discard_execution_dispatch_frame`, `_decision_template_key`.
- `services/orion-execution-dispatch-runtime/app/worker.py`: staleness-drain loop, EWMA update/re-stamp logic, naive-datetime normalize.
- `services/orion-execution-dispatch-runtime/app/store.py`: `load_latest_staleness_discard_baseline`.
- `services/orion-execution-dispatch-runtime/app/settings.py`: `EXECUTION_DISPATCH_STALENESS_MIN_SEC`/`_MAX_SEC`/`_OVERRIDE_SEC`.
- `services/orion-execution-dispatch-runtime/.env_example`, `README.md`: documented.
- `tests/test_execution_dispatch_runtime_worker.py`, `tests/test_execution_dispatch_builder.py`: new coverage (drain, cap, EWMA re-stamp, override, randomization, naive-datetime regression).
- `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md`: full live-data investigation + Part 2 spec (not implemented).

## Schema / bus / API changes

- Added: `ExecutionDispatchFrameV1.staleness_discard_count_ewma`/`_var`/`_n` (defaulted floats/int, JSONB-backed, no migration).
- No bus/API changes.

## Env/config changes

- Added keys: `EXECUTION_DISPATCH_STALENESS_MIN_SEC=120.0`, `EXECUTION_DISPATCH_STALENESS_MAX_SEC=300.0`, `EXECUTION_DISPATCH_STALENESS_OVERRIDE_SEC` (unset by default — commented in `.env_example`, since an empty string fails `float | None` parsing in pydantic-settings, confirmed live).
- `.env_example` updated: yes.
- local `.env` synced: yes — this worktree has no local `.env` (gitignored, not inherited by a fresh worktree), so the real shared-checkout `.env` (`/mnt/scripts/Orion-Sapienform/services/orion-execution-dispatch-runtime/.env`) was updated directly with matching values (verified independently by the review subagent).
- Skipped keys: none.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-execution-dispatch-staleness-discard
PYTHONPATH=. .venv/bin/python -m pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_policy_loader.py tests/test_execution_dispatch_envelopes.py tests/test_execution_dispatch_bus_catalog.py tests/test_execution_dispatch_result_extraction.py tests/test_execution_dispatch_cortex_client.py tests/test_execution_dispatch_transport_dry_run.py -q
# 114 passed
```

## Evals run

None — no eval harness exists for this service; not building one in this pass (real production/consumption throughput math was verified against live Postgres data instead, documented in the design doc).

## Docker/build/smoke checks

Not run in this pass — no live deploy. The prior related patch (PR #1497) was deployed and its behavior verified against real live data within this same investigation; this patch has not yet been deployed.

## Review findings fixed

- Finding: a tick where the policy-decision queue is fully empty from the start skips the EWMA persistence entirely (no frame exists to carry a `value=0.0` sample on).
  - Fix: disclosed explicitly in code comments and the design doc rather than patched with a synthetic no-op frame (would be inventing content to carry a metric, not recording something real) — low severity, only under-samples the true-idle case, never the backlog case this patch exists for.
  - Evidence: `app/worker.py` `STALENESS_DISCARD_EWMA_ALPHA` comment, `orion/schemas/execution_dispatch_frame.py` field comment, design doc Part 1.
- Finding: `_drain_stale_policy_frames` subtracts `datetime.now(timezone.utc)` from `PolicyDecisionFrameV1.generated_at` without normalizing — a naive `generated_at` would raise, permanently stalling the FIFO queue behind that exact frame.
  - Fix: normalize before subtracting, same idiom `_derive_daily_risk_cap` already uses in this same file.
  - Evidence: `app/worker.py::_drain_stale_policy_frames`, new regression test `test_worker_handles_naive_generated_at_without_crashing`.
- No other material findings — reviewer independently hand-traced the EWMA re-stamp logic across all 4 `_tick()` branches (drain-then-fresh, drain-then-empty, drain-hits-cap, zero-discard), confirmed the drain loop's cap is exact (201 calls including the re-stamp, verified against a real test), confirmed the `.env`/`.env_example` empty-string-parsing reasoning by reproducing the pydantic error live, and confirmed the real shared-checkout `.env` was actually synced (read directly, not assumed). Verdict: ship as-is.

## Restart required

```bash
# orion-execution-dispatch-runtime reads app/worker.py, app/settings.py, and the new
# schema fields directly — restart to pick up the fix:
docker compose --env-file .env --env-file services/orion-execution-dispatch-runtime/.env \
  -f services/orion-execution-dispatch-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: medium
- Concern: unverified against live traffic post-deploy — this patch has not yet been deployed. Once deployed, the backlog should drain quickly (cheap discards vs. ~9s real dispatches), but the *steady-state* behavior (production still likely exceeding raw dispatch throughput) means a rolling fraction of candidates will always go stale rather than dispatch, under this patch alone. That's disclosed as an intentional trade-off (real, current dispatch over queued false-freshness debt), not a bug — but it means Part 2 (real throughput) is still a real open question, not optional polish.
- Mitigation: `staleness_discard_count_ewma` is exactly the signal to watch post-deploy to confirm the backlog actually drains and stays near 0 rather than oscillating. Design doc names the concrete next investigation (trace `orion-cortex-exec`'s real concurrent capacity) before scoping Part 2 further.
- Severity: low
- Concern: the empty-queue EWMA-skip gap and the naive-datetime fix are both edge cases with low real-world likelihood (every real producer in this repo uses tz-aware datetimes; a fully-idle queue is the opposite of the observed failure mode).
- Mitigation: both disclosed explicitly in code and docs rather than silently left as unstated behavior; the naive-datetime one is now defended against directly.