### PR TITLE
fix(scripts): env sync was a silent no-op in every worktree

### DIFF
--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -24,12 +24,57 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 KEY_LINE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+
+
+def main_worktree_root(start: Path | None = None) -> Path:
+    """Where the live `.env` files actually live.
+
+    `.env` is gitignored, so it exists ONLY in the primary checkout -- never in a
+    linked worktree. But CLAUDE.md mandates that all work happen in a worktree,
+    so running this script the way the contract tells you to made it a silent
+    no-op: every service reported `skip <name>: no .env` and it exited 0.
+
+    Confirmed live 2026-07-31: run from a linked worktree it printed 24
+    `no .env` skips and returned success, so a genuine divergence went
+    unreported. That is exactly how
+    `EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_ERROR_THRESHOLD` stayed at the
+    retired metric's `1.0` after PR #1542 changed the template to `0.15` --
+    shipping a detector that was structurally unable to fire, with the
+    "env parity is non-negotiable" gate reporting clean the whole time.
+
+    `.env_example` is still read from the CURRENT worktree (it is the branch's
+    template, and the whole point is to compare the change you just made against
+    the live file). Only `.env` resolves here.
+
+    Falls back to the current root when git is unavailable or this is already the
+    primary checkout, so behavior is unchanged outside a linked worktree.
+    """
+    base = start or ROOT
+    try:
+        common = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=base,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return base
+    if not common:
+        return base
+    # In the primary checkout the common dir is `<root>/.git`; in a linked
+    # worktree it is still the PRIMARY checkout's `.git`, which is what makes
+    # this resolvable at all.
+    candidate = Path(common).resolve().parent
+    return candidate if (candidate / "services").is_dir() else base
 
 # Host .env may legitimately differ from docker-oriented .env_example.
 NEVER_SYNC_KEYS = frozenset(
@@ -400,23 +445,46 @@ def main() -> int:
     args = parser.parse_args()
 
     services_dir = ROOT / "services"
+    # `.env_example` comes from THIS worktree (the branch's template); `.env`
+    # comes from the primary checkout, which is the only place it exists.
+    env_root = main_worktree_root()
+    env_services_dir = env_root / "services"
+    if env_root != ROOT:
+        print(f"reading live .env from primary checkout: {env_root}")
     names = args.services or list(DEFAULT_SERVICES)
     all_updated: list[str] = []
     all_diverged: list[str] = []
+    skipped_missing_env = 0
     for name in names:
         svc = services_dir / name
         if not svc.is_dir():
             print(f"unknown service: {name}", file=sys.stderr)
             return 1
         result = sync_file(
-            svc / ".env",
+            env_services_dir / name / ".env",
             svc / ".env_example",
             dry_run=args.dry_run,
             all_keys=args.all_keys,
             force=args.force,
         )
+        if any(u.endswith(": no .env") for u in result.updated):
+            skipped_missing_env += 1
         all_updated.extend(result.updated)
         all_diverged.extend(result.diverged)
+
+    # A run where EVERY service lacked a .env is not a clean run -- it is the
+    # silent no-op this script used to perform from a linked worktree. Fail
+    # loudly rather than reporting success, so the "env parity is
+    # non-negotiable" gate cannot pass by having checked nothing.
+    if names and skipped_missing_env == len(names):
+        print(
+            f"ERROR: no .env found for any of the {len(names)} services under "
+            f"{env_services_dir}. Nothing was checked, so this is NOT a pass. "
+            "If this is a fresh host, create the .env files first; otherwise the "
+            "primary-checkout path resolved wrongly.",
+            file=sys.stderr,
+        )
+        return 1
 
     if not all_updated and not all_diverged:
         print("No changes needed (feature keys already match .env_example).")

--- a/tests/scripts/test_sync_local_env_from_example.py
+++ b/tests/scripts/test_sync_local_env_from_example.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "scripts"))
 
