### PR TITLE
perf(execution-dispatch): fix anti-join query plan, ~170x fewer/faster backlog queries

### DIFF
--- a/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
+++ b/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
@@ -148,6 +148,89 @@ artifact).
 (`load_freshest_policy_frame_without_dispatch`), `app/worker.py` (extracted `_age_sec` shared
 helper, new `_check_freshest_fallback`, `_tick` wiring), README, tests.
 
+## Part 1c: same-day follow-up #2 — the real bottleneck was a query plan, not LLM latency
+
+Deployed Part 1b, checked live again (the same discipline that found 1b's own bug in the first
+place). Real dispatch had resumed but was stuck at ~1/minute — far below the ~6.8/min ceiling Part
+2 was scoped against. Instead of assuming the cause, ran `EXPLAIN ANALYZE` on the real live
+queries.
+
+**Root cause, precise**: `load_latest_policy_frame_without_dispatch` (ASC) and
+`load_freshest_policy_frame_without_dispatch` (DESC) both used `LEFT JOIN
+substrate_execution_dispatch_frames d ON ... WHERE d.frame_id IS NULL`. Despite real indexes
+existing on both join columns, Postgres chose a `Parallel Hash Left Join` — full scans of both
+tables, ~280-300ms per call, independent of the actual answer size. The FIFO drain called this
+**up to 200 times per tick**. Real, independently-measured tick cadence (via
+`staleness_discard_count_ewma_n`'s growth over an exact 10-minute window — a real counter, not an
+inferred number): **8 ticks**, ~75s each. 1,542 frames processed across those 8 ticks (~193/tick)
+confirms the drain was hitting its 200-cap almost every single tick. ~193 × ~280ms ≈ 54s of the
+75s directly attributable to this one query pattern.
+
+**Adversarial pass before accepting the conclusion** (explicitly requested, not skipped):
+- *Stale planner statistics?* Ran `ANALYZE` on both tables live, re-ran `EXPLAIN ANALYZE`. Plan
+  and cost unchanged (~302ms). Ruled out.
+- *Was the ~75s/tick figure just arithmetic, not measured?* Re-derived independently via the
+  `staleness_discard_count_ewma_n` counter (increments exactly once per real `_tick()` call) —
+  confirmed 8 ticks in 10 real minutes, matching the inferred figure exactly.
+- *Could the INSERT side (`save_dispatch_frame`) be a second hidden bottleneck?* Checked its SQL —
+  a simple indexed single-row upsert on the primary key, not O(N) like the SELECT. A minor
+  contributor via per-call transaction round-trip overhead, not the dominant cost.
+- *Could my own diagnostic queries have inflated the live numbers?* Checked the direction of the
+  bias — ad-hoc `EXPLAIN ANALYZE` runs warm Postgres's shared buffer cache, which if anything makes
+  the measurement a *floor*, not an inflated worst case; and `EXPLAIN ANALYZE`'s reported execution
+  time is server-side processing time, independent of which client submitted the query.
+
+**Fix, two different shapes for two different access patterns** (confirmed via `EXPLAIN ANALYZE`,
+not assumed symmetric):
+- `load_freshest_policy_frame_without_dispatch` (DESC) → rewritten to `WHERE NOT EXISTS (...)`.
+  Measured: ~294ms → ~0.19ms (~1500x). Correct because almost nothing near "now" is processed yet,
+  so a nested-loop anti-join plan terminates on the first probe.
+- `load_oldest_policy_frames_without_dispatch(limit)` (ASC, renamed from the old singular
+  `load_latest_policy_frame_without_dispatch`) → same `LEFT JOIN` shape kept (a `NOT EXISTS`
+  rewrite here measured **worse**, 6+ seconds — a large prefix of already-processed ancient
+  history, predating the original backlog, means a nested loop walks hundreds of thousands of
+  already-matched rows before the first true miss), but now fetches the whole `MAX_STALE_DISCARDS_
+  PER_TICK`-sized batch in ONE query instead of calling the `LIMIT 1` version in a 200-iteration
+  while loop. The Hash Join's dominant cost (building the hash table) is paid once regardless of
+  LIMIT size (measured: `LIMIT 1` ~280ms, `LIMIT 200` ~327ms) — batching cuts real per-tick SELECT
+  cost from ~56s to ~0.3s. Confirmed live against the real table (not just mocked): 200 real frames
+  fetched, correctly ordered, in 464ms including Python/pydantic overhead.
+
+**Files touched**: `services/orion-execution-dispatch-runtime/app/store.py`
+(`load_oldest_policy_frames_without_dispatch` replacing `load_latest_policy_frame_without_
+dispatch`, `load_freshest_policy_frame_without_dispatch` rewritten to `NOT EXISTS`,
+`_validate_policy_frame_row` extracted as a shared validate-or-retire helper), `app/worker.py`
+(`_drain_stale_policy_frames` rewritten to fetch-then-iterate instead of loop-and-fetch), README,
+tests (worker + store, including two new store-level happy-path tests for the batch and `NOT
+EXISTS` query shapes, plus a mixed-batch regression test added in review -- see below).
+
+**Two real side effects of the batch rewrite, found in review, both real improvements but
+disclosed here since neither was originally intentional or tested for on the first pass**:
+- **A schema-incompatible row no longer stalls the whole tick.** The old single-row lookup
+  returned `None` the instant it hit ANY incompatible row (a pre-2026-07-22 SelfStateV1-burn-era
+  payload, say), which the old `while` loop treated identically to "queue empty" -- stopping the
+  entire tick's drain even if perfectly valid rows sat right behind it in FIFO order. The new
+  batch method (`load_oldest_policy_frames_without_dispatch`) retires the bad row (same stub-frame
+  mechanism as before) and simply excludes it from the returned list, so the other valid rows in
+  the same batch still get processed the same tick. Locked in by
+  `test_load_oldest_policy_frames_without_dispatch_skips_only_the_bad_row_in_a_mixed_batch`.
+- **The per-tick discard cap is now a SQL-only guarantee, not also enforced in Python.** The old
+  `while discarded < MAX_STALE_DISCARDS_PER_TICK` loop was a real, independent backstop against
+  ever discarding more than the cap in one tick, regardless of what the store returned. The new
+  code trusts the store's bound `:limit` parameter entirely -- if `load_oldest_policy_frames_
+  without_dispatch` ever returned more than `limit` rows (a bug, not an expected case), nothing in
+  `worker.py` would stop it. `test_max_stale_discards_per_tick_caps_the_drain`'s docstring was
+  tightened in review to say this explicitly rather than imply a worker-side cap still exists.
+
+**What this does to Part 2**: doesn't eliminate the question, but changes its urgency and framing.
+The concurrency work below was scoped against a ~9s-per-real-dispatch ceiling; with query cost no
+longer dominating, real tick cadence should approach the ~2s poll interval, and real dispatch
+throughput should approach the ~6.8/min ceiling Part 2 always assumed as the starting point — not
+exceed it. Concurrent dispatch is still the only way past that ~6.8/min number itself (still
+bounded by sequential `await self._send_one(...)` calls), so Part 2 remains real, valid future
+work — it's just no longer entangled with what turned out to be a separate, bigger, already-fixed
+problem.
+
 ## Part 2: throughput redesign — design mode, not implemented
 
 ### Arsonist summary

--- a/orion/execution_dispatch/builder.py
+++ b/orion/execution_dispatch/builder.py
@@ -270,7 +270,7 @@ def build_unevaluable_execution_dispatch_frame(
     """A policy frame whose proposal could not be loaded still needs an
     execution_dispatch_frame -- otherwise it's the oldest undispatched policy
     frame forever, permanently blocking every policy frame queued behind it
-    in the FIFO `load_latest_policy_frame_without_dispatch` query. Record
+    in the FIFO `load_oldest_policy_frames_without_dispatch` query. Record
     honestly (dispatch_attempted=False, zero candidates, a warning), don't
     silently drop or silently dispatch. Uses the same
     stable_execution_dispatch_frame_id as a real build would, so this is

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -79,7 +79,7 @@ promotes the candidate to a real, evidenced `dispatched` status.
 
 **Staleness discard (2026-07-30)**: this service consumes `substrate_policy_decision_frames`
 strictly FIFO, oldest-undispatched-first (`ExecutionDispatchRuntimeStore.
