### PR TITLE
fix(substrate)!: finish retiring the transport domain; bus_synaptic is the instrument

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-31-transport-domain-ewma-successor-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-31-transport-domain-ewma-successor-pr.md
@@ -207,10 +207,40 @@ What that rules out:
 `EXTERNALLY_OWNED_METADATA_KEYS`, excluded from the `MERGE` write, which is itself a clue about the
 writer's shape. `salience: 0.556078` does come back.
 
-**Status: `UNVERIFIED`, and materially bigger than this PR.** If a substrate concept node cannot be
-deleted, no substrate node can be retired from the graph at all — only from its readers. Chasing it
-further inside a retirement PR would be the wrong place; it needs its own investigation. No denylist
-was added either: that would paper over a writer nobody has identified yet.
+### Root cause found (FalkorDB `MONITOR`)
+
+The writer logs nothing, so the only way to see it was to watch the wire. Client `172.18.0.39` =
+**`orion-athena-cortex-exec-background`**, writing 11 distinct node_ids × 17 each in one ~0.8s burst:
+
+```text
+node:substrate.{biometrics,bus_synaptic,chat,codebase,execution,harness_closure,route,transport}
+sub-concept-seed-{orion,juniper,orion_juniper_relationship}
+
+MATCH (n) RETURN count(n)  ->  11
+```
+
+Eleven written, eleven in the graph: it round-trips the **entire substrate node set** back from a
+stale in-process snapshot — `chat_stance.py`'s process-level `_UNIFICATION_LAYER` singleton →
+`CognitiveUnificationLayer` → `SubstrateGraphMaterializer.apply_record()`. The values are frozen
+originals at full float precision (`salience=0.556077777777778`, `activation=0.166125`).
+
+Two compounding defects in `orion/substrate/materializer.py::apply_record()`:
+
+1. **Deleting a node makes the write less safe.** Present → `else` branch: `merge_node()` +
+   `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`. Absent → `if existing_node is None:` →
+   `upsert_node()`, a wholesale overwrite with no merge and no protection. The delete is what puts
+   the node on the unprotected path.
+2. **`EXTERNALLY_OWNED_METADATA_KEYS` only covers `metadata`.** `observed_at`, `recency_score`,
+   `salience`, `activation` are not metadata keys, so they are clobbered on every burst even on the
+   protected branch — the mechanism behind the previously unexplained `observed_at` oscillation on
+   live nodes.
+
+**Status: `UNVERIFIED` for the deletion, and materially bigger than this PR.** No substrate node can
+be retired from the graph while a general snapshot round-tripper rewrites all eleven, and live
+domains' temporal fields are being overwritten with stale values several times a second. The fix is
+a change to the unification layer's write scope — cognition wiring, so it needs a decision, not a
+drive-by patch inside a retirement PR. No denylist was added: that would paper over the
+round-tripper instead of scoping it.
 
 The four code changes in this PR are unaffected — they remove every *reader* of the node, which is
 the part that was actually feeding cognition.
@@ -329,10 +359,12 @@ scripts/safe_docker_build.sh orion-proposal-runtime up -d --build
   Replayed over the real 7-day `repair_pressure_appraisal_log`: 45 readings, 6 distinct values, 34 of
   them one identical constant, `0` sustained-trend ticks. The wiring is proven; the input series is
   not capable of expressing a trend. Follow-up is a better series for hop 0, not more hop plumbing.
-- **Severity: HIGH, open. A substrate concept node cannot be deleted from the live graph.**
-  Measured three ways above; unexplained. This blocks the physical half of any node retirement,
-  transport's included. Needs its own investigation patch — the first question is which process
-  replays a byte-identical frozen snapshot within 6s while logging nothing.
+- **Severity: HIGH, open. `orion-cortex-exec-background` round-trips the whole substrate node set
+  from a stale snapshot.** Root-caused above. Two consequences beyond transport: (a) no substrate
+  node can be deleted, and deleting one moves it to the materializer's *unprotected* create branch;
+  (b) `observed_at`/`recency_score`/`salience`/`activation` on live domains are overwritten with
+  stale values several times a second, because `EXTERNALLY_OWNED_METADATA_KEYS` only guards
+  `metadata`. Needs a scoping decision on the unification layer's write path.
 - **Severity: note. `node:substrate.harness_closure` is the same shape of zombie** — 7 days stale at
   a hardcoded `0.65`. It is already excluded from the domain map deliberately, so it does not
   contaminate the reducer, but its producer looks dead too. Not touched here; scope was transport.

--- a/docs/superpowers/pr-reports/2026-07-31-transport-domain-ewma-successor-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-31-transport-domain-ewma-successor-pr.md
@@ -341,4 +341,4 @@ scripts/safe_docker_build.sh orion-proposal-runtime up -d --build
 
 ## PR link
 
-<pending>
+https://github.com/junebug-junie/Orion-Sapienform/pull/1544