+import sync_local_env_from_example as sync_mod  # noqa: E402
 from sync_local_env_from_example import (  # noqa: E402
     NEVER_SYNC_KEYS,
     example_value_is_host_placeholder,
@@ -140,3 +141,59 @@ def test_sync_file_missing_key_auto_added_default_and_force(tmp_path: Path) -> N
         assert "CRYSTALLIZER_NEW_KEY=example_value" in text
         assert any("CRYSTALLIZER_NEW_KEY" in c for c in result.updated)
         assert not result.diverged
+
+
+# --- worktree resolution (2026-07-31) -------------------------------------
+#
+# `.env` is gitignored, so it exists only in the primary checkout. CLAUDE.md
+# mandates all work happen in a linked worktree, so running this script the way
+# the contract instructs made it a silent no-op: 24 services reported
+# `skip <name>: no .env` and it exited 0. A real divergence
+# (EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_ERROR_THRESHOLD left at the retired
+# metric's 1.0 after PR #1542 moved the template to 0.15) went unreported, and a
+# detector that could not fire shipped with the parity gate reporting clean.
+
+
+def test_main_worktree_root_resolves_primary_checkout_from_a_linked_worktree(tmp_path):
+    """A linked worktree must resolve `.env` back to the primary checkout."""
+    import subprocess as sp
+
+    primary = tmp_path / "primary"
+    (primary / "services").mkdir(parents=True)
+    sp.run(["git", "init", "-q", str(primary)], check=True)
+    sp.run(["git", "-C", str(primary), "config", "user.email", "t@t"], check=True)
+    sp.run(["git", "-C", str(primary), "config", "user.name", "t"], check=True)
+    (primary / "README.md").write_text("x\n")
+    sp.run(["git", "-C", str(primary), "add", "-A"], check=True)
+    sp.run(["git", "-C", str(primary), "commit", "-qm", "init"], check=True)
+
+    linked = tmp_path / "linked"
+    sp.run(
+        ["git", "-C", str(primary), "worktree", "add", "-q", "-b", "wt", str(linked)],
+        check=True,
+    )
+
+    assert sync_mod.main_worktree_root(linked).resolve() == primary.resolve()
+    # Idempotent from the primary checkout itself.
+    assert sync_mod.main_worktree_root(primary).resolve() == primary.resolve()
+
+
+def test_main_worktree_root_falls_back_outside_a_git_repo(tmp_path):
+    """No git, no repo, no surprises -- behave exactly as before."""
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert sync_mod.main_worktree_root(plain) == plain
+
+
+def test_main_worktree_root_falls_back_when_services_dir_is_absent(tmp_path):
+    """Guard against resolving to something that is not this repo.
+
+    A bare/odd git layout must not silently redirect `.env` writes somewhere
+    unrelated -- the `services/` probe is what makes the redirect safe.
+    """
+    import subprocess as sp
+
+    repo = tmp_path / "norepo"
+    repo.mkdir()
+    sp.run(["git", "init", "-q", str(repo)], check=True)
+    assert sync_mod.main_worktree_root(repo) == repo


### PR DESCRIPTION
## Summary

`scripts/sync_local_env_from_example.py` checked nothing and reported success when run the way
CLAUDE.md requires. Two mandates were in direct conflict:

- §2: all work happens in a linked worktree.
- §7: env parity is non-negotiable, enforced by this script.

`.env` is gitignored, so it exists **only in the primary checkout**. From a worktree the script
printed 24 × `skip <name>: no .env` and exited `0`.

## This shipped a dead detector today

PR #1542 changed `bus_synaptic_prediction_error` from a magnitude to a **fraction** and moved
`EQUILIBRIUM_METACOG_TRANSPORT_BUS_SYNAPTIC_ERROR_THRESHOLD` `1.0 → 0.15` in `.env_example`. Its own
report explicitly called out that the live `.env` had to follow. The sync script — run from the
worktree, as required — reported clean.

The live value stayed `1.0`. Under the fraction definition that means *every edge in the mesh
anomalous at once*: structurally unreachable. The detector was silently incapable of firing until
caught by hand hours later, against a live reading of `0.0128`.

## Fix

`.env` now resolves against the primary checkout via
`git rev-parse --path-format=absolute --git-common-dir` — from inside a linked worktree that points
at the *primary* checkout's `.git`, so its parent is the primary checkout.

`.env_example` still resolves against the **current worktree**. That is the branch's template, and
comparing the change you just made against the live file is the entire point.

Guarded so the redirect cannot land somewhere unrelated: the resolved path must contain a
`services/` directory, else fall back. No git, a bare repo, or an already-primary checkout all fall
back to today's behavior unchanged.

**Second half:** a run where *every* service lacked a `.env` now exits `1` instead of `0`. A gate
that checked nothing must not report a pass — that property is what let this hide, and it would have
hidden the next one.

## Verified live

From the worktree, after the fix:

```text
reading live .env from primary checkout: /mnt/scripts/Orion-Sapienform
Would update:
  orion-spark-concept-induction: +CHANNEL_GOAL_PROPOSAL='orion:memory:goals:proposed'
  orion-world-pulse:             +CHANNEL_GOAL_PROPOSAL='orion:memory:goals:proposed'
  orion-attention-runtime:       +CHANNEL_GOAL_PROPOSAL='orion:memory:goals:proposed'
Diverged (not changed — local value differs from .env_example):
  orion-memory-consolidation: CRYSTALLIZER_EMBED_HOST_URL local='http://orion-athena-vector-host:8320/embedding' example=''
  orion-memory-consolidation: CHROMA_HOST      local='orion-athena-vector-db' example=''
  orion-hub: GRAPHITI_ADAPTER_URL   local='http://127.0.0.1:8640' example='http://orion-athena-graphiti-adapter:8000'
  orion-hub: HUB_AITOWN_UI_URL      local='http://100.121.214.30:5173' example='http://127.0.0.1:5173'
  orion-field-digester: FIELD_CHANNEL_CORPUS_PATH   local='/mnt/telemetry/...' example=''
  orion-field-digester: FIELD_CHANNEL_ANOMALY_ENABLED local='true' example='false'
```

None of that was visible to the old invocation.

**Not applied here:** the 3 missing `CHANNEL_GOAL_PROPOSAL` keys are real live drift from an earlier
merged change, not from this branch. Safe by the script's own contract (a missing key has no
existing value to clobber), but left for the owning change rather than folded into a scripts fix.

