### PR TITLE
feat(execution-dispatch): concurrent dispatch, closes the ~65-70% steady-state proposal loss

### DIFF
--- a/config/execution_dispatch/execution_dispatch_policy.v1.yaml
+++ b/config/execution_dispatch/execution_dispatch_policy.v1.yaml
@@ -50,4 +50,13 @@ hard_blocks:
 
 limits:
   max_dispatch_candidates: 5
-  max_dispatches_per_tick: 1
+  # 2026-07-31 (docs/superpowers/specs/2026-07-30-execution-dispatch-
+  # staleness-discard-design.md's Part 2): raised from 1 -- sends are now
+  # concurrent (asyncio.gather(..., return_exceptions=True) in
+  # _send_prepared_candidates), so this is a real per-tick fan-out width,
+  # not just a formerly-inert loop bound. 5 is a disclosed, uncalibrated
+  # starting value (meaningfully closes the measured ~12-17/min production
+  # vs ~4-5/min sequential-dispatch gap without a large first-patch blast
+  # radius) -- revisit against real post-deploy dispatch-rate data, same
+  # discipline as every other constant shipped in this arc.
+  max_dispatches_per_tick: 5

--- a/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
+++ b/docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md
@@ -231,7 +231,15 @@ bounded by sequential `await self._send_one(...)` calls), so Part 2 remains real
 work — it's just no longer entangled with what turned out to be a separate, bigger, already-fixed
 problem.
 
