### PR TITLE
fix(execution-dispatch): fresh-priority fallback so real dispatch is never starved by backlog depth

### DIFF
--- a/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
+++ b/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
@@ -113,6 +113,41 @@ against current field state, and drops the rest instead of queuing it up as fals
 debt) — but it is a real, disclosed trade-off, not a full fix. Part 2 below specs the throughput
 side.
 
+## Part 1b: same-day follow-up — FIFO-only drain starved real-time dispatch entirely
+
+Deployed this same day, and checked against real live data within minutes (not left to "should
+work"). Found something the original patch got wrong: **zero real dispatches happened in the 6+
+minutes following deploy.** `substrate_policy_decision_frames` backlog dropped steadily
+(~46,617 → ~46,134, a consistent ~165/min drain rate, confirmed via real per-minute row counts)
+— the discard mechanism itself worked exactly as designed. But `action_outcomes` had **zero** new
+rows in that same window.
+
+**Root cause**: the original design assumed the drain would "quickly clear backlog, letting real
+dispatch resume." It doesn't work that way under strict FIFO. `_drain_stale_policy_frames` walks
+oldest-first and only *stops* (handing back a candidate to process) once it finds a frame within
+the freshness window. With a 37-hour-deep backlog and a 120-300s freshness window, essentially
+every frame in that backlog is stale by definition — so every tick spends its entire
+`MAX_STALE_DISCARDS_PER_TICK` (200) budget discarding ancient garbage and *never reaches* a frame
+recent enough to actually dispatch. At the measured ~165/min drain rate, that's **~4.6 hours of
+total dispatch silence** before the drain would naturally catch up to real time. The PR's own risk
+section undersold this ("a rolling fraction of candidates will go stale") — in practice it was
+100% stale, 0% dispatched, for hours, not a rolling fraction.
+
+**Fix**: `ExecutionDispatchRuntimeStore.load_freshest_policy_frame_without_dispatch()` (new,
+`ORDER BY generated_at DESC LIMIT 1`, same schema-validation-failure handling as the existing FIFO
+lookup) — a direct "is there something current available right now" check. `_tick()` calls this
+as a fallback whenever `_drain_stale_policy_frames` doesn't surface a candidate (empty queue, or
+the cap was hit first). If the single newest unprocessed frame is within the staleness window, it
+gets processed for real dispatch this tick regardless of how deep the old backlog behind it is.
+Old backlog still drains steadily via the unchanged FIFO path — this only ensures real-time
+dispatch is never additionally gated by backlog depth. Correctly returns nothing when even the
+newest available frame is already stale (production itself has stalled, not a backlog-depth
+artifact).
+
+**Files touched**: `services/orion-execution-dispatch-runtime/app/store.py`
+(`load_freshest_policy_frame_without_dispatch`), `app/worker.py` (extracted `_age_sec` shared
+helper, new `_check_freshest_fallback`, `_tick` wiring), README, tests.
+
 ## Part 2: throughput redesign — design mode, not implemented
 
 ### Arsonist summary

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -115,6 +115,20 @@ deliberate deep-backlog catch-up ever becomes desirable again (e.g. Orion's own 
 cadence changes later) instead of reverting this patch. Same "explicit override, don't touch the
 derived machinery" shape as `ORION_DISPATCH_RISK_CAP_ADVISORY_ONLY` above.
 