## Files changed

- `scripts/sync_local_env_from_example.py`: `main_worktree_root()`, `.env` path redirect, fail-loud
  on an all-skipped run.
- `tests/scripts/test_sync_local_env_from_example.py`: 3 new tests.

## Schema / bus / API changes

None.

## Env/config changes

No keys added, removed, or renamed. This changes *where the tool looks*, not any value.

## Tests run

```text
$ pytest tests/scripts/test_sync_local_env_from_example.py -q
11 passed
```

Red-before-green against `origin/main`:

```text
FAILED test_main_worktree_root_resolves_primary_checkout_from_a_linked_worktree
FAILED test_main_worktree_root_falls_back_outside_a_git_repo
FAILED test_main_worktree_root_falls_back_when_services_dir_is_absent
3 failed, 8 passed
```

The worktree test builds a **real** `git worktree add` pair in `tmp_path` rather than mocking
`rev-parse`, so it exercises the actual git behavior the fix depends on.

## Docker/build/smoke checks

Not applicable — a repo-local script, no service runtime touched.

## Restart required

```text
No restart required.
```

## Risks / concerns

- **Severity: note.** The script now *writes* to the primary checkout's `.env` when run from a
  worktree. That is the intended and mandated behavior (§7 says sync the live `.env`), `.env` is
  gitignored, and no git operation is involved — but it is a real behavior change worth knowing.
- **Severity: note.** Diverged keys still exit `0`, unchanged. Making divergence itself fail would
  break `make agent-check` for the six legitimate host-specific overrides above; that needs a
  changed-in-this-branch comparison, which is its own patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)