### PR TITLE
feat(structural-mass): codebase-mass bus contract + composite scoring

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -2157,6 +2157,25 @@ channels:
     stability: "experimental"
     since: "2026-05-09"
 
+  # Codebase-mass domain (docs/superpowers/specs/2026-07-30-codebase-mass-
+  # signal-design.md) -- sixth prediction_error domain, sensing git/GitHub/
+  # graphify structural change. orion-cocreation-signals (not yet a live
+  # service as of this contract patch) will own all external I/O for this
+  # domain; orion-substrate-runtime's existing fast tick reads this event and
+  # writes node:substrate.codebase via codebase_prediction_error() -- no
+  # external I/O added to orion-substrate-runtime itself. Each event carries
+  # exactly one producer domain's real delta (git/pr_lifecycle/graph); see
+  # orion/schemas/codebase_delta.py's own docstring for why the other two
+  # nested fields are always None, not a fabricated zero.
+  - name: "orion:substrate:codebase_delta"
+    kind: "event"
+    schema_id: "CodebaseDeltaV1"
+    message_kind: "substrate.codebase_delta.v1"
+    producer_services: ["orion-cocreation-signals"]
+    consumer_services: ["orion-substrate-runtime"]
+    stability: "experimental"
+    since: "2026-07-30"
+
   - name: "orion:mind:artifact"
     kind: "event"
     schema_id: "MindRunArtifactV1"

--- a/orion/schemas/codebase_delta.py
+++ b/orion/schemas/codebase_delta.py
@@ -1,0 +1,95 @@
+"""Bus payload schema for the codebase-mass domain's ``orion:substrate:codebase_delta``
+channel (docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md). Each
+event carries exactly one producer domain's real delta -- git, PR lifecycle, or
+graphify structural -- since each producer runs on its own independent interval
+(the design spec's "Dedicated service" section); the other two nested fields are
+``None`` on any given event, not a fabricated zero.
+
+Field shapes mirror ``orion/structural_mass/{git_delta,pr_lifecycle,graph_delta}.py``'s
+own dataclasses as closely as pydantic/JSON allows (e.g. tuples become lists, since
+JSON has no tuple type) -- this schema is the wire format those pure dataclasses get
+serialized into, not an independent redesign of their shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class GitDeltaPayloadV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    prev_sha: str
+    head_sha: str
+    commit_count: int
+    files_added: int
+    files_deleted: int
+    files_modified: int
+    lines_added: int
+    lines_removed: int
+
+
+class PrLifecycleDeltaPayloadV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    since: datetime
+    until: datetime
+    submitted_count: int
+    merged_count: int
+    closed_without_merge_count: int
+    submitted_numbers: list[int] = Field(default_factory=list)
+    merged_numbers: list[int] = Field(default_factory=list)
+    closed_without_merge_numbers: list[int] = Field(default_factory=list)
+    possibly_truncated: bool = False
+
+
+class GraphDeltaPayloadV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    node_count_delta: int
+    edge_count_delta: int
+    community_count_delta: int
+    # None (not a fabricated 0.0/1.0) when the source snapshots' god_nodes could
+    # not be determined -- see orion/structural_mass/graph_delta.py's docstring.
+    god_node_jaccard_similarity: float | None = None
+    god_nodes_entered: list[str] | None = None
+    god_nodes_exited: list[str] | None = None
+
+
+class CodebaseDeltaV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["codebase_delta.v1"] = "codebase_delta.v1"
+    # Which one of git/pr_lifecycle/graph fired this event -- the other two
+    # nested fields are None on any given event, never a fabricated zero delta
+    # for a producer that simply didn't run this tick.
+    domain: Literal["git", "pr_lifecycle", "graph"]
+    observed_at: datetime
+    git: GitDeltaPayloadV1 | None = None
+    pr_lifecycle: PrLifecycleDeltaPayloadV1 | None = None
+    graph: GraphDeltaPayloadV1 | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_domain_populated(self) -> "CodebaseDeltaV1":
+        """Enforces the invariant this schema's own docstring only states in
+        prose (flagged by code review 2026-07-30): the field matching
+        ``domain`` must be populated, and the other two must be ``None`` --
+        not just as a convention producers are expected to follow, but as
+        something a bad payload actually fails validation on. Without this,
+        a malformed event (e.g. ``domain="git"`` with ``pr_lifecycle`` also
+        set, or ``domain="git"`` with ``git=None``) would pass schema
+        validation silently and only misbehave once a real consumer reads
+        the wrong/missing field -- exactly the kind of "schema-valid payload
+        with meaningless content" root CLAUDE.md's "no empty-shell
+        cognition" section warns about."""
+        fields = {"git": self.git, "pr_lifecycle": self.pr_lifecycle, "graph": self.graph}
+        populated = [name for name, value in fields.items() if value is not None]
+        if populated != [self.domain]:
+            raise ValueError(
+                f"domain={self.domain!r} requires exactly the {self.domain!r} field "
+                f"populated and the other two None; got populated={populated!r}"
+            )
+        return self

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -118,6 +118,7 @@ from orion.schemas.self_experiments import (
     SelfExperimentRecordV1,
     SelfExperimentSpecV1,
 )
+from orion.schemas.codebase_delta import CodebaseDeltaV1
 from orion.schemas.organ_emission import OrganEmissionV1
 from orion.schemas.reduction_receipt import ProjectionUpdateV1, ReductionReceiptV1
 from orion.schemas.state_delta import StateDeltaV1
@@ -712,6 +713,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "ExecutionTrajectoryProjectionV1": ExecutionTrajectoryProjectionV1,
     "TransportBusStateV1": TransportBusStateV1,
     "TransportBusProjectionV1": TransportBusProjectionV1,
+    "CodebaseDeltaV1": CodebaseDeltaV1,
     "CortexClientRequest": CortexClientRequest,
     "CortexClientResult": CortexClientResult,
     "AgentTraceToolStatV1": AgentTraceToolStatV1,

