### PR TITLE
fix(field-attention): persist EWMA baseline for precision-weighted salience, gate goal-provenance on confidence

### DIFF
--- a/orion/attention/field_attention/builder.py
+++ b/orion/attention/field_attention/builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from orion.attention.field_attention.candidate_precision_weighted import PrecisionEwmaBaseline
 from orion.attention.field_attention.policy import FieldAttentionPolicyV1
 from orion.attention.field_attention.scoring import clamp01
 from orion.attention.field_attention.selectors import (
@@ -22,7 +23,7 @@ def build_attention_frame(
     *,
     field: FieldStateV1,
     policy: FieldAttentionPolicyV1,
-    prediction_error_histories: dict[str, list[float]] | None = None,
+    prediction_error_baselines: dict[str, PrecisionEwmaBaseline] | None = None,
     previous_frame: FieldAttentionFrameV1 | None = None,
     now: datetime | None = None,
 ) -> FieldAttentionFrameV1:
@@ -35,15 +36,23 @@ def build_attention_frame(
     relative to its own history" as its core theory; a second, hand-tuned
     novelty layer on top of it would reintroduce exactly the disease this
     patch removes -- deliberate asymmetry, not an oversight).
-    `prediction_error_histories` is Candidate A's real input:
-    {node_id: real historical error series}, caller-fetched
-    (`AttentionRuntimeStore.load_prediction_error_history`) so this stays a
-    pure function -- see `select_node_targets`'s own docstring.
+
+    `prediction_error_baselines` is Candidate A's real input: {node_id:
+    PrecisionEwmaBaseline}, a persisted, incrementally-updated running
+    baseline per target, caller-fetched/advanced
+    (`AttentionRuntimeStore.advance_node_prediction_error_baseline`) so this
+    stays a pure function -- see `select_node_targets`'s own docstring.
+    2026-07-30 fix (Sentience Striving Program officer review, `orion/
+    sentience_striving_program/README.md` §12): was `prediction_error_
+    histories: dict[str, list[float]]`, a raw ASC-by-time error history
+    re-fetched fresh from a ~30-minute rolling retention window every tick
+    -- replaced with a persisted baseline whose observation count survives
+    that window's own pruning, per that section's full incident record.
     """
     generated_at = now or datetime.now(timezone.utc)
 
     node_targets = select_node_targets(
-        field, policy, prediction_error_histories or {}
+        field, policy, prediction_error_baselines or {}
     ) + select_host_targets(field, policy, previous_frame)
     capability_targets = select_capability_targets(field, policy, previous_frame)
     system_targets = select_system_targets(field, policy)

--- a/orion/attention/field_attention/candidate_precision_weighted.py
+++ b/orion/attention/field_attention/candidate_precision_weighted.py
@@ -93,18 +93,128 @@ history to compute a meaningful variance from at build time. If/when a future li
 one of those four lanes produces enough qualifying receipts, the replay script
 (`scripts/analysis/measure_precision_weighted_salience_probe.py`) will report that
 honestly rather than silently including a reducer this module was never checked against.
+
+## 2026-07-30 update: live-wired, and the rolling-window recompute was the live bug
+
+Both paragraphs above are historical (2026-07-21 build-time) record, kept as-is rather
+than rewritten -- but two of their claims are no longer accurate as of 2026-07-30 and a
+reader relying on them would be misled:
+
+- **No longer "shadow, read-only."** `selectors.py::select_node_targets` imports and
+  calls `precision_weighted_salience()`/`normalize_across_targets()` live, on every real
+  `orion-attention-runtime` tick (see that module's own 2026-07-30 docstring section).
+  Do not treat this module as inert.
+- **No longer scoped to `node_biometrics` only.** All five `PREDICTION_ERROR_NATIVE_TARGETS`
+  (`selectors.py`) are live-scored, `bus_synaptic` included (its own retirement of
+  `transport` as predecessor is documented there).
+
+**The live incident this update fixes** (found in a same-day Sentience Striving Program
+officer review, 2026-07-30 -- see `orion/sentience_striving_program/README.md` §12 for
+the full record): `precision_weighted_salience()` itself is fine and unchanged below --
+the bug was upstream, in what fed it. The original live wiring called this function with
+a freshly re-queried window from `substrate_reduction_receipts` on *every single tick*
+(`AttentionRuntimeStore.load_prediction_error_history`), and that table only retains
+success receipts for `ORION_RECEIPT_RETENTION_SUCCESS_MINUTES` (30 min live) -- a rolling
+window, not a cumulative history. Live-confirmed 2026-07-30 (~23:30-23:42 UTC):
+`node:substrate.chat` was the *only* one of the five domains with any qualifying receipts
+in that window at all (the other four sat at `n_samples=0`), with exactly `n=2` real
+samples, `variance` barely above `PRECISION_VARIANCE_FLOOR` (~1.56e-6),
+`precision=640000`, and `confidence_score=0.1` (`n_samples / QUALIFYING_MIN_ROWS`, an
+honest, correctly-computed low number). Because it was the sole real competitor,
+`normalize_across_targets()`'s own documented single-target edge case (below) correctly
+and unavoidably pinned its `salience_score` to `1.0` -- mathematically correct given the
+edge case's own contract, but the *input* feeding it (`n_samples=2`, i.e. two receipts
+that happened to survive a 30-minute prune window) was not a real basis for that
+confidence. This held for a 280+-tick live streak and repeatedly won real
+`FieldGoalProvenanceV1` publishes via `goal_provenance.py`'s dominance-streak producer,
+each one biasing real chat-level attention scoring through
+`orion/substrate/attention/goal_context.py::set_active_goal()`.
+
+**Fix**: `n_samples`/`variance` are no longer recomputed from a pruning-window-bounded
+raw list on every tick. `PrecisionEwmaBaseline` (below) is a small, persisted,
+incrementally-updated running baseline -- one row per target, advanced by exactly one
+real new `substrate_reduction_receipts` row at a time via `orion.bus.ewma.
+compute_ewma_update` (`AttentionRuntimeStore.advance_node_prediction_error_baseline`,
+`services/orion-attention-runtime/app/store.py`) -- so `observation_count` is a true,
+monotonically-increasing count of every real receipt this target has *ever* incorporated,
+never reset by the retention pruner. `precision_weighted_salience_from_baseline()` scores
+against that persisted baseline instead of a freshly recomputed population variance.
+`precision_weighted_salience(error_history: list[float])` (below) is kept exactly as it
+was -- it remains the right tool for offline/replay analysis over a full historical
+export where a persisted incremental baseline doesn't apply
+(`scripts/analysis/measure_precision_weighted_salience_probe.py`,
+`measure_candidate_a_vs_b_head_to_head.py`) -- it is simply no longer what the live tick
+path calls. As defense in depth beyond this fix, `goal_provenance.py::
+top_node_substrate_target` also now requires a minimum `confidence_score` before a target
+is eligible to win a goal-provenance publish at all, so a future single-competitor edge
+case (from a new target, or a cold-started baseline after a service/table reset) cannot
+reproduce the same failure shape even if this specific baseline fix were somehow bypassed.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+from orion.bus.ewma import compute_ewma_update
+
 # Precision = 1 / variance diverges as variance -> 0 (a target whose recent error has
 # been almost perfectly constant). This is the "variance-near-zero instability risk"
 # named in the tentative-plan doc's Candidate A section. Floored here at a concrete
 # epsilon so precision saturates at a finite ceiling (1 / PRECISION_VARIANCE_FLOOR)
 # instead of diverging to +inf or raising a ZeroDivisionError.
+#
+# Only used by `precision_weighted_salience()` (the raw-list, offline/replay path) --
+# the live EWMA-baseline path below uses `NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE`
+# instead (see that constant's own comment for why it is not simply reused here).
 PRECISION_VARIANCE_FLOOR: float = 1e-6
+
+# 2026-07-30 EWMA-baseline fix (see module docstring's "live-wired" update above).
+# `alpha` reuses `execution_prediction_error`/`codebase_prediction_error`'s own 0.2
+# (`orion/substrate/prediction_error.py`) rather than inventing a new number: like
+# those domains, this baseline advances once per real observation (one real
+# `substrate_reduction_receipts` row), not on a fixed wall-clock cadence, so the same
+# per-observation smoothing constant applies for the same reason.
+NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA: float = 0.2
+
+# Domain-specific `min_variance` for `compute_ewma_update`, replacing that function's
+# own default (`_MIN_VARIANCE=1e-6`, calibrated for orion-bus-mirror's real-time-gap-
+# in-seconds domain) -- reused blindly once already in this exact codebase
+# (`execution_prediction_error`'s first draft) and caught only after live data showed
+# the borrowed constant was five orders of magnitude off that domain's real scale.
+# Checked live here too rather than assumed clean by analogy (2026-07-30, `psql`
+# against real `substrate_reduction_receipts`, all five `PREDICTION_ERROR_NATIVE_
+# TARGETS` reducers):
+#
+#   reducer                        n    min     max   mean      variance
+#   substrate.route_arbitration    2    0.0004  0.0004 0.0004   0.0 (exact tie)
+#   substrate.chat_session         2    0.0028  0.0053 0.00405  3.12e-06
+#   substrate.node_biometrics    129    0.0003  0.2618 0.04967  2.50e-03
+#   substrate.bus_synaptic        45    0.0003  1.0    0.09944  2.92e-02
+#   substrate.execution_trajectory 91   0.0041  1.0    0.31321  1.05e-01
+#
+# Unlike `codebase_prediction_error`'s git/pr/graph sub-domains (raw magnitudes on
+# wildly different unit scales -- lines changed vs. PR counts vs. graph node/edge
+# deltas -- each needing its own floor), all five targets here are the *output* of
+# `orion/substrate/prediction_error.py`'s own instruments, which already saturate
+# every one of them to the same normalized `[0, 1]` "surprise score" scale. A single
+# shared floor is therefore the right shape (not five separate ones), but the module's
+# existing `PRECISION_VARIANCE_FLOOR` (1e-6) was never itself checked against this
+# specific value family before being reused live -- checking it now: the smallest real
+# non-degenerate variance measured (chat, 3.12e-06) sits only ~5x above 1e-6, meaning
+# that floor was providing almost no real headroom against exactly the kind of
+# coincidentally-tiny difference between two low-volume samples this whole incident is
+# about (chat's real n=2 pair differed by only ~0.0025). Raised one order of magnitude
+# to 1e-5: still four-plus orders of magnitude below every domain's real non-degenerate
+# variance observed above (biometrics 2.50e-03 is the next-smallest), so it never binds
+# for a domain with genuine spread, while giving a low-n near-tied reading a slightly
+# less extreme precision ceiling (1e5 instead of 1e6). This is a minor, disclosed
+# tightening, not the load-bearing fix -- the load-bearing fix is
+# `observation_count` becoming a real cumulative count (via `PrecisionEwmaBaseline`
+# below) plus `goal_provenance.py`'s confidence-gated selection; a target can still
+# legitimately reach `variance_floored=True` here once it has genuinely accumulated
+# many real observations that happen to be near-constant, which is real information
+# (Feldman & Friston 2010's "high precision" case), not a bug.
+NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE: float = 1e-5
 
 
 @dataclass(frozen=True)
@@ -243,3 +353,129 @@ def normalize_across_targets(raw_scores: dict[str, float]) -> dict[str, float]:
         return {target_id: 1.0 for target_id in raw_scores}
     span = hi - lo
     return {target_id: (v - lo) / span for target_id, v in raw_scores.items()}
+
+
+# -- Persisted EWMA baseline (2026-07-30 fix) ----------------------------------
+# See module docstring's "live-wired" update section for the incident this section
+# exists to fix. `precision_weighted_salience()`/`normalize_across_targets()` above
+# are UNCHANGED -- this is a new, parallel input path for the live tick, not a
+# rewrite of the existing pure functions.
+
+
+@dataclass(frozen=True)
+class PrecisionEwmaBaseline:
+    """One `node:substrate.*` target's persisted, incrementally-updated running
+    prediction-error baseline -- the live-tick replacement for re-querying a raw
+    history list from `substrate_reduction_receipts` every tick (see module
+    docstring). Threaded explicitly by the caller and read from / written back to a
+    real persisted row (`AttentionRuntimeStore.advance_node_prediction_error_baseline`,
+    `substrate_node_prediction_error_baseline` table) -- the same explicit-baseline-
+    threading shape `orion/substrate/prediction_error.py`'s `_DomainEwmaBaseline`/
+    `CodebaseMassBaseline` use, applied here to a Postgres-row-backed target instead
+    of a projection-field-backed one (no `FieldStateV1`-adjacent projection schema
+    exists for this data; a small dedicated table was the minimal seam, see the
+    manual-migration file this table lives in for the exact DDL).
+
+    `observation_count` is the field that actually fixes the live incident: unlike
+    the old `n_samples = len(raw_history_list)`, this is a true monotonically
+    increasing count of every real receipt this target has EVER incorporated,
+    surviving `substrate_reduction_receipts`' ~30-minute retention prune indefinitely
+    (the prune only ever deletes the raw receipt row after this baseline has already
+    absorbed its value -- deleting the source data does not undo an update already
+    folded into `ewma`/`variance`/`observation_count`).
+
+    `last_value` is the most recently incorporated real observation -- what
+    `precision_weighted_salience_from_baseline()` treats as "the current error being
+    weighted," the same role `error_history[-1]` played in the raw-list path. `None`
+    only for the true cold-start case (`observation_count == 0`, no real receipt has
+    ever been incorporated for this target)."""
+
+    ewma: float = 0.0
+    variance: float = 0.0
+    observation_count: int = 0
+    last_value: float | None = None
+
+
+def advance_precision_baseline(
+    baseline: PrecisionEwmaBaseline,
+    new_values: list[float],
+    *,
+    alpha: float,
+    min_variance: float,
+) -> PrecisionEwmaBaseline:
+    """Fold zero or more real NEW observations (oldest-first -- e.g. every real
+    `substrate_reduction_receipts` row that landed since this baseline was last
+    advanced) into a persisted EWMA baseline, one at a time, via
+    `orion.bus.ewma.compute_ewma_update`. Pure function, no I/O -- the caller
+    (`AttentionRuntimeStore.advance_node_prediction_error_baseline`) is responsible
+    for fetching `new_values` and persisting the returned baseline.
+
+    Returns ``baseline`` unchanged (the identical object, not merely an equal one)
+    when ``new_values`` is empty -- "nothing new landed at this exact poll instant"
+    must never be treated as "this target has no real history," which is the exact
+    failure this whole fix exists to correct. A caller can safely skip persisting
+    when the return value ``is`` the input (no real advance happened this tick).
+    """
+    if not new_values:
+        return baseline
+    result = baseline
+    for value in new_values:
+        update = compute_ewma_update(
+            prev_ewma=result.ewma,
+            prev_variance=result.variance,
+            prev_count=result.observation_count,
+            value=value,
+            alpha=alpha,
+            min_variance=min_variance,
+        )
+        result = PrecisionEwmaBaseline(
+            ewma=update.ewma,
+            variance=update.variance,
+            observation_count=result.observation_count + 1,
+            last_value=value,
+        )
+    return result
+
+
+def precision_weighted_salience_from_baseline(
+    baseline: PrecisionEwmaBaseline,
+    *,
+    min_variance: float,
+) -> PrecisionWeightedSalienceResult:
+    """Candidate A salience computed from a persisted, incrementally-updated EWMA
+    baseline (`advance_precision_baseline`, above) instead of a freshly recomputed
+    population variance over a rolling-window history list
+    (`precision_weighted_salience`, above -- kept for offline/replay analysis, see
+    module docstring). This is the function the live tick path
+    (`selectors.py::select_node_targets`) actually calls as of 2026-07-30.
+
+    ``variance``/``precision``/``salience`` in the returned result use the EWMA's own
+    running variance estimate, not a population variance recomputed from scratch.
+    ``n_samples`` is ``baseline.observation_count`` -- a real cumulative count that
+    survives `substrate_reduction_receipts` retention pruning indefinitely, unlike the
+    raw-list path's ``len(error_history)`` (bounded to whatever currently fits inside
+    the ~30-minute retention window). ``current_error`` is ``baseline.last_value``.
+
+    Edge case: ``observation_count == 0`` (no real receipt has ever been incorporated
+    for this target -- true cold start, not merely "nothing new this tick") returns
+    the same zero-everything result as ``precision_weighted_salience([])`` -- "no
+    data" and "confidently calm" remain different claims, per that function's own
+    documented contract.
+    """
+    if baseline.observation_count == 0 or baseline.last_value is None:
+        return _EMPTY_RESULT
+
+    variance_floored = baseline.variance < min_variance
+    effective_variance = max(baseline.variance, min_variance)
+    precision = 1.0 / effective_variance
+    current_error = baseline.last_value
+    salience = precision * abs(current_error)
+
+    return PrecisionWeightedSalienceResult(
+        salience=salience,
+        precision=precision,
+        variance=baseline.variance,
+        current_error=current_error,
+        n_samples=baseline.observation_count,
+        variance_floored=variance_floored,
+    )

--- a/orion/attention/field_attention/goal_provenance.py
+++ b/orion/attention/field_attention/goal_provenance.py
@@ -16,10 +16,43 @@ from dataclasses import dataclass
 from orion.attention.field_attention.selectors import PREDICTION_ERROR_NATIVE_TARGETS
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 
+# 2026-07-30 fix (Sentience Striving Program officer review -- see
+# `orion/sentience_striving_program/README.md` §12 for the full incident record).
+# Defense in depth, added ON TOP OF the real fix (`candidate_precision_weighted.py`'s
+# `PrecisionEwmaBaseline` replacing the rolling-window recompute) -- not a substitute
+# for it. Live-confirmed 2026-07-30: a target with `confidence_score=0.1`
+# (`node:substrate.chat`, `observation_count`/`n_samples=2`, far below
+# `QUALIFYING_MIN_ROWS=20`) won a sustained 280+-tick goal-provenance dominance
+# streak purely because it was the tick's *sole* real competitor --
+# `normalize_across_targets()`'s own documented single-target edge case correctly
+# and unavoidably assigns `salience_score=1.0` in that situation (there is no other
+# real competitor to rank against), so `top_node_substrate_target()`'s plain
+# `max(candidates, key=salience_score)` had no way to distinguish "genuinely
+# dominant" from "alone in the room with barely any real data."
+#
+# `confidence_score` (`selectors.py::select_node_targets`) is
+# `clamp01(observation_count / QUALIFYING_MIN_ROWS)` -- `1.0` means the target has
+# accumulated at least `QUALIFYING_MIN_ROWS` real observations. Requiring the full
+# `1.0` here (not some fraction of it) reuses the exact same "qualifying" bar this
+# codebase already treats as the real trust threshold for a variance estimate
+# (`QUALIFYING_MIN_ROWS`'s own name and `scripts/analysis/
+# measure_precision_weighted_salience_probe.py`'s identical constant) rather than
+# picking a new, separately-calibrated fraction -- one real bar, reused, not two.
+# This gate is intentionally independent of the EWMA-baseline fix: even after that
+# fix, `observation_count` still starts at 0 for a target with no persisted baseline
+# row yet (a brand-new target, or one whose baseline table was reset) -- this floor
+# ensures such a target cannot win a real goal-provenance publish while genuinely
+# thin, regardless of what future bug might reintroduce a rolling-window-style
+# under-count elsewhere.
+MIN_CONFIDENCE_FOR_GOAL_PROVENANCE: float = 1.0
+
 
 def top_node_substrate_target(frame: FieldAttentionFrameV1) -> FieldAttentionTargetV1 | None:
     """The highest-salience target among ``frame.node_targets`` that is one of
