### PR TITLE
feat(substrate-runtime): consumer patch for codebase-mass domain

### DIFF
--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -153,6 +153,31 @@ class CodebaseMassBaseline:
     pr: _DomainEwmaBaseline = field(default_factory=_DomainEwmaBaseline)
     graph: _DomainEwmaBaseline = field(default_factory=_DomainEwmaBaseline)
 
+    def to_json_dict(self) -> dict:
+        """Wire format for the consumer patch's ``substrate_codebase_mass_baseline``
+        table (docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md,
+        "Producer + consumer patch design") -- same
+        ``dataclasses.dataclass`` -> ``dict`` -> ``jsonb`` convention
+        ``orion/structural_mass/snapshot_history.py::GraphSnapshotStats`` already
+        uses, not a new pattern invented here."""
+        return {
+            "git": {"ewma": self.git.ewma, "variance": self.git.variance, "n": self.git.n},
+            "pr": {"ewma": self.pr.ewma, "variance": self.pr.variance, "n": self.pr.n},
+            "graph": {"ewma": self.graph.ewma, "variance": self.graph.variance, "n": self.graph.n},
+        }
+
+    @classmethod
+    def from_json_dict(cls, data: dict) -> "CodebaseMassBaseline":
+        def _sub(key: str) -> _DomainEwmaBaseline:
+            raw = data.get(key) or {}
+            return _DomainEwmaBaseline(
+                ewma=float(raw.get("ewma", 0.0)),
+                variance=float(raw.get("variance", 0.0)),
+                n=int(raw.get("n", 0)),
+            )
+
+        return cls(git=_sub("git"), pr=_sub("pr"), graph=_sub("graph"))
+
 
 @dataclass(frozen=True)
 class CodebasePredictionErrorResult:

--- a/orion/substrate/tests/test_prediction_error.py
+++ b/orion/substrate/tests/test_prediction_error.py
@@ -663,6 +663,38 @@ class TestBusSynapticPredictionError:
         assert bus_synaptic_prediction_error([0.0, 3.0]) == pytest.approx(0.3188367996970756)
 
 