-## Part 2: throughput redesign — scoped, ready to implement
+## Part 2: throughput redesign — implemented (2026-07-31)
+
+Shipped exactly as scoped below: `max_dispatches_per_tick` 1→5,
+`asyncio.gather(..., return_exceptions=True)` in `_send_prepared_candidates`, `_send_one` split
+into a total outer wrapper (`_send_one`) and its original body (`_send_one_inner`). All three
+adversarial-pass findings below (the corrected bus-RPC-safety mechanism, and both rounds on
+`_send_one`'s exception safety) are reflected in the real diff, not just this doc. See
+`services/orion-execution-dispatch-runtime/README.md`'s "Concurrent sends" section for the
+production-facing account.
 
 Status change from the original draft below: every missing question that gated this has now been
 answered with real evidence (live trace + direct code reads), not assumption. This section is the
@@ -274,12 +282,14 @@ steady-state dispatch can only ever process ~30% of what's produced.
    has no `await` inside it, so it is a single, non-preemptible operation regardless of how many
    concurrent `_send_one()` calls are in flight — this is not the same hazard as real OS-thread
    concurrency, and reaching for a lock here would be solving a problem that doesn't exist in this
-   execution model. The one real, disclosed behavior change: `_check_theater_tripwire()` currently
-   re-checks after every sequential send (`worker.py:429`, "lets the tripwire fire the same tick it
-   actually crosses the threshold"); under `asyncio.gather`, there's no clean mid-batch checkpoint,
-   so the recheck moves to once-per-batch (after `gather` returns) instead of once-per-candidate.
-   Coarser, not unsafe — the tripwire's own 10-sample window makes this a small, acceptable
-   granularity change, not a correctness regression.
+   execution model. **Correction (implementation-time review, 2026-07-31): the "granularity
+   change" originally claimed here was wrong.** Checked the actual pre-patch code directly
+   (`git show HEAD:.../worker.py | rg "_check_theater_tripwire\(\)"`): it was already called
+   exactly once per tick, after the (then-sequential) send step — the same relative position
+   `_send_prepared_candidates` calls it from today. There was never a per-candidate recheck to
+   compare against; `worker.py:429` (this doc's original citation) pointed at a line inside
+   `_derive_daily_risk_cap`'s docstring, unrelated to the tripwire. No granularity change actually
+   occurred — this entry is corrected rather than left as a false "disclosed trade-off."
 5. **Is the bus/RPC layer itself safe for concurrent use on one shared connection?** Checked, not
    assumed — and an adversarial re-check (explicitly requested, given "bus RPC is the backbone to
    the entire mesh") **found and corrected a real error in this section's first draft**: the
@@ -377,8 +387,9 @@ contract change — `ExecutionDispatchCandidateV1`/`ExecutionDispatchFrameV1` ar
 - `services/orion-execution-dispatch-runtime/app/worker.py::_send_prepared_candidates`: replace
   the sequential `for candidate in to_send: newly_dispatched.append(await self._send_one(...))`
   loop with `newly_dispatched = await asyncio.gather(*(self._send_one(client, bus, frame, c) for c
-  in to_send))`. Move the `_check_theater_tripwire()` recheck to after the `gather` (already
-  effectively true given the loop restructure).
+  in to_send))`. `_check_theater_tripwire()`'s call site does not move — it was already called
+  once per tick, after the send step, in the pre-patch code (see the corrected missing question 4
+  above); no relocation needed.
 - `services/orion-execution-dispatch-runtime/app/worker.py::_send_one`: **required companion
   change, not optional** (missing question 7) — wrap the entire body in a broad `try/except
   Exception`, converting any failure (not just an RPC failure) into the same `dispatch_status=

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -24,11 +24,38 @@ Real sends require **both** gates open:
 
 When both are open, the worker sends `prepared_for_dispatch` candidates to `orion-cortex-exec`
 over `orion:cortex:exec:request:background` (via `orion.execution_dispatch.cortex_client
-.ExecutionDispatchCortexClient`, one real RPC per candidate, bounded by
-`EXECUTION_DISPATCH_RPC_TIMEOUT_SEC`), persists the result to `substrate_dispatch_results`, and
-promotes the candidate to a real, evidenced `dispatched` status.
+.ExecutionDispatchCortexClient`, bounded by `EXECUTION_DISPATCH_RPC_TIMEOUT_SEC`), persists the
+result to `substrate_dispatch_results`, and promotes the candidate to a real, evidenced
+`dispatched` status.
 
-**Budgets**, both enforced per tick before any send happens:
+**Concurrent sends (2026-07-31, Part 2 of docs/superpowers/specs/2026-07-30-execution-dispatch-
+staleness-discard-design.md)**: up to `limits.max_dispatches_per_tick` (now **5**, was 1) real
+cortex-exec RPCs per tick run concurrently via `asyncio.gather(..., return_exceptions=True)` in
+`_send_prepared_candidates`, not sequentially. Fixes a real, measured steady-state gap: with
+production of new proposals holding around ~12-17/min and each real dispatch bound by a ~7-13s
+synchronous RPC, sequential (`max_dispatches_per_tick=1`) dispatch structurally could never process
+more than ~4-5/min — roughly 65-70% of every real, current proposal was going stale and getting
+discarded, forever, not as a temporary backlog artifact but as the permanent steady state (measured
+live: ~4.6/min dispatched vs ~12.6/min produced once the backlog from Part 1 fully drained).
+
+`return_exceptions=True` is load-bearing, not a style choice — verified empirically across two
+adversarial passes before shipping (see the design doc's "Part 2, missing question 7" for the full
+account with real test output): without it, one candidate's failure can cancel a still-in-flight
+sibling mid-RPC via `asyncio.run()`'s own shutdown path (real production code invokes this via
+`asyncio.run(self._send_prepared_candidates(frame))` inside `_tick()`), which could cancel a
+candidate *after* its real cortex-exec call already succeeded but *before* the result gets recorded
+— the exact double-send the idempotency guard in `_send_one` exists to prevent.
+`_send_one`/`_send_one_inner` were split so the outer `_send_one` is a total function that can
+never raise (any unexpected failure degrades to a `dispatch_error` candidate) — required
+independently of `return_exceptions=True`, since a raw exception object in the gathered results
+list would fail `ExecutionDispatchFrameV1.dispatched_candidates`'s schema validation outright.
+Real headroom downstream was confirmed, not assumed, before raising the fan-out width: `orion-
+cortex-exec`'s `background` lane already handles unbounded concurrent requests
+(`concurrent_handlers=True`, no cap).
+
+**Budgets**, both enforced per tick before any send happens (unchanged by the concurrency patch —
+the whole `to_send` batch's risk budget is reserved synchronously, before any concurrent RPCs
+fire, so making the *sending* step concurrent doesn't touch this reservation logic):
 - `config/execution_dispatch/execution_dispatch_policy.v1.yaml`'s `limits.max_dispatches_per_tick`
 - A **self-calibrating daily risk ceiling** (rolling UTC calendar day) -- a real cumulative
   risk-score budget, not a blind action count and, as of 2026-07-29, not a fixed hand-picked

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -615,10 +615,29 @@ class ExecutionDispatchRuntimeWorker:
             result_prefix=self._settings.cortex_exec_result_prefix,
             timeout_sec=self._settings.execution_dispatch_rpc_timeout_sec,
         )
-        newly_dispatched: list[ExecutionDispatchCandidateV1] = []
+        # 2026-07-31 (docs/superpowers/specs/2026-07-30-execution-dispatch-
+        # staleness-discard-design.md's Part 2): concurrent, not sequential.
+        # return_exceptions=True is not optional -- verified empirically,
+        # not assumed (missing question 7, two adversarial passes): bare
+        # gather() lets one candidate's failure cancel its siblings
+        # mid-flight via asyncio.run()'s own shutdown path (this is called
+        # from _tick() via asyncio.run(self._send_prepared_candidates(...))),
+        # which could cancel a candidate AFTER its real cortex-exec RPC
+        # already succeeded but BEFORE save_dispatch_result records it --
+        # the exact double-send the idempotency guard above exists to
+        # prevent. return_exceptions=True keeps every candidate running to
+        # real completion regardless of a batch-mate's failure. _send_one
+        # itself (not _send_one_inner) is also now a total function that
+        # cannot raise, so in practice no exception object should ever
+        # appear in this results list -- return_exceptions=True remains the
+        # correct belt-and-suspenders choice regardless, since it removes
+        # the cross-candidate cancellation risk structurally rather than
+        # relying solely on _send_one never having a bug.
         try:
-            for candidate in to_send:
-                newly_dispatched.append(await self._send_one(client, bus, frame, candidate))
+            newly_dispatched = await asyncio.gather(
+                *(self._send_one(client, bus, frame, candidate) for candidate in to_send),
+                return_exceptions=True,
+            )
         finally:
             await bus.close()
 
@@ -659,6 +678,50 @@ class ExecutionDispatchRuntimeWorker:
         return self.theater_tripwire_active
 
     async def _send_one(
+        self,
+        client: ExecutionDispatchCortexClient,
+        bus: OrionBusAsync,
+        frame: ExecutionDispatchFrameV1,
+        candidate: ExecutionDispatchCandidateV1,
+    ) -> ExecutionDispatchCandidateV1:
+        """Total wrapper around _send_one_inner -- must never raise.
+
+        2026-07-31 (docs/superpowers/specs/2026-07-30-execution-dispatch-
+        staleness-discard-design.md's Part 2, missing question 7, verified
+        empirically across two adversarial passes before this shipped):
+        _send_prepared_candidates now runs concurrent sends via asyncio.
+        gather(..., return_exceptions=True). That flag is the real fix for
+        the cross-candidate cancellation risk (a sibling's failure can no
+        longer cancel this candidate mid-flight, confirmed by direct test,
+        not assumed) -- but return_exceptions=True only prevents gather()
+        itself from raising; it does nothing to stop a raw exception object
+        from landing in the results list if _send_one_inner ever raises for
+        its OWN reasons (not a sibling's). ExecutionDispatchFrameV1.
+        dispatched_candidates: list[ExecutionDispatchCandidateV1] cannot
+        hold a raw exception -- Pydantic would reject the whole frame. This
+        wrapper is what keeps that guarantee: every candidate that goes in
+        comes back out as a real ExecutionDispatchCandidateV1, recording a
+        real dispatch_error if anything unexpected happened, never a bare
+        exception escaping upward.
+        """
+        try:
+            return await self._send_one_inner(client, bus, frame, candidate)
+        except Exception as exc:
+            logger.warning(
+                "execution_dispatch_send_one_unexpected_failure dispatch_id=%s error=%s",
+                candidate.dispatch_id,
+                exc,
+                exc_info=True,
+            )
+            return candidate.model_copy(
+                update={
+                    "dispatch_status": "dispatched",
+                    "dispatched_at": datetime.now(timezone.utc),
+                    "dispatch_error": f"unexpected _send_one failure: {str(exc)[:450]}",
+                }
+            )
+
+    async def _send_one_inner(
         self,
         client: ExecutionDispatchCortexClient,
         bus: OrionBusAsync,

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import math
 import sys
+import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -466,6 +468,39 @@ def _patch_bus_and_client(monkeypatch, outcomes: dict[str, object]) -> MagicMock
     fake_bus.publish = AsyncMock()
     monkeypatch.setattr(worker_mod, "OrionBusAsync", MagicMock(return_value=fake_bus))
     monkeypatch.setattr(worker_mod, "ExecutionDispatchCortexClient", _FakeClient)
+    return fake_bus
+
+
+# 2026-07-31 (docs/superpowers/specs/2026-07-30-execution-dispatch-
+# staleness-discard-design.md's Part 2): a real, measurable delay per call
+# -- concurrency tests need actual wall-clock overlap to prove anything,
+# not just absence-of-crash.
+_SLOW_CLIENT_DELAY_SEC = 0.15
+
+
+class _SlowFakeClient:
+    """Like _FakeClient, but dispatch() awaits a real delay first."""
+
+    def __init__(self, *_, **__) -> None:
+        pass
+
+    async def dispatch(self, *, verb, mode, context, dispatch_id, timeout_sec=None):
+        await asyncio.sleep(_SLOW_CLIENT_DELAY_SEC)
+        outcome = _FAKE_CLIENT_OUTCOMES[dispatch_id]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _patch_bus_and_slow_client(monkeypatch, outcomes: dict[str, object]) -> MagicMock:
+    _FAKE_CLIENT_OUTCOMES.clear()
+    _FAKE_CLIENT_OUTCOMES.update(outcomes)
+    fake_bus = MagicMock()
+    fake_bus.connect = AsyncMock()
+    fake_bus.close = AsyncMock()
+    fake_bus.publish = AsyncMock()
+    monkeypatch.setattr(worker_mod, "OrionBusAsync", MagicMock(return_value=fake_bus))
+    monkeypatch.setattr(worker_mod, "ExecutionDispatchCortexClient", _SlowFakeClient)
     return fake_bus
 
 
@@ -1275,3 +1310,137 @@ async def test_send_prepared_candidates_stamps_baseline_fields_on_early_return_p
 
     assert updated.daily_risk_baseline_ewma == 140.0
     assert updated.daily_risk_baseline_ewma_n == 2
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_sends_concurrently_not_sequentially(monkeypatch) -> None:
+    """2026-07-31 Part 2 (docs/superpowers/specs/2026-07-30-execution-
+    dispatch-staleness-discard-design.md): the whole point of this patch --
+    real RPC wait time must actually overlap across candidates, not just
+    avoid raising. 3 candidates, each with a _SLOW_CLIENT_DELAY_SEC-second
+    simulated RPC: sequential would take >= 3x that; concurrent should land
+    well under 2x a single delay even with real scheduling overhead."""
+    worker = _make_worker(monkeypatch)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    _patch_bus_and_slow_client(
+        monkeypatch,
+        {
+            "dispatch:1": {"result": {"final_text": '{"observation": "a"}'}},
+            "dispatch:2": {"result": {"final_text": '{"observation": "b"}'}},
+            "dispatch:3": {"result": {"final_text": '{"observation": "c"}'}},
+        },
+    )
+    frame = _frame_with_candidates(
+        _candidate("dispatch:1", risk_score=0.01),
+        _candidate("dispatch:2", risk_score=0.01),
+        _candidate("dispatch:3", risk_score=0.01),
+    )
+
+    start = time.monotonic()
+    updated = await worker._send_prepared_candidates(frame)
+    elapsed = time.monotonic() - start
+
+    assert len(updated.dispatched_candidates) == 3
+    assert elapsed < _SLOW_CLIENT_DELAY_SEC * 2
+
+
+@pytest.mark.asyncio
+async def test_send_one_wrapper_converts_unexpected_failure_to_dispatch_error(monkeypatch) -> None:
+    """_send_one must be a total function -- an unexpected failure anywhere
+    in _send_one_inner (not just the RPC call) degrades to a dispatch_error
+    candidate, never raises. Required for asyncio.gather(return_exceptions=
+    True) to never see a raw exception object in its results list, which
+    ExecutionDispatchFrameV1.dispatched_candidates: list[
+    ExecutionDispatchCandidateV1] cannot hold."""
+    worker = _make_worker(monkeypatch)
+    candidate = _candidate("dispatch:boom")
+    frame = _frame_with_candidates(candidate)
+
+    async def _raise(*_args, **_kwargs):
+        raise RuntimeError("simulated unexpected failure")
+
+    worker._send_one_inner = _raise
+
+    result = await worker._send_one(client=None, bus=None, frame=frame, candidate=candidate)
+
+    assert result.dispatch_status == "dispatched"
+    assert result.dispatch_error is not None
+    assert "simulated unexpected failure" in result.dispatch_error
+
+
+def test_send_prepared_candidates_uses_return_exceptions_true(monkeypatch) -> None:
+    """Regression guard for the real risk found on the third adversarial
+    pass at Part 2's design: bare asyncio.gather() (no return_exceptions=
+    True) lets one candidate's failure cancel a still-in-flight sibling.
+    Confirmed live by direct test before this shipped, not assumed -- and
+    that cancellation is specifically a consequence of asyncio.run()'s own
+    shutdown path when its top-level coroutine exits via an exception, NOT
+    of gather() itself (gather()'s own documented behavior, without
+    return_exceptions, is to propagate the first exception WITHOUT
+    cancelling siblings -- they only get cancelled if whatever awaited
+    gather() then also exits, and something -- asyncio.run() here -- reacts
+    to that exit by tearing down remaining tasks). Real production code
+    hits exactly this shape: _tick() calls asyncio.run(self.
+    _send_prepared_candidates(frame)) from a background thread
+    (asyncio.to_thread). This test intentionally skips @pytest.mark.asyncio
+    and calls asyncio.run() directly for that reason -- a pytest-asyncio-
+    managed loop does not tear down the same way between test statements,
+    so it would not actually reproduce the real risk being guarded against.
+
+    Also bypasses _send_one's own hardening on purpose (mocks _send_one
+    directly, not _send_one_inner), so this test proves gather()'s own
+    return_exceptions=True usage in isolation, independent of _send_one's
+    separate defense-in-depth (tested separately, test_send_one_wrapper_
+    converts_unexpected_failure_to_dispatch_error). If a future change ever
+    "simplified" the gather(...) call back to bare gather(), this test must
+    fail."""
+    worker = _make_worker(monkeypatch)
+    worker._store.sum_risk_dispatched_today = MagicMock(return_value=0.0)
+    worker._store.latest_bus_synaptic_prediction_error = MagicMock(return_value=0.1)
+    _patch_bus_and_client(monkeypatch, {})
+
+    slow_completed = False
+
+    async def _fake_send_one(client, bus, frame, candidate):
+        nonlocal slow_completed
+        if candidate.dispatch_id == "dispatch:bad":
+            raise RuntimeError("simulated failure bypassing _send_one's own hardening")
+        await asyncio.sleep(_SLOW_CLIENT_DELAY_SEC)
+        slow_completed = True
+        return candidate.model_copy(
+            update={
+                "dispatch_status": "dispatched",
+                "dispatched_at": NOW,
+                "result_ref": "result:dispatch:good",
+            }
+        )
+
+    worker._send_one = _fake_send_one
+    frame = _frame_with_candidates(
+        _candidate("dispatch:bad", risk_score=0.01),
+        _candidate("dispatch:good", risk_score=0.01),
+    )
+
+    # Deliberately not asserting on the returned frame's content: this test
+    # bypasses _send_one's own hardening on purpose, so newly_dispatched can
+    # legitimately contain a raw RuntimeError alongside the real candidate
+    # -- that malformed-frame consequence is exactly why _send_one's
+    # hardening is required in real production code, tested separately.
+    # Swallow whatever asyncio.run() raises/returns here; only slow_
+    # completed matters to this test.
+    try:
+        asyncio.run(worker._send_prepared_candidates(frame))
+    except Exception:
+        pass
+
+    # If return_exceptions=True is ever removed, the "bad" coroutine's raw
+    # exception propagates out of gather() and out of _send_prepared_
+    # candidates, making the top-level coroutine given to asyncio.run() exit
+    # via that exception -- asyncio.run()'s own shutdown then cancels the
+    # still-sleeping "good" coroutine before it can set slow_completed. This
+    # assertion is the real, direct proof, run the same way production
+    # actually invokes this code.
+    assert slow_completed is True


### PR DESCRIPTION
## Summary

- Part 2 of the arc in `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md`, scoped across three adversarial passes in PR #1525, implemented here exactly as scoped.
- Real, measured problem: production of new proposals runs ~12-17/min; sequential dispatch (`max_dispatches_per_tick=1`, one real ~7-13s cortex-exec RPC at a time) caps throughput at ~4-5/min. Confirmed live: ~4.6/min dispatched vs ~12.6/min produced — **~65-70% of every real, current proposal going stale and discarded, forever, as the permanent steady state**, not a temporary backlog artifact.
- Fix: `max_dispatches_per_tick` 1→5, sequential send loop replaced with `asyncio.gather(..., return_exceptions=True)`, `_send_one` split into a total wrapper (`_send_one`) + its original body (`_send_one_inner`, byte-for-byte unchanged).
- `return_exceptions=True` is load-bearing, not stylistic — verified empirically (not assumed) that without it, one candidate's failure can cancel a still-in-flight sibling mid-RPC via `asyncio.run()`'s own shutdown path, risking cancellation *after* a real dispatch already succeeded but *before* it's recorded — the exact double-send the idempotency guard exists to prevent.

## Outcome moved

Real dispatch throughput should approach production rate instead of being capped at ~30-35% of it. `staleness_discard_count_ewma` and real dispatch rate are the metrics to watch post-deploy to confirm.

## Current architecture

`_send_prepared_candidates` selected up to `max_dispatches_per_tick` candidates by risk budget, then sequentially `await`ed `_send_one()` for each — one real cortex-exec RPC (~7-13s) fully blocking the tick before the next could even be attempted.

## Architecture touched

`services/orion-execution-dispatch-runtime/app/worker.py` (`_send_prepared_candidates`, `_send_one` split into `_send_one`/`_send_one_inner`), `config/execution_dispatch/execution_dispatch_policy.v1.yaml`. No schema/bus/API changes.

## Files changed

- `config/execution_dispatch/execution_dispatch_policy.v1.yaml`: `max_dispatches_per_tick: 1 → 5`.
- `services/orion-execution-dispatch-runtime/app/worker.py`: concurrent send loop, `_send_one` exception-safety split.
- `services/orion-execution-dispatch-runtime/README.md`, `docs/superpowers/specs/2026-07-30-execution-dispatch-staleness-discard-design.md`: documented; design doc also corrected (see Review findings below).
- `tests/test_execution_dispatch_runtime_worker.py`: 3 new tests (concurrency wall-clock proof, `_send_one` wrapper unit test, `return_exceptions=True` regression guard).

## Schema / bus / API changes

None.

## Env/config changes

None (policy YAML, not `.env`).

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-execution-dispatch-concurrent-send
PYTHONPATH=. .venv/bin/python -m pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_policy_loader.py tests/test_execution_dispatch_envelopes.py tests/test_execution_dispatch_bus_catalog.py tests/test_execution_dispatch_result_extraction.py tests/test_execution_dispatch_cortex_client.py tests/test_execution_dispatch_transport_dry_run.py -q
# 122 passed
```

All three new tests were revert-tested locally, not just written and trusted: flipped `return_exceptions=True → False`, confirmed the corresponding test fails; reverted the concurrent-send loop to sequential, confirmed the wall-clock test fails; restored both, confirmed a byte-identical diff and all tests passing again.

## Evals run

None — no eval harness for this service. Real production/consumption steady-state math (the actual thing this patch exists to fix) was verified directly against live Postgres data across this whole arc, documented in the design doc.

## Docker/build/smoke checks

Not run in this pass — no live deploy yet for this specific patch.

## Review findings fixed

- Finding: the design doc's original Part 2 draft claimed the theater tripwire recheck was moving from per-candidate to per-batch granularity as a disclosed trade-off of this patch.
  - Fix: checked the actual pre-patch code directly (`git show HEAD:.../worker.py | rg "_check_theater_tripwire\(\)"`) — it was already called exactly once per tick, in the same relative position, before this patch. No granularity change ever occurred; the claim was factually wrong and has been corrected in the design doc. No code change was needed — the shipped placement was already correct.
  - Evidence: design doc diff, `git show` output quoted above.
- Reviewing subagent independently re-ran every empirically-checkable claim rather than trusting the PR's own account: did its own revert/restore cycle on `return_exceptions=True` (confirmed byte-identical restore via md5sum), independently reverted the concurrent-send loop and confirmed the wall-clock test fails without it, re-derived the risk-budget-reservation-is-synchronous claim by reading the code directly, and independently re-verified the bus-RPC per-call connection isolation claims from earlier in this arc against the real source files. No other material findings — verdict "ship as-is."

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-execution-dispatch-runtime/.env \
  -f services/orion-execution-dispatch-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: not yet verified against live traffic (this patch hasn't been deployed). The mechanism is thoroughly reviewed and tested, but "does real dispatch throughput actually approach production rate" should be confirmed the same way every other claim in this arc was — watching real data post-deploy, not assuming.
- Mitigation: `staleness_discard_count_ewma` and real dispatch rate (`action_outcomes`) are the exact metrics to check immediately after restart, same discipline used to find and fix every prior issue in this arc.
- Severity: low
- Concern: `max_dispatches_per_tick=5` is a disclosed, uncalibrated starting value, not derived from a load test against `orion-cortex-exec`'s real concurrent capacity (that capacity was confirmed unbounded at the code level, not load-tested).
- Mitigation: revisit against real post-deploy dispatch-rate data, same discipline as every other constant shipped in this arc.