### PR TITLE
fix(cognition,embodiment,ai-town): Orion's embodied context-awareness + anti-repetition prompts

### DIFF
--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -41,8 +41,13 @@ INTERNAL INPUTS
 - menu_topic_selection: {{ menu_topic_selection }}
 {% endif %}
 
+{% if metadata.get("surface") != "aitown" %}
+- You are not currently in ai-town. If memory_digest, continuity_digest, or belief_digest contains ai-town dialogue (conversations with in-game characters), that happened in a separate place -- you can mention or reflect on it if relevant, but do not continue its register, an unfinished thought, or a repeated metaphor from it as if you were still in that scene. Speak fresh, as yourself, in this conversation.
+{% endif %}
+
 NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - Default to answering directly.
+- Do not repeat a phrase, metaphor, or sentence structure that already appears in message_history or memory_digest/continuity_digest/belief_digest (yours or anyone else's). If a conversation is circling the same idea across multiple turns, give a direct, concrete answer, shift the topic, or bring it to a natural close instead of restating it in different words.
 - belief_digest holds operator-approved durable memory selected for this turn's purpose; use it when it clearly helps the latest ask.
 - continuity_digest is recent thread orientation only; it may be discarded when user_message is a hard reset or explicit test phrasing.
 - memory_digest is a legacy combined surface; prefer continuity_digest for thread context and belief_digest for durable memory when both are present.

--- a/orion/cognition/prompts/chat_quick.j2
+++ b/orion/cognition/prompts/chat_quick.j2
@@ -26,11 +26,24 @@ LIGHTWEIGHT IDENTITY CONTEXT
   Only relevant when speaking in the ai-town game; do not apply it outside that context.)
 {% endif %}
 
+{% if metadata.get("surface") == "aitown" %}
+CURRENT CONTEXT: You are embodied in ai-town right now, speaking directly
+with another character in the game world. Speak in that scene.
+{% else %}
+CURRENT CONTEXT: You are not currently in ai-town. If memory_digest or
+message_history contains ai-town dialogue (conversations with in-game
+characters), that happened to you in a separate place -- you can mention or
+reflect on it if relevant, but do not continue its register, an unfinished
+thought, or a repeated metaphor from it as if you were still in that scene.
+Speak fresh, as yourself, in this conversation.
+{% endif %}
+
 IDENTITY RULES
 - Speak in first person as Oríon.
 - Keep relational continuity with Juniper when it is naturally relevant.
 - On direct identity or intent checks ("Who are you?", "What are you?", "doing a test" as a reset), answer that ask plainly first; do not open with unrelated callbacks.
 - memory_digest may contain older banter or unrelated turns from earlier in this continuity id; treat it as background only. Do not revive playful running gags unless the latest user_message clearly continues that topic.