+class TestCodebaseMassBaselineSerialization:
+    """Wire-format round-trip for the consumer patch's
+    substrate_codebase_mass_baseline table -- CodebaseMassBaseline.to_json_dict()/
+    from_json_dict()."""
+
+    def test_round_trip_preserves_all_three_sub_baselines(self) -> None:
+        baseline = CodebaseMassBaseline(
+            git=_DomainEwmaBaseline(ewma=1.5, variance=2.5, n=3),
+            pr=_DomainEwmaBaseline(ewma=4.5, variance=5.5, n=6),
+            graph=_DomainEwmaBaseline(ewma=7.5, variance=8.5, n=9),
+        )
+        restored = CodebaseMassBaseline.from_json_dict(baseline.to_json_dict())
+        assert restored == baseline
+
+    def test_round_trip_default_baseline(self) -> None:
+        baseline = CodebaseMassBaseline()
+        restored = CodebaseMassBaseline.from_json_dict(baseline.to_json_dict())
+        assert restored == baseline
+
+    def test_from_json_dict_tolerates_missing_keys(self) -> None:
+        """A row from before some future field addition, or a hand-edited
+        JSON blob missing a sub-domain entirely, must not crash -- defaults
+        to a fresh cold-start sub-baseline for whatever's missing."""
+        restored = CodebaseMassBaseline.from_json_dict({"git": {"ewma": 1.0, "variance": 2.0, "n": 3}})
+        assert restored.git == _DomainEwmaBaseline(ewma=1.0, variance=2.0, n=3)
+        assert restored.pr == _DomainEwmaBaseline()
+        assert restored.graph == _DomainEwmaBaseline()
+
+    def test_from_json_dict_empty_dict_is_fresh_baseline(self) -> None:
+        assert CodebaseMassBaseline.from_json_dict({}) == CodebaseMassBaseline()
+
+
 class TestCodebasePredictionError:
     """Contract patch (docs/superpowers/specs/2026-07-30-codebase-mass-signal-
     design.md) -- composite scoring across all three structural_mass producer

--- a/services/orion-sql-db/manual_migration_codebase_mass_baseline_v1.sql
+++ b/services/orion-sql-db/manual_migration_codebase_mass_baseline_v1.sql
@@ -1,0 +1,40 @@
+-- Append-only store for CodebaseMassBaseline (codebase-mass domain's
+-- three-domain EWMA state -- orion/substrate/prediction_error.py's
+-- codebase_prediction_error()), one row per real consumer tick.
+--
+-- Same shape as manual_migration_attention_self_model_v1.sql, and for the
+-- identical reason: this domain's EWMA baseline has no persisted reducer
+-- projection to live on (unlike the other five domains in
+-- orion/substrate/prediction_error.py, each of which stores its own
+-- baseline directly on a projection object) -- see
+-- docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md's
+-- "Producer + consumer patch design" section for the full reasoning,
+-- including why the originally-proposed alternative (piggyback on
+-- node:substrate.codebase's own ConceptNodeV1.metadata) was verified wrong:
+-- services/orion-substrate-runtime/app/worker.py::_write_prediction_error_node()
+-- builds a fresh metadata dict every call, carrying forward only a narrow,
+-- dynamics-engine-owned key allowlist -- a custom baseline key there would
+-- be silently dropped on the very next write.
+--
+-- Deliberately a brand-new table with exactly one writer
+-- (services/orion-substrate-runtime/app/worker.py's
+-- _codebase_delta_listener_loop(), gated behind
+-- SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE) -- this repo has a
+-- documented, repeated failure class of a periodic tick clobbering a field
+-- it doesn't exclusively own (execution_load cross-lane stomp PR #1338,
+-- orion-field-digester's generic decay clobber, SubstrateDynamicsEngine.
+-- tick()'s bus_synaptic clobber PR #1449). A table nothing else has ever
+-- written to makes that failure class structurally impossible here, not
+-- just avoided by convention.
+--
+-- Apply: psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_codebase_mass_baseline_v1.sql
+
+create table if not exists substrate_codebase_mass_baseline (
+    baseline_id text primary key,
+    generated_at timestamptz not null,
+    baseline_json jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_codebase_mass_baseline_generated
+    on substrate_codebase_mass_baseline(generated_at desc);

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -226,6 +226,14 @@ EMBODIMENT_DRIVES_STATE_CHANNEL=orion:memory:drives:state
 # Consumed for the brain-frame field_anomaly dimension. Producer: orion-field-digester's
 # mood-arc reconstruction-error scorer (app/anomaly_scorer.py).
 FIELD_CHANNEL_ANOMALY_SCORE_CHANNEL=orion:field_channel:anomaly_score
+# codebase_prediction_error consumer (docs/superpowers/specs/2026-07-30-codebase-mass-
+# signal-design.md). Producer: orion-cocreation-signals. Default-off, matching every
+# other tick in this service -- flip only after a live-data sanity check against the
+# new substrate_codebase_mass_baseline table (apply
+# manual_migration_codebase_mass_baseline_v1.sql first).
+SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE=false
+CHANNEL_CODEBASE_DELTA=orion:substrate:codebase_delta
+SUBSTRATE_CODEBASE_MASS_BASELINE_RETENTION_DAYS=30.0
 # --- Computed salience v2 (shadow-first, default-off) ---
 ORION_ATTENTION_SALIENCE_V2_ENABLED=true
 ORION_ATTENTION_HABITUATION_ENABLED=true

--- a/services/orion-substrate-runtime/app/settings.py
+++ b/services/orion-substrate-runtime/app/settings.py
@@ -259,6 +259,30 @@ class Settings(BaseSettings):
     field_channel_anomaly_score_channel: str = Field(
         "orion:field_channel:anomaly_score", alias="FIELD_CHANNEL_ANOMALY_SCORE_CHANNEL"
     )
+    # codebase_prediction_error consumer (docs/superpowers/specs/2026-07-30-
+    # codebase-mass-signal-design.md, "Producer + consumer patch design").
+    # Own dedicated flag, not piggybacked on SUBSTRATE_WRITE_PREDICTION_ERROR_NODES
+    # -- same reasoning as SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED above: this
+    # domain has a materially different risk surface (external I/O lives in
+    # a separate service, orion-cocreation-signals, but the consumer side
+    # here adds a new Postgres table + a new bus subscription, not a
+    # reducer-projection read like the other five domains). Default-off,
+    # matching every other tick in this file -- flip only after a live-data
+    # sanity check against the new substrate_codebase_mass_baseline table.
+    enable_codebase_prediction_error_node: bool = Field(
+        False, alias="SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE"
+    )
+    codebase_delta_channel: str = Field(
+        "orion:substrate:codebase_delta", alias="CHANNEL_CODEBASE_DELTA"
+    )
+    # Append-only substrate_codebase_mass_baseline retention -- this domain's
+    # tick cadence is far coarser than the AST self-model's (real events at
+    # minutes-to-hours granularity, not a 30s broadcast cadence), so 30 days
+    # is a real-world-comparable window, not copied verbatim from
+    # ORION_ATTENTION_BROADCAST_LOG_RETENTION_HOURS's 7-day default.
+    codebase_mass_baseline_retention_days: float = Field(
+        30.0, alias="SUBSTRATE_CODEBASE_MASS_BASELINE_RETENTION_DAYS"
+    )
 
     # Health monitor -> orion-notify attention alerts. Edge-triggered (fires only
     # on healthy->unhealthy transitions), not polled-and-spammed.

--- a/services/orion-substrate-runtime/app/store.py
+++ b/services/orion-substrate-runtime/app/store.py
@@ -24,6 +24,7 @@ from orion.schemas.transport_projection import TransportBusProjectionV1
 from orion.schemas.grammar import GrammarEventV1
 from orion.schemas.organ_emission import OrganEmissionV1
 from orion.schemas.reduction_receipt import ReductionReceiptV1
+from orion.substrate.prediction_error import CodebaseMassBaseline
 from orion.core.schemas.substrate_episodes import EpisodeSummaryV1
 from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
 from orion.schemas.attention_self_model import AttentionSelfModelV1
@@ -644,6 +645,81 @@ class BiometricsSubstrateStore:
         except Exception:
             logger.exception("substrate_attention_self_model_field_frame_load_failed")
             return None
+
+    def get_latest_codebase_mass_baseline(self) -> CodebaseMassBaseline:
+        """Latest row from `substrate_codebase_mass_baseline`, or a fresh
+        cold-start baseline if none exists yet (a real, honest "no history
+        yet" state -- not an error, matches every other domain's own
+        cold-start handling in orion/substrate/prediction_error.py)."""
+        try:
+            with self._engine.connect() as conn:
+                row = conn.execute(
+                    text(
+                        """
+                        SELECT baseline_json FROM substrate_codebase_mass_baseline
+                        ORDER BY generated_at DESC LIMIT 1
+                        """
+                    )
+                ).mappings().first()
+            if not row:
+                return CodebaseMassBaseline()
+            payload = row["baseline_json"]
+            if isinstance(payload, str):
+                payload = json.loads(payload)
+            if not isinstance(payload, dict):
+                return CodebaseMassBaseline()
+            return CodebaseMassBaseline.from_json_dict(payload)
+        except Exception:
+            logger.exception("substrate_codebase_mass_baseline_load_failed")
+            return CodebaseMassBaseline()
+
+    def save_codebase_mass_baseline(
+        self, baseline: CodebaseMassBaseline, *, retention_days: float
+    ) -> None:
+        """Append one CodebaseMassBaseline row per real consumer tick; prunes
+        rows beyond retention.
+
+        `substrate_codebase_mass_baseline` has exactly one writer in the
+        whole repo -- this method, called only from
+        `_codebase_delta_listener_loop()`'s message handler. Same
+        single-writer, brand-new-table reasoning as
+        `save_attention_self_model()` above (see that method's own
+        docstring) -- confirmed necessary here specifically because the
+        originally-proposed alternative (piggyback on
+        `node:substrate.codebase`'s own metadata) was verified wrong: see
+        `manual_migration_codebase_mass_baseline_v1.sql`'s own comment.
+        """
+        generated_at = datetime.now(timezone.utc)
+        digest = hashlib.sha256(
+            f"{generated_at.isoformat()}|{json.dumps(baseline.to_json_dict(), sort_keys=True)}".encode("utf-8")
+        ).hexdigest()[:24]
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO substrate_codebase_mass_baseline (
+                        baseline_id, generated_at, baseline_json, created_at
+                    ) VALUES (
+                        :baseline_id, :generated_at, :baseline_json, :created_at
+                    )
+                    ON CONFLICT (baseline_id) DO NOTHING
+                    """
+                ),
+                {
+                    "baseline_id": f"codebase-mass-baseline-{digest}",
+                    "generated_at": generated_at,
+                    "baseline_json": Json(baseline.to_json_dict()),
+                    "created_at": generated_at,
+                },
+            )
+            conn.execute(
+                text(
+                    f"""
+                    DELETE FROM substrate_codebase_mass_baseline
+                    WHERE generated_at < now() - interval '{float(retention_days)} days'
+                    """
+                ),
+            )
 
     def save_attention_self_model(
         self, model: AttentionSelfModelV1, *, retention_hours: float

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -19,10 +19,14 @@ from orion.schemas.biometrics_projection import (
     ActiveNodePressureProjectionV1,
     NodeBiometricsProjectionV1,
 )
+from orion.schemas.codebase_delta import CodebaseDeltaV1
 from orion.schemas.grammar import GrammarEventV1
 from orion.schemas.harness_finalize import HarnessPostTurnClosureV1
 from orion.schemas.reduction_receipt import ReductionReceiptV1
 from orion.schemas.telemetry.field_channel_anomaly_score import FieldChannelAnomalyScoreV1
+from orion.structural_mass.git_delta import GitChurnDelta
+from orion.structural_mass.graph_delta import GraphStructuralDelta
+from orion.structural_mass.pr_lifecycle import PrLifecycleDelta
 from orion.substrate.biometrics_loop.constants import (
     ACTIVE_NODE_PRESSURE_PROJECTION_ID,
     GRAMMAR_CURSOR_NAME,
@@ -44,9 +48,11 @@ from orion.substrate.transport_loop.constants import (
     TRANSPORT_GRAMMAR_CURSOR_NAME,
 )
 from orion.substrate.prediction_error import (
+    CodebaseMassBaseline,
     biometrics_prediction_error,
     bus_synaptic_prediction_error,
     chat_prediction_error,
+    codebase_prediction_error,
     execution_prediction_error,
     route_prediction_error,
 )
@@ -94,6 +100,15 @@ _HARNESS_CLOSURE_UNRESOLVED_ERROR = 0.65
 # upserts to and the domain names orion.substrate.attention_self_model expects in
 # prediction_error_by_domain. node:substrate.harness_closure is intentionally
 # excluded -- it is not one of that reducer's recognized domains.
+# node:substrate.codebase (codebase_prediction_error(), 2026-07-31) is ALSO
+# intentionally excluded here, for a different reason: the design spec
+# (docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md, Phase 3)
+# explicitly defers wiring any downstream consumer -- including this reducer's
+# own prediction_error_by_domain -- until Phase 1's replay reads MET. Confirmed
+# live by code review 2026-07-31: without this comment, a future "complete the
+# domain parity" pass could add this entry without realizing that decision was
+# already made deliberately, not an oversight. Revisit only alongside a real
+# Phase 3 patch, not as a drive-by fix.
 _PREDICTION_ERROR_DOMAIN_NODE_IDS = {
     "node:substrate.execution": "execution",
     "node:substrate.transport": "transport",
@@ -343,6 +358,18 @@ class BiometricsSubstrateWorker:
                 asyncio.create_task(
                     self._field_channel_anomaly_listener_loop(),
                     name="substrate-field-channel-anomaly-listener",
+                )
+            )
+        # codebase_prediction_error consumer (docs/superpowers/specs/2026-07-
+        # 30-codebase-mass-signal-design.md). Own dedicated flag, default off
+        # -- see SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE's own comment
+        # in settings.py for why this doesn't reuse
+        # SUBSTRATE_WRITE_PREDICTION_ERROR_NODES.
+        if self._bus is not None and s.enable_codebase_prediction_error_node:
+            self._tasks.append(
+                asyncio.create_task(
+                    self._codebase_delta_listener_loop(),
+                    name="substrate-codebase-delta-listener",
                 )
             )
 
@@ -1335,6 +1362,122 @@ class BiometricsSubstrateWorker:
             return
         self._latest_field_anomaly = score
         self._latest_field_anomaly_at = datetime.now(timezone.utc)
+
+    async def _codebase_delta_listener_loop(self) -> None:
+        """Subscribe to the codebase-mass domain's bus channel and score+write
+        each real event (docs/superpowers/specs/2026-07-30-codebase-mass-
+        signal-design.md, "Producer + consumer patch design").
+
+        Mirrors `_field_channel_anomaly_listener_loop`'s subscribe shape, but
+        does real work per message rather than caching a value: reads the
+        persisted `CodebaseMassBaseline` (own dedicated table, see
+        `store.get_latest_codebase_mass_baseline()`'s own docstring for why
+        this domain can't reuse `_write_prediction_error_node()`'s node
+        metadata the way it was first proposed), reconstructs whichever one
+        of git/pr_lifecycle/graph the event carries, scores it via
+        `codebase_prediction_error()`, writes the score to
+        `node:substrate.codebase` via the same shared
+        `_write_prediction_error_node()` writer every other domain uses, and
+        persists the updated baseline for the next tick. This service still
+        does zero external I/O of its own for this domain -- all git/GitHub/
+        graphify access lives in `orion-cocreation-signals`, the producer of
+        this channel.
+        """
+        channel = self._settings.codebase_delta_channel
+        logger.info("substrate_codebase_delta_listener subscribing channel=%s", channel)
+        try:
+            async with self._bus.subscribe(channel) as pubsub:
+                while not self._stop.is_set():
+                    try:
+                        msg = await asyncio.wait_for(
+                            pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
+                            timeout=1.2,
+                        )
+                    except asyncio.TimeoutError:
+                        continue
+                    except asyncio.CancelledError:
+                        break
+                    if not msg or msg.get("type") not in ("message", "pmessage"):
+                        continue
+                    try:
+                        await asyncio.to_thread(self._handle_codebase_delta_message, msg)
+                    except Exception:
+                        logger.exception("substrate_codebase_delta_handle_failed")
+        except asyncio.CancelledError:
+            raise
+        finally:
+            logger.info("substrate_codebase_delta_listener stopped channel=%s", channel)
+
+    def _handle_codebase_delta_message(self, raw_msg: dict[str, Any]) -> None:
+        decoded = self._bus.codec.decode(raw_msg.get("data"))
+        if not decoded.ok:
+            logger.warning("substrate_codebase_delta_decode_failed: %s", decoded.error)
+            return
+        try:
+            event = CodebaseDeltaV1.model_validate(decoded.envelope.payload or {})
+        except ValueError as exc:
+            logger.error("substrate_codebase_delta_invalid err=%s", exc)
+            return
+
+        git_delta = pr_delta = graph_delta = None
+        if event.domain == "git" and event.git is not None:
+            g = event.git
+            git_delta = GitChurnDelta(
+                prev_sha=g.prev_sha, head_sha=g.head_sha, commit_count=g.commit_count,
+                files_added=g.files_added, files_deleted=g.files_deleted,
+                files_modified=g.files_modified, lines_added=g.lines_added,
+                lines_removed=g.lines_removed,
+            )
+        elif event.domain == "pr_lifecycle" and event.pr_lifecycle is not None:
+            p = event.pr_lifecycle
+            pr_delta = PrLifecycleDelta(
+                since=p.since, until=p.until, submitted_count=p.submitted_count,
+                merged_count=p.merged_count, closed_without_merge_count=p.closed_without_merge_count,
+                submitted_numbers=tuple(p.submitted_numbers), merged_numbers=tuple(p.merged_numbers),
+                closed_without_merge_numbers=tuple(p.closed_without_merge_numbers),
+                possibly_truncated=p.possibly_truncated,
+            )
+        elif event.domain == "graph" and event.graph is not None:
+            gr = event.graph
+            graph_delta = GraphStructuralDelta(
+                node_count_delta=gr.node_count_delta, edge_count_delta=gr.edge_count_delta,
+                community_count_delta=gr.community_count_delta,
+                god_node_jaccard_similarity=gr.god_node_jaccard_similarity,
+                god_nodes_entered=tuple(gr.god_nodes_entered) if gr.god_nodes_entered is not None else None,
+                god_nodes_exited=tuple(gr.god_nodes_exited) if gr.god_nodes_exited is not None else None,
+            )
+        else:
+            # Schema-illegal given CodebaseDeltaV1's own model_validator (the
+            # producer can't construct/publish this shape), but a live
+            # consumer must not trust a wire payload just because the
+            # producer's own validator would have rejected it -- fail open,
+            # not silently proceed with three None deltas (a real
+            # codebase_prediction_error() call with nothing populated is a
+            # legitimate "no-op tick" elsewhere; here it would misrepresent a
+            # decode-time data problem as one).
+            logger.error(
+                "substrate_codebase_delta_domain_field_mismatch domain=%s", event.domain
+            )
+            return
+
+        baseline = self._store.get_latest_codebase_mass_baseline()
+        result = codebase_prediction_error(
+            git_delta=git_delta, pr_delta=pr_delta, graph_delta=graph_delta, baseline=baseline,
+        )
+        now = datetime.now(timezone.utc)
+        self._write_prediction_error_node(
+            node_id="node:substrate.codebase",
+            error=result.score,
+            now=now,
+            reducer_key="codebase",
+        )
+        self._store.save_codebase_mass_baseline(
+            result.baseline, retention_days=self._settings.codebase_mass_baseline_retention_days,
+        )
+        logger.info(
+            "substrate_codebase_delta_scored domain=%s score=%.3f",
+            event.domain, result.score,
+        )
 
     async def _perception_ingest_loop(self) -> None:
         """Subscribe to town perception and fold it into the substrate graph.

--- a/services/orion-substrate-runtime/tests/test_store_codebase_mass_baseline.py
+++ b/services/orion-substrate-runtime/tests/test_store_codebase_mass_baseline.py
@@ -1,0 +1,129 @@
+"""Unit tests for the codebase-mass consumer patch's two new store methods
+(docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md, "Producer
++ consumer patch design"): `get_latest_codebase_mass_baseline` (cold-start-
+tolerant read) and `save_codebase_mass_baseline` (this tick's sole write
+path, into a table nothing else in the repo touches).
+
+Mocked here (same pattern as the sibling test_store_attention_self_model.py
+uses); the round trip against a real Postgres instance was verified directly
+during development -- see this patch's PR report.
+"""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SUBSTRATE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SUBSTRATE_ROOT))
+
+from orion.substrate.prediction_error import CodebaseMassBaseline, _DomainEwmaBaseline
+
+
+class _RecordingEngine:
+    def __init__(self, first_row=None):
+        self.executed = []
+        self._first_row = first_row
+
+    @contextmanager
+    def begin(self):
+        conn = MagicMock()
+
+        def execute(stmt, params=None):
+            self.executed.append((str(stmt), params))
+            return MagicMock()
+
+        conn.execute.side_effect = execute
+        yield conn
+
+    @contextmanager
+    def connect(self):
+        conn = MagicMock()
+
+        def execute(stmt, params=None):
+            self.executed.append((str(stmt), params))
+            m = MagicMock()
+            m.mappings.return_value.first.return_value = self._first_row
+            return m
+
+        conn.execute.side_effect = execute
+        yield conn
+
+
+def _store_with(engine):
+    from app.store import BiometricsSubstrateStore
+
+    store = BiometricsSubstrateStore.__new__(BiometricsSubstrateStore)
+    store._engine = engine
+    return store
+
+
+def test_get_latest_codebase_mass_baseline_parses_row():
+    baseline = CodebaseMassBaseline(
+        git=_DomainEwmaBaseline(ewma=1.0, variance=2.0, n=3),
+        pr=_DomainEwmaBaseline(ewma=4.0, variance=5.0, n=6),
+        graph=_DomainEwmaBaseline(ewma=7.0, variance=8.0, n=9),
+    )
+    row = {"baseline_json": baseline.to_json_dict()}
+    eng = _RecordingEngine(first_row=row)
+    store = _store_with(eng)
+
+    restored = store.get_latest_codebase_mass_baseline()
+
+    assert restored == baseline
+    sql = eng.executed[0][0]
+    assert "SELECT baseline_json FROM substrate_codebase_mass_baseline" in sql
+    assert "ORDER BY generated_at DESC" in sql
+
+
+def test_get_latest_codebase_mass_baseline_returns_fresh_when_empty():
+    """No row yet is a real, honest cold-start state -- a fresh baseline, not
+    None and not an error (matches every domain's own cold-start handling in
+    orion/substrate/prediction_error.py, unlike get_latest_field_attention_
+    frame's None-on-empty, since CodebaseMassBaseline's own default IS the
+    correct cold-start value, not an absence to special-case downstream)."""
+    eng = _RecordingEngine(first_row=None)
+    store = _store_with(eng)
+    assert store.get_latest_codebase_mass_baseline() == CodebaseMassBaseline()
+
+
+def test_get_latest_codebase_mass_baseline_fails_open_on_error():
+    eng = MagicMock()
+    eng.connect.side_effect = RuntimeError("db down")
+    store = _store_with(eng)
+    assert store.get_latest_codebase_mass_baseline() == CodebaseMassBaseline()  # must not raise
+
+
+def test_get_latest_codebase_mass_baseline_handles_string_encoded_json():
+    """Some drivers return jsonb as a raw string, not a pre-parsed dict --
+    matches get_latest_field_attention_frame's own defensive handling."""
+    baseline = CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=1.0, variance=2.0, n=3))
+    import json as _json
+
+    row = {"baseline_json": _json.dumps(baseline.to_json_dict())}
+    eng = _RecordingEngine(first_row=row)
+    store = _store_with(eng)
+    assert store.get_latest_codebase_mass_baseline() == baseline
+
+
+def test_save_codebase_mass_baseline_inserts_and_prunes():
+    eng = _RecordingEngine()
+    store = _store_with(eng)
+    baseline = CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=1.0, variance=2.0, n=3))
+
+    store.save_codebase_mass_baseline(baseline, retention_days=30.0)
+
+    sqls = " ".join(s for s, _ in eng.executed)
+    assert "INSERT INTO substrate_codebase_mass_baseline" in sqls
+    assert "DELETE FROM substrate_codebase_mass_baseline" in sqls
+    assert "30.0 days" in sqls
+    insert_params = eng.executed[0][1]
+    assert insert_params["baseline_id"].startswith("codebase-mass-baseline-")
+    assert insert_params["baseline_json"].adapted == baseline.to_json_dict()