-load_latest_policy_frame_without_dispatch()`). Because a real dispatch is a synchronous
+load_oldest_policy_frames_without_dispatch()`). Because a real dispatch is a synchronous
 `cortex-exec` RPC (~7-11s measured live, one per real send, bounded by
 `EXECUTION_DISPATCH_RPC_TIMEOUT_SEC`), this single-threaded consumer cannot keep pace with real
 production of new policy decisions (~16/min produced vs ~6.8/min consumed, measured live
@@ -128,6 +128,38 @@ it's within the staleness window. A genuinely current proposal is never gated be
 the old backlog is; old backlog still drains steadily in the background via the unchanged FIFO
 path. Returns correctly-empty only when even the newest available frame is already stale, i.e.
 production itself has stalled, not backlog depth hiding something current.
+
+**Query performance fix (2026-07-30, same-day follow-up to the follow-up)**: deployed the
+fresh-priority fallback above and found, live, that real dispatch had resumed but was still only
+happening ~1/minute — far below the ~6.8/min ceiling. Traced with `EXPLAIN ANALYZE` (not
+guessed): both the FIFO drain's per-row lookup and the freshest-check both used a
+`LEFT JOIN substrate_execution_dispatch_frames d ON ... WHERE d.frame_id IS NULL` anti-join.
+Postgres was **not** using the available indexes for either — a full `Parallel Hash Left Join`
+scanning both tables, ~280-300ms per call, *regardless of table size beyond a point*. The drain
+loop called this **up to 200 times per tick** (`MAX_STALE_DISCARDS_PER_TICK`) — up to ~56 seconds
+of pure query time per tick, confirmed as the real, dominant cause of the observed ~75s/tick
+cadence (independently verified via `staleness_discard_count_ewma_n` growth over a precise
+10-minute window: 8 real ticks, not an inferred number). Adversarially re-tested against stale
+planner statistics as an alternative explanation (`ANALYZE` on both tables, re-ran `EXPLAIN
+ANALYZE`) — plan and cost unchanged, ruled out.
+
+Two different fixes for two different access patterns (confirmed via `EXPLAIN ANALYZE`, not
+assumed symmetric):
+- **`load_freshest_policy_frame_without_dispatch`** (DESC, newest-first): rewritten to
+  `WHERE NOT EXISTS (SELECT 1 FROM substrate_execution_dispatch_frames d WHERE d.source_policy_
+  frame_id = p.frame_id)`. Almost nothing near "now" has been processed yet, so Postgres's
+  nested-loop anti-join plan terminates on the very first probe. Measured: ~294ms → ~0.19ms
+  (~1500x). A `NOT EXISTS` rewrite for the *other* direction is measurably **worse** (~6+ seconds
+  — a huge prefix of already-processed ancient history, predating the original backlog, means a
+  nested loop has to walk hundreds of thousands of already-matched rows before finding the first
+  true miss), so this rewrite is intentionally direction-specific, not applied everywhere.
+- **`load_oldest_policy_frames_without_dispatch(limit)`** (ASC, FIFO drain): batches the whole
+  per-tick fetch into ONE query (`LIMIT :limit`, kept as the `LEFT JOIN` shape — the cheaper
+  available plan for this direction) instead of a while loop calling a `LIMIT 1` version up to 200
+  times. The Hash Join's dominant cost is building the hash table, which happens once regardless
+  of LIMIT size (measured: `LIMIT 1` ~280ms, `LIMIT 200` ~327ms, not 200x) — batching cuts real
+  per-tick SELECT cost from ~56s to ~0.3s. Confirmed live against the real table: 200 frames in
+  464ms (includes Python/pydantic overhead beyond the raw SQL execution time).
 
 See `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md` for the
 full live-data investigation (real backlog depth, throughput math, root cause) and the deferred

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -28,9 +28,78 @@ class ExecutionDispatchRuntimeStore:
             json_deserializer=json.loads,
         )
 
