### PR TITLE
fix(substrate): write prediction-error nodes on every tick for all four remaining domains

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-30-substrate-prediction-error-node-write-gate-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-substrate-prediction-error-node-write-gate-pr.md
@@ -159,4 +159,4 @@ ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 scripts/safe_docker_build.sh orion-substrate
 
 ## PR link
 
-<to be filled after push>
+https://github.com/junebug-junie/Orion-Sapienform/pull/1513

--- a/docs/superpowers/pr-reports/2026-07-30-substrate-prediction-error-node-write-gate-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-30-substrate-prediction-error-node-write-gate-pr.md
@@ -1,0 +1,162 @@
+# Prediction-error node write gate — all four remaining domains
+
+Branch: `fix/substrate-pe-node-write-gate`
+Date: 2026-07-30
+Status: **DONE**
+
+## Summary
+
+- Extends `0fe7de56f`'s `bus_synaptic` fix to the four domains that still gated
+  `_write_prediction_error_node()` behind `if error > 0.0:` — `biometrics`, `execution`, `chat`,
+  `route`.
+- Found live via the Attention Organ tab (PR #1504): `node:substrate.route` frozen at `0.00025`
+  with `observed_at` not advancing, while `orion-cortex-orch` had produced 1,608 grammar events in
+  the prior 3 hours — the tick was running the whole time.
+- A quiet domain returns `error == 0.0` on most ticks, so the gated write left the node holding its
+  last **non-zero** value indefinitely: a signal that can rise but can never come back down to a
+  genuine calm reading.
+- Guard is structural (AST over `worker.py`) rather than five per-domain fixtures — this bug has now
+  been found and fixed one-domain-at-a-time three times.
+- Live-verified after deploy: `route` now reads a real `0.0`, `execution` reaches `0.0` too.
+
+## Outcome moved
+
+Two Active-Inference domains that could never report "calm" now can. `node:substrate.route` went
+from a 10-hour-stale `0.00025` to a live `0.0`; `node:substrate.execution` was observed reaching
+`0.0` for the first time in the sampling window. Every consumer that polls these nodes' current
+value — `orion-equilibrium-service`'s transport gate, AST/HOT's `prediction_error_by_domain` — now
+reads a present-tense value rather than a stale high-water mark.
+
+## Current architecture
+
+Each `_*_tick()` in `services/orion-substrate-runtime/app/worker.py` computes a domain
+`prediction_error`, then writes two things under a single `if error > 0.0:` guard: a
+`save_receipt()` audit record and a durable `_write_prediction_error_node()` upsert of
+`node:substrate.<domain>`.
+
+`0fe7de56f` (2026-07-30, 20:01) split those two for `bus_synaptic` only — receipt stays gated, node
+write moved out — after that node was found frozen at a stale `1.0` for hours. The other four
+domains were left as they were.
+
+## Architecture touched
+
+`services/orion-substrate-runtime` only. No contract, schema, bus, or env changes.
+
+## Files changed
+
+- `services/orion-substrate-runtime/app/worker.py`: node write moved out of the `error > 0.0` guard
+  for `biometrics` (735), `execution` (2142), `chat` (2202), `route` (2255). `save_receipt()` left
+  gated in all four — it is an audit trail of notable events, not a polled current-state read, so
+  skipping it on a calm tick is correct and is not the bug.
+- `services/orion-substrate-runtime/tests/test_prediction_error_node_write_not_gated.py` (new): AST
+  check that no `_write_prediction_error_node()` call sits inside an `if error > 0.0:` block, plus a
+  companion asserting every domain still has a node write at all (so "fixing" it by deleting the
+  call fails too).
+
+## Why `route` specifically
+
+`route_prediction_error()` is a **categorical mismatch rate** over route-arbitration decisions
+(`lane`, `lane_reason`, `output_mode`, `mind_requested`) — not a continuous magnitude like the other
+instruments. With chat idle the arbitration decision does not change between batches, so the rate is
+exactly `0.0` every tick, and the gate never opened. `chat` is frozen for a different and legitimate
+reason (`_chat_tick()` returns early at `if not events:` — there is genuinely no chat traffic), which
+this patch does not and should not change.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. No `.env_example` change, nothing to sync.
+
+## Tests run
+
+```text
+$ pytest tests/test_prediction_error_node_write_not_gated.py -q
+2 passed in 0.10s
+
+$ pytest tests -q --ignore=tests/test_grammar_consumer_integration.py
+13 failed, 188 passed, 9 errors
+```
+
+Failures are **pre-existing**, established against a scratch worktree at `origin/main`:
+
+```text
+origin/main baseline : 23 FAILED/ERROR lines
+this branch          : 23 FAILED/ERROR lines
+symmetric difference : (empty)
+```
+
+`tests/test_grammar_consumer_integration.py` is excluded because it fails at *collection* on both
+branches (`ModuleNotFoundError: No module named 'app.models'` — there is no `app/models.py` in the
+service at all). Unrelated to this patch; not introduced here.
+
+Red-before-green, run against `origin/main`'s `worker.py`:
+
+```text
+correctly RED against origin/main:
+  node:substrate.biometrics at worker.py:744, node:substrate.execution at worker.py:2151,
+  node:substrate.chat at worker.py:2211, node:substrate.route at worker.py:2264
+```
+
+## Evals run
+
+```text
+No eval harness exists for services/orion-substrate-runtime.
+```
+
+Flagged rather than claimed. The behavior this patch restores is directly observable in the live
+node values (below), which is the meaningful check here.
+
+## Docker/build/smoke checks
+
+```text
+$ scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
+Container orion-athena-substrate-runtime Recreated / Started
+```
+
+Live node values sampled over 60s after deploy (FalkorDB `orion_substrate`):
+
+```text
+biometric=0.03   bus_synap=1.0  chat=0.0135  execution=0.0     route=0.0
+biometric=0.0008 bus_synap=1.0  chat=0.0135  execution=0.0     route=0.0
+biometric=0.0238 bus_synap=1.0  chat=0.0135  execution=0.2331  route=0.0
+biometric=0.0853 bus_synap=1.0  chat=0.0135  execution=0.2331  route=0.0
+```
+
+`route` was `0.00025` and static for 10 hours before this; it now reads a genuine `0.0`.
+`execution` reaches `0.0`, which it structurally could not do before. `bus_synaptic` remaining
+pinned at `1.0` is a **separate** defect with its own fix (`fix/bus-synaptic-per-edge-saturation`)
+— this patch isolates it rather than addressing it.
+
+## Review findings fixed
+
+Not run as a separate subagent pass for this patch — it is a four-line mechanical extension of an
+already-reviewed and already-merged fix (`0fe7de56f`), with a structural test that is confirmed red
+against `origin/main`. Called out here rather than silently skipped.
+
+## Restart required
+
+Already applied (see Docker checks). To redeploy from the main checkout after merge:
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+git pull --ff-only
+ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
+```
+
+## Risks / concerns
+
+- **Severity: note.** Node writes now happen on every tick for four more domains, so upsert volume
+  against `orion_substrate` rises. `bus_synaptic` has been running this way since 20:01 today with
+  no observed issue, and these ticks are far lower-frequency than the concept-induction pipeline
+  already hitting the same store.
+- **Severity: note.** `node:substrate.chat` is still frozen (6 days), by a different mechanism this
+  patch deliberately does not touch — `_chat_tick()` returns before any write when there are no chat
+  grammar events. It is nonetheless still averaged into `prediction_error_confidence` by the
+  upstream reducer, which is worth its own decision.
+
+## PR link
+
+<to be filled after push>

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -741,13 +741,25 @@ class BiometricsSubstrateWorker:
                         now=now,
                     )
                 )
-                self._write_prediction_error_node(
-                    node_id="node:substrate.biometrics",
-                    error=error,
-                    now=now,
-                    reducer_key="node_biometrics",
-                    contributing_id=last_id,
-                )
+            # Write the node on every tick, not just when error > 0.0 -- the
+            # same fix already applied to bus_synaptic (2026-07-30), extended
+            # here after `route` was found frozen at a stale 0.00025 while its
+            # tick kept running: a categorical/quiet domain returns error == 0.0
+            # on most ticks, so gating the node write left the node holding its
+            # last NON-ZERO value indefinitely. Consumers that poll this node's
+            # raw current value (orion-equilibrium-service, AST/HOT's
+            # prediction_error_by_domain) then read a stale high-water mark as
+            # if it were a current reading -- a value that can rise but never
+            # come back down to a genuine calm 0.0. The receipt above stays
+            # gated: it is an audit trail of notable events, not a polled
+            # "current state" read, so skipping it on a calm tick is correct.
+            self._write_prediction_error_node(
+                node_id="node:substrate.biometrics",
+                error=error,
+                now=now,
+                reducer_key="node_biometrics",
+                contributing_id=last_id,
+            )
 
         return last_id, published
 
@@ -2148,13 +2160,25 @@ class BiometricsSubstrateWorker:
                         now=now,
                     )
                 )
-                self._write_prediction_error_node(
-                    node_id="node:substrate.execution",
-                    error=error,
-                    now=now,
-                    reducer_key="execution_trajectory",
-                    contributing_id=last_id,
-                )
+            # Write the node on every tick, not just when error > 0.0 -- the
+            # same fix already applied to bus_synaptic (2026-07-30), extended
+            # here after `route` was found frozen at a stale 0.00025 while its
+            # tick kept running: a categorical/quiet domain returns error == 0.0
+            # on most ticks, so gating the node write left the node holding its
+            # last NON-ZERO value indefinitely. Consumers that poll this node's
+            # raw current value (orion-equilibrium-service, AST/HOT's
+            # prediction_error_by_domain) then read a stale high-water mark as
+            # if it were a current reading -- a value that can rise but never
+            # come back down to a genuine calm 0.0. The receipt above stays
+            # gated: it is an audit trail of notable events, not a polled
+            # "current state" read, so skipping it on a calm tick is correct.
+            self._write_prediction_error_node(
+                node_id="node:substrate.execution",
+                error=error,
+                now=now,
+                reducer_key="execution_trajectory",
+                contributing_id=last_id,
+            )
 
         return last_id
 
@@ -2208,13 +2232,25 @@ class BiometricsSubstrateWorker:
                         now=now,
                     )
                 )
-                self._write_prediction_error_node(
-                    node_id="node:substrate.chat",
-                    error=error,
-                    now=now,
-                    reducer_key="chat_session",
-                    contributing_id=last_id,
-                )
+            # Write the node on every tick, not just when error > 0.0 -- the
+            # same fix already applied to bus_synaptic (2026-07-30), extended
+            # here after `route` was found frozen at a stale 0.00025 while its
+            # tick kept running: a categorical/quiet domain returns error == 0.0
+            # on most ticks, so gating the node write left the node holding its
+            # last NON-ZERO value indefinitely. Consumers that poll this node's
+            # raw current value (orion-equilibrium-service, AST/HOT's
+            # prediction_error_by_domain) then read a stale high-water mark as
+            # if it were a current reading -- a value that can rise but never
+            # come back down to a genuine calm 0.0. The receipt above stays
+            # gated: it is an audit trail of notable events, not a polled
+            # "current state" read, so skipping it on a calm tick is correct.
+            self._write_prediction_error_node(
+                node_id="node:substrate.chat",
+                error=error,
+                now=now,
+                reducer_key="chat_session",
+                contributing_id=last_id,
+            )
 
         return last_id
 
@@ -2261,13 +2297,25 @@ class BiometricsSubstrateWorker:
                         now=now,
                     )
                 )
-                self._write_prediction_error_node(
-                    node_id="node:substrate.route",
-                    error=error,
-                    now=now,
-                    reducer_key="route_arbitration",
-                    contributing_id=last_id,
-                )
+            # Write the node on every tick, not just when error > 0.0 -- the
+            # same fix already applied to bus_synaptic (2026-07-30), extended
+            # here after `route` was found frozen at a stale 0.00025 while its
+            # tick kept running: a categorical/quiet domain returns error == 0.0
+            # on most ticks, so gating the node write left the node holding its
+            # last NON-ZERO value indefinitely. Consumers that poll this node's
+            # raw current value (orion-equilibrium-service, AST/HOT's
+            # prediction_error_by_domain) then read a stale high-water mark as
+            # if it were a current reading -- a value that can rise but never
+            # come back down to a genuine calm 0.0. The receipt above stays
+            # gated: it is an audit trail of notable events, not a polled
+            # "current state" read, so skipping it on a calm tick is correct.
+            self._write_prediction_error_node(
+                node_id="node:substrate.route",
+                error=error,
+                now=now,
+                reducer_key="route_arbitration",
+                contributing_id=last_id,
+            )
 
         return last_id
 

--- a/services/orion-substrate-runtime/tests/test_prediction_error_node_write_not_gated.py
+++ b/services/orion-substrate-runtime/tests/test_prediction_error_node_write_not_gated.py
@@ -1,0 +1,101 @@
+"""Structural gate: no `_write_prediction_error_node()` call may sit inside an
+`if error > 0.0:` block.
+
+This is deliberately an AST check over `worker.py`'s source rather than five
+separate tick fixtures. The bug it guards has now been found three separate
+times on three different domains (`bus_synaptic` frozen at a stale 1.0 for
+hours, 2026-07-30; `route` frozen at a stale 0.00025 while its tick kept
+running; `chat` likewise), and each time it was fixed for exactly the one
+domain that happened to be noticed. The failure is structural and identical
+every time, so the guard should be structural too -- CLAUDE.md §4: "when a
+latent failure repeats, turn it into deterministic code, a test, an eval, or
+a skill."
+
+Why gating the node write is wrong, in one line: a domain whose
+`prediction_error` is legitimately 0.0 on a quiet tick keeps its last
+NON-ZERO value in the graph forever, so every consumer that polls the node's
+current value (`orion-equilibrium-service`'s transport gate, AST/HOT's
+`prediction_error_by_domain`) reads a stale high-water mark as if it were a
+present-tense reading -- a signal that can rise but can never come back down
+to a genuine calm state. That is precisely the failure mode CLAUDE.md's
+metric quality gate step 4 exists to catch.
+
+The receipt write (`save_receipt`) staying inside the gate is correct and is
+NOT flagged here: receipts are an audit trail of notable prediction-error
+events, not a polled current-state read.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+WORKER_PATH = Path(__file__).resolve().parents[1] / "app" / "worker.py"
+
+
+def _is_error_gt_zero_test(node: ast.expr) -> bool:
+    """Match `error > 0.0` (and `error > 0`)."""
+    if not isinstance(node, ast.Compare):
+        return False
+    if not (isinstance(node.left, ast.Name) and node.left.id == "error"):
+        return False
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.Gt):
+        return False
+    comparator = node.comparators[0]
+    return isinstance(comparator, ast.Constant) and comparator.value == 0
+
+
+def _node_write_calls(tree: ast.AST) -> list[ast.Call]:
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "_write_prediction_error_node":
+            out.append(node)
+    return out
+
+
+def test_no_prediction_error_node_write_is_gated_on_error_greater_than_zero() -> None:
+    tree = ast.parse(WORKER_PATH.read_text(encoding="utf-8"))
+
+    gated: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If) or not _is_error_gt_zero_test(node.test):
+            continue
+        for stmt in node.body:
+            for call in _node_write_calls(stmt):
+                # Recover the node_id kwarg so a failure names the domain
+                # rather than just a line number.
+                node_id = "<unknown>"
+                for kw in call.keywords:
+                    if kw.arg == "node_id" and isinstance(kw.value, ast.Constant):
+                        node_id = str(kw.value.value)
+                gated.append((call.lineno, node_id))
+
+    assert not gated, (
+        "_write_prediction_error_node() must be called on EVERY tick, not only when "
+        "error > 0.0 -- a gated write leaves the node holding its last non-zero value "
+        "indefinitely on a quiet domain, which every polling consumer reads as a current "
+        "reading. Move the call out of the `if error > 0.0:` block (the save_receipt call "
+        "stays gated). Offending call sites: "
+        + ", ".join(f"{node_id} at worker.py:{lineno}" for lineno, node_id in gated)
+    )
+
+
+def test_every_prediction_error_domain_still_writes_its_node() -> None:
+    """Companion to the above: moving a call out of the gate must not have
+    silently deleted it. Asserts all five Active-Inference domains plus
+    transport still have a node write somewhere in the module."""
+    tree = ast.parse(WORKER_PATH.read_text(encoding="utf-8"))
+
+    written: set[str] = set()
+    for call in _node_write_calls(tree):
+        for kw in call.keywords:
+            if kw.arg == "node_id" and isinstance(kw.value, ast.Constant):
+                written.add(str(kw.value.value))
+
+    for domain in ("biometrics", "execution", "chat", "route", "bus_synaptic"):
+        assert f"node:substrate.{domain}" in written, (
+            f"node:substrate.{domain} has no _write_prediction_error_node() call at all"
+        )


### PR DESCRIPTION
# Prediction-error node write gate — all four remaining domains

Branch: `fix/substrate-pe-node-write-gate`
Date: 2026-07-30
Status: **DONE**

## Summary

- Extends `0fe7de56f`'s `bus_synaptic` fix to the four domains that still gated
  `_write_prediction_error_node()` behind `if error > 0.0:` — `biometrics`, `execution`, `chat`,
  `route`.
- Found live via the Attention Organ tab (PR #1504): `node:substrate.route` frozen at `0.00025`
  with `observed_at` not advancing, while `orion-cortex-orch` had produced 1,608 grammar events in
  the prior 3 hours — the tick was running the whole time.
- A quiet domain returns `error == 0.0` on most ticks, so the gated write left the node holding its
  last **non-zero** value indefinitely: a signal that can rise but can never come back down to a
  genuine calm reading.
- Guard is structural (AST over `worker.py`) rather than five per-domain fixtures — this bug has now
  been found and fixed one-domain-at-a-time three times.
- Live-verified after deploy: `route` now reads a real `0.0`, `execution` reaches `0.0` too.

## Outcome moved

Two Active-Inference domains that could never report "calm" now can. `node:substrate.route` went
from a 10-hour-stale `0.00025` to a live `0.0`; `node:substrate.execution` was observed reaching
`0.0` for the first time in the sampling window. Every consumer that polls these nodes' current
value — `orion-equilibrium-service`'s transport gate, AST/HOT's `prediction_error_by_domain` — now
reads a present-tense value rather than a stale high-water mark.

## Current architecture

Each `_*_tick()` in `services/orion-substrate-runtime/app/worker.py` computes a domain
`prediction_error`, then writes two things under a single `if error > 0.0:` guard: a
`save_receipt()` audit record and a durable `_write_prediction_error_node()` upsert of
`node:substrate.<domain>`.

`0fe7de56f` (2026-07-30, 20:01) split those two for `bus_synaptic` only — receipt stays gated, node
write moved out — after that node was found frozen at a stale `1.0` for hours. The other four
domains were left as they were.

## Architecture touched

`services/orion-substrate-runtime` only. No contract, schema, bus, or env changes.

## Files changed

- `services/orion-substrate-runtime/app/worker.py`: node write moved out of the `error > 0.0` guard
  for `biometrics` (735), `execution` (2142), `chat` (2202), `route` (2255). `save_receipt()` left
  gated in all four — it is an audit trail of notable events, not a polled current-state read, so
  skipping it on a calm tick is correct and is not the bug.
- `services/orion-substrate-runtime/tests/test_prediction_error_node_write_not_gated.py` (new): AST
  check that no `_write_prediction_error_node()` call sits inside an `if error > 0.0:` block, plus a
  companion asserting every domain still has a node write at all (so "fixing" it by deleting the
  call fails too).

## Why `route` specifically

`route_prediction_error()` is a **categorical mismatch rate** over route-arbitration decisions
(`lane`, `lane_reason`, `output_mode`, `mind_requested`) — not a continuous magnitude like the other
instruments. With chat idle the arbitration decision does not change between batches, so the rate is
exactly `0.0` every tick, and the gate never opened. `chat` is frozen for a different and legitimate
reason (`_chat_tick()` returns early at `if not events:` — there is genuinely no chat traffic), which
this patch does not and should not change.

## Schema / bus / API changes

None.

## Env/config changes

None. No `.env_example` change, nothing to sync.

## Tests run

```text
$ pytest tests/test_prediction_error_node_write_not_gated.py -q
2 passed in 0.10s

$ pytest tests -q --ignore=tests/test_grammar_consumer_integration.py
13 failed, 188 passed, 9 errors
```

Failures are **pre-existing**, established against a scratch worktree at `origin/main`:

```text
origin/main baseline : 23 FAILED/ERROR lines
this branch          : 23 FAILED/ERROR lines
symmetric difference : (empty)
```

`tests/test_grammar_consumer_integration.py` is excluded because it fails at *collection* on both
branches (`ModuleNotFoundError: No module named 'app.models'` — there is no `app/models.py` in the
service at all). Unrelated to this patch; not introduced here.

Red-before-green, run against `origin/main`'s `worker.py`:

```text
correctly RED against origin/main:
  node:substrate.biometrics at worker.py:744, node:substrate.execution at worker.py:2151,
  node:substrate.chat at worker.py:2211, node:substrate.route at worker.py:2264
```

## Evals run

```text
No eval harness exists for services/orion-substrate-runtime.
```

Flagged rather than claimed. The behavior this patch restores is directly observable in the live
node values (below), which is the meaningful check here.

## Docker/build/smoke checks

```text
$ scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
Container orion-athena-substrate-runtime Recreated / Started
```

Live node values sampled over 60s after deploy (FalkorDB `orion_substrate`):

```text
biometric=0.03   bus_synap=1.0  chat=0.0135  execution=0.0     route=0.0
biometric=0.0008 bus_synap=1.0  chat=0.0135  execution=0.0     route=0.0
biometric=0.0238 bus_synap=1.0  chat=0.0135  execution=0.2331  route=0.0
biometric=0.0853 bus_synap=1.0  chat=0.0135  execution=0.2331  route=0.0
```

`route` was `0.00025` and static for 10 hours before this; it now reads a genuine `0.0`.
`execution` reaches `0.0`, which it structurally could not do before. `bus_synaptic` remaining
pinned at `1.0` is a **separate** defect with its own fix (`fix/bus-synaptic-per-edge-saturation`)
— this patch isolates it rather than addressing it.

## Review findings fixed

Not run as a separate subagent pass for this patch — it is a four-line mechanical extension of an
already-reviewed and already-merged fix (`0fe7de56f`), with a structural test that is confirmed red
against `origin/main`. Called out here rather than silently skipped.

## Restart required

Already applied (see Docker checks). To redeploy from the main checkout after merge:

```bash
cd /mnt/scripts/Orion-Sapienform
git pull --ff-only
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
```

## Risks / concerns

- **Severity: note.** Node writes now happen on every tick for four more domains, so upsert volume
  against `orion_substrate` rises. `bus_synaptic` has been running this way since 20:01 today with
  no observed issue, and these ticks are far lower-frequency than the concept-induction pipeline
  already hitting the same store.
- **Severity: note.** `node:substrate.chat` is still frozen (6 days), by a different mechanism this
  patch deliberately does not touch — `_chat_tick()` returns before any write when there are no chat
  grammar events. It is nonetheless still averaged into `prediction_error_confidence` by the
  upstream reducer, which is worth its own decision.

## PR link

<to be filled after push>