--- a/docs/superpowers/pr-reports/2026-07-31-transport-domain-ewma-successor-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-31-transport-domain-ewma-successor-pr.md
@@ -1,0 +1,344 @@
+# Finish retiring the transport domain; bus_synaptic is the instrument
+
+Branch: `fix/transport-domain-ewma-successor`
+Date: 2026-07-31
+Status: **DONE_WITH_CONCERNS** (see the failed live-node deletion)
+
+## Summary
+
+- The 2026-07-26 pass killed `node:substrate.transport`'s **write** and deliberately kept everything
+  else. Five days later the reducer was still **reading** it.
+- `_PREDICTION_ERROR_DOMAIN_NODE_IDS` still mapped `node:substrate.transport -> "transport"`, so the
+  brain-frame reducer handed `transport` to `reduce_attention_self_model()` on every tick, off a node
+  frozen since 2026-07-24.
+- `transport_prediction_error()` **deleted**, not left importable.
+- `predicted_shift`'s argmax was **unfiltered** — any key a caller supplied could become Orion's
+  stated "what is about to shift". Now gated on `ACTIVE_INFERENCE_DOMAINS`.
+- Ships a **failing gate**, not another comment: set equality between the node map and
+  `ACTIVE_INFERENCE_DOMAINS`.
+- Stale node **could not** be deleted from live FalkorDB — it resurrects in 6s from a frozen 7-day-old
+  snapshot, and survives stopping `substrate-runtime`. Reported as an open defect, not claimed as done.
+- Also flips `ORION_METACOG_HOP_PROPOSE_ENABLED` to `true` (Juniper's go-ahead).
+
+## Outcome moved
+
+The Active-Inference domain set is now the same set everywhere: producer, reducer map, confidence
+aggregate, and `predicted_shift`. Before this patch those four disagreed, and the disagreement was
+invisible because the disagreeing member was frozen.
+
+Live state of the node (it is still there — see the deletion section):
+
+```text
+node:substrate.transport
+  prediction_error   0.556078
+  observed_at        2026-07-24T21:55:26Z    (7 days stale)
+  recency_score      0.0
+  salience           0.556078                <- visible to generic concept consumers
+  relationships      0
+  provenance         substrate_runtime_worker / substrate_prediction_error   (producer dead)
+```
+
+## Why a comment was not enough
+
+Nothing failed for those five days. The 2026-07-26 patch's own comment said killing the write "is
+the entire change" — it was not, because a reader still listed the dead identity, and no test
+expressed the invariant that a domain's producer and its readers must retire together.
+
+This is CLAUDE.md's "deterministic gates over repeated yelling" case verbatim: the right fix for a
+partial retirement is a failing gate, not a louder comment.
+
+## The `predicted_shift` finding, stated honestly
+
+`reduce_attention_self_model()`'s `predicted_shift` took an argmax over
+`prediction_error_trend_by_domain` **with no filter**. `transport` was in that dict every live tick.
+
+It **never actually won**. All persisted rows carrying a `predicted_shift`:
+
+```text
+execution      4597
+biometrics     1490
+bus_synaptic   1031
+route             1
+transport         0
+```
+
+That is not the filter working — there was no filter. It is that a frozen node has a flat `0.0`
+trend, so `abs(trend) > abs(top_trend_val)` could never fire for it. A dead domain was invisible
+here exactly as long as it stayed dead; a single backfill, replay, or one-off write would have made
+the loudest key in the dict a retired instrument.
+
+Removing the map entry alone fixes this instance and leaves the next retired domain free to repeat
+it. The filter is the seam; the map entry is the instance.
+
+## Current architecture
+
+```text
+_*_tick()  ->  _write_prediction_error_node()  ->  node:substrate.<domain>  (FalkorDB orion_substrate)
+                                                          |
+        _brain_frame_prediction_error_by_domain() reads them back via _PREDICTION_ERROR_DOMAIN_NODE_IDS
+                                                          |
+                              +---------------------------+---------------------------+
+                              |                                                       |
+              compute_prediction_error_trend()                        reduce_attention_self_model()
+                              |                                          |                    |
+                    predicted_shift (was UNFILTERED)      prediction_error_confidence   confidence
+                                                          (ACTIVE_INFERENCE_DOMAINS)    (branch-gated)
+```
+
+`config/field/orion_field_topology.v1.yaml`'s `capability:transport` edge had **already** migrated to
+`node:substrate.bus_synaptic` and needed no change — the EWMA successor was in place there. Verified
+directly: zero references to `node:substrate.transport` remain in that file.
+
+## Files changed
+
+- `services/orion-substrate-runtime/app/worker.py`: map entry removed; the stale "kept, not deleted"
+  comment block replaced with what actually happened.
+- `orion/substrate/prediction_error.py`: `transport_prediction_error()` deleted, replaced by a
+  comment recording why the "keep it, replay might want it" rationale did not hold.
+- `orion/substrate/attention_self_model.py`: `predicted_shift` argmax filtered; two docstring claims
+  that were true-and-load-bearing ("remains present in `prediction_error_by_domain` when a caller
+  supplies it") corrected.
+- `services/orion-substrate-runtime/tests/test_prediction_error_domain_map.py` (new): the gate.
+- `orion/substrate/tests/test_attention_self_model.py`: two tests for the filter.
+- `services/orion-hub/scripts/attention_organ_routes.py`: `transport` removed from
+  `KNOWN_PREDICTION_ERROR_DOMAINS` (review finding 4).
+- `scripts/analysis/measure_ast_hot_reducer.py`: the SECOND copy of the domain map, plus a stale
+  4-domain claim in its generated report (review finding 2).
+- `services/orion-substrate-runtime/README.md`: retirement section completed and corrected.
+- `services/orion-proposal-runtime/.env_example`: hop 0 flag flipped, with rationale.
+
+## Schema / bus / API changes
+
+- Added: none.
+- Removed: `transport_prediction_error()` (public symbol in `orion.substrate.prediction_error`,
+  zero callers).
+- Renamed: none.
+- Behavior changed: `prediction_error_by_domain` / `prediction_error_trend_by_domain` no longer carry
+  a `transport` key. `predicted_shift` can no longer name a non-`ACTIVE_INFERENCE_DOMAINS` domain.
+- Compatibility: consumers iterate these dicts rather than indexing them, so a missing key is a
+  smaller set, not a `KeyError`. `services/orion-hub/scripts/attention_organ_routes.py` drops
+  `transport` from `KNOWN_PREDICTION_ERROR_DOMAINS` (review finding — see below).
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- Behavior changed: `ORION_METACOG_HOP_PROPOSE_ENABLED` `false -> true` in `.env_example`.
+- `.env_example` updated: yes.
+- local `.env` synced: **yes, done** — `services/orion-proposal-runtime/.env` line 21 edited directly
+  to `true`. `scripts/sync_local_env_from_example.py` does not overwrite an existing value, so this
+  was a hand edit, verified after. `.env` confirmed still gitignored (`git check-ignore`).
+- `docker-compose.yml` inline default stays `:-false`. Intentional: the compose default is the
+  ships-off posture for a fresh operator; the live `.env` carries the enabled value.
+- skipped keys requiring operator action: none.
+
+### Why the hop 0 flag is safe to flip now
+
+It shipped off behind "flip only after a real, non-degenerate candidate is observed post-deploy" —
+which was **unsatisfiable as written**: the converter only runs when the flag is on, so nothing could
+ever be observed while it stayed off. Zero `cognitive_hop` candidates existed in
+`substrate_proposal_frames` across its whole history, confirmed by query.
+
+What actually makes it safe:
+
+- `required_policy_gate="operator_review"` is unconditional in `orion/metacog/proposal.py` — worst
+  case is a noisy proposal queue, never autonomous action.
+- The arena already runs a live external producer under the identical contract: `reverie_thought`,
+  518 candidates in a 3h window.
+- The converter fails open — `worker.py` wraps it so a metacog read cannot break proposal generation.
+
+**Measured post-deploy, and the answer is: it does not fire, and cannot on this input.**
+
+The flag is confirmed live in the container (`ORION_METACOG_HOP_PROPOSE_ENABLED=true`), 90 proposal
+frames were built in the first 5 minutes, `0` carried a `cognitive_hop` candidate, and `0`
+`metacog_hop_candidate_failed` exceptions were logged — so the converter runs cleanly and returns
+`None`, rather than erroring.
+
+Replaying the **real** reducer over the **real** 7-day series (not a fixture):
+
+```text
+readings                45          (repair_pressure_appraisal_log, 7d, ~6.4/day)
+sustained trend ticks    0          <- across the entire window
+latest                  z=-0.526, consecutive_elevated=0, baseline n=45
+distinct values          6 of 45
+modal value             34 of 45    (0.08706577244027125, the text-fallback constant)
+```
+
+**76% of the series is one identical constant.** This is the metric quality gate's step-4 failure in
+its degenerate form: the input is not a signal with a rest state, it is a constant with occasional
+excursions. `is_sustained_trend` requires 3 consecutive *escalating* elevated ticks; a series that
+sits on one value and steps off it briefly cannot produce that, and the flat run also drives the EWMA
+variance toward its floor so the excursions that do occur score absurd z-scores rather than
+meaningful ones.
+
+This is recorded as a **result, not a caveat**. Hop 0 is correctly wired and provably exercised
+against live data; what it lacks is an input series capable of expressing a trend. The next patch on
+this arc should be choosing/constructing that series, not more hop plumbing. Leaving the flag on is
+still right: it is now a live, zero-cost observation point, and the alternative (off) is what made
+this measurable only after five days of it being unobservable.
+
+## Live data change attempted (CLAUDE.md section 14) — and it FAILED
+
+Snapshot taken first (`/tmp/retire-substrate-transport-node/before_snapshot.txt` — full properties
+plus relationship count). Single node, zero relationships, dead producer, well under the threshold
+that requires asking.
+
+**The delete does not stick.** Three attempts, each reporting `Nodes deleted: 1`, each undone:
+
+| # | method | result |
+|---|--------|--------|
+| 1 | plain `DELETE` while everything running | back within a minute, `activation` still ticking `0.166125 -> 0.166074 -> 0.166064` |
+| 2 | `stop substrate-runtime` -> delete (`count(n)=0` verified while down) -> `up -d` | back anyway |
+| 3 | delete on running system, polled every 2s | **resurrected after 6 seconds** |
+
+What that rules out:
+
+- **Not the dynamics loop.** `SUBSTRATE_DYNAMICS_TICK_INTERVAL_SEC` defaults to 30s; this took 6s.
+- **Not `FalkorSubstrateStore`'s in-process cache alone.** That cache dies with the process, and
+  attempt 2 deleted the node while the process was down.
+- **Not a fresh write.** The restored node carries `activation: 0.166125` — the *exact* pre-delete
+  value, not a decayed one — with `recency_score: 0.0` and `observed_at: 2026-07-24T21:55:26Z`.
+  Something replays a frozen 7-day-old snapshot verbatim.
+- **No log line.** `substrate-runtime`, `recall`, `attention-runtime`, `field-digester`,
+  `graph-compression` all silent across the resurrection window.
+
+`prediction_error` is the one property that does not come back — it is in
+`EXTERNALLY_OWNED_METADATA_KEYS`, excluded from the `MERGE` write, which is itself a clue about the
+writer's shape. `salience: 0.556078` does come back.
+
+**Status: `UNVERIFIED`, and materially bigger than this PR.** If a substrate concept node cannot be
+deleted, no substrate node can be retired from the graph at all — only from its readers. Chasing it
+further inside a retirement PR would be the wrong place; it needs its own investigation. No denylist
+was added either: that would paper over a writer nobody has identified yet.
+
+The four code changes in this PR are unaffected — they remove every *reader* of the node, which is
+the part that was actually feeding cognition.
+
+## Tests run
+
+```text
+$ pytest orion/substrate/tests/test_attention_self_model.py -q
+48 passed
+
+services/orion-substrate-runtime$ pytest tests/test_prediction_error_domain_map.py -q
+3 passed
+
+services/orion-substrate-runtime$ pytest tests -q --ignore=tests/test_grammar_consumer_integration.py
+23 FAILED/ERROR lines
+```
+
+Those 23 are **pre-existing**, established against a detached scratch worktree at `origin/main`:
+
+```text
+origin/main : 23 FAILED/ERROR lines
+this branch : 23 FAILED/ERROR lines
+diff        : one captured log line's line number (worker.py:540 -> :555), from added comments
+```
+
+Red-before-green, both new test files run against `origin/main`:
+
+```text
+test_prediction_error_domain_map.py
+  FAILED  ... only in the node map: ['transport']
+  FAILED  transport_prediction_error() is back in orion/substrate/prediction_error.py
+
+test_attention_self_model.py
+  FAILED  TestPredictedShift::test_retired_domain_cannot_win_the_argmax
+  FAILED  TestPredictedShift::test_only_retired_domains_yields_no_prediction
+```
+
+## Evals run
+
+```text
+No eval harness exists for services/orion-substrate-runtime or orion/substrate.
+```
+
+Flagged, not claimed.
+
+## Docker/build/smoke checks
+
+See "Restart required". Deploy evidence appended post-merge.
+
+## Review findings fixed
+
+Code review ran in a subagent per CLAUDE.md section 12. Six material findings, all addressed.
+
+- **Finding 1 (HIGH): the live node deletion did not stick; the claim was false.** Review checked
+  the live rail and found `node:substrate.transport` present with `activation` still ticking.
+  - Fix: the claim is **retracted**. Two further deletion attempts (including one with
+    `substrate-runtime` stopped) also failed; the third measured a 6-second resurrection. Documented
+    as an open defect with the evidence, in both the README and this report, rather than restated as
+    done. Status `UNVERIFIED`.
+  - Evidence: `Nodes deleted: 1` three times; `count(n)=1` after each; restored `activation`
+    `0.166125` byte-identical to the pre-delete snapshot.
+- **Finding 2 (MEDIUM): a second, ungated copy of the domain map.**
+  `scripts/analysis/measure_ast_hot_reducer.py` — the harness `attention_self_model.py`'s own
+  docstring names as this reducer's validation path — still listed `transport`, so it would have
+  averaged six values where production averages five for the same tick.
+  - Fix: entry removed, its now-inverted rationale rewritten, and the gate **extended to parse that
+    file too**, so the class of drift is closed rather than this one instance. Its stale generated
+    report line (a 4-domain claim printed next to a 5-domain number, wrong since 2026-07-25) fixed
+    in the same pass.
+- **Finding 3 (MEDIUM): the new gate had a one-line bypass.** Review demonstrated that
+  `_PREDICTION_ERROR_DOMAIN_NODE_IDS["node:substrate.transport"] = "transport"` on a later line was
+  invisible to the AST parser — both tests passed with the retired domain live again. Separately, a
+  type annotation turned the node into `ast.AnnAssign` and made the gate blame a missing constant.
+  - Fix: `ast.walk` over both assignment forms, plus explicit rejection of subscript assignment,
+    `.update()`, `.setdefault()`, `.pop()`. Helpers now raise `AssertionError` rather than
+    `pytest.fail()` **specifically so the bypasses are themselves testable** — `pytest.fail` raises a
+    `BaseException` subclass that `pytest.raises(Exception)` does not catch, so a teeth-test written
+    against it would have silently proven nothing.
+  - Evidence: new `TestTheGateHasTeeth` reproduces all three shapes; 7 passed.
+- **Finding 4: Hub `KNOWN_PREDICTION_ERROR_DOMAINS` still listed `transport`.** Either state is
+  wrong — "still ticking, still readable elsewhere" while the node exists, or a permanent red
+  "no node" badge once it does not.
+  - Fix: removed. `harness_closure` deliberately stays: it is excluded from the aggregate but has a
+    live producer, which is what that heading is for.
+- **Finding 5: a docstring added by this commit overclaimed** — "`predicted_shift` filters to this
+  constant like every other consumer". Not true: the branch-gated `confidence` still iterates the
+  raw dict.
+  - Fix: rewritten to name that consumer as the deliberate exception.
+- **Finding 6: undisclosed level-shift in branch-gated `confidence`.** Dropping the frozen `0.556`
+  term shrinks the denominator 6 -> 5; future rows in that branch read ~0.09 higher for identical
+  substrate state. 25 persisted rows used the 6-domain basis, all before 2026-07-29T05:01:06Z.
+  - Fix: disclosed at the constant's definition and here. Not suppressed — the basis string
+    self-documents which domain set produced each value.
+- **Finding 7: the PR report was untracked.** Fixed; committed with the code.
+
+Review also verified clean, independently: the `transport_prediction_error()` deletion is safe (zero
+importers, no star-import, no `getattr`/`importlib` lookup, both named analysis scripts confirmed to
+mention it only in prose); no `KeyError` risk (every reader iterates, none indexes `["transport"]`);
+and the env flip cannot auto-dispatch — traced through four independent layers
+(`required_policy_gate`, `policy/evaluator.py`'s decision branches,
+`execution_dispatch_policy.v1.yaml`'s `blocked_policy_decisions`, and the absent
+`proposal_kind_to_cortex` route).
+
+## Restart required
+
+```bash
+scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
+scripts/safe_docker_build.sh orion-proposal-runtime up -d --build
+```
+
+`orion-proposal-runtime` is required for the flag flip to take effect — the value is read at boot.
+
+## Risks / concerns
+
+- **Severity: should-know. Hop 0 fires zero times on its current input, measured not predicted.**
+  Replayed over the real 7-day `repair_pressure_appraisal_log`: 45 readings, 6 distinct values, 34 of
+  them one identical constant, `0` sustained-trend ticks. The wiring is proven; the input series is
+  not capable of expressing a trend. Follow-up is a better series for hop 0, not more hop plumbing.
+- **Severity: HIGH, open. A substrate concept node cannot be deleted from the live graph.**
+  Measured three ways above; unexplained. This blocks the physical half of any node retirement,
+  transport's included. Needs its own investigation patch — the first question is which process
+  replays a byte-identical frozen snapshot within 6s while logging nothing.
+- **Severity: note. `node:substrate.harness_closure` is the same shape of zombie** — 7 days stale at
+  a hardcoded `0.65`. It is already excluded from the domain map deliberately, so it does not
+  contaminate the reducer, but its producer looks dead too. Not touched here; scope was transport.
+- **Severity: note. `orion_metacog` still has no consumer** (~3,050 rows/day, of which ~1,275 come
+  from the still-level-triggered `rpc_health` transport branch). Unrelated to this patch, still open.
+
+## PR link
+
+<pending>

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -52,7 +52,17 @@ from this filtered set" -- and that was true and load-bearing: the caller
 producer write was killed, off a node frozen at `0.556` since 2026-07-24, and
 `predicted_shift`'s argmax below read the dict *unfiltered*. Both ends are now
 closed: the caller's map entry is deleted and gated by a set-equality test, and
-`predicted_shift` filters to this constant like every other consumer.
+`predicted_shift` filters to this constant.
+
+One consumer in this module still does NOT filter, deliberately: the
+branch-gated `confidence`/`confidence_basis` pair, via
+`_aggregate_prediction_error_confidence`. That is its documented pre-existing
+behavior (see that function and `ACTIVE_INFERENCE_DOMAINS`' own comment) and is
+left unchanged here rather than quietly altered inside a retirement patch --
+but note it means removing a domain from the caller's map shifts that field's
+value for identical substrate state. Measured for this retirement: 25 persisted
+rows used the 6-domain basis, all before 2026-07-29T05:01:06Z; future rows in
+that branch read about 0.09 higher, because a frozen 0.556 term left the mean.
 """
 
 from __future__ import annotations

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -42,10 +42,17 @@ were execution/transport/biometrics/chat/route, but `transport` was excluded
 from `ACTIVE_INFERENCE_DOMAINS` (see that constant's docstring) as confirmed
 dead -- a real, bounded replacement now exists: `bus_synaptic`, built on top
 of the bus-synaptic-graph arc. `ACTIVE_INFERENCE_DOMAINS` now covers
-execution/biometrics/chat/route/bus_synaptic (five active domains, not six --
-the old broken `transport` domain remains present in
+execution/biometrics/chat/route/bus_synaptic (five active domains, not six).
+
+**2026-07-31: `transport` is fully gone, not merely excluded.** This docstring
+previously ended "the old broken `transport` domain remains present in
 `prediction_error_by_domain` when a caller supplies it, just still excluded
-from this filtered set).
+from this filtered set" -- and that was true and load-bearing: the caller
+(`orion-substrate-runtime`) went on supplying it for five days after its
+producer write was killed, off a node frozen at `0.556` since 2026-07-24, and
+`predicted_shift`'s argmax below read the dict *unfiltered*. Both ends are now
+closed: the caller's map entry is deleted and gated by a set-equality test, and
+`predicted_shift` filters to this constant like every other consumer.
 """
 
 from __future__ import annotations
@@ -82,12 +89,16 @@ DEFAULT_BROADCAST_STALE_THRESHOLD_SEC = 60.0
 # 2h real window, `substrate_field_state`): 3534/3534 ticks (100% coverage --
 # better than execution/chat/route's near-0% coverage) with real variance
 # (min=0.17, max=1.0, mean=0.30), not the old `transport` domain's flat 0.0.
-# The old `transport` domain itself (`transport_prediction_error()`, narrow
-# 2-Redis-Streams scope) remains excluded and unfixed -- `bus_synaptic` is an
-# additive replacement candidate sitting alongside it, not a repair of it.
+# The old `transport` domain (`transport_prediction_error()`, narrow
+# 2-Redis-Streams scope) was excluded here as of 2026-07-25 and fully deleted
+# 2026-07-31 -- function, caller map entry, and the live node. `bus_synaptic`
+# started as an additive replacement candidate sitting alongside it and is now
+# simply the transport instrument.
+#
 # This constant does NOT affect the pre-existing branch-gated
 # `confidence`/`confidence_basis` fields below, which keep their original
-# (unfiltered, all-domains) formula unchanged -- additive only.
+# (unfiltered, all-domains) formula unchanged -- additive only. It DOES now
+# gate `predicted_shift` (2026-07-31), which was previously unfiltered.
 ACTIVE_INFERENCE_DOMAINS = frozenset({"execution", "biometrics", "chat", "route", "bus_synaptic"})
 
 
@@ -307,10 +318,28 @@ def reduce_attention_self_model(
     # self_state.dimension_trajectory fallback. Computed unconditionally
     # (not gated on which attention_reason branch fires below), matching the
     # old self_state block's own positioning.
+    #
+    # Restricted to ACTIVE_INFERENCE_DOMAINS 2026-07-31. This argmax was
+    # previously unfiltered, so ANY key a caller put in the dict could win and
+    # become Orion's stated "what is about to shift" -- including a retired
+    # domain. That was live: `orion-substrate-runtime`'s
+    # `_PREDICTION_ERROR_DOMAIN_NODE_IDS` still listed `node:substrate.transport`
+    # five days after its producer write was killed, so `transport` was in this
+    # dict every tick, reading a frozen 0.556.
+    #
+    # It never actually won (checked all 7,119 persisted rows carrying a
+    # predicted_shift: execution 4,597 / biometrics 1,490 / bus_synaptic 1,031 /
+    # route 1, transport 0) -- precisely BECAUSE it was frozen, so its trend was
+    # a flat 0.0 and `abs(trend) > abs(top_trend_val)` could never fire for it.
+    # A dead domain was invisible here only for as long as it stayed dead. The
+    # filter is the seam; removing that map entry alone would fix this instance
+    # and leave the next retired domain free to repeat it.
     if prediction_error_trend_by_domain:
         top_domain: str | None = None
         top_trend_val = 0.0
         for domain, trend in prediction_error_trend_by_domain.items():
+            if domain not in ACTIVE_INFERENCE_DOMAINS:
+                continue
             if abs(trend) > abs(top_trend_val):
                 top_domain, top_trend_val = domain, trend
         if top_domain is not None and top_trend_val != 0.0:

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -394,39 +394,27 @@ def execution_prediction_error(
     return min(1.0, max(0.0, update.zscore) / _EXECUTION_PREDICTION_ERROR_ZSCORE_SATURATION)
 
 
-def transport_prediction_error(
-    prev: TransportBusProjectionV1,
-    curr: TransportBusProjectionV1,
-) -> float:
-    """0-1 surprise score: how much did transport bus health change this batch?
-
-    **Retired from live use 2026-07-26** (docs/superpowers/specs/2026-07-26-
-    transport-domain-retirement-bus-synaptic-successor-design.md). This diffs
-    stream_backlog_health/delivery_confidence/stream_backlog_pressure -- fields
-    fed by BUS_OBSERVER_STREAMS' narrow 2-Redis-Stream "world_pulse" census, not
-    real inter-service bus traffic. Already excluded from attention_self_model
-    .py's ACTIVE_INFERENCE_DOMAINS as known-dead; `services/orion-substrate-
-    runtime/app/worker.py::_transport_tick()` no longer calls this function
-    live -- bus_synaptic_prediction_error() (below) is the real, mesh-wide
-    successor, already flowing into every consumer this fed. Kept here (not
-    deleted) though it now has zero callers anywhere in the repo, live or
-    offline -- checked: measure_transport_bus_signal_history.py and measure_
-    transport_biometrics_prediction_error_correlation.py only mention this
-    function's name in prose docstrings, they read persisted values directly
-    from Postgres, no import. Do not wire this back into a live tick.
-    """
-    deltas: list[float] = []
-    for bus_id, curr_bus in curr.buses.items():
-        prev_bus = prev.buses.get(bus_id)
-        if prev_bus is None:
-            continue
-        for field in ("stream_backlog_health", "delivery_confidence", "stream_backlog_pressure"):
-            pv = getattr(prev_bus, field, 0.0)
-            cv = getattr(curr_bus, field, 0.0)
-            deltas.append(abs(cv - pv))
-    return min(1.0, _mean(deltas) / _THRESHOLD) if deltas else 0.0
-
-
+# transport_prediction_error() DELETED 2026-07-31.
+#
+# Retired from live use 2026-07-26 (docs/superpowers/specs/2026-07-26-transport-
+# domain-retirement-bus-synaptic-successor-design.md) but kept in the file on
+# the reasoning that "deleting it buys nothing and risks a future script wanting
+# it for genuine historical replay." That reasoning was wrong twice over:
+#
+#   1. It buys the thing CLAUDE.md section 0A actually asks for. A retired instrument
+#      that still exists is one a future patch wires back in -- and the entry
+#      that kept it alive downstream (orion-substrate-runtime's
+#      _PREDICTION_ERROR_DOMAIN_NODE_IDS) survived FIVE DAYS past the write being
+#      killed for exactly that reason: nothing failed when it stayed.
+#   2. The replay case is not lost. It diffed TransportBusProjectionV1's
+#      stream_backlog_health / delivery_confidence / stream_backlog_pressure --
+#      fields still persisted, still readable, and recoverable in ~10 lines by
+#      any script that genuinely needs them. Keeping a live-importable symbol is
+#      not the cheap way to preserve that; git history is.
+#
+# The successor is bus_synaptic_prediction_error() above: mesh-wide real
+# inter-service publish traffic via orion_bus_synapse's per-edge EWMA z-scores,
+# rather than a 2-Redis-Stream "world_pulse" census that was never bus health.
 def biometrics_prediction_error(
     prev: NodeBiometricsProjectionV1,
     curr: NodeBiometricsProjectionV1,

--- a/orion/substrate/tests/test_attention_self_model.py
+++ b/orion/substrate/tests/test_attention_self_model.py
@@ -300,6 +300,42 @@ class TestPredictedShift:
 
         assert model.predicted_shift is None
 
+    def test_retired_domain_cannot_win_the_argmax(self) -> None:
+        """A domain outside ACTIVE_INFERENCE_DOMAINS is not eligible, however loud.
+
+        2026-07-31: this argmax was unfiltered, so any key a caller supplied
+        could become Orion's stated "what is about to shift". `transport` was
+        in that dict on every live tick for five days after its producer write
+        was killed. It never actually won -- only because a frozen node has a
+        flat 0.0 trend. The moment such a node moved at all (a backfill, a
+        one-off write, a replay) it would have outranked every real domain here.
+        """
+        model = reduce_attention_self_model(
+            None, None, now=NOW,
+            prediction_error_trend_by_domain={
+                "transport": 0.9,      # retired: loudest, must be ignored
+                "execution": 0.02,     # live: quiet, must still win
+            },
+        )
+
+        assert model.predicted_shift is not None
+        assert "execution" in model.predicted_shift
+        assert "transport" not in model.predicted_shift
+
+    def test_only_retired_domains_yields_no_prediction(self) -> None:
+        """Filtered down to nothing is honestly absent, not a fallback.
+
+        Same convention as `test_no_trend_data_yields_no_prediction` -- this
+        reducer never invents a value when its inputs are all ineligible.
+        """
+        model = reduce_attention_self_model(
+            None, None, now=NOW,
+            prediction_error_trend_by_domain={"transport": 0.9, "harness_closure": -0.4},
+        )
+
+        assert model.predicted_shift is None
+        assert model.predicted_shift_basis == ""
+
     def test_predicted_shift_computed_independent_of_attention_reason_branch(self) -> None:
         """The old self_state-driven predicted_shift was computed
         unconditionally, before the attention_reason branching -- the new

--- a/scripts/analysis/measure_ast_hot_reducer.py
+++ b/scripts/analysis/measure_ast_hot_reducer.py
@@ -105,15 +105,20 @@ MAX_ROWS: int = 200_000
 
 # The real, live Predictive-Processing domains
 # (`orion/substrate/prediction_error.py`), keyed by their FieldStateV1 node
-# id. `node:substrate.transport` is included despite its documented
-# structurally-narrow scope (`services/orion-substrate-runtime/README.md`'s
-# "transport domain is one queue" note) -- excluding it would be an
-# undisclosed thumb on the scale, not a fix; its near-permanent 0.0 is
-# reported honestly in `_aggregate_prediction_error_confidence`'s own basis
-# string instead.
+# id.
+#
+# `node:substrate.transport` REMOVED 2026-07-31, and the rationale that kept it
+# here is retired with it. That rationale was "excluding it would be an
+# undisclosed thumb on the scale, not a fix" -- correct while the domain was
+# merely *known-narrow* but still live. It is no longer live: the producer write
+# was killed 2026-07-26 and the reducer's own map entry (worker.py's
+# `_PREDICTION_ERROR_DOMAIN_NODE_IDS`) was removed 2026-07-31. Keeping it here
+# now inverts the original intent -- this harness exists to REPRODUCE what the
+# live reducer computes, so including a domain the live reducer no longer reads
+# is itself the thumb on the scale: `_aggregate_prediction_error_confidence`
+# would average 6 values here against 5 in production, for the same tick.
 PREDICTION_ERROR_DOMAIN_NODES: dict[str, str] = {
     "execution": "node:substrate.execution",
-    "transport": "node:substrate.transport",
     "biometrics": "node:substrate.biometrics",
     "chat": "node:substrate.chat",
     "route": "node:substrate.route",
@@ -694,9 +699,12 @@ def render_report(
         "### `prediction_error_confidence` (2026-07-24, unconditional, ACTIVE_INFERENCE_DOMAINS only)",
         "",
         "Closes the branch-starvation gap above: computed regardless of attention_reason, "
-        "restricted to execution/biometrics/chat/route (transport excluded -- confirmed "
-        "live 2026-07-24 that it reads exactly 0.0 for 100% of a real window, see "
-        "docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md).",
+        "restricted to ACTIVE_INFERENCE_DOMAINS: execution/biometrics/chat/route/bus_synaptic. "
+        "(This line said 'execution/biometrics/chat/route' until 2026-07-31 -- stale since "
+        "bus_synaptic was added 2026-07-25, so the harness printed a 4-domain claim next to a "
+        "5-domain number. transport was excluded 2026-07-24 after reading exactly 0.0 for 100% "
+        "of a real window, see docs/notes/2026-07-24-attention-reason-branch-starvation-finding.md, "
+        "and fully retired 2026-07-31.)",
         "",
         f"- Ticks with a non-null `prediction_error_confidence`: {n_pe_confidence} / {n} "
         f"({pct(n_pe_confidence)})",

--- a/services/orion-hub/scripts/attention_organ_routes.py
+++ b/services/orion-hub/scripts/attention_organ_routes.py
@@ -69,6 +69,18 @@ router = APIRouter(prefix="/api/attention-organ", tags=["attention-organ"])
 # below (orion/substrate/attention_self_model.py), same "sibling domain node,
 # not yet folded into the confidence aggregate" status bus_synaptic held for
 # a while before that was a separate, explicit decision.
+#
+# `transport` REMOVED 2026-07-31, when the domain was fully retired (producer,
+# reducer map entry, function, and the live node). Leaving it listed puts this
+# surface in one of two wrong states and there is no third: while the stale node
+# still existed it rendered under the "still ticking, still readable elsewhere"
+# heading -- asserting a retired domain is live -- and once the node is gone it
+# renders a permanent red "no node" badge, which this module's own comment below
+# calls "a different, louder failure", for a domain nobody should be alarmed
+# about. A retired domain belongs off the list, not in a warning state forever.
+#
+# `harness_closure` deliberately STAYS: it is excluded from the aggregate but
+# has a live producer, which is exactly what that heading is for.
 KNOWN_PREDICTION_ERROR_DOMAINS: tuple[str, ...] = (
     "biometrics",
     "bus_synaptic",
@@ -76,7 +88,6 @@ KNOWN_PREDICTION_ERROR_DOMAINS: tuple[str, ...] = (
     "codebase",
     "execution",
     "route",
-    "transport",
     "harness_closure",
 )
 

--- a/services/orion-proposal-runtime/.env_example
+++ b/services/orion-proposal-runtime/.env_example
@@ -21,10 +21,31 @@ LOG_LEVEL=INFO
 # Phase B: incorporate spontaneous-thought (reverie) proposals (default-off,
 # operator_review-gated, never auto-dispatch).
 # Hop 0 of the stream-of-consciousness chain: a sustained metacog trend competing
-# as a first-class arena candidate. Ships OFF -- flip only after a real,
-# non-degenerate candidate is observed post-deploy. Carries operator_review
-# unconditionally, so it can compete for a budget slot but never auto-dispatch.
-ORION_METACOG_HOP_PROPOSE_ENABLED=false
+# as a first-class arena candidate. Carries operator_review unconditionally, so
+# it can compete for a budget slot but never auto-dispatch.
+#
+# Flipped ON 2026-07-31 (Juniper's explicit go-ahead). It shipped off with
+# "flip only after a real, non-degenerate candidate is observed post-deploy",
+# which was unsatisfiable as written: the converter only runs when this flag is
+# on, so nothing could ever be observed while it stayed off. Zero cognitive_hop
+# candidates existed in `substrate_proposal_frames` at flip time, across its
+# whole history.
+#
+# What actually makes this safe to turn on rather than that unreachable
+# precondition: `required_policy_gate="operator_review"` is unconditional in
+# `orion/metacog/proposal.py`, so the worst case is a noisy proposal queue, not
+# autonomous action; the arena already runs a live external producer under the
+# identical contract (`reverie_thought`, 518 candidates in a 3h window); and the
+# converter fails open -- `worker.py` catches everything around it so a metacog
+# read can never break proposal generation.
+#
+# What to watch first: whether hop 0 fires AT ALL. Its reducer detects sustained
+# ESCALATION, not sustained elevation (measured 2026-07-31 against the real
+# reducer), and `repair_pressure` runs ~8.7 rows/day. Silence here is a real
+# possible outcome and means the trend shape needs work, not that the wiring is
+# broken -- check for `cognitive_hop` in `substrate_proposal_frames` before
+# concluding either.
+ORION_METACOG_HOP_PROPOSE_ENABLED=true
 ORION_REVERIE_PROPOSE_ENABLED=true
 # Phase B dispatch gate ("sends email"). Default-off. Only records an inspectable
 # posture on the candidate; never lowers the operator_review gate — a human still

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -667,11 +667,47 @@ while it stayed, which is exactly why a comment was not enough. Now:
   `EXTERNALLY_OWNED_METADATA_KEYS` and is excluded from the `MERGE` write — which is itself a clue
   about the shape of the writer. `salience: 0.556078` does come back.
 
-  This is broader than transport: if a substrate concept node cannot be deleted, then **no**
-  substrate node can be retired from the graph, only from its readers. That deserves its own
-  investigation and its own patch, and deliberately was not chased further inside a retirement PR.
-  No denylist was added either — a retired-id registry would paper over a writer nobody has
-  identified yet, which is the wrong order of operations.
+  **Root cause found 2026-07-31 via FalkorDB `MONITOR`** (the writer logs nothing, so the only way
+  to see it was to watch the wire). The resurrecting client is `172.18.0.39` =
+  `orion-athena-cortex-exec-background`, and it is not transport-specific:
+
+  ```text
+  distinct node_ids written in ONE ~0.8s burst, 17 writes each:
+    node:substrate.biometrics      node:substrate.bus_synaptic   node:substrate.chat
+    node:substrate.codebase        node:substrate.execution      node:substrate.harness_closure
+    node:substrate.route           node:substrate.transport
+    sub-concept-seed-orion         sub-concept-seed-juniper
+    sub-concept-seed-orion_juniper_relationship
+
+  MATCH (n) RETURN count(n)  ->  11
+  ```
+
+  Eleven written, eleven in the graph. **`orion-cortex-exec-background` round-trips the entire
+  substrate node set back into FalkorDB from a stale in-process snapshot**, via
+  `chat_stance.py`'s process-level `_UNIFICATION_LAYER` singleton →
+  `CognitiveUnificationLayer` → `SubstrateGraphMaterializer.apply_record()`. The written values are
+  the frozen originals at full float precision (`salience=0.556077777777778`,
+  `activation=0.166125`), not anything freshly computed.
+
+  Two compounding defects, both visible in `orion/substrate/materializer.py::apply_record()`:
+
+  1. **Deleting a node makes the write *less* safe, not safer.** With the node present it takes the
+     `else` branch — `merge_node()` plus `skip_metadata_keys=EXTERNALLY_OWNED_METADATA_KEYS`. With
+     the node absent it takes `if existing_node is None:` → `upsert_node(canonical_node)`, a
+     **wholesale overwrite with no merge and no clobber protection at all**. So the delete is what
+     moves the node onto the unprotected path.
+  2. **`EXTERNALLY_OWNED_METADATA_KEYS` only covers `metadata`.** `observed_at`, `recency_score`,
+     `salience`, and `activation` are not metadata keys, so this writer overwrites them on every
+     burst even on the protected merge branch — which is the mechanism behind the previously
+     unexplained `observed_at` oscillation seen on live nodes (a fresh timestamp replaced by an
+     older one, then forward again).
+
+  So this is broader than transport: **no substrate node can be retired from the graph** while a
+  general snapshot round-tripper rewrites all eleven of them, and every reducer-owned temporal field
+  on live domains is being clobbered by stale values several times a second. Fixing it is a change
+  to the cognitive unification layer's write scope, not to this retirement — flagged for a decision
+  rather than patched here. No denylist was added: a retired-id registry would paper over the
+  round-tripper instead of scoping it.
 
   Snapshot of the node as it stood: `/tmp/retire-substrate-transport-node/before_snapshot.txt`.
 

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -616,12 +616,31 @@ confirmed unaffected by removing this write: reducer-health/cursor tracking (`re
 `_log_transport_incident_signals()` (a separate, still-running diagnostic logger),
 `catalog_drift_pressure`/`observer_failure_pressure` (fed by a different function,
 `compute_transport_pressures()`, and still live in `config/field/orion_field_topology.v1.yaml`'s
-`capability:transport` edge per PR #1394). `transport_prediction_error()` itself is kept (not
-deleted) though review confirmed it has zero callers anywhere in the repo now -- the two analysis
-scripts this doc originally credited (`measure_transport_bus_signal_history.py`,
-`measure_transport_biometrics_prediction_error_correlation.py`) only name it in prose, they read
-persisted values directly from Postgres. Review also caught one dead read: `prev_projection =
+`capability:transport` edge per PR #1394). Review also caught one dead read: `prev_projection =
 load_projection()` was only ever consumed by the removed call, deleted alongside it.
+
+**COMPLETED, 2026-07-31: the rest of the retirement.** The 2026-07-26 pass killed the *write* and
+deliberately kept everything else -- `transport_prediction_error()` "kept (not deleted) as the
+cheapest option", and `app/worker.py`'s `_PREDICTION_ERROR_DOMAIN_NODE_IDS` still mapping
+`node:substrate.transport -> transport`. The cost of that showed up five days later: the brain-frame
+reducer had gone on reading that node every tick and handing `transport` to
+`reduce_attention_self_model()`, off a node that stopped moving on 2026-07-24
+(`prediction_error=0.556`, `observed_at=2026-07-24T21:55:26Z`, zero relationships). Nothing failed
+while it stayed, which is exactly why a comment was not enough. Now:
+
+- `transport_prediction_error()` **deleted** from `orion/substrate/prediction_error.py`.
+- The `node:substrate.transport` map entry **removed**, gated by a set-equality test against
+  `ACTIVE_INFERENCE_DOMAINS` (`tests/test_prediction_error_domain_map.py`) so the two cannot drift
+  apart again in either direction.
+- `reduce_attention_self_model()`'s `predicted_shift` argmax, previously **unfiltered**, now
+  restricted to `ACTIVE_INFERENCE_DOMAINS`. `transport` never actually won it (0 of 7,119 persisted
+  rows) -- but only because a frozen node has a flat `0.0` trend. That is a dead domain being
+  invisible for as long as it stays dead, not a filter.
+- The stale node itself **deleted from live FalkorDB** (`orion_substrate`), snapshotted first to
+  `/tmp/retire-substrate-transport-node/before_snapshot.txt`.
+
+`config/field/orion_field_topology.v1.yaml`'s `capability:transport` edge had already migrated to
+`node:substrate.bus_synaptic` and needed no change -- the EWMA successor was already in place there.
 
 **Fixed 2026-07-28: `execution_prediction_error()` moved off the fixed `_THRESHOLD=0.30` divisor
 onto a self-calibrating EWMA baseline (PR #1434).** Live Postgres data (120 real

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -546,10 +546,12 @@ than 3 of the original 5 `prediction_error` domains at time of writing. On that 
 `orion/substrate/attention_self_model.py`'s `ACTIVE_INFERENCE_DOMAINS` frozenset now includes
 `"bus_synaptic"` (five active domains: execution, biometrics, chat, route, bus_synaptic), feeding
 `prediction_error_confidence`. This is a different consumer than `orion-equilibrium-service`'s
-transport metacog gate (PRs #1385/#1387, wired separately, same node). The still-broken `transport`
-domain (`transport_prediction_error()`) remains excluded and unfixed — see
+transport metacog gate (PRs #1385/#1387, wired separately, same node). The broken `transport`
+domain (`transport_prediction_error()`) was excluded here on 2026-07-25 and **fully retired
+2026-07-31** — function deleted, reducer map entry removed, live node deleted; see the
+"COMPLETED, 2026-07-31" section below and
 `docs/superpowers/specs/2026-07-22-l6-self-model-ast-hot-active-inference-design.md`'s
-2026-07-25 revision for the full caveat.
+2026-07-25 revision for the original caveat.
 
 **Corrected 2026-07-26: the sanity-check pass above was incomplete.** It checked non-degeneracy
 (step 4 of CLAUDE.md's metric-quality-gate) but skipped the theory-anchor/commensurability check
@@ -636,8 +638,42 @@ while it stayed, which is exactly why a comment was not enough. Now:
   restricted to `ACTIVE_INFERENCE_DOMAINS`. `transport` never actually won it (0 of 7,119 persisted
   rows) -- but only because a frozen node has a flat `0.0` trend. That is a dead domain being
   invisible for as long as it stays dead, not a filter.
-- The stale node itself **deleted from live FalkorDB** (`orion_substrate`), snapshotted first to
-  `/tmp/retire-substrate-transport-node/before_snapshot.txt`.
+- The stale node itself: **NOT deleted. `UNVERIFIED` / open defect — see below.** All four changes
+  above are reader-side and stand on their own; the node is now unreferenced by any of them, but it
+  is still physically present in `orion_substrate`.
+
+  **`node:substrate.transport` cannot be deleted from the live graph.** Three attempts, each
+  reporting `Nodes deleted: 1`, each undone:
+
+  1. Plain `GRAPH.QUERY ... DELETE n` while everything ran — back within a minute, `activation`
+     ticking (`0.166125 → 0.166074 → 0.166064`, i.e. actively written).
+  2. `stop orion-substrate-runtime` → delete (verified `count(n) = 0` while stopped) → `up -d`.
+     Back anyway.
+  3. Delete again on the running system, polled every 2s: **resurrected after 6 seconds.**
+
+  What rules out the obvious explanations:
+
+  - **Not the dynamics loop.** `SUBSTRATE_DYNAMICS_TICK_INTERVAL_SEC` defaults to 30s; the
+    resurrection took 6s.
+  - **Not `FalkorSubstrateStore`'s in-process cache alone.** That cache dies with the process, and
+    attempt 2 deleted the node while the process was down.
+  - **Not a fresh write.** The restored node carries `activation: 0.166125` — the *exact*
+    pre-deletion value, not a decayed one — plus `recency_score: 0.0`,
+    `observed_at: 2026-07-24T21:55:26Z`. Something replays a frozen 7-day-old snapshot verbatim.
+  - **No log line anywhere.** Checked `substrate-runtime`, `recall`, `attention-runtime`,
+    `field-digester`, `graph-compression` over the resurrection window: nothing.
+
+  `prediction_error` is the one property that does *not* come back, because it sits in
+  `EXTERNALLY_OWNED_METADATA_KEYS` and is excluded from the `MERGE` write — which is itself a clue
+  about the shape of the writer. `salience: 0.556078` does come back.
+
+  This is broader than transport: if a substrate concept node cannot be deleted, then **no**
+  substrate node can be retired from the graph, only from its readers. That deserves its own
+  investigation and its own patch, and deliberately was not chased further inside a retirement PR.
+  No denylist was added either — a retired-id registry would paper over a writer nobody has
+  identified yet, which is the wrong order of operations.
+
+  Snapshot of the node as it stood: `/tmp/retire-substrate-transport-node/before_snapshot.txt`.
 
 `config/field/orion_field_topology.v1.yaml`'s `capability:transport` edge had already migrated to
 `node:substrate.bus_synaptic` and needed no change -- the EWMA successor was already in place there.

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -109,9 +109,24 @@ _HARNESS_CLOSURE_UNRESOLVED_ERROR = 0.65
 # domain parity" pass could add this entry without realizing that decision was
 # already made deliberately, not an oversight. Revisit only alongside a real
 # Phase 3 patch, not as a drive-by fix.
+#
+# node:substrate.transport REMOVED 2026-07-31 -- the last live read of the
+# retired transport domain. Its producer write was killed 2026-07-26
+# (docs/superpowers/specs/2026-07-26-transport-domain-retirement-bus-synaptic-
+# successor-design.md) but this entry stayed, so the reducer kept reading a node
+# that had stopped moving: live at removal time it held prediction_error=0.556
+# with observed_at=2026-07-24, five days after its last write and seven days
+# stale. node:substrate.bus_synaptic (already below) is the real EWMA successor
+# and already occupies this domain's role in every consumer -- including
+# config/field/orion_field_topology.v1.yaml's capability:transport edge, which
+# migrated to it. This entry was the leftover.
+#
+# Kept as a set-equality test (tests/test_prediction_error_domain_map.py)
+# against ACTIVE_INFERENCE_DOMAINS rather than a comment, because "the write is
+# dead but a reader still lists it" is exactly the partial retirement CLAUDE.md
+# §0A forbids, and a comment does not stop the next patch re-adding it.
 _PREDICTION_ERROR_DOMAIN_NODE_IDS = {
     "node:substrate.execution": "execution",
-    "node:substrate.transport": "transport",
     "node:substrate.biometrics": "biometrics",
     "node:substrate.chat": "chat",
     "node:substrate.route": "route",
@@ -2543,14 +2558,14 @@ class BiometricsSubstrateWorker:
             # config/field/orion_field_topology.v1.yaml's still-live edge) is
             # unaffected -- confirmed via _grammar_reducer_poll_loop that reducer-
             # health/cursor tracking is driven by last_id, not by this block.
-            # transport_prediction_error() itself is kept, not deleted -- review
-            # confirmed it has zero callers anywhere in the repo now, live or
-            # offline (the two analysis scripts this comment originally claimed
-            # used it, measure_transport_bus_signal_history.py and measure_
-            # transport_biometrics_prediction_error_correlation.py, only mention
-            # its name in prose docstrings -- both read persisted values
-            # straight out of Postgres, no import). Kept anyway as the cheapest
-            # option (deleting it buys nothing and risks a future script
-            # wanting it for genuine historical replay).
+            # 2026-07-31: transport_prediction_error() is now DELETED outright,
+            # and so is _PREDICTION_ERROR_DOMAIN_NODE_IDS' node:substrate.transport
+            # entry above. The 2026-07-26 pass kept both "as the cheapest option
+            # (deleting it buys nothing)" -- and the cost showed up: that reader
+            # entry went on feeding a node that had stopped moving for another
+            # five days (live at removal: prediction_error=0.556,
+            # observed_at=2026-07-24), because nothing failed while it stayed.
+            # Killing the write is NOT the entire change when a reader still
+            # lists the dead identity.
 
         return last_id

--- a/services/orion-substrate-runtime/tests/test_prediction_error_domain_map.py
+++ b/services/orion-substrate-runtime/tests/test_prediction_error_domain_map.py
@@ -28,25 +28,106 @@ WORKER = Path(__file__).resolve().parents[1] / "app" / "worker.py"
 PREDICTION_ERROR = (
     Path(__file__).resolve().parents[3] / "orion" / "substrate" / "prediction_error.py"
 )
+REPLAY_HARNESS = (
+    Path(__file__).resolve().parents[3]
+    / "scripts" / "analysis" / "measure_ast_hot_reducer.py"
+)
 
 
-def _domain_map() -> dict[str, str]:
+MAP_NAME = "_PREDICTION_ERROR_DOMAIN_NODE_IDS"
+
+
+def _domain_map(source: str | None = None) -> dict[str, str]:
     """Parse the map out of worker.py without importing it.
 
     `app.worker` pulls in the whole substrate runtime (Redis, Postgres, FalkorDB
     clients) at import time, which this gate has no reason to require.
+
+    Review finding 2026-07-31: the first version of this helper walked only
+    `tree.body` for `ast.Assign`, which made the gate bypassable in two ways,
+    both reproduced against the real parser:
+
+    - A later `_PREDICTION_ERROR_DOMAIN_NODE_IDS["node:substrate.transport"] =
+      "transport"` was completely invisible. Both tests passed while the runtime
+      map had six entries and the retired domain was live again -- exactly the
+      bug this gate exists to stop.
+    - Adding a type annotation (`: dict[str, str] = {...}`) turns the node into
+      an `ast.AnnAssign`, which the isinstance check skipped, so the gate
+      `pytest.fail`ed blaming a missing constant for a cosmetic edit. Fail-closed
+      rather than dangerous, but misleading -- and annotated is the style BOTH
+      sibling maps in this repo already use.
+
+    So: walk the whole tree, accept both assignment forms, and reject any
+    post-hoc mutation of the name outright rather than trying to evaluate it.
     """
-    tree = ast.parse(WORKER.read_text())
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
+    tree = ast.parse(source if source is not None else WORKER.read_text())
+
+    _reject_post_hoc_mutation(tree)
+
+    found: dict[str, str] | None = None
+    for node in ast.walk(tree):
+        target_names: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            target_names = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            target_names = [node.target]
+        else:
             continue
-        if not any(
-            isinstance(t, ast.Name) and t.id == "_PREDICTION_ERROR_DOMAIN_NODE_IDS"
-            for t in node.targets
+        if not any(isinstance(t, ast.Name) and t.id == MAP_NAME for t in target_names):
+            continue
+        if node.value is None:
+            continue
+        try:
+            found = ast.literal_eval(node.value)
+        except (ValueError, TypeError):
+            raise AssertionError(
+                f"{MAP_NAME} is no longer a literal dict (comprehension, call, or "
+                "computed value). This gate can only check a literal. Either keep it "
+                "literal or replace this gate with one that imports the real value."
+            )
+    if found is None:
+        raise AssertionError(f"{MAP_NAME} not found as a literal assignment in worker.py")
+    return found
+
+
+def _reject_post_hoc_mutation(tree: ast.AST) -> None:
+    """No `map[...] = ...`, `.update(...)`, or `.setdefault(...)` on the name.
+
+    A parser that reads one literal cannot see a mutation applied afterwards, so
+    the gate forbids the shape rather than pretending to evaluate it.
+
+    Raises `AssertionError`, not `pytest.fail()`, specifically so
+    `TestTheGateHasTeeth` below can assert this fires -- `pytest.fail` raises a
+    `BaseException` subclass, which `pytest.raises(Exception)` does not catch,
+    so a teeth-test written against it silently proves nothing.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Assign, ast.AugAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for t in targets:
+                if (
+                    isinstance(t, ast.Subscript)
+                    and isinstance(t.value, ast.Name)
+                    and t.value.id == MAP_NAME
+                ):
+                    raise AssertionError(
+                        f"{MAP_NAME} is mutated by subscript assignment at line "
+                        f"{node.lineno}. This gate reads the literal only, so a "
+                        "post-hoc entry would be invisible to it. Put every domain "
+                        "in the literal."
+                    )
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"update", "setdefault", "pop", "__setitem__"}
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == MAP_NAME
         ):
-            continue
-        return ast.literal_eval(node.value)
-    pytest.fail("_PREDICTION_ERROR_DOMAIN_NODE_IDS not found in worker.py")
+            raise AssertionError(
+                f"{MAP_NAME}.{node.func.attr}() at line {node.lineno} mutates the map "
+                "after definition, which this gate cannot see. Put every domain in "
+                "the literal."
+            )
 
 
 def test_domain_map_matches_active_inference_domains_exactly():
@@ -66,6 +147,51 @@ def test_domain_map_matches_active_inference_domains_exactly():
         "If a domain is being retired, remove it from BOTH in the same patch. "
         "If one is being added, wire it into both, or add it here with a comment "
         "explaining the deliberate asymmetry (see harness_closure/codebase)."
+    )
+
+
+def test_replay_harness_domain_map_matches_the_live_one():
+    """The AST/HOT replay harness carries a SECOND copy of this map.
+
+    `scripts/analysis/measure_ast_hot_reducer.py` is the harness
+    `attention_self_model.py`'s own module docstring names as this reducer's
+    validation path ("must be measured against real historical data ... before
+    anything downstream consumes it"). It keeps its own
+    `PREDICTION_ERROR_DOMAIN_NODES` and calls the same
+    `reduce_attention_self_model()`.
+
+    Review finding 2026-07-31: the first version of this gate parsed worker.py
+    only, so that second copy kept `transport` after the live one dropped it --
+    meaning the harness would average SIX values where production averages five,
+    for the same tick, and silently stop reproducing live `confidence`. A
+    validation harness that disagrees with the thing it validates is worse than
+    no harness.
+    """
+    tree = ast.parse(REPLAY_HARNESS.read_text())
+    found: dict[str, str] | None = None
+    for node in ast.walk(tree):
+        targets = (
+            list(node.targets)
+            if isinstance(node, ast.Assign)
+            else [node.target]
+            if isinstance(node, ast.AnnAssign)
+            else []
+        )
+        if any(
+            isinstance(t, ast.Name) and t.id == "PREDICTION_ERROR_DOMAIN_NODES"
+            for t in targets
+        ) and node.value is not None:
+            found = ast.literal_eval(node.value)
+    assert found is not None, "PREDICTION_ERROR_DOMAIN_NODES not found in the replay harness"
+    # Note the inverted key/value orientation vs the live map -- domain -> node_id
+    # there, node_id -> domain here. Compared as domain sets, not raw dicts.
+    assert set(found) == set(ACTIVE_INFERENCE_DOMAINS), (
+        "measure_ast_hot_reducer.py's PREDICTION_ERROR_DOMAIN_NODES and "
+        "ACTIVE_INFERENCE_DOMAINS disagree.\n"
+        f"  only in the harness: {sorted(set(found) - set(ACTIVE_INFERENCE_DOMAINS))}\n"
+        f"  only in the reducer: {sorted(set(ACTIVE_INFERENCE_DOMAINS) - set(found))}\n"
+        "The harness must replay the same domain set the live reducer reads, or its "
+        "output is not comparable to production."
     )
 
 
@@ -95,3 +221,51 @@ def test_retired_transport_producer_stays_deleted():
         "It measured a 2-Redis-Stream 'world_pulse' census, not inter-service bus "
         "traffic. The successor is bus_synaptic_prediction_error()."
     )
+
+
+class TestTheGateHasTeeth:
+    """The bypasses code review actually demonstrated, asserted so they stay closed.
+
+    A gate nobody has tried to defeat is a gate nobody knows the shape of. Each
+    of these reproduces a real bypass found on 2026-07-31 against the first
+    version of `_domain_map()`.
+    """
+
+    _LITERAL = (
+        "_PREDICTION_ERROR_DOMAIN_NODE_IDS = {\n"
+        '    "node:substrate.execution": "execution",\n'
+        '    "node:substrate.biometrics": "biometrics",\n'
+        '    "node:substrate.chat": "chat",\n'
+        '    "node:substrate.route": "route",\n'
+        '    "node:substrate.bus_synaptic": "bus_synaptic",\n'
+        "}\n"
+    )
+
+    def test_subscript_reintroduction_is_caught(self):
+        """The exact bypass review reproduced: add the retired domain on a later line."""
+        source = self._LITERAL + (
+            '_PREDICTION_ERROR_DOMAIN_NODE_IDS["node:substrate.transport"] = "transport"\n'
+        )
+        with pytest.raises(AssertionError) as excinfo:
+            _domain_map(source)
+        assert "subscript" in str(excinfo.value).lower()
+
+    def test_update_call_is_caught(self):
+        source = self._LITERAL + (
+            '_PREDICTION_ERROR_DOMAIN_NODE_IDS.update({"node:substrate.transport": "transport"})\n'
+        )
+        with pytest.raises(AssertionError) as excinfo:
+            _domain_map(source)
+        assert "update" in str(excinfo.value)
+
+    def test_annotated_assignment_still_parses(self):
+        """Adding a type annotation must not make the gate cry 'not found'.
+
+        Both sibling maps in this repo (measure_ast_hot_reducer.py,
+        attention_organ_routes.py) are annotated, so this is a likely edit.
+        """
+        source = self._LITERAL.replace(
+            "_PREDICTION_ERROR_DOMAIN_NODE_IDS = {",
+            "_PREDICTION_ERROR_DOMAIN_NODE_IDS: dict[str, str] = {",
+        )
+        assert set(_domain_map(source).values()) == set(ACTIVE_INFERENCE_DOMAINS)

--- a/services/orion-substrate-runtime/tests/test_prediction_error_domain_map.py
+++ b/services/orion-substrate-runtime/tests/test_prediction_error_domain_map.py
@@ -1,0 +1,97 @@
+"""The reducer's domain map must not outlive a domain's producer.
+
+CLAUDE.md section 0A: "When a metric is replaced by a better one, retire the old
+one completely -- do not leave a partial exclusion in place." The transport
+domain is the worked example of the failure this guards:
+
+- 2026-07-26: `node:substrate.transport`'s producer write was removed.
+- 2026-07-31: `_PREDICTION_ERROR_DOMAIN_NODE_IDS` was STILL listing it, so the
+  brain-frame reducer read that node every tick and handed `transport` to
+  `reduce_attention_self_model()`. Live value at removal: `prediction_error=0.556`,
+  `observed_at=2026-07-24` -- seven days stale.
+
+Nothing failed for those five days, which is exactly why a comment is not
+sufficient here. This is the failing gate CLAUDE.md asks for instead of a
+reminder.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from orion.substrate.attention_self_model import ACTIVE_INFERENCE_DOMAINS
+
+WORKER = Path(__file__).resolve().parents[1] / "app" / "worker.py"
+PREDICTION_ERROR = (
+    Path(__file__).resolve().parents[3] / "orion" / "substrate" / "prediction_error.py"
+)
+
+
+def _domain_map() -> dict[str, str]:
+    """Parse the map out of worker.py without importing it.
+
+    `app.worker` pulls in the whole substrate runtime (Redis, Postgres, FalkorDB
+    clients) at import time, which this gate has no reason to require.
+    """
+    tree = ast.parse(WORKER.read_text())
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "_PREDICTION_ERROR_DOMAIN_NODE_IDS"
+            for t in node.targets
+        ):
+            continue
+        return ast.literal_eval(node.value)
+    pytest.fail("_PREDICTION_ERROR_DOMAIN_NODE_IDS not found in worker.py")
+
+
+def test_domain_map_matches_active_inference_domains_exactly():
+    """Set equality, not subset.
+
+    Subset in one direction alone misses the real bug: a retired domain that
+    still has a reader is a superset violation, and a live domain the reducer
+    silently stopped reading is a subset violation. Both are the same class of
+    "the map and the reducer disagree about what is real".
+    """
+    mapped = set(_domain_map().values())
+    assert mapped == set(ACTIVE_INFERENCE_DOMAINS), (
+        "worker.py's _PREDICTION_ERROR_DOMAIN_NODE_IDS and "
+        "attention_self_model.ACTIVE_INFERENCE_DOMAINS disagree.\n"
+        f"  only in the node map: {sorted(mapped - set(ACTIVE_INFERENCE_DOMAINS))}\n"
+        f"  only in the reducer:  {sorted(set(ACTIVE_INFERENCE_DOMAINS) - mapped)}\n"
+        "If a domain is being retired, remove it from BOTH in the same patch. "
+        "If one is being added, wire it into both, or add it here with a comment "
+        "explaining the deliberate asymmetry (see harness_closure/codebase)."
+    )
+
+
+def test_every_mapped_node_id_uses_the_domain_naming_convention():
+    for node_id, domain in _domain_map().items():
+        assert node_id == f"node:substrate.{domain}", (
+            f"{node_id!r} does not follow node:substrate.<domain>; "
+            "_write_prediction_error_node() upserts that fixed identity, so a "
+            "mismatch here reads a node that is never written."
+        )
+
+
+def test_retired_transport_producer_stays_deleted():
+    """`transport_prediction_error()` was deleted 2026-07-31, not just unwired.
+
+    It was previously "kept, not deleted -- deleting it buys nothing", which is
+    how a retired instrument gets wired back in. A live-importable symbol is an
+    invitation; git history is the archive.
+    """
+    source = PREDICTION_ERROR.read_text()
+    tree = ast.parse(source)
+    defined = {
+        n.name for n in tree.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert "transport_prediction_error" not in defined, (
+        "transport_prediction_error() is back in orion/substrate/prediction_error.py. "
+        "It measured a 2-Redis-Stream 'world_pulse' census, not inter-service bus "
+        "traffic. The successor is bus_synaptic_prediction_error()."
+    )


### PR DESCRIPTION
# Finish retiring the transport domain; bus_synaptic is the instrument

Branch: `fix/transport-domain-ewma-successor`
Date: 2026-07-31
Status: **DONE_WITH_CONCERNS** (see the failed live-node deletion)

## Summary

- The 2026-07-26 pass killed `node:substrate.transport`'s **write** and deliberately kept everything
  else. Five days later the reducer was still **reading** it.
- `_PREDICTION_ERROR_DOMAIN_NODE_IDS` still mapped `node:substrate.transport -> "transport"`, so the
  brain-frame reducer handed `transport` to `reduce_attention_self_model()` on every tick, off a node
  frozen since 2026-07-24.
- `transport_prediction_error()` **deleted**, not left importable.
- `predicted_shift`'s argmax was **unfiltered** — any key a caller supplied could become Orion's
  stated "what is about to shift". Now gated on `ACTIVE_INFERENCE_DOMAINS`.
- Ships a **failing gate**, not another comment: set equality between the node map and
  `ACTIVE_INFERENCE_DOMAINS`.
- Stale node **could not** be deleted from live FalkorDB — it resurrects in 6s from a frozen 7-day-old
  snapshot, and survives stopping `substrate-runtime`. Reported as an open defect, not claimed as done.
- Also flips `ORION_METACOG_HOP_PROPOSE_ENABLED` to `true` (Juniper's go-ahead).

## Outcome moved

The Active-Inference domain set is now the same set everywhere: producer, reducer map, confidence
aggregate, and `predicted_shift`. Before this patch those four disagreed, and the disagreement was
invisible because the disagreeing member was frozen.

Live state of the node (it is still there — see the deletion section):

```text
node:substrate.transport
  prediction_error   0.556078
  observed_at        2026-07-24T21:55:26Z    (7 days stale)
  recency_score      0.0
  salience           0.556078                <- visible to generic concept consumers
  relationships      0
  provenance         substrate_runtime_worker / substrate_prediction_error   (producer dead)
```

## Why a comment was not enough

Nothing failed for those five days. The 2026-07-26 patch's own comment said killing the write "is
the entire change" — it was not, because a reader still listed the dead identity, and no test
expressed the invariant that a domain's producer and its readers must retire together.

This is CLAUDE.md's "deterministic gates over repeated yelling" case verbatim: the right fix for a
partial retirement is a failing gate, not a louder comment.

## The `predicted_shift` finding, stated honestly

`reduce_attention_self_model()`'s `predicted_shift` took an argmax over
`prediction_error_trend_by_domain` **with no filter**. `transport` was in that dict every live tick.

It **never actually won**. All persisted rows carrying a `predicted_shift`:

```text
execution      4597
biometrics     1490
bus_synaptic   1031
route             1
transport         0
```

That is not the filter working — there was no filter. It is that a frozen node has a flat `0.0`
trend, so `abs(trend) > abs(top_trend_val)` could never fire for it. A dead domain was invisible
here exactly as long as it stayed dead; a single backfill, replay, or one-off write would have made
the loudest key in the dict a retired instrument.

Removing the map entry alone fixes this instance and leaves the next retired domain free to repeat
it. The filter is the seam; the map entry is the instance.

## Current architecture

```text
_*_tick()  ->  _write_prediction_error_node()  ->  node:substrate.<domain>  (FalkorDB orion_substrate)
                                                          |
        _brain_frame_prediction_error_by_domain() reads them back via _PREDICTION_ERROR_DOMAIN_NODE_IDS
                                                          |
                              +---------------------------+---------------------------+
                              |                                                       |
              compute_prediction_error_trend()                        reduce_attention_self_model()
                              |                                          |                    |
                    predicted_shift (was UNFILTERED)      prediction_error_confidence   confidence
                                                          (ACTIVE_INFERENCE_DOMAINS)    (branch-gated)
```

`config/field/orion_field_topology.v1.yaml`'s `capability:transport` edge had **already** migrated to
`node:substrate.bus_synaptic` and needed no change — the EWMA successor was in place there. Verified
directly: zero references to `node:substrate.transport` remain in that file.

## Files changed

- `services/orion-substrate-runtime/app/worker.py`: map entry removed; the stale "kept, not deleted"
  comment block replaced with what actually happened.
- `orion/substrate/prediction_error.py`: `transport_prediction_error()` deleted, replaced by a
  comment recording why the "keep it, replay might want it" rationale did not hold.
- `orion/substrate/attention_self_model.py`: `predicted_shift` argmax filtered; two docstring claims
  that were true-and-load-bearing ("remains present in `prediction_error_by_domain` when a caller
  supplies it") corrected.
- `services/orion-substrate-runtime/tests/test_prediction_error_domain_map.py` (new): the gate.
- `orion/substrate/tests/test_attention_self_model.py`: two tests for the filter.
- `services/orion-hub/scripts/attention_organ_routes.py`: `transport` removed from
  `KNOWN_PREDICTION_ERROR_DOMAINS` (review finding 4).
- `scripts/analysis/measure_ast_hot_reducer.py`: the SECOND copy of the domain map, plus a stale
  4-domain claim in its generated report (review finding 2).
- `services/orion-substrate-runtime/README.md`: retirement section completed and corrected.
- `services/orion-proposal-runtime/.env_example`: hop 0 flag flipped, with rationale.

## Schema / bus / API changes

- Added: none.
- Removed: `transport_prediction_error()` (public symbol in `orion.substrate.prediction_error`,
  zero callers).
- Renamed: none.
- Behavior changed: `prediction_error_by_domain` / `prediction_error_trend_by_domain` no longer carry
  a `transport` key. `predicted_shift` can no longer name a non-`ACTIVE_INFERENCE_DOMAINS` domain.
- Compatibility: consumers iterate these dicts rather than indexing them, so a missing key is a
  smaller set, not a `KeyError`. `services/orion-hub/scripts/attention_organ_routes.py` drops
  `transport` from `KNOWN_PREDICTION_ERROR_DOMAINS` (review finding — see below).

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- Behavior changed: `ORION_METACOG_HOP_PROPOSE_ENABLED` `false -> true` in `.env_example`.
- `.env_example` updated: yes.
- local `.env` synced: **yes, done** — `services/orion-proposal-runtime/.env` line 21 edited directly
  to `true`. `scripts/sync_local_env_from_example.py` does not overwrite an existing value, so this
  was a hand edit, verified after. `.env` confirmed still gitignored (`git check-ignore`).
- `docker-compose.yml` inline default stays `:-false`. Intentional: the compose default is the
  ships-off posture for a fresh operator; the live `.env` carries the enabled value.
- skipped keys requiring operator action: none.

### Why the hop 0 flag is safe to flip now

It shipped off behind "flip only after a real, non-degenerate candidate is observed post-deploy" —
which was **unsatisfiable as written**: the converter only runs when the flag is on, so nothing could
ever be observed while it stayed off. Zero `cognitive_hop` candidates existed in
`substrate_proposal_frames` across its whole history, confirmed by query.

What actually makes it safe:

- `required_policy_gate="operator_review"` is unconditional in `orion/metacog/proposal.py` — worst
  case is a noisy proposal queue, never autonomous action.
- The arena already runs a live external producer under the identical contract: `reverie_thought`,
  518 candidates in a 3h window.
- The converter fails open — `worker.py` wraps it so a metacog read cannot break proposal generation.

**Measured post-deploy, and the answer is: it does not fire, and cannot on this input.**

The flag is confirmed live in the container (`ORION_METACOG_HOP_PROPOSE_ENABLED=true`), 90 proposal
frames were built in the first 5 minutes, `0` carried a `cognitive_hop` candidate, and `0`
`metacog_hop_candidate_failed` exceptions were logged — so the converter runs cleanly and returns
`None`, rather than erroring.

Replaying the **real** reducer over the **real** 7-day series (not a fixture):

```text
readings                45          (repair_pressure_appraisal_log, 7d, ~6.4/day)
sustained trend ticks    0          <- across the entire window
latest                  z=-0.526, consecutive_elevated=0, baseline n=45
distinct values          6 of 45
modal value             34 of 45    (0.08706577244027125, the text-fallback constant)
```

**76% of the series is one identical constant.** This is the metric quality gate's step-4 failure in
its degenerate form: the input is not a signal with a rest state, it is a constant with occasional
excursions. `is_sustained_trend` requires 3 consecutive *escalating* elevated ticks; a series that
sits on one value and steps off it briefly cannot produce that, and the flat run also drives the EWMA
variance toward its floor so the excursions that do occur score absurd z-scores rather than
meaningful ones.

This is recorded as a **result, not a caveat**. Hop 0 is correctly wired and provably exercised
against live data; what it lacks is an input series capable of expressing a trend. The next patch on
this arc should be choosing/constructing that series, not more hop plumbing. Leaving the flag on is
still right: it is now a live, zero-cost observation point, and the alternative (off) is what made
this measurable only after five days of it being unobservable.

## Live data change attempted (CLAUDE.md section 14) — and it FAILED

Snapshot taken first (`/tmp/retire-substrate-transport-node/before_snapshot.txt` — full properties
plus relationship count). Single node, zero relationships, dead producer, well under the threshold
that requires asking.

**The delete does not stick.** Three attempts, each reporting `Nodes deleted: 1`, each undone:

| # | method | result |
|---|--------|--------|
| 1 | plain `DELETE` while everything running | back within a minute, `activation` still ticking `0.166125 -> 0.166074 -> 0.166064` |
| 2 | `stop substrate-runtime` -> delete (`count(n)=0` verified while down) -> `up -d` | back anyway |
| 3 | delete on running system, polled every 2s | **resurrected after 6 seconds** |

What that rules out:

- **Not the dynamics loop.** `SUBSTRATE_DYNAMICS_TICK_INTERVAL_SEC` defaults to 30s; this took 6s.
- **Not `FalkorSubstrateStore`'s in-process cache alone.** That cache dies with the process, and
  attempt 2 deleted the node while the process was down.
- **Not a fresh write.** The restored node carries `activation: 0.166125` — the *exact* pre-delete
  value, not a decayed one — with `recency_score: 0.0` and `observed_at: 2026-07-24T21:55:26Z`.
  Something replays a frozen 7-day-old snapshot verbatim.
- **No log line.** `substrate-runtime`, `recall`, `attention-runtime`, `field-digester`,
  `graph-compression` all silent across the resurrection window.

`prediction_error` is the one property that does not come back — it is in
`EXTERNALLY_OWNED_METADATA_KEYS`, excluded from the `MERGE` write, which is itself a clue about the
writer's shape. `salience: 0.556078` does come back.

**Status: `UNVERIFIED`, and materially bigger than this PR.** If a substrate concept node cannot be
deleted, no substrate node can be retired from the graph at all — only from its readers. Chasing it
further inside a retirement PR would be the wrong place; it needs its own investigation. No denylist
was added either: that would paper over a writer nobody has identified yet.

The four code changes in this PR are unaffected — they remove every *reader* of the node, which is
the part that was actually feeding cognition.

## Tests run

```text
$ pytest orion/substrate/tests/test_attention_self_model.py -q
48 passed

services/orion-substrate-runtime$ pytest tests/test_prediction_error_domain_map.py -q
3 passed

services/orion-substrate-runtime$ pytest tests -q --ignore=tests/test_grammar_consumer_integration.py
23 FAILED/ERROR lines
```

Those 23 are **pre-existing**, established against a detached scratch worktree at `origin/main`:

```text
origin/main : 23 FAILED/ERROR lines
this branch : 23 FAILED/ERROR lines
diff        : one captured log line's line number (worker.py:540 -> :555), from added comments
```

Red-before-green, both new test files run against `origin/main`:

```text
test_prediction_error_domain_map.py
  FAILED  ... only in the node map: ['transport']
  FAILED  transport_prediction_error() is back in orion/substrate/prediction_error.py

test_attention_self_model.py
  FAILED  TestPredictedShift::test_retired_domain_cannot_win_the_argmax
  FAILED  TestPredictedShift::test_only_retired_domains_yields_no_prediction
```

## Evals run

```text
No eval harness exists for services/orion-substrate-runtime or orion/substrate.
```

Flagged, not claimed.

## Docker/build/smoke checks

See "Restart required". Deploy evidence appended post-merge.

## Review findings fixed

Code review ran in a subagent per CLAUDE.md section 12. Six material findings, all addressed.

- **Finding 1 (HIGH): the live node deletion did not stick; the claim was false.** Review checked
  the live rail and found `node:substrate.transport` present with `activation` still ticking.
  - Fix: the claim is **retracted**. Two further deletion attempts (including one with
    `substrate-runtime` stopped) also failed; the third measured a 6-second resurrection. Documented
    as an open defect with the evidence, in both the README and this report, rather than restated as
    done. Status `UNVERIFIED`.
  - Evidence: `Nodes deleted: 1` three times; `count(n)=1` after each; restored `activation`
    `0.166125` byte-identical to the pre-delete snapshot.
- **Finding 2 (MEDIUM): a second, ungated copy of the domain map.**
  `scripts/analysis/measure_ast_hot_reducer.py` — the harness `attention_self_model.py`'s own
  docstring names as this reducer's validation path — still listed `transport`, so it would have
  averaged six values where production averages five for the same tick.
  - Fix: entry removed, its now-inverted rationale rewritten, and the gate **extended to parse that
    file too**, so the class of drift is closed rather than this one instance. Its stale generated
    report line (a 4-domain claim printed next to a 5-domain number, wrong since 2026-07-25) fixed
    in the same pass.
- **Finding 3 (MEDIUM): the new gate had a one-line bypass.** Review demonstrated that
  `_PREDICTION_ERROR_DOMAIN_NODE_IDS["node:substrate.transport"] = "transport"` on a later line was
  invisible to the AST parser — both tests passed with the retired domain live again. Separately, a
  type annotation turned the node into `ast.AnnAssign` and made the gate blame a missing constant.
  - Fix: `ast.walk` over both assignment forms, plus explicit rejection of subscript assignment,
    `.update()`, `.setdefault()`, `.pop()`. Helpers now raise `AssertionError` rather than
    `pytest.fail()` **specifically so the bypasses are themselves testable** — `pytest.fail` raises a
    `BaseException` subclass that `pytest.raises(Exception)` does not catch, so a teeth-test written
    against it would have silently proven nothing.
  - Evidence: new `TestTheGateHasTeeth` reproduces all three shapes; 7 passed.
- **Finding 4: Hub `KNOWN_PREDICTION_ERROR_DOMAINS` still listed `transport`.** Either state is
  wrong — "still ticking, still readable elsewhere" while the node exists, or a permanent red
  "no node" badge once it does not.
  - Fix: removed. `harness_closure` deliberately stays: it is excluded from the aggregate but has a
    live producer, which is what that heading is for.
- **Finding 5: a docstring added by this commit overclaimed** — "`predicted_shift` filters to this
  constant like every other consumer". Not true: the branch-gated `confidence` still iterates the
  raw dict.
  - Fix: rewritten to name that consumer as the deliberate exception.
- **Finding 6: undisclosed level-shift in branch-gated `confidence`.** Dropping the frozen `0.556`
  term shrinks the denominator 6 -> 5; future rows in that branch read ~0.09 higher for identical
  substrate state. 25 persisted rows used the 6-domain basis, all before 2026-07-29T05:01:06Z.
  - Fix: disclosed at the constant's definition and here. Not suppressed — the basis string
    self-documents which domain set produced each value.
- **Finding 7: the PR report was untracked.** Fixed; committed with the code.

Review also verified clean, independently: the `transport_prediction_error()` deletion is safe (zero
importers, no star-import, no `getattr`/`importlib` lookup, both named analysis scripts confirmed to
mention it only in prose); no `KeyError` risk (every reader iterates, none indexes `["transport"]`);
and the env flip cannot auto-dispatch — traced through four independent layers
(`required_policy_gate`, `policy/evaluator.py`'s decision branches,
`execution_dispatch_policy.v1.yaml`'s `blocked_policy_decisions`, and the absent
`proposal_kind_to_cortex` route).

## Restart required

```bash
scripts/safe_docker_build.sh orion-substrate-runtime up -d --build
scripts/safe_docker_build.sh orion-proposal-runtime up -d --build
```

`orion-proposal-runtime` is required for the flag flip to take effect — the value is read at boot.

## Risks / concerns

- **Severity: should-know. Hop 0 fires zero times on its current input, measured not predicted.**
  Replayed over the real 7-day `repair_pressure_appraisal_log`: 45 readings, 6 distinct values, 34 of
  them one identical constant, `0` sustained-trend ticks. The wiring is proven; the input series is
  not capable of expressing a trend. Follow-up is a better series for hop 0, not more hop plumbing.
- **Severity: HIGH, open. A substrate concept node cannot be deleted from the live graph.**
  Measured three ways above; unexplained. This blocks the physical half of any node retirement,
  transport's included. Needs its own investigation patch — the first question is which process
  replays a byte-identical frozen snapshot within 6s while logging nothing.
- **Severity: note. `node:substrate.harness_closure` is the same shape of zombie** — 7 days stale at
  a hardcoded `0.65`. It is already excluded from the domain map deliberately, so it does not
  contaminate the reducer, but its producer looks dead too. Not touched here; scope was transport.
- **Severity: note. `orion_metacog` still has no consumer** (~3,050 rows/day, of which ~1,275 come
  from the still-level-triggered `rpc_health` transport branch). Unrelated to this patch, still open.

## PR link

<pending>
