### PR TITLE
fix(hub): recalibrate unreachable attention SURFACE_MIN_SALIENCE gate (0.5 -> 0.40)

### DIFF
--- a/scripts/analysis/measure_attention_surface_threshold_calibration.py
+++ b/scripts/analysis/measure_attention_surface_threshold_calibration.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+"""Read-only measurement: is `services/orion-hub/scripts/attention_loops_
+store.py`'s `SURFACE_MIN_SALIENCE` gate reachable by real `attention_
+salience_trace` data, and -- if not -- which replacement is actually
+supported by the measured distribution?
+
+Confirmed live (2026-07-30/31, this script re-derives every number below
+fresh, never hardcoded): `SURFACE_MIN_SALIENCE = 0.5` has been structurally
+unreachable since it was introduced in commit `6bfe87aaf` (2026-07-07,
+"feat(hub): operator-legible PendingAttentionCardV1 builder") with no
+calibration rationale in that commit message. The max score ever observed
+across the real trace table's entire history is `0.490` -- below the
+`>= 0.5` gate every single time. This is why `attention_loop_outcome` (the
+operator Resolve/Dismiss verdict table) has zero rows, ever: no threshold
+has ever let a single card through for a human to judge.
+
+This is GitHub issue #1512's ground-truth gap (see `docs/notes/2026-07-30-
+chat-attention-ground-truth-gap-finding.md`, `scripts/analysis/measure_
+chat_attention_ground_truth_gap.py`), one level down: not "is chat-level
+salience redundant with Layer 5" but "is the *downstream surfacing gate* on
+top of chat-level salience even reachable."
+
+Per CLAUDE.md sec 0A's Metric Quality Gate, this script does NOT just
+re-guess a new absolute number. It measures two competing repair strategies
+against the real distribution before either is chosen:
+
+1. **A relative/percentile-based rule**, recomputed live from recent real
+   scores -- can't go stale the way a hardcoded `0.5` did, and doesn't
+   overclaim any specific number means "objectively worth attention."
+2. **A recalibrated static constant**, chosen from measured real
+   percentiles (not min/max) -- simpler, but re-introduces the same
+   staleness risk this whole investigation exists to fix, unless it is
+   explicitly documented as a bootstrap instrument rather than a validated
+   quality bar.
+
+The real risk with option 1 at this data volume, checked explicitly below:
+
+- **Pseudo-replication.** `attention_salience_trace` is not a population of
+  many independent loops -- confirmed live, a small number of `theme_key`s
+  account for the overwhelming majority of rows (one recurring loop firing
+  hundreds of times, not hundreds of distinct loops). A row-level
+  percentile over this table is mostly describing "how loud are the
+  chattiest 1-2 loops today," not a real population percentile across
+  distinct concepts.
+- **Small-n instability.** With only a handful of distinct `theme_key`
+  values ever recorded, a percentile computed over *distinct current
+  scores* (the population size that actually matters for "is this loop
+  relatively high right now") is quantized into a handful of possible
+  values and can swing sharply as a single theme appears, disappears, or
+  gets suppressed -- checked below via an expanding-window and
+  trailing-window replay of the real history, day by day.
+
+This script does not decide policy on its own — it reports the measured
+numbers so the patch's actual threshold choice (in `attention_loops_store.
+py`) can cite a specific, reproducible measurement rather than a second
+guess. It also checks whether `SURFACE_MIN_AGE_SEC` (the companion age
+gate, same commit, same lack-of-calibration risk) is actually binding on
+real data, since CLAUDE.md's "only change what's shown broken" rule means
+that gate should NOT be touched unless this measurement shows it is also
+unreachable or trivially always-true in a way that defeats its purpose.
+
+This performs NO writes, emits NO events, flips NO flags, changes NO
+consumer. Read-only, matching `measure_chat_attention_ground_truth_gap.py`
+and `measure_phase3_biometrics_drive_shadow_comparison.py`'s own
+conventions (pure computation layer separate from psycopg2 I/O, dataclass
+results, progress log, Markdown report under /tmp).
+
+Run:
+    python scripts/analysis/measure_attention_surface_threshold_calibration.py --window-hours 168
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+logger = logging.getLogger("orion.analysis.attention_surface_threshold_calibration")
+
+# 168h (7 days) -- covers attention_salience_trace's full real history with
+# margin, same window convention as measure_chat_attention_ground_truth_gap.py.
+DEFAULT_WINDOW_HOURS: float = 168.0
+MAX_ROWS: int = 200_000
+
+# The gates under test -- imported as literals here (not from the store
+# module) because this script's whole point is to measure whether the
+# CURRENTLY SHIPPED constants are reachable; importing them would still be
+# correct today, but pinning the literals makes the "as of this run" claim
+# explicit even if a future edit changes the module before this script is
+# re-run against fresh data.
+CURRENT_SURFACE_MIN_SALIENCE: float = 0.5
+CURRENT_SURFACE_MIN_AGE_SEC: float = 300.0
+
+# Candidate static thresholds to evaluate against the measured distribution,
+# spanning the percentile band a "top slice, not everything" bootstrap gate
+# would plausibly sit in.
+CANDIDATE_STATIC_THRESHOLDS: tuple[float, ...] = (0.35, 0.40, 0.45, 0.50)
+
+OUTPUT_DIR = Path("/tmp/attention-surface-threshold-calibration")
+REPORT_PATH = OUTPUT_DIR / "report.md"
+CSV_PATH = OUTPUT_DIR / "daily_percentile_stability.csv"
+PROGRESS_PATH = OUTPUT_DIR / "progress.log"
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+
+# ===========================================================================
+# Pure layer -- no I/O. Deterministic, unit-testable without a DB.
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class TraceRow:
+    created_at: datetime
+    theme_key: str
+    salience: float
+
+
+@dataclass(frozen=True)
+class DistributionStats:
+    """Real distribution shape of `attention_salience_trace.salience` over
+    the window -- never assumed, always computed from the rows passed in.
+    """
+
+    count: int
+    min_v: Optional[float]
+    max_v: Optional[float]
+    mean_v: Optional[float]
+    stdev_v: Optional[float]
+    percentiles: dict[int, float] = field(default_factory=dict)
+
+    @property
+    def is_populated(self) -> bool:
+        return self.count > 0
+
+
+def compute_percentile(sorted_values: list[float], pct: float) -> float:
+    """Linear-interpolation percentile (matches Postgres `percentile_cont`),
+    over an already-sorted list. `pct` in [0, 100].
+    """
+    if not sorted_values:
+        raise ValueError("cannot compute a percentile of an empty sequence")
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    k = (pct / 100.0) * (len(sorted_values) - 1)
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = k - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+_REPORTED_PERCENTILES = (50, 60, 65, 70, 75, 85, 90, 95)
+
+
+def count_rows_at_or_above(rows: list[TraceRow], threshold: float) -> int:
+    return sum(1 for r in rows if r.salience >= threshold)
+
+
+def compute_distribution_stats(rows: list[TraceRow]) -> DistributionStats:
+    values = sorted(r.salience for r in rows)
+    if not values:
+        return DistributionStats(count=0, min_v=None, max_v=None, mean_v=None, stdev_v=None)
+    stdev_v = statistics.pstdev(values) if len(values) > 1 else 0.0
+    percentiles = {p: compute_percentile(values, p) for p in _REPORTED_PERCENTILES}
+    return DistributionStats(
+        count=len(values),
+        min_v=values[0],
+        max_v=values[-1],
+        mean_v=statistics.fmean(values),
+        stdev_v=stdev_v,
+        percentiles=percentiles,
+    )
+
+
+@dataclass(frozen=True)
+class ConcentrationResult:
+    """How much of the row volume comes from just the top-N loudest themes
+    -- the pseudo-replication check. A row-level percentile computed over a
+    table dominated by 1-2 chatty themes is not measuring "population of
+    distinct loops," it is measuring "loudness of the loudest few."
+    """
+
+    distinct_theme_count: int
+    top2_share: Optional[float]  # fraction of all rows contributed by the top 2 themes
+    counts_by_theme: dict[str, int]
+
+
+def compute_concentration(rows: list[TraceRow]) -> ConcentrationResult:
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r.theme_key] = counts.get(r.theme_key, 0) + 1
+    total = sum(counts.values())
+    top2 = sum(sorted(counts.values(), reverse=True)[:2])
+    return ConcentrationResult(
+        distinct_theme_count=len(counts),
+        top2_share=(top2 / total) if total else None,
+        counts_by_theme=counts,
+    )
+
+
+@dataclass(frozen=True)
+class LatestPerTheme:
+    """Most recent (by created_at) real score per theme -- the exact value
+    `load_pending_loops()`'s live query gates against today (its `DISTINCT
+    ON (theme_key) ... ORDER BY t.theme_key, t.created_at DESC` clause), not
+    each theme's historical max. A candidate threshold must be checked
+    against THIS population, not the raw row distribution, to know what it
+    would actually surface right now.
+    """
+
+    theme_key: str
+    salience: float
+    created_at: datetime
+
+
+def compute_latest_per_theme(rows: list[TraceRow]) -> list[LatestPerTheme]:
+    latest: dict[str, TraceRow] = {}
+    for r in rows:
+        cur = latest.get(r.theme_key)
+        if cur is None or r.created_at > cur.created_at:
+            latest[r.theme_key] = r
+    return sorted(
+        (LatestPerTheme(theme_key=k, salience=v.salience, created_at=v.created_at) for k, v in latest.items()),
+        key=lambda x: x.salience,
+        reverse=True,
+    )
+
+
+@dataclass(frozen=True)
+class CandidateThresholdResult:
+    threshold: float
+    surfaced_theme_keys: tuple[str, ...]
+
+    @property
+    def surfaced_count(self) -> int:
+        return len(self.surfaced_theme_keys)
+
+
+def evaluate_candidate_thresholds(
+    latest: list[LatestPerTheme], candidates: tuple[float, ...]
+) -> list[CandidateThresholdResult]:
+    return [
+        CandidateThresholdResult(
+            threshold=t,
+            surfaced_theme_keys=tuple(x.theme_key for x in latest if x.salience >= t),
+        )
+        for t in candidates
+    ]
+
+
+@dataclass(frozen=True)
+class DailyStabilityPoint:
+    day: str
+    cumulative_n: int
+    cumulative_p85: Optional[float]
+    trailing7_n: int
+    trailing7_p85: Optional[float]
+
+
+def compute_daily_percentile_stability(
+    rows: list[TraceRow], pct: float = 85.0
+) -> list[DailyStabilityPoint]:
+    """Replays the real history day by day and recomputes an *expanding*
+    (all data to date) and a *trailing-7-day* percentile at each day
+    boundary. This is the direct, reproducible test of "would a
+    percentile-based rule have been stable/usable in this system's own real
+    early history" rather than a hand-wave -- if either series swings
+    sharply while n is small, that is measured evidence against a naive
+    percentile-of-all-rows rule at this data volume, not an assumption.
+    """
+    if not rows:
+        return []
+    ordered = sorted(rows, key=lambda r: r.created_at)
+    first_day = ordered[0].created_at.date()
+    last_day = ordered[-1].created_at.date()
+    points: list[DailyStabilityPoint] = []
+    day = first_day
+    while day <= last_day:
+        day_end = _end_of_day_utc(day)
+        cumulative = [r.salience for r in ordered if r.created_at < day_end]
+        trailing_start = day_end - timedelta(days=7)
+        trailing = [r.salience for r in ordered if trailing_start <= r.created_at < day_end]
+        cumulative_p = compute_percentile(sorted(cumulative), pct) if cumulative else None
+        trailing_p = compute_percentile(sorted(trailing), pct) if trailing else None
+        points.append(
+            DailyStabilityPoint(
+                day=day.isoformat(),
+                cumulative_n=len(cumulative),
+                cumulative_p85=cumulative_p,
+                trailing7_n=len(trailing),
+                trailing7_p85=trailing_p,
+            )
+        )
+        day = day + timedelta(days=1)
+    return points
+
+
+def _end_of_day_utc(day) -> datetime:
+    """Exclusive upper bound for `day` (i.e. midnight UTC at the START of
+    the NEXT day) -- used as a `<` cutoff so a row created exactly at
+    midnight is attributed to the day it actually falls on, not the
+    previous one.
+    """
+    from datetime import time as _time
+
+    return datetime.combine(day, _time.min, tzinfo=timezone.utc) + timedelta(days=1)
+
+
+@dataclass(frozen=True)
+class AgeGateResult:
+    """Is `SURFACE_MIN_AGE_SEC` actually binding on real data -- i.e. does
+    it ever exclude a theme that would otherwise surface, or is every real
+    theme already far past the age floor by the time it accumulates enough
+    recurrence to matter? Computed from each theme's earliest real
+    `created_at` vs "now" (the same clock `load_pending_loops()` uses),
+    never assumed either way.
+    """
+
+    theme_key: str
+    age_seconds: float
+    clears_current_gate: bool
+
+
+def compute_age_gate_results(
+    rows: list[TraceRow], now: datetime, min_age_sec: float
+) -> list[AgeGateResult]:
+    first_seen: dict[str, datetime] = {}
+    for r in rows:
+        cur = first_seen.get(r.theme_key)
+        if cur is None or r.created_at < cur:
+            first_seen[r.theme_key] = r.created_at
+    out = []
+    for theme_key, fs in first_seen.items():
+        age = max(0.0, (now - fs).total_seconds())
+        out.append(AgeGateResult(theme_key=theme_key, age_seconds=age, clears_current_gate=age >= min_age_sec))
+    return sorted(out, key=lambda x: x.age_seconds)
+
+
+# ===========================================================================
+# I/O layer -- psycopg2 read-only. Same connection contract as the other
+# measure_*.py scripts in this directory (refuses a non-read-only session).
+# ===========================================================================
+
+
+def open_readonly_connection(dsn: str):
+    try:
+        import psycopg2
+    except Exception:  # pragma: no cover
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("refusing to run: session is not read-only (got %r)", value)
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to enforce read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+    return conn
+
+
+def fetch_trace_rows(conn, since: datetime) -> tuple[list[TraceRow], bool]:
+    if conn is None:
+        return [], False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT created_at, theme_key, salience
+                FROM attention_salience_trace
+                WHERE created_at >= %s
+                ORDER BY created_at ASC
+                LIMIT %s
+                """,
+                (since, MAX_ROWS),
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.error("failed to fetch attention_salience_trace", exc_info=True)
+        return [], False
+    out: list[TraceRow] = []
+    for created_at, theme_key, salience in rows:
+        if created_at is None or not theme_key or salience is None:
+            continue
+        ts = created_at if created_at.tzinfo else created_at.replace(tzinfo=timezone.utc)
+        out.append(TraceRow(created_at=ts, theme_key=str(theme_key), salience=float(salience)))
+    return out, len(rows) >= MAX_ROWS
+
+
+def fetch_loop_outcome_count(conn, since: datetime) -> Optional[int]:
+    """Real row count in `attention_loop_outcome` within the window --
+    `None` (never `0`) on any fetch failure, so a DB hiccup can never
+    masquerade as a confirmed-zero finding.
+    """
+    if conn is None:
+        return None
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM attention_loop_outcome WHERE created_at >= %s",
+                (since,),
+            )
+            row = cur.fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        logger.error("failed to fetch attention_loop_outcome count", exc_info=True)
+        return None
+
+
+# ===========================================================================
+# Report rendering + orchestration.
+# ===========================================================================
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._start = time.monotonic()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._fh = path.open("w", encoding="utf-8")
+        except Exception:
+            self._fh = None
+
+    def emit(self, title: str, *, percent: float, processed: int, total: int) -> None:
+        elapsed = max(time.monotonic() - self._start, 1e-6)
+        rate = processed / elapsed
+        line = (
+            f"{datetime.now(timezone.utc).isoformat()} | {title} | "
+            f"{percent:5.1f}% | rows={processed}/{total} | rate={rate:.1f}/s"
+        )
+        logger.info(line)
+        if self._fh is not None:
+            try:
+                self._fh.write(line + "\n")
+                self._fh.flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+
+
+def write_stability_csv(path: Path, points: list[DailyStabilityPoint]) -> None:
+    import csv
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["day", "cumulative_n", "cumulative_p85", "trailing7_n", "trailing7_p85"])
+        for p in points:
+            writer.writerow([p.day, p.cumulative_n, p.cumulative_p85, p.trailing7_n, p.trailing7_p85])
+
+
+def render_report(
+    *,
+    window_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    stats: DistributionStats,
+    rows_clearing_current_gate: int,
+    concentration: ConcentrationResult,
+    latest: list[LatestPerTheme],
+    candidate_results: list[CandidateThresholdResult],
+    stability: list[DailyStabilityPoint],
+    age_results: list[AgeGateResult],
+    outcome_count: Optional[int],
+    caveats: list[str],
+) -> str:
+    lines = [
+        "# Attention surface-threshold recalibration -- read-only measurement",
+        "",
+        "Measures whether `SURFACE_MIN_SALIENCE=0.5` "
+        "(`services/orion-hub/scripts/attention_loops_store.py`) is reachable by real "
+        "`attention_salience_trace` data, and which replacement strategy (relative "
+        "percentile vs. recalibrated static constant) is actually supported at this "
+        "data volume. Read-only. No writes, no events, no flag/config changes.",
+        "",
+        f"- Window: last {window_label} ({window_start.isoformat()} -> {window_end.isoformat()})",
+        f"- Current gate: SURFACE_MIN_SALIENCE={CURRENT_SURFACE_MIN_SALIENCE}, "
+        f"SURFACE_MIN_AGE_SEC={CURRENT_SURFACE_MIN_AGE_SEC}",
+        "",
+        "## 1. Is the current salience gate reachable?",
+        "",
+    ]
+    if not stats.is_populated:
+        lines.append(
+            "- **INCONCLUSIVE**: no `attention_salience_trace` rows in this window; "
+            "cannot evaluate reachability. See coverage caveats."
+        )
+    else:
+        lines.extend(
+            [
+                f"- Rows: {stats.count}",
+                f"- min={stats.min_v:.3f}  max={stats.max_v:.3f}  "
+                f"mean={stats.mean_v:.3f}  stdev={stats.stdev_v:.3f}",
+                "- Percentiles: "
+                + ", ".join(f"p{p}={v:.3f}" for p, v in sorted(stats.percentiles.items())),
+                (
+                    f"- **VERDICT: UNREACHABLE.** Max observed score ({stats.max_v:.3f}) is "
+                    f"below SURFACE_MIN_SALIENCE ({CURRENT_SURFACE_MIN_SALIENCE}). Zero rows "
+                    "in this window's entire real history have ever cleared the gate."
+                    if stats.max_v is not None and stats.max_v < CURRENT_SURFACE_MIN_SALIENCE
+                    else f"- **VERDICT: reachable** -- {rows_clearing_current_gate}/{stats.count} "
+                    f"rows clear the current gate "
+                    f"(max {stats.max_v:.3f} >= {CURRENT_SURFACE_MIN_SALIENCE})."
+                ),
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "## 2. Pseudo-replication check (is a row-level percentile a real population "
+            "percentile, or just \"how loud are the chattiest loops\"?)",
+            "",
+            f"- Distinct `theme_key` values: {concentration.distinct_theme_count}",
+        ]
+    )
+    if concentration.top2_share is not None:
+        lines.append(
+            f"- Top-2 loudest themes' share of ALL rows: {concentration.top2_share:.1%}"
+        )
+        if concentration.top2_share >= 0.75:
+            lines.append(
+                "- **VERDICT: heavily concentrated.** A row-level percentile over this table "
+                "mostly describes the loudness of 1-2 recurring loops, not a real population "
+                "percentile across distinct concepts -- weak evidence for a naive row-level "
+                "percentile-of-all-rows surfacing rule."
+            )
+    else:
+        lines.append("- Could not compute (no rows).")
+    lines.extend(
+        [
+            "",
+            "## 3. What each candidate threshold would surface RIGHT NOW "
+            "(latest real score per theme -- the exact population `load_pending_loops()` "
+            "gates against today)",
+            "",
+        ]
+    )
+    if latest:
+        lines.append(
+            "| theme_key | latest salience |\n|---|---|\n"
+            + "\n".join(f"| {x.theme_key} | {x.salience:.3f} |" for x in latest)
+        )
+        lines.append("")
+        for cr in candidate_results:
+            lines.append(
+                f"- threshold {cr.threshold:.2f}: surfaces {cr.surfaced_count}/{len(latest)} "
+                f"real themes right now"
+                + (f" -- {list(cr.surfaced_theme_keys)}" if cr.surfaced_theme_keys else "")
+            )
+    else:
+        lines.append("- No current per-theme data (no rows).")
+    lines.extend(
+        [
+            "",
+            "## 4. Percentile stability replay (would a relative rule have been stable "
+            "across this system's own real early history?)",
+            "",
+        ]
+    )
+    if stability:
+        lines.append("| day | cumulative n | cumulative p85 | trailing-7d n | trailing-7d p85 |")
+        lines.append("|---|---|---|---|---|")
+        for p in stability:
+            lines.append(
+                f"| {p.day} | {p.cumulative_n} | "
+                f"{'' if p.cumulative_p85 is None else f'{p.cumulative_p85:.3f}'} | "
+                f"{p.trailing7_n} | "
+                f"{'' if p.trailing7_p85 is None else f'{p.trailing7_p85:.3f}'} |"
+            )
+        p85_values = [p.cumulative_p85 for p in stability if p.cumulative_p85 is not None]
+        if len(p85_values) >= 2:
+            swing = max(p85_values) - min(p85_values)
+            lines.append("")
+            lines.append(
+                f"- Cumulative p85 swung by {swing:.3f} across the replay "
+                f"(from {min(p85_values):.3f} to {max(p85_values):.3f}) as real data "
+                "accumulated -- this is the measured early-history instability, not an "
+                "assumption. A percentile computed when n was small in this system's own "
+                "past would have set a materially different bar than the same percentile "
+                "computed today."
+            )
+    else:
+        lines.append("- No data to replay.")
+    lines.extend(
+        [
+            "",
+            "## 5. Is SURFACE_MIN_AGE_SEC actually binding?",
+            "",
+        ]
+    )
+    if age_results:
+        lines.append(f"- SURFACE_MIN_AGE_SEC={CURRENT_SURFACE_MIN_AGE_SEC}s ({CURRENT_SURFACE_MIN_AGE_SEC/60:.0f} min)")
+        for a in age_results:
+            lines.append(
+                f"- {a.theme_key}: first seen {a.age_seconds:.0f}s ago "
+                f"({'clears' if a.clears_current_gate else 'BLOCKED by'} age gate)"
+            )
+        blocked = [a for a in age_results if not a.clears_current_gate]
+        if blocked:
+            lines.append(
+                f"- **{len(blocked)} theme(s) currently blocked by the age gate** -- expected "
+                "and working as designed (prevents a transient noise spike from creating a "
+                "card within the first few minutes); these will naturally clear once "
+                f"{CURRENT_SURFACE_MIN_AGE_SEC:.0f}s has elapsed."
+            )
+        else:
+            lines.append(
+                "- All real themes in this window are already well past the age gate -- it "
+                "is not currently excluding anything real, and real first-seen timestamps "
+                "don't make it trivially always-true either (new themes do start under the "
+                "gate and age out normally)."
+            )
+    else:
+        lines.append("- No data.")
+    lines.extend(
+        [
+            "",
+            "## 6. Ground-truth outcome count (why this matters)",
+            "",
+            f"- `attention_loop_outcome` rows in window: "
+            f"{'ERROR (see caveats)' if outcome_count is None else outcome_count}",
+        ]
+    )
+    if outcome_count == 0:
+        lines.append(
+            "- Zero, confirming the chicken-and-egg this patch exists to break: no threshold "
+            "has ever let a card through for a human to Resolve/Dismiss, so there is no real "
+            "verdict data to learn a threshold from."
+        )
+    lines.extend(
+        [
+            "",
+            "## What this does NOT decide",
+            "",
+            "- Does not recalibrate or redesign the underlying SEED_WEIGHTS/"
+            "LinearSalienceCombiner formula (orion/substrate/attention/salience.py) -- that "
+            "formula's own docstring already discloses it as an unrefit seed-v1 placeholder; "
+            "see GitHub issue #1512.",
+            "- Does not claim the chosen replacement threshold is an objectively correct "
+            "quality bar -- there is no ground truth to validate against (section 6). It is "
+            "a bootstrap instrument to start collecting that ground truth, not a discovery "
+            "of the 'real' cutoff.",
+            "",
+            "## Coverage caveats",
+            "",
+        ]
+    )
+    if caveats:
+        lines.extend(f"- {c}" for c in caveats)
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(window: timedelta, window_label: str) -> int:
+    now = datetime.now(timezone.utc)
+    window_start = now - window
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    progress = ProgressLog(PROGRESS_PATH)
+    caveats: list[str] = []
+
+    progress.emit("connect", percent=0.0, processed=0, total=0)
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        caveats.append("postgres unavailable or not read-only; nothing measured")
+        progress.close()
+        print("ERROR: could not open a read-only postgres connection; see log")
+        return 2
+
+    trace_rows, truncated = fetch_trace_rows(conn, window_start)
+    if truncated:
+        caveats.append(f"attention_salience_trace rows truncated at MAX_ROWS={MAX_ROWS}")
+    progress.emit("trace loaded", percent=40.0, processed=len(trace_rows), total=len(trace_rows))
+
+    outcome_count = fetch_loop_outcome_count(conn, window_start)
+    if outcome_count is None:
+        caveats.append("attention_loop_outcome count fetch failed")
+    progress.emit("outcome count loaded", percent=60.0, processed=0, total=0)
+
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+    if not trace_rows:
+        caveats.append("no attention_salience_trace rows in window")
+
+    stats = compute_distribution_stats(trace_rows)
+    rows_clearing_current_gate = count_rows_at_or_above(trace_rows, CURRENT_SURFACE_MIN_SALIENCE)
+    concentration = compute_concentration(trace_rows)
+    latest = compute_latest_per_theme(trace_rows)
+    candidate_results = evaluate_candidate_thresholds(latest, CANDIDATE_STATIC_THRESHOLDS)
+    stability = compute_daily_percentile_stability(trace_rows)
+    age_results = compute_age_gate_results(trace_rows, now, CURRENT_SURFACE_MIN_AGE_SEC)
+
+    write_stability_csv(CSV_PATH, stability)
+
+    progress.emit("done", percent=100.0, processed=len(trace_rows), total=len(trace_rows))
+    progress.close()
+
+    report = render_report(
+        window_label=window_label,
+        window_start=window_start,
+        window_end=now,
+        stats=stats,
+        rows_clearing_current_gate=rows_clearing_current_gate,
+        concentration=concentration,
+        latest=latest,
+        candidate_results=candidate_results,
+        stability=stability,
+        age_results=age_results,
+        outcome_count=outcome_count,
+        caveats=caveats,
+    )
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    print(report)
+    print(f"\nartifacts: {REPORT_PATH}, {CSV_PATH}, {PROGRESS_PATH}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only measurement of whether SURFACE_MIN_SALIENCE is reachable by real "
+            "attention_salience_trace data, and which replacement strategy is supported."
+        )
+    )
+    parser.add_argument(
+        "--window-hours", type=float, default=DEFAULT_WINDOW_HOURS,
+        help=f"analysis window in hours (default {DEFAULT_WINDOW_HOURS})",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = build_arg_parser().parse_args(argv)
+    window = timedelta(hours=args.window_hours)
+    window_label = f"{args.window_hours:g}h"
+    return run(window, window_label)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/analysis/tests/test_measure_attention_surface_threshold_calibration.py
+++ b/scripts/analysis/tests/test_measure_attention_surface_threshold_calibration.py
@@ -1,0 +1,275 @@
+"""Deterministic unit tests for measure_attention_surface_threshold_calibration.py.
+
+No DB, no network. Everything exercised here is pure: percentile math,
+concentration/pseudo-replication accounting, latest-per-theme extraction,
+candidate-threshold evaluation, the daily percentile-stability replay, and
+the age-gate check all operate on plain synthetic `TraceRow` lists. Same
+sibling-module-by-file-path loading pattern as
+test_measure_capability_channel_health.py.
+
+Covers the edge cases the chosen repair strategy actually has to reason
+about even though production code ended up as a static constant, not a
+live percentile rule: very few rows, all-identical scores, and a sudden
+distribution shift -- because this script's own percentile-stability replay
+is the evidence base the PR cites for rejecting a percentile-based rule at
+the current data volume, and that evidence has to be trustworthy on its own
+degenerate inputs before it can be trusted on real ones.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "measure_attention_surface_threshold_calibration.py"
+_spec = importlib.util.spec_from_file_location("measure_attention_surface_threshold_calibration", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules["measure_attention_surface_threshold_calibration"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _row(theme_key: str, salience: float, created_at: datetime) -> "mod.TraceRow":
+    return mod.TraceRow(created_at=created_at, theme_key=theme_key, salience=salience)
+
+
+_NOW = datetime(2026, 7, 31, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ===========================================================================
+# compute_percentile -- pure math, must match Postgres percentile_cont shape.
+# ===========================================================================
+
+
+def test_compute_percentile_single_value_returns_that_value() -> None:
+    assert mod.compute_percentile([0.42], 50) == 0.42
+    assert mod.compute_percentile([0.42], 95) == 0.42
+
+
+def test_compute_percentile_empty_raises() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        mod.compute_percentile([], 50)
+
+
+def test_compute_percentile_all_identical_values() -> None:
+    values = [0.4] * 50
+    assert mod.compute_percentile(values, 50) == 0.4
+    assert mod.compute_percentile(values, 95) == 0.4
+
+
+def test_compute_percentile_known_interpolation() -> None:
+    values = [0.0, 1.0]
+    assert mod.compute_percentile(values, 50) == 0.5
+    assert mod.compute_percentile(values, 0) == 0.0
+    assert mod.compute_percentile(values, 100) == 1.0
+
+
+# ===========================================================================
+# compute_distribution_stats -- degenerate + normal inputs.
+# ===========================================================================
+
+
+def test_compute_distribution_stats_empty_is_not_populated() -> None:
+    stats = mod.compute_distribution_stats([])
+    assert stats.count == 0
+    assert not stats.is_populated
+    assert stats.min_v is None
+
+
+def test_compute_distribution_stats_all_identical_scores_has_zero_stdev() -> None:
+    rows = [_row("t1", 0.4, _NOW) for _ in range(10)]
+    stats = mod.compute_distribution_stats(rows)
+    assert stats.count == 10
+    assert stats.min_v == stats.max_v == 0.4
+    assert stats.stdev_v == 0.0
+    assert all(v == 0.4 for v in stats.percentiles.values())
+
+
+def test_compute_distribution_stats_very_few_rows() -> None:
+    rows = [_row("t1", 0.3, _NOW), _row("t2", 0.5, _NOW)]
+    stats = mod.compute_distribution_stats(rows)
+    assert stats.count == 2
+    assert stats.min_v == 0.3
+    assert stats.max_v == 0.5
+
+
+# ===========================================================================
+# count_rows_at_or_above -- the "is the current gate reachable" check.
+# ===========================================================================
+
+
+def test_count_rows_at_or_above_reproduces_the_confirmed_live_bug() -> None:
+    # Real shape confirmed live 2026-07-31: max ever recorded is 0.490.
+    rows = [_row("t1", v, _NOW) for v in (0.35, 0.41, 0.458, 0.489, 0.490)]
+    assert mod.count_rows_at_or_above(rows, 0.5) == 0
+    assert mod.count_rows_at_or_above(rows, 0.40) == 4
+
+
+# ===========================================================================
+# compute_concentration -- pseudo-replication check.
+# ===========================================================================
+
+
+def test_compute_concentration_single_theme_is_fully_concentrated() -> None:
+    rows = [_row("only-theme", 0.4, _NOW) for _ in range(20)]
+    result = mod.compute_concentration(rows)
+    assert result.distinct_theme_count == 1
+    assert result.top2_share == 1.0
+
+
+def test_compute_concentration_matches_measured_live_shape() -> None:
+    # Confirmed live 2026-07-31: top 2 of 6 theme_keys account for 89.8% of
+    # all rows. Reproduced here with an equivalent skew, not the exact
+    # counts, to test the accounting logic rather than pin a live number.
+    rows = (
+        [_row("loud-1", 0.4, _NOW) for _ in range(150)]
+        + [_row("loud-2", 0.4, _NOW) for _ in range(140)]
+        + [_row("quiet-1", 0.4, _NOW) for _ in range(6)]
+        + [_row("quiet-2", 0.4, _NOW) for _ in range(12)]
+        + [_row("quiet-3", 0.4, _NOW) for _ in range(20)]
+        + [_row("quiet-4", 0.4, _NOW) for _ in range(4)]
+    )
+    result = mod.compute_concentration(rows)
+    assert result.distinct_theme_count == 6
+    assert result.top2_share is not None
+    assert result.top2_share > 0.85
+
+
+def test_compute_concentration_empty() -> None:
+    result = mod.compute_concentration([])
+    assert result.distinct_theme_count == 0
+    assert result.top2_share is None
+
+
+# ===========================================================================
+# compute_latest_per_theme -- the exact population load_pending_loops()
+# actually gates against (most recent row per theme, not historical max).
+# ===========================================================================
+
+
+def test_compute_latest_per_theme_picks_most_recent_not_max() -> None:
+    rows = [
+        _row("t1", 0.9, _NOW - timedelta(days=5)),  # old peak, not "latest"
+        _row("t1", 0.3, _NOW),  # latest -- this is what should be reported
+        _row("t2", 0.5, _NOW - timedelta(hours=1)),
+    ]
+    latest = mod.compute_latest_per_theme(rows)
+    by_theme = {x.theme_key: x.salience for x in latest}
+    assert by_theme["t1"] == 0.3
+    assert by_theme["t2"] == 0.5
+
+
+def test_compute_latest_per_theme_sorted_descending_by_salience() -> None:
+    rows = [_row("low", 0.2, _NOW), _row("high", 0.8, _NOW), _row("mid", 0.5, _NOW)]
+    latest = mod.compute_latest_per_theme(rows)
+    assert [x.theme_key for x in latest] == ["high", "mid", "low"]
+
+
+def test_compute_latest_per_theme_empty() -> None:
+    assert mod.compute_latest_per_theme([]) == []
+
+
+# ===========================================================================
+# evaluate_candidate_thresholds
+# ===========================================================================
+
+
+def test_evaluate_candidate_thresholds_matches_measured_live_result() -> None:
+    # Real per-theme latest scores confirmed live 2026-07-31.
+    rows = [
+        _row("open-loop-e11d318a9036", 0.458, _NOW),
+        _row("open-loop-3be13c7644a0", 0.413, _NOW),
+        _row("open-loop-8f8766373aba", 0.385, _NOW),
+        _row("open-loop-1c822db7221d", 0.384, _NOW),
+        _row("open-loop-733aad95961b", 0.366, _NOW),
+        _row("open-loop-9d84d08cddf5", 0.356, _NOW),
+    ]
+    latest = mod.compute_latest_per_theme(rows)
+    results = mod.evaluate_candidate_thresholds(latest, (0.35, 0.40, 0.45, 0.50))
+    by_threshold = {r.threshold: r.surfaced_count for r in results}
+    assert by_threshold[0.35] == 6
+    assert by_threshold[0.40] == 2
+    assert by_threshold[0.45] == 1
+    assert by_threshold[0.50] == 0
+
+
+# ===========================================================================
+# compute_daily_percentile_stability -- the small-n instability + sudden
+# distribution shift edge cases.
+# ===========================================================================
+
+
+def test_daily_percentile_stability_empty() -> None:
+    assert mod.compute_daily_percentile_stability([]) == []
+
+
+def test_daily_percentile_stability_very_few_rows_single_day() -> None:
+    rows = [_row("t1", 0.4, _NOW), _row("t2", 0.5, _NOW)]
+    points = mod.compute_daily_percentile_stability(rows)
+    assert len(points) == 1
+    assert points[0].cumulative_n == 2
+
+
+def test_daily_percentile_stability_detects_sudden_distribution_shift() -> None:
+    # First 3 days: low, stable scores (small n). Day 4: a sudden jump to
+    # much higher scores. A percentile-based rule computed on day 3 would
+    # have set a bar the day-4 population blows past -- exactly the
+    # "shifts confusingly even when a loop's own score hasn't changed"
+    # risk named in the task. This test proves the replay actually
+    # detects that shift rather than smoothing over it.
+    day0 = _NOW.replace(hour=0, minute=0, second=0, microsecond=0)
+    rows = []
+    for d in range(3):
+        for _ in range(10):
+            rows.append(_row(f"stable-{d}", 0.30, day0 + timedelta(days=d)))
+    for _ in range(10):
+        rows.append(_row("shifted", 0.90, day0 + timedelta(days=3)))
+    points = mod.compute_daily_percentile_stability(rows, pct=85.0)
+    assert len(points) == 4
+    pre_shift = points[2].cumulative_p85
+    post_shift = points[3].cumulative_p85
+    assert pre_shift is not None and post_shift is not None
+    assert post_shift > pre_shift
+    # trailing-7d window includes the shift immediately (short lookback)
+    assert points[3].trailing7_p85 == post_shift
+
+
+def test_daily_percentile_stability_all_identical_scores_is_flat() -> None:
+    day0 = _NOW.replace(hour=0, minute=0, second=0, microsecond=0)
+    rows = [_row("t1", 0.4, day0 + timedelta(days=d)) for d in range(5)]
+    points = mod.compute_daily_percentile_stability(rows, pct=85.0)
+    values = [p.cumulative_p85 for p in points if p.cumulative_p85 is not None]
+    assert values and all(v == 0.4 for v in values)
+
+
+# ===========================================================================
+# compute_age_gate_results -- confirms SURFACE_MIN_AGE_SEC binding check.
+# ===========================================================================
+
+
+def test_age_gate_results_new_theme_is_blocked() -> None:
+    rows = [_row("new", 0.9, _NOW - timedelta(seconds=10))]
+    results = mod.compute_age_gate_results(rows, _NOW, min_age_sec=300.0)
+    assert len(results) == 1
+    assert results[0].clears_current_gate is False
+
+
+def test_age_gate_results_old_theme_clears() -> None:
+    rows = [_row("old", 0.9, _NOW - timedelta(days=6))]
+    results = mod.compute_age_gate_results(rows, _NOW, min_age_sec=300.0)
+    assert results[0].clears_current_gate is True
+
+
+def test_age_gate_results_uses_earliest_row_per_theme() -> None:
+    rows = [
+        _row("t1", 0.9, _NOW - timedelta(days=6)),  # earliest
+        _row("t1", 0.9, _NOW - timedelta(seconds=5)),  # most recent, ignored for age
+    ]
+    results = mod.compute_age_gate_results(rows, _NOW, min_age_sec=300.0)
+    assert len(results) == 1
+    assert results[0].age_seconds >= timedelta(days=6).total_seconds() - 1
+    assert results[0].clears_current_gate is True

--- a/services/orion-hub/scripts/attention_loops_store.py
+++ b/services/orion-hub/scripts/attention_loops_store.py
@@ -199,7 +199,53 @@ def suppress_loop(theme_key: str, *, cooldown_sec: float = 86400.0) -> bool:
         return False
 
 
-SURFACE_MIN_SALIENCE = 0.5
+# --- SURFACE_MIN_SALIENCE: a bootstrap instrument, not a validated quality bar ---
+#
+# Was 0.5 from 2026-07-07 (commit 6bfe87aaf, "feat(hub): operator-legible
+# PendingAttentionCardV1 builder") to 2026-07-31, with no calibration rationale
+# ever recorded. Confirmed live 2026-07-30/31 (`scripts/analysis/measure_
+# attention_surface_threshold_calibration.py`): the max score
+# `attention_salience_trace` has EVER recorded, across its entire real history
+# (332 rows, 6 distinct theme_keys, 2026-07-24 onward), is 0.490 -- structurally
+# below 0.5, every single time. `attention_loop_outcome` (the operator
+# Resolve/Dismiss verdict table) had zero rows as a direct result: no threshold
+# had ever let a single card through for a human to judge.
+#
+# Recalibrated to 0.40, chosen from that same measurement's real distribution
+# (min=0.350, p50=0.395, p85=0.484, max=0.490). A relative/percentile-based
+# rule (recomputed live from recent scores, so it can't go stale the way a
+# hardcoded 0.5 did) was measured and rejected FOR NOW, not on principle:
+#   - Pseudo-replication: the top 2 of 6 theme_keys account for 89.8% of all
+#     rows, so a row-level percentile mostly describes "how loud are the
+#     chattiest 1-2 loops," not a real population percentile across distinct
+#     concepts.
+#   - Small-n instability: the same percentile (p85), replayed day-by-day
+#     across this system's own real early history, swung from 0.385 to 0.486
+#     (a 0.101 range) as data accumulated from 16 to 332 rows -- too unstable
+#     to trust yet with only ~6 distinct loops ever recorded.
+# If theme diversity grows materially, re-run the measurement script and
+# reconsider a percentile-based rule.
+#
+# 0.40 is NOT an objectively correct "worth a human's time" cutoff -- there is
+# no ground truth to derive one from (that's the whole point: attention_loop_
+# outcome is empty). The underlying SEED_WEIGHTS/LinearSalienceCombiner formula
+# (orion/substrate/attention/salience.py) is itself an explicitly-documented,
+# never-refit seed-v1 placeholder (GitHub issue #1512 tracks whether it needs
+# the same kind of redesign Layer 5 field attention got in PR #1484/#1529;
+# NOT addressed by this patch). This constant's only job is to let SOME real
+# loops surface so human Resolve/Dismiss verdicts can start accumulating --
+# the actual prerequisite for ever learning a real threshold (or a real
+# formula) from ground truth instead of guessing again. It WILL need
+# recalibration again if SEED_WEIGHTS is ever refit or the formula's absolute
+# scale otherwise shifts -- don't treat "it works today" as "it's done."
+SURFACE_MIN_SALIENCE = 0.40
+
+# Measured 2026-07-31 (same script, section 5): every real theme_key in the
+# live table was already 3500s-600000s past this gate, i.e. it is not
+# currently excluding anything real, and it does not degenerate into
+# trivially-always-true either (a brand-new theme does start under the gate
+# and age out normally over the 5 minutes). Left unchanged -- no evidence of
+# the same staleness bug found for SURFACE_MIN_SALIENCE.
 SURFACE_MIN_AGE_SEC = 300.0
 
 