-    def load_latest_policy_frame_without_dispatch(self) -> PolicyDecisionFrameV1 | None:
+    def _validate_policy_frame_row(
+        self, payload: object, *, log_label: str
+    ) -> PolicyDecisionFrameV1 | None:
+        """Shared validate-or-retire logic for a single raw policy_decision_
+        frame_json payload. Returns None (and retires the row via a stub
+        dispatch frame) on schema-validation failure -- see
+        _retire_incompatible_policy_frame's own docstring for why this must
+        never just re-degrade to None without retiring: a naive skip would
+        re-select the exact same incompatible row forever."""
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        try:
+            return PolicyDecisionFrameV1.model_validate(payload)
+        except ValidationError:
+            raw_frame_id = payload.get("frame_id") if isinstance(payload, dict) else None
+            raw_proposal_frame_id = (
+                payload.get("source_proposal_frame_id") if isinstance(payload, dict) else None
+            )
+            logger.warning(
+                "policy_decision_frame_incompatible_schema %s frame_id=%s",
+                log_label,
+                raw_frame_id,
+                exc_info=True,
+            )
+            if raw_frame_id:
+                self._retire_incompatible_policy_frame(raw_frame_id, raw_proposal_frame_id)
+            return None
+
+    def load_oldest_policy_frames_without_dispatch(
+        self, limit: int
+    ) -> list[PolicyDecisionFrameV1]:
+        """Up to `limit` oldest unprocessed policy frames in ONE query
+        (2026-07-30, docs/superpowers/specs/2026-07-30-execution-dispatch-
+        staleness-discard-design.md's "Part 1c" -- a real, EXPLAIN-ANALYZE-
+        verified performance fix, not a guess). This replaces what used to
+        be a `LIMIT 1` query called up to MAX_STALE_DISCARDS_PER_TICK (200)
+        times per tick from a while loop in _drain_stale_policy_frames.
+
+        Real numbers (live, 2026-07-30): this anti-join (`LEFT JOIN ... WHERE
+        d.frame_id IS NULL`) costs ~280-300ms per call regardless of LIMIT
+        size (Postgres builds the full hash-joined result before sorting for
+        LIMIT either way -- confirmed via EXPLAIN ANALYZE, LIMIT 1 costs
+        ~280ms, LIMIT 200 costs ~327ms, not 200x more). Calling it once per
+        tick with LIMIT=200 instead of 200 times with LIMIT=1 cuts real
+        per-tick SELECT cost from ~56s to ~0.3s -- this was the actual
+        dominant cost behind the ~75s/tick cadence observed live after the
+        staleness-discard + fresh-priority-fallback patches shipped (traced
+        via EXPLAIN ANALYZE, adversarially re-tested against stale-planner-
+        statistics as an alternative explanation -- ruled out, a fresh
+        ANALYZE on both tables left the plan and cost unchanged).
+
+        Deliberately still the `LEFT JOIN` shape here, not `NOT EXISTS`: a
+        `NOT EXISTS` rewrite is dramatically cheaper for the DESC "freshest"
+        direction (load_freshest_policy_frame_without_dispatch below,
+        ~1500x) precisely because almost nothing near "now" has been
+        processed yet, so a nested-loop anti-join terminates on the first
+        probe -- but for THIS ascending direction, a huge prefix of already-
+        processed ancient history (predating the backlog that motivated this
+        whole feature) sits before the real backlog start, and a nested loop
+        would have to walk hundreds of thousands of already-matched rows
+        before finding the first true miss (confirmed live: 6+ seconds,
+        *slower* than the Hash Join it would replace). Batching the LIMIT is
+        the real fix for this direction; the query shape itself is already
+        the cheaper available plan for oldest-first access.
+
+        Each row is validated individually -- a schema-incompatible row
+        (see _validate_policy_frame_row) is retired and simply excluded from
+        the returned list rather than aborting the whole batch, so one bad
+        historical row can't block every valid one fetched alongside it.
+        """
         with self._engine.connect() as conn:
-            row = (
+            rows = (
                 conn.execute(
                     text(
                         """
@@ -40,41 +109,22 @@ class ExecutionDispatchRuntimeStore:
                           ON d.source_policy_frame_id = p.frame_id
                         WHERE d.frame_id IS NULL
                         ORDER BY p.generated_at ASC
-                        LIMIT 1
+                        LIMIT :limit
                         """
                     ),
+                    {"limit": limit},
                 )
                 .mappings()
-                .first()
+                .all()
             )
-        if not row:
-            return None
-        payload = row["policy_decision_frame_json"]
-        if isinstance(payload, str):
-            payload = json.loads(payload)
-        try:
-            return PolicyDecisionFrameV1.model_validate(payload)
-        except ValidationError:
-            # This is the FIFO "oldest undispatched policy frame" lookup --
-            # a naive None-degrade would re-select this exact row forever
-            # (it can never validate), permanently blocking every policy
-            # frame queued behind it. A schema migration (e.g. 2026-07-22's
-            # SelfStateV1 burn) can leave historical rows like this
-            # incompatible with the currently-running PolicyDecisionFrameV1.
-            # Retire it with a stub, unattempted dispatch frame so the FIFO
-            # advances past it.
-            raw_frame_id = payload.get("frame_id") if isinstance(payload, dict) else None
-            raw_proposal_frame_id = (
-                payload.get("source_proposal_frame_id") if isinstance(payload, dict) else None
+        frames: list[PolicyDecisionFrameV1] = []
+        for row in rows:
+            frame = self._validate_policy_frame_row(
+                row["policy_decision_frame_json"], log_label="oldest_batch_lookup"
             )
-            logger.warning(
-                "policy_decision_frame_incompatible_schema fifo_lookup frame_id=%s",
-                raw_frame_id,
-                exc_info=True,
-            )
-            if raw_frame_id:
-                self._retire_incompatible_policy_frame(raw_frame_id, raw_proposal_frame_id)
-            return None
+            if frame is not None:
+                frames.append(frame)
+        return frames
 
     def load_freshest_policy_frame_without_dispatch(self) -> PolicyDecisionFrameV1 | None:
         """The single newest unprocessed policy frame, regardless of backlog
@@ -87,7 +137,17 @@ class ExecutionDispatchRuntimeStore:
         drain doesn't surface a candidate to process, so a genuinely current
         proposal is never gated behind however deep the old backlog is.
 
-        Same schema-validation-failure handling as load_latest_policy_frame_
+        `NOT EXISTS`, not `LEFT JOIN ... WHERE d.frame_id IS NULL` (2026-07-30
+        "Part 1c" perf fix, same design doc as load_oldest_policy_frames_
+        without_dispatch above -- see that method's docstring for the full
+        account of why the two directions need DIFFERENT query shapes).
+        Confirmed live via EXPLAIN ANALYZE: this exact rewrite took the LEFT
+        JOIN version's ~294ms down to ~0.19ms for this specific (DESC)
+        direction -- almost nothing near "now" has been processed yet, so
+        Postgres's nested-loop anti-join plan terminates on the very first
+        probe instead of building a full hash join over both tables.
+
+        Same schema-validation-failure handling as load_oldest_policy_frames_
         without_dispatch above (retire an incompatible row via a stub
         dispatch frame rather than re-selecting it forever) -- this query can
         hit the exact same incompatible-row case, just approached from the
@@ -100,9 +160,10 @@ class ExecutionDispatchRuntimeStore:
                         """
                         SELECT p.policy_decision_frame_json
                         FROM substrate_policy_decision_frames p
-                        LEFT JOIN substrate_execution_dispatch_frames d
-                          ON d.source_policy_frame_id = p.frame_id
-                        WHERE d.frame_id IS NULL
+                        WHERE NOT EXISTS (
+                          SELECT 1 FROM substrate_execution_dispatch_frames d
+                          WHERE d.source_policy_frame_id = p.frame_id
+                        )
                         ORDER BY p.generated_at DESC
                         LIMIT 1
                         """
@@ -113,32 +174,17 @@ class ExecutionDispatchRuntimeStore:
             )
         if not row:
             return None
-        payload = row["policy_decision_frame_json"]
-        if isinstance(payload, str):
-            payload = json.loads(payload)
-        try:
-            return PolicyDecisionFrameV1.model_validate(payload)
-        except ValidationError:
-            raw_frame_id = payload.get("frame_id") if isinstance(payload, dict) else None
-            raw_proposal_frame_id = (
-                payload.get("source_proposal_frame_id") if isinstance(payload, dict) else None
-            )
-            logger.warning(
-                "policy_decision_frame_incompatible_schema freshest_lookup frame_id=%s",
-                raw_frame_id,
-                exc_info=True,
-            )
-            if raw_frame_id:
-                self._retire_incompatible_policy_frame(raw_frame_id, raw_proposal_frame_id)
-            return None
+        return self._validate_policy_frame_row(
+            row["policy_decision_frame_json"], log_label="freshest_lookup"
+        )
 
     def _retire_incompatible_policy_frame(
         self, raw_frame_id: str, raw_proposal_frame_id: str | None
     ) -> None:
         """Insert a stub, unattempted execution_dispatch_frame for a policy
-        frame that failed schema validation, so
-        load_latest_policy_frame_without_dispatch's FIFO lookup doesn't
-        re-select this exact row forever."""
+        frame that failed schema validation, so load_oldest_policy_frames_
+        without_dispatch's/load_freshest_policy_frame_without_dispatch's
+        lookups don't re-select this exact row forever."""
         stub = ExecutionDispatchFrameV1(
             frame_id=f"execution.dispatch.frame:{raw_frame_id}:schema_incompatible",
             generated_at=datetime.now(timezone.utc),

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -266,6 +266,23 @@ class ExecutionDispatchRuntimeWorker:
         candidate for this tick to process normally), an empty queue, or
         MAX_STALE_DISCARDS_PER_TICK, whichever comes first.
 
+        2026-07-30 perf fix (docs/superpowers/specs/2026-07-30-execution-
+        dispatch-staleness-discard-design.md's "Part 1c", EXPLAIN-ANALYZE-
+        verified live): fetches the whole candidate batch in ONE query
+        (store.load_oldest_policy_frames_without_dispatch) instead of a while
+        loop calling a LIMIT-1 lookup up to MAX_STALE_DISCARDS_PER_TICK (200)
+        times. That old shape cost ~280-300ms PER CALL regardless of LIMIT
+        size (Postgres builds the same full hash-joined result before
+        sorting either way) -- 200 calls/tick was ~56s of pure query time,
+        confirmed live as the real, dominant cause of the ~75s/tick cadence
+        observed after this feature and the fresh-priority fallback both
+        shipped (adversarially re-tested against stale planner statistics as
+        an alternative explanation via a fresh ANALYZE; ruled out, plan and
+        cost were unchanged). Fetching the same 200-row batch in one query
+        costs ~300ms total, not 200x that -- a ~170x real reduction in
+        per-tick SELECT cost, unlocking a tick cadence close to the intended
+        ~2s poll interval instead of ~75s.
+
         Each discard frame saved here carries the CURRENT (not-yet-updated-
         for-this-tick) baseline forward, same as every other saved frame --
         the real update for this tick's own discard count is computed once,
@@ -275,12 +292,10 @@ class ExecutionDispatchRuntimeWorker:
         Returns (fresh_policy_frame_or_none, discarded_count, last_discard_
         frame_or_none).
         """
+        batch = self._store.load_oldest_policy_frames_without_dispatch(MAX_STALE_DISCARDS_PER_TICK)
         discarded = 0
         last_discard_frame: ExecutionDispatchFrameV1 | None = None
-        while discarded < MAX_STALE_DISCARDS_PER_TICK:
-            candidate_frame = self._store.load_latest_policy_frame_without_dispatch()
-            if candidate_frame is None:
-                return None, discarded, last_discard_frame
+        for candidate_frame in batch:
             age_sec = self._age_sec(candidate_frame)
             threshold_sec = self._staleness_threshold_sec()
             if age_sec <= threshold_sec:

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -85,13 +85,16 @@ def _legacy_self_state_policy_payload() -> dict:
     }
 
 
-def test_load_latest_policy_frame_without_dispatch_retires_incompatible_row(monkeypatch) -> None:
+def test_load_oldest_policy_frames_without_dispatch_retires_incompatible_row(monkeypatch) -> None:
     # Live incident (2026-07-22): the SelfStateV1 burn removed
     # source_self_state_id from PolicyDecisionFrameV1. This is the FIFO
-    # "oldest undispatched policy frame" lookup -- a naive raise here
-    # crash-loops the whole worker forever (confirmed live). It must
-    # degrade to None AND write a stub, unattempted dispatch frame so the
-    # FIFO advances past the bad row.
+    # "oldest undispatched policy frames" batch lookup (2026-07-30 perf fix:
+    # renamed/batched from the old single-row load_latest_policy_frame_
+    # without_dispatch -- see that method's replacement docstring) -- a
+    # naive raise here crash-loops the whole worker forever (confirmed
+    # live). An incompatible row must be excluded from the returned batch
+    # AND write a stub, unattempted dispatch frame so the FIFO advances past
+    # the bad row instead of re-selecting it forever.
     store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
     fake_engine = MagicMock()
     conn = MagicMock()
@@ -109,20 +112,140 @@ def test_load_latest_policy_frame_without_dispatch_retires_incompatible_row(monk
             insert_calls.append(params or {})
             result.rowcount = 1
         else:
-            result.mappings.return_value.first.return_value = {
-                "policy_decision_frame_json": _legacy_self_state_policy_payload(),
-            }
+            result.mappings.return_value.all.return_value = [
+                {"policy_decision_frame_json": _legacy_self_state_policy_payload()}
+            ]
         return result
 
     conn.execute.side_effect = execute_side_effect
     monkeypatch.setattr(store, "_engine", fake_engine)
 
-    result = store.load_latest_policy_frame_without_dispatch()
+    result = store.load_oldest_policy_frames_without_dispatch(limit=200)
 
-    assert result is None
+    assert result == []
     assert len(insert_calls) == 1
     assert insert_calls[0]["source_policy_frame_id"] == "policy.frame:legacy:substrate_policy.v1"
     assert insert_calls[0]["source_proposal_frame_id"] == "proposal.frame:legacy:proposal_policy.v1"
+
+
+def _valid_policy_payload(frame_id: str) -> dict:
+    return {
+        "schema_version": "policy.decision.frame.v1",
+        "frame_id": frame_id,
+        "generated_at": NOW.isoformat(),
+        "source_proposal_frame_id": f"proposal.frame:{frame_id}",
+        "decisions": [],
+        "overall_risk": 0.0,
+    }
+
+
+def test_load_oldest_policy_frames_without_dispatch_returns_valid_batch(monkeypatch) -> None:
+    """2026-07-30 perf fix (docs/superpowers/specs/2026-07-30-execution-
+    dispatch-staleness-discard-design.md's "Part 1c"): this now fetches a
+    whole batch in one query (.mappings().all(), LIMIT :limit) instead of a
+    single row (.mappings().first(), LIMIT 1) called in a loop -- confirms
+    the happy path actually builds a real list of validated frames, not just
+    the incompatible-row edge case above."""
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    captured_params: dict = {}
+
+    def execute_side_effect(stmt, params=None):
+        captured_params.update(params or {})
+        result = MagicMock()
+        result.mappings.return_value.all.return_value = [
+            {"policy_decision_frame_json": _valid_policy_payload("policy.frame:a")},
+            {"policy_decision_frame_json": _valid_policy_payload("policy.frame:b")},
+        ]
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_oldest_policy_frames_without_dispatch(limit=200)
+
+    assert [f.frame_id for f in result] == ["policy.frame:a", "policy.frame:b"]
+    assert captured_params["limit"] == 200
+
+
+def test_load_oldest_policy_frames_without_dispatch_skips_only_the_bad_row_in_a_mixed_batch(
+    monkeypatch,
+) -> None:
+    """Regression guard (code review, 2026-07-30): a schema-incompatible row
+    anywhere in the batch must be retired and excluded WITHOUT truncating or
+    dropping the other, valid rows around it -- a real behavior improvement
+    over the old single-row lookup, which returned None (and so stopped the
+    whole tick's drain) the instant it hit ANY incompatible row, even with
+    valid rows queued right behind it. Batch position of the bad row (here:
+    the middle one) is deliberate -- proves the loop doesn't just handle a
+    bad row at the start or end."""
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+    insert_calls: list[dict] = []
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_execution_dispatch_frames" in sql:
+            insert_calls.append(params or {})
+            result.rowcount = 1
+        else:
+            result.mappings.return_value.all.return_value = [
+                {"policy_decision_frame_json": _valid_policy_payload("policy.frame:a")},
+                {"policy_decision_frame_json": _legacy_self_state_policy_payload()},
+                {"policy_decision_frame_json": _valid_policy_payload("policy.frame:c")},
+            ]
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_oldest_policy_frames_without_dispatch(limit=200)
+
+    assert [f.frame_id for f in result] == ["policy.frame:a", "policy.frame:c"]
+    assert len(insert_calls) == 1
+    assert insert_calls[0]["source_policy_frame_id"] == "policy.frame:legacy:substrate_policy.v1"
+
+
+def test_load_freshest_policy_frame_without_dispatch_uses_not_exists(monkeypatch) -> None:
+    """2026-07-30 perf fix: this direction uses WHERE NOT EXISTS, not
+    LEFT JOIN ... WHERE d.frame_id IS NULL -- EXPLAIN ANALYZE confirmed live
+    this is ~1500x cheaper for the DESC/newest-first direction specifically
+    (0.19ms vs ~294ms), because almost nothing near "now" has been processed
+    yet, so a nested-loop anti-join terminates on the very first probe."""
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    captured_sql: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        captured_sql.append(str(stmt))
+        result = MagicMock()
+        result.mappings.return_value.first.return_value = {
+            "policy_decision_frame_json": _valid_policy_payload("policy.frame:freshest")
+        }
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_freshest_policy_frame_without_dispatch()
+
+    assert result is not None
+    assert result.frame_id == "policy.frame:freshest"
+    assert "NOT EXISTS" in captured_sql[0]
+    assert "LEFT JOIN" not in captured_sql[0]
+    assert "DESC" in captured_sql[0]
 
 
 def test_load_by_policy_frame_id(monkeypatch) -> None:

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -59,7 +59,7 @@ def test_worker_skips_when_no_policy_pending(monkeypatch) -> None:
 
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=None)
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(return_value=[])
     worker._store.load_freshest_policy_frame_without_dispatch = MagicMock(return_value=None)
     worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
@@ -88,7 +88,7 @@ def test_worker_records_unevaluable_frame_when_proposal_missing(monkeypatch) -> 
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
     policy_frame = _policy_frame()
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=policy_frame)
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(return_value=[policy_frame])
     worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.load_proposal_frame = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
@@ -116,7 +116,7 @@ def test_worker_saves_dispatch_frame_for_pending_policy(monkeypatch) -> None:
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
     policy_frame = _policy_frame()
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=policy_frame)
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(return_value=[policy_frame])
     worker._store.load_latest_staleness_discard_baseline = MagicMock(return_value=None)
     worker._store.load_proposal_frame = MagicMock(return_value=_proposal())
     worker._store.save_dispatch_frame = MagicMock()
@@ -178,8 +178,8 @@ def test_staleness_threshold_falls_in_configured_range_without_override(monkeypa
 def test_worker_discards_a_lone_stale_policy_frame_without_dispatching(monkeypatch) -> None:
     worker = _staleness_worker(monkeypatch, override_sec=120.0)
     stale_frame = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=6))
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
-        side_effect=[stale_frame, None]
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(
+        return_value=[stale_frame]
     )
 
     worker._tick()
@@ -218,8 +218,8 @@ def test_worker_materializes_per_candidate_discard_summary(monkeypatch) -> None:
             ]
         }
     )
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
-        side_effect=[stale_frame, None]
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(
+        return_value=[stale_frame]
     )
 
     worker._tick()
@@ -233,8 +233,8 @@ def test_worker_drains_stale_frames_then_processes_a_fresh_one(monkeypatch) -> N
     stale_1 = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=6), frame_id="policy.frame:stale-1")
     stale_2 = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=3), frame_id="policy.frame:stale-2")
     fresh = _policy_frame_at(datetime.now(timezone.utc) - timedelta(seconds=1), frame_id="policy.frame:fresh")
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
-        side_effect=[stale_1, stale_2, fresh]
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(
+        return_value=[stale_1, stale_2, fresh]
     )
 
     worker._tick()
@@ -260,7 +260,7 @@ def test_worker_falls_back_to_freshest_when_drain_finds_nothing(monkeypatch) -> 
     regardless of how deep the old backlog behind it is."""
     worker = _staleness_worker(monkeypatch, override_sec=120.0)
     ancient = _policy_frame_at(datetime.now(timezone.utc) - timedelta(days=2))
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=ancient)
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(return_value=[ancient])
     fresh = _policy_frame_at(datetime.now(timezone.utc) - timedelta(seconds=1), frame_id="policy.frame:fresh")
     worker._store.load_freshest_policy_frame_without_dispatch = MagicMock(return_value=fresh)
 
@@ -278,7 +278,7 @@ def test_worker_fallback_correctly_finds_nothing_when_freshest_is_also_stale(mon
     artifact. Must not fabricate a real-dispatch attempt in that case."""
     worker = _staleness_worker(monkeypatch, override_sec=120.0)
     ancient = _policy_frame_at(datetime.now(timezone.utc) - timedelta(days=2))
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=ancient)
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(return_value=[ancient])
     also_stale_but_newest = _policy_frame_at(
         datetime.now(timezone.utc) - timedelta(hours=1), frame_id="policy.frame:newest-but-stale"
     )
@@ -292,14 +292,32 @@ def test_worker_fallback_correctly_finds_nothing_when_freshest_is_also_stale(mon
 
 
 def test_max_stale_discards_per_tick_caps_the_drain(monkeypatch) -> None:
+    """2026-07-30 perf fix: the cap is now enforced by the LIMIT passed to
+    the single batch query (load_oldest_policy_frames_without_dispatch), not
+    by an application-level while loop counting single-row fetches -- there
+    is no longer any worker-side backstop against the store ever returning
+    more than the requested limit (that trust boundary moved entirely to
+    Postgres honoring the bound :limit parameter). This test verifies what's
+    actually left on the worker side: it requests exactly MAX_STALE_
+    DISCARDS_PER_TICK, and correctly processes a full-size all-stale batch
+    in full (every item discarded, none skipped) rather than stopping short.
+    It does NOT and cannot prove the cap holds if the store ever returned an
+    oversized batch -- that would need a store/SQL-level test, not this
+    one."""
     worker = _staleness_worker(monkeypatch, override_sec=120.0)
-    ancient = _policy_frame_at(datetime.now(timezone.utc) - timedelta(days=2))
-    # Same object every call -- an unbounded drain loop would spin forever;
-    # the cap must stop it after exactly MAX_STALE_DISCARDS_PER_TICK saves.
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=ancient)
+    ancient_batch = [
+        _policy_frame_at(
+            datetime.now(timezone.utc) - timedelta(days=2), frame_id=f"policy.frame:ancient-{i}"
+        )
+        for i in range(worker_mod.MAX_STALE_DISCARDS_PER_TICK)
+    ]
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(return_value=ancient_batch)
 
     worker._tick()
 
+    worker._store.load_oldest_policy_frames_without_dispatch.assert_called_once_with(
+        worker_mod.MAX_STALE_DISCARDS_PER_TICK
+    )
     # +1: the final re-stamp save of the last discard frame with this tick's
     # now-final EWMA count, same reasoning as test_worker_discards_a_lone_
     # stale_policy_frame_without_dispatching above.
@@ -317,8 +335,8 @@ def test_staleness_discard_ewma_advances_and_persists(monkeypatch) -> None:
         }
     )
     stale_frame = _policy_frame_at(datetime.now(timezone.utc) - timedelta(hours=6))
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
-        side_effect=[stale_frame, None]
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(
+        return_value=[stale_frame]
     )
 
     worker._tick()
@@ -338,7 +356,7 @@ def test_worker_fresh_policy_frame_never_discarded(monkeypatch) -> None:
     real-time traffic."""
     worker = _staleness_worker(monkeypatch, override_sec=300.0)
     fresh = _policy_frame_at(datetime.now(timezone.utc))
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=fresh)
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(return_value=[fresh])
 
     worker._tick()
 
@@ -361,8 +379,8 @@ def test_worker_handles_naive_generated_at_without_crashing(monkeypatch) -> None
     worker = _staleness_worker(monkeypatch, override_sec=120.0)
     naive_stale = _policy_frame_at(datetime.now() - timedelta(hours=6))
     assert naive_stale.generated_at.tzinfo is None
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(
-        side_effect=[naive_stale, None]
+    worker._store.load_oldest_policy_frames_without_dispatch = MagicMock(
+        return_value=[naive_stale]
     )
 
     worker._tick()  # must not raise


### PR DESCRIPTION
## Summary

- Same-day follow-up to PR #1514. Deployed, checked live: real dispatch had resumed but was stuck at ~1/min, far below the ~6.8/min ceiling. Ran `EXPLAIN ANALYZE` against the real live queries instead of assuming the cause.
- Root cause: both FIFO-drain and freshest-check queries used a `LEFT JOIN ... WHERE d.frame_id IS NULL` anti-join. Despite real indexes on the join columns, Postgres chose a full `Parallel Hash Left Join` — ~280-300ms per call, called up to 200 times per tick. Real tick cadence verified independently (via `staleness_discard_count_ewma_n` growth over an exact 10-minute window, not inferred): 8 ticks, ~75s each.
- **Adversarial pass run before accepting the conclusion** (see design doc): ruled out stale planner statistics (fresh `ANALYZE`, plan/cost unchanged), confirmed tick cadence via an independent real counter, checked the INSERT side wasn't a hidden bottleneck, checked whether the diagnostic queries themselves biased the measurement.
- Fix, two different query shapes for two different access patterns (confirmed via `EXPLAIN ANALYZE`, not assumed symmetric): `NOT EXISTS` rewrite for the DESC/freshest direction (~294ms → ~0.19ms, ~1500x), batch-fetch (one query instead of 200) for the ASC/FIFO direction (kept the `LEFT JOIN` shape — `NOT EXISTS` measured *worse* there, 6+ seconds, due to a huge prefix of already-processed ancient history).
- Confirmed live against the real table: 200-frame batch in 464ms (was ~56,000ms), freshest-check in 4.6ms (was ~294ms).

## Outcome moved

Real per-tick query cost for backlog handling drops from ~56s to ~0.3s — unlocks a tick cadence close to the intended ~2s poll interval instead of the ~75s observed live, directly fixing the ~1/min real-dispatch rate.

## Current architecture

Both the FIFO drain (`load_latest_policy_frame_without_dispatch`, called once per discard in a 200-iteration loop) and the freshest-check (`load_freshest_policy_frame_without_dispatch`, added in PR #1514) used the same `LEFT JOIN` anti-join pattern, which the query planner executed via a full hash join over both tables regardless of available indexes.

## Architecture touched

`services/orion-execution-dispatch-runtime/app/store.py`, `app/worker.py`. No schema/bus/API changes.

## Files changed

- `services/orion-execution-dispatch-runtime/app/store.py`: `load_latest_policy_frame_without_dispatch` replaced by `load_oldest_policy_frames_without_dispatch(limit)` (batch fetch); `load_freshest_policy_frame_without_dispatch` rewritten to `NOT EXISTS`; `_validate_policy_frame_row` extracted as a shared validate-or-retire helper.
- `services/orion-execution-dispatch-runtime/app/worker.py`: `_drain_stale_policy_frames` rewritten to fetch-then-iterate instead of loop-and-fetch.
- `services/orion-execution-dispatch-runtime/README.md`, `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md`: documented (design doc has the full live-data investigation, adversarial pass, and two disclosed side-effect behavior changes).
- `orion/execution_dispatch/builder.py`: stale docstring reference to the old method name fixed.
- `tests/test_execution_dispatch_runtime_store.py`, `tests/test_execution_dispatch_runtime_worker.py`: new/updated coverage.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-execution-dispatch-query-perf
PYTHONPATH=. .venv/bin/python -m pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_policy_loader.py -q
# 97 passed
```

## Evals run

None — no eval harness for this service. `EXPLAIN ANALYZE` against the real live database (both before and after the fix, plus the adversarial re-tests) was the real verification, documented in the design doc's "Part 1c" section.

## Docker/build/smoke checks

Not run in this pass — no live deploy yet for this specific patch.

## Review findings fixed

- Finding: two stale docstring references to the old `load_latest_policy_frame_without_dispatch` method name (`README.md`, `orion/execution_dispatch/builder.py`).
  - Fix: updated to the new method name.
  - Evidence: `git diff` on both files.
- Finding: no test exercised a schema-incompatible row in the *middle* of a mixed batch (only all-valid and all-invalid cases existed).
  - Fix: added `test_load_oldest_policy_frames_without_dispatch_skips_only_the_bad_row_in_a_mixed_batch`, proving the bad row is retired and excluded without truncating the valid rows around it.
  - Evidence: new test, passing.
- Finding: `test_max_stale_discards_per_tick_caps_the_drain`'s docstring implied a worker-side cap backstop still exists; it doesn't anymore (the cap moved entirely into the SQL `LIMIT` parameter).
  - Fix: tightened the docstring to state precisely what the test does and doesn't prove; documented the same trade-off in the design doc.
  - Evidence: docstring + design doc diff.
- Reviewer independently re-ran `EXPLAIN ANALYZE` against the live database (not just trusting this account) and reproduced all three claimed plan/cost changes within the same order of magnitude. No other material findings.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-execution-dispatch-runtime/.env \
  -f services/orion-execution-dispatch-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: the per-tick discard cap is now enforced only by the SQL `LIMIT` parameter, not also by an independent worker-side loop counter (disclosed above and in the design doc). If `load_oldest_policy_frames_without_dispatch` ever had a bug returning more than `limit` rows, nothing in `worker.py` would catch it.
- Mitigation: the query is simple and directly parameterized (`LIMIT :limit`), low risk of drifting; disclosed explicitly rather than silently accepted.
- Severity: low
- Concern: not yet verified against live traffic post-deploy (this specific patch hasn't been deployed).
- Mitigation: same live-verification discipline used throughout this investigation — check `staleness_discard_count_ewma`, real dispatch rate, and backlog drain rate immediately after restart.