--- a/orion/schemas/tests/test_codebase_delta.py
+++ b/orion/schemas/tests/test_codebase_delta.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.codebase_delta import (
+    CodebaseDeltaV1,
+    GitDeltaPayloadV1,
+    GraphDeltaPayloadV1,
+    PrLifecycleDeltaPayloadV1,
+)
+from orion.schemas.registry import _REGISTRY, resolve
+
+_NOW = datetime(2026, 7, 30, tzinfo=timezone.utc)
+
+
+def test_codebase_delta_registered() -> None:
+    assert "CodebaseDeltaV1" in _REGISTRY
+    assert resolve("CodebaseDeltaV1") is CodebaseDeltaV1
+
+
+def test_git_domain_round_trip() -> None:
+    event = CodebaseDeltaV1(
+        domain="git",
+        observed_at=_NOW,
+        git=GitDeltaPayloadV1(
+            prev_sha="a" * 40,
+            head_sha="b" * 40,
+            commit_count=3,
+            files_added=1,
+            files_deleted=0,
+            files_modified=2,
+            lines_added=100,
+            lines_removed=40,
+        ),
+    )
+    dumped = event.model_dump(mode="json")
+    restored = CodebaseDeltaV1.model_validate(dumped)
+    assert restored == event
+    assert restored.pr_lifecycle is None
+    assert restored.graph is None
+
+
+def test_pr_lifecycle_domain_round_trip() -> None:
+    event = CodebaseDeltaV1(
+        domain="pr_lifecycle",
+        observed_at=_NOW,
+        pr_lifecycle=PrLifecycleDeltaPayloadV1(
+            since=_NOW,
+            until=_NOW,
+            submitted_count=5,
+            merged_count=3,
+            closed_without_merge_count=0,
+            submitted_numbers=[1, 2, 3, 4, 5],
+            merged_numbers=[1, 2, 3],
+            possibly_truncated=False,
+        ),
+    )
+    dumped = event.model_dump(mode="json")
+    restored = CodebaseDeltaV1.model_validate(dumped)
+    assert restored == event
+    assert restored.git is None
+    assert restored.graph is None
+
+
+def test_graph_domain_round_trip_with_none_jaccard() -> None:
+    """god_node_jaccard_similarity=None (unparseable GRAPH_REPORT.md) must
+    survive a JSON round-trip as None, not get coerced to 0.0/1.0."""
+    event = CodebaseDeltaV1(
+        domain="graph",
+        observed_at=_NOW,
+        graph=GraphDeltaPayloadV1(
+            node_count_delta=-40,
+            edge_count_delta=-110,
+            community_count_delta=-3,
+            god_node_jaccard_similarity=None,
+            god_nodes_entered=None,
+            god_nodes_exited=None,
+        ),
+    )
+    dumped = event.model_dump(mode="json")
+    restored = CodebaseDeltaV1.model_validate(dumped)
+    assert restored == event
+    assert restored.graph.god_node_jaccard_similarity is None
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        CodebaseDeltaV1.model_validate(
+            {"domain": "git", "observed_at": _NOW.isoformat(), "unexpected_field": 1}
+        )
+
+
+def test_domain_field_mismatch_rejected_when_declared_field_missing() -> None:
+    """domain='git' but the git field itself is None -- must fail validation,
+    not silently construct a schema-valid-but-empty-shell event."""
+    with pytest.raises(ValidationError, match="git"):
+        CodebaseDeltaV1(domain="git", observed_at=_NOW)
+
+
+def test_domain_field_mismatch_rejected_when_wrong_field_populated() -> None:
+    """domain='git' but pr_lifecycle is populated instead -- must fail, not
+    silently accept a payload whose declared domain doesn't match its real
+    content."""
+    with pytest.raises(ValidationError, match="git"):
+        CodebaseDeltaV1(
+            domain="git",
+            observed_at=_NOW,
+            pr_lifecycle=PrLifecycleDeltaPayloadV1(
+                since=_NOW, until=_NOW, submitted_count=1, merged_count=0, closed_without_merge_count=0
+            ),
+        )
+
+
+def test_domain_field_mismatch_rejected_when_extra_domain_also_populated() -> None:
+    """domain='git' with a real git payload AND a real graph payload both set
+    -- the design spec's contract is exactly one domain per event, not a
+    convenient multi-domain batch; must be rejected, not silently accepted
+    with the extra field ignored."""
+    with pytest.raises(ValidationError, match="git"):
+        CodebaseDeltaV1(
+            domain="git",
+            observed_at=_NOW,
+            git=GitDeltaPayloadV1(
+                prev_sha="a" * 40, head_sha="b" * 40, commit_count=1,
+                files_added=0, files_deleted=0, files_modified=1,
+                lines_added=10, lines_removed=0,
+            ),
+            graph=GraphDeltaPayloadV1(node_count_delta=1, edge_count_delta=1, community_count_delta=0),
+        )
+
+
+def test_domain_must_be_one_of_the_three_literals() -> None:
+    with pytest.raises(ValidationError):
+        CodebaseDeltaV1.model_validate({"domain": "not_a_real_domain", "observed_at": _NOW.isoformat()})

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from orion.bus.ewma import compute_ewma_update
@@ -11,6 +11,8 @@ from orion.schemas.execution_projection import ExecutionTrajectoryProjectionV1
 from orion.schemas.route_projection import RouteArbitrationProjectionV1
 from orion.schemas.transport_projection import TransportBusProjectionV1
 from orion.structural_mass.git_delta import GitChurnDelta
+from orion.structural_mass.graph_delta import GraphStructuralDelta
+from orion.structural_mass.pr_lifecycle import PrLifecycleDelta
 from orion.substrate.chat_loop.grammar_extract import compute_chat_pressure_hints
 
 _THRESHOLD = 0.30
@@ -64,54 +66,92 @@ _EXECUTION_PREDICTION_ERROR_ZSCORE_SATURATION = 3.0
 _EXECUTION_PREDICTION_ERROR_MIN_VARIANCE = 1e-10
 
 
-# 2026-07-30: codebase_prediction_error's EWMA baseline calibration (Phase 1 skeleton,
-# docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md -- no bus wiring, no
-# NODE_CHANNELS registration yet, see that spec's "Recommended next patch"). alpha=0.2
-# reuses execution_prediction_error's own alpha rather than inventing a new number for
-# a domain that, like execution, updates per real observation (a real git-churn tick,
-# not a fixed wall-clock cadence). min_variance calibrated against this repo's own real,
-# if shallow-clone-limited, commit history via
-# scripts/analysis/measure_codebase_prediction_error.py -- see that constant's own
-# comment for the live numbers.
+# 2026-07-30: codebase_prediction_error's EWMA baseline calibration (Phase 1 contract
+# patch, docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md). alpha=0.2
+# reuses execution_prediction_error's own alpha for all three sub-domains rather than
+# inventing three new numbers -- each sub-domain, like execution, updates per real
+# observation (a real producer tick), not a fixed wall-clock cadence.
 _CODEBASE_PREDICTION_ERROR_EWMA_ALPHA = 0.2
 _CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION = 3.0
 
 # 2026-07-30: live-confirmed via scripts/analysis/measure_codebase_prediction_error.py
