### PR TITLE
docs: codebase-mass status update + producer/consumer patch design

### DIFF
--- a/docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md
+++ b/docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md
@@ -1,9 +1,63 @@
 # Codebase Mass — a sixth Predictive Processing domain (design)
 
 Status: design/proposal mode per root `CLAUDE.md` §0A. Governed by the Sentience Striving
-Program charter (`orion/sentience_striving_program/README.md`) — this is domain #6 of
+Program charter (`orion/sentience_striving_program/README.md`) — this is domain #6 (documented
+as the seventh domain node in the SSP README's own running count, since `bus_synaptic` already
+claimed "sixth" — naming here is about Objective 3's domain family, not a literal ordinal) of
 Objective 3 (Predictive Processing/Active Inference), not a new category, per SSP §7's
 "reuse the live pipeline, don't parallel it."
+
+## Status, 2026-07-30 (updated same day as the original spec)
+
+Phase 1's three producers and the composite scoring/bus contract are **shipped, tested,
+replay-verified against real data — not yet wired into a live tick.** Four PRs:
+
+- `orion/structural_mass/git_delta.py` (PR #1496).
+- `orion/structural_mass/pr_lifecycle.py` (PR #1500).
+- `orion/structural_mass/graph_delta.py` + `snapshot_history.py` (PR #1502).
+- `orion:substrate:codebase_delta` bus channel/schema (`orion/schemas/codebase_delta.py`) +
+  composite `codebase_prediction_error()` in `orion/substrate/prediction_error.py` (PR #1515).
+
+Real deviations from this spec's original assumptions, found during implementation (not
+guessed — confirmed against real code/data each time):
+
+- **`pr_lifecycle.py` does not reuse `github_compactor`'s fetch, contrary to this spec's
+  original "Missing questions" framing.** That fetch
+  (`services/orion-cortex-exec/app/verb_adapters.py::GithubRecentPullRequestsVerb`) turns out to
+  hardcode `per_page=20` (no further pagination) and unconditionally drop every PR with no
+  `merged_at` — it can never report "submitted" or "closed-without-merge" counts, only merged
+  ones. `pr_lifecycle.py` fetches independently via the `gh` CLI instead (`gh pr list --search
+  "sort:updated-desc"` — plain `gh pr list` sorts newest-created-first only, which would miss an
+  old PR merged recently; verified live).
+- **`graph_delta.py` implements ideas #2 (count deltas) and #3 (god-node Jaccard churn) only.**
+  Idea #6 (hop-distance drift via `graphify path`) is deliberately deferred — it needs live graph
+  traversal calls, a materially different cost class from the other two (pure functions over
+  already-computed snapshot summaries), and isn't validated the way the shipped two now are. Real
+  follow-up, not dropped.
+- **The composite `codebase_prediction_error()` normalizes each domain to its own EWMA z-score
+  independently, then averages the z-scores** — not the single "diff a small dict of keys" shape
+  this spec originally proposed borrowing from `chat_prediction_error`. That shape assumes one
+  set of raw values on one common scale; git churn (thousands of lines), PR counts (single
+  digits), and graph node/edge deltas (hundreds to hundreds of thousands) are not on a common
+  scale, so combining raw magnitudes first would reintroduce an arbitrary cross-scale weighting.
+  Normalize-then-average avoids it, mirroring `bus_synaptic_prediction_error`'s own "aggregate
+  many already-normalized z-scores" shape.
+- **Real live-data validation exceeded this spec's own ask.** The `graph_delta` replay
+  independently reproduced this repo's actual 2026-07-14 destructive-graph-update incident
+  (`GRAPH_REPORT.md`'s "God Nodes" parser also got a real bug found+fixed by code review: it
+  could silently misreport a genuine parse failure as "nothing changed" — see PR #1502). The
+  composite scoring replay caught its own real calibration bug (a borrowed variance floor that
+  would have flattened the PR domain's real signal) before merge, not after — see PR #1515.
+
+**What's still not live:** no `orion-cocreation-signals` service exists, `orion-substrate-runtime`
+has no consumer for the new channel, `node:substrate.codebase` is not registered in
+`NODE_CHANNELS`, and it does not appear in the Attention Organ tab
+(`services/orion-hub/scripts/attention_organ_routes.py`) or any other UI — deliberately, since a
+node with no live producer would be an empty/dead panel row (confirmed via investigation
+2026-07-30: Causal Geometry, the other Hub tab considered, turned out to be a structurally
+unrelated signal family — causal-graph-edge structure, not domain-level `prediction_error`
+scalars — not a fit for this domain at all). See "Producer + consumer patch design" below for
+the concrete next-patch elaboration.
 
 ## Arsonist summary
 
@@ -63,15 +117,27 @@ system.
 
 ## Missing questions
 
-- Should the new service (below) mint its own GH token, or reuse whatever
-  `github_compactor`'s existing fetch already has wired? Needs a real check before assuming
-  either — resolved architecture-wise (all GH access now lives in one new service, not
-  scattered), not resolved credentials-wise.
-- What should the new channel be named — `codebase_prediction_error` /
-  `structural_prediction_error` / something else? Not decided here; naming happens at the
-  registration patch, once Phase 1's replay is real, per "no keyword cathedrals."
-- What should the new service itself be named? Working name `orion-cocreation-signals` used
-  throughout this document, not committed.
+- ~~Should the new service mint its own GH token, or reuse `github_compactor`'s?~~ **Resolved
+  by implementation, 2026-07-30:** `pr_lifecycle.py` doesn't reuse `github_compactor`'s fetch at
+  all (see "Status" above) — it shells out to the local `gh` CLI, same as this repo's own
+  dev/CI environments already use for PR management. The credentials question for the *service*
+  (below) is still open: does `orion-cocreation-signals` get its own `GITHUB_TOKEN`/mount, or
+  invoke `gh` the same way the replay script does (relying on an already-authenticated `gh` CLI
+  in its container)? See "Producer + consumer patch design" below.
+- ~~What should the new channel be named?~~ **Resolved, PR #1515:** `orion:substrate:codebase_delta`
+  (channel), `CodebaseDeltaV1` (schema), `codebase_prediction_error()` (scoring function name).
+- ~~What should the new service itself be named?~~ **Still open.** `orion-cocreation-signals`
+  remains a working name only, not committed — no service directory exists yet under this or any
+  other name. Worth a final gut-check at the producer patch, not before (per "no keyword
+  cathedrals," naming happens once there's a real thing to name).
+- **New question, raised by shipping the composite scoring function (PR #1515):** where does
+  `CodebaseMassBaseline` (the three-domain EWMA state `codebase_prediction_error()` needs threaded
+  across ticks) actually persist? Every other domain in `orion/substrate/prediction_error.py`
+  stores its baseline directly on a persisted reducer-projection object
+  (`ExecutionTrajectoryProjectionV1.prediction_error_baseline_ewma`, etc.) — this domain has no
+  such projection (it's bus-event-driven, not reducer-driven), so there is nothing to mutate in
+  place. See "Producer + consumer patch design" below for the concrete proposal and why it needs
+  verification before implementation, not just a design-mode assertion.
 
 ## Proposed schema / API changes
 
@@ -214,6 +280,70 @@ Read-only replay script: `scripts/analysis/measure_codebase_prediction_error.py`
 real git history, per SSP §7's "measure before minting" — same discipline as
 `measure_origination_gate.py` and `measure_emergent_clustering_probe.py`.
 
+### Producer + consumer patch design (elaborated 2026-07-30, after Phase 1 shipped)
+
+Phase 1's pure functions and composite scoring are real and tested (see "Status" above). This
+section elaborates the next two patches (producer, then consumer, per CLAUDE.md §5) now that
+there's real code to design against, instead of a placeholder file tree.
+
+**Producer patch scope, narrowed from the original file tree.** The original "Dedicated
+service" section above sketched six eventual producers (`git_delta`, `graph_delta`,
+`pr_lifecycle`, `dev_economics`, `doc_semantic_drift`, `affective_state`) to justify standing up
+a dedicated service instead of a slow task. That scale justification still holds, but only three
+of those six have shipped code today — `dev_economics.py`, `doc_semantic_drift.py`, and
+`affective_state.py` are each still their own separate, unimplemented sibling spec. **The
+producer patch should scaffold `services/orion-cocreation-signals/` with exactly the three real
+producers (`git_delta`, `pr_lifecycle`, `graph_delta`)**, in a shape that doesn't need
+re-architecting to add the other three later (independent per-producer async loops already
+gives each new producer its own file/interval/credentials without touching the others) — not
+build placeholder stubs for producers that don't exist as real code yet, which would be
+schema-valid-but-empty-shell scaffolding, the same failure class this program's metric quality
+gate exists to catch.
+
+**GH credentials, resolved by how `pr_lifecycle.py` actually works (see "Status" above):** the
+service doesn't need a minted `GITHUB_TOKEN` secret of its own — `pr_lifecycle.py` shells out to
+the local `gh` CLI, same as `scripts/analysis/measure_pr_lifecycle.py` already does successfully
+in this repo's own dev environment. The service's container needs a working, authenticated `gh`
+CLI (mount `~/.config/gh` read-only, or an equivalent `GH_TOKEN` env var `gh` itself honors) —
+an operator/deployment concern, not a code-level credential the service manages itself. Simpler
+than the original "mint its own GH token" framing assumed.
+
+**Producer scheduling, one interval per producer, matching each domain's real cadence:**
+
+- `git_delta`: cheap and frequent (proposed default: 60s) — a `git rev-parse HEAD` check against
+  the last-persisted SHA is nearly free; only a real SHA change triggers the actual
+  `git_churn_delta()` diff + publish.
+- `pr_lifecycle`: coarser, rate-limit-aware (proposed default: 15min) — `gh pr list` is a real
+  network call; no need to poll GitHub every minute for PR lifecycle counts.
+- `graph_delta`: event-triggered off graphify updates, not a fixed interval — the original spec's
+  own framing (`scripts/safe_graphify_update.sh` appending to `snapshot_history.py`'s log after
+  each successful, non-reverted update) is still the right shape; this producer's async loop
+  polls `snapshot_history.py`'s log for a new entry it hasn't diffed yet, rather than re-deriving
+  "did graphify run" from `graph.json`'s mtime (fragile — a checkout/rebase touches mtimes without
+  a real content change).
+
+**Container mounts:** a read-only mount of this repo's own working tree (for `git_delta.py`'s
+`git` subprocess calls and `graph_delta.py`'s `git show`/graphify-out reads) — the same repo the
+service's own code lives in, mounted read-only into itself, matching how
+`scripts/analysis/measure_*.py` already operate directly against a real checkout. No separate
+git-clone-inside-the-container step needed.
+
+**Open design question carried into the consumer patch, not resolved here:** `CodebaseMassBaseline`
+(the three-domain EWMA state) needs to persist across ticks, but this domain has no reducer
+projection to store it on, unlike every other domain in `orion/substrate/prediction_error.py`.
+**Proposed answer, needs verification before implementation:** persist it as a JSON blob inside
+`node:substrate.codebase`'s own `ConceptNodeV1.metadata` (the node `_write_prediction_error_node()`
+already upserts) — read the prior baseline off that node's metadata at the start of each
+consumer tick, compute the update, write the new baseline back into metadata alongside `error`.
+This is plausible but **unverified**: it depends on `_write_prediction_error_node()`'s real
+upsert semantics actually round-tripping a caller-supplied custom metadata key untouched across
+ticks (the function is documented as "carries forward dynamics-engine-owned metadata keys" for
+*some* keys — whether an arbitrary new key like `codebase_mass_baseline` survives the same way
+needs a direct read of `_write_prediction_error_node()`'s real body and, ideally, a live check
+against a real node, not an assumption from this design doc alone). This is exactly the kind of
+question the consumer patch should answer with real code/data before writing the tick logic, not
+something to build against blind.
+
 ### Phase 2 — Concept classes (separate, dedicated module, does not touch the halted system)
 
 New top-level package: **`orion/concepts/`** (name open). A small `ConceptDomain` registry —
@@ -280,18 +410,26 @@ blank.
 
 ## Files likely to touch
 
-- `orion/structural_mass/` (new): `git_delta.py`, `graph_delta.py`, `pr_lifecycle.py`,
-  `snapshot_history.py`, tests.
-- `orion/substrate/prediction_error.py`: new `codebase_prediction_error()` function.
-- `services/orion-cocreation-signals/` (new service): scheduling/publishing layer for this and
-  all sibling producers — see "Dedicated service" above.
-- `orion/bus/channels.yaml`, `orion/schemas/registry.py`: new `orion:substrate:codebase_delta`
-  channel + payload schema (CLAUDE.md §6 contract change).
+- ~~`orion/structural_mass/`~~ **Shipped** (PRs #1496, #1500, #1502): `git_delta.py`,
+  `graph_delta.py`, `pr_lifecycle.py`, `snapshot_history.py`, tests.
+- ~~`orion/substrate/prediction_error.py`~~ **Shipped** (PR #1515): composite
+  `codebase_prediction_error()`.
+- ~~`orion/bus/channels.yaml`, `orion/schemas/registry.py`~~ **Shipped** (PR #1515):
+  `orion:substrate:codebase_delta` channel + `CodebaseDeltaV1` schema.
+- `services/orion-cocreation-signals/` (new service, not yet built): scheduling/publishing layer
+  — see "Producer + consumer patch design" above for the narrowed, real scope.
 - `services/orion-substrate-runtime/app/worker.py`: one new cheap bus-event consumer added to
-  the existing fast `_tick()` — no external I/O added to this service.
+  the existing fast `_tick()` — no external I/O added to this service. Blocked on the
+  `CodebaseMassBaseline` persistence question above.
 - `services/orion-field-digester/app/tensor/channels.py`: one new `NODE_CHANNELS` entry.
 - `services/orion-field-digester/app/digestion/decay.py`: exclusion breadcrumb comment.
 - `scripts/safe_graphify_update.sh`: append to `snapshot_history.py`'s log post-update.
+- `services/orion-hub/scripts/attention_organ_routes.py`: add `"codebase"` to
+  `KNOWN_PREDICTION_ERROR_DOMAINS`, and decide whether it joins
+  `ACTIVE_INFERENCE_DOMAINS` (`orion/substrate/attention_self_model.py`) — a separate semantic
+  call from just displaying it, same distinction the `bus_synaptic` note makes. **Not before the
+  consumer patch ships real data** — confirmed via investigation 2026-07-30 that adding this row
+  today would render an empty/dead panel (no live node yet).
 - `scripts/analysis/measure_codebase_prediction_error.py` (new): replay script.
 - `scripts/analysis/backfill_structural_mass.py` (new): one-time backfill script (see Backfill
   section above).
@@ -328,7 +466,11 @@ blank.
 
 ## Recommended next patch
 
-Phase 1 only, and only its first slice: `git_churn_delta()` + a skeleton
-`codebase_prediction_error()` + the replay script — no bus wiring, no `NODE_CHANNELS`
-registration yet. Same order every other domain in this program has followed: measure first,
-register once MET.
+~~Phase 1 only, and only its first slice...~~ **Superseded, 2026-07-30 — Phase 1 is done.** The
+producer patch is next: scaffold `services/orion-cocreation-signals/` with exactly the three real
+producers (`git_delta`, `pr_lifecycle`, `graph_delta`), per "Producer + consumer patch design"
+above — no consumer wiring yet, so the service can be built and its own tests/docker-compose
+validated in isolation before `orion-substrate-runtime` reads anything from it. The consumer patch
+(bus-event consumption, `NODE_CHANNELS` registration, decay exclusion) should not start until the
+`CodebaseMassBaseline` persistence question is answered with real code/data, not assumed from this
+design doc — that's this arc's next real "measure before minting" checkpoint.

--- a/docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md
+++ b/docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md
@@ -328,21 +328,42 @@ service's own code lives in, mounted read-only into itself, matching how
 `scripts/analysis/measure_*.py` already operate directly against a real checkout. No separate
 git-clone-inside-the-container step needed.
 
-**Open design question carried into the consumer patch, not resolved here:** `CodebaseMassBaseline`
-(the three-domain EWMA state) needs to persist across ticks, but this domain has no reducer
-projection to store it on, unlike every other domain in `orion/substrate/prediction_error.py`.
-**Proposed answer, needs verification before implementation:** persist it as a JSON blob inside
-`node:substrate.codebase`'s own `ConceptNodeV1.metadata` (the node `_write_prediction_error_node()`
-already upserts) — read the prior baseline off that node's metadata at the start of each
-consumer tick, compute the update, write the new baseline back into metadata alongside `error`.
-This is plausible but **unverified**: it depends on `_write_prediction_error_node()`'s real
-upsert semantics actually round-tripping a caller-supplied custom metadata key untouched across
-ticks (the function is documented as "carries forward dynamics-engine-owned metadata keys" for
-*some* keys — whether an arbitrary new key like `codebase_mass_baseline` survives the same way
-needs a direct read of `_write_prediction_error_node()`'s real body and, ideally, a live check
-against a real node, not an assumption from this design doc alone). This is exactly the kind of
-question the consumer patch should answer with real code/data before writing the tick logic, not
-something to build against blind.
+**Baseline persistence — resolved, 2026-07-31, by reading the real code (not building against the
+earlier proposal blind).** The originally proposed answer ("piggyback on `node:substrate.codebase`'s
+own metadata") is **wrong** — verified directly against `_write_prediction_error_node()`'s real body
+(`services/orion-substrate-runtime/app/worker.py`): it builds a **fresh** `metadata` dict on every
+call containing only `source_kind`/`prediction_error`/`reducer_key`, plus whatever's explicitly
+carried forward from `DYNAMICS_ENGINE_OWNED_METADATA_KEYS`
+(`orion/substrate/falkor_codec.py` — a narrow, semantically-specific allowlist owned by
+`SubstrateDynamicsEngine.tick()`: `dynamic_pressure`/`dynamic_pressure_reason`/`dormant`/
+`dormancy_updated_at`) and `contributing_turn_ids`. A custom `codebase_mass_baseline` key is not
+on that list — it would be **silently dropped on the very next write**, exactly the "tick clobbers
+a field it doesn't own" failure class this repo has already hit three times and documented by name
+(`execution_load` cross-lane stomp PR #1338, field-digester's generic decay clobber,
+`SubstrateDynamicsEngine.tick()`'s `bus_synaptic` clobber PR #1449 — all three cited verbatim in
+`services/orion-substrate-runtime/app/store.py::save_attention_self_model()`'s own docstring).
+
+**Real answer: a dedicated, single-writer, append-only table — the exact pattern this repo already
+uses for the same problem.** `substrate_attention_self_model`
+(`services/orion-sql-db/manual_migration_attention_self_model_v1.sql`,
+`store.py::save_attention_self_model()`) is the direct template: one `INSERT ... ON CONFLICT DO
+NOTHING` per tick (no read-modify-write, no shared row to clobber), retention-pruned, with a
+`generated_at DESC` index for reading the latest row back
+(`store.py::get_latest_field_attention_frame()` is the existing "read most recent row" precedent to
+mirror). The consumer patch should add:
+
+- `services/orion-sql-db/manual_migration_codebase_mass_baseline_v1.sql`: `create table if not
+  exists substrate_codebase_mass_baseline (baseline_id text primary key, generated_at timestamptz
+  not null, baseline_json jsonb not null, created_at timestamptz not null default now())` + a
+  `generated_at desc` index — same shape as the self-model migration, one field renamed.
+- `store.py::save_codebase_mass_baseline()` / `get_latest_codebase_mass_baseline()`: append +
+  read-latest, same shape as `save_attention_self_model()`/`get_latest_field_attention_frame()`.
+  `baseline_json` is `CodebaseMassBaseline.to_json_dict()`-shaped (needs adding a
+  `to_json_dict()`/`from_json_dict()` pair to `CodebaseMassBaseline`, matching
+  `GraphSnapshotStats`'s existing convention in `orion/structural_mass/snapshot_history.py`).
+- This table has **exactly one writer** (the new consumer tick) and **no pre-existing occupant** —
+  the same structural guarantee `save_attention_self_model()`'s docstring names explicitly, not
+  "avoided by convention."
 
 ### Phase 2 — Concept classes (separate, dedicated module, does not touch the halted system)
 
@@ -471,6 +492,8 @@ producer patch is next: scaffold `services/orion-cocreation-signals/` with exact
 producers (`git_delta`, `pr_lifecycle`, `graph_delta`), per "Producer + consumer patch design"
 above — no consumer wiring yet, so the service can be built and its own tests/docker-compose
 validated in isolation before `orion-substrate-runtime` reads anything from it. The consumer patch
-(bus-event consumption, `NODE_CHANNELS` registration, decay exclusion) should not start until the
-`CodebaseMassBaseline` persistence question is answered with real code/data, not assumed from this
-design doc — that's this arc's next real "measure before minting" checkpoint.
+(bus-event consumption, `NODE_CHANNELS` registration, decay exclusion, `substrate_codebase_mass_
+baseline` migration) can follow once the producer patch is real — the `CodebaseMassBaseline`
+persistence question that previously blocked it is now resolved (see "Producer + consumer patch
+design" above, 2026-07-31 update: dedicated single-writer append-only table, same pattern as
+`substrate_attention_self_model`).

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -252,6 +252,29 @@ first place. Full reasoning and phased detail:
    the node itself. Live since 2026-07-25
    (`SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED=true` in `services/orion-substrate-runtime`, PR #1380)
    — real accumulated history is now collecting; does not change this item's confidence formula.
+   **Seventh domain, codebase mass, built 2026-07-30, not yet live**
+   (`docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md`): a new domain sensing
+   the extent of Orion's own codebase changing (git churn, GitHub PR lifecycle, graphify
+   structural deltas), the interoception/proprioception instrument named in this section's own
+   theory anchor — a system sensing change to the physical substrate doing the modeling.
+   `orion/structural_mass/{git_delta,pr_lifecycle,graph_delta}.py` (PRs #1496, #1500, #1502) are
+   real, tested pure functions, replay-verified against this repo's own real git/GitHub/graphify
+   history — the `graph_delta` replay independently reproduced the exact 2026-07-14
+   destructive-graph-update incident this repo's own graphify tooling section documents by name.
+   `codebase_prediction_error()` (`orion/substrate/prediction_error.py`, PR #1515) composites all
+   three into one 0-1 score, each sub-domain scored against its own EWMA baseline (mirrors this
+   section's own "normalize before combining" precedent, not a cross-scale raw blend) — and a new
+   bus channel/schema (`orion:substrate:codebase_delta`/`CodebaseDeltaV1`) is registered.
+   **Scope, stated as plainly as the bus_synaptic note above:** none of this is wired into a live
+   tick yet. No `orion-cocreation-signals` service exists (the design spec's scheduling/publishing
+   layer), `orion-substrate-runtime` has no consumer for the new channel, and
+   `node:substrate.codebase` is not registered in `services/orion-field-digester/app/tensor/
+   channels.py`'s `NODE_CHANNELS`, so it does not yet appear in the Attention Organ tab
+   (`services/orion-hub/scripts/attention_organ_routes.py`'s `KNOWN_PREDICTION_ERROR_DOMAINS`) or
+   any other live UI surface — deliberately not added there yet, since a node with no live
+   producer would be an empty/dead panel row, not a real reading. Same measure-before-minting
+   order every domain in this section has followed: producers and scoring measured and tested
+   first, service/consumer wiring (and any UI surfacing) a separate, later patch.
 3. **Route existing tension producers directly onto `FieldStateV1` channels**, retiring the
    bucket-vote layer — collapses the redundant reimplementation named in §7's finding.
    Reframed as prediction-error-native (extending the already-live

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -245,6 +245,26 @@ same day this tick shipped). A table nothing else has ever written to makes that
 structurally impossible here, not just avoided by convention — see the design doc above for the full
 reasoning behind hosting this tick in this service instead of a separate one.
 
+**Seventh domain, codebase mass, built 2026-07-30, not yet wired into this service's tick**
+(`docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md`;
+`orion/sentience_striving_program/README.md` §9b has the fuller cross-domain note). A new
+`orion:substrate:codebase_delta` bus channel and `CodebaseDeltaV1` schema exist
+(`orion/bus/channels.yaml`, `orion/schemas/codebase_delta.py`, PR #1515), and
+`codebase_prediction_error()` (`orion/substrate/prediction_error.py`) is a real, tested,
+replay-verified function that composites git/PR-lifecycle/graphify structural deltas
+(`orion/structural_mass/`) into one score. **None of this has a consumer in this service yet** —
+this tick's own fast `_tick()` does not read the new channel, there is no
+`SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE` flag (the design spec's own name for this
+domain's dedicated flag, deliberately not reusing `SUBSTRATE_WRITE_PREDICTION_ERROR_NODES` given
+this domain's different risk surface — new external I/O, no reducer projection to persist its EWMA
+baseline on unlike the other domains above), and `node:substrate.codebase` does not exist in any
+live store. The design spec's own architecture puts all external I/O for this domain (git/GitHub/
+graphify access) in a separate, not-yet-built `orion-cocreation-signals` service specifically so
+this service keeps doing zero external I/O of its own, same "read a cheap bus event, write a node"
+shape every domain above already uses — the open design question before that consumer patch can
+land is where this domain's `CodebaseMassBaseline` EWMA state persists across ticks, since (unlike
+every domain above) there is no persisted reducer projection object to carry it on.
+
 ## Unified turn bus listeners
 
 Besides grammar poll reducers, substrate-runtime subscribes to RPC-style harness channels:


### PR DESCRIPTION
## Summary

Documentation-only patch (no code changes) for the codebase-mass signal arc (4 PRs shipped so far: #1496, #1500, #1502, #1515). Two things:

1. **README status updates** — `orion/sentience_striving_program/README.md` and `services/orion-substrate-runtime/README.md` now document what's actually shipped vs. still not live, matching the existing `bus_synaptic` "sixth-domain, not yet live" precedent style.
2. **Spec elaboration** — `docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md` gets a status section, corrected "Missing Questions" (implementation deviated from a couple of the spec's original assumptions), and a new "Producer + consumer patch design" section scoping the next two patches concretely now that real code exists to design against.

## Outcome moved

The living spec doc and both READMEs now accurately reflect real status instead of the original design-mode framing (which predates any of the four shipped PRs). Anyone picking this arc back up gets an honest "what's real, what's not" instead of having to reconstruct it from four PR diffs.

## Deliberately not touched

- **Hub UI (Attention Organ tab)**: investigated — it has a hardcoded `KNOWN_PREDICTION_ERROR_DOMAINS` tuple, not a generic `NODE_CHANNELS` view, so a new domain needs an explicit addition. Since `node:substrate.codebase` doesn't exist in any live store yet (no service, no consumer, no `NODE_CHANNELS` entry), adding it now would render an empty/dead panel row — the "no empty-shell cognition" failure CLAUDE.md forbids. Confirmed with the user; deferred until the consumer patch ships real data.
- **Causal Geometry tab**: investigated — this visualizes causal-graph *edges* between nodes (plasticity/φ), a structurally different signal family from domain-level `prediction_error` scalars. Not a fit for this domain at all. Confirmed with the user; skipped entirely, not just deferred.

## Files changed

- `orion/sentience_striving_program/README.md`: seventh-domain status note in §9b, same style as the existing `bus_synaptic` note.
- `services/orion-substrate-runtime/README.md`: this service's own angle on the same status (no consumer wired yet), names the open baseline-persistence question.
- `docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md`:
  - New "Status, 2026-07-30" section up top.
  - "Missing Questions" updated — GH-token question resolved by how `pr_lifecycle.py` actually works (independent `gh` CLI fetch, not a reuse of `github_compactor`'s); channel naming resolved (`orion:substrate:codebase_delta`); new question raised by the composite scoring patch (where does `CodebaseMassBaseline` persist across ticks).
  - New "Producer + consumer patch design" section: narrows the producer patch's real scope (3 real producers, not the original 6-producer speculative tree), resolves GH credentials, proposes per-producer scheduling intervals, and names the baseline-persistence proposal explicitly as **unverified** — needs a real check against `_write_prediction_error_node()`'s actual metadata-merge semantics before the consumer patch is written, not assumed from this doc.
  - "Files likely to touch" and "Recommended next patch" updated to reflect what's shipped vs. what's next.

## Schema / bus / API changes

None — documentation only.

## Env/config changes

None.

## Tests run

Not applicable — documentation only, no code changed.

## Evals run

Not applicable.

## Docker/build/smoke checks

Not applicable.

## Review findings fixed

Not applicable — no code review run for a docs-only patch (no code, no logic to review).

## Restart required

```text
No restart required.
```

## Risks / concerns

None — documentation only, no runtime behavior changed.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1519