@@ -209,6 +255,12 @@ def load_pending_loops(limit: int = 50) -> list[tuple[OpenLoopV1, datetime, int,
     Surfacing policy (quiet panel): salience >= SURFACE_MIN_SALIENCE and age >=
     SURFACE_MIN_AGE_SEC, excluding themes already suppressed (resolved/dismissed).
     Reads the salience trace table; best-effort -> [] on any miss.
+
+    SURFACE_MIN_SALIENCE is a recalibrated bootstrap threshold, not a
+    validated "worth a human's time" quality bar -- see the constant's own
+    docstring comment above for the full measurement and rationale
+    (`scripts/analysis/measure_attention_surface_threshold_calibration.py`,
+    GitHub issue #1512).
     """
     try:
         from sqlalchemy import text

--- a/services/orion-hub/tests/test_attention_loops_reader.py
+++ b/services/orion-hub/tests/test_attention_loops_reader.py
@@ -100,3 +100,133 @@ def test_latest_salience_for_theme_string_features(monkeypatch):
 def test_latest_salience_for_theme_no_row(monkeypatch):
     monkeypatch.setattr(store, "_engine", lambda: _Engine([]))
     assert store.latest_salience_for_theme("missing") == (0.0, {})
+
+
+# --- SURFACE_MIN_SALIENCE recalibration regression coverage -----------------
+#
+# Confirmed live 2026-07-30/31 (`scripts/analysis/measure_attention_surface_
+# threshold_calibration.py`): the real attention_salience_trace table's max
+# score EVER recorded is 0.490 -- structurally below the old 0.5 gate, every
+# single time, since the gate was introduced 2026-07-07. The rows below use
+# the exact real per-theme "latest score" shape measured live on 2026-07-31
+# (6 distinct theme_keys, scores 0.356-0.458, all < 0.5), not synthetic
+# round numbers, so this test replays reality rather than asserting the fix
+# in prose.
+#
+# `_Conn`/`_Engine` above (shared by the rest of this file) don't apply the
+# `min_sal`/`limit` bind params -- they just hand back whatever row list was
+# constructed, because `load_pending_loops()`'s salience filter lives in the
+# SQL WHERE clause, not in Python. A mock that ignores those params would
+# silently pass this test regardless of what SURFACE_MIN_SALIENCE is set to
+# -- exactly the kind of test that would NOT have caught the original bug.
+# `_FilteringConn` instead re-implements that one clause so these tests
+# actually exercise the real gate.
+
+
+class _FilteringConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, _stmt, params=None):
+        params = params or {}
+        min_sal = params.get("min_sal")
+        rows = self._rows
+        if min_sal is not None:
+            rows = [r for r in rows if float(r["salience"]) >= min_sal]
+        return _Result(rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class _FilteringEngine:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def connect(self):
+        return _FilteringConn(self._rows)
+
+
+_REAL_LATEST_SCORES_2026_07_31 = {
+    "open-loop-e11d318a9036": 0.458,
+    "open-loop-3be13c7644a0": 0.413,
+    "open-loop-8f8766373aba": 0.385,
+    "open-loop-1c822db7221d": 0.384,
+    "open-loop-733aad95961b": 0.366,
+    "open-loop-9d84d08cddf5": 0.356,
+}
+
+
+def _real_shaped_rows(now):
+    return [
+        {
+            "theme_key": theme_key, "loop_id": theme_key, "salience": salience,
+            "features": {}, "description": f"loop {theme_key}",
+            "created_at": now - timedelta(days=1),
+            "recurrence_count": 10, "first_seen": now - timedelta(days=6),
+        }
+        for theme_key, salience in _REAL_LATEST_SCORES_2026_07_31.items()
+    ]
+
+
+def test_old_threshold_would_block_every_real_row(monkeypatch):
+    """Documents the bug directly: at the OLD SURFACE_MIN_SALIENCE=0.5, not a
+    single real historical score would ever have surfaced -- this is exactly
+    why attention_loop_outcome had zero rows, ever.
+    """
+    now = datetime.now(timezone.utc)
+    rows = _real_shaped_rows(now)
+    monkeypatch.setattr(store, "SURFACE_MIN_SALIENCE", 0.5)
+    monkeypatch.setattr(store, "_engine", lambda: _FilteringEngine(rows))
+    assert store.load_pending_loops() == []
+    assert all(r["salience"] < 0.5 for r in rows)
+
+
+def test_recalibrated_threshold_surfaces_real_historical_loops(monkeypatch):
+    """Proves the recalibration actually unblocks the gate: at the new
+    SURFACE_MIN_SALIENCE=0.40, the two highest real historical scores
+    surface, matching the live measurement script's "2/6 real themes" result
+    for this exact snapshot -- not just any surfacing, the measured amount.
+    """
+    now = datetime.now(timezone.utc)
+    rows = _real_shaped_rows(now)
+    assert store.SURFACE_MIN_SALIENCE == 0.40
+    monkeypatch.setattr(store, "_engine", lambda: _FilteringEngine(rows))
+    out = store.load_pending_loops()
+    surfaced_ids = {loop.id for loop, *_ in out}
+    assert surfaced_ids == {"open-loop-e11d318a9036", "open-loop-3be13c7644a0"}
+
+
+def test_recalibrated_threshold_still_filters_low_scores(monkeypatch):
+    """The recalibration is a real gate, not a rubber stamp -- the four
+    lowest real historical scores (0.356-0.385) stay below 0.40 and must not
+    surface.
+    """
+    now = datetime.now(timezone.utc)
+    rows = _real_shaped_rows(now)
+    monkeypatch.setattr(store, "_engine", lambda: _FilteringEngine(rows))
+    out = store.load_pending_loops()
+    surfaced_ids = {loop.id for loop, *_ in out}
+    for theme_key, salience in _REAL_LATEST_SCORES_2026_07_31.items():
+        if salience < 0.40:
+            assert theme_key not in surfaced_ids
+
+
+def test_surface_min_age_sec_unchanged_and_still_enforced(monkeypatch):
+    """Companion age gate (measured live 2026-07-31 to NOT be currently
+    binding on real data) is left untouched by this patch -- confirm it
+    still filters a too-new row even at the new salience threshold.
+    """
+    assert store.SURFACE_MIN_AGE_SEC == 300.0
+    now = datetime.now(timezone.utc)
+    rows = [{
+        "theme_key": "brand-new", "loop_id": "open-loop-new", "salience": 0.9,
+        "features": {}, "description": "",
+        "created_at": now - timedelta(seconds=10),
+        "recurrence_count": 1, "first_seen": now - timedelta(seconds=10),
+    }]
+    monkeypatch.setattr(store, "_engine", lambda: _FilteringEngine(rows))
+    assert store.load_pending_loops() == []


### PR DESCRIPTION
## Summary

- `services/orion-hub/scripts/attention_loops_store.py::load_pending_loops()` gated the operator "pending attention" Resolve/Dismiss cards on `salience >= SURFACE_MIN_SALIENCE` (`0.5`, set 2026-07-07, commit `6bfe87aaf`, no calibration rationale ever recorded).
- Confirmed live: the real `attention_salience_trace` table has never recorded a score above `0.490` across its entire history (332 rows, 6 distinct `theme_key`s, since 2026-07-24) -- the gate has been structurally unreachable since it was introduced.
- Direct consequence: `attention_loop_outcome` (the human Resolve/Dismiss verdict table) has zero rows, ever -- no threshold had ever let a single card through for a human to judge.
- Added a read-only measurement script (`scripts/analysis/measure_attention_surface_threshold_calibration.py`) that measures the real distribution, a pseudo-replication/concentration check, what candidate thresholds would surface right now, a day-by-day percentile-stability replay, and whether the companion age gate is binding -- before picking a replacement, per CLAUDE.md's Metric Quality Gate.
- Recalibrated `SURFACE_MIN_SALIENCE` to `0.40` (a static constant, chosen after measurement showed a percentile-based rule too unstable/pseudo-replicated at this data volume), documented explicitly in code as a bootstrap instrument, not a validated quality bar.
- Left `SURFACE_MIN_AGE_SEC=300` unchanged -- measured and confirmed it is not currently binding on real data.

## Outcome moved

The operator Resolve/Dismiss pending-attention panel can now actually surface real loops (2 of the 6 currently-tracked loops clear the new gate today), unblocking the chicken-and-egg that has kept `attention_loop_outcome` at zero rows since the feature shipped. This is the prerequisite for ever learning a real threshold (or evaluating/retiring the underlying salience formula) from real human judgment instead of a second guess.

## Current architecture

`load_pending_loops()` reads `attention_salience_trace` (written by `services/orion-thought/app/reverie.py::build_salience_trace()`, scored by `orion/substrate/attention/salience.py`'s `LinearSalienceCombiner`/`SEED_WEIGHTS` blend), applies `salience >= SURFACE_MIN_SALIENCE AND age >= SURFACE_MIN_AGE_SEC` in the SQL `WHERE` clause, and returns loops for `services/orion-hub/scripts/attention_loops_routes.py`'s `GET /api/attention/loops` and the Resolve/Dismiss endpoints, which write `AttentionLoopOutcomeV1` rows to `attention_loop_outcome`.

## Architecture touched

- `services/orion-hub/scripts/attention_loops_store.py` -- the two module-level constants and their surrounding documentation.
- New read-only analysis script under `scripts/analysis/` -- no runtime/service change, no bus/schema change.

## Files changed

- `services/orion-hub/scripts/attention_loops_store.py`: recalibrated `SURFACE_MIN_SALIENCE` 0.5 -> 0.40 with an extensive comment explaining the measurement, the rejected percentile alternative, and the "bootstrap instrument, not a validated quality bar" framing; `SURFACE_MIN_AGE_SEC` left at 300.0 with a comment recording that it was checked and found not currently binding.
- `services/orion-hub/tests/test_attention_loops_reader.py`: added regression tests replaying the real historical per-theme "latest score" shape (0.356-0.458, measured live 2026-07-31) proving the old 0.5 gate blocked every real row and the new 0.40 gate surfaces exactly the top 2 of 6 real historical loops; added a dedicated `_FilteringConn`/`_FilteringEngine` mock that actually applies the SQL `min_sal` bind param (the existing shared mock ignores it, which would have let a broken threshold pass silently).
- `scripts/analysis/measure_attention_surface_threshold_calibration.py` (new): read-only measurement instrument, pure-computation layer separated from psycopg2 I/O, matching the house convention (`measure_chat_attention_ground_truth_gap.py`, `measure_phase3_biometrics_drive_shadow_comparison.py`).
- `scripts/analysis/tests/test_measure_attention_surface_threshold_calibration.py` (new): 22 unit tests for the script's pure functions, covering the edge cases the chosen strategy has to reason about even though production landed on a static constant: very few rows, all-identical scores, a synthetic sudden distribution shift, and single-theme concentration.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: `GET /api/attention/loops` and the Resolve/Dismiss endpoints will now surface real loops that previously could never appear (any loop whose latest real score is >= 0.40, was previously invisible below 0.5).
- Compatibility notes: purely a downstream surfacing-gate constant change; no schema, no payload shape change, no consumer contract change.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: not applicable (no env keys touched).
- local `.env` synced: not applicable.
- skipped keys requiring operator action: none.

## Tests run

```text
/tmp/hubtest_venv/bin/python3 -m pytest services/orion-hub/tests -q -k "attention" \
    --ignore=services/orion-hub/tests/test_fcc_model_labels_api.py \
    --ignore=services/orion-hub/tests/test_graphiti_config_parity.py \
    --ignore=services/orion-hub/tests/test_heartbeat_chassis.py \
    --ignore=services/orion-hub/tests/test_memory_consolidation_draft_routes.py \
    --ignore=services/orion-hub/tests/test_memory_graph_consolidation_draft_approve.py
81 passed, 1034 deselected

/tmp/hubtest_venv/bin/python3 -m pytest scripts/analysis/tests -q
346 passed
```

The 5 ignored files fail to collect on this worktree for unrelated reasons (missing `Settings` env keys for other services, e.g. `CHANNEL_VOICE_TRANSCRIPT`) -- confirmed pre-existing and unrelated to this patch by inspecting the collection error directly (a `pydantic_core.ValidationError` for a different service's settings class).

## Evals run

No dedicated eval harness exists for this operator-tooling surfacing gate. The measurement script itself (`scripts/analysis/measure_attention_surface_threshold_calibration.py`) is the closest equivalent -- it was run against live Postgres data (real `attention_salience_trace`, 332 rows) as part of this patch's own calibration process, not as an automated eval. Re-running it periodically (recommended in its own docstring) is the intended ongoing check.

```text
POSTGRES_URI="postgresql://postgres:postgres@localhost:55432/conjourney" \
    /tmp/hubtest_venv/bin/python3 scripts/analysis/measure_attention_surface_threshold_calibration.py --window-hours 168
-> confirmed: max-ever-recorded=0.490 (gate unreachable), top-2-theme concentration=89.8%,
   cumulative p85 swung 0.385->0.486 as data grew from 16->332 rows, age gate not binding,
   0.40 surfaces 2/6 real themes right now.
```

## Docker/build/smoke checks

Not applicable -- this is a pure Python constant/comment change plus a new offline analysis script in `orion-hub`. No Dockerfile, dependency, port, health-check, or worker change. No Docker build/smoke run.

## Review findings fixed

- Finding: the measurement script's own top-level docstring cited the max-ever-recorded score as `0.489`, while every other citation in the patch (the code comment in `attention_loops_store.py`, the new test file, the unit test data) cited `0.490` -- an internal contradiction on a script whose whole point is "never hardcoded, always re-derived."
  - Fix: corrected the docstring to `0.490`, matching the real live-query result and every other citation in the patch.
  - Evidence: `scripts/analysis/measure_attention_surface_threshold_calibration.py` line 12; re-ran the script against live Postgres afterward to reconfirm `0.490` is the real number.

## Restart required

```text
No restart required.
```

This is a query-time constant read fresh on every `GET /api/attention/loops` call (no caching, no background worker holding the old value) -- confirmed by reading `load_pending_loops()`: `SURFACE_MIN_SALIENCE` is read directly as a module-level constant inside the function body's SQL bind params on every invocation, not captured at process start into some other state.

## Risks / concerns

- Severity: low
- Concern: `0.40` is a bootstrap instrument, not a validated "worth a human's time" cutoff -- explicitly disclosed in code comments and this PR. It may surface loops Juniper considers noise, or miss ones worth attention, until real Resolve/Dismiss verdicts accumulate to inform a better rule.
- Mitigation: documented extensively in-code and here; the measurement script is designed to be re-run periodically, and the same script's percentile-replay logic is ready to be revisited once more `attention_loop_outcome` ground truth exists or theme diversity grows beyond the current 6 distinct loops.
- Severity: low
- Concern: `SURFACE_MIN_SALIENCE` will need recalibration again if `SEED_WEIGHTS`/`LinearSalienceCombiner` (`orion/substrate/attention/salience.py`) is ever refit (tracked separately in GitHub issue #1512) or the formula's absolute output scale otherwise shifts.
- Mitigation: explicitly flagged in the constant's own code comment as a known future staleness risk, not silently assumed permanent this time.

## Documentation

Referenced GitHub issue #1512 in this PR description (this patch advances part of that issue's ground-truth-gap finding, previously written up in `docs/notes/2026-07-30-chat-attention-ground-truth-gap-finding.md` from PR #1518) -- will also leave a comment on issue #1512 linking this PR. Chose NOT to add a new section to `orion/sentience_striving_program/README.md`: that charter's precedent format (PR #1529 sec 12) documents cognition/autonomy-loop pathologies; this patch is scoped, reversible, operator-UI-surfacing-gate calibration with no cognition-loop or autonomy-loop behavior change, so a thorough PR description plus an issue comment is sufficient given the non-goals section explicitly ruling out touching the underlying salience formula.

## PR link

(populated by `gh pr create` below)