--- a/services/orion-substrate-runtime/tests/test_worker_codebase_delta_consumer.py
+++ b/services/orion-substrate-runtime/tests/test_worker_codebase_delta_consumer.py
@@ -1,0 +1,156 @@
+"""Unit tests for the codebase-mass consumer patch's message handler
+(docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md, "Producer
++ consumer patch design"): `_handle_codebase_delta_message`.
+
+Uses the real OrionCodec to encode/decode a real CodebaseDeltaV1-carrying
+BaseEnvelope (genuine wire round-trip), with the store and
+_write_prediction_error_node mocked -- those are already covered by
+test_store_codebase_mass_baseline.py and test_worker_prediction_error_node.py
+respectively.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+for path in (REPO_ROOT, SUBSTRATE_ROOT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from app.worker import BiometricsSubstrateWorker
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.codec import OrionCodec
+from orion.schemas.codebase_delta import (
+    CodebaseDeltaV1,
+    GitDeltaPayloadV1,
+    GraphDeltaPayloadV1,
+    PrLifecycleDeltaPayloadV1,
+)
+from orion.substrate.prediction_error import CodebaseMassBaseline, _DomainEwmaBaseline
+
+_NOW = datetime(2026, 7, 31, tzinfo=timezone.utc)
+_SOURCE = ServiceRef(name="cocreation-signals", version="0.1.0", node="athena")
+
+
+def _encode(event: CodebaseDeltaV1) -> dict:
+    codec = OrionCodec()
+    envelope = BaseEnvelope(
+        kind="substrate.codebase_delta.v1", source=_SOURCE, payload=event.model_dump(mode="json")
+    )
+    return {"type": "message", "data": codec.encode(envelope)}
+
+
+def _make_worker(*, baseline: CodebaseMassBaseline | None = None) -> tuple[BiometricsSubstrateWorker, MagicMock, MagicMock]:
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._bus = MagicMock()
+    worker._bus.codec = OrionCodec()
+    fake_store = MagicMock()
+    fake_store.get_latest_codebase_mass_baseline.return_value = baseline or CodebaseMassBaseline()
+    worker._store = fake_store
+    worker._settings = MagicMock()
+    worker._settings.codebase_mass_baseline_retention_days = 30.0
+    fake_write = MagicMock()
+    worker._write_prediction_error_node = fake_write
+    return worker, fake_store, fake_write
+
+
+def test_git_domain_scores_and_persists() -> None:
+    worker, fake_store, fake_write = _make_worker(
+        baseline=CodebaseMassBaseline(git=_DomainEwmaBaseline(ewma=500.0, variance=10_000.0, n=5))
+    )
+    event = CodebaseDeltaV1(
+        domain="git",
+        observed_at=_NOW,
+        git=GitDeltaPayloadV1(
+            prev_sha="a" * 40, head_sha="b" * 40, commit_count=1,
+            files_added=0, files_deleted=0, files_modified=1,
+            lines_added=520, lines_removed=0,
+        ),
+    )
+    worker._handle_codebase_delta_message(_encode(event))
+
+    fake_write.assert_called_once()
+    _, kwargs = fake_write.call_args
+    assert kwargs["node_id"] == "node:substrate.codebase"
+    assert kwargs["reducer_key"] == "codebase"
+    assert kwargs["error"] == pytest.approx(0.2 / 3.0)  # zscore (520-500)/sqrt(10000)=0.2
+
+    fake_store.save_codebase_mass_baseline.assert_called_once()
+    saved_baseline, save_kwargs = fake_store.save_codebase_mass_baseline.call_args
+    assert saved_baseline[0].git.n == 6
+    assert save_kwargs["retention_days"] == 30.0
+
+
+def test_pr_lifecycle_domain_scores() -> None:
+    worker, fake_store, fake_write = _make_worker()
+    event = CodebaseDeltaV1(
+        domain="pr_lifecycle",
+        observed_at=_NOW,
+        pr_lifecycle=PrLifecycleDeltaPayloadV1(
+            since=_NOW, until=_NOW, submitted_count=3, merged_count=2, closed_without_merge_count=0,
+        ),
+    )
+    worker._handle_codebase_delta_message(_encode(event))
+
+    fake_write.assert_called_once()
+    fake_store.save_codebase_mass_baseline.assert_called_once()
+    saved_baseline = fake_store.save_codebase_mass_baseline.call_args[0][0]
+    assert saved_baseline.pr.n == 1
+    assert saved_baseline.git.n == 0  # untouched -- this tick only carried pr_lifecycle
+
+
+def test_graph_domain_scores_with_none_jaccard() -> None:
+    """god_node_jaccard_similarity=None (unparseable upstream) must survive
+    through the whole real decode -> reconstruct -> score path without
+    crashing or getting coerced."""
+    worker, fake_store, fake_write = _make_worker()
+    event = CodebaseDeltaV1(
+        domain="graph",
+        observed_at=_NOW,
+        graph=GraphDeltaPayloadV1(
+            node_count_delta=-40, edge_count_delta=-110, community_count_delta=-3,
+            god_node_jaccard_similarity=None,
+        ),
+    )
+    worker._handle_codebase_delta_message(_encode(event))
+
+    fake_write.assert_called_once()
+    fake_store.save_codebase_mass_baseline.assert_called_once()
+
+
+def test_malformed_wire_payload_rejected_by_schema_validation() -> None:
+    """A wire payload with domain='git' but no real git field (violates
+    CodebaseDeltaV1's own model_validator) is rejected at the
+    `CodebaseDeltaV1.model_validate()` call itself (ValidationError, a
+    ValueError subclass) -- proves the handler's decode/validate step, not
+    the separate domain-dispatch `else` branch in the handler (that branch
+    is unreachable given any *validated* CodebaseDeltaV1 instance today --
+    kept only as forward-compatible defense against a future domain Literal
+    value this consumer hasn't been updated to handle, not something a
+    current unit test can construct without bypassing pydantic entirely)."""
+    worker, fake_store, fake_write = _make_worker()
+    raw_payload = {"domain": "git", "observed_at": _NOW.isoformat(), "git": None}
+    codec = OrionCodec()
+    envelope = BaseEnvelope(kind="substrate.codebase_delta.v1", source=_SOURCE, payload=raw_payload)
+    raw_msg = {"type": "message", "data": codec.encode(envelope)}
+
+    worker._handle_codebase_delta_message(raw_msg)
+
+    fake_write.assert_not_called()
+    fake_store.get_latest_codebase_mass_baseline.assert_not_called()
+    fake_store.save_codebase_mass_baseline.assert_not_called()
+
+
+def test_decode_failure_does_not_raise() -> None:
+    worker, fake_store, fake_write = _make_worker()
+    worker._handle_codebase_delta_message({"type": "message", "data": b"not-valid-envelope-bytes"})
+    fake_write.assert_not_called()
+    fake_store.save_codebase_mass_baseline.assert_not_called()


### PR DESCRIPTION
## Summary

Consumer patch of the codebase-mass wiring arc (contract → producer → consumer, CLAUDE.md §5) — the final link from `orion-cocreation-signals` (already live-deployed, publishing real events) through to a real `node:substrate.codebase` write in `orion-substrate-runtime`.

**This modifies a live, currently-running production service.** Gated behind a new, default-off flag (`SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE`) — deploying this patch changes **zero live behavior** until that flag is explicitly flipped on, matching the established convention every other tick in `worker.py` already follows (`SUBSTRATE_DYNAMICS_TICK_ENABLED`, `SUBSTRATE_BUS_SYNAPTIC_TICK_ENABLED`, `SUBSTRATE_ATTENTION_SELF_MODEL_TICK_ENABLED`, all shipped off, flipped on only after a live-data sanity check).

## Outcome moved

The full chain (structural_mass producers → composite scoring → bus contract → producer service → consumer) is now real, tested, and ready to flip on — pending a replay/live-data check against the new table, per this program's own "measure before minting" discipline.

## Persistence design

This domain has no reducer projection to store its EWMA baseline on (unlike the other five domains in `orion/substrate/prediction_error.py`). Resolved via a dedicated, single-writer, append-only Postgres table (`substrate_codebase_mass_baseline`), modeled directly on this repo's own existing precedent for the exact same problem (`substrate_attention_self_model`) — see `manual_migration_codebase_mass_baseline_v1.sql`'s comment for why the originally-proposed alternative (piggyback on the node's own metadata) was verified wrong before building against it.

## Current architecture

Before this patch: `orion:substrate:codebase_delta` had real producers publishing to it (`orion-cocreation-signals`, live), but nothing consumed the channel — no live effect on Orion's cognition.

## Architecture touched

`services/orion-substrate-runtime`: new listener task (gated), new store methods, new settings, new migration. `orion/substrate/prediction_error.py`: new serialization helpers on `CodebaseMassBaseline`.

## Files changed

- `orion/substrate/prediction_error.py`: `CodebaseMassBaseline.to_json_dict()`/`from_json_dict()`.
- `services/orion-sql-db/manual_migration_codebase_mass_baseline_v1.sql` (new): the persistence table.
- `services/orion-substrate-runtime/app/store.py`: `get_latest_codebase_mass_baseline()` / `save_codebase_mass_baseline()`.
- `services/orion-substrate-runtime/app/settings.py`: `enable_codebase_prediction_error_node`, `codebase_delta_channel`, `codebase_mass_baseline_retention_days`.
- `services/orion-substrate-runtime/app/worker.py`: `_codebase_delta_listener_loop()` + `_handle_codebase_delta_message()`, wired into `start()`'s gated task list; explicit deferred-exclusion comment at `_PREDICTION_ERROR_DOMAIN_NODE_IDS` (review finding, see below).
- `services/orion-substrate-runtime/.env_example`: 3 new keys, default-off.
- Tests: `test_prediction_error.py` (+4), `test_store_codebase_mass_baseline.py` (new, 5), `test_worker_codebase_delta_consumer.py` (new, 5, real `OrionCodec` encode/decode round-trip).

## Schema / bus / API changes

None new — reuses `orion:substrate:codebase_delta`/`CodebaseDeltaV1` from the already-merged contract patch. New Postgres table only (migration file above).

## Env/config changes

- Added: `SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE` (default `false`), `CHANNEL_CODEBASE_DELTA` (default `orion:substrate:codebase_delta`), `SUBSTRATE_CODEBASE_MASS_BASELINE_RETENTION_DAYS` (default `30.0`).
- `.env_example` updated.
- **Real deployed `.env` synced directly** (not deferred) — added the same 3 keys with matching default-off values to `/mnt/scripts/Orion-Sapienform/services/orion-substrate-runtime/.env` on the shared checkout, per CLAUDE.md's env-parity mandate. No behavior change (values match code defaults).
- No skipped keys.

## Tests run

```
services/orion-substrate-runtime/tests/ + orion/substrate/tests/test_prediction_error.py
(excluding one pre-existing broken integration test requiring a differently-configured Postgres port,
confirmed broken on main too, unrelated to this patch):
262 passed, 16 pre-existing failures (confirmed identical on a clean main checkout with none of
this patch's changes -- none of the 16 are caused by this patch)
```

## Evals run

Real integration verification against this repo's actual local Postgres (`localhost:55432`), not just mocked unit tests:

```
$ psql -h localhost -p 55432 -U postgres -d conjourney -f services/orion-sql-db/manual_migration_codebase_mass_baseline_v1.sql
CREATE TABLE
CREATE INDEX

$ python3 -c "... store.save_codebase_mass_baseline(b, retention_days=30.0); restored = store.get_latest_codebase_mass_baseline(); assert restored == b ..."
ROUND TRIP OK
```
(test row deleted afterward — `DELETE FROM substrate_codebase_mass_baseline`)

No replay against real bus traffic yet — that's the explicit next step before flipping the flag on (see "Recommended next patch" below).

## Docker/build/smoke checks

```
$ docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
    -f services/orion-substrate-runtime/docker-compose.yml config --quiet
(exit 0, no output -- config parses cleanly with the real synced env values)
```

Read-only validation only — **did not** `docker compose up`/restart the live `orion-substrate-runtime` container as part of this PR. That's a separate, explicit step to take after this merges (see below).

## Review findings fixed

- Finding (Medium): `_PREDICTION_ERROR_DOMAIN_NODE_IDS` (feeds the brain-frame `prediction_error_by_domain` reducer) wasn't updated for the new `node:substrate.codebase`, and nothing marked that as deliberate. Once the flag is flipped on later, the node would tick live but silently never appear in this one specific reducer's output, with no record of whether that was intentional — same failure shape as this repo's own documented `transport_prediction_error`/`ACTIVE_INFERENCE_DOMAINS` incident, inverted direction.
  - Fix: added an explicit comment at the exclusion site (matching the existing `harness_closure` exclusion's own documented style) naming this as deliberate, deferred to the design spec's Phase 3, not an oversight.
  - Evidence: `services/orion-substrate-runtime/app/worker.py`, `_PREDICTION_ERROR_DOMAIN_NODE_IDS`'s own comment block.
- Everything else reviewed came back clean: "zero behavior change while off" claim verified true (gating traced end-to-end, no import-time side effects); exception safety verified sufficient (per-message try/except, matches sibling listener loops, `_write_prediction_error_node()` independently fail-open); the read-then-write baseline pattern verified race-free in the current single-task, non-replicated deployment topology (worth revisiting only if this service is ever horizontally scaled); JSON round-trip and settings naming both verified correct.

## Restart required

```text
No restart required to merge this PR — the flag defaults off, so deploying this patch (rebuilding
and restarting orion-substrate-runtime with the new code) changes zero live behavior.

A restart of the LIVE orion-substrate-runtime container IS required to pick up this patch's code at
all (new listener task exists in the binary but stays dormant until the flag flips). Exact command
(NOT run as part of this PR — flagged for explicit operator action):

  docker compose \
    --env-file .env \
    --env-file services/orion-substrate-runtime/.env \
    -f services/orion-substrate-runtime/docker-compose.yml \
    up -d --build

Given this is a live production service (unlike the brand-new orion-cocreation-signals deploy
earlier in this arc), I did not run this restart myself -- flagging it for explicit confirmation
first, per this repo's own risk-proportionality convention (new isolated service vs. an existing
service other real consumers depend on).
```

## Risks / concerns

- Severity: Low (with the flag off, as shipped)
- Concern: The flag is off, so this PR alone changes nothing live. The real next decision is when/whether to (1) restart `orion-substrate-runtime` to pick up the dormant code, and separately (2) flip `SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE=true` after a real replay against live bus traffic — both deserve their own explicit sign-off, not bundled into this PR's merge.
- Mitigation: Both are named explicitly above as separate next steps, not implied as automatic follow-ons.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1527