-# against this repo's own real (shallow-clone-limited to 49 ticks/50 commits locally --
-# a real limitation, not a full backfill; see the design spec's "Backfill" section for
-# why a deeper replay needs scripts/analysis/backfill_structural_mass.py, not this
-# script) recent commit history, one tick per real commit: raw per-tick line-churn
-# magnitude (lines_changed) ranged 0-15,285 (mean 2,611, stdev 4,314; only 2/48 ticks
-# were true zero-churn no-ops), and the EWMA's own accumulated variance warmed up into
-# the 1.5M-60M range within a handful of ticks -- squared-magnitude units on a
-# thousands-scale raw signal are naturally large, several orders of magnitude *above*
-# the shared orion/bus/ewma.py default (1e-6), the mirror-image relationship to
-# execution_prediction_error's real variance (which sat far *below* that default).
-# Because the EWMA's own accumulated variance dominates this floor immediately once
-# any real deviation has been folded in, this constant's only actual effect across the
-# whole replayed window was guarding the single first real z-score computation (the
-# second observed tick, where prev_variance is still exactly 0.0 from the cold-start
-# branch) against amplifying a small real deviation into a false-large z purely from
-# dividing by a near-zero floor -- every later tick's z-score was already governed by
-# the domain's own real accumulated variance regardless of this constant's exact value.
-# Set low relative to this domain's observed real variance scale (not tuned to match
-# it -- there is nothing here for it to match, it is intentionally never the binding
-# term past the first tick) while staying safely nonzero; revisit only if a much
-# larger/deeper replay (post-backfill) shows a materially different cold-start regime.
-_CODEBASE_PREDICTION_ERROR_MIN_VARIANCE = 1.0
+# against this repo's own real git history (1395 real ticks, one per commit, this
+# repo's local clone deepened past its earlier ~50-commit shallow boundary during
+# this session): warmed-up EWMA variance (n>=5) ranged 43,876.72 to
+# 1,393,837,889,266.80, mean ~1.69e10 -- several orders of magnitude above any
+# floor near 1.0, so this floor is never the binding term past the very first
+# real tick, same conclusion (different exact numbers) as the Phase-1 skeleton
+# patch's single-domain version of this same constant. Kept as its own floor, not
+# shared with _PR_MIN_VARIANCE/_GRAPH_MIN_VARIANCE below, because -- as the next
+# constant's own comment shows -- assuming "large raw magnitude implies large
+# variance too" across sub-domains is exactly the mistake this split exists to
+# avoid; each floor is set from that domain's own measured numbers, not inferred
+# from another's.
+_GIT_MIN_VARIANCE = 1.0
+
+# 2026-07-30: live-confirmed via the same replay script against this repo's real
+# GitHub PR history (1395 real ticks): warmed-up EWMA variance (n>=5) ranged
+# 0.0000 to 1.5058, mean 0.1499 -- **this is the domain the borrowed-git-floor
+# mistake would actually have broken.** The Phase-1-skeleton reasoning ("PR raw
+# magnitude is single-digit scale, several orders of magnitude below git's, so a
+# shared floor would be wrong") was correct about raw magnitude but did not
+# check *variance* specifically before this contract patch's first draft reused
+# git's 1.0 floor here anyway -- variance of small-integer counts near their own
+# mean is frequently sub-1 (confirmed: real mean 0.1499, real min exactly 0.0),
+# so a 1.0 floor would have been the *binding* term on most real PR ticks,
+# silently flattening this domain's real z-scores toward the floor's own scale
+# instead of its actual spread -- the identical failure shape
+# execution_prediction_error's own fix already exists to prevent, just
+# reintroduced one domain over by assuming a plausible-sounding number instead
+# of measuring it. Set two orders of magnitude below the real mean (0.1499) --
+# small enough to stay out of the way of real variance on almost every tick,
+# nonzero to guard the true zero-variance ticks (real min was exactly 0.0)
+# against a division by zero.
+_PR_MIN_VARIANCE = 0.001
+
+# 2026-07-30: live-confirmed via the same replay script against this repo's real,
+# sparse graphify-out/graph.json history: only 6 real diffed ticks exist at all
+# (graph is by far this composite's sparsest domain), and only 2 of those are
+# "warmed up" (n>=5, i.e. the 5th and 6th real observations) -- not a large
+# sample, an honest one. (An earlier version of this replay script's own
+# instrumentation bug inflated this to a reported "n=240" by re-appending the
+# same frozen baseline.variance on every one of the ~240 intervening non-firing
+# ticks between real graph observations -- caught and fixed by code review
+# 2026-07-30, see scripts/analysis/measure_codebase_prediction_error.py's own
+# comment at the fix site. The *values* were already correct even under the
+# bug, since duplicating real numbers doesn't change their min/max/mean -- but
+# the sample-count evidence itself was fabricated, worth naming plainly rather
+# than quietly correcting.) Those 2 real values ranged 2,616,891,929.63 to
+# 3,243,755,333.97 -- several orders of magnitude above any floor near 1.0,
+# same conclusion as git for the same underlying reason: this domain's raw
+# magnitude is itself in the hundreds-to-hundred-thousands range from the
+# 2026-07-14 destructive-update incident alone (see
+# orion/structural_mass/graph_delta.py's own docstring for that incident's
+# exact numbers), so its squared-deviation variance is naturally huge too.
+_GRAPH_MIN_VARIANCE = 1.0
+
+
+@dataclass(frozen=True)
+class _DomainEwmaBaseline:
+    ewma: float = 0.0
+    variance: float = 0.0
+    n: int = 0
 
 
 @dataclass(frozen=True)
 class CodebaseMassBaseline:
     """EWMA baseline state for ``codebase_prediction_error``, threaded explicitly by
     the caller rather than read off a persisted projection -- unlike the other five
-    domains in this module, no ``structural_mass`` projection schema or bus channel
-    exists yet (Phase 1 skeleton only; see this module's codebase_prediction_error
-    docstring)."""
+    domains in this module, no ``structural_mass`` projection schema exists to mutate
+    in place (this domain is bus-event-driven, not reducer-projection-driven; see the
+    design spec's "Dedicated service" section). One independent sub-baseline per
+    producer domain (``git``/``pr``/``graph``), since each producer runs on its own
+    interval and a given tick may carry only one domain's real delta (the other two
+    ``None`` -- see ``codebase_prediction_error``'s docstring)."""
 
-    ewma: float = 0.0
-    variance: float = 0.0
-    n: int = 0
+    git: _DomainEwmaBaseline = field(default_factory=_DomainEwmaBaseline)
+    pr: _DomainEwmaBaseline = field(default_factory=_DomainEwmaBaseline)
+    graph: _DomainEwmaBaseline = field(default_factory=_DomainEwmaBaseline)
 
 
 @dataclass(frozen=True)
@@ -120,66 +160,102 @@ class CodebasePredictionErrorResult:
     baseline: CodebaseMassBaseline
 
 
-def codebase_prediction_error(
-    delta: GitChurnDelta,
-    baseline: CodebaseMassBaseline,
-) -> CodebasePredictionErrorResult:
-    """0-1 surprise score: how much did this tick's git churn deviate from this
-    domain's own recent normal.
-
-    **Phase 1 skeleton** (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
-    design.md) -- not wired into any tick, no ``NODE_CHANNELS`` registration, no bus
-    channel. Exists so the replay script
-    (``scripts/analysis/measure_codebase_prediction_error.py``) has a real function to
-    call before any of that is built, per this program's "measure before minting"
-    discipline (SSP §7) -- same order every other domain in this module has followed.
-
-    Unlike the other five domains, there is no ``prev``/``curr`` projection pair to
-    diff here -- ``GitChurnDelta`` (``orion/structural_mass/git_delta.py``) is
-    already a diff (of two git SHAs), so this function's job is scoring *that*
-    delta's magnitude against this domain's own EWMA baseline, the same shape
-    ``execution_prediction_error`` uses once it already has its raw per-tick delta
-    in hand. Raw magnitude is ``delta.lines_changed`` (net lines added + removed) --
-    the single continuous scale that best reflects "how much of the codebase moved,"
-    with commit/file counts available on ``delta`` itself for callers that want them
-    as separate descriptive fields (e.g. a future concept-classification consumer)
-    without folding them into this one scalar and reintroducing an arbitrary
-    cross-scale weighting (commits vs. files vs. lines) this function deliberately
-    avoids, the same reasoning ``route_prediction_error``'s docstring gives for not
-    hand-encoding categorical fields into one number.
-
-    No baseline state is read from or written to any persisted store -- the caller
-    owns threading ``baseline`` from one call to the next (mirrors
-    ``compute_ewma_update``'s own explicit-state-in, explicit-state-out shape,
-    rather than the other domains' "mutate the projection in place" pattern, since
-    there is no projection object to mutate here yet).
-
-    Returns ``score=0.0`` on the very first observation (``baseline.n == 0``) --
-    ``compute_ewma_update`` returns no z-score until a real baseline exists, and
-    reporting a nonzero value here would misrepresent "no baseline yet" as
-    "measured, not anomalous" (this repo's "no empty-shell cognition" rule). A
-    below-baseline tick (this commit churned *less* than usual) is clamped to 0.0,
-    not reported as negative surprise -- "surprising" here means "more churn than
-    usual," matching ``execution_prediction_error``'s same clamp for the same
-    reason.
-    """
-    raw_magnitude = float(delta.lines_changed)
+def _domain_zscore(
+    magnitude: float | None,
+    baseline: _DomainEwmaBaseline,
+    *,
+    min_variance: float,
+) -> tuple[float | None, _DomainEwmaBaseline]:
+    """One sub-domain's EWMA update: absent magnitude (this tick carried no real
+    delta for this domain) leaves the baseline untouched and contributes no
+    z-score -- not a 0.0 "calm" reading, an honest "no observation this tick"
+    (this repo's "no empty-shell cognition" rule, applied per sub-domain)."""
+    if magnitude is None:
+        return None, baseline
     update = compute_ewma_update(
         prev_ewma=baseline.ewma,
         prev_variance=baseline.variance,
         prev_count=baseline.n,
-        value=raw_magnitude,
+        value=magnitude,
         alpha=_CODEBASE_PREDICTION_ERROR_EWMA_ALPHA,
-        min_variance=_CODEBASE_PREDICTION_ERROR_MIN_VARIANCE,
+        min_variance=min_variance,
     )
-    new_baseline = CodebaseMassBaseline(
+    new_baseline = _DomainEwmaBaseline(
         ewma=update.ewma, variance=update.variance, n=baseline.n + 1
     )
     if update.zscore is None:
-        return CodebasePredictionErrorResult(score=0.0, baseline=new_baseline)
-    score = min(
-        1.0, max(0.0, update.zscore) / _CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION
+        return None, new_baseline
+    return max(0.0, update.zscore), new_baseline
+
+
+def codebase_prediction_error(
+    *,
+    git_delta: GitChurnDelta | None,
+    pr_delta: PrLifecycleDelta | None,
+    graph_delta: GraphStructuralDelta | None,
+    baseline: CodebaseMassBaseline,
+) -> CodebasePredictionErrorResult:
+    """0-1 composite surprise score across all three ``structural_mass`` producer
+    domains -- how much did this tick's git churn, GitHub PR activity, and/or
+    graphify structural change deviate from each domain's own recent normal.
+
+    **Contract patch** (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
+    design.md) -- the scoring half of Phase 1's "measure first, register once MET"
+    order; bus channel/schema registration and service/consumer wiring are separate,
+    later patches (this function has no bus dependency itself, so it can be tested
+    and calibrated before either exists).
+
+    **Each of the three producers runs on its own independent interval** (design
+    spec's "Dedicated service" section -- git: cheap/frequent, PR lifecycle:
+    coarser/rate-limit-aware, graph: event-triggered off graphify updates), so a
+    given tick's inputs may populate only one, two, or all three of
+    ``git_delta``/``pr_delta``/``graph_delta``; the other(s) are ``None``, meaning
+    "that producer didn't fire this tick," not "that producer observed zero
+    change." Each populated domain is scored independently against its *own* EWMA
+    baseline (mirrors ``execution_prediction_error``'s single-domain z-score, just
+    three parallel instances instead of one) rather than folding raw magnitudes
+    from different unit scales (lines of code vs. PR counts vs. graph node/edge
+    counts) into one combined raw number first -- that would reintroduce exactly
+    the arbitrary cross-scale weighting problem the individual domains' own
+    docstrings (``git_delta.py``, ``pr_lifecycle.py``) already avoid at one level
+    down. Normalizing each domain to a z-score *before* combining means the
+    composite is a mean of already-unit-less, already-self-calibrating values, the
+    same principle ``bus_synaptic_prediction_error`` uses when it aggregates many
+    already-normalized edge z-scores into one score.
+
+    The final score is the mean of whichever sub-domain z-scores are actually
+    available this tick (at least one -- if all three are ``None``, i.e. no
+    producer fired, this returns ``score=0.0`` without touching the baseline at
+    all, a real "nothing happened," not a computed reading), saturating at
+    ``_CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION`` (3.0) same as every other
+    z-score-based domain in this module. A below-baseline sub-domain tick is
+    clamped to 0.0 before averaging (mirrors every other domain's "surprising
+    means more than usual, not merely different" clamp), so a quiet git day
+    alongside a genuinely surprising PR spike still surfaces the PR spike rather
+    than being diluted toward 0 by an unclamped negative git contribution.
+    """
+    git_magnitude = None if git_delta is None else float(git_delta.lines_changed)
+    pr_magnitude = (
+        None
+        if pr_delta is None
+        else float(pr_delta.submitted_count + pr_delta.merged_count + pr_delta.closed_without_merge_count)
     )
+    graph_magnitude = (
+        None
+        if graph_delta is None
+        else float(abs(graph_delta.node_count_delta) + abs(graph_delta.edge_count_delta))
+    )
+
+    git_zscore, new_git = _domain_zscore(git_magnitude, baseline.git, min_variance=_GIT_MIN_VARIANCE)
+    pr_zscore, new_pr = _domain_zscore(pr_magnitude, baseline.pr, min_variance=_PR_MIN_VARIANCE)
+    graph_zscore, new_graph = _domain_zscore(graph_magnitude, baseline.graph, min_variance=_GRAPH_MIN_VARIANCE)
+
+    new_baseline = CodebaseMassBaseline(git=new_git, pr=new_pr, graph=new_graph)
+    zscores = [z for z in (git_zscore, pr_zscore, graph_zscore) if z is not None]
+    if not zscores:
+        return CodebasePredictionErrorResult(score=0.0, baseline=new_baseline)
+    mean_zscore = sum(zscores) / len(zscores)
+    score = min(1.0, mean_zscore / _CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION)
     return CodebasePredictionErrorResult(score=score, baseline=new_baseline)
 
 

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -24,8 +24,11 @@ from orion.schemas.route_projection import (
     RouteArbitrationRunStateV1,
 )
 from orion.structural_mass.git_delta import GitChurnDelta
+from orion.structural_mass.graph_delta import GraphStructuralDelta
+from orion.structural_mass.pr_lifecycle import PrLifecycleDelta
 from orion.substrate.prediction_error import (
     CodebaseMassBaseline,
+    _DomainEwmaBaseline,
     biometrics_prediction_error,
     bus_synaptic_prediction_error,
     chat_prediction_error,
@@ -661,14 +664,14 @@ class TestBusSynapticPredictionError:
 
 
 class TestCodebasePredictionError:
-    """Phase 1 skeleton (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
-    design.md) -- not wired into any tick yet. Unlike the other five instruments,
-    the input is already a diff (``GitChurnDelta``, itself a diff of two git SHAs),
-    so there is no prev/curr projection pair here; state (the EWMA baseline) is
-    threaded explicitly via ``CodebaseMassBaseline`` rather than mutated on a
-    persisted projection object, since no such schema exists yet."""
+    """Contract patch (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
+    design.md) -- composite scoring across all three structural_mass producer
+    domains (git/pr/graph), each on its own independent EWMA baseline since each
+    producer runs on its own interval and a given tick may populate only some of
+    them. Not wired into any tick/bus channel yet -- that's a separate, later
+    patch; this only proves the scoring function itself is correct."""
 
-    def _delta(
+    def _git(
         self,
         *,
         lines_added: int = 0,
@@ -689,85 +692,180 @@ class TestCodebasePredictionError:
             lines_removed=lines_removed,
         )
 
-    def test_no_commit_since_last_tick_is_explicit_no_op(self) -> None:
-        """A zero-magnitude delta (git_churn_delta's own prev_sha == head_sha
-        shape) must read 0.0, and -- like every other domain's cold-start
-        behavior -- must still seed the baseline rather than silently no-op the
-        state too."""
-        delta = self._delta(commit_count=0, lines_added=0, lines_removed=0)
+    def _pr(
+        self,
+        *,
+        submitted_count: int = 0,
+        merged_count: int = 0,
+        closed_without_merge_count: int = 0,
+    ) -> PrLifecycleDelta:
+        _now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        return PrLifecycleDelta(
+            since=_now,
+            until=_now,
+            submitted_count=submitted_count,
+            merged_count=merged_count,
+            closed_without_merge_count=closed_without_merge_count,
+        )
+
+    def _graph(
+        self,
+        *,
+        node_count_delta: int = 0,
+        edge_count_delta: int = 0,
+        community_count_delta: int = 0,
+        god_node_jaccard_similarity: float | None = 1.0,
+    ) -> GraphStructuralDelta:
+        return GraphStructuralDelta(
+            node_count_delta=node_count_delta,
+            edge_count_delta=edge_count_delta,
+            community_count_delta=community_count_delta,
+            god_node_jaccard_similarity=god_node_jaccard_similarity,
+        )
+
+    def test_no_producers_fired_is_explicit_no_op_and_baseline_untouched(self) -> None:
+        """All three domains None (no producer fired this tick) must read 0.0
+        without mutating any sub-baseline -- a real 'nothing happened,' not a
+        computed reading against absent data."""
         baseline = CodebaseMassBaseline()
-        result = codebase_prediction_error(delta, baseline)
+        result = codebase_prediction_error(
+            git_delta=None, pr_delta=None, graph_delta=None, baseline=baseline
+        )
         assert result.score == 0.0
-        assert result.baseline.n == 1
-        assert result.baseline.ewma == 0.0
+        assert result.baseline == baseline
+        assert result.baseline.git.n == 0
 
     def test_first_tick_is_cold_start_but_seeds_baseline(self) -> None:
-        """No established baseline yet (baseline.n == 0) -- must return 0.0 (no
-        z-score to compute against -- 'no empty-shell cognition'), but the
-        returned baseline must carry this tick's real raw magnitude forward so
-        the very next tick has something real to compare against."""
-        delta = self._delta(lines_added=400, lines_removed=200)
+        """No established baseline yet for the one domain that fired -- must
+        return 0.0 (no z-score to compute against), but must seed that domain's
+        sub-baseline so the next tick has something real to compare against.
+        Other two domains' sub-baselines stay untouched (n=0)."""
         baseline = CodebaseMassBaseline()
-        result = codebase_prediction_error(delta, baseline)
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=400, lines_removed=200),
+            pr_delta=None,
+            graph_delta=None,
+            baseline=baseline,
+        )
         assert result.score == 0.0
-        assert result.baseline.ewma == pytest.approx(600.0)
-        assert result.baseline.variance == 0.0
-        assert result.baseline.n == 1
+        assert result.baseline.git.ewma == pytest.approx(600.0)
+        assert result.baseline.git.n == 1
+        assert result.baseline.pr.n == 0
+        assert result.baseline.graph.n == 0
 
-    def test_one_normal_commit_scores_against_established_baseline(self) -> None:
-        """Once a baseline is established, a tick close to that baseline's own
-        recent normal should read a low/near-zero score, not a spike -- this is
-        the 'genuine rest state' the metric-quality-gate step 4 requires (a
-        normal-sized commit must not look anomalous by construction)."""
-        baseline = CodebaseMassBaseline(ewma=500.0, variance=10_000.0, n=5)
-        delta = self._delta(lines_added=300, lines_removed=220)  # magnitude 520
-        result = codebase_prediction_error(delta, baseline)
-        # zscore = (520 - 500) / sqrt(10_000) = 0.2 -> well below saturation
+    def test_single_domain_scores_against_its_own_established_baseline(self) -> None:
+        baseline = CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=500.0, variance=10_000.0, n=5))
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=300, lines_removed=220),  # magnitude 520
+            pr_delta=None,
+            graph_delta=None,
+            baseline=baseline,
+        )
+        # zscore = (520 - 500) / sqrt(10_000) = 0.2 -> mean of just this one zscore
         assert result.score == pytest.approx(0.2 / 3.0)
