### PR TITLE
feat(hub): add Cocreation Signals operator tab for the codebase-mass domain

### DIFF
--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -173,6 +173,7 @@ from .self_brain_routes import router as self_brain_router
 from .field_channel_glossary_routes import router as field_channel_glossary_router
 from .bus_synaptic_graph_routes import router as bus_synaptic_graph_router
 from .attention_organ_routes import router as attention_organ_router
+from .cocreation_signals_routes import router as cocreation_signals_router
 from .chat_turn_trace_routes import router as chat_turn_trace_router
 router.include_router(grammar_atlas_router)
 router.include_router(chat_turn_trace_router)
@@ -191,6 +192,7 @@ router.include_router(self_brain_router)
 router.include_router(field_channel_glossary_router)
 router.include_router(bus_synaptic_graph_router)
 router.include_router(attention_organ_router)
+router.include_router(cocreation_signals_router)
 
 
 def _hub_uses_host_network_mode() -> bool:

--- a/services/orion-hub/scripts/cocreation_signals_routes.py
+++ b/services/orion-hub/scripts/cocreation_signals_routes.py
@@ -1,0 +1,288 @@
+"""Read-only Hub API for the "cocreation signals" (codebase-mass) operator tab.
+
+Surfaces the real data behind the codebase-mass Predictive Processing domain
+(``docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md``):
+``orion-cocreation-signals`` publishes ``CodebaseDeltaV1`` events (git churn /
+PR lifecycle / graph structural deltas) to
+``orion:substrate:codebase_delta``, ``orion-substrate-runtime``'s
+``_handle_codebase_delta_message()`` scores each one with
+``codebase_prediction_error()`` and persists two things per real tick:
+
+1. ``substrate_codebase_mass_baseline`` -- the running EWMA state (one row
+   per tick, only the latest matters for "what does the baseline think is
+   normal right now").
+2. ``substrate_codebase_delta_log`` -- the raw per-tick payload (real commit
+   counts / PR numbers / graph deltas) plus that tick's score, unconditional
+   (not gated on score, unlike the separate ``ReductionReceiptV1`` audit
+   trail feeding ``orion-field-digester``) -- a complete history, added
+   2026-07-31 specifically so a tab like this one would have real data to
+   show instead of only the current aggregate.
+
+Everything here is a read. No writes, no bus publishes, no new channel or
+schema. A number this tab shows is a number some real producer actually
+produced -- there is no synthetic/demo data path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import create_engine, text
+
+router = APIRouter(prefix="/api/cocreation-signals", tags=["cocreation-signals"])
+
+KNOWN_DOMAINS: tuple[str, ...] = ("git", "pr_lifecycle", "graph")
+
+ALLOWED_HISTORY_HOURS: frozenset[int] = frozenset({1, 6, 24, 168})
+DEFAULT_HISTORY_HOURS: int = 24
+HISTORY_ROW_CAP: int = 4000
+
+_engine_instance: Any = None
+
+
+def _engine():
+    global _engine_instance
+    if _engine_instance is None:
+        uri = os.getenv("POSTGRES_URI", "").strip()
+        if not uri:
+            raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+        _engine_instance = create_engine(uri, pool_pre_ping=True)
+    return _engine_instance
+
+
+# --------------------------------------------------------------------------
+# Pure helpers (no I/O) -- separated so shaping logic is testable against
+# fixed rows, matching this repo's established route-module convention (see
+# attention_organ_routes.py's build_domain_rows/summarize_history).
+# --------------------------------------------------------------------------
+
+
+def normalize_history_hours(hours: int | None) -> int:
+    if hours in ALLOWED_HISTORY_HOURS:
+        return int(hours)
+    return DEFAULT_HISTORY_HOURS
+
+
+def _coerce_json(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (TypeError, ValueError):
+            return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def build_domain_summary(
+    latest_rows: list[dict[str, Any]],
+    window_counts: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """One row per known domain: most recent real tick + this window's stats.
+
+    Every domain in KNOWN_DOMAINS is always present, even with zero data --
+    a domain with no events at all is a different, louder fact than a domain
+    with a calm score, and must not be silently omitted from the list.
+    """
+    now = now or datetime.now(timezone.utc)
+    latest_by_domain = {str(r.get("domain")): r for r in latest_rows}
+    counts_by_domain = {str(r.get("domain")): r for r in window_counts}
+
+    out: list[dict[str, Any]] = []
+    for domain in KNOWN_DOMAINS:
+        latest = latest_by_domain.get(domain)
+        counts = counts_by_domain.get(domain)
+
+        observed_at = latest.get("observed_at") if latest else None
+        age_sec: float | None = None
+        if isinstance(observed_at, datetime):
+            ts = observed_at if observed_at.tzinfo else observed_at.replace(tzinfo=timezone.utc)
+            age_sec = round((now - ts).total_seconds(), 1)
+
+        out.append(
+            {
+                "domain": domain,
+                "present": latest is not None,
+                "latest_score": float(latest["score"]) if latest and latest.get("score") is not None else None,
+                "latest_observed_at": observed_at.isoformat() if isinstance(observed_at, datetime) else None,
+                "latest_age_sec": age_sec,
+                "latest_payload": _coerce_json(latest.get("event_json")).get(domain) if latest else None,
+                "window_event_count": int(counts["n"]) if counts else 0,
+                "window_avg_score": float(counts["avg_score"]) if counts and counts.get("avg_score") is not None else None,
+                "window_max_score": float(counts["max_score"]) if counts and counts.get("max_score") is not None else None,
+            }
+        )
+    return out
+
+
+def build_history_series(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Split a flat, time-ordered row list into one series per domain.
+
+    Kept as a plain dict-of-lists (not a merged/interpolated series) since
+    the three domains tick on entirely different, unrelated cadences (git
+    ~60s when there's a new commit, pr_lifecycle ~15min unconditional, graph
+    ~5min) -- forcing them onto one shared x-axis would either lie about
+    resolution or require inventing values no producer produced.
+    """
+    series: dict[str, list[dict[str, Any]]] = {domain: [] for domain in KNOWN_DOMAINS}
+    for row in rows:
+        domain = str(row.get("domain"))
+        observed_at = row.get("observed_at")
+        score = row.get("score")
+        series.setdefault(domain, []).append(
+            {
+                "observed_at": observed_at.isoformat() if isinstance(observed_at, datetime) else str(observed_at),
+                "score": float(score) if score is not None else None,
+            }
+        )
+    return series
+
+
+# --------------------------------------------------------------------------
+# I/O
+# --------------------------------------------------------------------------
+
+
+def _load_latest_baseline() -> tuple[dict[str, Any] | None, datetime | None]:
+    with _engine().connect() as conn:
+        row = (
+            conn.execute(
+                text(
+                    """
+                    SELECT generated_at, baseline_json
+                    FROM substrate_codebase_mass_baseline
+                    ORDER BY generated_at DESC
+                    LIMIT 1
+                    """
+                )
+            )
+            .mappings()
+            .first()
+        )
+    if not row:
+        return None, None
+    return _coerce_json(row["baseline_json"]), row["generated_at"]
+
+
+def _load_latest_per_domain() -> list[dict[str, Any]]:
+    with _engine().connect() as conn:
+        rows = (
+            conn.execute(
+                text(
+                    """
+                    SELECT DISTINCT ON (domain) domain, score, observed_at, event_json
+                    FROM substrate_codebase_delta_log
+                    ORDER BY domain, observed_at DESC
+                    """
+                )
+            )
+            .mappings()
+            .all()
+        )
+    return [dict(r) for r in rows]
+
+
+def _load_window_counts(*, hours: int) -> list[dict[str, Any]]:
+    with _engine().connect() as conn:
+        rows = (
+            conn.execute(
+                text(
+                    """
+                    SELECT domain, count(*) AS n, avg(score) AS avg_score, max(score) AS max_score
+                    FROM substrate_codebase_delta_log
+                    WHERE observed_at >= NOW() - (:hours * INTERVAL '1 hour')
+                    GROUP BY domain
+                    """
+                ),
+                {"hours": hours},
+            )
+            .mappings()
+            .all()
+        )
+    return [dict(r) for r in rows]
+
+
+@router.get("/snapshot")
+def snapshot() -> dict[str, Any]:
+    """One poll = one request. Baseline and per-domain summary degrade
+    independently: either being unavailable leaves its own block flagged
+    rather than 500ing the whole response.
+    """
+    now = datetime.now(timezone.utc)
+
+    baseline: dict[str, Any] | None = None
+    baseline_generated_at: datetime | None = None
+    baseline_error: str | None = None
+    try:
+        baseline, baseline_generated_at = _load_latest_baseline()
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        baseline_error = f"{type(exc).__name__}: {exc}"
+
+    domains: list[dict[str, Any]] = []
+    domains_error: str | None = None
+    try:
+        domains = build_domain_summary(
+            _load_latest_per_domain(),
+            _load_window_counts(hours=24),
+            now=now,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        domains_error = f"{type(exc).__name__}: {exc}"
+
+    return {
+        "generated_at": now.isoformat(),
+        "baseline": {
+            "ok": baseline is not None,
+            "error": baseline_error,
+            "generated_at": baseline_generated_at.isoformat() if baseline_generated_at else None,
+            "model": baseline,
+        },
+        "domains": {
+            "ok": domains_error is None,
+            "error": domains_error,
+            "known_domains": list(KNOWN_DOMAINS),
+            "rows": domains,
+        },
+    }
+
+
+@router.get("/history")
+def history(hours: int = Query(DEFAULT_HISTORY_HOURS)) -> dict[str, Any]:
+    window_hours = normalize_history_hours(hours)
+    with _engine().connect() as conn:
+        # DESC + reverse (not ASC + LIMIT) so a window wide enough to hit the
+        # cap keeps the NEWEST rows, not the oldest -- same reasoning as
+        # attention_organ_routes.history().
+        result = (
+            conn.execute(
+                text(
+                    """
+                    SELECT domain, score, observed_at
+                    FROM substrate_codebase_delta_log
+                    WHERE observed_at >= NOW() - (:hours * INTERVAL '1 hour')
+                    ORDER BY observed_at DESC
+                    LIMIT :row_cap
+                    """
+                ),
+                {"hours": window_hours, "row_cap": HISTORY_ROW_CAP},
+            )
+            .mappings()
+            .all()
+        )
+    rows = [dict(r) for r in reversed(result)]
+    series = build_history_series(rows)
+    return {
+        "window_hours": window_hours,
+        "row_cap": HISTORY_ROW_CAP,
+        "truncated": len(rows) >= HISTORY_ROW_CAP,
+        "sample_count": len(rows),
+        "series": series,
+    }

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -649,6 +649,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const aiTownPanel = document.getElementById("ai-town");
   const attentionOrganTabButton = document.getElementById("attentionOrganTabButton");
   const attentionOrganPanel = document.getElementById("attention-organ");
+  const cocreationSignalsTabButton = document.getElementById("cocreationSignalsTabButton");
+  const cocreationSignalsPanel = document.getElementById("cocreation-signals");
   const fieldAttentionTabButton = document.getElementById("fieldAttentionTabButton");
   const fieldAttentionPanel = document.getElementById("field-attention");
   const pressureAnalyticsFrame = document.getElementById("pressureAnalyticsFrame");
@@ -952,6 +954,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (tabKey === "attention-organ" && !attentionOrganPanel) {
       effectiveTab = "hub";
     }
+    if (tabKey === "cocreation-signals" && !cocreationSignalsPanel) {
+      effectiveTab = "hub";
+    }
     if (tabKey === "field-attention" && !fieldAttentionPanel) {
       effectiveTab = "hub";
     }
@@ -972,6 +977,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const isCollapseMirror = effectiveTab === "collapse-mirror";
     const isAiTown = effectiveTab === "ai-town";
     const isAttentionOrgan = effectiveTab === "attention-organ";
+    const isCocreationSignals = effectiveTab === "cocreation-signals";
     const isFieldAttention = effectiveTab === "field-attention";
     hubTabPanel.classList.toggle("hidden", !isHub);
     topicStudioPanel.classList.toggle("hidden", !isTopicStudio);
@@ -1092,6 +1098,18 @@ document.addEventListener("DOMContentLoaded", () => {
         window.OrionAttentionOrgan.deactivate();
       }
     }
+    if (cocreationSignalsPanel) {
+      cocreationSignalsPanel.classList.toggle("hidden", !isCocreationSignals);
+      // Same lifecycle contract as Attention Organ, above -- a distinct
+      // subsystem (codebase-mass domain), same poll-only-while-visible rule.
+      if (isCocreationSignals) {
+        if (window.OrionCocreationSignals && typeof window.OrionCocreationSignals.activate === "function") {
+          window.OrionCocreationSignals.activate();
+        }
+      } else if (window.OrionCocreationSignals && typeof window.OrionCocreationSignals.deactivate === "function") {
+        window.OrionCocreationSignals.deactivate();
+      }
+    }
     if (fieldAttentionPanel) {
       fieldAttentionPanel.classList.toggle("hidden", !isFieldAttention);
       // Same lifecycle contract as Attention Organ, above -- a distinct
@@ -1146,6 +1164,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (attentionOrganTabButton) {
       styleTabButton(attentionOrganTabButton, isAttentionOrgan);
+    }
+    if (cocreationSignalsTabButton) {
+      styleTabButton(cocreationSignalsTabButton, isCocreationSignals);
     }
     if (fieldAttentionTabButton) {
       styleTabButton(fieldAttentionTabButton, isFieldAttention);
@@ -1736,6 +1757,8 @@ document.addEventListener("DOMContentLoaded", () => {
       setActiveTab("ai-town");
     } else if (h === "#attention-organ" && attentionOrganPanel && attentionOrganTabButton) {
       setActiveTab("attention-organ");
+    } else if (h === "#cocreation-signals" && cocreationSignalsPanel && cocreationSignalsTabButton) {
+      setActiveTab("cocreation-signals");
     } else if (h === "#field-attention" && fieldAttentionPanel && fieldAttentionTabButton) {
       setActiveTab("field-attention");
     } else {
@@ -1751,6 +1774,7 @@ document.addEventListener("DOMContentLoaded", () => {
         || h === "#collapse-mirror"
         || h === "#ai-town"
         || h === "#attention-organ"
+        || h === "#cocreation-signals"
         || h === "#field-attention"
       ) {
         history.replaceState(null, "", "#hub");
@@ -11546,6 +11570,13 @@ document.addEventListener("DOMContentLoaded", () => {
         event.preventDefault();
         setActiveTab("attention-organ");
         history.replaceState(null, "", "#attention-organ");
+      });
+    }
+    if (cocreationSignalsTabButton && cocreationSignalsPanel) {
+      cocreationSignalsTabButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        setActiveTab("cocreation-signals");
+        history.replaceState(null, "", "#cocreation-signals");
       });
     }
     if (fieldAttentionTabButton && fieldAttentionPanel) {

--- a/services/orion-hub/static/js/cocreation-signals.js
+++ b/services/orion-hub/static/js/cocreation-signals.js
@@ -1,0 +1,506 @@
+// Cocreation Signals operator tab.
+//
+// Live view of the codebase-mass Predictive Processing domain
+// (docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md):
+//
+//   orion-cocreation-signals (git/PR/graph deltas, real external I/O)
+//     -> orion-substrate-runtime's codebase_prediction_error() scorer
+//       -> substrate_codebase_mass_baseline (EWMA state) + substrate_codebase_delta_log (raw history)
+//
+// Backed entirely by /api/cocreation-signals/snapshot + /history. Panel
+// show/hide is app.js's setActiveTab; this module exposes
+// activate()/deactivate() so polling runs only while the tab is visible,
+// following attention-organ.js's lifecycle contract. Rendered state is left
+// in the DOM on deactivate.
+//
+// Ticks here are far slower than Attention Organ's (git ~60s only on a new
+// commit, pr_lifecycle ~15min unconditional, graph ~5min) so this polls on a
+// slower default cadence -- a 2s poll against data that moves every 15
+// minutes would just be repeated identical reads.
+(function () {
+  "use strict";
+
+  var SNAPSHOT_URL = "/api/cocreation-signals/snapshot";
+  var HISTORY_URL = "/api/cocreation-signals/history";
+  var SVG_NS = "http://www.w3.org/2000/svg";
+
+  var HISTORY_REFRESH_MS = 30000;
+
+  var DOMAIN_LABELS = {
+    git: "git churn",
+    pr_lifecycle: "PR lifecycle",
+    graph: "graph structure",
+  };
+
+  // CodebaseMassBaseline.to_json_dict() (orion/substrate/prediction_error.py)
+  // uses the short key "pr", not "pr_lifecycle" -- a real, deliberate
+  // difference from CodebaseDeltaV1's wire field name that DOMAIN_LABELS
+  // above is keyed on. Kept as its own map (not a rename) so each label set
+  // matches the real key space of the table it renders, rather than forcing
+  // one spelling and silently mislabeling the other.
+  var BASELINE_DOMAIN_LABELS = {
+    git: "git churn",
+    pr: "PR lifecycle",
+    graph: "graph structure",
+  };
+
+  var state = {
+    active: false,
+    timer: null,
+    inFlight: false,
+    lastSnapshotAt: 0,
+    lastHistoryAt: 0,
+    historyError: null,
+    intervalMs: 15000,
+    windowHours: 24,
+    live: true,
+  };
+
+  var els = {};
+  var lastHistory = null;
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function bindElements() {
+    els.panel = $("cocreation-signals");
+    els.status = $("cocreationSignalsStatus");
+    els.baseline = $("cocreationSignalsBaseline");
+    els.domains = $("cocreationSignalsDomains");
+    els.windowSelect = $("cocreationSignalsWindow");
+    els.intervalSelect = $("cocreationSignalsInterval");
+    els.liveToggle = $("cocreationSignalsLive");
+    els.refreshBtn = $("cocreationSignalsRefreshBtn");
+    return !!els.panel;
+  }
+
+  // ---------------------------------------------------------------- helpers
+
+  function num(value, digits) {
+    if (value === null || value === undefined || value === "") return "—";
+    var parsed = Number(value);
+    if (!isFinite(parsed)) return "—";
+    return parsed.toFixed(digits === undefined ? 4 : digits);
+  }
+
+  function int(value) {
+    if (value === null || value === undefined || value === "") return "—";
+    var parsed = Number(value);
+    if (!isFinite(parsed)) return "—";
+    return parsed.toLocaleString();
+  }
+
+  function age(seconds) {
+    if (seconds === null || seconds === undefined) return "—";
+    var s = Number(seconds);
+    if (!isFinite(s)) return "—";
+    if (s < 0) return s > -2 ? "0.0s" : s.toFixed(1) + "s";
+    if (s < 90) return s.toFixed(1) + "s";
+    if (s < 5400) return (s / 60).toFixed(1) + "m";
+    if (s < 172800) return (s / 3600).toFixed(1) + "h";
+    return (s / 86400).toFixed(1) + "d";
+  }
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = String(text);
+    return node;
+  }
+
+  function card(host, title, subtitle) {
+    host.textContent = "";
+    var head = el("div", "flex items-baseline justify-between gap-2 mb-3");
+    head.appendChild(el("h3", "text-sm font-semibold text-gray-100", title));
+    if (subtitle) {
+      head.appendChild(el("span", "text-[10px] uppercase tracking-wide text-gray-500", subtitle));
+    }
+    host.appendChild(head);
+    return host;
+  }
+
+  function statTile(label, value, tone) {
+    var wrap = el("div", "rounded-lg border border-gray-800 bg-black/30 px-2 py-1.5");
+    wrap.appendChild(el("div", "text-[10px] uppercase tracking-wide text-gray-500", label));
+    wrap.appendChild(el("div", "text-sm font-mono " + (tone || "text-gray-100"), value));
+    return wrap;
+  }
+
+  function kvRow(label, value, tone) {
+    var row = el("div", "flex items-start justify-between gap-3 py-1 border-b border-gray-800/60 last:border-b-0");
+    row.appendChild(el("div", "text-[11px] text-gray-400 shrink-0", label));
+    row.appendChild(el("div", "text-[11px] font-mono text-right break-all " + (tone || "text-gray-200"), value));
+    return row;
+  }
+
+  function badge(text, tone) {
+    return el("span", "inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold border " + tone, text);
+  }
+
+  function note(host, text, tone) {
+    host.appendChild(el("p", "text-[10px] leading-relaxed mt-2 " + (tone || "text-gray-500"), text));
+  }
+
+  function errorBlock(host, title, message) {
+    card(host, title, "unavailable");
+    host.appendChild(
+      el(
+        "div",
+        "text-[11px] font-mono text-red-300 bg-red-950/30 border border-red-900/60 rounded-lg p-2 break-all",
+        message || "no data"
+      )
+    );
+  }
+
+  function svg(viewBox, heightClass) {
+    var node = document.createElementNS(SVG_NS, "svg");
+    node.setAttribute("viewBox", viewBox);
+    node.setAttribute("preserveAspectRatio", "none");
+    node.setAttribute("class", "w-full " + (heightClass || "h-16"));
+    return node;
+  }
+
+  function svgEl(tag, attrs) {
+    var node = document.createElementNS(SVG_NS, tag);
+    Object.keys(attrs || {}).forEach(function (key) {
+      node.setAttribute(key, attrs[key]);
+    });
+    return node;
+  }
+
+  // Score is unbounded (a z-score-derived quantity, not clamped to [0,1] the
+  // way ACTIVE_INFERENCE_DOMAINS' prediction_error is) -- render against the
+  // window's own observed max rather than a fixed scale, since a fixed 0..1
+  // scale would flatten every real point to the same pixel for this domain.
+  function renderSeries(host, points, opts) {
+    opts = opts || {};
+    var withValue = points.filter(function (p) {
+      return isFinite(p.score);
+    });
+    if (!withValue.length) {
+      note(host, opts.emptyText || "No samples in this window yet.");
+      return;
+    }
+    var chart = svg("0 0 100 40", opts.heightClass || "h-20");
+    var maxScore = withValue.reduce(function (acc, p) {
+      return Math.max(acc, p.score);
+    }, 0);
+    var hi = maxScore > 0 ? maxScore * 1.1 : 1;
+
+    function y(value) {
+      return 38 - (Math.max(0, Math.min(hi, value)) / hi) * 36;
+    }
+
+    var times = points.map(function (p) {
+      var parsed = Date.parse(p.observed_at);
+      return Number.isFinite(parsed) ? parsed : NaN;
+    });
+    var usable = times.filter(Number.isFinite);
+    var min = usable.length ? Math.min.apply(null, usable) : 0;
+    var max = usable.length ? Math.max.apply(null, usable) : 0;
+    var span = max - min;
+
+    function x(index) {
+      if (span > 0 && Number.isFinite(times[index])) {
+        return ((times[index] - min) / span) * 100;
+      }
+      return points.length > 1 ? (index / (points.length - 1)) * 100 : 0;
+    }
+
+    var circles = [];
+    points.forEach(function (p, index) {
+      if (!isFinite(p.score)) return;
+      circles.push({ cx: x(index), cy: y(p.score), score: p.score });
+    });
+    if (circles.length > 1) {
+      chart.appendChild(
+        svgEl("polyline", {
+          points: circles.map(function (c) {
+            return c.cx + "," + c.cy;
+          }).join(" "),
+          fill: "none",
+          stroke: opts.color || "#818cf8",
+          "stroke-width": 0.8,
+          "vector-effect": "non-scaling-stroke",
+        })
+      );
+    }
+    circles.forEach(function (c) {
+      chart.appendChild(svgEl("circle", { cx: c.cx, cy: c.cy, r: 1.2, fill: opts.color || "#818cf8" }));
+    });
+    host.appendChild(chart);
+    host.appendChild(
+      el("div", "text-[9px] text-gray-500 font-mono", "n=" + withValue.length + " · max " + num(maxScore, 3))
+    );
+  }
+
+  // ---------------------------------------------------------------- panels
+
+  function renderBaseline(host, snapshot) {
+    var baseline = snapshot.baseline || {};
+    if (!baseline.ok || !baseline.model) {
+      errorBlock(host, "EWMA baseline", baseline.error || "No substrate_codebase_mass_baseline row found yet.");
+      return;
+    }
+    var model = baseline.model;
+    card(host, "EWMA baseline", "substrate_codebase_mass_baseline, live");
+
+    var grid = el("div", "grid grid-cols-3 gap-2");
+    KNOWN(model).forEach(function (domain) {
+      var sub = model[domain] || {};
+      var wrap = el("div", "rounded-lg border border-gray-800 bg-black/30 px-2 py-1.5");
+      wrap.appendChild(el("div", "text-[10px] uppercase tracking-wide text-gray-500", BASELINE_DOMAIN_LABELS[domain] || domain));
+      wrap.appendChild(el("div", "text-sm font-mono text-gray-100", "ewma " + num(sub.ewma, 2)));
+      wrap.appendChild(el("div", "text-[10px] font-mono text-gray-500", "var " + num(sub.variance, 2) + " · n=" + int(sub.n)));
+      grid.appendChild(wrap);
+    });
+    host.appendChild(grid);
+
+    var ageWrap = el("div", "mt-2");
+    ageWrap.appendChild(
+      kvRow(
+        "baseline age",
+        age(
+          baseline.generated_at
+            ? (Date.now() - Date.parse(baseline.generated_at)) / 1000
+            : null
+        )
+      )
+    );
+    host.appendChild(ageWrap);
+
+    note(
+      host,
+      "Three independent EWMA sub-baselines, one per domain -- what codebase_prediction_error() currently " +
+        "treats as 'normal' git/PR/graph activity. n is real ticks folded in since this baseline first started, " +
+        "not a window count."
+    );
+  }
+
+  function KNOWN(model) {
+    return ["git", "pr", "graph"].filter(function (key) {
+      return model && Object.prototype.hasOwnProperty.call(model, key);
+    });
+  }
+
+  function renderDomains(host, snapshot, history) {
+    var domains = snapshot.domains || {};
+    if (!domains.ok) {
+      errorBlock(host, "Domain activity", domains.error);
+      return;
+    }
+    card(host, "Domain activity", (history ? history.window_hours + "h window" : "…"));
+
+    (domains.rows || []).forEach(function (row) {
+      var wrap = el("div", "mb-4 last:mb-0");
+      var head = el("div", "flex items-baseline justify-between gap-2 mb-1");
+      var labelWrap = el("div", "flex items-center gap-1.5");
+      labelWrap.appendChild(el("span", "text-[12px] text-gray-200", DOMAIN_LABELS[row.domain] || row.domain));
+      if (!row.present) {
+        labelWrap.appendChild(badge("no events yet", "border-gray-700 bg-gray-900 text-gray-500"));
+      }
+      head.appendChild(labelWrap);
+      head.appendChild(
+        el(
+          "span",
+          "text-[10px] font-mono text-gray-500",
+          "latest " + num(row.latest_score, 3) + " · seen " + age(row.latest_age_sec)
+        )
+      );
+      wrap.appendChild(head);
+
+      var statsGrid = el("div", "grid grid-cols-3 gap-2 mb-2");
+      statsGrid.appendChild(statTile("Events (window)", int(row.window_event_count)));
+      statsGrid.appendChild(statTile("Avg score", num(row.window_avg_score, 3)));
+      statsGrid.appendChild(statTile("Max score", num(row.window_max_score, 3)));
+      wrap.appendChild(statsGrid);
+
+      var seriesWrap = el("div");
+      var points = (history && history.series && history.series[row.domain]) || [];
+      renderSeries(seriesWrap, points, { emptyText: "No " + row.domain + " ticks in this window." });
+      wrap.appendChild(seriesWrap);
+
+      host.appendChild(wrap);
+    });
+
+    if (history && history.truncated) {
+      note(
+        host,
+        "History truncated at the " + history.row_cap + "-row cap -- widen the window or wait for a shorter one.",
+        "text-amber-400/80"
+      );
+    }
+  }
+
+  // ------------------------------------------------------------ poll cycle
+
+  function setStatus(text, tone) {
+    if (!els.status) return;
+    els.status.textContent = text;
+    els.status.className = "text-xs min-h-[1.25rem] " + (tone || "text-gray-400");
+  }
+
+  function historyAgeBanner(host) {
+    if (!state.historyError) return;
+    var ageSec = state.lastHistoryAt ? (Date.now() - state.lastHistoryAt) / 1000 : null;
+    host.appendChild(
+      el(
+        "div",
+        "mb-2 rounded-lg border border-amber-800 bg-amber-950/30 px-2 py-1 text-[10px] text-amber-200",
+        "History refresh failing (" +
+          state.historyError +
+          ") — showing data from " +
+          (ageSec === null ? "an earlier fetch" : age(ageSec) + " ago") +
+          ", not now."
+      )
+    );
+  }
+
+  async function fetchJson(url) {
+    var resp = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!resp.ok) {
+      throw new Error("HTTP " + resp.status + " from " + url);
+    }
+    return resp.json();
+  }
+
+  async function poll(opts) {
+    opts = opts || {};
+    if (state.inFlight) return;
+    state.inFlight = true;
+    try {
+      var snapshot = await fetchJson(SNAPSHOT_URL);
+      state.lastSnapshotAt = Date.now();
+
+      var needHistory =
+        opts.forceHistory || !lastHistory || Date.now() - state.lastHistoryAt >= HISTORY_REFRESH_MS;
+      if (needHistory) {
+        try {
+          lastHistory = await fetchJson(HISTORY_URL + "?hours=" + state.windowHours);
+          state.lastHistoryAt = Date.now();
+          state.historyError = null;
+        } catch (err) {
+          state.historyError = String(err.message || err);
+        }
+      }
+
+      if (state.historyError) historyAgeBanner(els.domains);
+      renderBaseline(els.baseline, snapshot);
+      renderDomains(els.domains, snapshot, lastHistory);
+
+      var problems = [];
+      if (!(snapshot.baseline || {}).ok) problems.push("baseline");
+      if (!(snapshot.domains || {}).ok) problems.push("domains");
+      if (state.historyError) problems.push("history");
+      if (problems.length) {
+        setStatus(
+          "Updated " + new Date().toLocaleTimeString() + " — degraded source(s): " + problems.join(", "),
+          "text-amber-400"
+        );
+      } else {
+        setStatus(
+          "Updated " +
+            new Date().toLocaleTimeString() +
+            " · polling every " +
+            state.intervalMs / 1000 +
+            "s" +
+            (state.live ? "" : " (paused)"),
+          "text-gray-400"
+        );
+      }
+    } catch (err) {
+      setStatus("Failed to load: " + (err.message || err), "text-red-400");
+    } finally {
+      state.inFlight = false;
+    }
+  }
+
+  function stopTimer() {
+    if (state.timer !== null) {
+      clearInterval(state.timer);
+      state.timer = null;
+    }
+  }
+
+  function startTimer() {
+    stopTimer();
+    if (!state.active || !state.live) return;
+    state.timer = setInterval(function () {
+      if (!els.panel || els.panel.classList.contains("hidden")) {
+        deactivate();
+        return;
+      }
+      poll();
+    }, state.intervalMs);
+  }
+
+  function activate() {
+    if (!els.panel && !bindElements()) return;
+    state.active = true;
+    poll({ forceHistory: true });
+    startTimer();
+  }
+
+  function deactivate() {
+    state.active = false;
+    stopTimer();
+  }
+
+  function wireControls() {
+    if (els.windowSelect) {
+      els.windowSelect.addEventListener("change", function () {
+        state.windowHours = Number(els.windowSelect.value) || 24;
+        poll({ forceHistory: true });
+      });
+    }
+    if (els.intervalSelect) {
+      els.intervalSelect.addEventListener("change", function () {
+        state.intervalMs = Number(els.intervalSelect.value) || 15000;
+        startTimer();
+      });
+    }
+    if (els.liveToggle) {
+      els.liveToggle.addEventListener("change", function () {
+        state.live = !!els.liveToggle.checked;
+        if (state.live) {
+          poll();
+          startTimer();
+        } else {
+          stopTimer();
+          setStatus("Paused. Press Refresh for a single update.", "text-gray-400");
+        }
+      });
+    }
+    if (els.refreshBtn) {
+      els.refreshBtn.addEventListener("click", function () {
+        poll({ forceHistory: true });
+      });
+    }
+  }
+
+  function init() {
+    if (!bindElements()) return;
+    state.intervalMs = Number(els.intervalSelect && els.intervalSelect.value) || 15000;
+    state.windowHours = Number(els.windowSelect && els.windowSelect.value) || 24;
+    state.live = !els.liveToggle || !!els.liveToggle.checked;
+    wireControls();
+    if (!els.panel.classList.contains("hidden")) {
+      activate();
+    }
+  }
+
+  window.OrionCocreationSignals = {
+    activate: activate,
+    deactivate: deactivate,
+    refresh: function () {
+      poll({ forceHistory: true });
+    },
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -133,6 +133,13 @@
             role="button"
           >Attention Organ</a>
           <a
+            id="cocreationSignalsTabButton"
+            href="#cocreation-signals"
+            data-hash-target="#cocreation-signals"
+            class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
+            role="button"
+          >Cocreation Signals</a>
+          <a
             id="fieldAttentionTabButton"
             href="#field-attention"
             data-hash-target="#field-attention"
@@ -872,6 +879,53 @@
           <div id="attentionOrganIntake" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
           <div id="attentionOrganDissipation" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
         </div>
+      </section>
+
+      <section id="cocreation-signals" data-panel="cocreation-signals" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[40rem]">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="min-w-0">
+            <h2 class="text-xl font-bold text-white">Cocreation Signals — codebase-mass Predictive Processing</h2>
+            <p class="text-xs text-gray-400 max-w-4xl">
+              Live view of the codebase-mass domain: real git churn / PR lifecycle / graph structural deltas from
+              <code class="text-gray-500">orion-cocreation-signals</code>, scored by
+              <code class="text-gray-500">codebase_prediction_error()</code> and persisted to
+              <code class="text-gray-500">substrate_codebase_mass_baseline</code> (EWMA state) and
+              <code class="text-gray-500">substrate_codebase_delta_log</code> (raw per-tick history). Served by
+              <code class="text-gray-500">/api/cocreation-signals/*</code>.
+              Design spec: <code class="text-gray-500">docs/superpowers/specs/2026-07-30-codebase-mass-signal-design.md</code>.
+              Read-only — this surface consumes signals, it does not produce or publish any.
+            </p>
+          </div>
+          <div class="flex items-center gap-2 text-xs shrink-0">
+            <label class="inline-flex items-center gap-1 text-gray-400">
+              Window
+              <select id="cocreationSignalsWindow" class="rounded border border-gray-600 bg-gray-800 text-gray-200 px-2 py-1">
+                <option value="1">1 hour</option>
+                <option value="6">6 hours</option>
+                <option value="24" selected>24 hours</option>
+                <option value="168">7 days</option>
+              </select>
+            </label>
+            <label class="inline-flex items-center gap-1 text-gray-400">
+              Poll
+              <select id="cocreationSignalsInterval" class="rounded border border-gray-600 bg-gray-800 text-gray-200 px-2 py-1">
+                <option value="5000">5s</option>
+                <option value="15000" selected>15s</option>
+                <option value="30000">30s</option>
+                <option value="60000">60s</option>
+              </select>
+            </label>
+            <label class="inline-flex items-center gap-2 text-gray-400">
+              <input id="cocreationSignalsLive" type="checkbox" class="rounded border border-gray-600 bg-gray-800" checked />
+              Live
+            </label>
+            <button type="button" id="cocreationSignalsRefreshBtn" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 hover:bg-gray-700">Refresh</button>
+          </div>
+        </div>
+        <div id="cocreationSignalsStatus" class="text-xs text-gray-400 min-h-[1.25rem]">Open this tab to start polling.</div>
+
+        <div id="cocreationSignalsBaseline" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
+        <div id="cocreationSignalsDomains" class="rounded-xl border border-gray-800 bg-gray-950/40 p-4"></div>
       </section>
 
       <section id="field-attention" data-panel="field-attention" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
@@ -3480,6 +3534,7 @@
   <script src="/static/js/collapse-mirror.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/aitown-panel.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/attention-organ.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
+  <script src="/static/js/cocreation-signals.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/field-attention.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/self_observability.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/app.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>

--- a/services/orion-hub/tests/test_cocreation_signals_page.py
+++ b/services/orion-hub/tests/test_cocreation_signals_page.py
@@ -1,0 +1,304 @@
+"""Cocreation Signals operator tab: pure-logic unit tests + wiring contract.
+
+Same rationale as test_attention_organ_page.py: this tab is registered in
+six separate places in app.js (element binding, missing-panel fallback,
+visibility flag, toggle, button styling, hash routing + click handler) plus
+a script tag plus a nav anchor. Missing any one of them produces a tab that
+looks fine until a specific interaction (deep link, switching away and back,
+a fresh reload) silently falls back to Hub -- a failure shape this file
+turns into a failing test instead of a manual click path.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+os.environ.setdefault("CHANNEL_VOICE_TRANSCRIPT", "orion:voice:transcript")
+os.environ.setdefault("CHANNEL_VOICE_LLM", "orion:voice:llm")
+os.environ.setdefault("CHANNEL_VOICE_TTS", "orion:voice:tts")
+os.environ.setdefault("CHANNEL_COLLAPSE_INTAKE", "orion:collapse:intake")
+os.environ.setdefault("CHANNEL_COLLAPSE_TRIAGE", "orion:collapse:triage")
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+from scripts import api_routes  # noqa: E402
+from scripts import cocreation_signals_routes as routes  # noqa: E402
+from scripts.cocreation_signals_routes import (  # noqa: E402
+    ALLOWED_HISTORY_HOURS,
+    DEFAULT_HISTORY_HOURS,
+    KNOWN_DOMAINS,
+    build_domain_summary,
+    build_history_series,
+    normalize_history_hours,
+)
+
+INDEX_HTML = (HUB_ROOT / "templates" / "index.html").read_text(encoding="utf-8")
+APP_JS = (HUB_ROOT / "static" / "js" / "app.js").read_text(encoding="utf-8")
+TAB_JS = (HUB_ROOT / "static" / "js" / "cocreation-signals.js").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# build_domain_summary
+# --------------------------------------------------------------------------
+
+
+def test_build_domain_summary_includes_every_known_domain_even_with_no_data() -> None:
+    """A domain with zero events is a different, louder fact than a domain
+    with a calm score -- must not be silently omitted from the list."""
+    out = build_domain_summary([], [])
+    assert {row["domain"] for row in out} == set(KNOWN_DOMAINS)
+    for row in out:
+        assert row["present"] is False
+        assert row["latest_score"] is None
+        assert row["window_event_count"] == 0
+
+
+def test_build_domain_summary_shapes_present_row_with_real_values() -> None:
+    now = datetime.now(timezone.utc)
+    observed_at = now - timedelta(seconds=42.5)
+    latest_rows = [
+        {
+            "domain": "git",
+            "score": 0.314,
+            "observed_at": observed_at,
+            "event_json": {
+                "domain": "git",
+                "git": {"lines_added": 520, "commit_count": 3},
+            },
+        }
+    ]
+    window_counts = [{"domain": "git", "n": 5, "avg_score": 0.1, "max_score": 0.9}]
+
+    out = build_domain_summary(latest_rows, window_counts, now=now)
+    git_row = next(r for r in out if r["domain"] == "git")
+    assert git_row["present"] is True
+    assert git_row["latest_score"] == 0.314
+    assert git_row["latest_age_sec"] == 42.5
+    assert git_row["latest_payload"] == {"lines_added": 520, "commit_count": 3}
+    assert git_row["window_event_count"] == 5
+    assert git_row["window_avg_score"] == 0.1
+    assert git_row["window_max_score"] == 0.9
+
+
+def test_build_domain_summary_matches_pr_lifecycle_wire_field_not_pr() -> None:
+    """CodebaseDeltaV1's real wire field is `pr_lifecycle`, not `pr` --
+    KNOWN_DOMAINS and this lookup must key off the same name the producer
+    actually publishes and save_codebase_delta_log() actually persists
+    (orion/schemas/codebase_delta.py), not the shorter `pr` key
+    CodebaseMassBaseline.to_json_dict() happens to use for the same concept
+    in a different table."""
+    now = datetime.now(timezone.utc)
+    latest_rows = [
+        {
+            "domain": "pr_lifecycle",
+            "score": 0.0,
+            "observed_at": now,
+            "event_json": {
+                "domain": "pr_lifecycle",
+                "pr_lifecycle": {"submitted_count": 2, "merged_count": 1},
+            },
+        }
+    ]
+    out = build_domain_summary(latest_rows, [], now=now)
+    row = next(r for r in out if r["domain"] == "pr_lifecycle")
+    assert row["present"] is True
+    assert row["latest_payload"] == {"submitted_count": 2, "merged_count": 1}
+
+
+def test_build_domain_summary_tolerates_string_encoded_json() -> None:
+    """Some drivers return jsonb as a raw string, not a pre-parsed dict."""
+    now = datetime.now(timezone.utc)
+    latest_rows = [
+        {
+            "domain": "graph",
+            "score": 0.0,
+            "observed_at": now,
+            "event_json": '{"domain": "graph", "graph": {"node_count_delta": -3}}',
+        }
+    ]
+    out = build_domain_summary(latest_rows, [], now=now)
+    graph_row = next(r for r in out if r["domain"] == "graph")
+    assert graph_row["latest_payload"] == {"node_count_delta": -3}
+
+
+def test_build_domain_summary_unknown_domain_in_rows_is_ignored_not_crashed() -> None:
+    """A future fourth domain landing in Postgres before this module is
+    updated must not 500 the whole snapshot -- it's just absent from the
+    fixed KNOWN_DOMAINS list until this module catches up."""
+    now = datetime.now(timezone.utc)
+    out = build_domain_summary(
+        [{"domain": "future_domain", "score": 1.0, "observed_at": now, "event_json": {}}],
+        [],
+        now=now,
+    )
+    assert {row["domain"] for row in out} == set(KNOWN_DOMAINS)
+
+
+# --------------------------------------------------------------------------
+# build_history_series
+# --------------------------------------------------------------------------
+
+
+def test_build_history_series_splits_by_domain_without_interpolation() -> None:
+    now = datetime.now(timezone.utc)
+    rows = [
+        {"domain": "git", "score": 0.1, "observed_at": now},
+        {"domain": "pr_lifecycle", "score": 0.0, "observed_at": now + timedelta(minutes=1)},
+        {"domain": "git", "score": 0.2, "observed_at": now + timedelta(minutes=2)},
+    ]
+    series = build_history_series(rows)
+    assert set(series.keys()) == set(KNOWN_DOMAINS)
+    assert len(series["git"]) == 2
+    assert len(series["pr_lifecycle"]) == 1
+    assert len(series["graph"]) == 0
+    assert series["git"][0]["score"] == 0.1
+    assert series["git"][1]["score"] == 0.2
+
+
+def test_build_history_series_handles_empty_input() -> None:
+    series = build_history_series([])
+    assert set(series.keys()) == set(KNOWN_DOMAINS)
+    assert all(v == [] for v in series.values())
+
+
+# --------------------------------------------------------------------------
+# normalize_history_hours
+# --------------------------------------------------------------------------
+
+
+def test_normalize_history_hours_rejects_unlisted_windows() -> None:
+    assert normalize_history_hours(24) == 24
+    for allowed in ALLOWED_HISTORY_HOURS:
+        assert normalize_history_hours(allowed) == allowed
+    assert normalize_history_hours(999) == DEFAULT_HISTORY_HOURS
+    assert normalize_history_hours(None) == DEFAULT_HISTORY_HOURS
+
+
+# --------------------------------------------------------------------------
+# Wiring contract
+# --------------------------------------------------------------------------
+
+
+def test_routes_are_registered_on_the_hub_api_router() -> None:
+    route_paths = {route.path for route in api_routes.router.routes}
+    assert "/api/cocreation-signals/snapshot" in route_paths
+    assert "/api/cocreation-signals/history" in route_paths
+
+
+def test_template_declares_nav_button_panel_and_script_tag() -> None:
+    assert 'data-hash-target="#cocreation-signals"' in INDEX_HTML
+    assert 'id="cocreationSignalsTabButton"' in INDEX_HTML
+    assert 'id="cocreation-signals" data-panel="cocreation-signals"' in INDEX_HTML
+    assert "/static/js/cocreation-signals.js?v={{HUB_UI_ASSET_VERSION}}" in INDEX_HTML
+    for mount_id in (
+        "cocreationSignalsStatus",
+        "cocreationSignalsBaseline",
+        "cocreationSignalsDomains",
+    ):
+        assert f'id="{mount_id}"' in INDEX_HTML, mount_id
+
+
+def test_app_js_registers_the_panel_in_every_place_setactivetab_needs() -> None:
+    assert 'document.getElementById("cocreation-signals")' in APP_JS  # element binding
+    assert 'tabKey === "cocreation-signals" && !cocreationSignalsPanel' in APP_JS  # fallback
+    assert 'const isCocreationSignals = effectiveTab === "cocreation-signals";' in APP_JS  # flag
+    assert 'cocreationSignalsPanel.classList.toggle("hidden", !isCocreationSignals);' in APP_JS  # toggle
+    assert "styleTabButton(cocreationSignalsTabButton, isCocreationSignals);" in APP_JS  # styling
+    assert 'h === "#cocreation-signals" && cocreationSignalsPanel' in APP_JS  # hash routing
+    assert 'history.replaceState(null, "", "#cocreation-signals");' in APP_JS  # click handler
+
+
+def test_app_js_drives_the_panels_poll_lifecycle_on_tab_switch() -> None:
+    assert "window.OrionCocreationSignals.activate()" in APP_JS
+    assert "window.OrionCocreationSignals.deactivate()" in APP_JS
+
+
+def test_tab_js_is_standalone_and_reads_only_its_own_api() -> None:
+    assert "window.OrionCocreationSignals" in TAB_JS
+    assert "activate:" in TAB_JS and "deactivate:" in TAB_JS
+    assert '"/api/cocreation-signals/snapshot"' in TAB_JS
+    assert '"/api/cocreation-signals/history"' in TAB_JS
+    assert "window.OrionHub" not in TAB_JS
+    assert '"POST"' not in TAB_JS and "method: 'POST'" not in TAB_JS
+
+
+def test_tab_js_renders_structure_not_a_raw_json_dump() -> None:
+    assert "JSON.stringify" not in TAB_JS
+    assert "createElementNS" in TAB_JS
+    for renderer in ("renderBaseline", "renderDomains", "renderSeries"):
+        assert f"function {renderer}(" in TAB_JS, renderer
+
+
+# --------------------------------------------------------------------------
+# Endpoint behavior (fake engine, no real Postgres)
+# --------------------------------------------------------------------------
+
+
+class _FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, *_args, **_kwargs):
+        rows = self._rows
+
+        class _Result:
+            def mappings(self_inner):
+                return self_inner
+
+            def first(self_inner):
+                return rows[0] if rows else None
+
+            def all(self_inner):
+                return rows
+
+        return _Result()
+
+
+class _FakeEngine:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def connect(self):
+        return _FakeConn(self._rows)
+
+
+def test_snapshot_reports_cold_start_when_no_data_exists(monkeypatch) -> None:
+    monkeypatch.setattr(routes, "_engine", lambda: _FakeEngine([]))
+    result = routes.snapshot()
+    assert result["baseline"]["ok"] is False
+    assert result["domains"]["ok"] is True
+    assert {row["domain"] for row in result["domains"]["rows"]} == set(KNOWN_DOMAINS)
+    assert all(not row["present"] for row in result["domains"]["rows"])
+
+
+def test_snapshot_degrades_independently_on_engine_error(monkeypatch) -> None:
+    def raise_error():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(routes, "_engine", raise_error)
+    result = routes.snapshot()
+    assert result["baseline"]["ok"] is False
+    assert "db down" in result["baseline"]["error"]
+    assert result["domains"]["ok"] is False
+
+
+def test_history_reports_truncated_when_row_cap_hit(monkeypatch) -> None:
+    now = datetime.now(timezone.utc)
+    rows = [{"domain": "git", "score": 0.1, "observed_at": now} for _ in range(routes.HISTORY_ROW_CAP)]
+    monkeypatch.setattr(routes, "_engine", lambda: _FakeEngine(rows))
+    result = routes.history(hours=24)
+    assert result["truncated"] is True
+    assert result["sample_count"] == routes.HISTORY_ROW_CAP


### PR DESCRIPTION
## Summary

- New read-only Hub tab, "Cocreation Signals", showing the codebase-mass Predictive Processing domain's real live data: git churn / PR lifecycle / graph structural deltas and the composite `codebase_prediction_error()` score.
- Two endpoints: `GET /api/cocreation-signals/snapshot` (current EWMA baseline + per-domain latest tick/window stats) and `GET /api/cocreation-signals/history?hours=N` (time series per domain for charting).
- Modeled directly on the existing Attention Organ tab's pattern: pure helper functions separated from I/O (unit-testable without Postgres), independent per-source degradation, `activate()`/`deactivate()` poll lifecycle gated on tab visibility, and the same six-point `app.js` registration (element binding, missing-panel fallback, visibility flag, toggle, button styling, hash routing + click handler).
- This tab exists now specifically because PR #1534 (merged) added `substrate_codebase_delta_log`, the raw-event history table this tab reads for its charts -- before that, only the current EWMA aggregate existed, not enough for a time-series view.

## Outcome moved

An operator can now see the codebase-mass domain's real activity (which domain ticked, how often, what score) in one place, instead of only via direct Postgres queries or FalkorDB node reads.

## Current architecture

`orion-substrate-runtime`'s `_handle_codebase_delta_message()` already scores every real `CodebaseDeltaV1` event and persists it to two tables (`substrate_codebase_mass_baseline`, `substrate_codebase_delta_log`, both live since PR #1527/#1534). Nothing in `orion-hub` read either table before this patch.

## Architecture touched

- `services/orion-hub` only. Read-only: no writes, no bus publishes, no new schema/channel.

## Files changed

- `services/orion-hub/scripts/cocreation_signals_routes.py` (new): the two endpoints + pure helpers (`build_domain_summary`, `build_history_series`, `normalize_history_hours`).
- `services/orion-hub/scripts/api_routes.py`: router registration.
- `services/orion-hub/static/js/cocreation-signals.js` (new): frontend, `window.OrionCocreationSignals`.
- `services/orion-hub/static/js/app.js`: the six tab-registration touch points.
- `services/orion-hub/templates/index.html`: nav button, panel, script tag.
- `services/orion-hub/tests/test_cocreation_signals_page.py` (new): pure-helper tests, wiring-contract tests (asserts every registration point literally exists), endpoint tests against a fake SQLAlchemy engine.

## Schema / bus / API changes

- Added: `GET /api/cocreation-signals/snapshot`, `GET /api/cocreation-signals/history`. No bus/schema contract changes -- read-only against two already-live tables.

## Env/config changes

None. `POSTGRES_URI` was already available to `orion-hub` via its existing `env_file:` passthrough (unlike `orion-substrate-runtime`, this service doesn't need per-key `environment:` entries).

## Tests run

```
cd services/orion-hub
python3 -m pytest tests/test_cocreation_signals_page.py tests/test_attention_organ_page.py -q
# 50 passed

python3 -m pytest tests -q
# 33 failed, 1108 passed, 2 skipped, 2 errors -- confirmed pre-existing via git stash
# comparison against unmodified main (identical failures in unrelated subsystems:
# memory consolidation drafts, recall strategy profiles, substrate effects, etc.)
```

## Evals run

No eval harness applicable -- this is a read-only UI surface over already-tested/live-verified backend data (the scorer and persistence layer were verified in PR #1527/#1534).

## Docker/build/smoke checks

Not yet deployed live -- planning to redeploy `orion-hub` and do a real browser check after this PR merges.

## Review findings fixed

- Finding: `renderBaseline()`'s per-domain label lookup used `DOMAIN_LABELS` (keyed `git`/`pr_lifecycle`/`graph`, matching `CodebaseDeltaV1`'s wire field names) but `CodebaseMassBaseline.to_json_dict()` (a different table) uses the shorter key `pr`, not `pr_lifecycle` -- so the baseline panel's PR tile fell through to the raw string `"pr"` instead of showing "PR lifecycle" like the Domain Activity panel two rows below it.
  - Fix: added a second `BASELINE_DOMAIN_LABELS` map keyed on the baseline table's real key space (`git`/`pr`/`graph`), used only by `renderBaseline()`.
  - Evidence: `services/orion-hub/static/js/cocreation-signals.js` (`BASELINE_DOMAIN_LABELS` + its use in the per-domain tile renderer).
- Finding: no test exercised `build_domain_summary()` with the `pr_lifecycle` domain specifically -- the one domain name whose wire field (`pr_lifecycle`) differs from its baseline-table counterpart (`pr`), i.e. exactly the ambiguity the label bug above came from.
  - Fix: added `test_build_domain_summary_matches_pr_lifecycle_wire_field_not_pr`.
  - Evidence: `services/orion-hub/tests/test_cocreation_signals_page.py`.

## Restart required

```bash
scripts/safe_docker_build.sh orion-hub up -d --build
```

## Risks / concerns

- Severity: low
- Concern: not yet browser-verified live (Hub is a heavier rebuild than substrate-runtime and this session hasn't done that redeploy yet).
- Mitigation: will redeploy and do a real click-through + API check before calling this fully done.

## PR link

(filled in after creation)