+**Fresh-priority fallback (2026-07-30, same-day follow-up)**: deployed and found live, within
+minutes, that the FIFO-only drain above has a real failure mode — a deep pre-existing backlog
+(the exact 46,617-row/37h one that motivated this feature) means every tick's entire
+`MAX_STALE_DISCARDS_PER_TICK` budget goes to old garbage without ever reaching a frame recent
+enough to dispatch. Confirmed live: **zero real dispatches for the first 6+ minutes** after this
+shipped. Fixed the same day: whenever `_drain_stale_policy_frames` doesn't surface a candidate
+(empty queue, or the cap was hit first), `_tick()` now also checks
+`ExecutionDispatchRuntimeStore.load_freshest_policy_frame_without_dispatch()` — the single
+*newest* unprocessed policy frame, `ORDER BY generated_at DESC` — and processes it directly if
+it's within the staleness window. A genuinely current proposal is never gated behind however deep
+the old backlog is; old backlog still drains steadily in the background via the unchanged FIFO
+path. Returns correctly-empty only when even the newest available frame is already stale, i.e.
+production itself has stalled, not backlog depth hiding something current.
+
 See `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md` for the
 full live-data investigation (real backlog depth, throughput math, root cause) and the deferred
 part-2 throughput redesign this was scoped alongside but does not itself implement.

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -76,6 +76,62 @@ class ExecutionDispatchRuntimeStore:
                 self._retire_incompatible_policy_frame(raw_frame_id, raw_proposal_frame_id)
             return None
 
+    def load_freshest_policy_frame_without_dispatch(self) -> PolicyDecisionFrameV1 | None:
+        """The single newest unprocessed policy frame, regardless of backlog
+        depth (2026-07-30, docs/superpowers/specs/2026-07-30-execution-
+        dispatch-staleness-discard-design.md's own follow-up finding: a real
+        deep backlog fully starved real-time dispatch under the FIFO-only
+        design, since _drain_stale_policy_frames' oldest-first walk can spend
+        its entire per-tick discard budget on old backlog without ever
+        reaching "now"). _tick() checks this as a fallback whenever the FIFO
+        drain doesn't surface a candidate to process, so a genuinely current
+        proposal is never gated behind however deep the old backlog is.
+
+        Same schema-validation-failure handling as load_latest_policy_frame_
+        without_dispatch above (retire an incompatible row via a stub
+        dispatch frame rather than re-selecting it forever) -- this query can
+        hit the exact same incompatible-row case, just approached from the
+        newest end instead of the oldest.
+        """
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT p.policy_decision_frame_json
+                        FROM substrate_policy_decision_frames p
+                        LEFT JOIN substrate_execution_dispatch_frames d
+                          ON d.source_policy_frame_id = p.frame_id
+                        WHERE d.frame_id IS NULL
+                        ORDER BY p.generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["policy_decision_frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        try:
+            return PolicyDecisionFrameV1.model_validate(payload)
+        except ValidationError:
+            raw_frame_id = payload.get("frame_id") if isinstance(payload, dict) else None
+            raw_proposal_frame_id = (
+                payload.get("source_proposal_frame_id") if isinstance(payload, dict) else None
+            )
+            logger.warning(
+                "policy_decision_frame_incompatible_schema freshest_lookup frame_id=%s",
+                raw_frame_id,
+                exc_info=True,
+            )
+            if raw_frame_id:
+                self._retire_incompatible_policy_frame(raw_frame_id, raw_proposal_frame_id)
+            return None
+
     def _retire_incompatible_policy_frame(
         self, raw_frame_id: str, raw_proposal_frame_id: str | None
     ) -> None:

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -211,6 +211,50 @@ class ExecutionDispatchRuntimeWorker:
             self._settings.execution_dispatch_staleness_max_sec,
         )
 