-        assert result.baseline.n == 6
+        assert result.baseline.git.n == 6
+
+    def test_two_domains_average_their_independent_zscores(self) -> None:
+        """git and pr both fire this tick; graph doesn't. Composite score is the
+        mean of exactly the two available z-scores, not diluted by a phantom
+        third 0.0 for the domain that didn't observe anything."""
+        baseline = CodebaseMassBaseline(
+            git=_DomainEwmaBaseline(ewma=500.0, variance=10_000.0, n=5),
+            pr=_DomainEwmaBaseline(ewma=2.0, variance=1.0, n=5),
+        )
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=300, lines_removed=220),  # magnitude 520, z=0.2
+            pr_delta=self._pr(submitted_count=3, merged_count=2),  # magnitude 5, z=(5-2)/1=3.0
+            graph_delta=None,
+            baseline=baseline,
+        )
+        expected_mean_z = (0.2 + 3.0) / 2
+        assert result.score == pytest.approx(min(1.0, expected_mean_z / 3.0))
+        assert result.baseline.git.n == 6
+        assert result.baseline.pr.n == 6
+        assert result.baseline.graph.n == 0
+
+    def test_all_three_domains_average_together(self) -> None:
+        baseline = CodebaseMassBaseline(
+            git=_DomainEwmaBaseline(ewma=500.0, variance=10_000.0, n=5),
+            pr=_DomainEwmaBaseline(ewma=2.0, variance=1.0, n=5),
+            graph=_DomainEwmaBaseline(ewma=100.0, variance=400.0, n=5),
+        )
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=300, lines_removed=220),  # z=0.2
+            pr_delta=self._pr(submitted_count=3, merged_count=2),  # z=3.0
+            graph_delta=self._graph(node_count_delta=120, edge_count_delta=0),  # magnitude 120, z=(120-100)/20=1.0
+            baseline=baseline,
+        )
+        expected_mean_z = (0.2 + 3.0 + 1.0) / 3
+        assert result.score == pytest.approx(min(1.0, expected_mean_z / 3.0))
 
     def test_saturates_exactly_at_zscore_saturation_boundary(self) -> None:
