### PR TITLE
feat(hub): surface codebase domain in Attention Organ tab

### DIFF
--- a/services/orion-hub/scripts/attention_organ_routes.py
+++ b/services/orion-hub/scripts/attention_organ_routes.py
@@ -62,10 +62,18 @@ router = APIRouter(prefix="/api/attention-organ", tags=["attention-organ"])
 # `active=False`, precisely so a retired instrument that is still ticking is
 # visible rather than hidden -- CLAUDE.md's "a narrow, known-bad instrument
 # merely excluded from one consumer is not retired, it is hiding".
+# `codebase` added 2026-07-31 (docs/superpowers/specs/2026-07-30-codebase-
+# mass-signal-design.md) once node:substrate.codebase started ticking live
+# with real data (SUBSTRATE_WRITE_CODEBASE_PREDICTION_ERROR_NODE flipped on
+# the same day) -- deliberately still excluded from ACTIVE_INFERENCE_DOMAINS
+# below (orion/substrate/attention_self_model.py), same "sibling domain node,
+# not yet folded into the confidence aggregate" status bus_synaptic held for
+# a while before that was a separate, explicit decision.
 KNOWN_PREDICTION_ERROR_DOMAINS: tuple[str, ...] = (
     "biometrics",
     "bus_synaptic",
     "chat",
+    "codebase",
     "execution",
     "route",
     "transport",


### PR DESCRIPTION
## Summary

Adds `codebase` to `KNOWN_PREDICTION_ERROR_DOMAINS` in the Attention Organ tab, now that `node:substrate.codebase` is live and ticking with real data (flag flipped 2026-07-31).

## Outcome moved

Previously deferred explicitly (confirmed via investigation that adding this row before a live producer existed would render an empty/dead panel). That blocker is now resolved — real data exists.

## Scope decision

Deliberately **not** added to `ACTIVE_INFERENCE_DOMAINS` (`orion/substrate/attention_self_model.py`) — that list changes the actual computed `prediction_error_confidence`/`predicted_shift` values other consumers read, a materially bigger decision than a display toggle, and this domain has almost no accumulated history yet. Same status `bus_synaptic` held before its own inclusion there was a separate, explicit decision.

## Files changed

- `services/orion-hub/scripts/attention_organ_routes.py`

## Tests run

```
services/orion-hub/tests/test_field_attention_operator_panel.py test_attention_organ_page.py: 52 passed
```

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build
```

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/1532