+    @staticmethod
+    def _age_sec(frame: PolicyDecisionFrameV1) -> float:
+        # Defensive normalize, same idiom as _derive_daily_risk_cap above:
+        # PolicyDecisionFrameV1.generated_at is typed as a plain datetime,
+        # not enforced tz-aware. A naive value here would raise on the
+        # subtraction below -- caught by _poll_loop's broad except, but
+        # this exact policy frame would then be stuck unresolved forever
+        # in whichever lookup found it, reproducing the same queue-blocking
+        # failure shape build_unevaluable_execution_dispatch_frame exists to
+        # prevent for a missing proposal. Shared by _drain_stale_policy_
+        # frames (FIFO lookup) and _check_freshest_fallback (newest-first
+        # lookup) -- both need the identical normalize-then-subtract logic.
+        frame_generated_at = frame.generated_at
+        if frame_generated_at.tzinfo is None:
+            frame_generated_at = frame_generated_at.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - frame_generated_at).total_seconds()
+
+    def _check_freshest_fallback(self) -> PolicyDecisionFrameV1 | None:
+        """2026-07-30 follow-up (docs/superpowers/specs/2026-07-30-execution-
+        dispatch-staleness-discard-design.md's own live-verified finding):
+        the FIFO staleness drain alone can fully starve real-time dispatch
+        when the backlog is deep -- confirmed live, zero real dispatches in
+        the 6 minutes following that patch's deploy, because every tick's
+        entire MAX_STALE_DISCARDS_PER_TICK budget was spent discarding old
+        backlog without ever reaching a frame recent enough to process.
+
+        Called only when _drain_stale_policy_frames() didn't surface a
+        candidate this tick (queue exhausted, drain hit the cap, or the
+        queue was empty from the start). Checks the single NEWEST unprocessed
+        policy frame directly (store.load_freshest_policy_frame_without_
+        dispatch, ORDER BY generated_at DESC) -- if it's within a fresh
+        staleness threshold, a genuinely current proposal always gets a
+        chance to dispatch this tick regardless of how deep the old backlog
+        is. Returns None (correctly) if even the newest available frame is
+        already stale -- that means production itself has stalled, not that
+        backlog depth is hiding something current.
+        """
+        freshest = self._store.load_freshest_policy_frame_without_dispatch()
+        if freshest is None:
+            return None
+        if self._age_sec(freshest) <= self._staleness_threshold_sec():
+            return freshest
+        return None
+
     def _drain_stale_policy_frames(
         self, baseline: dict
     ) -> tuple[PolicyDecisionFrameV1 | None, int, ExecutionDispatchFrameV1 | None]:
@@ -237,18 +281,7 @@ class ExecutionDispatchRuntimeWorker:
             candidate_frame = self._store.load_latest_policy_frame_without_dispatch()
             if candidate_frame is None:
                 return None, discarded, last_discard_frame
-            # Defensive normalize, same idiom as _derive_daily_risk_cap above:
-            # PolicyDecisionFrameV1.generated_at is typed as a plain datetime,
-            # not enforced tz-aware. A naive value here would raise on the
-            # subtraction below -- caught by _poll_loop's broad except, but
-            # this exact policy frame would then be the permanent FIFO head
-            # forever (it can never resolve), reproducing the same
-            # queue-blocking failure shape build_unevaluable_execution_
-            # dispatch_frame exists to prevent for a missing proposal.
-            frame_generated_at = candidate_frame.generated_at
-            if frame_generated_at.tzinfo is None:
-                frame_generated_at = frame_generated_at.replace(tzinfo=timezone.utc)
-            age_sec = (datetime.now(timezone.utc) - frame_generated_at).total_seconds()
+            age_sec = self._age_sec(candidate_frame)
             threshold_sec = self._staleness_threshold_sec()
             if age_sec <= threshold_sec:
                 return candidate_frame, discarded, last_discard_frame
@@ -283,6 +316,16 @@ class ExecutionDispatchRuntimeWorker:
         policy_frame, discarded_this_tick, last_discard_frame = self._drain_stale_policy_frames(
             baseline
         )
+        if policy_frame is None:
+            # The FIFO drain didn't surface anything this tick (empty queue,
+            # or the cap was hit before reaching a fresh frame) -- check
+            # directly whether a genuinely current proposal exists anyway,
+            # so real dispatch is never starved by backlog depth alone. See
+            # _check_freshest_fallback's own docstring for the live incident
+            # this closes (zero real dispatches for the first 6+ minutes
+            # after the staleness-discard patch shipped, entirely consumed
+            # discarding old backlog).
+            policy_frame = self._check_freshest_fallback()
 
         update = compute_ewma_update(
             prev_ewma=baseline["staleness_discard_count_ewma"],

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -60,6 +60,7 @@ def test_worker_skips_when_no_policy_pending(monkeypatch) -> None:
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
     worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=None)