-        """No off-by-one at the saturation ceiling: a zscore of exactly 3.0 (this
-        module's _CODEBASE_PREDICTION_ERROR_ZSCORE_SATURATION) must score exactly
-        1.0, not something just short of or past it."""
-        baseline = CodebaseMassBaseline(ewma=500.0, variance=100.0, n=10)
-        delta = self._delta(lines_added=530, lines_removed=0)  # magnitude 530
-        # zscore = (530 - 500) / sqrt(100) = 3.0 exactly
-        result = codebase_prediction_error(delta, baseline)
+        """No off-by-one at the saturation ceiling: a single domain's zscore of
+        exactly 3.0 must score exactly 1.0."""
+        baseline = CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=500.0, variance=100.0, n=10))
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=530, lines_removed=0),  # magnitude 530, z=3.0 exactly
+            pr_delta=None,
+            graph_delta=None,
+            baseline=baseline,
+        )
         assert result.score == pytest.approx(1.0)
 
     def test_large_catch_up_diff_spanning_missed_ticks_scores_high(self) -> None:
-        """A big diff accumulated across several missed ticks (a commit made on
-        another node, via Cursor, or without the post-commit hook firing --
-        the design spec's 'self-healing by construction' shape) should read as
-        a real spike relative to the domain's own established baseline, not be
-        silently absorbed."""
-        baseline = CodebaseMassBaseline(ewma=500.0, variance=10_000.0, n=20)
-        delta = self._delta(
-            lines_added=9000, lines_removed=6000, commit_count=14, files_modified=40
-        )  # magnitude 15,000
-        result = codebase_prediction_error(delta, baseline)
+        """A big diff accumulated across several missed ticks should read as a
+        real spike relative to the domain's own established baseline."""
+        baseline = CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=500.0, variance=10_000.0, n=20))
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=9000, lines_removed=6000, commit_count=14, files_modified=40),
+            pr_delta=None,
+            graph_delta=None,
+            baseline=baseline,
+        )
         # zscore = (15_000 - 500) / sqrt(10_000) = 145.0 -> far past saturation
         assert result.score == pytest.approx(1.0)
 
