### PR TITLE
feat(hub): add read-only Field Attention operator tab

### DIFF
--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -649,6 +649,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const aiTownPanel = document.getElementById("ai-town");
   const attentionOrganTabButton = document.getElementById("attentionOrganTabButton");
   const attentionOrganPanel = document.getElementById("attention-organ");
+  const fieldAttentionTabButton = document.getElementById("fieldAttentionTabButton");
+  const fieldAttentionPanel = document.getElementById("field-attention");
   const pressureAnalyticsFrame = document.getElementById("pressureAnalyticsFrame");
   const pressureAnalyticsRefresh = document.getElementById("pressureAnalyticsRefresh");
   const substrateLatticeTabButton = document.getElementById("substrateLatticeTabButton");
@@ -950,6 +952,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (tabKey === "attention-organ" && !attentionOrganPanel) {
       effectiveTab = "hub";
     }
+    if (tabKey === "field-attention" && !fieldAttentionPanel) {
+      effectiveTab = "hub";
+    }
     const isHub = effectiveTab === "hub";
     const isTopicStudio = effectiveTab === "topic-studio";
     const isServiceLogs = effectiveTab === "service-logs";
@@ -967,6 +972,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const isCollapseMirror = effectiveTab === "collapse-mirror";
     const isAiTown = effectiveTab === "ai-town";
     const isAttentionOrgan = effectiveTab === "attention-organ";
+    const isFieldAttention = effectiveTab === "field-attention";
     hubTabPanel.classList.toggle("hidden", !isHub);
     topicStudioPanel.classList.toggle("hidden", !isTopicStudio);
     serviceLogsPanel.classList.toggle("hidden", !isServiceLogs);
@@ -1086,6 +1092,18 @@ document.addEventListener("DOMContentLoaded", () => {
         window.OrionAttentionOrgan.deactivate();
       }
     }
+    if (fieldAttentionPanel) {
+      fieldAttentionPanel.classList.toggle("hidden", !isFieldAttention);
+      // Same lifecycle contract as Attention Organ, above -- a distinct
+      // subsystem (FieldAttentionFrameV1), same poll-only-while-visible rule.
+      if (isFieldAttention) {
+        if (window.OrionFieldAttention && typeof window.OrionFieldAttention.activate === "function") {
+          window.OrionFieldAttention.activate();
+        }
+      } else if (window.OrionFieldAttention && typeof window.OrionFieldAttention.deactivate === "function") {
+        window.OrionFieldAttention.deactivate();
+      }
+    }
     styleTabButton(hubTabButton, isHub);
     styleTabButton(topicStudioTabButton, isTopicStudio);
     styleTabButton(serviceLogsTabButton, isServiceLogs);
@@ -1128,6 +1146,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (attentionOrganTabButton) {
       styleTabButton(attentionOrganTabButton, isAttentionOrgan);
+    }
+    if (fieldAttentionTabButton) {
+      styleTabButton(fieldAttentionTabButton, isFieldAttention);
     }
   }
 
