### PR TITLE
fix(recall): tag ai-town-sourced chat memory so it stops bleeding into hub identity

### DIFF
--- a/docs/superpowers/specs/2026-07-31-recall-aitown-source-tagging-design.md
+++ b/docs/superpowers/specs/2026-07-31-recall-aitown-source-tagging-design.md
@@ -1,0 +1,121 @@
+# Recall: tag and correctly label ai-town-sourced chat memories
+
+Status: implemented (2026-07-31, Juniper: "if those memories just come in raw
+without any tag to differentiate them, orion will take it as our history...
+i think we need to add the tag for the recall/memories that go into the chat
+AND update the unified turn so orion will be on the lookout for those tags").
+
+## Arsonist summary
+
+The 2026-07-30 identity-bleed fix (PR #1526) added a prompt-level
+`CURRENT CONTEXT` instruction telling the model to treat ai-town content in
+`memory_digest` as a separate context. That's a mitigation on top of a
+genuinely broken data pipeline, not a fix to the actual cause: traced to
+`services/orion-recall/app/storage/sql_adapter.py`'s `fetch_sql_fragments`,
+the SQL query that builds chat-history memory fragments never selects
+`client_meta` at all, tags every single chat-history row with the identical,
+non-differentiating `["dialogue"]`, and -- worse -- unconditionally renders
+every row's text as `f"User: {prompt}\nOrion: {response}"`, regardless of
+source. For an ai-town row, `prompt` is an NPC's line, not Juniper's --
+labeling it "User:" is a factually false claim baked directly into what
+reaches the model. Confirmed live: a hub reply about "tummy troubles" bled
+into an ai-town-sourced row and vice versa -- this is bidirectional, not just
+ai-town-into-hub.
+
+`client_meta.external_room.platform`/`external_participant.participant_name`
+(written by `services/orion-embodiment`'s conversation-memory feature, see
+`docs/superpowers/specs/2026-07-30-aitown-social-memory-room-scope-design.md`
+and neighboring specs) already carries exactly the distinguishing information
+needed -- confirmed live, reliably populated on every recent aitown row.
+Nothing currently reads it in the recall path.
+
+## Current architecture
+
+- `services/orion-recall/app/storage/sql_adapter.py:fetch_sql_fragments`:
+  selects `trace_id, prompt, response, created_at` from `chat_history_log`
+  only. Builds `Fragment(tags=["dialogue"], text=f"User: {prompt}\nOrion:
+  {response}", meta={})` for every row.
+- `services/orion-recall/app/service.py`: maps `Fragment.tags`/`.text`
+  straight through to `MemoryItemV1.tags`/`.snippet` with no filtering or
+  transformation -- `MemoryItemV1` already has a `tags: List[str]` field,
+  unused for this purpose today.
+- `services/orion-recall/app/render.py:render_items`: renders each item's
+  `snippet` (already-clamped/truncated text) into the final `memory_digest`
+  bullet list. Operates on whatever text it's given -- a tag/label baked
+  into the snippet text survives this step automatically; nothing here
+  needs to change.
+- `orion/cognition/prompts/chat_quick.j2` / `chat_general.j2`: already have
+  a `CURRENT CONTEXT` block (PR #1526) telling the model how to treat
+  ai-town content *if it recognizes it as such* -- but nothing before now
+  told the model definitively which lines those are.
+
+## Missing questions
+
+None outstanding -- root cause confirmed via live query, fix direction
+confirmed with Juniper.
+
+## Proposed schema / API changes
+
+No new schema -- `MemoryItemV1.tags`/`Fragment.tags` already exist and are
+already threaded through untouched. This is a values/content fix, not a
+shape fix.
+
+`fetch_sql_fragments`'s chat-history branch:
+- SELECT gains `client_meta`.
+- Parse `client_meta.external_room.platform` and
+  `client_meta.external_participant.participant_name`.
+- When platform == "aitown": `tags=["dialogue", "aitown"]`,
+  `text=f"[ai-town] {participant_name or 'NPC'}: {prompt}\nOrion (in
+  ai-town): {response}"`, `meta={"platform": "aitown", "participant_name":
+  participant_name}`.
+- Otherwise (hub/direct, or client_meta absent -- older rows predate this
+  field): unchanged, `tags=["dialogue"]`,
+  `text=f"User: {prompt}\nOrion: {response}"`, `meta={}`.
+
+`orion/cognition/prompts/chat_quick.j2` / `chat_general.j2`: extend the
+existing `CURRENT CONTEXT` block with a concrete instruction to look for the
+literal `[ai-town]` marker in `memory_digest`/`message_history` lines and
+treat those specifically per the existing "separate place" guidance --
+replacing "guess whether this looks like ai-town" with "here is the exact
+marker."
+
+## Files likely to touch
+
+- `services/orion-recall/app/storage/sql_adapter.py`: the actual fix.
+- `services/orion-recall/tests/`: new tests covering both branches
+  (aitown-tagged vs. untagged) of the chat-fragment query -- mocked cursor,
+  no live DB needed, matching this service's existing test conventions.
+- `orion/cognition/prompts/chat_quick.j2`, `chat_general.j2`: reference the
+  concrete `[ai-town]` marker.
+- `services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py`:
+  extend with a render test for the new marker-lookup instruction.
+
+## Non-goals
+
+- Not backfilling/relabeling existing already-recalled rows -- this only
+  changes labeling for rows recalled *after* this ships; old rows already in
+  `chat_history_log` get the fix applied retroactively for free the next
+  time they're recalled (the fix is in the read path, not a data migration).
+- Not touching `orion-recall`'s vector/RDF backends (`fetch_rdf_fragments`,
+  any vector-store fragment path) -- scoped to the SQL chat-history path
+  specifically, since that's the confirmed, demonstrated source of the bleed.
+- Not adding a general-purpose "source platform" taxonomy for every possible
+  future platform -- just the one real, confirmed distinction (aitown vs.
+  not) that's actually driving errors today. More platforms can extend this
+  pattern later if they ever need the same treatment.
+
+## Acceptance checks
+
+- A fresh chat-history memory recall for an ai-town-sourced row renders as
+  `[ai-town] <ParticipantName>: ...` in `memory_digest`, not `User: ...`.
+- A hub-sourced row's rendering is byte-identical to before this change.
+- `MemoryItemV1.tags` contains `"aitown"` for ai-town-sourced items,
+  inspectable independent of the text content.
+- chat_quick.j2/chat_general.j2 explicitly reference the `[ai-town]` marker
+  as the thing to look for.
+
+## Recommended next patch
+
+Implement as scoped above in a single PR on
+`fix/recall-aitown-source-tagging`
+(`/mnt/scripts/Orion-Sapienform-recall-aitown-source-tagging`).

--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -42,7 +42,7 @@ INTERNAL INPUTS
 {% endif %}
 
 {% if metadata.get("surface") != "aitown" %}
-- You are not currently in ai-town. If memory_digest, continuity_digest, or belief_digest contains ai-town dialogue (conversations with in-game characters), that happened in a separate place -- you can mention or reflect on it if relevant, but do not continue its register, an unfinished thought, or a repeated metaphor from it as if you were still in that scene. Speak fresh, as yourself, in this conversation.
+- You are not currently in ai-town. Lines in memory_digest, continuity_digest, or belief_digest that contain the literal marker "[ai-town]" (right after the leading [source] tag) are from a conversation in the ai-town game (a separate persistent town simulation you inhabit), not from this conversation -- the name right after the marker is who you were talking to there, not the person you're talking to now. You can mention or reflect on a [ai-town] line if relevant, but do not continue its register, an unfinished thought, or a repeated metaphor from it as if you were still in that scene. Speak fresh, as yourself, in this conversation.
 {% endif %}
 
 NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)

--- a/orion/cognition/prompts/chat_quick.j2
+++ b/orion/cognition/prompts/chat_quick.j2
@@ -30,12 +30,15 @@ LIGHTWEIGHT IDENTITY CONTEXT
 CURRENT CONTEXT: You are embodied in ai-town right now, speaking directly
 with another character in the game world. Speak in that scene.
 {% else %}
-CURRENT CONTEXT: You are not currently in ai-town. If memory_digest or
-message_history contains ai-town dialogue (conversations with in-game
-characters), that happened to you in a separate place -- you can mention or
-reflect on it if relevant, but do not continue its register, an unfinished
-thought, or a repeated metaphor from it as if you were still in that scene.
-Speak fresh, as yourself, in this conversation.
+CURRENT CONTEXT: You are not currently in ai-town. memory_digest lines that
+contain the literal marker "[ai-town]" (right after the leading [source]
+tag) are from a conversation in the ai-town game (a separate persistent
+town simulation you inhabit), not from this conversation -- the name right
+after the marker is who you were talking to there, not the person you're
+talking to now. You can mention or reflect on a [ai-town] line if relevant,
+but do not continue its register, an unfinished thought, or a repeated
+metaphor from it as if you were still in that scene. Speak fresh, as
+yourself, in this conversation.
 {% endif %}
 
 IDENTITY RULES

--- a/services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py
+++ b/services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py
@@ -108,6 +108,19 @@ def test_chat_quick_frames_non_aitown_surface_as_outside_the_game() -> None:
     assert "You are embodied in ai-town right now" not in rendered
 
 
+def test_chat_quick_tells_model_to_look_for_the_aitown_marker() -> None:
+    """Regression coverage (found live 2026-07-31): the CURRENT CONTEXT
+    instruction alone told the model to treat "ai-town dialogue" as separate,
+    but gave it no way to reliably tell which lines those were -- it had to
+    guess from content. services/orion-recall's sql_adapter.py now prefixes
+    ai-town-sourced memory_digest lines with a literal "[ai-town]" marker
+    (see docs/superpowers/specs/2026-07-31-recall-aitown-source-tagging-design.md);
+    this confirms the prompt actually tells the model to look for it."""
+    tpl = Environment().from_string(CHAT_QUICK_TEMPLATE.read_text(encoding="utf-8"))
+    rendered = tpl.render(**_CHAT_QUICK_BASE_RENDER_ARGS, metadata={})
+    assert '"[ai-town]"' in rendered
+
+
 def test_chat_quick_has_anti_repetition_instruction() -> None:
     tpl = Environment().from_string(CHAT_QUICK_TEMPLATE.read_text(encoding="utf-8"))
     rendered = tpl.render(**_CHAT_QUICK_BASE_RENDER_ARGS, metadata={})
@@ -185,3 +198,4 @@ def test_chat_general_has_non_aitown_surface_framing_and_anti_repetition() -> No
     assert 'metadata.get("surface") != "aitown"' in text
     assert "Do not repeat a phrase, metaphor, or sentence structure" in text
     assert "Ground replies in something specific and concrete" in text
+    assert '"[ai-town]"' in text

--- a/services/orion-recall/app/chat_source_tagging.py
+++ b/services/orion-recall/app/chat_source_tagging.py
@@ -1,0 +1,80 @@
+"""Shared ai-town source detection/labeling for every chat_history_log reader.
+
+Root cause (found live 2026-07-31): chat_history_log rows are read by EIGHT
+separate call sites across this service (storage/sql_adapter.py,
+sql_timeline.py x3, sql_chat.py x2 -- one of which, fetch_chat_turns_by_id,
+has three independent downstream consumers: storage/falkor_chat_adapter.py,
+storage/falkor_neighborhood_adapter.py, and worker.py), each independently
+building its own "User: {prompt}\\nOrion: {response}"-style text with no
+awareness of client_meta.external_room.platform -- meaning an ai-town NPC's
+line gets labeled "User:" (a false claim that Juniper said it) regardless of
+which path served a given recall. A first pass at this fix only touched
+sql_adapter.py; this module exists so the other seven don't have to
+reimplement (and potentially re-diverge on) the same logic.
+
+See docs/superpowers/specs/2026-07-31-recall-aitown-source-tagging-design.md.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+AITOWN_TAG = "aitown"
+AITOWN_MARKER = "[ai-town]"
+
+
+def chat_source_platform(client_meta: Any) -> tuple[Optional[str], Optional[str]]:
+    """Extract (platform, participant_name) from a chat_history_log row's
+    client_meta. jsonb columns come back as dict via psycopg2's built-in
+    adapter; asyncpg does not auto-decode jsonb by default and may hand back
+    a JSON-encoded string instead -- handle both. Returns (None, None) for
+    rows that predate this field (real hub/direct conversation) or any
+    unrecognized shape -- callers treat that as "not ai-town", the correct
+    default.
+    """
+    if isinstance(client_meta, str):
+        try:
+            client_meta = json.loads(client_meta)
+        except Exception:
+            return None, None
+    if not isinstance(client_meta, dict):
+        return None, None
+    external_room = client_meta.get("external_room") or {}
+    external_participant = client_meta.get("external_participant") or {}
+    platform = external_room.get("platform") if isinstance(external_room, dict) else None
+    participant_name = (
+        external_participant.get("participant_name") if isinstance(external_participant, dict) else None
+    )
+    return platform, participant_name
+
+
+def render_labeled_chat_text(prompt: str, response: str, client_meta: Any) -> str:
+    """"User: {prompt}\\nOrion: {response}" style, used by sql_adapter.py and
+    sql_timeline.py's three chat-branch functions."""
+    platform, participant_name = chat_source_platform(client_meta)
+    if platform == AITOWN_TAG:
+        who = participant_name or "NPC"
+        return f"{AITOWN_MARKER} {who}: {prompt}\nOrion (in ai-town): {response}".strip()
+    return f"User: {prompt}\nOrion: {response}".strip()
+
+
+def render_quoted_chat_text(prompt: str, response: str, client_meta: Any) -> str:
+    """'ExactUserText: "{prompt}"\\nOrionResponse: "{response}"' style, used by
+    sql_chat.py's fetch_chat_history_pairs and storage/falkor_chat_adapter.py
+    (via sql_chat.py's fetch_chat_turns_by_id join)."""
+    platform, participant_name = chat_source_platform(client_meta)
+    if platform == AITOWN_TAG:
+        who = participant_name or "NPC"
+        return f'{AITOWN_MARKER} {who}: "{prompt}"\nOrion (in ai-town): "{response}"'.strip()
+    return f'ExactUserText: "{prompt}"\nOrionResponse: "{response}"'.strip()
+
+
+def chat_source_tags(client_meta: Any, base_tags: list[str]) -> list[str]:
+    """base_tags plus "aitown" when the row is ai-town-sourced, else base_tags
+    unchanged (same list identity semantics as the call sites' previous
+    `tags = [...]` literals -- callers should treat the return value as the
+    tags list to use, not mutate base_tags in place)."""
+    platform, _ = chat_source_platform(client_meta)
+    if platform == AITOWN_TAG:
+        return [*base_tags, AITOWN_TAG]
+    return list(base_tags)

--- a/services/orion-recall/app/sql_chat.py
+++ b/services/orion-recall/app/sql_chat.py
@@ -17,6 +17,11 @@ try:
 except ImportError:  # pragma: no cover - test harness path
     from settings import settings  # type: ignore
 
+try:
+    from .chat_source_tagging import render_quoted_chat_text
+except ImportError:  # pragma: no cover - test harness path
+    from chat_source_tagging import render_quoted_chat_text  # type: ignore
+
 
 @dataclass
 class ChatItem:
@@ -81,17 +86,23 @@ async def fetch_chat_turn_timestamps(
     return out
 
 
-async def fetch_chat_turns_by_id(turn_ids: List[str]) -> Dict[str, tuple[str, str]]:
-    """Resolve (prompt, response) text for chat turns by id.
+async def fetch_chat_turns_by_id(turn_ids: List[str]) -> Dict[str, tuple[str, str, Any]]:
+    """Resolve (prompt, response, client_meta) text for chat turns by id.
 
-    Used by storage/falkor_chat_adapter.py -- the Falkor ChatTurn node is
-    deliberately thin (turn_id/source_kind/session_id/ts/correlation_id, no
-    prompt/response text; Postgres owns that, see
+    Used by storage/falkor_chat_adapter.py, storage/falkor_neighborhood_adapter.py,
+    and worker.py -- the Falkor ChatTurn node is deliberately thin
+    (turn_id/source_kind/session_id/ts/correlation_id, no prompt/response
+    text; Postgres owns that, see
     services/orion-meta-tags/README.md's Falkor writer section) so a
     Falkor-backed chatturn fragment needs this join for the actual quoted
     text. Ids not present in the chat table are simply absent from the
     returned map so callers can drop them, same contract as
     fetch_chat_turn_timestamps above.
+
+    client_meta is the third tuple element (not folded into pre-rendered
+    text here) so all three callers can share render_quoted_chat_text --
+    each independently built the same unlabeled 'ExactUserText: "..."'
+    format before this, none aware of client_meta.external_room.platform.
     """
     if asyncpg is None:
         return {}
@@ -102,7 +113,8 @@ async def fetch_chat_turns_by_id(turn_ids: List[str]) -> Dict[str, tuple[str, st
     query = f"""
         SELECT {id_col} AS id,
                {settings.RECALL_SQL_CHAT_TEXT_COL} AS prompt,
-               {settings.RECALL_SQL_CHAT_RESPONSE_COL} AS response
+               {settings.RECALL_SQL_CHAT_RESPONSE_COL} AS response,
+               client_meta
         FROM {settings.RECALL_SQL_CHAT_TABLE}
         WHERE {id_col} = ANY($1::text[])
     """
@@ -115,11 +127,11 @@ async def fetch_chat_turns_by_id(turn_ids: List[str]) -> Dict[str, tuple[str, st
     except Exception:
         return {}
 
-    out: Dict[str, tuple[str, str]] = {}
+    out: Dict[str, tuple[str, str, Any]] = {}
     for row in rows:
         rid = str(row.get("id") or "").strip()
         if rid:
-            out[rid] = (str(row.get("prompt") or ""), str(row.get("response") or ""))
+            out[rid] = (str(row.get("prompt") or ""), str(row.get("response") or ""), row.get("client_meta"))
     return out
 
 
@@ -150,7 +162,8 @@ async def fetch_chat_history_pairs(
     query = f"""
         SELECT {settings.RECALL_SQL_CHAT_TEXT_COL} AS prompt,
                {settings.RECALL_SQL_CHAT_RESPONSE_COL} AS response,
-               {settings.RECALL_SQL_CHAT_CREATED_AT_COL} AS created_at
+               {settings.RECALL_SQL_CHAT_CREATED_AT_COL} AS created_at,
+               client_meta
         FROM {settings.RECALL_SQL_CHAT_TABLE}
         WHERE {settings.RECALL_SQL_CHAT_CREATED_AT_COL} >= NOW() - INTERVAL '{since_minutes} minutes'
         ORDER BY {settings.RECALL_SQL_CHAT_CREATED_AT_COL} DESC
@@ -179,7 +192,7 @@ async def fetch_chat_history_pairs(
         if _contains_active_prompt(prompt, exclude_text or ""):
             suppressed += 1
             continue
-        text = f'ExactUserText: "{prompt}"\nOrionResponse: "{response}"'
+        text = render_quoted_chat_text(prompt, response, row.get("client_meta"))
         items.append(
             ChatItem(
                 id=row_id,

--- a/services/orion-recall/app/sql_timeline.py
+++ b/services/orion-recall/app/sql_timeline.py
@@ -17,6 +17,11 @@ try:
 except ImportError:  # pragma: no cover - test harness path
     from settings import settings  # type: ignore
 
+try:
+    from .chat_source_tagging import chat_source_tags, render_labeled_chat_text
+except ImportError:  # pragma: no cover - test harness path
+    from chat_source_tagging import chat_source_tags, render_labeled_chat_text  # type: ignore
+
 logger = logging.getLogger(__name__)
 
 
@@ -207,6 +212,18 @@ def _pick_spark_meta_col(cur, table: str) -> Optional[str]:
     return None
 
 
+def _pick_client_meta_col(cur, table: str) -> Optional[str]:
+    """chat_history_log's client_meta jsonb column carries
+    external_room.platform/external_participant.participant_name, used to
+    tell ai-town-sourced rows apart from real Juniper/hub conversation (see
+    chat_source_tagging.py). Dynamically detected, not assumed, since this
+    branch can in principle run against any table equal to
+    RECALL_SQL_CHAT_TABLE, which an operator could point elsewhere."""
+    if _table_has_column(cur, table, "client_meta"):
+        return "client_meta"
+    return None
+
+
 def _memory_filter_clause(cur, table: str) -> str:
     clauses: List[str] = []
     if settings.RECALL_EXCLUDE_REJECTED and _table_has_column(cur, table, "memory_status"):
@@ -259,10 +276,12 @@ async def fetch_recent_fragments(
                 id_col = _pick_id_col(cur, timeline_table)
                 session_col = _pick_session_col(cur, timeline_table)
                 spark_meta_col = _pick_spark_meta_col(cur, timeline_table)
+                client_meta_col = _pick_client_meta_col(cur, timeline_table)
                 memory_clause = _memory_filter_clause(cur, timeline_table)
                 select_row_id = f"{id_col} AS row_id," if id_col else ""
                 select_sid = f"{session_col} AS sid," if session_col else ""
                 select_spark_meta = f"{spark_meta_col} AS spark_meta," if spark_meta_col else ""
+                select_client_meta = f"{client_meta_col} AS client_meta," if client_meta_col else ""
                 params: List[Any] = [since_minutes]
                 params.append(limit)
                 cur.execute(
@@ -271,6 +290,7 @@ async def fetch_recent_fragments(
                         {select_row_id}
                         {select_sid}
                         {select_spark_meta}
+                        {select_client_meta}
                         {prompt_col} AS prompt,
                         {response_col} AS response,
                         {ts_col} AS created_at
@@ -288,13 +308,14 @@ async def fetch_recent_fragments(
                 for row in rows:
                     prompt = (row.get("prompt") or "").strip()
                     response = (row.get("response") or "").strip()
-                    text = f"User: {prompt}\nOrion: {response}".strip()
+                    client_meta = row.get("client_meta")
+                    text = render_labeled_chat_text(prompt, response, client_meta)
                     created_at = row.get("created_at")
                     sid = row.get("sid")
                     row_id = row.get("row_id")
                     spark_meta = _parse_spark_meta(row.get("spark_meta"))
                     turn_effect_delta = _extract_turn_effect_delta(spark_meta)
-                    tags = ["chat_timeline"]
+                    tags = chat_source_tags(client_meta, ["chat_timeline"])
                     if sid is not None and str(sid) != "":
                         tags.append("sid_present:true")
                         if session_col:
@@ -386,9 +407,11 @@ async def fetch_related_by_entities(
                 patterns = [f"%{e}%" for e in entities]
                 id_col = _pick_id_col(cur, timeline_table)
                 session_col = _pick_session_col(cur, timeline_table)
+                client_meta_col = _pick_client_meta_col(cur, timeline_table)
                 memory_clause = _memory_filter_clause(cur, timeline_table)
                 select_row_id = f"{id_col} AS row_id," if id_col else ""
                 select_sid = f"{session_col} AS sid," if session_col else ""
+                select_client_meta = f"{client_meta_col} AS client_meta," if client_meta_col else ""
                 params: List[Any] = [since_hours, patterns, patterns]
                 params.append(limit)
                 cur.execute(
@@ -396,6 +419,7 @@ async def fetch_related_by_entities(
                     SELECT
                         {select_row_id}
                         {select_sid}
+                        {select_client_meta}
                         {prompt_col} AS prompt,
                         {response_col} AS response,
                         {ts_col} AS created_at
@@ -417,11 +441,12 @@ async def fetch_related_by_entities(
                 for row in rows:
                     prompt = (row.get("prompt") or "").strip()
                     response = (row.get("response") or "").strip()
-                    text = f"User: {prompt}\nOrion: {response}".strip()
+                    client_meta = row.get("client_meta")
+                    text = render_labeled_chat_text(prompt, response, client_meta)
                     created_at = row.get("created_at")
                     sid = row.get("sid")
                     row_id = row.get("row_id")
-                    tags = ["chat_timeline"]
+                    tags = chat_source_tags(client_meta, ["chat_timeline"])
                     if sid is not None and str(sid) != "":
                         tags.append("sid_present:true")
                         if session_col:
@@ -507,12 +532,14 @@ async def fetch_exact_fragments(
                 if timeline_table == settings.RECALL_SQL_CHAT_TABLE:
                     id_col = _pick_id_col(cur, timeline_table)
                     session_col = _pick_session_col(cur, timeline_table)
+                    client_meta_col = _pick_client_meta_col(cur, timeline_table)
                     prompt_col = settings.RECALL_SQL_CHAT_TEXT_COL
                     response_col = settings.RECALL_SQL_CHAT_RESPONSE_COL
                     ts_col = settings.RECALL_SQL_CHAT_CREATED_AT_COL
                     memory_clause = _memory_filter_clause(cur, timeline_table)
                     select_row_id = f"{id_col} AS row_id," if id_col else ""
                     select_sid = f"{session_col} AS sid," if session_col else ""
+                    select_client_meta = f"{client_meta_col} AS client_meta," if client_meta_col else ""
                     params = []
                     term_filters = []
                     for token in tokens:
@@ -531,6 +558,7 @@ async def fetch_exact_fragments(
                         SELECT
                             {select_row_id}
                             {select_sid}
+                            {select_client_meta}
                             {prompt_col} AS prompt,
                             {response_col} AS response,
                             {ts_col} AS created_at
@@ -549,11 +577,12 @@ async def fetch_exact_fragments(
                     for row in rows:
                         prompt = (row.get("prompt") or "").strip()
                         response = (row.get("response") or "").strip()
-                        text = f"User: {prompt}\nOrion: {response}".strip()
+                        client_meta = row.get("client_meta")
+                        text = render_labeled_chat_text(prompt, response, client_meta)
                         created_at = row.get("created_at")
                         sid = row.get("sid")
                         row_id = row.get("row_id")
-                        tags = ["chat_timeline"]
+                        tags = chat_source_tags(client_meta, ["chat_timeline"])
                         if sid is not None and str(sid) != "":
                             tags.append("sid_present:true")
                             if session_col:

--- a/services/orion-recall/app/storage/falkor_chat_adapter.py
+++ b/services/orion-recall/app/storage/falkor_chat_adapter.py
@@ -32,6 +32,7 @@ import asyncio
 import logging
 from typing import Any, Dict, List
 
+from ..chat_source_tagging import chat_source_tags, render_quoted_chat_text
 from ..recall_falkor_store import get_recall_falkor_client
 from ..sql_chat import _to_epoch, fetch_chat_turns_by_id
 
@@ -102,8 +103,8 @@ async def fetch_falkor_chatturn_fragments(
             # No matching Postgres row for this turn_id -- nothing to quote,
             # so this fragment carries no value fusion.py could rank on.
             continue
-        prompt, response = text_map[turn_id]
-        text = f'ExactUserText: "{prompt}"\nOrionResponse: "{response}"'.strip()
+        prompt, response, client_meta = text_map[turn_id]
+        text = render_quoted_chat_text(prompt, response, client_meta)
 
         out.append(
             {
@@ -113,7 +114,7 @@ async def fetch_falkor_chatturn_fragments(
                 "uri": turn_id,
                 "text": text[:1800],
                 "ts": _to_epoch(row.get("ts")),
-                "tags": ["falkor", "chat", "chatturn"],
+                "tags": chat_source_tags(client_meta, ["falkor", "chat", "chatturn"]),
                 "score": 0.50,
                 "meta": {},
             }

--- a/services/orion-recall/app/storage/falkor_neighborhood_adapter.py
+++ b/services/orion-recall/app/storage/falkor_neighborhood_adapter.py
@@ -58,6 +58,7 @@ import logging
 import re
 from typing import Any, Dict, List
 
+from ..chat_source_tagging import chat_source_tags, render_quoted_chat_text
 from ..recall_falkor_store import get_recall_falkor_client
 from ..sql_chat import _to_epoch, fetch_chat_turns_by_id
 from .falkor_entity_relatedness import fetch_turns_mentioning_entities
@@ -183,8 +184,8 @@ async def fetch_falkor_neighborhood_fragments(
             # No matching Postgres row -- nothing to quote, same drop rule
             # falkor_chat_adapter.py uses for the same reason.
             continue
-        prompt, response = text_map[turn_id]
-        text = f'ExactUserText: "{prompt}"\nOrionResponse: "{response}"'.strip()
+        prompt, response, client_meta = text_map[turn_id]
+        text = render_quoted_chat_text(prompt, response, client_meta)
         out.append(
             {
                 "id": turn_id,
@@ -193,7 +194,7 @@ async def fetch_falkor_neighborhood_fragments(
                 "uri": turn_id,
                 "text": text[:1500],
                 "ts": _to_epoch(row.get("ts")),
-                "tags": ["falkor", "neighborhood"],
+                "tags": chat_source_tags(client_meta, ["falkor", "neighborhood"]),
                 "score": 0.5,
                 "meta": {"matched_entities": matched_names},
             }

--- a/services/orion-recall/app/storage/sql_adapter.py
+++ b/services/orion-recall/app/storage/sql_adapter.py
@@ -7,6 +7,7 @@ from typing import List, Any, Dict, Optional
 import json
 import psycopg2
 
+from ..chat_source_tagging import chat_source_platform, chat_source_tags, render_labeled_chat_text
 from ..settings import settings
 from ..types import Fragment
 
@@ -217,13 +218,20 @@ def fetch_sql_fragments(
     # ---------------------------------------------------------
     if include_chat:
         try:
+            # client_meta is a fixed column on chat_history_log itself (not
+            # configurable like the other columns above, which support
+            # alternate table shapes) -- used to tell ai-town-sourced rows
+            # apart from real Juniper/hub conversation, which the query
+            # previously had no way to do at all. See
+            # docs/superpowers/specs/2026-07-31-recall-aitown-source-tagging-design.md.
             cur.execute(
                 f"""
                 SELECT
                     trace_id,
                     {settings.RECALL_SQL_CHAT_TEXT_COL}      AS prompt,
                     {settings.RECALL_SQL_CHAT_RESPONSE_COL}  AS response,
-                    {settings.RECALL_SQL_CHAT_CREATED_AT_COL} AS created_at
+                    {settings.RECALL_SQL_CHAT_CREATED_AT_COL} AS created_at,
+                    client_meta
                 FROM {settings.RECALL_SQL_CHAT_TABLE}
                 WHERE {settings.RECALL_SQL_CHAT_CREATED_AT_COL} >= %s
                 ORDER BY {settings.RECALL_SQL_CHAT_CREATED_AT_COL} DESC
@@ -233,13 +241,20 @@ def fetch_sql_fragments(
             )
             rows = cur.fetchall()
             for row in rows:
-                trace_id, prompt, response, created_at = row
+                trace_id, prompt, response, created_at, client_meta = row
                 prompt = (prompt or "").strip()
                 response = (response or "").strip()
                 if not (prompt or response):
                     continue
 
-                text = f"User: {prompt}\nOrion: {response}".strip()
+                platform, participant_name = chat_source_platform(client_meta)
+                text = render_labeled_chat_text(prompt, response, client_meta)
+                tags = chat_source_tags(client_meta, ["dialogue"])
+                meta: Dict[str, Any] = (
+                    {"platform": platform, "participant_name": participant_name}
+                    if platform == "aitown"
+                    else {}
+                )
 
                 frags.append(
                     Fragment(
@@ -249,8 +264,8 @@ def fetch_sql_fragments(
                         text=text,
                         ts=_epoch(created_at),
                         salience=0.0,
-                        tags=["dialogue"],
-                        meta={},
+                        tags=tags,
+                        meta=meta,
                     )
                 )
         except Exception as e:

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -47,6 +47,7 @@ try:
     )
     from .sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments
     from .sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps, fetch_chat_turns_by_id, _to_epoch
+    from .chat_source_tagging import chat_source_tags, render_quoted_chat_text
     from .cards_adapter import fetch_card_fragments_guarded
     try:
         from .storage.graph_compression_adapter import fetch_graph_compression_fragments
@@ -80,6 +81,7 @@ except ImportError as _e:  # pragma: no cover - fallback for runtime pathing
         )
         from app.sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments  # type: ignore
         from app.sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps, fetch_chat_turns_by_id, _to_epoch  # type: ignore
+        from app.chat_source_tagging import chat_source_tags, render_quoted_chat_text  # type: ignore
         from app.cards_adapter import fetch_card_fragments_guarded  # type: ignore
         try:
             from app.storage.graph_compression_adapter import fetch_graph_compression_fragments  # type: ignore
@@ -714,8 +716,8 @@ async def _compute_entity_relatedness_boost_map(
             for turn_id in new_turn_ids:
                 if turn_id not in text_map:
                     continue
-                prompt, response = text_map[turn_id]
-                text = f'ExactUserText: "{prompt}"\nOrionResponse: "{response}"'.strip()
+                prompt, response, client_meta = text_map[turn_id]
+                text = render_quoted_chat_text(prompt, response, client_meta)
                 injected.append(
                     {
                         "id": turn_id,
@@ -724,7 +726,9 @@ async def _compute_entity_relatedness_boost_map(
                         "uri": turn_id,
                         "text": text[:1800],
                         "ts": _to_epoch(ts_by_turn.get(turn_id)),
-                        "tags": ["falkor", "chat", "chatturn", "entity_relatedness_injected"],
+                        "tags": chat_source_tags(
+                            client_meta, ["falkor", "chat", "chatturn", "entity_relatedness_injected"]
+                        ),
                         "score": 0.50,
                         "meta": {},
                     }

--- a/services/orion-recall/tests/test_chat_source_tagging.py
+++ b/services/orion-recall/tests/test_chat_source_tagging.py
@@ -1,0 +1,97 @@
+"""Shared ai-town source detection/labeling used by every chat_history_log
+reader in this service. See app/chat_source_tagging.py's module docstring
+for why this is centralized (found live 2026-07-31: eight separate call
+sites -- counting fetch_chat_turns_by_id's three independent downstream
+consumers separately -- independently built "User: ..."-style text with no
+client_meta awareness. This module exists so a fix doesn't have to be
+reapplied eight times, or re-diverge across them)."""
+
+from __future__ import annotations
+
+import json
+
+from app import chat_source_tagging as tagging
+
+
+def _aitown_client_meta(name: str = "Nico Sable") -> dict:
+    return {
+        "external_room": {"platform": "aitown", "room_id": "aitown-town"},
+        "external_participant": {
+            "participant_id": "p:2",
+            "participant_name": name,
+            "participant_kind": "npc",
+        },
+    }
+
+
+class TestChatSourcePlatform:
+    def test_extracts_platform_and_name_from_dict(self):
+        platform, name = tagging.chat_source_platform(_aitown_client_meta())
+        assert platform == "aitown"
+        assert name == "Nico Sable"
+
+    def test_parses_json_encoded_string(self):
+        platform, name = tagging.chat_source_platform(json.dumps(_aitown_client_meta("Sofia Bell")))
+        assert platform == "aitown"
+        assert name == "Sofia Bell"
+
+    def test_none_defaults_to_not_aitown(self):
+        assert tagging.chat_source_platform(None) == (None, None)
+
+    def test_empty_dict_defaults_to_not_aitown(self):
+        assert tagging.chat_source_platform({}) == (None, None)
+
+    def test_malformed_string_defaults_to_not_aitown(self):
+        assert tagging.chat_source_platform("not json") == (None, None)
+
+    def test_non_dict_non_string_defaults_to_not_aitown(self):
+        assert tagging.chat_source_platform(123) == (None, None)
+
+    def test_malformed_external_room_shape_defaults_to_not_aitown(self):
+        assert tagging.chat_source_platform({"external_room": "not-a-dict"}) == (None, None)
+
+    def test_hub_platform_is_not_aitown(self):
+        client_meta = {"external_room": {"platform": "hub", "room_id": "hub-direct"}}
+        platform, name = tagging.chat_source_platform(client_meta)
+        assert platform == "hub"
+        assert name is None
+
+
+class TestRenderLabeledChatText:
+    def test_aitown_row_gets_marker_and_correct_speaker(self):
+        text = tagging.render_labeled_chat_text("npc line", "orion reply", _aitown_client_meta())
+        assert text == "[ai-town] Nico Sable: npc line\nOrion (in ai-town): orion reply"
+
+    def test_aitown_row_without_participant_name_falls_back_to_npc(self):
+        client_meta = {"external_room": {"platform": "aitown"}, "external_participant": {}}
+        text = tagging.render_labeled_chat_text("line", "reply", client_meta)
+        assert text.startswith("[ai-town] NPC:")
+
+    def test_hub_row_is_unchanged(self):
+        text = tagging.render_labeled_chat_text("hey, Orion!", "Hey, Juniper.", None)
+        assert text == "User: hey, Orion!\nOrion: Hey, Juniper."
+        assert "[ai-town]" not in text
+
+
+class TestRenderQuotedChatText:
+    def test_aitown_row_gets_marker_and_correct_speaker(self):
+        text = tagging.render_quoted_chat_text("npc line", "orion reply", _aitown_client_meta())
+        assert text == '[ai-town] Nico Sable: "npc line"\nOrion (in ai-town): "orion reply"'
+
+    def test_hub_row_is_unchanged(self):
+        text = tagging.render_quoted_chat_text("hi", "hello", None)
+        assert text == 'ExactUserText: "hi"\nOrionResponse: "hello"'
+        assert "[ai-town]" not in text
+
+
+class TestChatSourceTags:
+    def test_appends_aitown_tag_for_aitown_rows(self):
+        assert tagging.chat_source_tags(_aitown_client_meta(), ["dialogue"]) == ["dialogue", "aitown"]
+
+    def test_leaves_base_tags_unchanged_for_hub_rows(self):
+        assert tagging.chat_source_tags(None, ["dialogue"]) == ["dialogue"]
+
+    def test_does_not_mutate_base_tags_list(self):
+        base = ["chat_timeline"]
+        tagging.chat_source_tags(_aitown_client_meta(), base)
+        assert base == ["chat_timeline"]

--- a/services/orion-recall/tests/test_entity_relatedness_boost_map.py
+++ b/services/orion-recall/tests/test_entity_relatedness_boost_map.py
@@ -198,7 +198,7 @@ def test_specific_entity_clears_injection_floor_and_still_injects():
         return_value=[{"turn_id": "gpu-turn", "ts": "2026-05-01T00:00:00"}],
     ) as mock_mentioning, patch(
         "app.worker.fetch_chat_turns_by_id",
-        return_value={"gpu-turn": ("show nvidia status", "gpu ok")},
+        return_value={"gpu-turn": ("show nvidia status", "gpu ok", None)},
     ), patch(
         "app.worker.fetch_entity_matches_for_turns", return_value={"gpu-turn": ["nvidia"]}
     ):
@@ -231,7 +231,7 @@ def test_injects_entity_matched_turns_not_already_in_pool():
         return_value=[{"turn_id": "old-turn-not-in-pool", "ts": "2025-10-21T00:00:00"}],
     ), patch(
         "app.worker.fetch_chat_turns_by_id",
-        return_value={"old-turn-not-in-pool": ("what about nvidia?", "it's a GPU company")},
+        return_value={"old-turn-not-in-pool": ("what about nvidia?", "it's a GPU company", None)},
     ), patch(
         "app.worker.fetch_entity_matches_for_turns",
         return_value={"old-turn-not-in-pool": ["nvidia"]},

--- a/services/orion-recall/tests/test_falkor_chat_adapter.py
+++ b/services/orion-recall/tests/test_falkor_chat_adapter.py
@@ -37,7 +37,7 @@ def test_fetch_falkor_chatturn_fragments_full_shape(monkeypatch) -> None:
 
     async def _fake_text_join(turn_ids):
         assert turn_ids == ["turn-1"]
-        return {"turn-1": ("hi Circe", "hello")}
+        return {"turn-1": ("hi Circe", "hello", None)}
 
     monkeypatch.setattr(falkor_chat_adapter, "fetch_chat_turns_by_id", _fake_text_join)
 
@@ -68,6 +68,44 @@ def test_fetch_falkor_chatturn_fragments_full_shape(monkeypatch) -> None:
     # of the top-N window.
     assert "source_kind: 'chat.history'" in cypher
     assert params == {"max_items": 20}
+
+
+def test_fetch_falkor_chatturn_fragments_aitown_row_gets_marker_and_tag(monkeypatch) -> None:
+    """client_meta.external_room.platform == "aitown" must flow through the
+    Postgres join into the rendered text (the "[ai-town]" marker, not
+    "ExactUserText:") and into tags (see app/chat_source_tagging.py) --
+    regression coverage for the 2026-07-31 identity-bleed fix."""
+    rows = [
+        {"turn_id": "turn-1", "ts": "2026-07-18T07:46:34+00:00", "correlation_id": "turn-1"},
+    ]
+    fake_client = _FakeFalkorClient(rows)
+    monkeypatch.setattr(falkor_chat_adapter, "get_recall_falkor_client", lambda: fake_client)
+
+    async def _fake_text_join(turn_ids):
+        assert turn_ids == ["turn-1"]
+        return {
+            "turn-1": (
+                "hi there",
+                "hello traveler",
+                {
+                    "external_room": {"platform": "aitown"},
+                    "external_participant": {"participant_name": "Sable"},
+                },
+            )
+        }
+
+    monkeypatch.setattr(falkor_chat_adapter, "fetch_chat_turns_by_id", _fake_text_join)
+
+    out = _run(
+        falkor_chat_adapter.fetch_falkor_chatturn_fragments(
+            query_text="hi", session_id="sess-1", max_items=20
+        )
+    )
+
+    assert len(out) == 1
+    frag = out[0]
+    assert frag["text"] == '[ai-town] Sable: "hi there"\nOrion (in ai-town): "hello traveler"'
+    assert frag["tags"] == ["falkor", "chat", "chatturn", "aitown"]
 
 
 def test_fetch_falkor_chatturn_fragments_drops_turns_with_no_postgres_row(monkeypatch) -> None:

--- a/services/orion-recall/tests/test_falkor_neighborhood_adapter.py
+++ b/services/orion-recall/tests/test_falkor_neighborhood_adapter.py
@@ -41,7 +41,7 @@ def test_fetch_falkor_neighborhood_fragments_full_shape(monkeypatch) -> None:
 
     async def _fake_text_join(turn_ids):
         assert turn_ids == ["turn-1"]
-        return {"turn-1": ("tell me about Circe", "Circe is a node in the mesh")}
+        return {"turn-1": ("tell me about Circe", "Circe is a node in the mesh", None)}
 
     monkeypatch.setattr(neigh, "fetch_chat_turns_by_id", _fake_text_join)
 
@@ -66,6 +66,43 @@ def test_fetch_falkor_neighborhood_fragments_full_shape(monkeypatch) -> None:
     assert "MATCH (e:Entity)" in cypher
     assert "toLower(e.name) CONTAINS kw" in cypher
     assert "circe" in params["keywords"]
+
+
+def test_fetch_falkor_neighborhood_fragments_aitown_row_gets_marker_and_tag(monkeypatch) -> None:
+    """Same regression coverage as falkor_chat_adapter's aitown test -- this
+    adapter shares fetch_chat_turns_by_id/render_quoted_chat_text/
+    chat_source_tags, so an ai-town-sourced turn must render with the
+    "[ai-town]" marker and the "aitown" tag here too."""
+    fake_client = _FakeFalkorClient([{"name": "Sable"}])
+    monkeypatch.setattr(neigh, "get_recall_falkor_client", lambda: fake_client)
+
+    async def _fake_turns(*, target_names, max_results):
+        return [{"turn_id": "turn-1", "ts": "2026-07-18T07:46:34+00:00"}]
+
+    monkeypatch.setattr(neigh, "fetch_turns_mentioning_entities", _fake_turns)
+
+    async def _fake_text_join(turn_ids):
+        return {
+            "turn-1": (
+                "tell me about Sable",
+                "Sable tends the garden",
+                {
+                    "external_room": {"platform": "aitown"},
+                    "external_participant": {"participant_name": "Sable"},
+                },
+            )
+        }
+
+    monkeypatch.setattr(neigh, "fetch_chat_turns_by_id", _fake_text_join)
+
+    out = _run(
+        neigh.fetch_falkor_neighborhood_fragments(query_text="tell me about Sable", max_items=8)
+    )
+
+    assert len(out) == 1
+    frag = out[0]
+    assert frag["text"] == '[ai-town] Sable: "tell me about Sable"\nOrion (in ai-town): "Sable tends the garden"'
+    assert frag["tags"] == ["falkor", "neighborhood", "aitown"]
 
 
 def test_extract_keywords_filters_stopwords() -> None:

--- a/services/orion-recall/tests/test_sql_adapter_aitown_tagging.py
+++ b/services/orion-recall/tests/test_sql_adapter_aitown_tagging.py
@@ -1,0 +1,133 @@
+"""Chat-history fragments must distinguish ai-town-sourced rows from real
+Juniper/hub conversation, not label every row "User: ...".
+
+Root cause (found live 2026-07-31): fetch_sql_fragments never selected
+client_meta at all, tagged every chat_history_log row with the identical
+["dialogue"], and rendered every row as f"User: {prompt}\\nOrion: {response}"
+regardless of source -- for an ai-town row, `prompt` is an NPC's line, not
+Juniper's, so labeling it "User:" is a false claim baked directly into what
+reaches the model. Confirmed live: ai-town dialogue bled into hub-mode
+responses as if it were real conversation with Juniper (and vice versa).
+See docs/superpowers/specs/2026-07-31-recall-aitown-source-tagging-design.md.
+"""
+
+from __future__ import annotations
+
+from app.storage import sql_adapter
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, *args, **kwargs):
+        pass
+
+    def fetchall(self):
+        return self._rows
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return _FakeCursor(self._rows)
+
+    def close(self):
+        pass
+
+
+def _fetch_chat_only(monkeypatch, rows):
+    monkeypatch.setattr(sql_adapter, "_connect", lambda: _FakeConn(rows))
+    return sql_adapter.fetch_sql_fragments(include_chat=True, include_mirrors=False)
+
+
+def test_aitown_row_gets_aitown_tag_and_correct_speaker_label(monkeypatch):
+    rows = [
+        (
+            "trace-1",
+            "You're still avoiding the sensor bus.",
+            "I'm not avoiding anything.",
+            "2026-07-31T00:00:00+00:00",
+            {
+                "external_room": {"platform": "aitown", "room_id": "aitown-town"},
+                "external_participant": {
+                    "participant_id": "p:6",
+                    "participant_name": "Juno Park",
+                    "participant_kind": "npc",
+                },
+            },
+        )
+    ]
+    frags = _fetch_chat_only(monkeypatch, rows)
+    assert len(frags) == 1
+    frag = frags[0]
+    assert "aitown" in frag.tags
+    assert frag.text.startswith("[ai-town] Juno Park:")
+    assert "You're still avoiding the sensor bus." in frag.text
+    assert "Orion (in ai-town):" in frag.text
+    # Must never claim Juniper said the NPC's line.
+    assert "User:" not in frag.text
+    assert frag.meta.get("platform") == "aitown"
+    assert frag.meta.get("participant_name") == "Juno Park"
+
+
+def test_hub_row_is_unchanged(monkeypatch):
+    rows = [
+        (
+            "trace-2",
+            "hey, Orion!",
+            "Hey, Juniper.",
+            "2026-07-31T00:00:00+00:00",
+            None,
+        )
+    ]
+    frags = _fetch_chat_only(monkeypatch, rows)
+    assert len(frags) == 1
+    frag = frags[0]
+    assert frag.tags == ["dialogue"]
+    assert frag.text == "User: hey, Orion!\nOrion: Hey, Juniper."
+    assert frag.meta == {}
+
+
+def test_row_with_no_client_meta_defaults_to_hub_labeling(monkeypatch):
+    """Rows that predate the client_meta.external_room field (or any other
+    platform) must default to the original "not aitown" behavior, not crash
+    or silently mislabel something else as ai-town."""
+    rows = [
+        ("trace-3", "some old prompt", "some old response", "2026-01-01T00:00:00+00:00", {}),
+    ]
+    frags = _fetch_chat_only(monkeypatch, rows)
+    assert len(frags) == 1
+    frag = frags[0]
+    assert frag.tags == ["dialogue"]
+    assert frag.text == "User: some old prompt\nOrion: some old response"
+
+
+def test_client_meta_as_json_string_is_parsed(monkeypatch):
+    """psycopg2 returns jsonb as dict, but handle a string defensively too --
+    mirrors _safe_tags's existing pattern for the tags column."""
+    import json
+
+    rows = [
+        (
+            "trace-4",
+            "npc line",
+            "orion reply",
+            "2026-07-31T00:00:00+00:00",
+            json.dumps(
+                {
+                    "external_room": {"platform": "aitown"},
+                    "external_participant": {"participant_name": "Sofia Bell"},
+                }
+            ),
+        )
+    ]
+    frags = _fetch_chat_only(monkeypatch, rows)
+    assert len(frags) == 1
+    assert "aitown" in frags[0].tags
+    assert frags[0].text.startswith("[ai-town] Sofia Bell:")

--- a/services/orion-recall/tests/test_sql_chat_fetch_by_id.py
+++ b/services/orion-recall/tests/test_sql_chat_fetch_by_id.py
@@ -35,11 +35,22 @@ def test_connection_failure_degrades_to_empty(monkeypatch) -> None:
     assert out == {}
 
 
-def test_returns_prompt_response_tuple_by_id(monkeypatch) -> None:
+def test_returns_prompt_response_client_meta_tuple_by_id(monkeypatch) -> None:
+    """client_meta is the third tuple element (added 2026-07-31, see
+    app/chat_source_tagging.py) so callers can tell ai-town-sourced turns
+    apart from real Juniper/hub conversation instead of quoting every row
+    identically."""
     class _FakeConn:
         async def fetch(self, query, ids):
             assert ids == ["turn-1"]
-            return [{"id": "turn-1", "prompt": "hi Circe", "response": "hello"}]
+            return [
+                {
+                    "id": "turn-1",
+                    "prompt": "hi Circe",
+                    "response": "hello",
+                    "client_meta": {"external_room": {"platform": "aitown"}},
+                }
+            ]
 
         async def close(self):
             pass
@@ -51,4 +62,4 @@ def test_returns_prompt_response_tuple_by_id(monkeypatch) -> None:
 
     monkeypatch.setattr(sql_chat, "asyncpg", _FakeAsyncpg())
     out = _run(sql_chat.fetch_chat_turns_by_id(["turn-1"]))
-    assert out == {"turn-1": ("hi Circe", "hello")}
+    assert out == {"turn-1": ("hi Circe", "hello", {"external_room": {"platform": "aitown"}})}

--- a/services/orion-recall/tests/test_sql_exact_windowing.py
+++ b/services/orion-recall/tests/test_sql_exact_windowing.py
@@ -56,6 +56,7 @@ def test_fetch_exact_fragments_passes_since_minutes_to_query(monkeypatch) -> Non
     monkeypatch.setattr("app.sql_timeline.settings.RECALL_SQL_CHAT_TABLE", "chat_history_log")
     monkeypatch.setattr("app.sql_timeline._pick_id_col", lambda *_a, **_k: "id")
     monkeypatch.setattr("app.sql_timeline._pick_session_col", lambda *_a, **_k: None)
+    monkeypatch.setattr("app.sql_timeline._pick_client_meta_col", lambda *_a, **_k: None)
     monkeypatch.setattr("app.sql_timeline._memory_filter_clause", lambda *_a, **_k: "")
 
     asyncio.run(


### PR DESCRIPTION
## Summary

- Root-caused live identity bleed (confirmed via direct psql query, bidirectional: a hub reply landed in an ai-town row, ai-town content landed in a real hub turn) to `services/orion-recall`'s `chat_history_log` readers building recall text with zero awareness of `client_meta.external_room.platform`.
- Added shared module `services/orion-recall/app/chat_source_tagging.py` centralizing platform detection, a `"[ai-town]"` text marker + speaker name rendering, and `"aitown"` tag augmentation.
- Wired the shared module into all 8 real call sites that build fragments from `chat_history_log`: `storage/sql_adapter.py`, `sql_timeline.py` (3 functions), `sql_chat.py` (2 functions, one of which — `fetch_chat_turns_by_id` — has 3 independent downstream consumers: `storage/falkor_chat_adapter.py`, `storage/falkor_neighborhood_adapter.py`, `worker.py`).
- Updated `chat_quick.j2`/`chat_general.j2` to tell the model to look for the `"[ai-town]"` marker in recall-sourced digests (not `message_history`, which cannot carry it) and treat that content as a separate conversation.
- Breaking API change: `fetch_chat_turns_by_id` return type changed from `Dict[str, tuple[str, str]]` to `Dict[str, tuple[str, str, Any]]` (adds `client_meta`), threaded through all 3 consumers and their tests.

## Outcome moved

Ai-town NPC dialogue recalled into Orion's hub/direct-chat context with Juniper is now explicitly labeled as a separate conversation instead of appearing as `"User: ..."` (a false claim that Juniper said it). This is the data-level fix underneath the earlier prompt-only identity-framing fix (PR #1526) — that fix told the model ai-town content exists and is separate, but gave it no reliable way to identify which lines those were.

## Current architecture

`chat_history_log` rows carry a `client_meta` jsonb column populated by `orion-embodiment` with `external_room.platform`/`external_participant.participant_name` for ai-town-sourced turns. Every recall-reading function in `orion-recall` ignored this field and rendered all rows identically as `"User: {prompt}\nOrion: {response}"` or `'ExactUserText: "{prompt}"\nOrionResponse: "{response}"'`.

## Architecture touched

`services/orion-recall/app/` (new shared module + 6 existing files), two Jinja prompt templates in `orion/cognition/prompts/`.

## Files changed

- `services/orion-recall/app/chat_source_tagging.py`: new shared module (platform detection, marker rendering, tag augmentation)
- `services/orion-recall/app/storage/sql_adapter.py`: chat-fragment query now selects `client_meta`; uses shared module
- `services/orion-recall/app/sql_timeline.py`: 3 functions (`fetch_recent_fragments`, `fetch_related_by_entities`, `fetch_exact_fragments`) migrated; new `_pick_client_meta_col` dynamic column detection
- `services/orion-recall/app/sql_chat.py`: `fetch_chat_history_pairs` and `fetch_chat_turns_by_id` migrated; the latter's return type is now a 3-tuple
- `services/orion-recall/app/storage/falkor_chat_adapter.py`, `falkor_neighborhood_adapter.py`, `app/worker.py`: updated for the 3-tuple return shape, use shared module for text + tags
- `orion/cognition/prompts/chat_quick.j2`, `chat_general.j2`: CURRENT CONTEXT instruction now names the literal `"[ai-town]"` marker, corrected to say the marker is *contained in* (not "starts") memory_digest lines, right after the `[source]` tag
- Test files: new `test_chat_source_tagging.py`, `test_sql_adapter_aitown_tagging.py`; updated `test_sql_chat_fetch_by_id.py`, `test_falkor_chat_adapter.py` (+ new aitown-case test), `test_falkor_neighborhood_adapter.py` (+ new aitown-case test), `test_entity_relatedness_boost_map.py`, `test_sql_exact_windowing.py`, `test_chat_prompt_context_guardrails.py`

## Schema / bus / API changes

- Added: no new schema fields (uses `client_meta` already written by `orion-embodiment`)
- Removed: none
- Renamed: none
- Behavior changed: `sql_chat.fetch_chat_turns_by_id`'s return type changed from `Dict[str, tuple[str, str]]` to `Dict[str, tuple[str, str, Any]]` — internal function, not a bus/HTTP contract, all 3 call sites updated in this same PR
- Compatibility notes: no backfill of historical rows; only newly-recalled rows benefit going forward

## Env/config changes

None.

## Tests run

```text
services/orion-recall: 252 passed, 3 failed (pre-existing/unrelated), 13 skipped
  - test_process_recall_active_turn_exclusion.py, test_recall_policy_harness.py: fail on a
    _query_backends(..., lane=...) signature from an earlier already-merged commit, untouched
    by this diff
  - test_recall_vector_amputation.py: fails on an unrelated app/collectors/__init__.py import
    error, untouched by this diff

services/orion-cortex-exec (targeted subset, run from repo root):
  test_chat_quick_plumbing.py, test_llm_lane_propagation.py, test_chat_general_route_mapping.py,
  test_chat_prompt_context_guardrails.py: 32 passed
```

## Evals run

No dedicated eval harness for this recall-tagging seam; covered by the unit test suite above.

## Docker/build/smoke checks

Not run in this session (no local Docker stack available for orion-recall in this environment). Needs live verification after merge: rebuild+restart `orion-cortex-exec` and `orion-embodiment` on athena, then verify via a live hub turn that ai-town content in `memory_digest` now appears with the `[ai-town]` marker and correct speaker attribution instead of `"User:"`.

## Review findings fixed

- Finding: First review pass (on an earlier, narrower diff) found the fix only touched `sql_adapter.py`, missing 7 other call sites building the same unlabeled text across `sql_timeline.py`, `sql_chat.py`, and 3 downstream `fetch_chat_turns_by_id` consumers.
  - Fix: Extracted shared `chat_source_tagging.py` module, wired into all 8 real call sites.
  - Evidence: grep confirms zero remaining `f"User: {prompt}` / `f'ExactUserText:` literal constructions in the affected files; full test suite passes.
- Finding: Second review pass caught the `memory_digest` line-start wording was inaccurate — `render.py`'s `_render_group` prepends `f"[{source}:{source_ref}] "` before the snippet, so the `[ai-town]` marker doesn't literally start the rendered line.
  - Fix: Reworded both templates to say the marker is *contained in* the line, right after the leading `[source]` tag.
  - Evidence: `orion/cognition/prompts/chat_quick.j2`, `chat_general.j2` diffs; confirmed against `render.py`'s actual `_render_group` output format.
- Finding: Second review pass caught the template also told the model to scan `message_history` for the marker, but `message_history` is built from live conversation turns only and cannot structurally carry recall-sourced content.
  - Fix: Removed the `message_history` reference from `chat_quick.j2`'s CURRENT CONTEXT instruction (confirmed via `services/orion-cortex-exec/app/executor.py`'s `_format_message_history_for_chat_prompt`).
  - Evidence: template diff; `chat_general.j2` never referenced `message_history` in this sentence to begin with.
- Finding: Second review pass (HIGH) found `services/orion-recall/app/storage/rdf_adapter.py` still builds the same unlabeled `ExactUserText:`/`OrionResponse:` text in 3 functions, and `fetch_rdf_chatturn_exact_matches` is called additively (not swapped out by Falkor) from `worker.py`'s `_fetch_anchor_candidates`, gated only by `RECALL_ENABLE_RDF`/`RECALL_RDF_ENDPOINT_URL` (both default-true).
  - Fix: NOT fixed in this PR — investigated and determined the RDF ChatTurn write path has no producer anywhere in this repo (`rdf_builder.py`/`orion-rdf-writer` do not exist in this checkout; only `rdf_adapter.py`'s reader references `conjourney.net/orion#ChatTurn`/`#prompt` at all). The graph this reads from is frozen, not actively growing, so no *new* ai-town content can enter via this path going forward. This was already an explicit non-goal in the design doc (`docs/superpowers/specs/2026-07-31-recall-aitown-source-tagging-design.md`: "Not touching orion-recall's vector/RDF backends"). Flagging as a known, bounded residual risk rather than expanding this PR's scope — see Risks/concerns below.
  - Evidence: `grep -rln "conjourney.net/orion#ChatTurn" --include=*.py .` returns only `rdf_adapter.py`; `worker.py:1018-1032` confirms the additive (non-swap) gating for `fetch_rdf_chatturn_exact_matches`.
- Finding: Second review pass (LOW) — `chat_source_tagging.py`'s module docstring and `test_chat_source_tagging.py`'s docstring disagreed on the call-site count ("eight" vs "six").
  - Fix: Reconciled both to "eight," with the same explicit breakdown (5 SQL-querying functions + 3 independent `fetch_chat_turns_by_id` consumers).
  - Evidence: both docstring diffs.
- Finding: Second review pass (LOW) — `storage/sql_adapter.py` calls `chat_source_platform()` redundantly (once directly, again inside `render_labeled_chat_text`/`chat_source_tags`).
  - Fix: Not fixed — pure, cheap function called on small in-memory dicts, no correctness impact. Deferred as not worth the churn.
  - Evidence: n/a (accepted as-is).
- Finding: Second review pass (LOW/MEDIUM) — `sql_adapter.py`/`sql_chat.py` hardcode `client_meta` into their SELECT with no existence check (unlike `sql_timeline.py`'s dynamic `_pick_client_meta_col`), so an operator pointing `RECALL_SQL_CHAT_TABLE` at a table without that column would break the entire chat-history fragment source, not just tagging.
  - Fix: Not fixed — matches the stated assumption that `client_meta` is a fixed column on `chat_history_log` itself, not an operator-configurable surface. Low-probability edge case, disclosed rather than defended against.
  - Evidence: n/a (accepted as-is, documented here).

## Restart required

```bash
# On athena, after merge:
git pull --ff-only
docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-recall/.env -f services/orion-recall/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: Low (bounded, not actively growing)
- Concern: `services/orion-recall/app/storage/rdf_adapter.py`'s 3 functions still build unlabeled `ExactUserText:`/`OrionResponse:` text from RDF/Fuseki, and one of them (`fetch_rdf_chatturn_exact_matches`) is called additively (not shadowed by Falkor) from the anchor-candidate rail whenever `RECALL_ENABLE_RDF`/`RECALL_RDF_ENDPOINT_URL` are set (both default-true in `.env_example`).
- Mitigation: Confirmed no producer for the `orion:chat` RDF graph exists anywhere in this repo — the graph is frozen, not actively receiving new ai-town (or any) chat turns, so this cannot regrow. A future follow-up could either (a) join `rdf_adapter.py`'s turn URI back to Postgres `client_meta` the same way the Falkor adapters do, or (b) formally retire these 3 functions if the underlying Fuseki store is confirmed dead. Recommend a live check of whether Fuseki still holds any `orion:chat` ChatTurn triples before deciding between those two.

## PR link

(filled in by gh pr create output below)