-    def test_below_baseline_tick_clamps_to_zero_not_negative(self) -> None:
-        """A quieter-than-usual tick (negative z-score) must clamp to 0.0, not
-        go negative -- 'surprising' means 'more churn than usual,' matching
-        execution_prediction_error's identical clamp for the same reason."""
-        baseline = CodebaseMassBaseline(ewma=5000.0, variance=1_000_000.0, n=10)
-        delta = self._delta(lines_added=10, lines_removed=5)  # magnitude 15
-        result = codebase_prediction_error(delta, baseline)
+    def test_below_baseline_tick_clamps_to_zero_before_averaging(self) -> None:
+        """A quieter-than-usual git tick (negative z-score) clamps to 0.0 before
+        averaging with a genuinely surprising PR tick -- the PR spike must not
+        be diluted toward 0 by an unclamped negative contribution from git."""
+        baseline = CodebaseMassBaseline(
+            git=_DomainEwmaBaseline(ewma=5000.0, variance=1_000_000.0, n=10),
+            pr=_DomainEwmaBaseline(ewma=2.0, variance=1.0, n=10),
+        )
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=10, lines_removed=5),  # magnitude 15, well below baseline
+            pr_delta=self._pr(submitted_count=3, merged_count=2),  # magnitude 5, z=3.0
+            graph_delta=None,
+            baseline=baseline,
+        )
+        # If git's negative zscore weren't clamped, mean would pull below 3.0/3.0=1.0.
+        # Clamped to 0.0: mean(0.0, 3.0) / 3.0 = 0.5.
+        assert result.score == pytest.approx(0.5)
+
+    def test_git_only_below_baseline_tick_is_exactly_zero(self) -> None:
+        baseline = CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=5000.0, variance=1_000_000.0, n=10))
+        result = codebase_prediction_error(
+            git_delta=self._git(lines_added=10, lines_removed=5),
+            pr_delta=None,
+            graph_delta=None,
+            baseline=baseline,
+        )
         assert result.score == 0.0
 
     def test_baseline_state_flows_independently_of_module_globals(self) -> None:
-        """Two independent baseline threads (e.g. two different replay windows)
-        must not interfere with each other -- state is entirely caller-owned,
-        no hidden module-level mutation."""
-        delta = self._delta(lines_added=100, lines_removed=0)
+        """Two independent baseline threads must not interfere with each other
+        -- state is entirely caller-owned, no hidden module-level mutation."""
         baseline_a = CodebaseMassBaseline()
-        baseline_b = CodebaseMassBaseline(ewma=9999.0, variance=1.0, n=50)
-        result_a = codebase_prediction_error(delta, baseline_a)
-        result_b = codebase_prediction_error(delta, baseline_b)
-        assert result_a.baseline.n == 1
-        assert result_b.baseline.n == 51
-        assert result_a.baseline.ewma != result_b.baseline.ewma
+        baseline_b = CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=9999.0, variance=1.0, n=50))
+        result_a = codebase_prediction_error(
+            git_delta=self._git(lines_added=100, lines_removed=0), pr_delta=None, graph_delta=None,
+            baseline=baseline_a,
+        )
+        result_b = codebase_prediction_error(
+            git_delta=self._git(lines_added=100, lines_removed=0), pr_delta=None, graph_delta=None,
+            baseline=baseline_b,
+        )
+        assert result_a.baseline.git.n == 1
+        assert result_b.baseline.git.n == 51
+        assert result_a.baseline.git.ewma != result_b.baseline.git.ewma

--- a/scripts/analysis/measure_codebase_prediction_error.py
+++ b/scripts/analysis/measure_codebase_prediction_error.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
 """Read-only replay of ``codebase_prediction_error()`` against this repo's own real
-commit history -- SSP §7's "measure before minting" discipline, same order every
-other domain in ``orion/substrate/prediction_error.py`` has followed (see
-docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md, "Recommended next
-patch"). No bus wiring, no NODE_CHANNELS registration -- this script only proves the
-function is non-degenerate before either of those exist.
+git/GitHub/graphify history -- SSP §7's "measure before minting" discipline, same
+order every other domain in ``orion/substrate/prediction_error.py`` has followed
+(see docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md). No bus
+wiring, no NODE_CHANNELS registration -- this script only proves the composite
+scoring function is non-degenerate before either of those exist.
 
-Walks ``git log --reverse`` on the given branch/range, computes one
-``git_churn_delta`` per consecutive commit pair (one tick per real commit), and
-reports whether the resulting scores are non-degenerate (real variance, not flat)
-and whether the domain can genuinely rest near a low/zero reading, per CLAUDE.md's
-metric-quality-gate step 4.
+Walks ``git log --reverse`` on the given branch/range, one tick per real commit.
+Each tick always has a real ``git_churn_delta``. It also carries a real
+``pr_lifecycle_delta`` for the window between the two commits' own timestamps
+(requires a real authenticated ``gh`` CLI -- this is intentionally not mocked).
+``graph_delta`` is only attached on ticks whose commit is one of the real,
+sparse set of commits that actually touched ``graphify-out/graph.json``
+(confirmed live: ~7 such commits exist in this repo's history) -- every other
+tick correctly passes ``graph_delta=None``, exercising the composite function's
+"not every domain fires every tick" contract for real, not synthetically.
 
 Run:
     python scripts/analysis/measure_codebase_prediction_error.py
-    python scripts/analysis/measure_codebase_prediction_error.py --max-commits 200
-    python scripts/analysis/measure_codebase_prediction_error.py --since-sha <sha> --until-sha <sha>
+    python scripts/analysis/measure_codebase_prediction_error.py --max-commits 49
 """
 
 from __future__ import annotations
@@ -24,16 +27,28 @@ import argparse
 import statistics
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_REPO_ROOT))
 
 from orion.structural_mass.git_delta import git_churn_delta  # noqa: E402
+from orion.structural_mass.graph_delta import graph_structural_delta  # noqa: E402
+from orion.structural_mass.pr_lifecycle import (  # noqa: E402
+    fetch_recent_prs,
+    pr_lifecycle_delta,
+)
+from orion.structural_mass.snapshot_history import (  # noqa: E402
+    graph_snapshot_stats_from_text,
+)
 from orion.substrate.prediction_error import (  # noqa: E402
     CodebaseMassBaseline,
     codebase_prediction_error,
 )
+
+_GRAPH_JSON_PATH = "graphify-out/graph.json"
+_GRAPH_REPORT_PATH = "graphify-out/GRAPH_REPORT.md"
 
 
 def _commit_shas(repo_path: Path, since_sha: str | None, until_sha: str, max_commits: int) -> list[str]:
@@ -51,12 +66,50 @@ def _commit_shas(repo_path: Path, since_sha: str | None, until_sha: str, max_com
     return shas
 
 
+def _all_commit_timestamps(repo_path: Path) -> dict[str, datetime]:
+    """One `git log` call for every commit's timestamp, not one `git show`
+    per commit -- 2 subprocess spawns total instead of 2x the tick count
+    (confirmed live: the naive per-commit version took 5+ minutes replaying
+    1400 ticks; this is the same data, just fetched in bulk)."""
+    result = subprocess.run(
+        ["git", "log", "--format=%H|%cI"], cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    timestamps: dict[str, datetime] = {}
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        sha, _, ts = line.partition("|")
+        timestamps[sha] = datetime.fromisoformat(ts)
+    return timestamps
+
+
+def _graph_touching_shas(repo_path: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "log", "--reverse", "--format=%H", "--follow", "--", _GRAPH_JSON_PATH],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def _git_show(sha: str, path: str, repo_path: Path) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{sha}:{path}"], cwd=repo_path, capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-path", default=str(_REPO_ROOT))
     parser.add_argument("--since-sha", default=None, help="Exclusive lower bound; default walks full local history.")
     parser.add_argument("--until-sha", default="HEAD")
     parser.add_argument("--max-commits", type=int, default=500, help="Cap on ticks replayed (0 = no cap).")
+    parser.add_argument("--owner", default="junebug-junie")
+    parser.add_argument("--repo", default="Orion-Sapienform")
+    parser.add_argument("--pr-fetch-limit", type=int, default=300)
     args = parser.parse_args()
 
     repo_path = Path(args.repo_path)
@@ -65,42 +118,103 @@ def main() -> int:
         print(f"Not enough commits to replay (found {len(shas)}) -- widen the range.")
         return 1
 
+    graph_touching = _graph_touching_shas(repo_path)
+    prs = fetch_recent_prs(args.owner, args.repo, limit=args.pr_fetch_limit)
+    timestamps = _all_commit_timestamps(repo_path)
+    print(f"Fetched {len(prs)} real PR record(s); {len(graph_touching)} real commit(s) "
+          f"touch {_GRAPH_JSON_PATH}\n")
+
     baseline = CodebaseMassBaseline()
-    raw_magnitudes: list[float] = []
     scores: list[float] = []
-    variances_after_warmup: list[float] = []
+    git_magnitudes: list[float] = []
+    pr_magnitudes: list[float] = []
+    graph_magnitudes: list[float] = []
+    graph_ticks = 0
+    git_variances_warm: list[float] = []
+    pr_variances_warm: list[float] = []
+    graph_variances_warm: list[float] = []
 
     print(f"Replaying {len(shas) - 1} tick(s) across {len(shas)} commits "
           f"({shas[0][:10]}..{shas[-1][:10]})\n")
-    print(f"{'sha':<12} {'commits':>7} {'+files':>6} {'-files':>6} {'~files':>6} "
-          f"{'lines':>8} {'zscore/score':>14}")
+    print(f"{'sha':<12} {'git_lines':>10} {'pr_events':>10} {'graph_mag':>10} {'score':>8}")
 
     for prev_sha, head_sha in zip(shas, shas[1:]):
-        delta = git_churn_delta(prev_sha, head_sha, repo_path=repo_path)
-        result = codebase_prediction_error(delta, baseline)
-        raw_magnitudes.append(float(delta.lines_changed))
-        scores.append(result.score)
-        if baseline.n >= 5:  # "warmed up" -- ignore cold-start variance=0.0 entries
-            variances_after_warmup.append(result.baseline.variance)
-        baseline = result.baseline
-        print(
-            f"{head_sha[:10]:<12} {delta.commit_count:>7} {delta.files_added:>6} "
-            f"{delta.files_deleted:>6} {delta.files_modified:>6} "
-            f"{delta.lines_changed:>8} {result.score:>14.4f}"
+        git_delta = git_churn_delta(prev_sha, head_sha, repo_path=repo_path)
+        git_magnitudes.append(float(git_delta.lines_changed))
+
+        since_ts = timestamps[prev_sha]
+        until_ts = timestamps[head_sha]
+        pr_delta = pr_lifecycle_delta(prs, since=since_ts, until=until_ts, fetch_limit=args.pr_fetch_limit)
+        pr_magnitude = pr_delta.submitted_count + pr_delta.merged_count + pr_delta.closed_without_merge_count
+        pr_magnitudes.append(float(pr_magnitude))
+
+        graph_delta = None
+        graph_magnitude_repr = "-"
+        if head_sha in graph_touching:
+            # Reconstruct against the *previous* graph-touching commit at or
+            # before prev_sha, not necessarily prev_sha itself (graph-touching
+            # commits are sparse -- most ticks aren't one).
+            prior_graph_shas = [s for s in graph_touching if s in shas[: shas.index(head_sha)]]
+            if prior_graph_shas:
+                prior_sha = max(prior_graph_shas, key=shas.index)
+                prev_snapshot = graph_snapshot_stats_from_text(
+                    _git_show(prior_sha, _GRAPH_JSON_PATH, repo_path),
+                    _git_show(prior_sha, _GRAPH_REPORT_PATH, repo_path),
+                    commit_sha=prior_sha, backfilled=True,
+                )
+                curr_snapshot = graph_snapshot_stats_from_text(
+                    _git_show(head_sha, _GRAPH_JSON_PATH, repo_path),
+                    _git_show(head_sha, _GRAPH_REPORT_PATH, repo_path),
+                    commit_sha=head_sha, backfilled=True,
+                )
+                graph_delta = graph_structural_delta(prev_snapshot, curr_snapshot)
+                magnitude = abs(graph_delta.node_count_delta) + abs(graph_delta.edge_count_delta)
+                graph_magnitudes.append(float(magnitude))
+                graph_magnitude_repr = str(magnitude)
+                graph_ticks += 1
+
+        result = codebase_prediction_error(
+            git_delta=git_delta, pr_delta=pr_delta, graph_delta=graph_delta, baseline=baseline
         )
+        scores.append(result.score)
+        baseline = result.baseline
+        # git/pr fire every tick, so baseline.X.n >= 5 always coincides with a
+        # real observation this tick -- but graph_delta is often None (most
+        # ticks aren't one of the sparse graph-touching commits), and
+        # _domain_zscore leaves a non-firing domain's baseline frozen
+        # unchanged. Without the `graph_delta is not None` guard here, every
+        # tick between two real graph observations would re-append the same
+        # stale, already-recorded variance value -- confirmed live during
+        # code review: this inflated 6 real graph observations into a
+        # reported "n=240" of mostly-duplicated values before this fix.
+        if baseline.git.n >= 5:
+            git_variances_warm.append(baseline.git.variance)
+        if baseline.pr.n >= 5:
+            pr_variances_warm.append(baseline.pr.variance)
+        if graph_delta is not None and baseline.graph.n >= 5:
+            graph_variances_warm.append(baseline.graph.variance)
+        print(f"{head_sha[:10]:<12} {git_delta.lines_changed:>10} {pr_magnitude:>10} "
+              f"{graph_magnitude_repr:>10} {result.score:>8.4f}")
 
     print("\n--- Distributional sanity (CLAUDE.md metric-quality-gate step 4) ---")
-    print(f"raw magnitude (lines_changed): min={min(raw_magnitudes):.0f} "
-          f"max={max(raw_magnitudes):.0f} mean={statistics.fmean(raw_magnitudes):.1f} "
-          f"stdev={statistics.pstdev(raw_magnitudes):.1f}")
-    print(f"score: min={min(scores):.4f} max={max(scores):.4f} "
+    print(f"git magnitude:   min={min(git_magnitudes):.0f} max={max(git_magnitudes):.0f} "
+          f"mean={statistics.fmean(git_magnitudes):.1f}")
+    print(f"pr magnitude:    min={min(pr_magnitudes):.0f} max={max(pr_magnitudes):.0f} "
+          f"mean={statistics.fmean(pr_magnitudes):.1f}")
+    if graph_magnitudes:
+        print(f"graph magnitude: min={min(graph_magnitudes):.0f} max={max(graph_magnitudes):.0f} "
+              f"mean={statistics.fmean(graph_magnitudes):.1f} ({graph_ticks} real tick(s) with graph data)")
+    else:
+        print("graph magnitude: no real graph-touching commits in this replay window")
+    print(f"composite score: min={min(scores):.4f} max={max(scores):.4f} "
           f"mean={statistics.fmean(scores):.4f}")
-    n_zero_magnitude = sum(1 for m in raw_magnitudes if m == 0.0)
-    print(f"zero-churn ticks (real no-op commits): {n_zero_magnitude}/{len(raw_magnitudes)}")
-    if variances_after_warmup:
-        print(f"warmed-up EWMA variance (n>=5): min={min(variances_after_warmup):.2f} "
-              f"max={max(variances_after_warmup):.2f} "
-              f"mean={statistics.fmean(variances_after_warmup):.2f}")
+
+    print("\n--- Per-domain warmed-up EWMA variance (n>=5) -- for min_variance calibration ---")
+    for label, values in (("git", git_variances_warm), ("pr", pr_variances_warm), ("graph", graph_variances_warm)):
+        if values:
+            print(f"{label:>6}: min={min(values):.4f} max={max(values):.4f} mean={statistics.fmean(values):.4f} n={len(values)}")
+        else:
+            print(f"{label:>6}: no warmed-up samples (fewer than 5 real ticks for this domain)")
 
     if len(set(scores)) == 1:
         print("\nFLAG: every score identical -- degenerate, do not trust this domain yet.")
@@ -111,7 +225,7 @@ def main() -> int:
               "2026-07-26 floor-bias history).")
         return 1
 
-    print("\nOK: scores are non-degenerate and include near-zero readings.")
+    print("\nOK: composite scores are non-degenerate and include near-zero readings.")
     return 0
 
 


### PR DESCRIPTION
## Summary

Contract patch of the `git_delta`/`pr_lifecycle`/`graph_delta` → live-substrate wiring arc (design: `docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md`), sequenced per CLAUDE.md §5's "contract → producer → consumer" order. **No service, no docker, no live tick wiring in this patch** — those are separate, later patches (this one is pure library + schema, matching the review-friendly pattern of the three prior sibling PRs in this arc: #1496, #1500, #1502).

- `orion/schemas/codebase_delta.py` (new): `CodebaseDeltaV1` bus payload schema — each real event carries exactly one producer domain's delta (git/pr_lifecycle/graph); a `model_validator` enforces this at validation time, not just in a docstring.
- `orion/bus/channels.yaml`: new `orion:substrate:codebase_delta` channel.
- `orion/schemas/registry.py`: registered `CodebaseDeltaV1`.
- `orion/substrate/prediction_error.py`: **replaced** the Phase-1 skeleton's git-only `codebase_prediction_error()` with a composite version scoring all three `structural_mass` domains independently.
- `scripts/analysis/measure_codebase_prediction_error.py`: rewritten to replay git+PR+graph together against this repo's real history.

## Outcome moved

`codebase_prediction_error()` now actually uses all three producers built in the prior three PRs (previously only `git_delta` was wired into it). Real replay against 1395 real commit-ticks confirms non-degenerate, self-calibrating composite scores.

## Real finding worth flagging

Live-confirmed via the real replay: git and graph domains' warmed-up EWMA variance is orders of magnitude above a `1.0` floor (inert past the first tick) — but the **PR domain's is not** (real range 0.0–1.5, mean 0.15). My first draft used `1.0` for all three by reasoning-by-analogy from git's raw-magnitude scale. That would have reintroduced the exact "borrowed variance floor doesn't transfer across domains" bug this repo has already been burned by once (`execution_prediction_error`'s own fix, referenced in this file). Caught by actually running the replay instead of trusting the analogy; fixed to `0.001`.

## Current architecture

Before this patch, `codebase_prediction_error()` only consumed `GitChurnDelta` (Phase-1 skeleton, PR #1496) — `pr_lifecycle.py` and `graph_delta.py` (PRs #1500, #1502) had no consumer at all.

## Architecture touched

New schema + bus channel contract (CLAUDE.md §6). No service, no compose, no consumer wiring yet.

## Files changed

- `orion/schemas/codebase_delta.py` (new): `CodebaseDeltaV1`, `GitDeltaPayloadV1`, `PrLifecycleDeltaPayloadV1`, `GraphDeltaPayloadV1`.
- `orion/schemas/tests/test_codebase_delta.py` (new): 9 tests (round-trip per domain, `extra=forbid`, domain/field-population invariant enforcement, registry lookup).
- `orion/bus/channels.yaml`: new channel entry.
- `orion/schemas/registry.py`: registration.
- `orion/substrate/prediction_error.py`: composite `codebase_prediction_error()`, `_DomainEwmaBaseline`, updated `CodebaseMassBaseline`.
- `orion/substrate/tests/test_prediction_error.py`: `TestCodebasePredictionError` fully rewritten (12 tests) for the new composite signature.
- `scripts/analysis/measure_codebase_prediction_error.py`: rewritten combined replay script.

## Schema / bus / API changes

- Added: `orion:substrate:codebase_delta` channel, `CodebaseDeltaV1` schema (registered in `_REGISTRY`).
- Behavior changed: `codebase_prediction_error()`'s signature changed from `(delta: GitChurnDelta, baseline: CodebaseMassBaseline)` (positional) to `(*, git_delta, pr_delta, graph_delta, baseline)` (keyword-only). Confirmed via repo-wide grep: no caller exists outside this file's own tests and the (already-updated) replay script — safe to change directly rather than maintain a compatibility shim, since this function has no live consumers yet.
- Compatibility notes: none needed — nothing outside this PR's own files called the old signature.

## Env/config changes

None.

## Tests run

```
orion/substrate/tests/test_prediction_error.py orion/schemas/tests/test_codebase_delta.py orion/structural_mass/tests/: 110 passed in 4.14s

Broader regression (orion/substrate/tests/ orion/schemas/tests/ orion/bus/tests/): 586 passed, 1 pre-existing unrelated failure
(orion/schemas/tests/test_context_provenance.py::test_static_ctx_assignments_covered -- confirmed failing on main before this
branch even started, unrelated to this patch: services/orion-cortex-exec/app/executor.py context-key classification, left by
concurrent work elsewhere in the repo)
```

## Evals run

```
$ python3 scripts/analysis/measure_codebase_prediction_error.py --max-commits 1400
Replaying 1399 tick(s) across 1400 commits
git magnitude:   min=0 max=2640159 mean=12875.6
pr magnitude:    min=0 max=3 mean=0.4
graph magnitude: min=0 max=121601 mean=43958.8 (6 real tick(s) with graph data)
composite score: min=0.0000 max=1.0000 mean=0.1064

--- Per-domain warmed-up EWMA variance (n>=5) -- for min_variance calibration ---
   git: min=43876.7159 max=1393837889266.7988 mean=16903556883.6983 n=1395
    pr: min=0.0000 max=1.5058 mean=0.1493 n=1395
 graph: min=2616891929.6334 max=3243755333.9702 mean=2930323631.8018 n=2

OK: composite scores are non-degenerate and include near-zero readings.
```

## Docker/build/smoke checks

Not applicable — no service, no runtime, no compose changes.

## Review findings fixed

- Finding (Should fix): The replay script's "warmed-up variance" sample count for the sparse graph domain was double-counting stale frozen state — appending `baseline.graph.variance` on every tick where `n>=5`, not only on ticks where `graph_delta` actually fired. Since `graph_delta` is `None` on ~99% of ticks (only ~7 real commits ever touch `graphify-out/graph.json`), this inflated 2 real warmed-up observations into a reported `n=240` of mostly-duplicated values. The *values* (2.6B–3.2B) were correct even under the bug — but the sample-count evidence itself was fabricated.
  - Fix: added a `graph_delta is not None` guard alongside the `n>=5` check. Updated `_GRAPH_MIN_VARIANCE`'s docstring to name the honest `n=2` and explain what happened, rather than quietly correcting it.
  - Evidence: `scripts/analysis/measure_codebase_prediction_error.py`'s per-tick variance-tracking block; rerun confirmed `n=2` (was `n=240`), same real values.
- Finding (Should fix): `CodebaseDeltaV1`'s "exactly one domain populated" invariant was documented in a docstring only — nothing enforced it. A malformed payload (`domain="git"` with `pr_lifecycle` also set, or `git=None`) would have passed schema validation silently.
  - Fix: added a `model_validator(mode="after")` that raises `ValueError` on any mismatch between `domain` and which nested field is actually populated.
  - Evidence: `orion/schemas/codebase_delta.py::_exactly_one_domain_populated`; 3 new tests (`test_domain_field_mismatch_rejected_when_*`).

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: Low
- Concern: `_PR_MIN_VARIANCE=0.001` and `_GRAPH_MIN_VARIANCE=1.0` are calibrated against this repo's own real history at the time of this patch — real variance scale could shift materially as more real ticks accumulate, especially for the graph domain (only 2 warmed-up samples exist today).
- Mitigation: Both constants' docstrings say this explicitly and point at the replay script as the way to recalibrate; nothing here is baked into a schema/manifest that's expensive to unwind (metric quality gate's reversibility check).

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1515
