### PR TITLE
docs(substrate): park exhaust/daydream/causal-self-state brainstorm + expose prediction_error_by_domain

### DIFF
--- a/docs/superpowers/specs/2026-07-31-substrate-exhaust-causal-self-state-design.md
+++ b/docs/superpowers/specs/2026-07-31-substrate-exhaust-causal-self-state-design.md
@@ -1,0 +1,261 @@
+# Substrate exhaust, daydream material, and causal self-state: design notes
+
+Status: **design/brainstorm, not proposal-mode-approved**. One small, additive,
+non-invasive patch shipped alongside this doc (see "Recommended next patch,
+shipped"); everything else here is investigation and open direction, not a
+committed roadmap. Any future work that touches memory, autonomy, or
+cognition-loop decision logic still needs explicit proposal-mode scoping per
+`AGENTS.md` before implementation.
+
+## Arsonist summary
+
+Juniper asked what Orion computes and throws away -- "exhaust" -- and whether
+that exhaust could feed a daydream/reverie stream, distinct from re-dispatch
+autonomy. The investigation ruled out the obvious candidate (AI Town's
+spontaneous-thought reverie loop -- known, already-fixed repetition-bug
+infrastructure junk, not interesting exhaust) and moved into the
+substrate-runtime's own "grammar" subsystem. That surfaced two structurally
+different discard mechanisms, neither of which alone matches what Juniper
+was actually after: real per-topic causal narrative ("I was doing X, which
+backed up Y, which is why I feel Z"). Checking for that directly found the
+existing grammar-ledger edges are templated fan-out, not discovered
+causality, and surfaced two more, separate, real "causal" mechanisms
+elsewhere in the repo that need reconciling before any new one gets built.
+Along the way, a fourth, smaller, exhaust instance was found and fixed: a
+per-domain prediction-error breakdown that gets computed every tick, folded
+into one confidence scalar, and discarded.
+
+## Current architecture
+
+### Two real discard paths in the grammar subsystem, different timescales
+
+**`orion:grammar:accepted-pressure`** (`orion/bus/channels.yaml` ~L2241) --
+produced only by `orion-substrate-runtime`'s `_tick()`
+(`services/orion-substrate-runtime/app/worker.py`), which runs biometrics
+grammar events through a reducer (`min_confidence`/staleness accept-gate)
+and republishes the accepted subset. `consumer_services: []`. Confirmed live
+2026-07-31: `redis-cli XLEN orion:grammar:accepted-pressure` = 0 -- this is a
+bare `PUBLISH`, not a stream, so nothing is even buffered; content evaporates
+in the same tick it's produced. `services/orion-substrate-runtime/app/
+grammar_truth.py` explicitly documents it as `"not canonical grammar
+ingress"`. This is the purest structural match to "exhaust" found this
+session, but its one confirmed direct producer
+(`orion/substrate/biometrics_loop/candidate_events.py::
+build_pressure_candidate_events()`) is mechanical: `summary=f"{semantic_role}
+for {node_id}"`, `text_value=node_id`. Real and gated, but not narratively
+rich.
+
+**Canonical `orion:grammar:event`** -> Postgres `grammar_atoms`/
+`grammar_events` ledger -- has real consumers (`orion-sql-writer` for
+persistence, `orion-equilibrium-service` for the chat-turn and
+transport-timeout metacog triggers, `orion-heartbeat` as a v0 research
+consumer). Live-queried 2026-07-31 (last 3h window): genuinely rich content
+-- `exec_plan_started` ("Execution plan started for verb=
+log_orion_metacognition; step_count=3"), `route_arbitration_decided`
+("lane=background, mind_requested=false..."), `exec_recall_gate_observed`
+("Recall policy resolved: run=False, profile=reflect.v1, reason=
+disabled_by_client"), `exec_result_assembled`, `capability_surface`. This
+*does* get discarded, just slowly: `services/orion-sql-writer/app/
+grammar_truth.py::apply_grammar_events_retention()` runs a batched `DELETE
+FROM grammar_events WHERE created_at < cutoff` at service startup,
+`GRAMMAR_EVENTS_RETENTION_DAYS=30` by default (`services/orion-sql-writer/
+.env_example`), with FK cascade into `grammar_atoms`. Every plan, arbitration
+decision, and declined-recall moment Orion ever generated quietly ages out
+past 30 days with nothing summarizing or reflecting on it first.
+
+### Grammar-ledger edges are templated, not causal
+
+Checked directly (live Postgres, 2026-07-31, 3h window) because Juniper's
+own instinct was that the ledger is "so abstracted from 'X topic caused this
+Y'" that it probably lacks real trace provenance. Confirmed: `grammar_edges`
+has 7,956 `influenced` edges in-window, **100% same-`trace_id`** (`0`
+cross-trace edges), and the actual pairing is a fixed per-tick template --
+every biometrics pressure-signal atom type (`disk_pressure_signal`,
+`gpu_pressure_signal`, `thermal_pressure_signal`, `memory_pressure_signal`,
+etc.) points to the same `capability_surface` atom, each pairing appearing
+exactly 886 times in the window. That's mechanical fan-out wiring, not
+discovered cross-domain causality. The `RelationType`/`TemporalHopType`
+enums in `orion/schemas/grammar.py` already anticipate richer use --
+`dream_reentry`, `counterfactual`, `future_candidate` hop types exist in the
+schema -- but grepping the full `orion/`/`services/` tree found zero
+consumers or producers of those three values anywhere. Schema-only, never
+built.
+
+### A real composite "mood" instrument already exists, one layer up
+
+`orion/substrate/attention_self_model.py::_aggregate_prediction_error_confidence()`
+takes live prediction-error from 5 real domains (execution, biometrics,
+chat, route, bus_synaptic) and computes `confidence = 1 - mean(prediction_error
+across domains)`. This is structurally close to what Juniper described --
+"I have X things going on, I'm backed up here, combined they make me feel
+chaotic" -- a single scalar synthesized from concurrent pressure across
+unrelated subsystems. It's real, live-verified (2026-07-23, 6h window:
+biometrics carries almost all real variance, other four domains present but
+tiny), and the code is honest about the resulting dilution rather than
+hiding it. Deliberately `mean()` not `max()`, specifically so it doesn't
+just restate whichever single domain attention-selection already surfaced
+as loudest (CLAUDE.md's metric-quality-gate independence check, applied at
+build time).
+
+Until this session's patch (below), the per-domain values that composed
+that mean were discarded the instant the scalar was computed -- the exact
+same "real content, computed, thrown away" shape as the grammar-exhaust
+channels above, just one level of abstraction up and un-gated by any
+staleness/retention window at all (it never touched storage in the first
+place).
+
+### Three separate existing "causal" mechanisms, not yet reconciled
+
+Before building anything new that claims to give Orion causal
+self-understanding, these three need to be checked against each other --
+this repo's metric-quality-gate "existing-mechanism check" applies here as
+much as it does to any new metric:
+
+1. **Grammar-ledger edges** (`grammar_edges.relation_type`) -- see above.
+   Same-trace, templated, not discovered causality.
+2. **`orion/signals/causal_helpers.py::with_missed_parent_notes()`** -- a
+   real, live consumer (`services/orion-signal-gateway/app/processor.py`,
+   plus test coverage in `orion/signals/adapters/tests/`). Checks a
+   *registry-declared* structural parent-organ hierarchy
+   (`OrionOrganRegistryEntry.causal_parent_organs`) against which parent
+   organs actually produced a recent signal in `prior_signals`; if a
+   declared parent is missing, appends an audit note to the signal. This is
+   more principled than the grammar edges (declared structure, not
+   per-tick mechanical fan-out) but it only flags *absence* -- it records
+   "expected causal parent didn't fire," never "this specific value caused
+   that specific downstream value." No positive causal attribution, no
+   content.
+3. **Causal Geometry v1** (PR #1087, #1102-ish spec closeout, 2026-07-16/17)
+   -- a different scope than either of the above, despite the name overlap:
+   causal geometry of *substrate structural mutation proposals* (a
+   `proposal -> trial -> HITL adopt` pipeline with divergence snapshots),
+   not causal explanation of moment-to-moment self-state. Phase A
+   (snapshot persistence, hub Snapshot/History panels) is live end-to-end,
+   bus-routed through `orion-sql-writer` per the corrected design. Phase B
+   (`SubstrateTrialRunner`) is wired and genuinely exercised per proposal,
+   but always resolves `"inconclusive"` today -- no replay corpus is
+   registered for its mutation class yet. Not dead, just unproven in
+   practice. Worth knowing this exists and what its real status is before
+   assuming "causal self-state" needs a new mechanism from scratch --  but
+   it answers a different question than Juniper's "why do I feel this way"
+   framing.
+
+None of the three currently produces "I feel uncertain because route
+arbitration and biometrics disagreed on X within the last minute" --  the
+closest existing building block for that is `causal_helpers.py`'s
+registry-declared parent-organ pattern, because it's the only one of the
+three based on *declared* structure rather than mechanical per-tick fan-out
+or a differently-scoped mutation-trial pipeline.
+
+### Self-modeling ladder placement convention
+
+Per prior work (Reverie/Dream substrate-native design), new reflective/
+narrative cognition is supposed to land ON the existing self-modeling
+ladder (layers 5-11), not as a parallel shadow mechanism. All ladder rungs
+are merged; ignition flags are off; rung 5 is awaiting sign-off. Any future
+daydream/exhaust-reflection consumer should be scoped against this ladder's
+existing rung structure rather than invented as a new standalone pipeline.
+
+## Missing questions
+
+- Why did Causal Geometry v1's Phase B trial runner never get a registered
+  replay corpus -- is that a small, unblockable gap, or does it reveal a
+  harder structural problem with running trials against live mutation
+  classes?
+- Would extending `causal_helpers.py`'s registry-declared parent-organ
+  pattern (already live, already tested) to the grammar-atom layer be
+  cheaper than inventing new edge-discovery logic for `grammar_edges`?
+- Where on the self-modeling ladder (which rung, if any) does "explain my
+  own composite confidence" belong?
+- Is `orion:grammar:accepted-pressure`'s zero-consumer status worth fixing
+  on its own, independent of the richer causal-provenance work -- i.e. is
+  a thin, mechanical exhaust stream still useful as raw "sprinkled" daydream
+  material even without narrative richness?
+
+## Proposed schema / API changes
+
+None proposed yet at the daydream/causal-bridge level -- this stays
+investigation-only per proposal-mode discipline (memory/cognition-loop
+changes need explicit scoping before implementation). The one schema change
+in this patch is additive-only and observability-only (see below).
+
+## Files likely to touch (future work, not this patch)
+
+- `orion/schemas/grammar.py` / grammar-atom producers, if `grammar_edges`
+  ever grows real cross-domain causal discovery instead of templated
+  fan-out.
+- `orion/signals/causal_helpers.py`, if its registry-declared pattern gets
+  extended to another domain.
+- Whatever rung of the self-modeling ladder ends up owning a "why do I feel
+  this way" reflective consumer.
+- `docs/superpowers/specs/2026-07-16-causal-geometry-v1-design.md` and its
+  closeout PR report, to check Phase B's replay-corpus gap in detail before
+  reviving it.
+
+## Non-goals
+
+- Not rebuilding `grammar_edges` into a general causal-inference engine in
+  this patch.
+- Not touching `orion:grammar:accepted-pressure`'s zero-consumer status in
+  this patch -- flagged as a separate, smaller, optional thread.
+- Not reviving Causal Geometry Phase B without first understanding why its
+  replay corpus was never registered.
+- Not building any new daydream/reverie consumer yet -- that's proposal-mode
+  work, not this session's scope.
+
+## Acceptance checks
+
+For this doc's own shipped patch (see below): tests pass, the new field is
+additive (no existing consumer's behavior changes), no schema/column-list
+drift risk (the persisted row is a single JSONB blob, not an explicit
+column list -- confirmed via `services/orion-substrate-runtime/app/
+store.py::save_attention_self_model()`).
+
+For any future work building on this doc: must show a live trace (not just
+a passing test) that a specific self-state readout can be explained by
+naming the specific atoms/signals that composed it, per CLAUDE.md's
+"runtime truth beats config truth."
+
+## Recommended next patch, shipped in this same branch
+
+**Expose `prediction_error_by_domain` on `AttentionSelfModelV1`.** The
+per-domain prediction-error snapshot that `_aggregate_prediction_error_
+confidence()`/`_unconditional_prediction_error_confidence()` already receive
+and average into `prediction_error_confidence` every tick were being
+discarded the moment the scalar was computed -- never stored on the output
+model, never persisted. This is the same "real, gated content computed and
+thrown away" shape as the grammar-exhaust channels above, at the cheapest
+possible fix point.
+
+- `orion/schemas/attention_self_model.py`: added `prediction_error_by_domain:
+  dict[str, float] | None = None`, additive field, no `extra="forbid"`
+  conflict.
+- `orion/substrate/attention_self_model.py::reduce_attention_self_model()`:
+  populates the new field with the same `ACTIVE_INFERENCE_DOMAINS`-filtered
+  dict that composed `prediction_error_confidence` (so the exposed
+  breakdown always matches exactly what the scalar actually averaged, never
+  a superset).
+- `orion/substrate/tests/test_attention_self_model.py`: 4 new tests
+  (`TestPredictionErrorByDomainExposed`) covering the mirrored-domain case,
+  the transport-exclusion case, and both honest-`None` cases.
+- Persistence: `services/orion-substrate-runtime/app/store.py::
+  save_attention_self_model()` writes the whole model as one JSONB blob
+  (`model.model_dump(mode="json")`), so this field round-trips into
+  `substrate_attention_self_model` automatically -- no migration, no
+  column-list update, no drift risk.
+- Scope check: `services/orion-hub/scripts/attention_organ_routes.py`
+  already independently re-derives a per-domain breakdown live, for the UI,
+  by calling `_brain_frame_prediction_error_by_domain()` directly against
+  the fresh brain-frame -- so this patch does not add new *live* UI
+  capability. What it fixes is the **persisted historical record**:
+  `substrate_attention_self_model` rows older than the current tick never
+  carried this breakdown before, so replay/history could never show *why* a
+  past confidence dip happened, only that it happened. Wiring this into the
+  hub UI's history view (reading the persisted field instead of only ever
+  recomputing live) is a natural, still-small follow-up, not done in this
+  patch.
+
+Tests: `orion/substrate/tests/test_attention_self_model.py` (52 passed,
+including the 4 new), `services/orion-substrate-runtime/tests/
+test_worker_attention_self_model_tick.py` (16 passed) -- both run via the
+main checkout's `.venv` from inside this task's worktree.

--- a/orion/schemas/attention_self_model.py
+++ b/orion/schemas/attention_self_model.py
@@ -92,6 +92,18 @@ class AttentionSelfModelV1(BaseModel):
     prediction_error_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     prediction_error_confidence_basis: str = ""
 
+    # --- The per-domain breakdown that composed prediction_error_confidence,
+    # additive. 2026-07-31: this dict was already computed by the caller and
+    # passed into the reducer every tick to build the scalar above, then
+    # discarded once collapsed into a single mean -- an "exhaust" instance of
+    # the same shape found elsewhere this session (real, gated content
+    # computed and thrown away with no consumer). Restricted to the same
+    # ACTIVE_INFERENCE_DOMAINS filter as prediction_error_confidence itself
+    # (see orion/substrate/attention_self_model.py), so this field always
+    # shows exactly the inputs that composed that scalar -- never a superset
+    # that includes a domain the confidence figure didn't actually use.
+    prediction_error_by_domain: dict[str, float] | None = None
+
     # --- What's predicted to shift next (modest, honestly scoped) ----------
     predicted_shift: str | None = None
     predicted_shift_basis: str = ""

--- a/orion/substrate/attention_self_model.py
+++ b/orion/substrate/attention_self_model.py
@@ -373,6 +373,14 @@ def reduce_attention_self_model(
     if pe_confidence is not None:
         model.prediction_error_confidence = _round_or_none(pe_confidence)
         model.prediction_error_confidence_basis = pe_confidence_basis
+        # Same ACTIVE_INFERENCE_DOMAINS filter the confidence scalar above was
+        # computed from -- exposed so the scalar can explain itself instead of
+        # being the only surviving trace of its own inputs (2026-07-31).
+        model.prediction_error_by_domain = {
+            domain: _round_or_none(value)
+            for domain, value in prediction_error_by_domain.items()
+            if domain in ACTIVE_INFERENCE_DOMAINS
+        } if prediction_error_by_domain else None
 
     hb_mean_ratio, hb_verdict, hb_basis = _heartbeat_h1_fields(heartbeat_h1)
     if hb_verdict is not None:

--- a/orion/substrate/tests/test_attention_self_model.py
+++ b/orion/substrate/tests/test_attention_self_model.py
@@ -449,6 +449,45 @@ class TestUnconditionalPredictionErrorConfidence:
         assert model.prediction_error_confidence == pytest.approx(0.5, abs=1e-4)
 
 
+class TestPredictionErrorByDomainExposed:
+    """`prediction_error_by_domain` (2026-07-31): the per-domain inputs that
+    composed `prediction_error_confidence` were computed every tick and then
+    discarded once collapsed into that single mean -- exposing them lets the
+    scalar explain itself instead of being the only surviving trace of its
+    own inputs."""
+
+    def test_mirrors_the_domains_that_composed_the_confidence_scalar(self) -> None:
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        assert model.prediction_error_by_domain == {
+            "execution": 0.0001,
+            "biometrics": 0.0459,
+            "chat": 0.0,
+            "route": 0.0,
+        }
+
+    def test_transport_excluded_even_when_supplied(self) -> None:
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain=_prediction_error_by_domain(),
+        )
+        assert "transport" not in model.prediction_error_by_domain
+
+    def test_none_when_confidence_is_none(self) -> None:
+        model = reduce_attention_self_model(
+            None, _field_frame(), now=NOW,
+            prediction_error_by_domain={"transport": 0.0},
+        )
+        assert model.prediction_error_confidence is None
+        assert model.prediction_error_by_domain is None
+
+    def test_none_when_no_prediction_error_data_supplied(self) -> None:
+        model = reduce_attention_self_model(None, _field_frame(), now=NOW)
+        assert model.prediction_error_by_domain is None
+
+
 def test_reference_tick_defaults_to_field_frame_generated_at() -> None:
     field_frame = _field_frame(generated_at=NOW)
     model = reduce_attention_self_model(None, field_frame)


### PR DESCRIPTION
## Summary

- Parks a session-long brainstorm arc into a real design doc: what Orion computes and discards ("exhaust"), whether it could feed a daydream/reverie stream, and whether Orion has real causal self-understanding of its own runtime state.
- Investigated `orion:grammar:accepted-pressure` (real, quality-gated, zero consumers, zero persistence — true real-time exhaust) vs. the canonical `orion:grammar:event` → Postgres ledger (rich content, real consumers, discarded only via 30-day retention).
- Checked `grammar_edges` directly against the "do we have real causal provenance" question: confirmed `influenced` edges are 100% same-trace, templated fan-out (every pressure-signal atom → the same `capability_surface` atom, uniform per-tick counts), not discovered cross-topic causality.
- Reconciled two other existing "causal" mechanisms found along the way — `orion/signals/causal_helpers.py`'s registry-declared parent-organ check, and Causal Geometry v1's (differently-scoped) mutation-trial pipeline — so future work extends rather than duplicates them.
- Ships one small, additive patch: `AttentionSelfModelV1.prediction_error_by_domain` — the per-domain prediction-error breakdown that already gets computed and averaged into `prediction_error_confidence` every tick was being discarded the moment the scalar was computed. Same "real content, computed, thrown away" shape as everything else surfaced this session, fixed at the cheapest point.

## Outcome moved

`substrate_attention_self_model` rows now carry the per-domain breakdown that explains their own `prediction_error_confidence` scalar, instead of only the collapsed mean. Previously only the hub UI's live re-derivation (`attention_organ_routes.py::_brain_frame_prediction_error_by_domain()`) could show this, and only for the current tick — historical/replay rows had no way to explain a past confidence dip.

## Current architecture

`reduce_attention_self_model()` already received `prediction_error_by_domain` as a caller-supplied argument and used it only to compute `prediction_error_confidence`/`prediction_error_confidence_basis`, then dropped it. `AttentionSelfModelV1` had no field for it.

## Architecture touched

- `orion/schemas/attention_self_model.py`
- `orion/substrate/attention_self_model.py`
- `orion/substrate/tests/test_attention_self_model.py`
- `docs/superpowers/specs/2026-07-31-substrate-exhaust-causal-self-state-design.md` (new)

## Files changed

- `orion/schemas/attention_self_model.py`: added `prediction_error_by_domain: dict[str, float] | None = None`, additive field.
- `orion/substrate/attention_self_model.py`: populates the new field with the same `ACTIVE_INFERENCE_DOMAINS`-filtered dict that composed `prediction_error_confidence`, so the two always agree.
- `orion/substrate/tests/test_attention_self_model.py`: 4 new tests (`TestPredictionErrorByDomainExposed`).
- `docs/superpowers/specs/2026-07-31-substrate-exhaust-causal-self-state-design.md`: consolidates the full investigation, including three open threads not yet acted on (grammar `accepted-pressure`'s zero-consumer status, Causal Geometry Phase B's unregistered replay corpus, and whether `causal_helpers.py`'s pattern should extend to the grammar-atom layer).

## Schema / bus / API changes

- Added: `AttentionSelfModelV1.prediction_error_by_domain` (optional, default `None`).
- Removed: none.
- Renamed: none.
- Behavior changed: none — purely additive; existing `confidence`/`prediction_error_confidence` fields and their computation are unchanged.
- Compatibility notes: persisted via `save_attention_self_model()`'s existing JSONB-blob write (`model.model_dump(mode="json")`), no explicit column list, no migration. Old rows without this field simply deserialize with `None`.

## Env/config changes

None.

## Tests run

```text
orion/substrate/tests/test_attention_self_model.py: 52 passed (48 pre-existing + 4 new)
services/orion-substrate-runtime/tests/test_worker_attention_self_model_tick.py: 16 passed
```

## Evals run

No eval harness exists for this seam (schema/reducer-level unit tests are the coverage here).

## Docker/build/smoke checks

Not applicable — no runtime/config/Docker changes; pure schema + reducer + test + doc patch.

## Review findings fixed

- Finding: reviewed for correctness (mirrors `prediction_error_confidence`'s exact filtered inputs), dict-aliasing safety, `extra="forbid"` consumer-breakage risk, and test tautology.
  - Fix: none required — review found no blocking issues. Two harmless, explicitly non-blocking nitpicks noted (a dead-code defensive ternary, one test redundant with another) — reviewer recommended no follow-up.
  - Evidence: full subagent review pass, live-verified aliasing/edge-case behavior via direct script calls, all 52 tests passing.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: Low
  - Concern: raw per-domain values in the new field are not range-clamped (unlike the aggregate `prediction_error_confidence`, which clamps its mean to `[0,1]`), so a future consumer of historical rows could see an out-of-range domain value alongside a clean-looking scalar.
  - Mitigation: this is honest — the field's whole purpose is exposing true raw inputs, not a sanitized restatement. Documented in the design doc and in review; no fix needed for this patch's scope.
- Severity: Low
  - Concern: this doc leaves three real threads open (accepted-pressure's zero consumers, Causal Geometry Phase B's replay-corpus gap, causal_helpers.py extension question) without committing to next steps.
  - Mitigation: explicitly scoped as design/brainstorm, not proposal-mode-approved, per the doc's own status line — intentional, not an oversight.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/substrate-exhaust-causal-self-state