+    worker._store.load_freshest_policy_frame_without_dispatch = MagicMock(return_value=None)
     worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
 
@@ -150,6 +151,10 @@ def _staleness_worker(monkeypatch, *, override_sec: float | None = None) -> Exec
     worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
     worker._store.load_proposal_frame = MagicMock(return_value=_proposal())
+    # Default: nothing fresher available either (2026-07-30 fresh-priority
+    # fallback) -- tests that specifically exercise the fallback override
+    # this explicitly.
+    worker._store.load_freshest_policy_frame_without_dispatch = MagicMock(return_value=None)
     return worker
 
 
@@ -239,6 +244,51 @@ def test_worker_drains_stale_frames_then_processes_a_fresh_one(monkeypatch) -> N
     final_saved = worker._store.save_dispatch_frame.call_args_list[-1][0][0]
     assert final_saved.source_policy_frame_id == fresh.frame_id
     assert final_saved.dispatch_attempted is False or final_saved.candidates == []
+    # The FIFO drain found a fresh frame on its own -- the newest-first
+    # fallback must never be consulted in that case.
+    worker._store.load_freshest_policy_frame_without_dispatch.assert_not_called()
+
+
+def test_worker_falls_back_to_freshest_when_drain_finds_nothing(monkeypatch) -> None:
+    """Regression guard for the live incident (2026-07-30, docs/superpowers/
+    specs/2026-07-30-execution-dispatch-staleness-discard-design.md): a deep
+    backlog made the FIFO drain spend its entire per-tick cap on ancient
+    frames without ever reaching one recent enough to process -- zero real
+    dispatches for 6+ minutes after the staleness-discard patch shipped.
+    When the drain hits its cap without finding anything fresh, _tick() must
+    still check for -- and process -- a genuinely current proposal directly,
+    regardless of how deep the old backlog behind it is."""
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    ancient = _policy_frame_at(datetime.now(timezone.utc) - timedelta(days=2))
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=ancient)
+    fresh = _policy_frame_at(datetime.now(timezone.utc) - timedelta(seconds=1), frame_id="policy.frame:fresh")
+    worker._store.load_freshest_policy_frame_without_dispatch = MagicMock(return_value=fresh)
+
+    worker._tick()
+
+    worker._store.load_proposal_frame.assert_called_once_with(fresh.source_proposal_frame_id)
+    final_saved = worker._store.save_dispatch_frame.call_args_list[-1][0][0]
+    assert final_saved.source_policy_frame_id == fresh.frame_id
+
+
+def test_worker_fallback_correctly_finds_nothing_when_freshest_is_also_stale(monkeypatch) -> None:
+    """If even the single newest unprocessed policy frame is already past
+    the staleness window, production itself has stalled -- there is
+    genuinely nothing current to dispatch this tick, not a backlog-depth
+    artifact. Must not fabricate a real-dispatch attempt in that case."""
+    worker = _staleness_worker(monkeypatch, override_sec=120.0)
+    ancient = _policy_frame_at(datetime.now(timezone.utc) - timedelta(days=2))
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=ancient)
+    also_stale_but_newest = _policy_frame_at(
+        datetime.now(timezone.utc) - timedelta(hours=1), frame_id="policy.frame:newest-but-stale"
+    )
+    worker._store.load_freshest_policy_frame_without_dispatch = MagicMock(
+        return_value=also_stale_but_newest
+    )
+
+    worker._tick()
+
+    worker._store.load_proposal_frame.assert_not_called()
 
 
 def test_max_stale_discards_per_tick_caps_the_drain(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Same-day follow-up to PR #1509 (staleness discard). Deployed, checked against real data within minutes: **zero real dispatches for 6+ minutes** post-deploy, despite the backlog draining steadily (~165/min, real per-minute counts).
- Root cause: `_drain_stale_policy_frames` walks the backlog strictly oldest-first, only stopping once it finds a frame within the freshness window. With a 37h-deep backlog, every frame in it is stale by definition — every tick spent its entire `MAX_STALE_DISCARDS_PER_TICK` (200) budget on ancient garbage and never reached anything recent enough to dispatch. At the measured drain rate that's ~4.6 hours of total dispatch silence.
- Fix: new `ExecutionDispatchRuntimeStore.load_freshest_policy_frame_without_dispatch()` (`ORDER BY generated_at DESC`), checked as a fallback whenever the FIFO drain doesn't surface a candidate. A genuinely current proposal is now always dispatched the same tick it arrives, regardless of backlog depth. Old backlog still drains via the unchanged FIFO path.
- Also traced Part 2's open question: `orion-cortex-exec`'s "background" lane already supports unbounded concurrent request handling (`asyncio.create_task` per message, no cap) — it is **not** the bottleneck. The constraint is entirely execution-dispatch-runtime's own sequential send loop, confirming Part 2's concurrency direction has real headroom (not implemented here).

## Outcome moved

Real cortex dispatch actions resume immediately for current proposals, independent of however deep the pre-existing backlog is — closes the total-dispatch-outage gap PR #1509 introduced as a side effect of its own fix.

## Current architecture

`_tick()` only ever consulted the FIFO oldest-first lookup; a deep backlog meant it could spend an entire tick's discard budget without ever finding something recent enough to act on.

## Architecture touched

`services/orion-execution-dispatch-runtime/app/worker.py` (new `_check_freshest_fallback`, extracted `_age_sec`, `_tick` wiring), `app/store.py` (new `load_freshest_policy_frame_without_dispatch`).

## Files changed

- `services/orion-execution-dispatch-runtime/app/store.py`: `load_freshest_policy_frame_without_dispatch`.
- `services/orion-execution-dispatch-runtime/app/worker.py`: `_age_sec` extracted as shared helper, new `_check_freshest_fallback`, `_tick` wiring.
- `services/orion-execution-dispatch-runtime/README.md`: documented.
- `tests/test_execution_dispatch_runtime_worker.py`: new coverage (fallback hit, fallback correctly-empty, fallback-not-consulted-when-unneeded).
- `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md`: "Part 1b" section with the full live incident + fix, plus the cortex-exec concurrency trace answering Part 2's missing question 1.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-execution-dispatch-fresh-priority
PYTHONPATH=. .venv/bin/python -m pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_policy_loader.py -q
# 94 passed
```

## Evals run

None — same as PR #1509, no eval harness for this service; live production/consumption/starvation math verified directly against Postgres instead (documented in the design doc's Part 1b).

## Docker/build/smoke checks

Not run in this pass — no live deploy yet for this specific patch (PR #1509 was deployed and this bug was found against that live deployment; this follow-up has not itself been deployed).

## Review findings fixed

No material findings — reviewing subagent (resumed after an unrelated session-limit interruption, continued from its own prior transcript) hand-traced the fallback wiring in `_tick()` end-to-end, confirmed the starvation-fix guarantee holds (a fresh proposal is dispatched the same tick it arrives, not eventually), confirmed no double-processing/race risk introduced by this diff (both queries share the same `LEFT JOIN ... WHERE d.frame_id IS NULL` filter and `save_dispatch_frame` upserts deterministically on `frame_id`), confirmed `_age_sec` has no leftover duplicate logic, and ran the real test suite itself (94/94 passing). One pre-existing, non-blocking quirk noted (a schema-invalid backlog row causes the FIFO drain to give up for the tick rather than skip past it) — not introduced by this patch, not fixed here.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-execution-dispatch-runtime/.env \
  -f services/orion-execution-dispatch-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: not yet verified against live traffic (this specific patch hasn't been deployed). The mechanism is straightforward and reviewed, but "does a fresh dispatch actually resume within one tick post-deploy" should be confirmed the same way the original starvation bug was found — watching `action_outcomes`/`substrate_execution_dispatch_frames` immediately after restart.
- Mitigation: same live-verification discipline used to find and fix this bug in the first place — check real data right after deploy, don't assume.