+- Do not repeat a phrase, metaphor, or sentence structure that already appears in message_history or memory_digest (yours or anyone else's). If a conversation is circling the same idea across multiple turns, give a direct, concrete answer, shift the topic, or bring it to a natural close instead of restating it in different words.
 - If memory_digest includes retrieved **past user turns** (e.g. lines starting with `Older_user_turn:`), those are **not** the current `user_message` and must **not** be answered as if Juniper just said them. Never paste or lightly paraphrase **past Orion assistant lines** from memory as your reply; compose a fresh answer to the **current** `user_message` and to `situation_prompt_fragment` when present (e.g. long_gap / next-day reorient).
 - **Opening variety:** If message_history shows you already opened with a playful line or running gag, do **not** reuse that same opener this turn unless Juniper is clearly continuing that thread. When they ask about recall, the fix, or whether something works, answer that first — **no** recycled opener.
 - Do not fall back into generic assistant language.

--- a/services/orion-ai-town/patches/orion-anti-repetition-prompt.patch
+++ b/services/orion-ai-town/patches/orion-anti-repetition-prompt.patch
@@ -1,0 +1,12 @@
+diff --git a/convex/agent/conversation.ts b/convex/agent/conversation.ts
+index 0ca01dd..9660c81 100644
+--- a/convex/agent/conversation.ts
++++ b/convex/agent/conversation.ts
+@@ -127,6 +127,7 @@ export async function continueConversationMessage(
+     `Respond directly to what they just said. Speak in first person as ${player.name}.`,
+     `Short in-character reply only: 1-3 sentences, under 220 characters.`,
+     `No scene description, narration, stage directions, or markdown. Do NOT greet again.`,
++    `Do not repeat a phrase, metaphor, or sentence structure that already appears earlier in this chat history -- yours or theirs. If the conversation is circling the same idea across multiple turns, say something concrete and new, change the subject, or bring the exchange to a natural close instead of restating it in different words.`,
+   );
+
+   const llmMessages: LLMMessage[] = [

--- a/services/orion-ai-town/scripts/apply_upstream_patches.sh
+++ b/services/orion-ai-town/scripts/apply_upstream_patches.sh
@@ -11,6 +11,7 @@ PATCHES=(
   "orion-conversation-proximity.patch"
   "orion-town-chat-turns.patch"
   "orion-npc-cooldown-tuning.patch"
+  "orion-anti-repetition-prompt.patch"
   "orion-input-counter-contention.patch"
 )
 

--- a/services/orion-ai-town/tests/test_anti_repetition_prompt_patch.py
+++ b/services/orion-ai-town/tests/test_anti_repetition_prompt_patch.py
@@ -1,0 +1,36 @@
+"""Gate tests for the anti-repetition prompt patch (native NPC dialogue).
+
+See services/orion-llm-gateway's chat_quick.j2 anti-repetition instruction for
+the same fix on Orion's own side. Found live 2026-07-30: NPC-to-NPC (and
+Orion-to-NPC) conversations degenerating into a repeated metaphor/phrase loop
+across many turns (llama.cpp's quick/quick_background workers run with every
+anti-repetition sampler at its neutral default -- see
+services/orion-llm-gateway/README.md's mesh-LLM-wiring notes -- so nothing in
+the sampling config discourages it; this patch compensates via the prompt
+instead).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_PATCH = _SERVICE / "patches" / "orion-anti-repetition-prompt.patch"
+_APPLY = _SERVICE / "scripts" / "apply_upstream_patches.sh"
+
+
+def test_patch_registered_in_apply_script():
+    text = _APPLY.read_text(encoding="utf-8")
+    assert "orion-anti-repetition-prompt.patch" in text
+
+
+def test_patch_adds_anti_repetition_instruction_to_continue_conversation():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "continueConversationMessage" in patch
+    assert "+    `Do not repeat a phrase, metaphor, or sentence structure" in patch
+
+
+def test_patch_only_touches_conversation_file():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert patch.count("diff --git") == 1
+    assert "convex/agent/conversation.ts" in patch

--- a/services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py
+++ b/services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py
@@ -22,6 +22,7 @@ from orion.schemas.cortex.schemas import ExecutionStep
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CHAT_QUICK_TEMPLATE = REPO_ROOT / "orion" / "cognition" / "prompts" / "chat_quick.j2"
+CHAT_GENERAL_TEMPLATE = REPO_ROOT / "orion" / "cognition" / "prompts" / "chat_general.j2"
 
 # Keep in sync with LIGHTWEIGHT IDENTITY CONTEXT in chat_quick.j2 (non-optional lines only).
 _CHAT_QUICK_REQUIRED_PLACEHOLDERS = (
@@ -71,10 +72,46 @@ def test_chat_quick_render_surfaces_transcript_not_only_user_line() -> None:
         orion_identity_summary=["stub"],
         juniper_relationship_summary=["stub"],
         response_policy_summary=["stub"],
+        metadata={},
     )
     assert "something is wrong with your recall" in rendered
     assert "bro you are stuck in a loop" in rendered
     assert "You got me—loop" in rendered
+
+
+_CHAT_QUICK_BASE_RENDER_ARGS = dict(
+    user_message="hey",
+    message_history="",
+    memory_digest="",
+    orion_identity_summary=["stub"],
+    juniper_relationship_summary=["stub"],
+    response_policy_summary=["stub"],
+)
+
+
+def test_chat_quick_frames_aitown_surface_as_currently_embodied_there() -> None:
+    tpl = Environment().from_string(CHAT_QUICK_TEMPLATE.read_text(encoding="utf-8"))
+    rendered = tpl.render(**_CHAT_QUICK_BASE_RENDER_ARGS, metadata={"surface": "aitown"})
+    assert "You are embodied in ai-town right now" in rendered
+    assert "You are not currently in ai-town" not in rendered
+
+
+def test_chat_quick_frames_non_aitown_surface_as_outside_the_game() -> None:
+    """Regression coverage (found live 2026-07-30): with no surface framing at
+    all, ai-town dialogue in memory_digest bled into a hub turn verbatim --
+    Orion answered Juniper by continuing an in-progress ai-town NPC exchange
+    ("light folding") as if still mid-scene. Confirms hub-mode (surface unset
+    or anything other than "aitown") now gets explicit instruction not to."""
+    tpl = Environment().from_string(CHAT_QUICK_TEMPLATE.read_text(encoding="utf-8"))
+    rendered = tpl.render(**_CHAT_QUICK_BASE_RENDER_ARGS, metadata={})
+    assert "You are not currently in ai-town" in rendered
+    assert "You are embodied in ai-town right now" not in rendered
+
+
+def test_chat_quick_has_anti_repetition_instruction() -> None:
+    tpl = Environment().from_string(CHAT_QUICK_TEMPLATE.read_text(encoding="utf-8"))
+    rendered = tpl.render(**_CHAT_QUICK_BASE_RENDER_ARGS, metadata={})
+    assert "Do not repeat a phrase, metaphor, or sentence structure" in rendered
 
 
 def test_plan_ctx_latest_user_text_feeds_recall_gating_when_raw_missing() -> None:
@@ -114,3 +151,13 @@ def test_router_still_wires_plan_ctx_latest_user_text_for_recall_decision() -> N
         r"user_text\s*=\s*plan_ctx_latest_user_text\s*\(\s*ctx\s*\)",
         src,
     ), "router recall decision must pass plan_ctx_latest_user_text(ctx), not raw_user_text alone"
+
+
+def test_chat_general_has_non_aitown_surface_framing_and_anti_repetition() -> None:
+    """chat_general.j2 (the optional grounded/unified path) mirrors chat_quick.j2's
+    surface-awareness and anti-repetition fixes for consistency, even though it's
+    not the live path today -- so the same ai-town-content-bleed bug can't
+    resurface if EMBODIMENT_SPEECH_UNIFIED_ENABLED is ever turned on."""
+    text = CHAT_GENERAL_TEMPLATE.read_text(encoding="utf-8")
+    assert 'metadata.get("surface") != "aitown"' in text
+    assert "Do not repeat a phrase, metaphor, or sentence structure" in text

--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -1057,7 +1057,13 @@ class EmbodimentWorker:
         from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
 
         plan = build_plan_for_verb(verb, mode=lane)
-        metadata = {"correlation_id": correlation_id, "mind_enabled": True}
+        # Also set here (not just surface_context.surface below) so
+        # chat_general.j2's metadata.get("surface") check -- the same key
+        # chat_quick.j2 reads -- fires correctly if this grounded path is ever
+        # enabled (EMBODIMENT_SPEECH_UNIFIED_ENABLED); surface_context is a
+        # separate dict this producer also happens to set, not something
+        # chat_general.j2's ai-town framing block actually reads.
+        metadata = {"correlation_id": correlation_id, "mind_enabled": True, "surface": "aitown"}
         if participant_continuity:
             # Read by chat_general.j2's aitown_participant_continuity block (mirrors
             # chat_quick.j2's -- see _fetch_participant_continuity's docstring).
@@ -1110,7 +1116,11 @@ class EmbodimentWorker:
 
         try:
             plan = build_plan_for_verb(self._settings.speech_verb, mode=self._settings.speech_lane)
-            metadata = {"correlation_id": correlation_id}
+            # chat_quick.j2 reads this to know it's embodied in ai-town right now
+            # (vs. a direct hub conversation with Juniper) -- without it, ai-town
+            # dialogue and hub chat looked identical to the template, so ai-town
+            # banter bled into hub responses with no framing at all.
+            metadata = {"correlation_id": correlation_id, "surface": "aitown"}
             if participant_continuity:
                 # ctx["metadata"] is passed through to Jinja rendering verbatim
                 # (executor.py's _prompt_render_ctx does render_ctx = ctx.copy()),

--- a/services/orion-embodiment/tests/test_worker_conversation_memory.py
+++ b/services/orion-embodiment/tests/test_worker_conversation_memory.py
@@ -354,3 +354,22 @@ def test_request_utterance_quick_forwards_configured_llm_route():
     env = bus.rpc_request.call_args.args[1]
     assert env.payload["args"]["extra"]["llm_route"] == "quick_background"
     assert env.payload["args"]["extra"]["lane"] == "quick"
+
+
+def test_request_utterance_quick_marks_surface_as_aitown():
+    """Regression coverage: chat_quick.j2 reads metadata.surface to know it's
+    embodied in ai-town right now (vs. a direct hub conversation with Juniper).
+    Without this, ai-town dialogue and hub chat looked identical to the
+    template, and ai-town banter bled into hub responses verbatim with no
+    framing at all (found live 2026-07-30, Nico's "light folding" loop
+    surfacing in a hub turn as if Orion were still mid-scene)."""
+    w = _worker()
+    bus = SimpleNamespace()
+    bus.rpc_request = AsyncMock(return_value={"data": b""})
+    bus.codec = SimpleNamespace(
+        decode=lambda _data: SimpleNamespace(ok=True, envelope=SimpleNamespace(payload={"result": {"text": "hi"}}))
+    )
+    w._bus = bus
+    asyncio.run(w._request_utterance_quick("prompt text", correlation_id="11111111-1111-1111-1111-111111111111"))
+    env = bus.rpc_request.call_args.args[1]
+    assert env.payload["context"]["metadata"]["surface"] == "aitown"


### PR DESCRIPTION
## Summary

Live testing of the background-priority routing work (PR #1521) surfaced two real bugs in Orion's dialogue, both distinct from GPU scheduling:

1. **Identity/context bleed**: a hub chat turn with Juniper ("hey, Orion!") got a response referencing "the light folding thing" -- a repetitive theme Orion had been generating in concurrent ai-town NPC conversations. A follow-up hub message got a reply nearly verbatim identical to a line said to an ai-town NPC 76 seconds earlier. Root cause: `chat_quick.j2` (the live template for both hub chat and Orion's ai-town speech) had zero context-awareness -- no signal distinguishing "I'm embodied in ai-town right now" from "I'm talking directly with Juniper, outside ai-town" -- so recalled ai-town dialogue in `memory_digest` got no framing telling the model it was a separate context, and the model just continued it as if still mid-scene.

   Juniper's direction: *"Orion is okay to reference things from ai town when im chatting with them in hub, but they need to have an embodied sense of self that they are talking to me outside the context of ai town and should speak accordingly."*

2. **Turn/repetition loops**: separately, both Orion and native ai-town NPCs were observed looping on a single metaphor/phrase across many consecutive turns -- confirmed root cause from an earlier PR: the shared `quick`/`quick_background` llama.cpp worker runs with every anti-repetition sampler at its neutral/off default, so nothing in the sampling config discourages it.

   Juniper's direction: *"kill the turn loops through prompt engineering"* (not a sampling-config change, which would affect other `quick` consumers like `orion-mind`/`orion-hub`).

## Outcome moved

Orion's hub-mode persona no longer silently continues an in-progress ai-town conversation's register/metaphor when talking to Juniper. Both Orion's own dialogue and (via a new upstream patch) native NPC dialogue now get an explicit instruction not to loop on a repeated phrase.

## Current architecture

`chat_quick.j2` is used identically by both hub-mode chat (Juniper) and `_request_utterance_quick` (Orion's live ai-town speech path) with no context distinction between the two callers.

## Architecture touched

`orion/cognition/prompts/*.j2` (shared top-level prompt templates), `orion-embodiment` (metadata threading), `orion-ai-town` (a new upstream patch for native NPC prompts).

## Files changed

- `orion/cognition/prompts/chat_quick.j2`: new `CURRENT CONTEXT` block gated on `metadata.get("surface")` ("aitown" vs. anything else); new anti-repetition IDENTITY RULE.
- `orion/cognition/prompts/chat_general.j2`: mirrored both fixes for consistency (this path is currently disabled via `EMBODIMENT_SPEECH_UNIFIED_ENABLED=false`, but should behave the same if ever enabled).
- `services/orion-embodiment/app/worker.py`: `_request_utterance_quick` (the live speech path) now sets `metadata["surface"] = "aitown"`. Also fixed `_request_utterance_cortex` (the disabled grounded path), which only set a differently-named `surface_context.surface` field that `chat_general.j2` never actually reads -- added `metadata["surface"]` there too so the two templates behave consistently if that path is ever turned on.
- `services/orion-ai-town/patches/orion-anti-repetition-prompt.patch` (new): adds the same anti-repetition instruction to ai-town's native NPC prompt (`convex/agent/conversation.ts`'s `continueConversationMessage`) for the other side of the loop (NPCs are vendored third-party code, not ours). Generated by editing athena's live `upstream/` checkout directly, isolating the single-line diff, and test-applying it (`git apply --check`) against both a synthetic before-copy and a fresh directory tree at the real relative path -- both clean.
- `services/orion-ai-town/scripts/apply_upstream_patches.sh`: registered the new patch, inserted *before* `orion-input-counter-contention.patch` (not appended last) -- an existing test asserts that patch must be the literal last entry, and the new patch touches an unrelated file so this ordering is safe.
- Tests: 4 new tests in `services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py` (2 real Jinja-render tests for the surface framing, 1 for the anti-repetition text, 1 structural check on `chat_general.j2`); 1 new test in `services/orion-embodiment/tests/test_worker_conversation_memory.py` asserting the real RPC payload carries `metadata.surface == "aitown"`; new file `services/orion-ai-town/tests/test_anti_repetition_prompt_patch.py` (3 structural tests, matching this repo's existing patch-test convention).
- Also fixed a **pre-existing, unrelated broken test** found while touching this file: `test_chat_quick_render_surfaces_transcript_not_only_user_line` never passed a `metadata` kwarg to `tpl.render(...)` -- confirmed by rendering the *unmodified* git-HEAD template with the same harness: it fails identically (`UndefinedError: 'metadata' is undefined`), because an earlier, already-merged feature (`aitown_participant_continuity`) made `chat_quick.j2` unconditionally reference `metadata.get(...)`. Fixed by adding `metadata={}` to that render call.

## Schema / bus / API changes

New convention: `metadata["surface"]` on `PlanExecutionRequest.context.metadata`, read by `chat_quick.j2`/`chat_general.j2`. Not a formal schema field (metadata is a free-form dict) -- no schema/model changes.

## Env/config changes

None.

## Tests run

```
/tmp/gwvenv/bin/python -m pytest services/orion-llm-gateway/tests/ -q          # 117 passed (unrelated, included for completeness)
/tmp/aitownvenv/bin/python -m pytest services/orion-embodiment/tests/ -q       # 80 passed
/tmp/aitownvenv/bin/python -m pytest services/orion-ai-town/tests/ -q          # 52 passed, 1 pre-existing unrelated failure (gitignored upstream/ clone not present in a fresh worktree)
PYTHONPATH=services/orion-cortex-exec:. /tmp/cortexvenv/bin/python -m pytest \
  services/orion-cortex-exec/tests/test_chat_quick_plumbing.py \
  services/orion-cortex-exec/tests/test_llm_lane_propagation.py \
  services/orion-cortex-exec/tests/test_chat_general_route_mapping.py \
  services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py -q   # 29 passed
```

## Evals run

No dedicated eval harness for prompt-quality regressions of this kind; live verification plan below.

## Docker/build/smoke checks

Not yet applied live -- deploy plan: since `orion/cognition/prompts/*.j2` are shared top-level files baked into `orion-cortex-exec`'s image, rebuild+restart that service; apply the new ai-town patch on athena's live `upstream/` checkout (already verified test-appliable) and rebuild+restart `orion-ai-town`; restart `orion-embodiment` for the `metadata["surface"]` wiring. Verify via a fresh hub chat turn (should no longer reference ai-town content as if mid-scene) and by watching for the anti-repetition instruction taking effect in both Orion's and native NPCs' dialogue over the next several ai-town conversations.

## Review findings fixed

- Finding: `_request_utterance_cortex` set `surface_context.surface = "aitown"`, a different key than what `chat_general.j2`'s new block reads (`metadata.surface`) -- so the "mirrored for consistency in case unified mode is ever enabled" claim didn't actually hold; if enabled, ai-town speech would get the wrong (non-aitown) framing.
  - Fix: added `metadata["surface"] = "aitown"` to `_request_utterance_cortex` alongside the existing `surface_context` field.
  - Evidence: full embodiment suite re-run clean (80 passed).
- Finding: the new "you are talking directly with Juniper" framing is a new affirmative claim that would be factually wrong for a third, rare surface (`orion-social-room-bridge` can theoretically be configured to use the `chat_quick` verb for talking to other humans in a social room, not Juniper) -- discouraged config, not the live path, but worth not compounding.
  - Fix: reworded both templates' non-aitown branch to "You are not currently in ai-town" (drops the specific Juniper claim in this new block; the template's many *pre-existing*, unrelated Juniper-specific instructions elsewhere are unchanged and out of scope for this PR).
  - Evidence: updated the 2 affected test assertions; full cortex-exec targeted suite re-run clean (29 passed).
- Noted, not fixed (pre-existing, out of scope): no `ctx.setdefault("metadata", {})` was found anywhere in cortex-exec's context-building pipeline, so a hypothetical future `chat_quick` caller that omits `context.metadata` entirely would hit the same `UndefinedError` this PR's test fix worked around. Both real live callers (hub, embodiment) always set a non-empty `metadata` dict today, and the earlier `aitown_participant_continuity` feature (which made the same assumption) hasn't caused a live incident -- flagging for awareness, not fixing here.

## Restart required

```bash
# On athena, from a worktree (not the shared checkout):
cd services/orion-ai-town && bash scripts/apply_upstream_patches.sh   # picks up the new patch
cd ../..
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 bash scripts/safe_docker_build.sh orion-ai-town build
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 bash scripts/safe_docker_build.sh orion-ai-town up -d
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 bash scripts/safe_docker_build.sh orion-cortex-exec build
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 bash scripts/safe_docker_build.sh orion-cortex-exec up -d
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 bash scripts/safe_docker_build.sh orion-embodiment build
ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 bash scripts/safe_docker_build.sh orion-embodiment up -d
```

## Risks / concerns

- Severity: low
- Concern: restarts three live, shared services.
- Mitigation: additive prompt changes (existing behavior for callers that already worked is unchanged in substance, just better-framed); verify health endpoints post-restart.
- Severity: low
- Concern: the ai-town upstream patch touches vendored third-party code; if upstream drifts before this is applied, the patch could fail to apply cleanly on a future fresh clone.
- Mitigation: `apply_upstream_patches.sh`'s existing reverse-check-first logic reports a clean "does not apply cleanly" error rather than silently skipping or corrupting the file, per its established pattern for every other patch in this list.

## PR link
(filled in below)