-    Candidate A's real ``node:substrate.*`` domains.
+    Candidate A's real ``node:substrate.*`` domains AND has accumulated enough real
+    observations to be trusted with a goal-provenance win
+    (``confidence_score >= MIN_CONFIDENCE_FOR_GOAL_PROVENANCE``, see that constant's
+    own comment for the live incident this guards against).
 
     Deliberately NOT ``frame.dominant_targets[0]`` (the frame's global top-1 winner):
     since the 2026-07-30 Candidate B patch, that slot is frequently a physical host or
@@ -28,8 +61,18 @@ def top_node_substrate_target(frame: FieldAttentionFrameV1) -> FieldAttentionTar
     the "never-fires" degenerate failure mode CLAUDE.md's metric-quality-gate warns
     against. This is a real sub-competition winner within the node-target subset, not
     a proxy for the whole field.
+
+    A tick where every real ``node:substrate.*`` competitor is still below the
+    confidence floor returns ``None`` -- the same honest "nothing real to report yet"
+    this producer already gives a tick with zero qualifying candidates, not a forced
+    pick of the least-thin option.
     """
-    candidates = [t for t in frame.node_targets if t.target_id in PREDICTION_ERROR_NATIVE_TARGETS]
+    candidates = [
+        t
+        for t in frame.node_targets
+        if t.target_id in PREDICTION_ERROR_NATIVE_TARGETS
+        and t.confidence_score >= MIN_CONFIDENCE_FOR_GOAL_PROVENANCE
+    ]
     if not candidates:
         return None
     return max(candidates, key=lambda t: t.salience_score)

--- a/orion/attention/field_attention/selectors.py
+++ b/orion/attention/field_attention/selectors.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import Literal
 
 from orion.attention.field_attention.candidate_precision_weighted import (
+    NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+    PrecisionEwmaBaseline,
     PrecisionWeightedSalienceResult,
     normalize_across_targets,
-    precision_weighted_salience,
+    precision_weighted_salience_from_baseline,
 )
 from orion.attention.field_attention.candidate_society_of_mind import novelty_scorer
 from orion.attention.field_attention.policy import FieldAttentionPolicyV1
@@ -241,7 +243,7 @@ def observation_mode_for(salience: float, policy: FieldAttentionPolicyV1) -> Obs
 def select_node_targets(
     field: FieldStateV1,
     policy: FieldAttentionPolicyV1,
-    prediction_error_histories: dict[str, list[float]],
+    prediction_error_baselines: dict[str, PrecisionEwmaBaseline],
 ) -> list[FieldAttentionTargetV1]:
     """Real, precision-weighted node targets only (Candidate A -- Feldman &
     Friston 2010, "Attention, Uncertainty, and Free-Energy":
@@ -263,19 +265,36 @@ def select_node_targets(
     to report a salience score computed from hand-picked channel weights.
     Same for all capability targets (`select_capability_targets`, below).
 
-    `prediction_error_histories`: {node_id: real ASC-by-time error history},
-    caller-fetched (`AttentionRuntimeStore.load_prediction_error_history`)
-    so this stays a pure function -- see that store method's own docstring
-    for the query shape and the ~30-minute rolling-retention caveat
-    (`substrate_reduction_receipts` only retains recent success receipts).
-    A target with zero real history (`n_samples == 0`) is excluded entirely,
-    not scored 0.0 -- "no data" and "confidently calm" are different claims.
+    2026-07-30 second fix (Sentience Striving Program officer review -- see
+    `orion/sentience_striving_program/README.md` §12): this used to take
+    `prediction_error_histories: dict[str, list[float]]`, a raw ASC-by-time
+    error history re-fetched fresh every tick from
+    `AttentionRuntimeStore.load_prediction_error_history` -- a rolling
+    ~30-minute window (`substrate_reduction_receipts`' own retention), not a
+    cumulative history. That let a target with as few as 2 real samples
+    surviving the window (live-confirmed: `node:substrate.chat`, n=2,
+    confidence_score=0.1) read a fully-confident-looking salience_score=1.0
+    once it happened to be the sole real competitor (`normalize_across_
+    targets()`'s own documented single-target edge case) -- correct given
+    that edge case's contract, but fed by an input with no real statistical
+    basis. Now takes `prediction_error_baselines`: {node_id:
+    PrecisionEwmaBaseline}, a persisted, incrementally-updated running
+    baseline per target (`AttentionRuntimeStore.
+    advance_node_prediction_error_baseline`) whose `observation_count` is a
+    true monotonic count of every real receipt ever incorporated, immune to
+    the retention pruner. A target with zero real observations ever
+    (`observation_count == 0`) is excluded entirely, not scored 0.0 -- "no
+    data" and "confidently calm" are different claims, same discipline as
+    before, just keyed off a real cumulative count instead of a
+    window-bounded one.
     """
     results: dict[str, PrecisionWeightedSalienceResult] = {}
     raw_scores: dict[str, float] = {}
-    for target_id, reducer_key in PREDICTION_ERROR_NATIVE_TARGETS.items():
-        history = prediction_error_histories.get(target_id, [])
-        result = precision_weighted_salience(history)
+    for target_id in PREDICTION_ERROR_NATIVE_TARGETS:
+        baseline = prediction_error_baselines.get(target_id, PrecisionEwmaBaseline())
+        result = precision_weighted_salience_from_baseline(
+            baseline, min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE
+        )
         if result.n_samples == 0:
             continue
         results[target_id] = result

--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -710,3 +710,81 @@ any candidate signal as real substrate for this section.
   agent-dispatch-scoped GWT mechanism, referenced not duplicated.
 - `config/substrate-lattice/transport_lattice_policy.v1.yaml` — working precedent for
   Objective 2.
+
+## 12. Layer 5 field attention precision-weighted salience — officer review and fix, 2026-07-30
+
+**What was reviewed.** Layer 5 field attention's Candidate A (precision-weighted
+prediction-error salience, Feldman & Friston 2010 —
+`orion/attention/field_attention/candidate_precision_weighted.py`/`selectors.py`) and the
+goal-provenance dominance-streak producer built on top of it in the same-day PR #1517
+(`goal_provenance.py`, `services/orion-attention-runtime/app/worker.py`). This review was
+run at Juniper's explicit request, framed as a Sentience Striving Program officer
+evaluation of a live, currently-running pipeline, not a retrospective or archival review —
+the pathology found was actively firing at review time.
+
+**Concrete evidence found, live.** `AttentionRuntimeStore.load_prediction_error_history`
+re-queried `substrate_reduction_receipts` fresh on every 2-second tick, and that table
+retains success receipts for only `ORION_RECEIPT_RETENTION_SUCCESS_MINUTES` (30 min
+live) — a rolling window, not a cumulative history, so a target's `n_samples` could rise
+and fall independent of how much real data it had ever actually produced.
+Live-confirmed 2026-07-30 (~23:30–23:42 UTC): `node:substrate.chat` was the *only* one of
+the five `PREDICTION_ERROR_NATIVE_TARGETS` domains with any qualifying receipts inside
+that window at all (the other four sat at `n_samples=0`), with exactly `n=2` real samples,
+`precision=640000` (variance ~1.56e-6, barely above the module's `1e-6` floor — a
+near-certainty produced by two points, not evidence of real stability), and
+`confidence_score=0.1` (the system's own honest `n_samples/QUALIFYING_MIN_ROWS`
+computation). Because it was the tick's sole real competitor,
+`normalize_across_targets()`'s own documented single-target edge case (correctly, given
+that edge case's own contract — there is no real basis to differentiate a lone competitor
+from itself) pinned its `salience_score` to `1.0`. This held for a live, still-running
+280+-consecutive-tick streak, and `goal_provenance.py`'s `update_dominance_streak()`
+(3-tick `goal_provenance_min_streak`) treated that as sustained real dominance, publishing
+a real `FieldGoalProvenanceV1` to `orion:memory:goals:proposed` on every qualifying tick —
+confirmed via live `docker logs` on `orion-athena-attention-runtime` showing hundreds of
+real `field_goal_provenance_published ... field_target_id=node:substrate.chat
+salience=1.000 streak=NNN` lines. `orion-substrate-runtime`'s `goal_context_listener.py`
+consumes this and calls `set_active_goal()`
+(`orion/substrate/attention/goal_context.py`), which — because
+`ORION_ATTENTION_TOPDOWN_ENABLED=true` is live — was actively biasing real chat-level
+attention scoring off a statistically meaningless `n=2` reading at the moment this review
+ran.
+
+**What was fixed.** `PrecisionEwmaBaseline`
+(`candidate_precision_weighted.py`) replaces the per-tick rolling-window recompute with a
+persisted, incrementally-updated running baseline per target
+(`substrate_node_prediction_error_baseline`, one row per `node:substrate.*` target),
+advanced by `AttentionRuntimeStore.advance_node_prediction_error_baseline` exactly once
+per real new `substrate_reduction_receipts` row — the same explicit-baseline-threading
+shape `orion/substrate/prediction_error.py`'s `execution_prediction_error`/
+`codebase_prediction_error` already use for the identical class of problem. `observation_
+count` is now a true monotonically-increasing count that survives the retention pruner
+indefinitely, so `confidence_score` (`n_samples/QUALIFYING_MIN_ROWS`) reflects a target's
+real cumulative evidence, not whatever happened to fit in a 30-minute window at poll time.
+As defense in depth on top of that fix, `goal_provenance.py::top_node_substrate_target`
+now also requires `confidence_score >= MIN_CONFIDENCE_FOR_GOAL_PROVENANCE` (1.0, i.e. at
+least `QUALIFYING_MIN_ROWS` real observations) before a target is eligible to win a
+goal-provenance publish at all, so a future thin, sole-competitor edge case (a brand-new
+target, or a baseline cold-started after a table reset) cannot reproduce the same failure
+shape even if the baseline fix above were somehow bypassed. The domain-specific EWMA
+`min_variance` was re-measured against live data for this patch rather than inherited
+unexamined from `orion/bus/ewma.py`'s own default (see `candidate_precision_weighted.py`'s
+`NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE` for the exact live numbers and reasoning).
+
+**What was explicitly deferred, not fixed here.** Candidate B
+(`select_host_targets`/`select_capability_targets`/`candidate_society_of_mind.py`, host
+and capability targets) was checked as part of this same review and found real and clean
+— bounded `[0, 1]` novelty diff, no min-max-forced-winner pathology — and was
+deliberately left untouched. `DominanceStreak` (`goal_provenance.py`) still resets to cold
+on an `orion-attention-runtime` restart (in-memory only, not persisted) — named here as a
+real, disclosed follow-up in the same fragility class as the fix above, not solved in this
+patch, to avoid cathedral scope creep on what was scoped as a review-and-fix, not a
+redesign.
+
+**Sign-off.** Juniper reviewed these findings and signed off on treating the
+goal-provenance dominance-streak pathology as exactly the kind of theater — a
+confident-looking number (`salience_score=1.0`, a 280+-tick streak) with a real downstream
+behavioral consequence (`set_active_goal()` biasing live chat attention) and no real
+statistical backing behind it (`n=2`, `confidence_score=0.1`) — that this program's
+"measure before minting" and "kill means kill" discipline (§7) exists to catch, live and
+not just archivally. This is a review-and-fix of a real, kept instrument, not a subsystem
+kill: Candidate A's theory and Candidate B are both real and both stay.

--- a/services/orion-attention-runtime/.env_example
+++ b/services/orion-attention-runtime/.env_example
@@ -17,8 +17,11 @@ ENABLE_ATTENTION_RUNTIME=true
 # select_capability_targets() always returns [] now, so the visibility
 # toggle this key gated had nothing left to toggle. See orion/attention/
 # field_attention/selectors.py's own docstring.
-# Candidate A (precision-weighted salience, 2026-07-30): real recent
-# prediction-error rows fetched per qualified node target, per tick.
+# Candidate A (precision-weighted salience). 2026-07-30 EWMA-baseline fix: bounds
+# how many real NEW prediction-error rows (since the persisted per-target
+# baseline's own cursor) are folded per node target, per tick -- a backlog cap,
+# not a rolling-window size (see app/settings.py's own comment and
+# orion/sentience_striving_program/README.md §12).
 ATTENTION_PREDICTION_ERROR_HISTORY_LIMIT=200
 ATTENTION_RUNTIME_PORT=8117
 LOG_LEVEL=INFO

--- a/services/orion-attention-runtime/README.md
+++ b/services/orion-attention-runtime/README.md
@@ -14,14 +14,30 @@ Layer 5 substrate service: polls latest `FieldStateV1` from Postgres and builds 
 
 ## Prerequisites
 
-Apply migration:
+Apply migrations:
 
 ```bash
 docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
   < services/orion-sql-db/manual_migration_attention_frame_v1.sql
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql
 ```
 
 Requires `orion-field-digester` (or equivalent) writing `substrate_field_state`.
+
+## Candidate A precision-weighted salience: persisted EWMA baseline (2026-07-30 fix)
+
+Each of the five `node:substrate.*` targets in `PREDICTION_ERROR_NATIVE_TARGETS`
+(`orion/attention/field_attention/selectors.py`) gets its own persisted, incrementally-
+updated running baseline in `substrate_node_prediction_error_baseline`
+(`AttentionRuntimeStore.advance_node_prediction_error_baseline`), advanced by exactly one
+real new `substrate_reduction_receipts` row at a time. This replaced a per-tick
+recompute over that table's own ~30-minute retention window, which let a target with as
+few as 2 real samples surviving the window win a fully-confident-looking
+`salience_score=1.0` -- see `orion/attention/field_attention/candidate_precision_weighted.py`'s
+module docstring and `orion/sentience_striving_program/README.md` section 12 for the full
+live-incident record. `observation_count` on the persisted baseline is a real cumulative
+count of every receipt this target has ever incorporated, immune to that retention prune.
 
 ## Run
 

--- a/services/orion-attention-runtime/app/settings.py
+++ b/services/orion-attention-runtime/app/settings.py
@@ -26,12 +26,18 @@ class Settings(BaseSettings):
     enable_attention_runtime: bool = Field(True, alias="ENABLE_ATTENTION_RUNTIME")
     attention_frame_retention_hours: float = Field(72.0, alias="ATTENTION_FRAME_RETENTION_HOURS")
     attention_frame_prune_interval_sec: float = Field(3600.0, alias="ATTENTION_FRAME_PRUNE_INTERVAL_SEC")
-    # Candidate A (precision-weighted salience, 2026-07-30): how many real
-    # recent prediction-error rows to fetch per qualified node target, per
-    # tick. Same order of magnitude as scripts/analysis/measure_precision_
-    # weighted_salience_probe.py's own real replay windows (tens to ~100
-    # rows within substrate_reduction_receipts' ~30-minute retention) --
-    # not a calibration knob, a fetch-size bound.
+    # Candidate A (precision-weighted salience). 2026-07-30 EWMA-baseline fix
+    # (see AttentionRuntimeStore.advance_node_prediction_error_baseline and
+    # orion/sentience_striving_program/README.md §12): this now bounds how many
+    # real NEW substrate_reduction_receipts rows (since the persisted baseline's
+    # own cursor) are folded into a node target's baseline per tick, not the size
+    # of a raw window recomputed from scratch every tick -- a fetch-size cap on a
+    # real backlog (e.g. after a restart), not a calibration knob. Kept at the
+    # same value used when this was still a per-tick rolling-window fetch size
+    # (tens to ~100 real rows within substrate_reduction_receipts' ~30-minute
+    # retention, per scripts/analysis/measure_precision_weighted_salience_probe.py's
+    # own real replay windows) -- still comfortably above any real per-tick
+    # receipt volume observed live.
     prediction_error_history_limit: int = Field(
         200, alias="ATTENTION_PREDICTION_ERROR_HISTORY_LIMIT"
     )

--- a/services/orion-attention-runtime/app/store.py
+++ b/services/orion-attention-runtime/app/store.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 
 from psycopg2.extras import Json
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
+from orion.attention.field_attention.candidate_precision_weighted import (
+    PrecisionEwmaBaseline,
+    advance_precision_baseline,
+)
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1
 from orion.schemas.field_state import FieldStateV1
+
+logger = logging.getLogger("orion.attention.runtime.store")
 
 # Batched, guard-railed prune: never deletes the newest frame (by generated_at,
 # matching load_latest_attention_frame's ordering).
@@ -65,6 +72,19 @@ class AttentionRuntimeStore:
         (`orion/attention/field_attention/candidate_precision_weighted.py::
         precision_weighted_salience`) to compute real precision (1/variance)
         from.
+
+        **No longer called by the live tick as of 2026-07-30** (Sentience Striving
+        Program officer review -- see `orion/sentience_striving_program/README.md`
+        §12): this method's own ~30-minute rolling-window recompute was the root
+        cause of a live incident (a target with as few as 2 real samples surviving
+        the window could win a fully-confident-looking `salience_score=1.0`). The
+        live tick now calls `advance_node_prediction_error_baseline` (below)
+        instead, which persists a cumulative baseline immune to this window. This
+        method is kept, unchanged, for offline/replay analysis over a full
+        historical export where a persisted incremental baseline doesn't apply
+        (`scripts/analysis/measure_precision_weighted_salience_probe.py`,
+        `measure_candidate_a_vs_b_head_to_head.py`) -- do not wire it back into the
+        live worker tick.
 
         2026-07-30 fix (caught while reviewing a sibling script's own
         divergence from this method): the query fetches the NEWEST `limit`
@@ -127,6 +147,180 @@ class AttentionRuntimeStore:
             except (TypeError, ValueError):
                 continue
         return out
+
+    def advance_node_prediction_error_baseline(
+        self,
+        *,
+        target_id: str,
+        reducer_key: str,
+        alpha: float,
+        min_variance: float,
+        fetch_limit: int,
+    ) -> PrecisionEwmaBaseline:
+        """Real EWMA-baseline sibling of `load_prediction_error_history` (above)
+        for Candidate A's live tick (2026-07-30 fix; see that method's own
+        docstring and `orion/sentience_striving_program/README.md` §12 for the
+        incident this replaces).
+
+        Reads this target's persisted baseline row from
+        `substrate_node_prediction_error_baseline` (or a cold-start zero baseline
+        if none exists yet), fetches only real `substrate_reduction_receipts` rows
+        strictly NEWER than the persisted cursor (`last_receipt_created_at`; no
+        cursor yet -> all real rows up to `fetch_limit`, oldest-first), folds them
+        into the baseline one at a time via
+        `candidate_precision_weighted.advance_precision_baseline`, persists the
+        advanced baseline plus the new cursor, and returns it.
+
+        A tick with no new real receipts is a true no-op: the persisted row is
+        read but never rewritten, and the unchanged baseline is returned as-is --
+        "nothing new landed at this exact 2-second poll instant" must never look
+        like "this target has no real history," which is exactly what the old
+        every-tick rolling-window recompute conflated. `observation_count` on the
+        returned baseline is therefore a real cumulative count across this
+        target's entire real receipt history, immune to
+        `substrate_reduction_receipts`' ~30-minute retention prune (the prune only
+        ever deletes a raw receipt row after this method has already folded its
+        value into the persisted baseline).
+
+        A row whose `prediction_error` value fails to parse (missing/malformed)
+        is skipped for the fold but its `created_at` still advances the cursor --
+        otherwise a single permanently-malformed row would wedge this target on
+        the same cursor position forever, re-fetching (and re-skipping) it every
+        tick. Degrades to a cold-start zero baseline (`observation_count=0`,
+        excluded by `select_node_targets` the same as any target with no real
+        data) on any DB error -- never touches the persisted row in that case, so
+        a transient failure cannot corrupt real accumulated state, only delay this
+        one tick's read of it; the very next successful tick reads the real
+        persisted baseline again. A baseline-advance failure must never crash the
+        attention tick, same contract as `load_prediction_error_history`'s `[]`
+        degrade.
+        """
+        try:
+            with self._engine.begin() as conn:
+                existing = (
+                    conn.execute(
+                        text(
+                            """
+                            SELECT ewma, variance, observation_count, last_value,
+                                   last_receipt_created_at
+                            FROM substrate_node_prediction_error_baseline
+                            WHERE target_id = :target_id
+                            """
+                        ),
+                        {"target_id": target_id},
+                    )
+                    .mappings()
+                    .first()
+                )
+                if existing is None:
+                    baseline = PrecisionEwmaBaseline()
+                    cursor = None
+                else:
+                    baseline = PrecisionEwmaBaseline(
+                        ewma=float(existing["ewma"]),
+                        variance=float(existing["variance"]),
+                        observation_count=int(existing["observation_count"]),
+                        last_value=(
+                            float(existing["last_value"])
+                            if existing["last_value"] is not None
+                            else None
+                        ),
+                    )
+                    cursor = existing["last_receipt_created_at"]
+
+                # Strict `>` cursor comparison (code review, 2026-07-30): if two real
+                # receipts for the same reducer ever land with an exactly identical
+                # `created_at` (same microsecond) and only one is captured before
+                # `fetch_limit` truncates a batch, the other would never be fetched
+                # again once the cursor advances past its own timestamp. Not
+                # observed live (each receipt is its own INSERT via a real reducer
+                # tick) and not worth a compound (created_at, receipt_id) cursor for
+                # a theoretical tie -- disclosed here rather than silently assumed
+                # impossible.
+                new_rows = (
+                    conn.execute(
+                        text(
+                            """
+                            SELECT
+                                receipt_json -> 'state_deltas' -> 0 -> 'after'
+                                    -> 'pressure_hints' ->> 'prediction_error' AS error,
+                                created_at
+                            FROM substrate_reduction_receipts
+                            WHERE (receipt_json -> 'state_deltas' -> 0 ->> 'reducer_id')
+                                  = :reducer_id
+                              AND (:cursor IS NULL OR created_at > :cursor)
+                            ORDER BY created_at ASC
+                            LIMIT :limit
+                            """
+                        ),
+                        {
+                            "reducer_id": f"substrate.{reducer_key}",
+                            "cursor": cursor,
+                            "limit": fetch_limit,
+                        },
+                    )
+                    .mappings()
+                    .all()
+                )
+
+                if not new_rows:
+                    return baseline
+
+                new_values: list[float] = []
+                newest_created_at = cursor
+                for row in new_rows:
+                    newest_created_at = row["created_at"]
+                    raw = row.get("error")
+                    if raw is None:
+                        continue
+                    try:
+                        new_values.append(float(raw))
+                    except (TypeError, ValueError):
+                        continue
+
+                advanced = advance_precision_baseline(
+                    baseline, new_values, alpha=alpha, min_variance=min_variance
+                )
+
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO substrate_node_prediction_error_baseline (
+                            target_id, reducer_key, ewma, variance,
+                            observation_count, last_value, last_receipt_created_at,
+                            updated_at
+                        ) VALUES (
+                            :target_id, :reducer_key, :ewma, :variance,
+                            :observation_count, :last_value, :last_receipt_created_at,
+                            :updated_at
+                        )
+                        ON CONFLICT (target_id) DO UPDATE SET
+                            reducer_key = EXCLUDED.reducer_key,
+                            ewma = EXCLUDED.ewma,
+                            variance = EXCLUDED.variance,
+                            observation_count = EXCLUDED.observation_count,
+                            last_value = EXCLUDED.last_value,
+                            last_receipt_created_at = EXCLUDED.last_receipt_created_at,
+                            updated_at = EXCLUDED.updated_at
+                        """
+                    ),
+                    {
+                        "target_id": target_id,
+                        "reducer_key": reducer_key,
+                        "ewma": advanced.ewma,
+                        "variance": advanced.variance,
+                        "observation_count": advanced.observation_count,
+                        "last_value": advanced.last_value,
+                        "last_receipt_created_at": newest_created_at,
+                        "updated_at": datetime.now(timezone.utc),
+                    },
+                )
+                return advanced
+        except Exception:
+            logger.exception(
+                "node_prediction_error_baseline_advance_failed target_id=%s", target_id
+            )
+            return PrecisionEwmaBaseline()
 
     def load_latest_attention_frame(self) -> FieldAttentionFrameV1 | None:
         with self._engine.connect() as conn:

--- a/services/orion-attention-runtime/app/worker.py
+++ b/services/orion-attention-runtime/app/worker.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from uuid import uuid4
 
 from orion.attention.field_attention.builder import build_attention_frame
+from orion.attention.field_attention.candidate_precision_weighted import (
+    NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+    NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+)
 from orion.attention.field_attention.goal_provenance import (
     DominanceStreak,
     top_node_substrate_target,
@@ -137,20 +141,30 @@ class AttentionRuntimeWorker:
             return None
 
         previous = self._store.load_latest_attention_frame()
-        # Candidate A (precision-weighted salience, 2026-07-30): real
-        # historical error series, per qualified target, fetched fresh every
-        # tick -- see select_node_targets' own docstring for why this can't
-        # be pre-computed once (the pure builder has no DB access).
-        histories = {
-            node_id: self._store.load_prediction_error_history(
-                reducer_key=reducer_key, limit=self._settings.prediction_error_history_limit
+        # Candidate A (precision-weighted salience): real, persisted,
+        # incrementally-updated EWMA baseline per qualified target, advanced by
+        # whatever real new substrate_reduction_receipts rows landed since the
+        # last tick (2026-07-30 fix -- see candidate_precision_weighted.py's
+        # module docstring and orion/sentience_striving_program/README.md §12
+        # for the live incident this replaces: the old per-tick raw-window
+        # recompute let a target with as few as 2 real samples surviving the
+        # ~30-minute retention window win a fully-confident-looking
+        # salience_score=1.0). `observation_count` on the returned baseline is
+        # a real cumulative count, immune to that retention pruner.
+        baselines = {
+            node_id: self._store.advance_node_prediction_error_baseline(
+                target_id=node_id,
+                reducer_key=reducer_key,
+                alpha=NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+                min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+                fetch_limit=self._settings.prediction_error_history_limit,
             )
             for node_id, reducer_key in PREDICTION_ERROR_NATIVE_TARGETS.items()
         }
         frame = build_attention_frame(
             field=field,
             policy=self._policy,
-            prediction_error_histories=histories,
+            prediction_error_baselines=baselines,
             previous_frame=previous,
         )
         self._store.save_attention_frame(frame)

--- a/services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql
+++ b/services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql
@@ -1,0 +1,27 @@
+-- Node prediction-error EWMA baseline v1 (2026-07-30 fix)
+-- Apply: psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql
+--
+-- Persisted, incrementally-updated running baseline for Candidate A's five
+-- node:substrate.* precision-weighted-salience targets
+-- (orion/attention/field_attention/selectors.py::PREDICTION_ERROR_NATIVE_TARGETS).
+-- Replaces AttentionRuntimeStore.load_prediction_error_history's per-tick
+-- ~30-minute rolling-window recompute -- see
+-- orion/attention/field_attention/candidate_precision_weighted.py's module
+-- docstring and orion/sentience_striving_program/README.md section 12 for the
+-- live incident this fixes. One row per target_id, advanced by
+-- AttentionRuntimeStore.advance_node_prediction_error_baseline (one real
+-- substrate_reduction_receipts row = one real update, not a per-tick recompute).
+
+create table if not exists substrate_node_prediction_error_baseline (
+    target_id text primary key,
+    reducer_key text not null,
+    ewma double precision not null default 0.0,
+    variance double precision not null default 0.0,
+    observation_count integer not null default 0,
+    last_value double precision,
+    last_receipt_created_at timestamptz,
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_node_prediction_error_baseline_updated_at
+    on substrate_node_prediction_error_baseline (updated_at desc);

--- a/tests/test_attention_candidate_precision_weighted.py
+++ b/tests/test_attention_candidate_precision_weighted.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 import pytest
 
 from orion.attention.field_attention.candidate_precision_weighted import (
+    NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+    NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
     PRECISION_VARIANCE_FLOOR,
+    PrecisionEwmaBaseline,
+    advance_precision_baseline,
     normalize_across_targets,
     precision_weighted_salience,
+    precision_weighted_salience_from_baseline,
 )
 
 
@@ -168,3 +173,130 @@ def test_normalize_across_targets_end_to_end_with_real_precision_weighted_salien
     normalized = normalize_across_targets(raw)
     assert set(normalized) == {"quiet", "noisy"}
     assert all(0.0 <= v <= 1.0 for v in normalized.values())
+
+
+# -- advance_precision_baseline / precision_weighted_salience_from_baseline ---
+# 2026-07-30 fix (Sentience Striving Program officer review, see
+# orion/sentience_striving_program/README.md §12): the live incident this section
+# regression-tests is that the OLD path (precision_weighted_salience() fed by a
+# freshly re-queried ~30-minute rolling window every tick) let a target's real
+# "n_samples" silently reset to whatever currently survived that window instead of
+# accumulating. The persisted EWMA baseline below is what actually fixes that.
+
+
+def test_advance_precision_baseline_empty_new_values_returns_same_object() -> None:
+    """A tick with no new real receipts must be a true no-op -- the caller uses
+    object identity to decide whether a DB write is even needed."""
+    baseline = PrecisionEwmaBaseline(ewma=0.1, variance=0.01, observation_count=5, last_value=0.1)
+    result = advance_precision_baseline(baseline, [], alpha=0.2, min_variance=1e-5)
+    assert result is baseline
+
+
+def test_advance_precision_baseline_cold_start_first_observation() -> None:
+    baseline = PrecisionEwmaBaseline()
+    result = advance_precision_baseline(baseline, [0.05], alpha=0.2, min_variance=1e-5)
+    assert result.observation_count == 1
+    assert result.last_value == pytest.approx(0.05)
+    assert result.ewma == pytest.approx(0.05)  # compute_ewma_update's own first-obs contract
+    assert result.variance == 0.0  # no fluctuation observed yet
+
+
+def test_advance_precision_baseline_observation_count_is_cumulative_not_windowed() -> None:
+    """The exact property that fixes the live incident: folding N real values in,
+    one at a time across separate calls (simulating separate ticks), accumulates
+    observation_count -- it never resets just because a caller's fetch this tick
+    was small."""
+    baseline = PrecisionEwmaBaseline()
+    for value in [0.01, 0.02]:
+        baseline = advance_precision_baseline(baseline, [value], alpha=0.2, min_variance=1e-5)
+    assert baseline.observation_count == 2
+    # A later tick that fetches a large batch of new real receipts (e.g. after a
+    # backlog) keeps accumulating on top, not starting over.
+    baseline = advance_precision_baseline(
+        baseline, [0.03, 0.04, 0.05], alpha=0.2, min_variance=1e-5
+    )
+    assert baseline.observation_count == 5
+    assert baseline.last_value == pytest.approx(0.05)
+
+
+def test_advance_precision_baseline_multiple_new_values_processed_in_order() -> None:
+    baseline = PrecisionEwmaBaseline()
+    baseline = advance_precision_baseline(
+        baseline, [0.1, 0.2, 0.9], alpha=0.2, min_variance=1e-5
+    )
+    assert baseline.observation_count == 3
+    assert baseline.last_value == pytest.approx(0.9)  # the most recent, not max/mean
+
+
+def test_precision_weighted_salience_from_baseline_cold_start_is_empty() -> None:
+    result = precision_weighted_salience_from_baseline(
+        PrecisionEwmaBaseline(), min_variance=1e-5
+    )
+    assert result.n_samples == 0
+    assert result.salience == 0.0
+    assert result.precision == 0.0
+
+
+def test_precision_weighted_salience_from_baseline_uses_observation_count_as_n_samples() -> None:
+    baseline = PrecisionEwmaBaseline(ewma=0.1, variance=0.02, observation_count=37, last_value=0.3)
+    result = precision_weighted_salience_from_baseline(baseline, min_variance=1e-5)
+    assert result.n_samples == 37
+    assert result.current_error == pytest.approx(0.3)
+    assert result.precision == pytest.approx(1.0 / 0.02)
+    assert result.salience == pytest.approx((1.0 / 0.02) * 0.3)
+
+
+def test_precision_weighted_salience_from_baseline_floors_near_zero_variance() -> None:
+    baseline = PrecisionEwmaBaseline(ewma=0.03, variance=1e-9, observation_count=10, last_value=0.031)
+    result = precision_weighted_salience_from_baseline(baseline, min_variance=1e-5)
+    assert result.variance_floored is True
+    assert result.precision == pytest.approx(1.0 / 1e-5)
+    import math
+
+    assert math.isfinite(result.precision)
+
+
+def test_precision_weighted_salience_from_baseline_does_not_falsely_pin_at_low_n() -> None:
+    """This is the concrete regression for the live incident: a baseline that has
+    only accumulated 2 real observations must still honestly report n_samples=2
+    (not silently inflate it), because it is the caller's/consumer's job
+    (goal_provenance.py's confidence gate) to distinguish 'real but thin' from
+    'real and trustworthy' -- this function's job is only to report the truth of
+    what the baseline has actually seen so far."""
+    baseline = PrecisionEwmaBaseline()
+    for value in [0.0028, 0.0053]:  # the real live chat_session pair, 2026-07-30
+        baseline = advance_precision_baseline(baseline, [value], alpha=0.2, min_variance=1e-5)
+    result = precision_weighted_salience_from_baseline(baseline, min_variance=1e-5)
+    assert result.n_samples == 2  # honest, not artificially inflated or reset
+
+
+def test_advance_and_score_synthetic_regime_shift_no_permanent_floor_pinning() -> None:
+    """A synthetic series with a real regime shift (long calm period, then a real
+    sustained change) should NOT stay permanently pinned at the variance floor once
+    enough real observations have accumulated -- confirms the EWMA baseline can
+    genuinely reflect a live process's real statistics over time, not just freeze
+    at whatever its first few samples looked like."""
+    calm = [0.05] * 15
+    shifted = [0.05, 0.4, 0.05, 0.45, 0.05, 0.5, 0.05, 0.42]
+    baseline = PrecisionEwmaBaseline()
+    for value in calm:
+        baseline = advance_precision_baseline(
+            baseline, [value], alpha=NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+            min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+        )
+    calm_result = precision_weighted_salience_from_baseline(
+        baseline, min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE
+    )
+    assert calm_result.variance_floored is True  # genuinely constant so far -- real, not a bug
+
+    for value in shifted:
+        baseline = advance_precision_baseline(
+            baseline, [value], alpha=NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+            min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+        )
+    shifted_result = precision_weighted_salience_from_baseline(
+        baseline, min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE
+    )
+    assert shifted_result.variance_floored is False
+    assert shifted_result.variance > calm_result.variance
+    assert baseline.observation_count == 15 + 8  # real cumulative count, not reset

--- a/tests/test_attention_field_goal_provenance.py
+++ b/tests/test_attention_field_goal_provenance.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from orion.attention.field_attention.goal_provenance import (
+    MIN_CONFIDENCE_FOR_GOAL_PROVENANCE,
     DominanceStreak,
     top_node_substrate_target,
     update_dominance_streak,
@@ -10,7 +11,9 @@ from orion.attention.field_attention.selectors import PREDICTION_ERROR_NATIVE_TA
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 
 
-def _target(target_id: str, salience: float, kind: str = "node") -> FieldAttentionTargetV1:
+def _target(
+    target_id: str, salience: float, kind: str = "node", *, confidence: float = 1.0
+) -> FieldAttentionTargetV1:
     return FieldAttentionTargetV1(
         target_id=target_id,
         target_kind=kind,
@@ -18,7 +21,7 @@ def _target(target_id: str, salience: float, kind: str = "node") -> FieldAttenti
         pressure_score=salience,
         novelty_score=salience,
         urgency_score=salience,
-        confidence_score=1.0,
+        confidence_score=confidence,
     )
 
 
@@ -51,6 +54,65 @@ def test_top_node_substrate_target_excludes_host_targets():
 
 def test_top_node_substrate_target_empty_frame_returns_none():
     assert top_node_substrate_target(_frame([])) is None
+
+
+# -- 2026-07-30 confidence-gate regression tests -------------------------------
+# Live incident (see orion/sentience_striving_program/README.md §12):
+# node:substrate.chat won a 280+-tick real goal-provenance dominance streak with
+# confidence_score=0.1 (observation_count=2, far below QUALIFYING_MIN_ROWS=20)
+# purely because it was the tick's sole real competitor --
+# normalize_across_targets()'s single-target edge case correctly assigned it
+# salience_score=1.0. The confidence gate below is defense in depth on top of
+# the real fix (the persisted EWMA baseline in candidate_precision_weighted.py).
+
+
+def test_top_node_substrate_target_rejects_sole_low_confidence_competitor():
+    """The exact live incident, reproduced: a single real competitor with
+    salience_score=1.0 (the honest, correct output of the single-target
+    min-max edge case) but confidence_score=0.1 (observation_count=2) must NOT
+    be treated as a trustworthy winner for goal-provenance purposes."""
+    real_domain = "node:substrate.chat"
+    frame = _frame([_target(real_domain, 1.0, confidence=0.1)])
+    assert top_node_substrate_target(frame) is None
+
+
+def test_top_node_substrate_target_accepts_sole_high_confidence_competitor():
+    # Same shape (sole real competitor, salience pinned to 1.0), but with
+    # observation_count >= QUALIFYING_MIN_ROWS this time -- a real, trustworthy
+    # signal, not the thin one above. Must still be selectable.
+    real_domain = "node:substrate.biometrics"
+    frame = _frame([_target(real_domain, 1.0, confidence=1.0)])
+    winner = top_node_substrate_target(frame)
+    assert winner is not None
+    assert winner.target_id == real_domain
+
+
+def test_top_node_substrate_target_prefers_confident_over_higher_salience_but_thin():
+    # A thin (low-confidence) competitor with a HIGHER raw salience_score must
+    # still lose to a confident, lower-salience real competitor -- confidence
+    # is a hard gate, not another factor blended into the ranking.
+    thin = _target("node:substrate.chat", 1.0, confidence=0.1)
+    confident = _target("node:substrate.biometrics", 0.4, confidence=1.0)
+    frame = _frame([thin, confident])
+    winner = top_node_substrate_target(frame)
+    assert winner is not None
+    assert winner.target_id == "node:substrate.biometrics"
+
+
+def test_top_node_substrate_target_boundary_at_min_confidence():
+    just_under = _target(
+        "node:substrate.chat", 0.9, confidence=MIN_CONFIDENCE_FOR_GOAL_PROVENANCE - 0.01
+    )
+    frame_under = _frame([just_under])
+    assert top_node_substrate_target(frame_under) is None
+
+    exactly_at = _target(
+        "node:substrate.chat", 0.9, confidence=MIN_CONFIDENCE_FOR_GOAL_PROVENANCE
+    )
+    frame_at = _frame([exactly_at])
+    winner = top_node_substrate_target(frame_at)
+    assert winner is not None
+    assert winner.target_id == "node:substrate.chat"
 
 
 def test_dominance_streak_resets_on_target_change():

--- a/tests/test_attention_field_selectors.py
+++ b/tests/test_attention_field_selectors.py
@@ -1,6 +1,12 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
+from orion.attention.field_attention.candidate_precision_weighted import (
+    NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+    NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+    PrecisionEwmaBaseline,
+    advance_precision_baseline,
+)
 from orion.attention.field_attention.policy import load_attention_policy
 from orion.attention.field_attention.selectors import (
     PREDICTION_ERROR_NATIVE_TARGETS,
@@ -13,6 +19,20 @@ from orion.attention.field_attention.selectors import (
 from orion.field.pressure import RECENT_PERTURBATION_EWMA_MIN_SAMPLES
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 from orion.schemas.field_state import FieldStateV1
+
+
+def _baseline(values: list[float]) -> PrecisionEwmaBaseline:
+    """Test helper: build a PrecisionEwmaBaseline the same way the live worker
+    does -- folding real values in one at a time via advance_precision_baseline
+    -- rather than hand-constructing baseline fields directly. Empty `values`
+    yields the cold-start zero baseline (n=0, excluded by select_node_targets)."""
+    baseline = PrecisionEwmaBaseline()
+    return advance_precision_baseline(
+        baseline,
+        values,
+        alpha=NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+        min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+    )
 
 REPO = Path(__file__).resolve().parents[1]
 POLICY = load_attention_policy(REPO / "config" / "attention" / "field_attention_policy.v1.yaml")
@@ -109,8 +129,8 @@ _FIELD_FOR_NODE_TESTS = FieldStateV1(
 
 
 def test_select_node_targets_scores_only_prediction_error_native_ids() -> None:
-    histories = {"node:substrate.execution": [0.05, 0.06, 0.04, 0.05, 0.9]}
-    targets = select_node_targets(_FIELD_FOR_NODE_TESTS, POLICY, histories)
+    baselines = {"node:substrate.execution": _baseline([0.05, 0.06, 0.04, 0.05, 0.9])}
+    targets = select_node_targets(_FIELD_FOR_NODE_TESTS, POLICY, baselines)
     target_ids = {t.target_id for t in targets}
     assert target_ids == {"node:substrate.execution"}
     assert "node:athena" not in target_ids  # never scored, not zero-scored
@@ -122,20 +142,46 @@ def test_select_node_targets_excludes_targets_with_no_real_history() -> None:
 
 
 def test_select_node_targets_excludes_targets_with_empty_history_list() -> None:
-    histories = {"node:substrate.execution": []}
-    targets = select_node_targets(_FIELD_FOR_NODE_TESTS, POLICY, histories)
+    baselines = {"node:substrate.execution": _baseline([])}
+    targets = select_node_targets(_FIELD_FOR_NODE_TESTS, POLICY, baselines)
     assert targets == []
 
 
 def test_select_node_targets_confidence_scales_with_sample_count() -> None:
     few = select_node_targets(
-        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": [0.1, 0.2]}
+        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": _baseline([0.1, 0.2])}
     )[0]
     many = select_node_targets(
-        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": [0.1] * 25 + [0.9]}
+        _FIELD_FOR_NODE_TESTS,
+        POLICY,
+        {"node:substrate.execution": _baseline([0.1] * 25 + [0.9])},
     )[0]
     assert few.confidence_score < many.confidence_score
     assert many.confidence_score == 1.0  # clamped at QUALIFYING_MIN_ROWS=20
+
+
+def test_select_node_targets_observation_count_survives_a_pruned_window() -> None:
+    """2026-07-30 regression test for the live incident (see orion/
+    sentience_striving_program/README.md §12): a target's real n_samples must
+    reflect its persisted baseline's cumulative observation_count, not shrink
+    just because a caller happens to construct the baseline from a small
+    per-tick fetch. Simulates two separate ticks (a real historical batch, then
+    a later small batch of only-new receipts) folding into the SAME persisted
+    baseline -- confidence must reflect the full accumulated count, not just the
+    most recent tick's fetch size."""
+    baseline = _baseline([0.1] * 19)  # tick 1: a real historical backlog
+    baseline = advance_precision_baseline(
+        baseline,
+        [0.2],  # tick 2: exactly one new real receipt
+        alpha=NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+        min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+    )
+    targets = select_node_targets(
+        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": baseline}
+    )
+    assert len(targets) == 1
+    assert targets[0].confidence_score == 1.0  # 20 real observations total, fully qualified
+    assert "n=20" in targets[0].reasons[0]
 
 
 def test_select_node_targets_only_covers_the_confirmed_five_reducers() -> None:
@@ -177,15 +223,21 @@ def test_select_node_targets_multi_target_competition_normalizes_min_to_zero_max
         "node:substrate.execution": [0.02, 0.03, 0.02, 0.03, 0.95],
     }
     from orion.attention.field_attention.candidate_precision_weighted import (
-        precision_weighted_salience,
+        precision_weighted_salience_from_baseline,
     )
 
-    raw = {k: precision_weighted_salience(v).salience for k, v in histories.items()}
+    baselines = {k: _baseline(v) for k, v in histories.items()}
+    raw = {
+        k: precision_weighted_salience_from_baseline(
+            b, min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE
+        ).salience
+        for k, b in baselines.items()
+    }
     weaker_id = min(raw, key=raw.get)
     stronger_id = max(raw, key=raw.get)
     assert raw[weaker_id] != raw[stronger_id]  # sanity: the fixture must be non-degenerate
 
-    targets = select_node_targets(_FIELD_FOR_NODE_TESTS, POLICY, histories)
+    targets = select_node_targets(_FIELD_FOR_NODE_TESTS, POLICY, baselines)
     by_id = {t.target_id: t for t in targets}
     assert len(targets) == 2
     # Min-max normalization: the weaker real competitor floors to exactly 0.0,
@@ -202,13 +254,13 @@ def test_select_node_targets_multi_target_competition_normalizes_min_to_zero_max
 
 def test_select_node_targets_min_samples_boundary_at_qualifying_min_rows() -> None:
     just_under = select_node_targets(
-        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": [0.1] * 19}
+        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": _baseline([0.1] * 19)}
     )[0]
     exactly_at = select_node_targets(
-        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": [0.1] * 20}
+        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": _baseline([0.1] * 20)}
     )[0]
     over = select_node_targets(
-        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": [0.1] * 25}
+        _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": _baseline([0.1] * 25)}
     )[0]
     assert just_under.confidence_score < 1.0
     assert exactly_at.confidence_score == 1.0
@@ -219,7 +271,7 @@ def test_select_node_targets_surfaces_variance_floored_in_reasons() -> None:
     # A near-perfectly-constant real history -- precision_weighted_salience's
     # own variance-floor instability case. Must be visible in `reasons`, not
     # silently absorbed into a plain-looking salience number.
-    near_constant = [0.5] * 25
+    near_constant = _baseline([0.5] * 25)
     targets = select_node_targets(
         _FIELD_FOR_NODE_TESTS, POLICY, {"node:substrate.execution": near_constant}
     )

--- a/tests/test_attention_frame_builder.py
+++ b/tests/test_attention_frame_builder.py
@@ -2,6 +2,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from orion.attention.field_attention.builder import build_attention_frame
+from orion.attention.field_attention.candidate_precision_weighted import (
+    NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+    NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+    PrecisionEwmaBaseline,
+    advance_precision_baseline,
+)
 from orion.attention.field_attention.policy import load_attention_policy
 from orion.schemas.field_state import FieldStateV1
 
@@ -13,7 +19,7 @@ NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
 def _synthetic_field() -> FieldStateV1:
     # node_vectors/capability_vectors are still part of FieldStateV1's real
     # schema (other consumers read them) but 2026-07-30's attention rewrite
-    # no longer scores them directly -- only `prediction_error_histories`
+    # no longer scores them directly -- only `prediction_error_baselines`
     # (passed separately, see below) drives node_targets now, and
     # capability_targets is always []. Included here to confirm the killed
     # hand-weighted path really produces nothing, not just that it's untested.
@@ -38,17 +44,27 @@ def _synthetic_field() -> FieldStateV1:
     )
 
 
-def _histories() -> dict[str, list[float]]:
-    # Calm baseline (small, real variance) then a real spike on the current
+def _baseline(values: list[float]) -> PrecisionEwmaBaseline:
+    baseline = PrecisionEwmaBaseline()
+    return advance_precision_baseline(
+        baseline,
+        values,
+        alpha=NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+        min_variance=NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+    )
+
+
+def _baselines() -> dict[str, PrecisionEwmaBaseline]:
+    # Calm history (small, real variance) then a real spike on the current
     # tick -- a genuine, non-degenerate precision-weighted-salience case.
     return {
-        "node:substrate.execution": [0.05, 0.06, 0.04, 0.05, 0.9],
+        "node:substrate.execution": _baseline([0.05, 0.06, 0.04, 0.05, 0.9]),
     }
 
 
 def test_builder_selects_only_prediction_error_native_targets() -> None:
     frame = build_attention_frame(
-        field=_synthetic_field(), policy=POLICY, prediction_error_histories=_histories(), now=NOW
+        field=_synthetic_field(), policy=POLICY, prediction_error_baselines=_baselines(), now=NOW
     )
     node_ids = {t.target_id for t in frame.node_targets}
     # The physical host node (node:athena) has no real prediction-error
@@ -62,7 +78,7 @@ def test_builder_selects_only_prediction_error_native_targets() -> None:
 def test_target_with_no_real_history_is_excluded_not_zero_scored() -> None:
     field = _synthetic_field()
     frame = build_attention_frame(
-        field=field, policy=POLICY, prediction_error_histories={}, now=NOW
+        field=field, policy=POLICY, prediction_error_baselines={}, now=NOW
     )
     assert frame.node_targets == []
     assert frame.capability_targets == []
@@ -70,7 +86,7 @@ def test_target_with_no_real_history_is_excluded_not_zero_scored() -> None:
 
 def test_dominant_channels_present() -> None:
     frame = build_attention_frame(
-        field=_synthetic_field(), policy=POLICY, prediction_error_histories=_histories(), now=NOW
+        field=_synthetic_field(), policy=POLICY, prediction_error_baselines=_baselines(), now=NOW
     )
     execution = next(t for t in frame.node_targets if t.target_id == "node:substrate.execution")
     assert "prediction_error" in execution.dominant_channels
@@ -78,14 +94,14 @@ def test_dominant_channels_present() -> None:
 
 def test_overall_salience_positive() -> None:
     frame = build_attention_frame(
-        field=_synthetic_field(), policy=POLICY, prediction_error_histories=_histories(), now=NOW
+        field=_synthetic_field(), policy=POLICY, prediction_error_baselines=_baselines(), now=NOW
     )
     assert frame.overall_salience > 0.0
 
 
 def test_targets_sorted_desc() -> None:
     frame = build_attention_frame(
-        field=_synthetic_field(), policy=POLICY, prediction_error_histories=_histories(), now=NOW
+        field=_synthetic_field(), policy=POLICY, prediction_error_baselines=_baselines(), now=NOW
     )
     scores = [t.salience_score for t in frame.dominant_targets]
     assert scores == sorted(scores, reverse=True)
@@ -93,21 +109,21 @@ def test_targets_sorted_desc() -> None:
 
 def test_frame_id_stable() -> None:
     field = _synthetic_field()
-    histories = _histories()
-    a = build_attention_frame(field=field, policy=POLICY, prediction_error_histories=histories, now=NOW)
-    b = build_attention_frame(field=field, policy=POLICY, prediction_error_histories=histories, now=NOW)
+    baselines = _baselines()
+    a = build_attention_frame(field=field, policy=POLICY, prediction_error_baselines=baselines, now=NOW)
+    b = build_attention_frame(field=field, policy=POLICY, prediction_error_baselines=baselines, now=NOW)
     assert a.frame_id == b.frame_id
 
 
 def test_source_field_tick_id() -> None:
     frame = build_attention_frame(
-        field=_synthetic_field(), policy=POLICY, prediction_error_histories=_histories(), now=NOW
+        field=_synthetic_field(), policy=POLICY, prediction_error_baselines=_baselines(), now=NOW
     )
     assert frame.source_field_tick_id == "tick_exec_attention"
 
 
 def test_recent_perturbations_carried() -> None:
     frame = build_attention_frame(
-        field=_synthetic_field(), policy=POLICY, prediction_error_histories=_histories(), now=NOW
+        field=_synthetic_field(), policy=POLICY, prediction_error_baselines=_baselines(), now=NOW
     )
     assert frame.recent_perturbations == ["state_delta:exec_1", "state_delta:exec_2"]

--- a/tests/test_attention_runtime_store.py
+++ b/tests/test_attention_runtime_store.py
@@ -109,3 +109,171 @@ def test_save_attention_frame_idempotent(monkeypatch) -> None:
     assert conn.execute.called
     sql = str(conn.execute.call_args[0][0])
     assert "ON CONFLICT (frame_id)" in sql
+
+
+# -- advance_node_prediction_error_baseline (2026-07-30 fix) -------------------
+# See orion/sentience_striving_program/README.md §12 for the live incident this
+# method exists to fix: the old per-tick rolling-window recompute
+# (load_prediction_error_history) let a target's real n_samples reset to
+# whatever survived a ~30-minute retention window. This method persists a
+# cumulative baseline instead.
+
+
+def _mock_engine_for_baseline(*, existing_row: dict | None, new_rows: list[dict]):
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    calls: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "substrate_node_prediction_error_baseline" in sql and "SELECT" in sql:
+            calls.append("read_baseline")
+            result.mappings.return_value.first.return_value = existing_row
+        elif "substrate_reduction_receipts" in sql:
+            calls.append("fetch_new_rows")
+            result.mappings.return_value.all.return_value = new_rows
+        elif "INSERT INTO substrate_node_prediction_error_baseline" in sql:
+            calls.append("persist_baseline")
+        else:
+            raise AssertionError(f"unexpected SQL in mock: {sql}")
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    return fake_engine, conn, calls
+
+
+def test_advance_node_prediction_error_baseline_cold_start_no_prior_row(monkeypatch) -> None:
+    store = AttentionRuntimeStore("postgresql://test:test@localhost/test")
+    now = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+    fake_engine, conn, calls = _mock_engine_for_baseline(
+        existing_row=None,
+        new_rows=[
+            {"error": "0.05", "created_at": now},
+            {"error": "0.9", "created_at": now},
+        ],
+    )
+    store._engine = fake_engine
+
+    baseline = store.advance_node_prediction_error_baseline(
+        target_id="node:substrate.execution",
+        reducer_key="execution_trajectory",
+        alpha=0.2,
+        min_variance=1e-5,
+        fetch_limit=200,
+    )
+
+    assert baseline.observation_count == 2
+    assert baseline.last_value == pytest.approx(0.9)
+    assert calls == ["read_baseline", "fetch_new_rows", "persist_baseline"]
+
+
+def test_advance_node_prediction_error_baseline_no_new_rows_skips_write(monkeypatch) -> None:
+    store = AttentionRuntimeStore("postgresql://test:test@localhost/test")
+    existing = {
+        "ewma": 0.1,
+        "variance": 0.02,
+        "observation_count": 10,
+        "last_value": 0.15,
+        "last_receipt_created_at": datetime(2026, 7, 30, 11, 0, tzinfo=timezone.utc),
+    }
+    fake_engine, conn, calls = _mock_engine_for_baseline(existing_row=existing, new_rows=[])
+    store._engine = fake_engine
+
+    baseline = store.advance_node_prediction_error_baseline(
+        target_id="node:substrate.chat",
+        reducer_key="chat_session",
+        alpha=0.2,
+        min_variance=1e-5,
+        fetch_limit=200,
+    )
+
+    # A true no-op tick: the persisted state is returned unchanged and no
+    # write is issued -- "nothing new landed this tick" must not be
+    # misrepresented as "no real history."
+    assert baseline.observation_count == 10
+    assert baseline.last_value == pytest.approx(0.15)
+    assert calls == ["read_baseline", "fetch_new_rows"]  # no persist_baseline call
+
+
+def test_advance_node_prediction_error_baseline_accumulates_on_existing_row(monkeypatch) -> None:
+    store = AttentionRuntimeStore("postgresql://test:test@localhost/test")
+    existing = {
+        "ewma": 0.05,
+        "variance": 0.0,
+        "observation_count": 2,
+        "last_value": 0.0053,
+        "last_receipt_created_at": datetime(2026, 7, 30, 11, 0, tzinfo=timezone.utc),
+    }
+    now = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+    fake_engine, conn, calls = _mock_engine_for_baseline(
+        existing_row=existing, new_rows=[{"error": "0.006", "created_at": now}]
+    )
+    store._engine = fake_engine
+
+    baseline = store.advance_node_prediction_error_baseline(
+        target_id="node:substrate.chat",
+        reducer_key="chat_session",
+        alpha=0.2,
+        min_variance=1e-5,
+        fetch_limit=200,
+    )
+
+    # Real cumulative count: 2 (persisted) + 1 (new this tick) = 3, not reset.
+    assert baseline.observation_count == 3
+    assert baseline.last_value == pytest.approx(0.006)
+    assert "persist_baseline" in calls
+
+
+def test_advance_node_prediction_error_baseline_skips_malformed_rows_but_advances_cursor(
+    monkeypatch,
+) -> None:
+    store = AttentionRuntimeStore("postgresql://test:test@localhost/test")
+    now = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+    fake_engine, conn, calls = _mock_engine_for_baseline(
+        existing_row=None,
+        new_rows=[
+            {"error": None, "created_at": now},
+            {"error": "not-a-number", "created_at": now},
+            {"error": "0.3", "created_at": now},
+        ],
+    )
+    store._engine = fake_engine
+
+    baseline = store.advance_node_prediction_error_baseline(
+        target_id="node:substrate.route",
+        reducer_key="route_arbitration",
+        alpha=0.2,
+        min_variance=1e-5,
+        fetch_limit=200,
+    )
+
+    # Only the one real parseable value is folded -- malformed rows are
+    # skipped for the fold, but the batch (and thus the cursor) is still
+    # consumed and persisted, per the method's own no-permanent-wedge contract.
+    assert baseline.observation_count == 1
+    assert baseline.last_value == pytest.approx(0.3)
+    assert "persist_baseline" in calls
+
+
+def test_advance_node_prediction_error_baseline_degrades_to_cold_start_on_error(
+    monkeypatch,
+) -> None:
+    store = AttentionRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    fake_engine.begin.side_effect = RuntimeError("boom")
+    store._engine = fake_engine
+
+    baseline = store.advance_node_prediction_error_baseline(
+        target_id="node:substrate.bus_synaptic",
+        reducer_key="bus_synaptic",
+        alpha=0.2,
+        min_variance=1e-5,
+        fetch_limit=200,
+    )
+
+    assert baseline.observation_count == 0
+    assert baseline.last_value is None

--- a/tests/test_attention_runtime_worker.py
+++ b/tests/test_attention_runtime_worker.py
@@ -11,6 +11,14 @@ sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(SVC))
 
 from app.worker import AttentionRuntimeWorker  # noqa: E402
+from orion.attention.field_attention.candidate_precision_weighted import (  # noqa: E402
+    NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA,
+    NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE,
+    PrecisionEwmaBaseline,
+)
+from orion.attention.field_attention.selectors import (  # noqa: E402
+    PREDICTION_ERROR_NATIVE_TARGETS,
+)
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1  # noqa: E402
 from orion.schemas.field_state import FieldStateV1  # noqa: E402
 
@@ -48,3 +56,54 @@ def test_worker_skips_when_frame_exists_for_tick(monkeypatch) -> None:
     worker._tick()
 
     worker._store.save_attention_frame.assert_not_called()
+
+
+def test_worker_tick_advances_baseline_per_native_target_and_wires_into_frame(monkeypatch) -> None:
+    """2026-07-30 EWMA-baseline fix regression test (code review finding: the
+    dict-comprehension in _tick() that calls advance_node_prediction_error_baseline
+    per PREDICTION_ERROR_NATIVE_TARGETS entry, and wires the result into
+    build_attention_frame via prediction_error_baselines=, had no test coverage --
+    only the pieces (store method, selector, builder) were tested in isolation).
+
+    Confirms: (1) advance_node_prediction_error_baseline is called exactly once per
+    real native target, with the real reducer_key mapping and the real EWMA
+    alpha/min_variance constants and the configured fetch_limit; (2) the returned
+    baselines actually reach the saved frame (a real node target appears, scored
+    off the mocked baseline), not silently dropped somewhere in the wiring.
+    """
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = AttentionRuntimeWorker()
+    worker._store.load_latest_field = MagicMock(return_value=_field())
+    worker._store.load_attention_frame_for_field_tick = MagicMock(return_value=None)
+    worker._store.load_latest_attention_frame = MagicMock(return_value=None)
+    worker._store.save_attention_frame = MagicMock()
+
+    real_baseline = PrecisionEwmaBaseline(
+        ewma=0.1, variance=0.02, observation_count=25, last_value=0.3
+    )
+    advance_mock = MagicMock(return_value=real_baseline)
+    worker._store.advance_node_prediction_error_baseline = advance_mock
+
+    worker._tick()
+
+    assert advance_mock.call_count == len(PREDICTION_ERROR_NATIVE_TARGETS)
+    called_target_ids = set()
+    for call in advance_mock.call_args_list:
+        kwargs = call.kwargs
+        called_target_ids.add(kwargs["target_id"])
+        assert kwargs["reducer_key"] == PREDICTION_ERROR_NATIVE_TARGETS[kwargs["target_id"]]
+        assert kwargs["alpha"] == NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA
+        assert kwargs["min_variance"] == NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE
+        assert kwargs["fetch_limit"] == worker._settings.prediction_error_history_limit
+    assert called_target_ids == set(PREDICTION_ERROR_NATIVE_TARGETS)
+
+    worker._store.save_attention_frame.assert_called_once()
+    saved_frame = worker._store.save_attention_frame.call_args[0][0]
+    saved_target_ids = {t.target_id for t in saved_frame.node_targets}
+    # Every real native target got the same mocked baseline (observation_count=25,
+    # i.e. fully qualified) -- all five should appear as real node targets, not be
+    # silently excluded, confirming the baselines dict genuinely reached the builder.
+    assert saved_target_ids == set(PREDICTION_ERROR_NATIVE_TARGETS)


### PR DESCRIPTION
## Summary

- Layer 5 field attention's Candidate A (precision-weighted prediction-error salience, Feldman & Friston 2010) recomputed a target's variance/precision from a fresh `~30-minute` rolling-retention Postgres query (`substrate_reduction_receipts`) on every 2-second tick — a rolling window, not a cumulative history.
- Live-confirmed 2026-07-30 (~23:30–23:42 UTC): this let `node:substrate.chat`, the *sole* real competitor that tick with only `n=2` samples (`confidence_score=0.1`), win a fully-confident-looking `salience_score=1.0` via `normalize_across_targets()`'s documented (and, in isolation, correct) single-target edge case.
- That score then won a live, still-running 280+-consecutive-tick "dominance streak" in `goal_provenance.py`, repeatedly publishing real `FieldGoalProvenanceV1` events to `orion:memory:goals:proposed` that biased live chat-level attention via `orion/substrate/attention/goal_context.py::set_active_goal()` (`ORION_ATTENTION_TOPDOWN_ENABLED=true` live).
- Fix: replace the per-tick rolling-window recompute with `PrecisionEwmaBaseline`, a persisted, incrementally-updated running baseline per `node:substrate.*` target (new table `substrate_node_prediction_error_baseline`), advanced by exactly one real new receipt at a time via `orion.bus.ewma.compute_ewma_update` — so `observation_count` is a true monotonic count immune to the retention pruner.
- As defense in depth, `goal_provenance.py::top_node_substrate_target` now also requires `confidence_score >= MIN_CONFIDENCE_FOR_GOAL_PROVENANCE` (1.0, i.e. `observation_count >= QUALIFYING_MIN_ROWS=20`) before a target is eligible to win a goal-provenance publish at all.
- Candidate B (host/capability novelty targets) was reviewed in the same pass and found real and clean — left untouched. `DominanceStreak` restart-persistence is a disclosed, deferred follow-up, not solved here.

## Outcome moved

A single, statistically-meaningless reading (2 real samples) can no longer win a real, repeated goal-provenance publish that biases live downstream attention scoring. `confidence_score`/`observation_count` now mean what their names claim: a real cumulative count of evidence, not whatever survived a 30-minute prune window at poll time.

## Current architecture

`orion-attention-runtime`'s worker polled `substrate_field_state` every 2s, built a `FieldAttentionFrameV1` via `build_attention_frame()`, and for each of 5 `node:substrate.*` targets re-fetched the newest N rows from `substrate_reduction_receipts` (bounded by that table's own 30-minute success-receipt retention) to feed `precision_weighted_salience()`'s population-variance computation fresh every tick. A separate goal-provenance producer (PR #1517, same day) tracked a 3-tick dominance streak on the frame's top node-target winner and published to the bus whenever that streak held.

## Architecture touched

- `orion/attention/field_attention/candidate_precision_weighted.py` — new `PrecisionEwmaBaseline` dataclass, `advance_precision_baseline()`, `precision_weighted_salience_from_baseline()`, domain-appropriate `NODE_TARGET_PREDICTION_ERROR_EWMA_ALPHA`/`NODE_TARGET_PREDICTION_ERROR_MIN_VARIANCE` constants (measured against live data, not inherited unexamined). Original `precision_weighted_salience()`/`normalize_across_targets()` are unchanged, kept for offline/replay analysis scripts.
- `orion/attention/field_attention/selectors.py` — `select_node_targets()` now takes `prediction_error_baselines: dict[str, PrecisionEwmaBaseline]` instead of raw histories.
- `orion/attention/field_attention/builder.py` — `build_attention_frame()`'s param renamed `prediction_error_histories` → `prediction_error_baselines`.
- `orion/attention/field_attention/goal_provenance.py` — new `MIN_CONFIDENCE_FOR_GOAL_PROVENANCE` gate on `top_node_substrate_target()`.
- `services/orion-attention-runtime/app/store.py` — new `advance_node_prediction_error_baseline()` (read baseline row → fetch real new receipts since cursor → fold via EWMA → upsert → return); old `load_prediction_error_history()` kept, no longer called live.
- `services/orion-attention-runtime/app/worker.py` — `_tick()` now advances/reads a persisted baseline per target instead of re-querying a raw window.
- `services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql` — new table.
- `orion/sentience_striving_program/README.md` — new §12, the full officer-review record.

## Files changed

- `orion/attention/field_attention/candidate_precision_weighted.py`: new EWMA-baseline pure functions + live-data-measured constants
- `orion/attention/field_attention/selectors.py`: `select_node_targets` signature swap to baselines
- `orion/attention/field_attention/builder.py`: `build_attention_frame` param swap to baselines
- `orion/attention/field_attention/goal_provenance.py`: confidence-gated `top_node_substrate_target`
- `services/orion-attention-runtime/app/store.py`: new `advance_node_prediction_error_baseline` method
- `services/orion-attention-runtime/app/worker.py`: wire the new store method into `_tick()`
- `services/orion-attention-runtime/app/settings.py`, `.env_example`: comment-only semantics update for `prediction_error_history_limit` (now a backlog fetch cap, not a window size)
- `services/orion-attention-runtime/README.md`: document new migration + EWMA-baseline behavior
- `services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql`: new `substrate_node_prediction_error_baseline` table
- `orion/sentience_striving_program/README.md`: new §12, officer-review record with live evidence and sign-off
- `tests/test_attention_candidate_precision_weighted.py`, `tests/test_attention_field_selectors.py`, `tests/test_attention_frame_builder.py`, `tests/test_attention_field_goal_provenance.py`, `tests/test_attention_runtime_store.py`, `tests/test_attention_runtime_worker.py`: updated for the new signatures + new regression coverage

## Schema / bus / API changes

- Added: `substrate_node_prediction_error_baseline` Postgres table (one row per `node:substrate.*` target).
- Removed: none.
- Renamed: `build_attention_frame(prediction_error_histories=...)` → `build_attention_frame(prediction_error_baselines=...)`; `select_node_targets(prediction_error_histories)` → `select_node_targets(prediction_error_baselines)`. Both are internal, in-process pure-function signatures, not a bus/schema contract — no external consumer.
- Behavior changed: `node:substrate.*` targets' `confidence_score`/`n_samples` now reflect a real cumulative observation count, not a rolling-window snapshot. `top_node_substrate_target()` can now return `None` on a tick where every real competitor is below the confidence floor (previously always picked *some* candidate if any existed).
- Compatibility notes: no bus channel/event shape changed. `AttentionRuntimeStore.load_prediction_error_history` is kept, unchanged, for offline/replay scripts (`scripts/analysis/measure_precision_weighted_salience_probe.py`, `measure_candidate_a_vs_b_head_to_head.py`) — do not wire it back into the live tick.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: comment-only, for `ATTENTION_PREDICTION_ERROR_HISTORY_LIMIT` (same key/default, new semantics description).
- local `.env` synced with `python3 scripts/sync_local_env_from_example.py`: ran; no local `.env` exists in this worktree for any service, nothing to sync.
- skipped keys requiring operator action: none.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/python3 -m pytest \
  tests/test_attention_candidate_precision_weighted.py \
  tests/test_attention_field_selectors.py \
  tests/test_attention_frame_builder.py \
  tests/test_attention_field_goal_provenance.py \
  tests/test_attention_runtime_store.py \
  tests/test_attention_runtime_worker.py \
  tests/test_attention_policy_loader.py \
  tests/test_attention_transport_visibility.py \
  tests/test_attention_candidate_society_of_mind.py \
  tests/test_voluntary_attention_wiring.py \
  tests/test_autonomy_goals_bus_catalog.py \
  tests/test_measure_precision_weighted_salience_probe.py \
  tests/test_measure_candidate_a_vs_b_head_to_head.py \
  tests/test_measure_society_of_mind_magnitude_probe.py \
  services/orion-attention-runtime/tests \
  services/orion-substrate-runtime/tests/test_goal_context_listener.py \
  services/orion-hub/tests/test_field_attention_operator_panel.py \
  services/orion-hub/tests/test_substrate_attention_debug_api.py \
  -q
-> 214 passed, 17 warnings (pre-existing pydantic protected-namespace warnings, unrelated)
```

Also confirmed full-repo `tests/ -k "attention or goal_provenance or precision_weighted"` collection errors (32 unrelated modules, e.g. topic_foundry/vision_retina/sql_writer) are pre-existing on `main` (reproduced identically via `git stash`), not introduced by this patch.

## Evals run

No dedicated eval harness exists for `orion-attention-runtime` beyond its `tests/` (confirmed: no `evals/` directory in that service). `scripts/analysis/measure_precision_weighted_salience_probe.py` and `measure_candidate_a_vs_b_head_to_head.py` are the closest thing to a replay eval for this candidate and were re-run as part of the test suite above (they exercise the untouched raw-list `precision_weighted_salience()` path, confirming it's genuinely unaffected).

## Docker/build/smoke checks

Not run — no Docker daemon exercised in this session, and the fix is Postgres/pure-Python only (no port/health-check/dependency changes). Migration DDL was hand-verified against `store.py`'s exact SELECT/INSERT column list and types by a code-review subagent pass, not smoke-tested against a live container.

## Review findings fixed

- Finding: MEDIUM — the worker's `_tick()` wiring (calling `advance_node_prediction_error_baseline` per target and passing the result into `build_attention_frame`) had no test coverage; only the pieces (store method, selector, builder) were tested in isolation.
  - Fix: added `test_worker_tick_advances_baseline_per_native_target_and_wires_into_frame` to `tests/test_attention_runtime_worker.py`, asserting the store method is called once per real native target with the correct `reducer_key`/`alpha`/`min_variance`/`fetch_limit`, and that the resulting frame's `node_targets` reflect the mocked baselines.
  - Evidence: `pytest tests/test_attention_runtime_worker.py -q` → 2 passed.
- Finding: LOW — strict `created_at > :cursor` comparison could theoretically skip a receipt if two rows for the same reducer ever share an identical microsecond timestamp and only one is captured before `fetch_limit` truncates a batch.
  - Fix: added an inline disclosure comment at the query site (`store.py`) rather than a compound cursor, since this is untested-live and each receipt is its own INSERT via a real reducer tick.
  - Evidence: comment added at `services/orion-attention-runtime/app/store.py`'s new-rows query.
- Other findings (NIT-level: docstring duplication across files, `load_prediction_error_history` intentionally dead from the live path) were reviewed and accepted as-is — both are disclosed, intentional, and matched the repo's existing "kept for offline/replay" pattern.

## Restart required

```bash
# Apply the new migration first:
docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
  < services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql

# Then restart only orion-attention-runtime:
docker compose \
  --env-file .env \
  --env-file services/orion-attention-runtime/.env \
  -f services/orion-attention-runtime/docker-compose.yml \
  up -d --build
curl -fsS http://localhost:8117/health
```

`orion-substrate-runtime` is explicitly **not** restarted or otherwise touched by this patch — per the task's non-goal, its stuck `node:substrate.chat` goal state self-heals via `goal_context.py`'s existing 4-hour dead-man's-switch, or replaces itself the moment a genuinely-confident target next wins a real goal-provenance publish under the fixed logic. Restarting `orion-substrate-runtime` is not required for this fix to take effect and was deliberately avoided given its documented 14-independent-tick-loop restart fragility.

## Risks / concerns

- Severity: LOW
- Concern: it will take real wall-clock time (potentially hours-to-days for the lowest-volume domains, `chat_session`/`route_arbitration`, at their historically observed ~2-receipts-per-30-min rate) for those two targets' `observation_count` to cross `QUALIFYING_MIN_ROWS=20` from a cold-started baseline table, during which they cannot win a goal-provenance publish even if genuinely dominant.
- Mitigation: this is the intended, disclosed behavior of the fix (thin evidence should not win), not a bug — the three higher-volume domains (biometrics/execution/bus_synaptic) cross the bar within minutes of real ticks. No action needed; named here for operator awareness only.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1529
