### PR TITLE
fix(attention-runtime): persist node-target goal-provenance dominance streak across restarts

### DIFF
--- a/orion/sentience_striving_program/README.md
+++ b/orion/sentience_striving_program/README.md
@@ -975,3 +975,68 @@ it has run for real long enough to have a distribution to measure against, which
 that recalibration is a separate, deliberately deferred follow-up, not folded into this
 patch. (Found during this patch's own code-review pass, 2026-07-31 — disclosed rather
 than silently left unmentioned.)
+
+## 14. Node-target goal-provenance dominance streak — restart persistence fix, 2026-07-31
+
+**What was reviewed.** §12 above (PR #1529) fixed Layer 5's precision-weighted salience but
+left one gap explicitly named, not solved: `orion.attention.field_attention.goal_provenance
+.DominanceStreak`, the consecutive-real-tick counter that gates whether a node-target goal
+gets emitted at all (`update_dominance_streak`'s `min_streak` debounce), lived only in
+`AttentionRuntimeWorker._node_streak` — a plain in-process attribute, reset to a cold streak
+(count=0) on every restart of `orion-attention-runtime`. At the time, this was an accepted,
+disclosed gap: the only consumer of the streak count was the emit-gate boolean itself, so
+the worst case of a restart was a brief warm-up delay (a few extra ticks) before the next
+real goal-provenance publish, not a wrong value reaching anywhere.
+
+That calculus changed the same day. `PR #1543` (merged, docs-only design doc, not yet
+implemented) investigated `orion/substrate/relational/adapters/autonomy_ctx.py`'s dead
+GraphDB-backed `autonomy` producer and proposed regrounding it on
+`orion.autonomy.goal_state.get_active_goal()` — tracing one hop further than its own first
+draft that this producer's output reaches `stance_react.j2`, the real LLM-facing chat-stance
+prompt, via `chat_stance.py`'s `summary.proposal_headlines`. Its own adversarial review pass
+(documented inline in that doc) caught that a bare `field_target_id` (`"node:substrate.
+biometrics"`) would be honest-shaped garbage in that prompt slot — the `identity_yaml`
+failure mode with a different data source — and proposed pairing it with the *same*
+`DominanceStreak.count` this section is about, composed directly into `goal_text` itself:
+`f"{goal.field_target_id} (dominant {goal.dominance_streak_ticks} ticks)"`.
+
+That single change means a restart-truncated streak stops being an internal gating quirk
+and starts being a wrong number in the real prompt. And it is a specifically dangerous kind
+of wrong: `goal_provenance_min_streak` defaults to `3`
+(`services/orion-attention-runtime/app/settings.py`), so the earliest a record can ever
+emit is `count=3` — a target genuinely dominant for ten straight hours reads identically,
+`"... (dominant 3 ticks)"`, to one dominant for the last three ticks, immediately after any
+restart. Nothing about that label looks broken; it just silently understates real dominance
+duration until the count climbs back up. This is the same failure shape this repo's own
+Metric Quality Gate names by example (the `bus_synaptic_prediction_error` floor incident,
+CLAUDE.md section 0A) — a plausible-looking number is the dangerous kind, not an obviously
+degenerate one. It also means PR #1543's own planned validation step ("build it, let it run
+a day, read whether `goal_text` is genuinely informative") would not reliably catch this
+specific failure mode: a restart-truncated streak doesn't read as noise, it reads as an
+ordinary small integer.
+
+**What was fixed.** `DominanceStreak` (`target_id`, `count`) is now persisted to a new
+singleton-row table, `substrate_goal_provenance_streak`
+(`services/orion-sql-db/manual_migration_goal_provenance_streak_v1.sql`), via two new
+`AttentionRuntimeStore` methods: `load_node_dominance_streak()` (lazy-loaded on the worker's
+first real tick, degrades to a cold streak on any DB error or missing row — never crashes
+the tick) and `save_node_dominance_streak()` (UPSERTed every real tick, same cheap shape as
+`save_attention_frame`). `AttentionRuntimeWorker._node_streak` changed from an eagerly
+constructed `DominanceStreak()` to `DominanceStreak | None`, loaded once from the store the
+first time `_maybe_build_goal` runs rather than always starting cold. No new env keys — this
+uses the service's existing `POSTGRES_URI`.
+
+**What was not done, and why.** This patch does not implement PR #1543's own schema
+addition (`dominance_streak_ticks`/`window_start_field_tick_id` on `FieldGoalProvenanceV1`,
+or the `autonomy_ctx.py` rewrite) — that doc's own "Recommended next patch" section already
+scopes that as a separate, deliberately deferred step gated on Missing Questions 6 and 7
+(delete-vs-fix, and whether the resulting label is honestly informative). This patch is a
+precondition for that step's own validation plan to mean anything, not a substitute for it.
+`DominanceStreak` was also not extended to track the streak's first tick id
+(`window_start_field_tick_id`, named in PR #1543's "Files likely to touch") — that field has
+no consumer yet since #1543 itself is unimplemented; adding it now would be exactly the kind
+of schema-without-a-producer-or-consumer this program's "no keyword cathedrals" rule exists
+to prevent. It should land alongside #1543's own implementation, if and when that proceeds.
+
+**Sign-off.** Reviewed and directed by Juniper: "re 2 have a look at pr 1543" surfaced the
+label-update connection above; "oky take it forward" authorized this fix.

--- a/services/orion-attention-runtime/README.md
+++ b/services/orion-attention-runtime/README.md
@@ -21,7 +21,14 @@ docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
   < services/orion-sql-db/manual_migration_attention_frame_v1.sql
 docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
   < services/orion-sql-db/manual_migration_node_prediction_error_baseline_v1.sql
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_goal_provenance_streak_v1.sql
 ```
+
+Note: `load_node_dominance_streak`/`save_node_dominance_streak` (below) degrade silently
+on any DB error, including a missing table -- skipping this migration does not crash the
+service, it just silently keeps the node-target dominance streak cold on every restart,
+which is exactly the bug the 2026-07-31 fix below exists to remove. Apply it.
 
 Requires `orion-field-digester` (or equivalent) writing `substrate_field_state`.
 
@@ -38,6 +45,18 @@ few as 2 real samples surviving the window win a fully-confident-looking
 module docstring and `orion/sentience_striving_program/README.md` section 12 for the full
 live-incident record. `observation_count` on the persisted baseline is a real cumulative
 count of every receipt this target has ever incorporated, immune to that retention prune.
+
+## Node-target dominance streak: restart persistence (2026-07-31 fix)
+
+`orion.attention.field_attention.goal_provenance.DominanceStreak` (the consecutive-real-tick
+counter gating whether a node-target goal-provenance record gets emitted at all) is persisted
+to `substrate_goal_provenance_streak` via `AttentionRuntimeStore.load_node_dominance_streak`/
+`save_node_dominance_streak`, lazy-loaded once on the worker's first real tick instead of
+always starting cold. Previously this streak lived only in-process, resetting to count=0 on
+every restart -- an accepted gap when its only consumer was an internal emit-debounce, but
+no longer acceptable once a real, still-unimplemented downstream consumer (a design doc,
+PR #1543) proposed surfacing this exact count directly into a real LLM-facing prompt. See
+`orion/sentience_striving_program/README.md` section 14 for the full incident record.
 
 ## Run
 

--- a/services/orion-attention-runtime/app/store.py
+++ b/services/orion-attention-runtime/app/store.py
@@ -12,10 +12,15 @@ from orion.attention.field_attention.candidate_precision_weighted import (
     PrecisionEwmaBaseline,
     advance_precision_baseline,
 )
+from orion.attention.field_attention.goal_provenance import DominanceStreak
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1
 from orion.schemas.field_state import FieldStateV1
 
 logger = logging.getLogger("orion.attention.runtime.store")
+
+# Singleton row id for the one real node-target dominance streak this service
+# tracks (see load_node_dominance_streak/save_node_dominance_streak below).
+_NODE_DOMINANCE_STREAK_ID = "node_target_dominance_streak"
 
 # Batched, guard-railed prune: never deletes the newest frame (by generated_at,
 # matching load_latest_attention_frame's ordering).
@@ -321,6 +326,82 @@ class AttentionRuntimeStore:
                 "node_prediction_error_baseline_advance_failed target_id=%s", target_id
             )
             return PrecisionEwmaBaseline()
+
+    def load_node_dominance_streak(self) -> DominanceStreak:
+        """Real, persisted node-target goal-provenance dominance streak
+        (`orion.attention.field_attention.goal_provenance.DominanceStreak`),
+        surviving a worker restart.
+
+        Previously this streak lived only in `AttentionRuntimeWorker.
+        _node_streak`, reset to `DominanceStreak()` (count=0) on every
+        process restart -- a disclosed, accepted gap when it only gated an
+        internal emit-debounce (PR #1529, worst case a brief warm-up delay).
+        That calculus changed once PR #1543's design doc (2026-07-31,
+        docs-only, not yet implemented) proposed surfacing this exact count
+        directly into `FieldGoalProvenanceV1.goal_text`, which reaches the
+        real LLM-facing chat-stance prompt: a restart-truncated streak would
+        then read as a small, plausible-looking-but-wrong number in that
+        prompt, not just an internal delay -- so this now needs to survive
+        a restart honestly.
+
+        Degrades to a cold `DominanceStreak()` on any DB error or missing
+        row (fresh deploy, or an intentionally-reset row) -- same
+        never-crash-the-tick contract as this file's other loaders.
+        """
+        try:
+            with self._engine.connect() as conn:
+                row = (
+                    conn.execute(
+                        text(
+                            """
+                            SELECT target_id, count FROM substrate_goal_provenance_streak
+                            WHERE streak_id = :streak_id
+                            """
+                        ),
+                        {"streak_id": _NODE_DOMINANCE_STREAK_ID},
+                    )
+                    .mappings()
+                    .first()
+                )
+        except Exception:
+            logger.exception("node_dominance_streak_load_failed")
+            return DominanceStreak()
+        if row is None:
+            return DominanceStreak()
+        return DominanceStreak(target_id=row["target_id"], count=int(row["count"]))
+
+    def save_node_dominance_streak(self, streak: DominanceStreak) -> None:
+        """Persist the node-target dominance streak advanced this tick. See
+        `load_node_dominance_streak` for why this needs to survive a
+        restart. UPSERTed every real tick (cheap, same shape as
+        `save_attention_frame`) -- never crashes the tick on a write
+        failure, only fails to persist this one tick's advance.
+        """
+        try:
+            with self._engine.begin() as conn:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO substrate_goal_provenance_streak (
+                            streak_id, target_id, count, updated_at
+                        ) VALUES (
+                            :streak_id, :target_id, :count, :updated_at
+                        )
+                        ON CONFLICT (streak_id) DO UPDATE SET
+                            target_id = EXCLUDED.target_id,
+                            count = EXCLUDED.count,
+                            updated_at = EXCLUDED.updated_at
+                        """
+                    ),
+                    {
+                        "streak_id": _NODE_DOMINANCE_STREAK_ID,
+                        "target_id": streak.target_id,
+                        "count": streak.count,
+                        "updated_at": datetime.now(timezone.utc),
+                    },
+                )
+        except Exception:
+            logger.exception("node_dominance_streak_save_failed")
 
     def load_latest_attention_frame(self) -> FieldAttentionFrameV1 | None:
         with self._engine.connect() as conn:

--- a/services/orion-attention-runtime/app/worker.py
+++ b/services/orion-attention-runtime/app/worker.py
@@ -37,10 +37,13 @@ class AttentionRuntimeWorker:
         self._stop = asyncio.Event()
         # Field-native goal-provenance producer (SSP sec6 Objective 3) -- see
         # docs/superpowers/specs/2026-07-30-goal-provenance-and-decision-lattice-
-        # observability-design.md. In-memory only: resets to a cold streak on
-        # restart, a safe failure mode (worst case is a brief warm-up delay
-        # before the next real emission, not a wrong one).
-        self._node_streak = DominanceStreak()
+        # observability-design.md. Persisted (2026-07-31 fix): lazy-loaded from
+        # `substrate_goal_provenance_streak` on the first real tick (see
+        # `_maybe_build_goal`) rather than always starting cold -- a restart no
+        # longer truncates a genuinely-long streak back to zero. See
+        # `AttentionRuntimeStore.load_node_dominance_streak`'s docstring for why
+        # this stopped being an acceptable in-memory-only gap.
+        self._node_streak: DominanceStreak | None = None
         self._bus = None
         self._poll_task: asyncio.Task[None] | None = None
 
@@ -179,11 +182,14 @@ class AttentionRuntimeWorker:
     def _maybe_build_goal(self, frame: FieldAttentionFrameV1) -> FieldGoalProvenanceV1 | None:
         if not self._settings.enable_goal_provenance_producer or self._bus is None:
             return None
+        if self._node_streak is None:
+            self._node_streak = self._store.load_node_dominance_streak()
         winner = top_node_substrate_target(frame)
         winner_id = winner.target_id if winner is not None else None
         self._node_streak, should_emit = update_dominance_streak(
             self._node_streak, winner_id, min_streak=self._settings.goal_provenance_min_streak
         )
+        self._store.save_node_dominance_streak(self._node_streak)
         if not should_emit or winner is None:
             return None
         return FieldGoalProvenanceV1(

--- a/services/orion-attention-runtime/tests/test_goal_provenance_producer.py
+++ b/services/orion-attention-runtime/tests/test_goal_provenance_producer.py
@@ -104,6 +104,39 @@ def test_maybe_build_goal_ignores_host_only_frame(monkeypatch):
     assert worker._maybe_build_goal(frame) is None
 
 
+def test_maybe_build_goal_lazy_loads_streak_from_store_once(monkeypatch):
+    """Regression (2026-07-31 fix): the streak used to always start cold
+    (`DominanceStreak()`), resetting real accumulated dominance to zero on
+    every restart. Now `_node_streak` starts as `None` and is lazy-loaded
+    from the store on the first real tick -- and only that first tick, not
+    every tick, since the in-memory value is authoritative once loaded."""
+    worker = _make_worker(monkeypatch, min_streak=5)
+    worker._node_streak = None
+    persisted = DominanceStreak(target_id="node:substrate.biometrics", count=2)
+    worker._store.load_node_dominance_streak.return_value = persisted
+    real_domain = "node:substrate.biometrics"
+    frame = _frame([_target(real_domain, 0.9)])
+
+    worker._maybe_build_goal(frame)  # loads persisted count=2, advances to 3
+    worker._maybe_build_goal(frame)  # advances to 4, no reload
+
+    worker._store.load_node_dominance_streak.assert_called_once()
+    assert worker._node_streak.count == 4
+
+
+def test_maybe_build_goal_persists_streak_every_tick(monkeypatch):
+    worker = _make_worker(monkeypatch, min_streak=3)
+    real_domain = "node:substrate.biometrics"
+    frame = _frame([_target(real_domain, 0.9)])
+
+    worker._maybe_build_goal(frame)
+
+    worker._store.save_node_dominance_streak.assert_called_once()
+    saved = worker._store.save_node_dominance_streak.call_args[0][0]
+    assert saved.target_id == real_domain
+    assert saved.count == 1
+
+
 @pytest.mark.asyncio
 async def test_publish_goal_calls_publish_with_reconnect(monkeypatch):
     worker = _make_worker(monkeypatch)

--- a/services/orion-sql-db/manual_migration_goal_provenance_streak_v1.sql
+++ b/services/orion-sql-db/manual_migration_goal_provenance_streak_v1.sql
@@ -1,0 +1,21 @@
+-- Goal-provenance node-target dominance streak v1 (2026-07-31 fix)
+-- Apply: psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_goal_provenance_streak_v1.sql
+--
+-- Persists orion-attention-runtime's node-target goal-provenance dominance
+-- streak (orion/attention/field_attention/goal_provenance.py::DominanceStreak)
+-- across process restarts. Previously in-memory only, resetting to a cold
+-- streak (count=0) on every restart -- named as a disclosed gap in PR #1529
+-- (Sentience Striving Program README section 12) and revisited after PR #1543
+-- (docs-only design doc) proposed surfacing this same streak count directly
+-- into FieldGoalProvenanceV1.goal_text, which reaches the real LLM-facing
+-- chat-stance prompt: a restart-truncated streak would then read as a small,
+-- plausible-looking-but-wrong number in that prompt rather than just a brief
+-- internal gating delay. Single singleton row (fixed streak_id), UPSERTed by
+-- AttentionRuntimeStore.save_node_dominance_streak on every real tick.
+
+create table if not exists substrate_goal_provenance_streak (
+    streak_id text primary key,
+    target_id text,
+    count integer not null default 0,
+    updated_at timestamptz not null default now()
+);


### PR DESCRIPTION
## Summary

- `orion.attention.field_attention.goal_provenance.DominanceStreak` (the consecutive-real-tick counter gating node-target goal-provenance emission) used to live only in `AttentionRuntimeWorker._node_streak`, resetting to a cold streak (count=0) on every `orion-attention-runtime` restart.
- Previously an accepted, disclosed gap (PR #1529): the only consumer was an internal emit-debounce boolean, so a restart's worst case was a brief warm-up delay, not a wrong value reaching anywhere.
- That calculus changed the same day: PR #1543 (merged, docs-only design doc, not implemented) proposes surfacing this exact streak count directly into `FieldGoalProvenanceV1.goal_text`, which reaches the real LLM-facing chat-stance prompt (`stance_react.j2`). A restart-truncated streak would then be a plausible-looking-but-wrong number in that prompt (`goal_provenance_min_streak` defaults to 3, so every post-restart record reads "dominant 3 ticks" regardless of true prior duration) -- not just an internal delay.
- Fixed by persisting `DominanceStreak` (`target_id`, `count`) to a new singleton-row Postgres table, lazy-loaded on the worker's first real tick.
- No new env keys -- reuses the service's existing `POSTGRES_URI`.

## Outcome moved

A restart of `orion-attention-runtime` no longer silently truncates a genuinely long node-target dominance streak back to zero. This is a precondition for PR #1543's own planned validation step ("build the streak field, run it a day, read whether it's informative") to mean anything -- a restart-truncated streak doesn't read as noise, it reads as an ordinary small integer, so that eyeball-test would not have reliably caught this failure mode on its own.

## Current architecture

`AttentionRuntimeWorker.__init__` eagerly constructed `self._node_streak = DominanceStreak()`. `_maybe_build_goal()` called `update_dominance_streak(self._node_streak, ...)` every real tick, mutating the in-process attribute only -- never read from or written to any persistent store.

## Architecture touched

- `services/orion-attention-runtime/app/store.py`: two new methods, `load_node_dominance_streak()` / `save_node_dominance_streak()`, matching the existing `advance_node_prediction_error_baseline`/`save_attention_frame` UPSERT-by-fixed-id conventions in the same file.
- `services/orion-attention-runtime/app/worker.py`: `self._node_streak` changed from an eagerly-constructed `DominanceStreak()` to `DominanceStreak | None`, lazy-loaded once inside `_maybe_build_goal()`; persisted every real tick after each `update_dominance_streak()` advance.

## Files changed

- `services/orion-sql-db/manual_migration_goal_provenance_streak_v1.sql`: new migration, `substrate_goal_provenance_streak` singleton-row table.
- `services/orion-attention-runtime/app/store.py`: `load_node_dominance_streak`/`save_node_dominance_streak`.
- `services/orion-attention-runtime/app/worker.py`: lazy-load + persist wiring.
- `services/orion-attention-runtime/tests/test_goal_provenance_producer.py`: two new tests (lazy-load-once, persist-every-tick), verified meaningful via live mutation testing in review.
- `services/orion-attention-runtime/README.md`: new migration added to Prerequisites (a code-review finding -- see below); new section documenting the fix.
- `orion/sentience_striving_program/README.md`: new section 14, full incident record and sign-off.

## Schema / bus / API changes

- Added: `substrate_goal_provenance_streak` table (`streak_id` PK, `target_id`, `count`, `updated_at`). Single singleton row, UPSERTed every real tick.
- No bus channel, schema field, or API changes.
- Confirmed out of scope for `scripts/check_substrate_projection_schema_drift.py`: that gate is explicitly restricted to `orion-substrate-runtime`'s fixed-`projection_id` rows loaded via `<Model>.model_validate(json_blob)` with `extra="forbid"`. This new table uses plain named SQL columns, no JSON blob, no pydantic `model_validate` -- genuinely a different, immune shape, not silently skipped.

## Env/config changes

- Added keys: none.
- `.env_example` updated: not applicable, no new env keys.
- local `.env` synced: not applicable.

## Tests run

```text
PYTHONPATH=<repo> .venv/bin/python -m pytest services/orion-attention-runtime/tests tests/test_attention_field_goal_provenance.py -q
40 passed
```
(One pre-existing, unrelated `test_heartbeat_chassis.py` collection error when run from inside the service dir instead of repo root -- a relative config-path cwd dependency, confirmed pre-existing and untouched by this patch.)

## Evals run

No eval harness exists for this service; none added (small, deterministic persistence fix, fully covered by unit tests).

## Docker/build/smoke checks

Not run in this session (no live Docker rebuild performed) -- migration must be applied and the service rebuilt before this takes effect live; see Restart required below.

## Review findings fixed

- Finding: `services/orion-attention-runtime/README.md`'s Prerequisites section listed the two existing migrations' apply commands but not the new one. Since `load_node_dominance_streak`/`save_node_dominance_streak` degrade silently on any DB error including a missing table, an operator following the documented Prerequisites without this line would get exactly the bug this patch fixes, with zero error surfaced.
  - Fix: added the new migration's apply command to Prerequisites, plus an explicit warning about the silent-degrade behavior if skipped.
  - Evidence: `services/orion-attention-runtime/README.md` diff, this PR.

## Restart required

```bash
docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
  < services/orion-sql-db/manual_migration_goal_provenance_streak_v1.sql
cd /mnt/scripts/Orion-Sapienform-goal-provenance-streak-persistence
scripts/safe_docker_build.sh orion-attention-runtime up -d --build
```

## Risks / concerns

- Severity: low
- Concern: `DominanceStreak` still does not track the streak's first tick id (`window_start_field_tick_id`, named in PR #1543's own "Files likely to touch"). Not added here since #1543 itself is unimplemented and has no consumer for that field yet.
- Mitigation: named explicitly in `orion/sentience_striving_program/README.md` section 14 as deliberately deferred, to land alongside #1543's own implementation if that proceeds.

## PR link

(filled in after `gh pr create` returns)