@@ -1715,6 +1736,8 @@ document.addEventListener("DOMContentLoaded", () => {
       setActiveTab("ai-town");
     } else if (h === "#attention-organ" && attentionOrganPanel && attentionOrganTabButton) {
       setActiveTab("attention-organ");
+    } else if (h === "#field-attention" && fieldAttentionPanel && fieldAttentionTabButton) {
+      setActiveTab("field-attention");
     } else {
       if (
         h === "#pressure"
@@ -1728,6 +1751,7 @@ document.addEventListener("DOMContentLoaded", () => {
         || h === "#collapse-mirror"
         || h === "#ai-town"
         || h === "#attention-organ"
+        || h === "#field-attention"
       ) {
         history.replaceState(null, "", "#hub");
       }
@@ -11522,6 +11546,13 @@ document.addEventListener("DOMContentLoaded", () => {
         event.preventDefault();
         setActiveTab("attention-organ");
         history.replaceState(null, "", "#attention-organ");
+      });
+    }
+    if (fieldAttentionTabButton && fieldAttentionPanel) {
+      fieldAttentionTabButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        setActiveTab("field-attention");
+        history.replaceState(null, "", "#field-attention");
       });
     }
     applyHashToTab();

--- a/services/orion-hub/static/js/field-attention.js
+++ b/services/orion-hub/static/js/field-attention.js
@@ -134,7 +134,23 @@
   // binary in real data (verified live 2026-07-30, 10,747 observations, only
   // ever exactly 0.0 or exactly 1.0), so a gradient would imply a precision
   // this signal does not have.
-  function confidenceBadge(value) {
+  //
+  // Review finding (2026-07-30): "system" targets are the one exception --
+  // select_system_targets() in orion/attention/field_attention/selectors.py
+  // hardcodes confidence_score=0.0 as a schema-required placeholder, not a
+  // real "not grounded yet" reading (no confidence concept applies to that
+  // aggregate signal at all). Rendering that as "cold-start" would read as
+  // "still warming up," which it can never stop being -- a permanent
+  // mislabel, not a transient one. targetKind lets the caller opt out of
+  // the binary badge for that one kind instead.
+  function confidenceBadge(value, targetKind) {
+    if (targetKind === "system") {
+      return badge(
+        "n/a",
+        "border-gray-700 bg-gray-900 text-gray-500",
+        "confidence_score not meaningful for system targets -- select_system_targets() hardcodes 0.0 as a placeholder"
+      );
+    }
     var v = Number(value);
     var grounded = isFinite(v) && v >= CONFIDENCE_GROUNDED_THRESHOLD;
     return badge(
@@ -249,7 +265,7 @@
       row.appendChild(el("td", "py-1.5 pr-3 font-mono text-gray-300", magnitude));
 
       var confCell = el("td", "py-1.5 pr-3");
-      confCell.appendChild(confidenceBadge(target.confidence_score));
+      confCell.appendChild(confidenceBadge(target.confidence_score, target.target_kind));
       row.appendChild(confCell);
 
       var modeCell = el("td", "py-1.5 pr-3");

--- a/services/orion-hub/static/js/field-attention.js
+++ b/services/orion-hub/static/js/field-attention.js
@@ -1,0 +1,436 @@
+// Field Attention operator tab.
+//
+// Read-only view of FieldAttentionFrameV1 -- the substrate field-attention
+// system (Candidate A precision-weighted prediction-error salience +
+// Candidate B Global-Workspace novelty salience), built by
+// orion/attention/field_attention/ and shipped in PR #1484/#1488. This is a
+// DIFFERENT subsystem from attention-organ.js's Attention Organ tab, which
+// visualizes orion-heartbeat's N-trajectory dissipation ensemble (AST/HOT) --
+// do not conflate the two, and do not reuse "attention-organ" naming here.
+//
+// Backed entirely by GET /api/substrate/attention/latest
+// (services/orion-hub/scripts/substrate_attention_routes.py, already
+// registered on the Hub API router -- this file does not add or change any
+// route). This module owns rendering and the poll lifecycle only; every
+// number it draws comes straight from that one real endpoint, and nothing
+// here writes back (no POST anywhere in this file).
+//
+// Panel show/hide is app.js's setActiveTab; this module exposes
+// activate()/deactivate() so polling runs ONLY while the tab is visible --
+// same lifecycle contract as attention-organ.js, including its guard against
+// a panel hidden by a path other than setActiveTab (self_observability.js
+// hides every section[data-panel] directly and never calls deactivate()).
+(function () {
+  "use strict";
+
+  var LATEST_URL = "/api/substrate/attention/latest";
+
+  // Production ticks every ~2s (verified live 2026-07-30 against persisted
+  // substrate_attention_frames rows). 5s is a light multiple of that, the
+  // same default attention-organ.js uses for its own poll timer.
+  var POLL_MS = 5000;
+
+  // Design-verified 2026-07-30 (see index.html's on-panel note and this
+  // file's renderHeader/confidenceBadge): confidence_score takes only 0.0 or
+  // 1.0 across 10,747 recent target-observations, so >= 0.5 is a safe binary
+  // split rather than a real threshold decision.
+  var CONFIDENCE_GROUNDED_THRESHOLD = 0.5;
+
+  var state = {
+    active: false,
+    timer: null,
+    inFlight: false,
+    lastFetchedAt: 0,
+    lastFrame: null,
+  };
+
+  var els = {};
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function bindElements() {
+    els.panel = $("field-attention");
+    els.status = $("fieldAttentionStatus");
+    els.header = $("fieldAttentionHeader");
+    els.dominant = $("fieldAttentionDominantTargets");
+    els.suppressed = $("fieldAttentionSuppressedTargets");
+    els.bottom = $("fieldAttentionBottomStrip");
+    els.refreshBtn = $("fieldAttentionRefreshBtn");
+    return !!els.panel;
+  }
+
+  // ---------------------------------------------------------------- helpers
+
+  function num(value, digits) {
+    if (value === null || value === undefined || value === "") return "—";
+    var parsed = Number(value);
+    if (!isFinite(parsed)) return "—";
+    return parsed.toFixed(digits === undefined ? 4 : digits);
+  }
+
+  function age(seconds) {
+    if (seconds === null || seconds === undefined) return "—";
+    var s = Number(seconds);
+    if (!isFinite(s)) return "—";
+    if (s < 0) return s > -2 ? "0.0s" : s.toFixed(1) + "s";
+    if (s < 90) return s.toFixed(1) + "s";
+    if (s < 5400) return (s / 60).toFixed(1) + "m";
+    if (s < 172800) return (s / 3600).toFixed(1) + "h";
+    return (s / 86400).toFixed(1) + "d";
+  }
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = String(text);
+    return node;
+  }
+
+  function badge(text, tone, title) {
+    var node = el("span", "inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold border " + tone, text);
+    if (title) node.title = title;
+    return node;
+  }
+
+  function note(host, text, tone) {
+    host.appendChild(el("p", "text-[10px] leading-relaxed mt-2 " + (tone || "text-gray-500"), text));
+  }
+
+  function errorBlock(host, title, message) {
+    host.textContent = "";
+    host.appendChild(el("h3", "text-sm font-semibold text-gray-100 mb-2", title));
+    host.appendChild(
+      el(
+        "div",
+        "text-[11px] font-mono text-red-300 bg-red-950/30 border border-red-900/60 rounded-lg p-2 break-all",
+        message || "no data"
+      )
+    );
+  }
+
+  // Candidate A's reason strings start with "precision-weighted
+  // prediction-error salience" (orion/attention/field_attention/selectors.py
+  // select_node_targets()); Candidate B's start with "Candidate B
+  // novelty-only salience" (same file's _novelty_targets()). A target whose
+  // reasons match neither (e.g. the system "recent field perturbation
+  // count" target) gets no candidate badge rather than a guessed one.
+  var CANDIDATE_A_PREFIX = "precision-weighted prediction-error salience";
+  var CANDIDATE_B_PREFIX = "Candidate B novelty-only salience";
+
+  function candidateBadgeFor(reasons) {
+    var first = Array.isArray(reasons) && reasons.length ? String(reasons[0]) : "";
+    if (first.indexOf(CANDIDATE_A_PREFIX) === 0) {
+      return badge("A", "border-sky-700 bg-sky-950/50 text-sky-200", "Candidate A -- precision-weighted prediction-error salience");
+    }
+    if (first.indexOf(CANDIDATE_B_PREFIX) === 0) {
+      return badge("B", "border-violet-700 bg-violet-950/50 text-violet-200", "Candidate B -- Global-Workspace novelty salience");
+    }
+    return badge("—", "border-gray-700 bg-gray-900 text-gray-500", "No candidate reason prefix matched");
+  }
+
+  // Rendered as a two-state badge, not a progress bar: confidence_score is
+  // binary in real data (verified live 2026-07-30, 10,747 observations, only
+  // ever exactly 0.0 or exactly 1.0), so a gradient would imply a precision
+  // this signal does not have.
+  function confidenceBadge(value) {
+    var v = Number(value);
+    var grounded = isFinite(v) && v >= CONFIDENCE_GROUNDED_THRESHOLD;
+    return badge(
+      grounded ? "grounded" : "cold-start",
+      grounded
+        ? "border-emerald-700 bg-emerald-950/50 text-emerald-200"
+        : "border-amber-700 bg-amber-950/50 text-amber-200",
+      "confidence_score=" + num(value, 2)
+    );
+  }
+
+  function observationModeBadge(mode) {
+    var tones = {
+      inspect: "border-red-700 bg-red-950/50 text-red-200",
+      summarize: "border-amber-700 bg-amber-950/50 text-amber-200",
+      watch: "border-sky-700 bg-sky-950/50 text-sky-200",
+      ignore: "border-gray-700 bg-gray-900 text-gray-500",
+    };
+    return badge(mode || "watch", tones[mode] || tones.watch);
+  }
+
+  // ---------------------------------------------------------------- renderers
+
+  function renderHeader(host, frame) {
+    host.textContent = "";
+    var generatedAt = frame.generated_at ? Date.parse(frame.generated_at) : NaN;
+    var ageSec = isFinite(generatedAt) ? (Date.now() - generatedAt) / 1000 : null;
+
+    var top = el("div", "flex flex-wrap items-baseline justify-between gap-3");
+    var left = el("div", "flex flex-wrap items-baseline gap-4");
+    left.appendChild(
+      el(
+        "div",
+        "text-[11px] font-mono " + (ageSec !== null && ageSec > 30 ? "text-amber-300" : "text-gray-300"),
+        "frame age " + age(ageSec)
+      )
+    );
+    left.appendChild(el("div", "text-[11px] font-mono text-gray-400", "policy " + (frame.attention_policy_id || "—")));
+    left.appendChild(el("div", "text-[11px] font-mono text-gray-400", "tick " + (frame.source_field_tick_id || "—")));
+    top.appendChild(left);
+
+    var right = el("div", "text-right");
+    right.appendChild(el("div", "text-lg font-mono text-gray-200 leading-none", num(frame.overall_salience, 3)));
+    right.appendChild(el("div", "text-[9px] uppercase tracking-wide text-gray-500 mt-0.5", "overall_salience (secondary)"));
+    top.appendChild(right);
+    host.appendChild(top);
+
+    note(
+      host,
+      "overall_salience is the max of this tick's already per-tick min-max-normalized target scores " +
+        "(normalize_across_targets() / build_attention_frame()), so it reads ≈1.0 on almost every tick whenever " +
+        "any node target competes -- it is not a “how much is going on” gauge. Read the ranked target table below instead."
+    );
+  }
+
+  function renderReasonsCell(reasons) {
+    var wrap = el("details", "text-[10px]");
+    var summary = el(
+      "summary",
+      "text-gray-400 cursor-pointer",
+      (Array.isArray(reasons) ? reasons.length : 0) + " reason(s)"
+    );
+    wrap.appendChild(summary);
+    var body = el("div", "mt-1 text-gray-300 whitespace-pre-wrap break-words max-w-md");
+    body.textContent = Array.isArray(reasons) && reasons.length ? reasons.join("\n") : "—";
+    wrap.appendChild(body);
+    return wrap;
+  }
+
+  function renderTargetsTable(host, title, subtitle, targets, opts) {
+    opts = opts || {};
+    host.textContent = "";
+    var head = el("div", "flex items-baseline justify-between gap-2 mb-3");
+    head.appendChild(el("h3", "text-sm font-semibold " + (opts.muted ? "text-gray-400" : "text-gray-100"), title));
+    if (subtitle) {
+      head.appendChild(el("span", "text-[10px] uppercase tracking-wide text-gray-500", subtitle));
+    }
+    host.appendChild(head);
+
+    if (!targets || !targets.length) {
+      note(host, opts.emptyText || "No targets in this list right now.");
+      return;
+    }
+
+    var table = el("table", "w-full text-[11px] border-collapse" + (opts.muted ? " opacity-70" : ""));
+    var thead = el("thead");
+    var headRow = el("tr", "text-left text-gray-500 border-b border-gray-800");
+    ["target", "kind", "candidate", "magnitude", "confidence", "mode", "reasons"].forEach(function (label) {
+      headRow.appendChild(el("th", "font-normal uppercase tracking-wide text-[9px] py-1 pr-3", label));
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    var tbody = el("tbody");
+    targets.forEach(function (target) {
+      var row = el("tr", "border-b border-gray-800/60 last:border-b-0 align-top");
+
+      var idCell = el("td", "py-1.5 pr-3 font-mono text-gray-200 break-all", target.target_id);
+      row.appendChild(idCell);
+
+      row.appendChild(el("td", "py-1.5 pr-3 text-gray-400", target.target_kind));
+
+      var candCell = el("td", "py-1.5 pr-3");
+      candCell.appendChild(candidateBadgeFor(target.reasons));
+      row.appendChild(candCell);
+
+      var channels = target.dominant_channels || {};
+      var magnitude =
+        channels.prediction_error !== undefined && channels.prediction_error !== null
+          ? num(channels.prediction_error, 4)
+          : "—";
+      row.appendChild(el("td", "py-1.5 pr-3 font-mono text-gray-300", magnitude));
+
+      var confCell = el("td", "py-1.5 pr-3");
+      confCell.appendChild(confidenceBadge(target.confidence_score));
+      row.appendChild(confCell);
+
+      var modeCell = el("td", "py-1.5 pr-3");
+      modeCell.appendChild(observationModeBadge(target.suggested_observation_mode));
+      row.appendChild(modeCell);
+
+      var reasonsCell = el("td", "py-1.5 pr-3");
+      reasonsCell.appendChild(renderReasonsCell(target.reasons));
+      row.appendChild(reasonsCell);
+
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    host.appendChild(table);
+  }
+
+  function renderBottomStrip(host, frame) {
+    host.textContent = "";
+    host.appendChild(el("h3", "text-sm font-semibold text-gray-100 mb-2", "Recent perturbations & warnings"));
+
+    var perturbations = frame.recent_perturbations || [];
+    var warnings = frame.warnings || [];
+
+    var pWrap = el("div", "mb-3");
+    pWrap.appendChild(
+      el("div", "text-[10px] uppercase tracking-wide text-gray-500 mb-1", "recent_perturbations (" + perturbations.length + ")")
+    );
+    if (perturbations.length) {
+      var pList = el("ul", "text-[11px] text-gray-300 space-y-0.5 list-disc list-inside");
+      perturbations.forEach(function (p) {
+        pList.appendChild(el("li", "", String(p)));
+      });
+      pWrap.appendChild(pList);
+    } else {
+      pWrap.appendChild(el("div", "text-[11px] text-gray-500", "none"));
+    }
+    host.appendChild(pWrap);
+
+    var wWrap = el("div");
+    wWrap.appendChild(
+      el("div", "text-[10px] uppercase tracking-wide text-gray-500 mb-1", "warnings (" + warnings.length + ")")
+    );
+    if (warnings.length) {
+      var wList = el("ul", "text-[11px] text-amber-300 space-y-0.5 list-disc list-inside");
+      warnings.forEach(function (w) {
+        wList.appendChild(el("li", "", String(w)));
+      });
+      wWrap.appendChild(wList);
+    } else {
+      wWrap.appendChild(el("div", "text-[11px] text-gray-500", "none"));
+    }
+    host.appendChild(wWrap);
+  }
+
+  function renderFrame(frame) {
+    renderHeader(els.header, frame);
+    renderTargetsTable(
+      els.dominant,
+      "Dominant targets",
+      "ranked by salience_score, backend-sorted/capped",
+      frame.dominant_targets || [],
+      { emptyText: "No active targets this tick." }
+    );
+    renderTargetsTable(
+      els.suppressed,
+      "Suppressed targets",
+      "below the policy's suppress_below threshold -- still real competitors, muted",
+      frame.suppressed_targets || [],
+      { muted: true, emptyText: "Nothing suppressed this tick." }
+    );
+    renderBottomStrip(els.bottom, frame);
+  }
+
+  // ------------------------------------------------------------ poll cycle
+
+  function setStatus(text, tone) {
+    if (!els.status) return;
+    els.status.textContent = text;
+    els.status.className = "text-xs min-h-[1.25rem] " + (tone || "text-gray-400");
+  }
+
+  async function poll() {
+    if (state.inFlight) return;
+    state.inFlight = true;
+    try {
+      var resp = await fetch(LATEST_URL, { headers: { Accept: "application/json" } });
+      if (resp.status === 404) {
+        // Not an error -- the substrate simply has not written a frame yet.
+        errorBlock(els.header, "Field Attention", "No FieldAttentionFrameV1 persisted yet.");
+        if (els.dominant) els.dominant.textContent = "";
+        if (els.suppressed) els.suppressed.textContent = "";
+        if (els.bottom) els.bottom.textContent = "";
+        setStatus("No frame available yet (HTTP 404) — " + new Date().toLocaleTimeString(), "text-amber-400");
+        return;
+      }
+      if (!resp.ok) {
+        throw new Error("HTTP " + resp.status + " from " + LATEST_URL);
+      }
+      var frame = await resp.json();
+      state.lastFrame = frame;
+      state.lastFetchedAt = Date.now();
+      renderFrame(frame);
+      setStatus("Updated " + new Date().toLocaleTimeString() + " · polling every " + POLL_MS / 1000 + "s", "text-gray-400");
+    } catch (err) {
+      setStatus("Failed to load: " + (err.message || err), "text-red-400");
+    } finally {
+      state.inFlight = false;
+    }
+  }
+
+  function stopTimer() {
+    if (state.timer !== null) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function startTimer() {
+    stopTimer();
+    if (!state.active) return;
+    state.timer = setInterval(function () {
+      // Visibility, not just the router's activate/deactivate calls, gates
+      // polling -- self_observability.js hides every section[data-panel]
+      // directly and preventDefault()s its own click, so app.js's
+      // setActiveTab (the only caller of deactivate()) never runs on that
+      // path. Checking the DOM here holds the contract against that case,
+      // same guard attention-organ.js uses.
+      if (!els.panel || els.panel.classList.contains("hidden")) {
+        deactivate();
+        return;
+      }
+      poll();
+    }, POLL_MS);
+  }
+
+  function activate() {
+    if (!els.panel && !bindElements()) return;
+    state.active = true;
+    poll();
+    startTimer();
+  }
+
+  function deactivate() {
+    state.active = false;
+    stopTimer();
+    // Rendered DOM is deliberately left in place, same as attention-organ.js
+    // -- switching away and back shows the last frame immediately.
+  }
+
+  function wireControls() {
+    if (els.refreshBtn) {
+      els.refreshBtn.addEventListener("click", function () {
+        poll();
+      });
+    }
+  }
+
+  function init() {
+    if (!bindElements()) return;
+    wireControls();
+    // Defensive only: both scripts are `defer`, and app.js's DOMContentLoaded
+    // handler (which calls setActiveTab) runs after this file finishes
+    // loading, so the panel is still hidden here in practice. This branch
+    // exists so a future load-order change cannot leave a visible panel
+    // unpolled -- same defensive shape as attention-organ.js's init().
+    if (!els.panel.classList.contains("hidden")) {
+      activate();
+    }
+  }
+
+  window.OrionFieldAttention = {
+    activate: activate,
+    deactivate: deactivate,
+    refresh: function () {
+      poll();
+    },
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -132,6 +132,13 @@
             class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
             role="button"
           >Attention Organ</a>
+          <a
+            id="fieldAttentionTabButton"
+            href="#field-attention"
+            data-hash-target="#field-attention"
+            class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
+            role="button"
+          >Field Attention</a>
           {{HUB_AITOWN_TAB_NAV}}
           <a
             id="selfObservabilityTabButton"
@@ -865,6 +872,45 @@
           <div id="attentionOrganIntake" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
           <div id="attentionOrganDissipation" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
         </div>
+      </section>
+
+      <section id="field-attention" data-panel="field-attention" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="min-w-0">
+            <h2 class="text-xl font-bold text-white">Field Attention — precision-weighted &amp; novelty salience</h2>
+            <p class="text-xs text-gray-400 max-w-4xl">
+              Live view of <code class="text-gray-500">FieldAttentionFrameV1</code>
+              (<code class="text-gray-500">orion/attention/field_attention/</code>, PR #1484/#1488): Candidate A
+              precision-weighted prediction-error salience (Feldman &amp; Friston 2010) competing against Candidate B
+              Global-Workspace novelty salience for the same target slots. Served by
+              <code class="text-gray-500">GET /api/substrate/attention/latest</code>. Read-only — this surface
+              consumes a signal, it does not produce or publish any. This is a different subsystem from the
+              <code class="text-gray-500">Attention Organ</code> tab above, which visualizes
+              <code class="text-gray-500">orion-heartbeat</code>'s AST/HOT dissipation ensemble — do not confuse the two.
+            </p>
+            <p class="text-[10px] text-gray-500 max-w-4xl mt-1">
+              <span class="text-gray-400">Overall salience</span> is shown small below, not as a headline gauge:
+              <code class="text-gray-500">build_attention_frame()</code> sets it to the max of this tick's target
+              scores after they have already been min-max normalized across competitors
+              (<code class="text-gray-500">normalize_across_targets()</code>), so it mathematically reads ≈1.0 on
+              almost every tick whenever any node target competes — it is not a "how much is going on" measure.
+              <span class="text-gray-400">Confidence</span> is rendered as a grounded/cold-start badge, not a
+              gradient — live data (10,747 recent target-observations) shows it only ever takes the values 0.0 or 1.0.
+            </p>
+          </div>
+          <div class="flex items-center gap-2 text-xs shrink-0">
+            <button type="button" id="fieldAttentionRefreshBtn" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 hover:bg-gray-700">Refresh</button>
+          </div>
+        </div>
+        <div id="fieldAttentionStatus" class="text-xs text-gray-400 min-h-[1.25rem]">Open this tab to start polling.</div>
+
+        <div id="fieldAttentionHeader" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+
+        <div id="fieldAttentionDominantTargets" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+
+        <div id="fieldAttentionSuppressedTargets" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+
+        <div id="fieldAttentionBottomStrip" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
       </section>
 
       <section id="self-observability" data-panel="self-observability" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
@@ -3434,6 +3480,7 @@
   <script src="/static/js/collapse-mirror.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/aitown-panel.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/attention-organ.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
+  <script src="/static/js/field-attention.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/self_observability.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/app.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
 </body>

--- a/services/orion-hub/tests/test_field_attention_operator_panel.py
+++ b/services/orion-hub/tests/test_field_attention_operator_panel.py
@@ -1,0 +1,206 @@
+"""Field Attention operator tab: wiring contract + static-content assertions.
+
+This tab visualizes FieldAttentionFrameV1 (orion/attention/field_attention/,
+PR #1484/#1488) -- a different subsystem from the Attention Organ tab
+(attention-organ.js / attention_organ_routes.py), which visualizes
+orion-heartbeat's AST/HOT dissipation ensemble. Modeled directly on
+test_attention_organ_page.py: this tab is the *fifth* panel registered in
+index.html that also needs five separate app.js registration points
+(element binding, missing-panel fallback, visibility toggle, button styling,
+hash routing) plus a script tag plus a nav anchor -- missing any one produces
+a tab that silently falls back to Hub on a specific interaction (deep link,
+switching away and back, a fresh reload) rather than failing loudly.
+
+The backend route (GET /api/substrate/attention/latest) is not touched by
+this patch -- it is already covered by test_substrate_attention_debug_api.py,
+which this file does not duplicate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+INDEX_HTML = (HUB_ROOT / "templates" / "index.html").read_text(encoding="utf-8")
+APP_JS = (HUB_ROOT / "static" / "js" / "app.js").read_text(encoding="utf-8")
+FIELD_ATTENTION_JS = (HUB_ROOT / "static" / "js" / "field-attention.js").read_text(encoding="utf-8")
+ATTENTION_ORGAN_JS = (HUB_ROOT / "static" / "js" / "attention-organ.js").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# Template wiring
+# --------------------------------------------------------------------------
+
+
+def test_template_declares_nav_button_panel_and_script_tag() -> None:
+    assert 'data-hash-target="#field-attention"' in INDEX_HTML
+    assert 'id="fieldAttentionTabButton"' in INDEX_HTML
+    assert 'id="field-attention" data-panel="field-attention"' in INDEX_HTML
+    assert "/static/js/field-attention.js?v={{HUB_UI_ASSET_VERSION}}" in INDEX_HTML
+    for mount_id in (
+        "fieldAttentionStatus",
+        "fieldAttentionHeader",
+        "fieldAttentionDominantTargets",
+        "fieldAttentionSuppressedTargets",
+        "fieldAttentionBottomStrip",
+        "fieldAttentionRefreshBtn",
+    ):
+        assert f'id="{mount_id}"' in INDEX_HTML, mount_id
+
+
+def test_template_panel_does_not_reuse_attention_organ_naming() -> None:
+    """These are two distinct subsystems -- a collision here would mean one
+    tab's DOM lookups silently bind to the other's elements."""
+    field_attention_section_start = INDEX_HTML.index('id="field-attention" data-panel="field-attention"')
+    field_attention_section_end = INDEX_HTML.index("</section>", field_attention_section_start)
+    section_html = INDEX_HTML[field_attention_section_start:field_attention_section_end]
+    assert "attentionOrgan" not in section_html
+    assert 'id="attention-organ"' not in section_html
+
+
+def test_template_notes_the_overall_salience_normalization_design() -> None:
+    """Design requirement: don't headline overall_salience as a big gauge,
+    and the on-page explanation must cite the real normalization design
+    (normalize_across_targets() / build_attention_frame()), not an invented
+    rationale."""
+    assert "normalize_across_targets" in INDEX_HTML
+    assert "build_attention_frame" in INDEX_HTML
+    assert "not a" in INDEX_HTML and "gauge" in INDEX_HTML
+
+
+def test_template_notes_confidence_is_binary_in_practice() -> None:
+    assert "grounded" in INDEX_HTML.lower()
+    assert "cold-start" in INDEX_HTML.lower()
+
+
+# --------------------------------------------------------------------------
+# app.js registration points
+# --------------------------------------------------------------------------
+
+
+def test_app_js_registers_the_panel_in_every_place_setactivetab_needs() -> None:
+    """All five registration points, not just the visible one -- see this
+    module's docstring for why each omission fails silently and differently."""
+    assert 'document.getElementById("fieldAttentionTabButton")' in APP_JS  # element binding (button)
+    assert 'document.getElementById("field-attention")' in APP_JS  # element binding (panel)
+    assert 'tabKey === "field-attention" && !fieldAttentionPanel' in APP_JS  # fallback
+    assert 'const isFieldAttention = effectiveTab === "field-attention";' in APP_JS  # flag
+    assert 'fieldAttentionPanel.classList.toggle("hidden", !isFieldAttention);' in APP_JS  # toggle
+    assert "styleTabButton(fieldAttentionTabButton, isFieldAttention);" in APP_JS  # styling
+    assert 'h === "#field-attention" && fieldAttentionPanel' in APP_JS  # hash routing
+    assert 'history.replaceState(null, "", "#field-attention");' in APP_JS  # click handler
+
+
+def test_app_js_resets_an_unresolvable_field_attention_hash_to_hub() -> None:
+    """Mirrors attention-organ's own fallback: an unresolvable #field-attention
+    hash (panel/button missing) must not leave the URL pointing at a tab that
+    never actually rendered."""
+    assert '|| h === "#field-attention"' in APP_JS
+
+
+def test_app_js_drives_the_panels_poll_lifecycle_on_tab_switch() -> None:
+    """Polling must stop when the tab is hidden -- both activate() and
+    deactivate() have to actually be called from setActiveTab, not just
+    defined in the module."""
+    assert "window.OrionFieldAttention.activate()" in APP_JS
+    assert "window.OrionFieldAttention.deactivate()" in APP_JS
+
+
+def test_app_js_does_not_confuse_field_attention_with_attention_organ() -> None:
+    """These are separate globals/ids; a copy-paste error here would make one
+    tab silently drive the other's lifecycle."""
+    assert "window.OrionFieldAttention" not in ATTENTION_ORGAN_JS
+    assert "window.OrionAttentionOrgan" not in FIELD_ATTENTION_JS
+
+
+# --------------------------------------------------------------------------
+# field-attention.js content
+# --------------------------------------------------------------------------
+
+
+def test_field_attention_js_is_standalone_and_reads_only_its_own_api() -> None:
+    assert "window.OrionFieldAttention" in FIELD_ATTENTION_JS
+    assert "activate:" in FIELD_ATTENTION_JS and "deactivate:" in FIELD_ATTENTION_JS
+    assert '"/api/substrate/attention/latest"' in FIELD_ATTENTION_JS
+    # Must not depend on app.js's globals -- same standalone contract as
+    # attention-organ.js and the Causal Geometry bundle.
+    assert "window.OrionHub" not in FIELD_ATTENTION_JS
+    # Read-only surface: no writes to any Orion endpoint from this tab.
+    assert '"POST"' not in FIELD_ATTENTION_JS and "method: 'POST'" not in FIELD_ATTENTION_JS
+
+
+def test_field_attention_js_renders_structure_not_a_raw_json_dump() -> None:
+    assert "JSON.stringify" not in FIELD_ATTENTION_JS
+    for renderer in (
+        "renderHeader",
+        "renderTargetsTable",
+        "renderBottomStrip",
+        "renderFrame",
+    ):
+        assert f"function {renderer}(" in FIELD_ATTENTION_JS, renderer
+
+
+def test_field_attention_js_candidate_badge_matches_real_reason_prefixes() -> None:
+    """Candidate A/B are derived from reasons[0]'s real text, produced by
+    orion/attention/field_attention/selectors.py's select_node_targets()
+    (Candidate A) and _novelty_targets() (Candidate B) -- these exact prefix
+    strings must stay byte-for-byte in sync with the producer or every
+    target would silently fall back to the "no candidate" badge."""
+    assert "precision-weighted prediction-error salience" in FIELD_ATTENTION_JS
+    assert "Candidate B novelty-only salience" in FIELD_ATTENTION_JS
+    assert "function candidateBadgeFor(" in FIELD_ATTENTION_JS
+
+
+def test_field_attention_js_confidence_rendered_as_binary_badge_not_gradient() -> None:
+    """Design requirement: confidence_score is binary in practice (verified
+    live: 10,747 recent target-observations, only ever 0.0 or 1.0) -- must be
+    a two-state badge, not a progress bar or sparkline."""
+    assert "function confidenceBadge(" in FIELD_ATTENTION_JS
+    assert '"grounded"' in FIELD_ATTENTION_JS
+    assert '"cold-start"' in FIELD_ATTENTION_JS
+
+
+def test_field_attention_js_dominant_and_suppressed_targets_both_rendered() -> None:
+    """Suppressed targets must stay visible (muted), not hidden -- this is
+    where an operator would have caught the pre-#1488 confidence-bucket bug
+    live."""
+    assert "dominant_targets" in FIELD_ATTENTION_JS
+    assert "suppressed_targets" in FIELD_ATTENTION_JS
+    assert "muted" in FIELD_ATTENTION_JS
+
+
+def test_field_attention_js_renders_recent_perturbations_and_warnings() -> None:
+    assert "recent_perturbations" in FIELD_ATTENTION_JS
+    assert "warnings" in FIELD_ATTENTION_JS
+
+
+def test_field_attention_js_guards_polling_on_real_visibility() -> None:
+    """Review finding from attention-organ.js's own history (M1): app.js's
+    setActiveTab is not the only thing that can hide this panel --
+    self_observability.js hides every section[data-panel] directly and
+    preventDefault()s its click, so deactivate() never fires on that path.
+    The timer must check the DOM, not trust the router."""
+    assert 'els.panel.classList.contains("hidden")' in FIELD_ATTENTION_JS
+    guard_region = FIELD_ATTENTION_JS[
+        FIELD_ATTENTION_JS.index("function startTimer") : FIELD_ATTENTION_JS.index("function activate")
+    ]
+    assert 'contains("hidden")' in guard_region
+    assert "deactivate();" in guard_region
+
+
+def test_field_attention_js_handles_404_as_no_frame_yet_not_a_crash() -> None:
+    """The backend 404s when no frame has been persisted yet
+    (substrate_attention_routes.py's attention_latest()) -- that is a real,
+    expected state (fresh deploy, substrate cold-start), not an error to
+    surface as a red "failed to load" the way a genuine fetch failure would."""
+    assert "resp.status === 404" in FIELD_ATTENTION_JS
+
+
+def test_field_attention_js_does_not_grow_unbounded_client_state() -> None:
+    """Unlike attention-organ.js's liveTrace, this tab renders only the
+    latest single frame on every poll -- there is no rolling client-side
+    array to bound in the first place, so nothing here should be
+    accumulating history across polls."""
+    assert "state.lastFrame = frame;" in FIELD_ATTENTION_JS
+    assert ".push(" not in FIELD_ATTENTION_JS

--- a/services/orion-hub/tests/test_field_attention_operator_panel.py
+++ b/services/orion-hub/tests/test_field_attention_operator_panel.py
@@ -175,6 +175,22 @@ def test_field_attention_js_renders_recent_perturbations_and_warnings() -> None:
     assert "warnings" in FIELD_ATTENTION_JS
 
 
+def test_field_attention_js_does_not_mislabel_system_targets_as_cold_start() -> None:
+    """Review finding (2026-07-30): select_system_targets() in
+    orion/attention/field_attention/selectors.py hardcodes
+    confidence_score=0.0 for the 'field:recent_perturbations' system target
+    as a schema-required placeholder, not a real "not grounded yet" reading
+    -- no confidence concept applies to that aggregate signal at all.
+    Rendering it through the ordinary binary grounded/cold-start badge would
+    show a permanent, never-resolving "cold-start" that reads as "still
+    warming up." confidenceBadge() must special-case target_kind === "system"
+    into a distinct "n/a" badge instead."""
+    assert "function confidenceBadge(value, targetKind)" in FIELD_ATTENTION_JS
+    assert 'targetKind === "system"' in FIELD_ATTENTION_JS
+    assert '"n/a"' in FIELD_ATTENTION_JS
+    assert "confidenceBadge(target.confidence_score, target.target_kind)" in FIELD_ATTENTION_JS
+
+
 def test_field_attention_js_guards_polling_on_real_visibility() -> None:
     """Review finding from attention-organ.js's own history (M1): app.js's
     setActiveTab is not the only thing that can hide this panel --


### PR DESCRIPTION
## Summary

- Adds a new, read-only Hub operator tab, "Field Attention," visualizing `FieldAttentionFrameV1` — the substrate field-attention system (Candidate A precision-weighted prediction-error salience + Candidate B Global-Workspace novelty salience, `orion/attention/field_attention/`, PR #1484/#1488).
- This is a distinct subsystem from the just-merged "Attention Organ" tab (orion-heartbeat's AST/HOT ensemble) — no naming/ID collisions between the two.
- Backend is untouched: consumes the already-shipped, already-registered `GET /api/substrate/attention/latest` (`services/orion-hub/scripts/substrate_attention_routes.py`).
- Ranked `dominant_targets` table with a Candidate A/B badge (derived from `reasons[0]`'s real prefix text), raw `prediction_error` magnitude, binary grounded/cold-start confidence badge, `suggested_observation_mode`, and expandable reasons.
- Muted `suppressed_targets` section rendered visibly below the active table (not hidden), plus a bottom strip for `recent_perturbations`/`warnings`.
- `overall_salience` is deliberately shown small (not a headline gauge), with an on-page note citing the real normalization design (`normalize_across_targets()` / `build_attention_frame()`) for why it reads ≈1.0 almost every tick.

## Outcome moved

Operators previously had no UI view into the field-attention arc at all (API-only, `psql`/`curl` required to inspect it). This adds a legible, polling, read-only surface — including visibility into suppressed targets, which is exactly where the pre-#1488 confidence-bucket bug would have been caught live.

## Current architecture

`FieldAttentionFrameV1` frames are built by `orion/attention/field_attention/builder.py::build_attention_frame()` and persisted to `substrate_attention_frames` (Postgres). `GET /api/substrate/attention/latest` already reads the newest row and returns `frame.model_dump(mode="json")`; already registered on the Hub API router (`services/orion-hub/scripts/api_routes.py`). No Hub UI consumed this endpoint before this patch.

## Architecture touched

Hub UI only — no schema, bus, or route changes.

## Files changed

- `services/orion-hub/templates/index.html`: new `fieldAttentionTabButton` nav link, new `<section id="field-attention">` panel (header/dominant-targets/suppressed-targets/bottom-strip mounts + on-page design notes), new `field-attention.js` script tag.
- `services/orion-hub/static/js/app.js`: five registration points mirrored from the Attention Organ tab — element lookups, missing-panel fallback, `isFieldAttention` flag, panel toggle + `activate()`/`deactivate()` calls, button styling, hash-routing branch + reset-to-hub list, click listener.
- `services/orion-hub/static/js/field-attention.js` (new): all rendering + poll lifecycle. Polls `GET /api/substrate/attention/latest` every 5s only while the tab is visible (DOM-visibility-guarded timer, same lifecycle contract as `attention-organ.js`). No writes anywhere in this file.
- `services/orion-hub/tests/test_field_attention_operator_panel.py` (new): wiring-contract tests modeled on `test_attention_organ_page.py` (template/app.js/JS-content string assertions) plus a regression test for the system-target confidence-badge fix below.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: none — `GET /api/substrate/attention/latest` is unmodified.
- Compatibility notes: n/a.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: no (no new env keys — this tab uses a fixed 5s poll interval, no configurable env var, matching the thin-seam guidance since there's no equivalent multi-window backend to select from).
- local `.env` synced: n/a (no `.env_example` changes).
- skipped keys requiring operator action: none.

## Tests run

```
/tmp/hubtest_venv/bin/python -m pytest \
  services/orion-hub/tests/test_field_attention_operator_panel.py \
  services/orion-hub/tests/test_substrate_attention_debug_api.py \
  services/orion-hub/tests/test_attention_organ_page.py \
  services/orion-hub/tests/test_attention_frame_debug_panel.py -q
# 55 passed, 16 warnings (pre-existing pydantic deprecation warnings, unrelated)

node --check services/orion-hub/static/js/field-attention.js   # OK
node --check services/orion-hub/static/js/app.js                # OK
```

Note: a full `pytest services/orion-hub/tests -q` in this environment hits 5 pre-existing collection errors (`test_fcc_model_labels_api.py`, `test_graphiti_config_parity.py`, `test_heartbeat_chassis.py`, `test_memory_consolidation_draft_routes.py`, `test_memory_graph_consolidation_draft_approve.py`) from missing `CHANNEL_VOICE_*` settings env vars in this transient test venv — the same gap `test_attention_organ_page.py` already works around with `os.environ.setdefault(...)` before importing `scripts.main`. Unrelated to this diff; this patch's own test file makes no `scripts.main` import and is unaffected.

## Evals run

No eval harness exists for `services/orion-hub` beyond its `tests/` directory (matches the pattern of the sibling Attention Organ PR). This is a read-only visualization surface with no model/quality dimension to eval — covered by the wiring/content tests above instead.

## Docker/build/smoke checks

`services/orion-hub/docker-compose.yml` bind-mounts `./templates:/app/templates` and `./static:/app/static` directly (overriding the Dockerfile's build-time `COPY services/orion-hub /app`), and `render_hub_index_html()` reads `index.html` from disk on every request (its own docstring: "Render Hub index.html from disk so volume-mounted template edits apply without stale cache"); `HubStaticFiles`/`StaticFiles` likewise serves static files fresh per request. No image rebuild or container restart is needed to pick up this patch's template/JS changes — a running `hub-app` container serves the new tab immediately, and the existing `?v={{HUB_UI_ASSET_VERSION}}` cache-busting query param handles browser cache.

## Review findings fixed

- Finding: `confidenceBadge()` would permanently render the `field:recent_perturbations` system target as "cold-start," since `select_system_targets()` (`orion/attention/field_attention/selectors.py`) hardcodes `confidence_score=0.0` there as a schema-required placeholder with no real grounding concept behind it — a permanent mislabel an operator could misread as a state that never resolves.
  - Fix: `confidenceBadge(value, targetKind)` now special-cases `targetKind === "system"` into a distinct "n/a" badge instead of the binary grounded/cold-start pair.
  - Evidence: `services/orion-hub/static/js/field-attention.js` (`confidenceBadge`), regression test `test_field_attention_js_does_not_mislabel_system_targets_as_cold_start` in `test_field_attention_operator_panel.py`, all 55 tests passing after the fix.
- Other findings from the review (candidate-badge prefix strings, app.js wiring consistency, ID collisions, XSS safety) were verified clean with no action needed — see review agent's report for detail; no blocking findings.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: low
- Concern: `confidence_score` being empirically binary (0.0/1.0) rather than schema-enforced is a live-data observation (2026-07-30), not a guarantee — if node-history retention windows or `QUALIFYING_MIN_ROWS` ever change, intermediate values become possible again. The badge's `>= 0.5` split degrades gracefully (still shows a sensible binary read, with the exact float in the tooltip), so this is not a correctness risk, just worth re-checking if that constant changes.
- Mitigation: exact `confidence_score` value is always available via the badge's `title` tooltip, and the on-page note discloses this is an empirical observation, not a schema contract.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1510
